### PR TITLE
Add Include to MPI_CHECK Makro Define for printf

### DIFF
--- a/src/libPMacc/include/communication/manager_common.h
+++ b/src/libPMacc/include/communication/manager_common.h
@@ -21,7 +21,9 @@
 
 #pragma once
 
-#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <string>
 
 const int GridManagerRank = 0;
 
@@ -33,4 +35,4 @@ enum {
   gridExchangeTag = 5
 };
 
-#define MPI_CHECK(cmd) {int error = cmd; if(error!=MPI_SUCCESS){printf("<%s>:%i ",__FILE__,__LINE__); throw std::runtime_error(std::string("[MPI] Error"));}}
+#define MPI_CHECK(cmd) {int error = cmd; if(error!=MPI_SUCCESS){std::cerr << "<" << __FILE__ << ">:" << __LINE__; throw std::runtime_error(std::string("[MPI] Error"));}}


### PR DESCRIPTION
The defined makro uses `printf` from `<cstdio>`.

For some reason the editor changed the file type (before: _ASCII text, with CRLF, LF line terminators_), so I decided to clean up the trailing white spaces, too...
Just append [?w=1](https://github.com/ComputationalRadiationPhysics/picongpu/pull/168/files?w=1) to the file diff to see the "real" changes.
