### PR TITLE
Use generic ValueTypes for fields in IO

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -156,6 +156,11 @@ TBG_macroCount="--elec_cnt.period 100 --ions_cnt.period 100"
 TBG_hdf5="--hdf5.period 100 --hdf5.file simData"
 
 
+# Dump simulation data (fields and particles) to ADIOS files.
+# Data is dumped every .period steps to the fileset .file.
+TBG_adios="--adios.period 100 --adios.file simData"
+
+
 # Restart the simulation from libSplash files created using TBG_hdf5.
 TBG_restart="--restart --restart-file simData"
 

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -37,7 +37,6 @@
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
 #include "fields/FieldJ.hpp"
-#include "fields/FieldTmp.def"
 #include "fields/FieldTmp.hpp"
 #include "particles/particleFilter/FilterFactory.hpp"
 #include "particles/particleFilter/PositionFilter.hpp"
@@ -118,6 +117,8 @@ private:
     struct GetFields
     {
     private:
+        typedef typename T::ValueType ValueType;
+        typedef typename GetComponentsType<ValueType>::type ComponentType;
 
         static std::vector<double> getUnit()
         {
@@ -136,12 +137,12 @@ private:
             T* field = &(dc.getData<T > (T::getCommTag()));
             params.get()->gridLayout = field->getGridLayout();
 
-            PICToAdios<float> adiosType;
+            PICToAdios<ComponentType> adiosType;
             writeField(params.get(),
-                       sizeof(float),
+                       sizeof(ComponentType),
                        adiosType.type,
                        domInfo,
-                       T::numComponents,
+                       GetNComponents<ValueType>::value,
                        T::getName(),
                        getUnit(),
                        field->getHostDataBox().getPointer());

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -119,6 +119,9 @@ private:
     struct GetDCFields
     {
     private:
+        typedef typename T::ValueType ValueType;
+        typedef typename GetComponentsType<ValueType>::type ComponentType;
+        typedef typename PICToSplash<ComponentType>::type SplashType;
 
         static std::vector<double> getUnit()
         {
@@ -132,8 +135,7 @@ private:
         HDINLINE void operator()(RefWrapper<ThreadParams*> params, const DomainInformation domInfo)
         {
 #ifndef __CUDA_ARCH__
-            ColTypeFloat ctFloat;
-
+            SplashType splashType;
             DataConnector &dc = DataConnector::getInstance();
 
             T* field = &(dc.getData<T > (T::getCommTag()));
@@ -141,8 +143,8 @@ private:
 
             writeField(params.get(),
                        domInfo,
-                       ctFloat,
-                       T::numComponents,
+                       splashType,
+                       GetNComponents<ValueType>::value,
                        T::getName(),
                        getUnit(),
                        field->getHostDataBox().getPointer());
@@ -354,7 +356,6 @@ private:
     {
         if (notifyFrequency > 0)
         {
-            mThreadParams.dataCollector = NULL;
             mThreadParams.gridPosition =
                 SubGrid<simDim>::getInstance().getSimulationBox().getGlobalOffset();
 


### PR DESCRIPTION
- use ValueType and derivatives instead of float
- add cfg doc for ADIOS

fixes this [issue](https://github.com/ComputationalRadiationPhysics/picongpu/issues/190)
