### PR TITLE
disable configuration of device scheduler

### DIFF
--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -285,7 +285,8 @@ private:
             //gpu mode is cudaComputeModeExclusiveProcess and a free device is automaticly selected.
             log<ggLog::CUDA_RT > ("Device is selected by CUDA automaticly. (because cudaComputeModeDefault is not set)");
         }
-        CUDA_CHECK(cudaSetDeviceFlags(cudaDeviceScheduleYield));
+        /* disabled because we get an error with CUDA 6.0 and more than one gpu per node*/
+        //CUDA_CHECK(cudaSetDeviceFlags(cudaDeviceScheduleYield));
     }
 
     //! how often calculated data will be dumped (picture or other format)


### PR DESCRIPTION
set of device scheduler triggers error: "cannot set while device is active in this process"
on systems with more than one gpu per node (and CUDA 6.0)

I will check why we get this error, there is no big problem to disable `cudaSetDeviceFlags` at the moment.
