### PR TITLE
Cell2Particle Attributes

### DIFF
--- a/src/picongpu/include/particles/access/Cell2Particle.tpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.tpp
@@ -28,11 +28,6 @@ namespace mpl = boost::mpl;
 
 namespace particleAccess
 {
-    
-struct Pos {};
-struct Mom {};
-struct LocalCellIdx {};
-struct Weight {};
 
 #define TEMPLATE_ARGS(Z, N, _) typename Arg ## N
 #define NORMAL_ARGS(Z, N, _) Arg ## N arg ## N
@@ -71,11 +66,7 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
         if (linearThreadIdx < particlesInSuperCell) \
         { \
             functor( \
-                PMacc::math::make_MapTuple<Pos, Mom, LocalCellIdx, Weight> \
-                (ref(frame->getPosition()[linearThreadIdx]), \
-                 ref(frame->getMomentum()[linearThreadIdx]), \
-                 ref(frame->getCellIdx()[linearThreadIdx]), \
-                 ref(frame->getWeighting()[linearThreadIdx])) \
+                frame, linearThreadIdx \
                 BOOST_PP_ENUM_TRAILING(N, ARGS, _) \
                 ); \
         } \

--- a/src/picongpu/include/plugins/ParticleDensity.tpp
+++ b/src/picongpu/include/plugins/ParticleDensity.tpp
@@ -50,27 +50,27 @@ template<typename BlockDim>
 struct ParticleDensityKernel
 {
     typedef void result_type;
-    
+
     int planeDir;
     int localPlane;
     ParticleDensityKernel() {}
     ParticleDensityKernel(int planeDir, int localPlane)
     : planeDir(planeDir), localPlane(localPlane) {}
-    
-    template<typename Particle, typename Field>
-    DINLINE void operator()(Particle particle, Field field, const ::PMacc::math::Int<3>& blockCellIdx) 
+
+    template<typename FramePtr, typename Field>
+    DINLINE void operator()(FramePtr particle, uint16_t particleID, Field field, const ::PMacc::math::Int<3>& blockCellIdx)
     {
-        lcellId_t linearCellIdx = particle[particleAccess::LocalCellIdx()];
+        lcellId_t linearCellIdx = particle->getCellIdx()[particleID];
         ::PMacc::math::Int<3> cellIdx(linearCellIdx % BlockDim::x::value,
                                (linearCellIdx / BlockDim::x::value) % BlockDim::x::value,
                                linearCellIdx / (BlockDim::x::value * BlockDim::y::value));
         if(cellIdx[planeDir] != localPlane) return;
-        
+
         ::PMacc::math::Int<3> globalCellIdx = blockCellIdx - (PMacc::math::Int<3>)BlockDim().vec() + cellIdx;
         /// \warn reduce a normalized float_X with particleAccess::Weight() / NUM_EL_PER_PARTICLE
         ///       to avoid overflows for heavy weightings
         ///
-        atomicAdd(&(*field(globalCellIdx.shrink<2>((planeDir+1)%3))), (int)particle[particleAccess::Weight()]);
+        atomicAdd(&(*field(globalCellIdx.shrink<2>((planeDir+1)%3))), (int)particle->getWeighting()[particleID]);
     }
 };
 

--- a/src/picongpu/include/plugins/ParticleSpectrum.tpp
+++ b/src/picongpu/include/plugins/ParticleSpectrum.tpp
@@ -52,11 +52,11 @@ struct Particle2Histrogram
     DINLINE Particle2Histrogram(float_X minEnergy, float_X maxEnergy)
         : minEnergy(minEnergy), maxEnergy(maxEnergy) {}
     
-    template<typename Particle, typename Histogram>
-    DINLINE void operator()(Particle particle, Histogram histogram) const
+    template<typename FramePtr, typename Histogram>
+    DINLINE void operator()(FramePtr particle, uint16_t particleID, Histogram histogram) const
     {
-        float3_X mom = particle[particleAccess::Mom()].get();
-        float_X weighting = particle[particleAccess::Weight()];
+        float3_X mom = particle->getMomentum()[particleID];
+        float_X weighting = particle->getWeighting()[particleID];
         const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
         const float_X mass = M_EL;
         const float_X mass_reci = float_X(1.0) / mass;


### PR DESCRIPTION
This Pull-Request removes the nice "one-particle-view" in the functor called by `Cell2Particle` by transparently giving in the `frame` and the `particleID` the functor should work on.

This has the major advantage to enable the use rvalue attributes like getCharge, getMass again. Furthermore, re-writing the whole particle in a MapTuple and writing a _second interface_ on _how to access particle attributes_ is not a good idea at all, sorry.

I am sure we can re-implement a "single-particle" kind of scope/view when René got his _flex-particles_ ready.
