### PR TITLE
Fix #104 - Check if the dir for "configure" exists

### DIFF
--- a/configure
+++ b/configure
@@ -49,7 +49,7 @@ cmakeFlagsNr=0
 eval set -- "$OPTS"
 
 while true ; do
-    case "$1" in  
+    case "$1" in
         -a|--arch)
             cuda_arch="-DCUDA_ARCH=$2"
             shift
@@ -77,8 +77,8 @@ done
 
 extension_param="$*"
 
-if [ -z "$extension_param" ] ; then
-   echo "No case path is given." >&2
+if [ ! -d "$extension_param" ] ; then
+   echo "Path \"$extension_param\" does not exist." >&2
    exit 1
 fi
 #check for cmakeFlags file (interprete with sh)

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -495,12 +495,12 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/scripts/" DESTINATION bin
 if( (NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "${PIC_EXTENSION_PATH}") OR 
     (NOT EXISTS "${CMAKE_INSTALL_PREFIX}/include"))
 
-    #copy all importend subfolders to install folder
+    #copy all important subfolders to install folder
     foreach(dir ${PIC_COPY_ON_INSTALL})
 
       #if source not exists than copy
       if(NOT EXISTS "${CMAKE_INSTALL_PREFIX}/${dir}")
-          #copy importend subfolders from extension path (default PIConGPU parameter)
+          #copy important subfolders from extension path (default PIConGPU parameter)
           if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/")
             install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/."
               DESTINATION "${CMAKE_INSTALL_PREFIX}/${dir}"
@@ -509,7 +509,7 @@ if( (NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "${PIC_EXTENSION_PATH}") OR
             )
           endif()
 
-          #copy importend subfolders from extension path (from extension path)
+          #copy important subfolders from extension path (from extension path)
           if(EXISTS "${PIC_EXTENSION_PATH}/${dir}/")
             install(DIRECTORY "${PIC_EXTENSION_PATH}/${dir}/."
                DESTINATION "${CMAKE_INSTALL_PREFIX}/${dir}"


### PR DESCRIPTION
This is a quick fix.
There might be some additional features in `src/picongpu/CMakeLists.txt` that can be removed, too
(like `CMAKE_INSTALL_PATH` != `EXTENSION_PATH` ?)
