### PR TITLE
Traits for splash types

### DIFF
--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -27,6 +27,8 @@
 #include "algorithms/ForEach.hpp"
 #include "algorithms/math.hpp"
 #include "traits/GetMargin.hpp"
+#include "traits/SplashToPIC.hpp"
+#include "traits/PICToSplash.hpp"
 #include "traits/GetType.hpp"
 
 namespace picongpu

--- a/src/picongpu/include/traits/PICToSplash.hpp
+++ b/src/picongpu/include/traits/PICToSplash.hpp
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+
+namespace traits
+{
+    /** Convert a PIConGPU Type to a Splash CollectionType
+     * 
+     * \tparam T_Type Typename in PIConGPU
+     * \return \p ::type as public typedef of a Splash DCollector::CollectionType
+     */
+    template<typename T_Type>
+    struct PICToSplash;
+
+} //namespace traits
+
+}// namespace picongpu
+
+#include "PICToSplash.tpp"

--- a/src/picongpu/include/traits/PICToSplash.tpp
+++ b/src/picongpu/include/traits/PICToSplash.tpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2013 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if (ENABLE_HDF5==1)
+#include <splash.h>
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+
+namespace traits
+{
+    /** Trait for bool */
+    template<>
+    struct PICToSplash<bool>
+    {
+        typedef DCollector::ColTypeBool type;
+    };
+    /** Trait for float */
+    template<>
+    struct PICToSplash<float>
+    {
+        typedef DCollector::ColTypeFloat type;
+    };
+
+    /** Trait for double */
+    template<>
+    struct PICToSplash<double>
+    {
+        typedef DCollector::ColTypeDouble type;
+    };
+
+    /** Trait for int */
+    template<>
+    struct PICToSplash<int>
+    {
+        typedef DCollector::ColTypeInt type;
+    };
+
+    /** Trait for DCollector::Dimensions */
+    template<>
+    struct PICToSplash<DCollector::Dimensions>
+    {
+        typedef DCollector::ColTypeDim type;
+    };
+
+} //namespace traits
+
+}// namespace picongpu
+
+#endif // (ENABLE_HDF5==1)

--- a/src/picongpu/include/traits/SplashToPIC.hpp
+++ b/src/picongpu/include/traits/SplashToPIC.hpp
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+
+namespace traits
+{
+    /** Convert a Splash CollectionType to a PIConGPU Type
+     * 
+     * \tparam T_SplashType Splash DCollector::CollectionType
+     * \return \p ::type as public typedef
+     */
+    template<typename T_SplashType>
+    struct SplashToPIC;
+
+} //namespace traits
+
+}// namespace picongpu
+
+#include "SplashToPIC.tpp"

--- a/src/picongpu/include/traits/SplashToPIC.tpp
+++ b/src/picongpu/include/traits/SplashToPIC.tpp
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2013 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if (ENABLE_HDF5==1)
+#include <splash.h>
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+
+namespace traits
+{
+    /** Trait for DCollector::ColTypeBool */
+    template<>
+    struct SplashToPIC<DCollector::ColTypeBool>
+    {
+        typedef bool type;
+    };
+
+    /** Trait for DCollector::ColTypeFloat */
+    template<>
+    struct SplashToPIC<DCollector::ColTypeFloat>
+    {
+        typedef float type;
+    };
+
+    /** Trait for DCollector::ColTypeDouble */
+    template<>
+    struct SplashToPIC<DCollector::ColTypeDouble>
+    {
+        typedef double type;
+    };
+
+    /** Trait for DCollector::ColTypeInt */
+    template<>
+    struct SplashToPIC<DCollector::ColTypeInt>
+    {
+        typedef int type;
+    };
+
+    /** Trait for DCollector::ColTypeInt */
+    template<>
+    struct SplashToPIC<DCollector::ColTypeDim>
+    {
+        typedef DCollector::Dimensions type;
+    };
+
+} //namespace traits
+
+}// namespace picongpu
+
+#endif // (ENABLE_HDF5==1)


### PR DESCRIPTION
Add some type traits to convert our units to libSplash [CollectionType](http://computationalradiationphysics.github.io/libSplash/class_d_collector_1_1_collection_type.html)s and back.

I did not add the trait to `HDF5Writer.hpp` to avoid merge conflicts with René's up-comming `flex-particles`.
Furthermore, we should honour the stored type and try a host-side TypeCast during `restarts`.

I will use the proposed traits first with a rebase in my [topic/phase-space](https://github.com/ax3l/picongpu/tree/topic/phase-space) branch.
