### PR TITLE
fix numeric pusher bug

### DIFF
--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -448,13 +448,13 @@ struct PushParticlePerFrame
              * pos in range [-1;2)
              * 
              * If pos is negative and very near to 0 (e.g. pos < -1e-8)
-             * and we move pos with pis+=1.0 back to normal in cell postion
+             * and we move pos with pos+=1.0 back to normal in cell postion
              * we get a rounding error and pos is assigned to 1. This breaks
              * our in cell definition range [0,1)
              * 
              * if pos negativ moveDir is set to -1
              * if pos positive and >1 moveDir is set to +1
-             * 0 (NULL) if particle stay in cell
+             * 0 (zero) if particle stays in cell
              */     
             float_X moveDir = math::floor(pos[i]);
             /* shift pos back to cell range [0;1)*/
@@ -462,12 +462,19 @@ struct PushParticlePerFrame
             /* check for rounding errors and correct them
              * if position now is 1 we have a rounding error
              * 
-             * We correct moveDir that we not have left the cell, thus
+             * We correct moveDir that we not have left the cell
              */
-            const float_X correctValue=math::floor(pos[i]);
-            moveDir += correctValue;
+            const float_X valueCorrector=math::floor(pos[i]);
+            /* One has also to correct moveDir for the following reason:
+             * Imagine a new particle moves to -1e-20, leaving the cell to the left,
+             * setting moveDir to -1.
+             * The new in-cell position will be -1e-20 + 1.0, 
+             * which can flip to 1.0 (wrong value).
+             * We move the particle back to the old cell at position 0.0 and 
+             * moveDir has to be corrected back, too (add +1 again).*/
+            moveDir += valueCorrector;
             /* If we have corrected moveDir we must set pos to 0 */
-            pos[i] -= correctValue;
+            pos[i] -= valueCorrector;
             dir[i] = typeCast<int>(moveDir);
         }
         particle[position_] = pos;

--- a/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
@@ -174,9 +174,8 @@ namespace picongpu
                     }
                     dr = r - pos;
                     
-                    dr.x() *= ( float_X(1.0) / CELL_WIDTH );
-                    dr.y() *= ( float_X(1.0) / CELL_HEIGHT );
-                    dr.z() *= ( float_X(1.0) / CELL_DEPTH );
+                    dr *= float3_X(1.0) / cell_size;
+
                 }
 
                 pos += dr;

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -64,7 +64,7 @@ struct Push
 
         for(uint32_t d=0;d<simDim;++d)
         {
-            pos[d] += ((vel[d] * deltaT / cell_size[d])); 
+            pos[d] += (vel[d] * deltaT) / cell_size[d]; 
         }      
 
     }

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -47,11 +47,10 @@ namespace picongpu
                 const PosType vel = velocity(mom, mass);
 
 
-                pos.x() += (vel.x() * DELTA_T / CELL_WIDTH);
-                pos.y() += (vel.y() * DELTA_T / CELL_HEIGHT);
-                pos.z() += (vel.z() * DELTA_T / CELL_DEPTH);
-
-
+                for(uint32_t d=0;d<simDim;++d)
+                {
+                    pos[d] += (vel[d] * DELTA_T) / cell_size[d]; 
+                }   
             }
         };
     } //namespace

--- a/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
@@ -46,11 +46,10 @@ namespace picongpu
                 const float_X mom_abs = abs( mom );
                 const PosType vel = mom * ( SPEED_OF_LIGHT / mom_abs );
 
-
-                pos.x() += (vel.x() * DELTA_T / CELL_WIDTH);
-                pos.y() += (vel.y() * DELTA_T / CELL_HEIGHT);
-                pos.z() += (vel.z() * DELTA_T / CELL_DEPTH);
-
+                for(uint32_t d=0;d<simDim;++d)
+                {
+                    pos[d] += (vel[d] * DELTA_T) / cell_size[d]; 
+                }   
             }
         };
     } //namespace

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -82,12 +82,11 @@ struct Push
         mom = momentum_atPlusHalf;
 
         const float3_X vel = velocity(momentum_atPlusHalf, mass);
-
-        pos.x() += (vel.x() * DELTA_T / CELL_WIDTH);
-        pos.y() += (vel.y() * DELTA_T / CELL_HEIGHT);
-        pos.z() += (vel.z() * DELTA_T / CELL_DEPTH);
-
-
+        
+        for(uint32_t d=0;d<simDim;++d)
+        {
+            pos[d] += (vel[d] * DELTA_T) / cell_size[d]; 
+        }   
     }
 };
 } //namespace


### PR DESCRIPTION
- fix that in cell position after particle push can shifted to [0.0,1.0] due to float rounding errors
- delete old hack for this problem which add 1.0 and substract -1.0 to the position inside of the pusher (thats not solve the problem if the compiler use O3 optimization)
