### PR TITLE
Fix header bin energy plugin

### DIFF
--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -297,8 +297,6 @@ private:
                 enableDetector = true;
 
             realNumBins = numBins + 2;
-            minEnergy = minEnergy * UNITCONV_keV_to_Joule * UNIT_ENERGY;
-            maxEnergy = maxEnergy * UNITCONV_keV_to_Joule * UNIT_ENERGY;
 
             //create an array of double on gpu und host
             gBins = new GridBuffer<double, DIM1 > (DataSpace<DIM1 > (realNumBins));
@@ -318,7 +316,7 @@ private:
                 }
                 //create header of the file
                 outFile << "#step <" << minEnergy << " ";
-                float_X binEnergy = (maxEnergy - minEnergy) * UNITCONV_Joule_to_keV * UNIT_ENERGY / (float) numBins;
+                float_X binEnergy = (maxEnergy - minEnergy) / (float) numBins;
                 for (int i = 1; i < realNumBins - 1; ++i)
                 {
 


### PR DESCRIPTION
I found this error while looking through the energy histogram output files.
Converting from PIConGPU units to SI units should be _multiplication_ not _division_. 
For most cases this just gives a wrong value for the `>maxEnergy` value in the header since most of the time `minEnergy=0`.
