### PR TITLE
Include cudaDeviceReset in StreamController

### DIFF
--- a/src/libPMacc/include/eventSystem/streams/StreamController.hpp
+++ b/src/libPMacc/include/eventSystem/streams/StreamController.hpp
@@ -68,7 +68,7 @@ namespace PMacc
 
         /**
          * Destructor.
-         * Deletes internal streams.
+         * Deletes internal streams. Tears down CUDA.
          */
         virtual ~StreamController()
         {
@@ -78,6 +78,11 @@ namespace PMacc
                 delete streams[i];
             }
             streams.clear();
+            
+            /* This is the single point in PIC where ALL CUDA work must be finished. */
+            /* Accessing CUDA objects after this point may fail! */
+            CUDA_CHECK(cudaDeviceSynchronize());
+            CUDA_CHECK(cudaDeviceReset());
         }
 
         /**


### PR DESCRIPTION
This has been tested on Taurus with VampirTrace in async CUPTI mode and CUDA 5.5, no errors.
