### PR TITLE
Remove PGI Experimental Support

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -13,7 +13,9 @@ Requirements
       `--slave /usr/bin/g++ g++ /usr/bin/g++-4.4`
   - *experimental alternatives:* **icc 12.1** with **cuda 5.5**
 
-- [CUDA 5.5](https://developer.nvidia.com/cuda-downloads) or higher
+- [CUDA 5.0](https://developer.nvidia.com/cuda-downloads) or higher
+  - **Attention:** You must use at least the 5.5+ [drivers](http://www.nvidia.com/Drivers)
+    even if you run with CUDA 5.0. Supported drivers: 319.82+/331.22+
 
 - at least one **CUDA** capable **GPU**
   - *Compute capability* **sm\_20** or higher

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -61,7 +61,7 @@ find_package(CUDA 5.0 REQUIRED)
 
 if(CUDA_VERSION VERSION_LESS 5.5)
     message(STATUS "CUDA Toolkit < 5.5 detected. We strongly recommend to still "
-                   "use CUDA 5.5+ drivers!")
+                   "use CUDA 5.5+ drivers (319.82 or higher)!")
 endif(CUDA_VERSION VERSION_LESS 5.5)
 
 set(CUDA_ARCH sm_20 CACHE STRING "Set GPU architecture")


### PR DESCRIPTION
Can not reproduce stable builds any more - skip support for now until there is basic host side support from NVidia (post-6.0).
