### PR TITLE
Fix #70 dimensions

### DIFF
--- a/src/picongpu/include/plugins/output/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/output/HDF5Writer.hpp
@@ -19,7 +19,6 @@
  */
 
 
-
 #pragma once
 
 #include <pthread.h>


### PR DESCRIPTION
- change &obj to obj.getPointer()
- reduce line lengths to about 80
