### PR TITLE
delete namespace detail in math and typeCast

### DIFF
--- a/src/libPMacc/include/algorithms/TypeCast.hpp
+++ b/src/libPMacc/include/algorithms/TypeCast.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -27,8 +27,6 @@ namespace algorithms
 {
 namespace typeCast
 {
-namespace detail
-{
 
 template<typename CastToType, typename Type>
 struct TypeCast
@@ -41,15 +39,13 @@ struct TypeCast
     }
 };
 
-} //namespace detail
 
 template<typename CastToType, typename Type>
-HDINLINE static typename detail::TypeCast<CastToType, Type>::result typeCast(const Type& value)
+HDINLINE static typename TypeCast<CastToType, Type>::result typeCast(const Type& value)
 {
-    return detail::TypeCast<CastToType, Type > ()(value);
+    return TypeCast<CastToType, Type > ()(value);
 }
 
 } //namespace typeCast
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/defines/abs.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/abs.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -29,30 +29,25 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<typename Type>
 struct Abs;
 
 template<typename Type>
 struct Abs2;
 
-} //namespace detail
 
 template<typename T1>
-HDINLINE static typename detail::Abs< T1>::result abs(T1 value)
+HDINLINE static typename Abs< T1>::result abs(T1 value)
 {
-    return detail::Abs< T1 > ()(value);
+    return Abs< T1 > ()(value);
 }
 
 template<typename T1>
-HDINLINE static typename detail::Abs2< T1 >::result abs2(const T1& value)
+HDINLINE static typename Abs2< T1 >::result abs2(const T1& value)
 {
-    return detail::Abs2< T1 > ()(value);
+    return Abs2< T1 > ()(value);
 }
 
 } //namespace math
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/defines/comparison.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/comparison.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -29,30 +29,25 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<typename T1,typename T2>
 struct Max;
 
 template<typename T1,typename T2>
 struct Min;
 
-} //namespace detail
 
 template<typename T1,typename T2>
-HDINLINE static typename detail::Min< T1,T2>::result min(const T1& value1,const T2& value2)
+HDINLINE static typename Min< T1,T2>::result min(const T1& value1,const T2& value2)
 {
-    return detail::Min< T1,T2 > ()(value1,value2);
+    return Min< T1,T2 > ()(value1,value2);
 }
 
 template<typename T1,typename T2>
-HDINLINE static typename detail::Max< T1,T2 >::result max(const T1& value1,const T2& value2)
+HDINLINE static typename Max< T1,T2 >::result max(const T1& value1,const T2& value2)
 {
-    return detail::Max< T1,T2 > ()(value1,value2);
+    return Max< T1,T2 > ()(value1,value2);
 }
 
 } //namespace math
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/defines/cross.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/cross.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -30,20 +30,15 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<typename Type1, typename Type2>
 struct Cross;
 
-} //namespace detail
 
 template<typename T1, typename T2>
-HDINLINE static typename detail::Cross< T1, T2 >::result cross(const T1& value, const T2& value2)
+HDINLINE static typename Cross< T1, T2 >::result cross(const T1& value, const T2& value2)
 {
-    return detail::Cross< T1, T2 > ()(value, value2);
+    return Cross< T1, T2 > ()(value, value2);
 }
 } //namespace math
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/defines/dot.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/dot.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -28,20 +28,15 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<typename Type1, typename Type2>
 struct Dot;
 
-} //namespace detail
 
 template<typename T1, typename T2>
-HDINLINE static typename detail::Dot< T1, T2 >::result dot(const T1& value, const T2& value2)
+HDINLINE static typename Dot< T1, T2 >::result dot(const T1& value, const T2& value2)
 {
-    return detail::Dot< T1, T2 > ()(value, value2);
+    return Dot< T1, T2 > ()(value, value2);
 }
 } //namespace math
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/defines/exp.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/exp.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc. 
  * 
@@ -29,8 +29,6 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
 
 template<typename Type>
 struct Exp;
@@ -38,23 +36,19 @@ struct Exp;
 template<typename Type>
 struct Log;
 
-
-} //namespace detail
-
 template<typename T1>
-HDINLINE static typename detail::Exp< T1 >::result exp(const T1& value)
+HDINLINE static typename Exp< T1 >::result exp(const T1& value)
 {
-    return detail::Exp< T1 > ()(value);
+    return Exp< T1 > ()(value);
 }
 
 template<typename T1>
-HDINLINE static typename detail::Log< T1 >::result log(const T1& value)
+HDINLINE static typename Log< T1 >::result log(const T1& value)
 {
-    return detail::Log< T1 > ()(value);
+    return Log< T1 > ()(value);
 }
 
 
 } //namespace math
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -29,30 +29,25 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<typename Type>
 struct Floor;
 
 template<typename Type>
 struct Float2int_rd;
 
-} //namespace detail
 
 template<typename T1>
-HDINLINE static typename detail::Floor< T1>::result floor(T1 value)
+HDINLINE static typename Floor< T1>::result floor(T1 value)
 {
-    return detail::Floor< T1 > ()(value);
+    return Floor< T1 > ()(value);
 }
 
 template<typename T1>
-DINLINE static typename detail::Float2int_rd< T1>::result float2int_rd(T1 value)
+DINLINE static typename Float2int_rd< T1>::result float2int_rd(T1 value)
 {
-    return detail::Float2int_rd< T1 > ()(value);
+    return Float2int_rd< T1 > ()(value);
 }
 
 } //namespace math
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/defines/pow.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/pow.hpp
@@ -29,13 +29,8 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<typename T1, typename T2>
 struct Pow;
-
-} //namespace detail
 
 
 /** Raised the base to the power exponent
@@ -45,9 +40,9 @@ struct Pow;
  * @return base rased to the power exponent 
  */
 template<typename T1, typename T2>
-HDINLINE static typename detail::Pow< T1, T2 >::result pow(const T1& base,const T2& exponent)
+HDINLINE static typename Pow< T1, T2 >::result pow(const T1& base,const T2& exponent)
 {
-    return detail::Pow< T1, T2 > ()(base, exponent);
+    return Pow< T1, T2 > ()(base, exponent);
 }
 
 } //namespace math

--- a/src/libPMacc/include/algorithms/math/defines/sqrt.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/sqrt.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -28,9 +28,6 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<typename Type>
 struct Sqrt;
 
@@ -38,18 +35,16 @@ template<typename Type>
 struct RSqrt;
 
 
-} //namespace detail
-
 template<typename T1>
-HDINLINE static typename detail::Sqrt< T1 >::result sqrt(const T1& value)
+HDINLINE static typename Sqrt< T1 >::result sqrt(const T1& value)
 {
-    return detail::Sqrt< T1 > ()(value);
+    return Sqrt< T1 > ()(value);
 }
 
 template<typename T1>
-HDINLINE static typename detail::RSqrt< T1 >::result rsqrt(const T1& value)
+HDINLINE static typename RSqrt< T1 >::result rsqrt(const T1& value)
 {
-    return detail::RSqrt< T1 > ()(value);
+    return RSqrt< T1 > ()(value);
 }
 
 } //namespace math

--- a/src/libPMacc/include/algorithms/math/defines/trigo.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/trigo.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc. 
  * 
@@ -29,8 +29,6 @@ namespace algorithms
 
 namespace math
 {
-namespace detail
-{
 
 template<typename Type>
 struct Sin;
@@ -45,38 +43,30 @@ template<typename Type>
 struct Sinc;
 
 
-
-} //namespace detail
-
 template<typename T1>
-HDINLINE static typename detail::Sin< T1 >::result sin(const T1& value)
+HDINLINE static typename Sin< T1 >::result sin(const T1& value)
 {
-    return detail::Sin< T1 > ()(value);
+    return Sin< T1 > ()(value);
 }
 
 template<typename T1>
-HDINLINE static typename detail::Cos<T1>::result cos(const T1& value)
+HDINLINE static typename Cos<T1>::result cos(const T1& value)
 {
-    return detail::Cos< T1 > ()(value);
+    return Cos< T1 > ()(value);
 }
 
 template<typename ArgType, typename SinType, typename CosType>
-HDINLINE static typename detail::SinCos< ArgType, SinType, CosType >::result sincos(ArgType arg, SinType& sinValue, CosType& cosValue)
+HDINLINE static typename SinCos< ArgType, SinType, CosType >::result sincos(ArgType arg, SinType& sinValue, CosType& cosValue)
 {
-    return detail::SinCos< ArgType, SinType, CosType > ()(arg, sinValue, cosValue);
+    return SinCos< ArgType, SinType, CosType > ()(arg, sinValue, cosValue);
 }
 
 template<typename T1>
-HDINLINE static typename detail::Sinc<T1>::result sinc(const T1& value)
+HDINLINE static typename Sinc<T1>::result sinc(const T1& value)
 {
-    return detail::Sinc< T1 > ()(value);
+    return Sinc< T1 > ()(value);
 }
-
-
-
-
 
 } //namespace math
 } //namespace algorithms
 }//namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -32,9 +32,6 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<>
 struct Abs<double>
 {
@@ -57,8 +54,6 @@ struct Abs2<double>
     }
 };
 
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc. 
  * 
@@ -32,9 +32,6 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<>
 struct Exp<double>
 {
@@ -58,9 +55,6 @@ struct Log<double>
 };
 
 
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-
-

--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -32,9 +32,6 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<>
 struct Floor<double>
 {
@@ -57,8 +54,7 @@ struct Float2int_rd<double>
     }
 };
 
-} //namespace detail
+
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2014 Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -31,9 +31,6 @@ namespace algorithms
 {
 namespace math
 {
-namespace detail
-{
-
 /*C++98 standard define a separate version for int and double exponent*/
 
 template<>
@@ -59,9 +56,6 @@ struct Pow<double, int>
 };
 
 
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-
-

--- a/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -31,8 +31,6 @@ namespace algorithms
 {
 namespace math
 {
-namespace detail
-{
 
 template<>
 struct Sqrt<double>
@@ -56,9 +54,6 @@ struct RSqrt<double>
     }
 };
 
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-
-

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc. 
  * 
@@ -30,8 +30,6 @@ namespace PMacc
 namespace algorithms
 {
 namespace math
-{
-namespace detail
 {
 
 template<>
@@ -82,12 +80,6 @@ struct Sinc<double>
     }
 };
 
-
-
-
-
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -30,8 +30,7 @@ namespace algorithms
 {
 namespace math
 {
-namespace detail
-{
+
 
 template<>
 struct Abs<float>
@@ -55,8 +54,6 @@ struct Abs2<float>
     }
 };
 
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc. 
  * 
@@ -31,8 +31,6 @@ namespace algorithms
 {
 namespace math
 {
-namespace detail
-{
 
 template<>
 struct Exp<float>
@@ -56,11 +54,6 @@ struct Log<float>
     }
 };
 
-
-
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-
-

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -32,9 +32,6 @@ namespace algorithms
 namespace math
 {
 
-namespace detail
-{
-
 template<>
 struct Floor<float>
 {
@@ -57,8 +54,6 @@ struct Float2int_rd<float>
     }
 };
 
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-

--- a/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2014 Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -30,8 +30,6 @@ namespace PMacc
 namespace algorithms
 {
 namespace math
-{
-namespace detail
 {
 
 /*C++98 standard define a separate version for int and float exponent*/
@@ -68,10 +66,6 @@ struct Pow<float, int>
     }
 };
 
-
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-
-

--- a/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -31,8 +31,6 @@ namespace algorithms
 {
 namespace math
 {
-namespace detail
-{
 
 template<>
 struct Sqrt<float>
@@ -56,9 +54,6 @@ struct RSqrt<float>
     }
 };
 
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-
-

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc. 
  * 
@@ -29,8 +29,6 @@ namespace PMacc
 namespace algorithms
 {
 namespace math
-{
-namespace detail
 {
 
 template<>
@@ -82,13 +80,6 @@ struct Sinc<float>
     }
 };
 
-
-
-
-
-
-} //namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
-

--- a/src/libPMacc/include/dimensions/DataSpace.tpp
+++ b/src/libPMacc/include/dimensions/DataSpace.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2014 Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -55,8 +55,6 @@ namespace algorithms
 {
 namespace typeCast
 {
-namespace detail
-{
 
 template<unsigned T_Dim>
 struct TypeCast<int, PMacc::DataSpace<T_Dim> >
@@ -79,7 +77,7 @@ struct TypeCast<T_CastToType, PMacc::DataSpace<T_Dim>  >
         return result( vector );
     }
 };
-}//namespace detail
+
 } //namespace typecast
 } //namespace algorithms
 

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc. 
  * 
@@ -56,8 +56,6 @@ namespace PMacc
 namespace algorithms
 {
 namespace math
-{
-namespace detail
 {
 
 /*#### comparison ############################################################*/
@@ -181,7 +179,6 @@ struct Pow< ::PMacc::math::Vector<T1, dim>, T2 >
     }
 };
 
-}//namespace detail
 } //namespace math
 } //namespace algorithms
 } // namespace PMacc
@@ -191,8 +188,6 @@ namespace PMacc
 namespace algorithms
 {
 namespace typeCast
-{
-namespace detail
 {
 
 template<typename CastToType, int dim>
@@ -216,7 +211,7 @@ struct TypeCast<CastToType, ::PMacc::math::Vector<OldType, dim> >
         return result( vector );
     }
 };
-}//namespace detail
+
 } //namespace typecast
 } //namespace algorithms
 } //PMacc


### PR DESCRIPTION
The old version to cover functor classes in a detail namespace were a design mistake. There are a lot of feature  were we need the direct access to the functor class and not to the static function.
