### PR TITLE
Increase Thread Sync Wait Time

### DIFF
--- a/src/cuda_memtest/cuda_memtest.cu
+++ b/src/cuda_memtest/cuda_memtest.cu
@@ -541,7 +541,7 @@ main(int argc, char** argv)
 
     struct timeval t0, t1;
     int ht=0;
-    double wait_time = 30;
+    double wait_time = 500;
     gettimeofday(&t0, NULL);
     
     while(1){


### PR DESCRIPTION
Holy crap.

**Edit:** I got the error message
`ERROR: Some GPU threads are not progressing (healthy_threads=0, num_gpus=1)`
today on hypnos since the `30ms` maximum wait time to check if all threads are still alive after the tests was not enough...

Nice, that @psychocoderHPC and @PrometheusPi were not affected. Didn't take 2-3h to figure that out *sarcAnote v4.2
