### PR TITLE
Radiation corrections

### DIFF
--- a/src/picongpu/include/plugins/Radiation.hpp
+++ b/src/picongpu/include/plugins/Radiation.hpp
@@ -778,7 +778,7 @@ private:
                 }
 
 
-                for (int i = 0; i < elements_amplitude; ++i)
+                for (unsigned int i = 0; i < elements_amplitude; ++i)
                     timeSumArray[i] += result[i];
                 writeFile(timeSumArray, folderTotalRad + "/" + filename_prefix + "_" + o_step.str() + ".dat");
                 writeBackup(timeSumArray, std::string("radRestart") + "/" + std::string("radRestart") + "_" + o_step.str() + ".dat");


### PR DESCRIPTION
With this change, the warning:
".../picongpu/src/picongpu/include/plugins/Radiation.hpp:781:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]"
plus its quite long template description is gone.
