### PR TITLE
Topic pic2xdmf with splited grids

### DIFF
--- a/src/tools/bin/pic2xdmf.py
+++ b/src/tools/bin/pic2xdmf.py
@@ -393,7 +393,7 @@ def get_args_parser():
 
     parser.add_argument("--fullpath", help="Use absolute paths for HDF5 files", action="store_true")
 
-    parser.add_argument("--no_splitgrid", help="Split the XML-tree in grid and poly and make seperate output file for each", action="store_true")
+    parser.add_argument("--no_splitgrid", help="Avoid the XML-tree to be split in grid and poly grids for seperate output files", action="store_true")
     
     return parser
 


### PR DESCRIPTION
I modefied pic2xdmf.py to be able to use the changes from [libsplash 113](https://github.com/ComputationalRadiationPhysics/libSplash/pull/113).
By adding '--splitgrid' to the commandline when you run the skript, you get two separate output files for grid and poly grids.
