### PR TITLE
fix #14: gcc 4.7 compile errors

### DIFF
--- a/src/libPMacc/include/mappings/kernel/AreaMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/AreaMapping.hpp
@@ -69,7 +69,7 @@ namespace PMacc
          */
         HINLINE DataSpace<DIM> getGridDim()
         {
-            return reduce(AreaMappingMethods<areaType, DIM>::getGridDim(*this,
+            return this->reduce(AreaMappingMethods<areaType, DIM>::getGridDim(*this,
                                                                         this->getGridSuperCells()));
         }
 

--- a/src/libPMacc/include/mappings/kernel/ExchangeMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/ExchangeMapping.hpp
@@ -94,7 +94,7 @@ namespace PMacc
          */
         HINLINE DataSpace<DIM> getGridDim()
         {
-            return reduce(ExchangeMappingMethods<areaType, DIM>::getGridDim(*this, exchangeType));
+            return this->reduce(ExchangeMappingMethods<areaType, DIM>::getGridDim(*this, exchangeType));
         }
 
         /**

--- a/src/libPMacc/include/mappings/kernel/StrideMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/StrideMapping.hpp
@@ -72,7 +72,7 @@ public:
      */
     HINLINE DataSpace<DIM> getGridDim()
     {
-        return reduce((StrideMappingMethods<areaType, DIM>::getGridDim(*this) - offset + Stride - 1) / Stride);
+        return this->reduce((StrideMappingMethods<areaType, DIM>::getGridDim(*this) - offset + Stride - 1) / Stride);
     }
 
     /**

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -104,7 +104,7 @@ public:
     void reset(bool preserveData = true)
     {
         __startOperation(ITask::TASK_HOST);
-        setCurrentSize(this->getDataSpace().getElementCount());
+        this->setCurrentSize(this->getDataSpace().getElementCount());
         if (!preserveData)
             memset(pointer, 0, this->getDataSpace().getElementCount() * sizeof (TYPE));
     }


### PR DESCRIPTION
- add this->functionName if we inherit from a template argument
  and access methods from this BaseClass
