### PR TITLE
Fix #53 warning game of life

### DIFF
--- a/src/libPMacc/include/mappings/simulation/SubGrid.hpp
+++ b/src/libPMacc/include/mappings/simulation/SubGrid.hpp
@@ -37,7 +37,7 @@ class SimulationBox
     static const uint32_t Dim = DIM;
 public:
 
-    HDINLINE SimulationBox(const Size& localSize,
+    SimulationBox(const Size& localSize,
                            const Size& globalSize,
                            const Size& globalOffset) :
     localSize(localSize),
@@ -49,7 +49,7 @@ public:
             assert(localSize[i] <= globalSize[i]);
     }
 
-    HDINLINE SimulationBox()
+    SimulationBox()
     {
 
     }


### PR DESCRIPTION
- delete HDINLINE in both constructors (there is no need for device side constructors of this struct)
