### PR TITLE
Do not try to link HDF5 static

### DIFF
--- a/src/cmake/FindSplash.cmake
+++ b/src/cmake/FindSplash.cmake
@@ -110,6 +110,10 @@ if(Splash_ROOT_DIR)
 
     # require hdf5 ############################################################
     #
+    # disabled: Some libraries like libdl are also included by MPI and would
+    #           be linked once static once dynamic. Upgrading MPI to static
+    #           binding is too intrusive so we stay with only libSplash static
+    #           and everything else "default".
     #if(Splash_USE_STATIC_LIBS)
     #    set(HDF5_USE_STATIC_LIBRARIES ON)
     #endif()


### PR DESCRIPTION
The problem here is more cumbersome. some libraries like libdl are also included by MPI and would be linked once static once dynamic.

Upgrading MPI to static binding is to intrusive so we stay with libSplash static only and everything else "default".

Detected while compiling `png2gas` which uses a slightly different CMake find_package order (MPI vs Splash) than PIConGPU.
