### PR TITLE
fix warning in __cudaKernel

### DIFF
--- a/src/libPMacc/include/ppFunctions.hpp
+++ b/src/libPMacc/include/ppFunctions.hpp
@@ -20,8 +20,7 @@
  */ 
  
 
-#ifndef PPFUNCTIONS_HPP
-#define	PPFUNCTIONS_HPP
+#pragma once
 
 
 #define PMACC_MIN(x,y) (((x)<=(y))?x:y)
@@ -34,5 +33,21 @@
 #define PMACC_MAX_DO(what,x,y) (((x)>(y))?x what:y what)
 #define PMACC_MIN_DO(what,x,y) (((x)<(y))?x what:y what)
 
-#endif	/* PPFUNCTIONS_HPP */
+/**
+ * Returns number of args... arguments.
+ *
+ * Can only count values of ... which can be casted to int type.
+ *
+ * @param ... arguments
+ */
+#define PMACC_COUNT_ARGS(...)  (sizeof((int[]){0, ##__VA_ARGS__})/sizeof(int)-1)
 
+/**
+ * Check if ... has arguments or not
+ *
+ * Can only used if values of ... can be casted to int type
+ *
+ * @param ... arguments
+ * @return false if no arguments are given, else true
+ */
+#define PMACC_HAS_ARGS(...)  ((sizeof((int[]){0, ##__VA_ARGS__}))==sizeof(int)?false:true)

--- a/src/picongpu/include/simulation_classTypes.hpp
+++ b/src/picongpu/include/simulation_classTypes.hpp
@@ -49,9 +49,8 @@ namespace picongpu
      *
      * @param ... parameters to pass to kernel
      */
-#define PIC_PMACC_CUDAPARAMS(...) (__VA_ARGS__,mapper);  \
-    taskKernel->activateChecks();              \
-   /* CUDA_CHECK(cudaThreadSynchronize());*/  \
+#define PIC_PMACC_CUDAPARAMS(...) (__VA_ARGS__,mapper);                        \
+        PMACC_ACTIVATE_KERNEL                                                  \
     }   /*this is used if call is EventTask.waitforfinished();*/
 
     /**
@@ -62,8 +61,8 @@ namespace picongpu
      * @param block sizes of block on gpu
      * @param ... amount of shared memory for the kernel (optional)
      */
-#define PIC_PMACC_CUDAKERNELCONFIG(block,...) <<<mapper.getGridDim(),(block),     \
-    PMACC_NUMARGS(__VA_ARGS__)==1?__VA_ARGS__:0,                      \
+#define PIC_PMACC_CUDAKERNELCONFIG(block,...) <<<mapper.getGridDim(),(block),  \
+    __VA_ARGS__+0,                                                             \
     taskKernel->getCudaStream()>>> PIC_PMACC_CUDAPARAMS
 
     /**
@@ -75,7 +74,8 @@ namespace picongpu
      * @param kernelname name of the CUDA kernel (can also used with templates etc. myKernnel<1>)
      * @param area area type for which the kernel is called
      */
-#define __picKernelArea(kernelname,description,area) {                                                    \
+#define __picKernelArea(kernelname,description,area) {                               \
+    CUDA_CHECK_KERNEL_MSG(cudaThreadSynchronize(),"picKernelArea crash before kernel call");       \
     AreaMapping<area,MappingDesc> mapper(description);                               \
     TaskKernel *taskKernel =  Factory::getInstance().createTaskKernel(#kernelname);  \
     kernelname PIC_PMACC_CUDAKERNELCONFIG


### PR DESCRIPTION
- fix warning if we use expression like 1==2?:10
- move preprocessor definition to ppFunctions.hpp
