### PR TITLE
gasSphereFlanks: add inner radius

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/gasConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gasConfig.param
@@ -141,6 +141,9 @@ namespace picongpu
             /** Radius of the constant sphere
              *  unit: meter */
             const double GAS_R_SI = 1.0e3;
+            /** Inner radius if you want to build a shell/ring
+             *  unit: meter */
+            const double GAS_RI_SI = 0.0;
             
             /** Middle of the constant sphere
              *  unit: meter */

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gasConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gasConfig.param
@@ -141,6 +141,9 @@ namespace picongpu
             /** Radius of the constant sphere
              *  unit: meter */
             const double GAS_R_SI = 1.0e3;
+            /** Inner radius if you want to build a shell/ring
+             *  unit: meter */
+            const double GAS_RI_SI = 0.0;
             
             /** Middle of the constant sphere
              *  unit: meter */

--- a/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
@@ -141,6 +141,9 @@ namespace picongpu
             /** Radius of the constant sphere
              *  unit: meter */
             const double GAS_R_SI = 1.0e3;
+            /** Inner radius if you want to build a shell/ring
+             *  unit: meter */
+            const double GAS_RI_SI = 0.0;
             
             /** Middle of the constant sphere
              *  unit: meter */

--- a/examples/ThermalTest/include/simulation_defines/param/gasConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gasConfig.param
@@ -141,6 +141,9 @@ namespace picongpu
             /** Radius of the constant sphere
              *  unit: meter */
             const double GAS_R_SI = 1.0e3;
+            /** Inner radius if you want to build a shell/ring
+             *  unit: meter */
+            const double GAS_RI_SI = 0.0;
             
             /** Middle of the constant sphere
              *  unit: meter */

--- a/examples/WeibelTransverse/include/simulation_defines/param/gasConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gasConfig.param
@@ -141,6 +141,9 @@ namespace picongpu
             /** Radius of the constant sphere
              *  unit: meter */
             const double GAS_R_SI = 1.0e3;
+            /** Inner radius if you want to build a shell/ring
+             *  unit: meter */
+            const double GAS_RI_SI = 0.0;
             
             /** Middle of the constant sphere
              *  unit: meter */

--- a/src/picongpu/include/particles/gasProfiles/gasSphereFlanks.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasSphereFlanks.hpp
@@ -40,15 +40,19 @@ namespace picongpu
             if( pos.y() < VACUUM_Y ) return float_X(0.0);
 
             const float_X r = math::abs( pos - float3_X(GAS_X, GAS_Y, GAS_Z) );
-            
-            // "hard core"
-            if( r <= GAS_R )
+
+            /* "shell": inner radius */
+            if( r < GAS_RI )
+                return float_X(0.0);
+            /* "hard core" */
+            else if( r <= GAS_R )
                 return float_X(1.0);
-            
-            // "soft exp. flanks"
-            //   note: by definition (return, see above) the
-            //         argument [ GAS_R - r ] will be element of (-inf, 0)
-            return math::exp( ( GAS_R - r ) * GAS_EXP );
+
+            /* "soft exp. flanks"
+             *   note: by definition (return, see above) the
+             *         argument [ GAS_R - r ] will be element of (-inf, 0) */
+            else
+                return math::exp( ( GAS_R - r ) * GAS_EXP );
         }
     }
 }

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -141,6 +141,9 @@ namespace picongpu
             /** Radius of the constant sphere
              *  unit: meter */
             const double GAS_R_SI = 1.0e3;
+            /** Inner radius if you want to build a shell/ring
+             *  unit: meter */
+            const double GAS_RI_SI = 0.0;
             
             /** Middle of the constant sphere
              *  unit: meter */

--- a/src/picongpu/include/simulation_defines/unitless/gasConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gasConfig.unitless
@@ -62,6 +62,7 @@ namespace picongpu
     namespace gasSphereFlanks
     {
         const float_X GAS_R = float_X( SI::GAS_R_SI / UNIT_LENGTH );
+        const float_X GAS_RI = float_X( SI::GAS_RI_SI / UNIT_LENGTH );
         const float_X GAS_X = float_X( SI::GAS_X_SI / UNIT_LENGTH );
         const float_X GAS_Y = float_X( SI::GAS_Y_SI / UNIT_LENGTH );
         const float_X GAS_Z = float_X( SI::GAS_Z_SI / UNIT_LENGTH );


### PR DESCRIPTION
This pull request allows to simulate spheric shells / hollow cylinders.

All examples have been patched to set the new variable, too (default inner radius = 0.0 -> full sphere).
