### PR TITLE
Add Conrad and move Benjamin to former members

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Active Team
 - Axel Huebl*
 - Richard Pausch*
 - Felix Schmitt*
-- Benjamin Schneider
+- Conrad Schumann
 - Rene Widera*
 
 ### Participants, Former Members and Thanks
@@ -152,6 +152,7 @@ The PIConGPU Team expresses its thanks to:
 - Wen Fu
 - Wolfgang Hoehnig
 - Remi Lehe
+- Benjamin Schneider
 - Joseph Schuchart
 - Klaus Steiniger
 


### PR DESCRIPTION
I moved @Ben-Schneider to the former members section for now.
@c-schumann-zih is about to finish his first pull request to `mainline` :rocket: :sparkles:
