### PR TITLE
Boost 1.55 noinline work around

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -154,7 +154,7 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # work-arounds
 if(Boost_VERSION EQUAL 105500)
     # see https://svn.boost.org/trac/boost/ticket/9392
-    message(STATUS "Boost: Applying noinline work around...")
+    message(STATUS "Boost: Applying noinline work around")
     set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -DBOOST_NOINLINE='__attribute__ ((noinline))'")
 endif(Boost_VERSION EQUAL 105500)


### PR DESCRIPTION
That's a work-around for the newly released [boost 1.55](http://www.boost.org/users/history/version_1_55_0.html), introducing a generic _noinline_ macro.

PIConGPU fails on an include, pulled into `BOOST_ASSERT_MSG` on `__host__` side calls like `include/boost/assert.hpp:102`.

The underlying problem is, that nvcc seems to understand
  `__attribute__ ((noinline))`
but not
  `__attribute__ ((__noinline__))`

I reported that on https://svn.boost.org/trac/boost/ticket/9392 - may we should open a nvcc ticket, too.
