### PR TITLE
Update gcc 4.8 support

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -6,7 +6,7 @@ Requirements
 
 ### Mandatory
 
-- **gcc** 4.3 to 4.7 (depends on current CUDA version)
+- **gcc** 4.4 to 4.8 (depends on current CUDA version)
   - *Debian/Ubuntu:*
     - `sudo apt-get install gcc-4.4 g++-4.4 build-essential`
     - `sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.4 60 \`


### PR DESCRIPTION
Just started a small history of supported compilers by checking our modules
  https://gist.github.com/ax3l/9489132

Dropping `gcc 4.3` support since this is even pre-`cuda 4.0` and hard to maintain nowadays.

Update to #257 - CUDA 5.5 even supports gcc 4.8
