### PR TITLE
Close #146 - Rename typeCast to precisionCast

### DIFF
--- a/examples/SingleParticleCurrent/include/CheckCurrent.hpp
+++ b/examples/SingleParticleCurrent/include/CheckCurrent.hpp
@@ -70,7 +70,7 @@ struct CheckCurrent
 
         container::HostBuffer<float3_X, 3> fieldJ_with_guards(fieldJ_device.size());
         fieldJ_with_guards = fieldJ_device;
-        container::View<container::HostBuffer<float3_X, 3> > fieldJ(fieldJ_with_guards.view(typeCast<int>(GuardDim().vec()), -typeCast<int>(GuardDim().vec())));
+        container::View<container::HostBuffer<float3_X, 3> > fieldJ(fieldJ_with_guards.view(precisionCast<int>(GuardDim().vec()), -precisionCast<int>(GuardDim().vec())));
         
         float3_X beta(BETA0_X, BETA0_Y, BETA0_Z);
         

--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -86,7 +86,7 @@ public:
 
         BOOST_AUTO(fieldE_coreBorder,
              this->fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
-                   typeCast<int>(GuardDim().vec()), -typeCast<int>(GuardDim().vec())));
+                   precisionCast<int>(GuardDim().vec()), -precisionCast<int>(GuardDim().vec())));
                    
         this->eField_zt[0] = new container::DeviceBuffer<float, 2 > (Size_t < 2 > (fieldE_coreBorder.size().z(), this->collectTimesteps));
         this->eField_zt[1] = new container::DeviceBuffer<float, 2 >(this->eField_zt[0]->size());
@@ -178,7 +178,7 @@ public:
 
         BOOST_AUTO(fieldE_coreBorder,
            this->fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
-                typeCast<int>(GuardDim().vec()), -typeCast<int>(GuardDim().vec())));
+                precisionCast<int>(GuardDim().vec()), -precisionCast<int>(GuardDim().vec())));
 
         for (size_t z = 0; z < eField_zt[0]->size().x(); z++)
         {

--- a/src/libPMacc/include/algorithms/TypeCast.hpp
+++ b/src/libPMacc/include/algorithms/TypeCast.hpp
@@ -25,7 +25,7 @@ namespace PMacc
 {
 namespace algorithms
 {
-namespace typeCast
+namespace precisionCast
 {
 
 template<typename CastToType, typename Type>
@@ -41,11 +41,11 @@ struct TypeCast
 
 
 template<typename CastToType, typename Type>
-HDINLINE static typename TypeCast<CastToType, Type>::result typeCast(const Type& value)
+HDINLINE static typename TypeCast<CastToType, Type>::result precisionCast(const Type& value)
 {
     return TypeCast<CastToType, Type > ()(value);
 }
 
-} //namespace typeCast
+} //namespace precisionCast
 } //namespace algorithms
 }//namespace PMacc

--- a/src/libPMacc/include/dimensions/DataSpace.tpp
+++ b/src/libPMacc/include/dimensions/DataSpace.tpp
@@ -53,7 +53,7 @@ struct GetNComponents<DataSpace<DIM>,false >
 
 namespace algorithms
 {
-namespace typeCast
+namespace precisionCast
 {
 
 template<unsigned T_Dim>

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -187,7 +187,7 @@ namespace PMacc
 {
 namespace algorithms
 {
-namespace typeCast
+namespace precisionCast
 {
 
 template<typename CastToType, int dim>

--- a/src/picongpu/include/algorithms/Gamma.hpp
+++ b/src/picongpu/include/algorithms/Gamma.hpp
@@ -36,12 +36,12 @@ struct Gamma
     template<typename MomType, typename MassType >
         HDINLINE valueType operator()(const MomType mom, const MassType mass)
     {
-        const valueType fMom2 = math::abs2( typeCast<valueType >( mom ) );
+        const valueType fMom2 = math::abs2( precisionCast<valueType >( mom ) );
         const valueType c2 = SPEED_OF_LIGHT*SPEED_OF_LIGHT;
         
-        const valueType m2_c2_reci = valueType(1.0) / typeCast<valueType >( mass * mass * c2 );
+        const valueType m2_c2_reci = valueType(1.0) / precisionCast<valueType >( mass * mass * c2 );
         
-        return math::sqrt( typeCast<valueType >( valueType(1.0) + fMom2 * m2_c2_reci ) );
+        return math::sqrt( precisionCast<valueType >( valueType(1.0) + fMom2 * m2_c2_reci ) );
     }
 
 

--- a/src/picongpu/include/algorithms/Velocity.hpp
+++ b/src/picongpu/include/algorithms/Velocity.hpp
@@ -37,7 +37,7 @@ namespace picongpu
             const float_X rc2 = MUE0_EPS0;
             const float_X m0_2 = mass0*mass0;
             const float_X fMom2 = math::abs2(mom);
-            float_X t = math::rsqrt(typeCast<sqrt_X>(m0_2 + fMom2 * rc2));
+            float_X t = math::rsqrt(precisionCast<sqrt_X>(m0_2 + fMom2 * rc2));
             return t * mom;
         }
     };

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -70,12 +70,12 @@ public:
 
         BOOST_AUTO(fieldE_coreBorder,
             fieldE.getGridBuffer().getDeviceBuffer().
-                   cartBuffer().view(typeCast<int>(GuardDim().vec()),
-                                     -typeCast<int>(GuardDim().vec())));
+                   cartBuffer().view(precisionCast<int>(GuardDim().vec()),
+                                     -precisionCast<int>(GuardDim().vec())));
         BOOST_AUTO(fieldB_coreBorder,
             fieldB.getGridBuffer().getDeviceBuffer().
-            cartBuffer().view(typeCast<int>(GuardDim().vec()),
-                              -typeCast<int>(GuardDim().vec())));
+            cartBuffer().view(precisionCast<int>(GuardDim().vec()),
+                              -precisionCast<int>(GuardDim().vec())));
         
         using namespace cursor::tools;
         using namespace PMacc::math::tools;

--- a/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -53,7 +53,7 @@ struct VillaBune
                                 velocity.y() * deltaTime / cellSize.y(),
                                 velocity.z() * deltaTime / cellSize.z());
 
-        const PosType oldPos = (PosType) (typeCast<float_X > (pos) - deltaPos);
+        const PosType oldPos = (PosType) (precisionCast<float_X > (pos) - deltaPos);
 
         addCurrentSplitX(oldPos, pos, charge, boxJ_par, deltaTime);
     }

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -79,7 +79,7 @@ HDINLINE float3_X laserTransversal(float3_X elong, const float_X, const float_X 
 {
     const float_64 exponent = (posX / W0x)*(posX / W0x) + (posZ / W0z)*(posZ / W0z);
 
-    return elong * typeCast<float_X > (math::exp(-exponent));
+    return elong * precisionCast<float_X > (math::exp(-exponent));
 
 }
 

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -109,9 +109,9 @@ HDINLINE float3_X laserTransversal(float3_X elong, const float_X, const float_X 
     const double exponent = r2 / (W0 * W0);
 #if !defined(__CUDA_ARCH__) // Host code path
 
-    return elong * typeCast<float3_X > (exp(-0.5 * exponent));
+    return elong * precisionCast<float3_X > (exp(-0.5 * exponent));
 #else
-    return elong * typeCast<float3_X > (math::exp(-0.5 * exponent));
+    return elong * precisionCast<float3_X > (math::exp(-0.5 * exponent));
 #endif
 }
 

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -180,7 +180,7 @@ __global__ void kernelAddTemperature(ParticlesBox<FRAME, simDim> pb, float_X ene
             // Which makes sense, since it means that we use a macroMass
             // and a macroEnergy now.
             const float3_X mom = tmpRand * (float_X) math::sqrt(
-                                                                typeCast<sqrt_X > (
+                                                                precisionCast<sqrt_X > (
                                                                                    macroEnergy * frame->getMass(macroWeighting)
                                                                                    )
                                                                 );
@@ -475,7 +475,7 @@ struct PushParticlePerFrame
             moveDir += valueCorrector;
             /* If we have corrected moveDir we must set pos to 0 */
             pos[i] -= valueCorrector;
-            dir[i] = typeCast<int>(moveDir);
+            dir[i] = precisionCast<int>(moveDir);
         }
         particle[position_] = pos;
 
@@ -490,7 +490,7 @@ struct PushParticlePerFrame
          * if particle is inside of the supercell the **unsigned** representation
          * of dir is always >= size of the supercell
          */
-        dir = typeCast<int>(typeCast<uint32_t >( localCell) >= typeCast<uint32_t >(TVec::getDataSpace())) * dir;
+        dir = precisionCast<int>(precisionCast<uint32_t >( localCell) >= precisionCast<uint32_t >(TVec::getDataSpace())) * dir;
 
         /* if partice is outside of the supercell we use mod to
          * set particle at cell supercell_size to 1

--- a/src/picongpu/include/particles/gasProfiles/gasFreeFormula.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasFreeFormula.hpp
@@ -39,16 +39,16 @@ namespace picongpu
             if (pos.y() < VACUUM_Y) return float_X(0.0);
 
             float_64 _unit_length=UNIT_LENGTH;
-            const floatD_64 pos_SI = typeCast<float_64>( pos ) * _unit_length;
+            const floatD_64 pos_SI = precisionCast<float_64>( pos ) * _unit_length;
 
             /* expected return value of the profile: [0.0:1.0] */
             SI::GasProfile gasProfile;
             const float_64 density_dbl = gasProfile( pos_SI );
 
-            float_X density = typeCast<float_X>( density_dbl );
+            float_X density = precisionCast<float_X>( density_dbl );
 
             /* validate formula and clip to [0.0:1.0] */
-            density *= typeCast<float_X>( density >= 0.0 );
+            density *= precisionCast<float_X>( density >= 0.0 );
             if( density > 1.0 ) density = 1.0;
 
             return density;

--- a/src/picongpu/include/particles/init/particleInitQuietStart.hpp
+++ b/src/picongpu/include/particles/init/particleInitQuietStart.hpp
@@ -67,7 +67,7 @@ public:
         DataSpace<simDim> inCellCoordinate = DataSpaceOperations<simDim>::map(numParDirection, curParticle);
 
 
-        return floatD_X(typeCast<float_X>(inCellCoordinate) * spacing + spacing * float_X(0.5));
+        return floatD_X(precisionCast<float_X>(inCellCoordinate) * spacing + spacing * float_X(0.5));
     }
 
     /** If the particles to initialize (numParsPerCell) end up with a 

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -65,7 +65,7 @@ struct Push
         const float_X gamma_prime = gamma(momentum_prime, mass);
         //sqrtf(1.0 + abs2(momentum_prime*(1.0/(mass * SPEED_OF_LIGHT))));
         const sqrt_Vay::float3_X tau(factor / mass * bField);
-        const sqrt_Vay::float_X u_star = math::dot( typeCast<sqrt_Vay::float_X>(momentum_prime), tau ) / typeCast<sqrt_Vay::float_X>( SPEED_OF_LIGHT * mass );
+        const sqrt_Vay::float_X u_star = math::dot( precisionCast<sqrt_Vay::float_X>(momentum_prime), tau ) / precisionCast<sqrt_Vay::float_X>( SPEED_OF_LIGHT * mass );
         const sqrt_Vay::float_X sigma = gamma_prime * gamma_prime - math::abs2( tau );
         const sqrt_Vay::float_X gamma_atPlusHalf = math::sqrt( sqrt_Vay::float_X(0.5) *
             ( sigma +

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -59,7 +59,7 @@ struct cast64Bit
 
     HDINLINE typename TypeCast<result, T_Type>::result operator()(const T_Type& value) const
     {
-        return typeCast<result>(value);
+        return precisionCast<result>(value);
     }
 };
 }

--- a/src/picongpu/include/plugins/FieldEnergy.tpp
+++ b/src/picongpu/include/plugins/FieldEnergy.tpp
@@ -74,9 +74,9 @@ void FieldEnergy::notify(uint32_t currentStep)
     FieldB& fieldB = dc.getData<FieldB > (FIELD_B, true);
 
     BOOST_AUTO(fieldE_coreBorder,
-            fieldE.getGridBuffer().getDeviceBuffer().cartBuffer().view(typeCast<int>(BlockDim().vec()), -typeCast<int>(BlockDim().vec())));
+            fieldE.getGridBuffer().getDeviceBuffer().cartBuffer().view(precisionCast<int>(BlockDim().vec()), -precisionCast<int>(BlockDim().vec())));
     BOOST_AUTO(fieldB_coreBorder,
-            fieldB.getGridBuffer().getDeviceBuffer().cartBuffer().view(typeCast<int>(BlockDim().vec()), -typeCast<int>(BlockDim().vec())));
+            fieldB.getGridBuffer().getDeviceBuffer().cartBuffer().view(precisionCast<int>(BlockDim().vec()), -precisionCast<int>(BlockDim().vec())));
             
     PMacc::GridController<3>& con = PMacc::GridController<3>::getInstance();
     PMacc::math::Size_t<3> gpuDim = (math::Size_t<3>)con.getGpuNodes();

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -68,7 +68,7 @@ struct SglParticle
         for(uint32_t i=0;i<simDim;++i)
             doubleGlobalCellOffset[i]=float_64(globalCellOffset[i]);
         
-        return floatD_64( doubleGlobalCellOffset+ typeCast<float_64>(position));
+        return floatD_64( doubleGlobalCellOffset+ precisionCast<float_64>(position));
     }
 
     template<typename T>
@@ -78,19 +78,19 @@ struct SglParticle
         for(uint32_t i=0;i<simDim;++i)
             pos[i]=( v.getGlobalCell()[i] * cell_size[i]*UNIT_LENGTH);
      
-        const float3_64 mom( typeCast<float_64>(v.momentum.x()) * UNIT_MASS * UNIT_SPEED,
-                             typeCast<float_64>(v.momentum.y()) * UNIT_MASS * UNIT_SPEED,
-                             typeCast<float_64>(v.momentum.z()) * UNIT_MASS * UNIT_SPEED );
+        const float3_64 mom( precisionCast<float_64>(v.momentum.x()) * UNIT_MASS * UNIT_SPEED,
+                             precisionCast<float_64>(v.momentum.y()) * UNIT_MASS * UNIT_SPEED,
+                             precisionCast<float_64>(v.momentum.z()) * UNIT_MASS * UNIT_SPEED );
         
-        const float_64 mass = typeCast<float_64>(v.mass) * UNIT_MASS;
-        const float_64 charge = typeCast<float_64>(v.charge) * UNIT_CHARGE;
+        const float_64 mass = precisionCast<float_64>(v.mass) * UNIT_MASS;
+        const float_64 charge = precisionCast<float_64>(v.charge) * UNIT_CHARGE;
 
         typedef std::numeric_limits< float_64 > dbl;
         out.precision(dbl::digits10);
 
         out << std::scientific << pos << " " << mom << " " << mass << " "
-            << typeCast<float_64>(v.weighting)
-            << " " << charge << " " << typeCast<float_64>(v.gamma);
+            << precisionCast<float_64>(v.weighting)
+            << " " << charge << " " << precisionCast<float_64>(v.gamma);
         return out;
     }
 };

--- a/src/picongpu/include/plugins/Radiation.hpp
+++ b/src/picongpu/include/plugins/Radiation.hpp
@@ -393,7 +393,7 @@ void kernelRadiationParticles(ParBox pb,
                                 // is considered
                                 // the form factor influences the real amplitude
 #if (__COHERENTINCOHERENTWEIGHTING__==1)
-                                const vec2 weighted_real_amp = real_amplitude_s[j] * typeCast<float_64 >
+                                const vec2 weighted_real_amp = real_amplitude_s[j] * precisionCast<float_64 >
                                     (myRadFormFactor(radWeighting_s[j], omega, look));
 #else
                                 // if coherent/incoherent radiation of single macro-particle 

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -69,7 +69,7 @@ void SliceFieldPrinter<Field, FieldId>::notify(uint32_t currentStep)
     BOOST_AUTO(field_coreBorder,
         dc.getData<Field > (FieldId, true).getGridBuffer().
             getDeviceBuffer().cartBuffer().
-            view(typeCast<int>(BlockDim().vec()), -typeCast<int>(BlockDim().vec())));
+            view(precisionCast<int>(BlockDim().vec()), -precisionCast<int>(BlockDim().vec())));
 
     std::ostringstream filename;
     filename << this->fieldName << "_" << currentStep << ".dat";

--- a/src/picongpu/include/plugins/TotalDivJ.tpp
+++ b/src/picongpu/include/plugins/TotalDivJ.tpp
@@ -86,7 +86,7 @@ void TotalDivJ::notify(uint32_t currentStep)
         
     container::DeviceBuffer<float, 3> fieldDivJ(fieldJ.size());
     zone::SphericZone<3> coreBorderZone(fieldJ.zone().size - (size_t)2*BlockDim().vec(),
-                                        fieldJ.zone().offset + typeCast<int>(BlockDim().vec()));
+                                        fieldJ.zone().offset + precisionCast<int>(BlockDim().vec()));
     //std::cout << coreBorderZone.size << ", " << coreBorderZone.offset << std::endl;
     using namespace lambda;
     algorithm::kernel::Foreach<BlockDim>()

--- a/src/picongpu/include/plugins/output/images/DensityToBinary.hpp
+++ b/src/picongpu/include/plugins/output/images/DensityToBinary.hpp
@@ -114,7 +114,7 @@ namespace picongpu
                     }
                     else
                     {
-                        const ValueType value = typeCast<ValueType>(data[y][x])
+                        const ValueType value = precisionCast<ValueType>(data[y][x])
                                               * unit;
 
                         /** \info take care, that gnuplots binary matrix does

--- a/src/picongpu/include/plugins/output/images/ParticleDensity.hpp
+++ b/src/picongpu/include/plugins/output/images/ParticleDensity.hpp
@@ -270,14 +270,14 @@ public:
         for(uint32_t i=0;i<simDim;i++)
             unitVolume*=UNIT_LENGTH;
         // that's a hack, but works for all species
-        //const float_64 charge = typeCast<float_64>(
+        //const float_64 charge = precisionCast<float_64>(
         //    ParticlesType::FrameType().getCharge(NUM_EL_PER_PARTICLE)) /
-        //    typeCast<float_64>(NUM_EL_PER_PARTICLE) * UNIT_CHARGE;
+        //    precisionCast<float_64>(NUM_EL_PER_PARTICLE) * UNIT_CHARGE;
 
         // Note: multiply NUM_EL_PER_PARTICLE again
         //       because of normalization during atomicAdd above
         //       to avoid float overflow for weightings
-        const float_64 unit = typeCast<float_64>(NUM_EL_PER_PARTICLE)
+        const float_64 unit = precisionCast<float_64>(NUM_EL_PER_PARTICLE)
             / (cellVolume * unitVolume);
         if (isMaster)
             output(resultBox.shift(header.window.offset), unit, header.window.size, header);

--- a/src/picongpu/include/plugins/radiation/complex.hpp
+++ b/src/picongpu/include/plugins/radiation/complex.hpp
@@ -54,8 +54,8 @@ public:
 
     HDINLINE Complex_T euler(T magnitude, const T& phase)
     {
-        real = magnitude * picongpu::math::cos(picongpu::typeCast<picongpu::float_X>(phase));
-        imaginary = magnitude * picongpu::math::sin(picongpu::typeCast<picongpu::float_X>(phase));
+        real = magnitude * picongpu::math::cos(picongpu::precisionCast<picongpu::float_X>(phase));
+        imaginary = magnitude * picongpu::math::sin(picongpu::precisionCast<picongpu::float_X>(phase));
         return *this;
     }
 

--- a/src/picongpu/include/simulation_defines/param/fieldBackground.param
+++ b/src/picongpu/include/simulation_defines/param/fieldBackground.param
@@ -55,7 +55,7 @@ namespace picongpu
              *       multiplying with DELTA_T_SI */
 
             /* specify your E-Field in V/m and convert to PIConGPU units */
-            const float_X sinArg = typeCast<float_X>( y_SI / period_SI * 2.0 * PI );
+            const float_X sinArg = precisionCast<float_X>( y_SI / period_SI * 2.0 * PI );
             return float3_X(0.0, math::sin( sinArg ) / unitField[1], 0.0);
         }
     };
@@ -87,7 +87,7 @@ namespace picongpu
              *       multiplying with DELTA_T_SI */
 
             /* specify your B-Field in T and convert to PIConGPU units */
-            const float_X sinArg = typeCast<float_X>( y_SI / period_SI * 2.0 * PI );
+            const float_X sinArg = precisionCast<float_X>( y_SI / period_SI * 2.0 * PI );
             return float3_X(0.0, math::cos( sinArg ) / unitField[1], 0.0);
         }
     };

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -81,7 +81,7 @@ typedef double precisionType;
 }
 
 namespace math = PMacc::algorithms::math;
-using namespace PMacc::algorithms::typeCast;
+using namespace PMacc::algorithms::precisionCast;
 using namespace PMacc::algorithms::promoteType;
 using namespace PMacc::algorithms::forEach;
 using namespace PMacc::traits;


### PR DESCRIPTION
- typeCast could be mismatched with a static_cast
- precisionCast casts the internal data types of e.g. vectors
