### PR TITLE
fix broken PositionFilter

### DIFF
--- a/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
@@ -77,7 +77,7 @@ public:
             typename FRAME::SuperCellSize
             > ((uint32_t) (frame[id][localCellIdx_]));
         DataSpace<dim> pos = this->superCellIdx + localCellIdx;
-        bool result = false;
+        bool result = true;
         for (uint32_t d = 0; d < dim; ++d)
             result= result && (this->offset[d] <= pos[d]) && (pos[d]<this->max[d]);
         return Base::operator() (frame, id) && result;


### PR DESCRIPTION
fix that position filter always return false

The neutral value for logical AND (`&&`) operation is true and not false^^

Old version:  false = false && anyBoolValue 
New Version: anyBoolValue = true && anyBoolValue 
