### PR TITLE
use explicit boost::mpl::vectorSIZE<>

### DIFF
--- a/src/libPMacc/include/compileTime/conversion/JoinToSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/JoinToSeq.hpp
@@ -39,7 +39,7 @@ namespace bmpl = boost::mpl;
  * @tparam T_2 a boost mpl sequence or single type
  */
 
-template<class T_1, class T_2 = bmpl::vector<> >
+template<typename T_1, typename T_2 = bmpl::vector0<> >
 struct JoinToSeq
 {
 private:

--- a/src/libPMacc/include/compileTime/conversion/MakeSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/MakeSeq.hpp
@@ -38,13 +38,13 @@ namespace bmpl = boost::mpl;
  *  
  * @tparam T_N a boost mpl sequence or single type
  */
-template<class T_1 = bmpl::vector<>, class T_2 = bmpl::vector<>,
-         class T_3 = bmpl::vector<>, class T_4 = bmpl::vector<>,
-         class T_5 = bmpl::vector<> >
+template<typename T_1 = bmpl::vector0<>, typename T_2 = bmpl::vector0<>,
+         typename T_3 = bmpl::vector0<>, typename T_4 = bmpl::vector0<>,
+         typename T_5 = bmpl::vector0<> >
 struct MakeSeq
 {
     typedef typename MakeSeqFromNestedSeq<
-    bmpl::vector<
+    bmpl::vector5<
     T_1,
     T_2,
     T_3,

--- a/src/libPMacc/include/compileTime/conversion/MakeSeqFromNestedSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/MakeSeqFromNestedSeq.hpp
@@ -39,7 +39,7 @@ namespace bmpl = boost::mpl;
  * 
  * @tparam T_In a boost mpl sequence or single type
  */
-template<class T_In>
+template<typename T_In>
 struct MakeSeqFromNestedSeq
 {
 private:
@@ -48,7 +48,7 @@ private:
 public:
     typedef typename bmpl::fold<
       Seq,
-      bmpl::vector<>,
+      bmpl::vector0<>,
       JoinToSeq<bmpl::_1,bmpl::_2>
     >::type type;
 };

--- a/src/libPMacc/include/compileTime/conversion/ToSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/ToSeq.hpp
@@ -38,7 +38,7 @@ namespace bmpl = boost::mpl;
 template<typename T_Type>
 struct ToSeq
 {
-    typedef typename bmpl::if_<bmpl::is_sequence< T_Type >,T_Type,bmpl::vector<T_Type> >::type type;
+    typedef typename bmpl::if_<bmpl::is_sequence< T_Type >,T_Type,bmpl::vector1<T_Type> >::type type;
 };
 
 }//namespace PMacc


### PR DESCRIPTION
use explicit boost::mpl::vectorSIZE with a lenght to avoid long template error messages
