### PR TITLE
Fields have 3 Components but simDim*3 Positions

### DIFF
--- a/src/picongpu/include/algorithms/ShiftCoordinateSystem.hpp
+++ b/src/picongpu/include/algorithms/ShiftCoordinateSystem.hpp
@@ -40,7 +40,7 @@ struct ShiftCoordinateSystem
      * @param fieldPos vector with relative coordinates for shift ( value range [0.0;0.5] )
      */
     template<typename Cursor, typename Vector >
-    HDINLINE void operator()(Cursor& cursor, Vector& vector, const float3_X & fieldPos)
+    HDINLINE void operator()(Cursor& cursor, Vector& vector, const floatD_X & fieldPos)
     {
         floatD_X coordinate_shift;
 

--- a/src/picongpu/include/algorithms/ShiftCoordinateSystemNative.hpp
+++ b/src/picongpu/include/algorithms/ShiftCoordinateSystemNative.hpp
@@ -40,7 +40,7 @@ struct ShiftCoordinateSystemNative
      * @param fieldPos vector with relative coordinates for shift ( value range [0.0;0.5] )
      */
     template<typename Cursor, typename Vector >
-    HDINLINE void operator()(Cursor& cursor, Vector& vector, const float3_X & fieldPos)
+    HDINLINE void operator()(Cursor& cursor, Vector& vector, const floatD_X & fieldPos)
     {
         for (uint32_t i = 0; i < simDim; ++i)
             vector[i] -= fieldPos[i];

--- a/src/picongpu/include/fields/numericalCellTypes/AllCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/AllCenteredCell.hpp
@@ -59,23 +59,39 @@ const float_X posB_z_z = 0.5;
 
 struct AllCenteredCell
 {
-    typedef ::PMacc::math::Vector<float3_X, DIM3> VectorVector;
+    /** \tparam floatD_X position of the component in the cell
+     *  \tparam DIM3     Fields (E/B) have 3 components, even in 1 or 2D ! */
+    typedef ::PMacc::math::Vector<floatD_X,DIM3> VectorVector;
 
     static HDINLINE VectorVector getEFieldPosition()
     {
+#if( SIMDIM == DIM3 )
         const float3_X posE_x(posE_x_x, posE_x_y, posE_x_z);
         const float3_X posE_y(posE_y_x, posE_y_y, posE_y_z);
         const float3_X posE_z(posE_z_x, posE_z_y, posE_z_z);
+#elif( SIMDIM == DIM2 )
+        const float2_X posE_x(posE_x_x, posE_x_y);
+        const float2_X posE_y(posE_y_x, posE_y_y);
+        const float2_X posE_z(posE_z_x, posE_z_y);
+#endif
 
+        /** position (floatD_x) in cell for E_x, E_y, E_z */
         return VectorVector(posE_x, posE_y, posE_z);
     }
 
     static HDINLINE VectorVector getBFieldPosition()
     {
+#if( SIMDIM == DIM3 )
         const float3_X posB_x(posB_x_x, posB_x_y, posB_x_z);
         const float3_X posB_y(posB_y_x, posB_y_y, posB_y_z);
         const float3_X posB_z(posB_z_x, posB_z_y, posB_z_z);
+#elif( SIMDIM == DIM2 )
+        const float2_X posB_x(posB_x_x, posB_x_y);
+        const float2_X posB_y(posB_y_x, posB_y_y);
+        const float2_X posB_z(posB_z_x, posB_z_y);
+#endif
 
+        /** position (floatD_x) in cell for B_x, B_y, B_z */
         return VectorVector(posB_x, posB_y, posB_z);
     }
 

--- a/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
@@ -58,24 +58,39 @@ const float_X posB_z_z = 0.0;
 
 struct YeeCell
 {
-    typedef ::PMacc::math::Vector<float3_X,DIM3> VectorVector;
+    /** \tparam floatD_X position of the component in the cell
+     *  \tparam DIM3     Fields (E/B) have 3 components, even in 1 or 2D ! */
+    typedef ::PMacc::math::Vector<floatD_X,DIM3> VectorVector;
 
-       static HDINLINE VectorVector getEFieldPosition() 
+    static HDINLINE VectorVector getEFieldPosition()
     {
+#if( SIMDIM == DIM3 )
         const float3_X posE_x(posE_x_x, posE_x_y, posE_x_z);
         const float3_X posE_y(posE_y_x, posE_y_y, posE_y_z);
         const float3_X posE_z(posE_z_x, posE_z_y, posE_z_z);
+#elif( SIMDIM == DIM2 )
+        const float2_X posE_x(posE_x_x, posE_x_y);
+        const float2_X posE_y(posE_y_x, posE_y_y);
+        const float2_X posE_z(posE_z_x, posE_z_y);
+#endif
 
+        /** position (floatD_x) in cell for E_x, E_y, E_z */
         return VectorVector(posE_x, posE_y, posE_z);
     }
 
-
-       static  HDINLINE VectorVector getBFieldPosition() 
+    static  HDINLINE VectorVector getBFieldPosition()
     {
+#if( SIMDIM == DIM3 )
         const float3_X posB_x(posB_x_x, posB_x_y, posB_x_z);
         const float3_X posB_y(posB_y_x, posB_y_y, posB_y_z);
         const float3_X posB_z(posB_z_x, posB_z_y, posB_z_z);
+#elif( SIMDIM == DIM2 )
+        const float2_X posB_x(posB_x_x, posB_x_y);
+        const float2_X posB_y(posB_y_x, posB_y_y);
+        const float2_X posB_z(posB_z_x, posB_z_y);
+#endif
 
+        /** position (floatD_x) in cell for B_x, B_y, B_z */
         return VectorVector(posB_x, posB_y, posB_z);
     }
 


### PR DESCRIPTION
Field E and Field B have 3 components for all simulations (1 to 3D) but their components reside at a spatial postion with simDim components (like the particle position).
