### PR TITLE
add newest architecture to default compile

### DIFF
--- a/examples/KelvinHelmholtz/cmakeFlags
+++ b/examples/KelvinHelmholtz/cmakeFlags
@@ -29,8 +29,8 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=sm_20"
-flags[1]="-DCUDA_ARCH=sm_35 -DPARAM_OVERWRITES:LIST=-DPARAM_DIMENSION=DIM2"
+flags[0]="-DCUDA_ARCH=sm_35"
+flags[1]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_DIMENSION=DIM2"
 flags[2]="-DCUDA_ARCH=sm_35 -DPARAM_OVERWRITES:LIST=-DPARAM_RADIATION=1"
 
 

--- a/examples/LaserWakefield/cmakeFlags
+++ b/examples/LaserWakefield/cmakeFlags
@@ -29,7 +29,7 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=sm_20"
+flags[0]="-DCUDA_ARCH=sm_35"
 flags[1]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_FIELDSOLVER=fieldSolverLehe;-DPARAM_PARTICLEPUSHER=particlePusherVay"
 flags[2]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_FIELDSOLVER=fieldSolverDirSplitting"
 flags[3]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_CURRENTSOLVER=currentSolverEsirkepov;-DPARAM_PARTICLESHAPE=shapeCIC"

--- a/examples/SingleParticleCurrent/cmakeFlags
+++ b/examples/SingleParticleCurrent/cmakeFlags
@@ -29,7 +29,7 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=sm_20"
+flags[0]="-DCUDA_ARCH=sm_35"
 
 
 ################################################################################

--- a/examples/SingleParticleRadiationWithLaser/cmakeFlags
+++ b/examples/SingleParticleRadiationWithLaser/cmakeFlags
@@ -29,7 +29,7 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=sm_20"
+flags[0]="-DCUDA_ARCH=sm_35"
 
 
 ################################################################################

--- a/examples/SingleParticleTest/cmakeFlags
+++ b/examples/SingleParticleTest/cmakeFlags
@@ -29,7 +29,7 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=sm_20"
+flags[0]="-DCUDA_ARCH=sm_35"
 
 
 ################################################################################

--- a/examples/ThermalTest/cmakeFlags
+++ b/examples/ThermalTest/cmakeFlags
@@ -29,7 +29,7 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=sm_20"
+flags[0]="-DCUDA_ARCH=sm_35"
 
 
 ################################################################################

--- a/examples/WeibelTransverse/cmakeFlags
+++ b/examples/WeibelTransverse/cmakeFlags
@@ -29,7 +29,7 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=sm_20"
+flags[0]="-DCUDA_ARCH=sm_35"
 
 
 ################################################################################


### PR DESCRIPTION
By default all example now use sm_35 as default architecture.
