### PR TITLE
Fix NDims during writeDomain

### DIFF
--- a/src/picongpu/include/plugins/output/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/output/HDF5Writer.hpp
@@ -520,7 +520,8 @@ private:
 
                 params->dataCollector->writeDomain(params->currentStep, /* id == time step */
                                                    colType,             /* data type */
-                                                   dims,                /* NDims of the field data (scalar, vector, ...) */
+                                                   simDim,              /* NDims of the field data == simDim
+                                                                           (NOT scalar=1 or vector=3 !) */
                                                    /* source buffer, stride, data size, offset */
                                                    DCollector::Dimensions(field_full[0] * dims, field_full[1], field_full[2]),
                                                    DCollector::Dimensions(dims, 1, 1),


### PR DESCRIPTION
Fixes the bug for writing fields introduced with [Pull #80](https://github.com/ComputationalRadiationPhysics/picongpu/commit/45aaaa88b08f477405c8e50fcb4a087bbf801c96#commitcomment-4286394)

fieldTmp (1 component but in a 3D domain living) should have screwed up the other fields a little due to that mismatch...
