### PR TITLE
Update Documentation: libPMacc

### DIFF
--- a/doc/PARTICIPATE.md
+++ b/doc/PARTICIPATE.md
@@ -281,7 +281,7 @@ Well - there are some! ;)
 Please **add the according license header** snippet to your *new files*:
 - for PIConGPU (GPLv3+): `src/tools/bin/addLicense <FileName>`
 - for libraries (LGPLv3+ & GPLv3+):
-  `export PROJECT_NAME=libgpugrid && src/tools/bin/addLicense <FileName>`
+  `export PROJECT_NAME=libPMacc && src/tools/bin/addLicense <FileName>`
 - delete other headers: `src/tools/bin/deleteHeadComment <FileName>`
 - add license to all .hpp files within a directory (recursive):
   `export PROJECT_NAME=PIConGPU && src/tools/bin/findAndDo <PATH> "*.hpp" src/tools/bin/addLicense`


### PR DESCRIPTION
`addLicense` did not include the right name for libPMacc (still refered to it as libgpugrid)
