### PR TITLE
update uncrustify file for picongpu

### DIFF
--- a/doc/picongpu_uncrustify.cfg
+++ b/doc/picongpu_uncrustify.cfg
@@ -728,7 +728,7 @@ sp_sign                                  = remove   # ignore/add/remove/force
 sp_incdec                                = remove   # ignore/add/remove/force
 
 # Add or remove space before a backslash-newline at the end of a line. Default=Add
-sp_before_nl_cont                        = add      # ignore/add/remove/force
+sp_before_nl_cont                        = force      # ignore/add/remove/force
 
 # Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
 # picongpu
@@ -1712,7 +1712,7 @@ mod_remove_empty_return                  = false    # false/true
 
 # Try to wrap comments at cmt_width columns
 # picongpu
-cmt_width                                = 80       # number
+cmt_width                                = 70       # number
 
 # Set the comment reflow mode (default: 0)
 # 0: no reflowing (apart from the line wrapping due to cmt_width)


### PR DESCRIPTION
This file is fully testet and create compileable code if we reformate our full project with this rules.

One point we must change is: move documentation of variables over the value (e.g. in *.param)

``` C++
const float_X CELL_WIDTH = float_X (SI::CELL_WIDTH_SI / UNIT_LENGTH); //normalized to UNIT_LENGTH
```

generated code by uncrustify

``` C++
 const float_X CELL_WIDTH = float_X( SI::CELL_WIDTH_SI / UNIT_LENGTH );   /* normalized
                                                                           * to
                                                                           * UNIT_LENGTH */
```

It should by something like this:

``` C++
/* normalized to UNIT_LENGTH */
const float_X CELL_WIDTH = float_X (SI::CELL_WIDTH_SI / UNIT_LENGTH); 
```
