### PR TITLE
Documentation: git 1.7.9.5+ and dev

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -30,7 +30,7 @@ Requirements
       e.g. version 1.49.0
   - *Debian/Ubuntu:* `sudo apt-get install libboost-program-options-dev libboost-regex-dev`
 
-- **git** 1.7.10 or [higher](https://help.github.com/articles/https-cloning-errors)
+- **git** 1.7.9.5 or [higher](https://help.github.com/articles/https-cloning-errors)
   - *Debian/Ubuntu:* `sudo apt-get install git`
 
 - **PIConGPU**

--- a/doc/PARTICIPATE.md
+++ b/doc/PARTICIPATE.md
@@ -39,7 +39,7 @@ If you are familiar with git, feel free to jump to our [github workflow](#github
 **Debian/Ubuntu**:
 - `sudo apt-get install git`
 - make sure `git --version` is at least at version
-  [1.7.10](https://help.github.com/articles/https-cloning-errors)
+  [1.7.9.5](https://help.github.com/articles/https-cloning-errors)
 
 Optional *one* of these. There are nice GUI tools available to get an overview
 on your repository.


### PR DESCRIPTION
Hey awesome PIConGPU-Developers,

I add some notes about using [at least](https://help.github.com/articles/https-cloning-errors) **git 1.7.9.5+** ~~1.7.10+~~ to
- INSTALL.md
- PARTICIPATE.md

Furthermore, the "workflow in a nutshell" contains now the note how to start the **pull request** to the right (= _dev_ ) branch instead of the master branch, since the master branch gets updates by the maintainers only.

Cheers,
_Axel_
