### PR TITLE
PNG Plugin #267 Valgrind Warnings Uninitialized

### DIFF
--- a/src/picongpu/include/plugins/output/header/DataHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/DataHeader.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2014 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU. 
  * 
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>. 
  */ 
  
-
-
-#ifndef DATAHEADER_HPP
-#define	DATAHEADER_HPP
+#pragma once
 
 struct DataHeader
 {
@@ -38,6 +35,3 @@ struct DataHeader
     }
 
 };
-
-#endif	/* DATAHEADER_HPP */
-

--- a/src/picongpu/include/plugins/output/header/SimHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/SimHeader.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU. 
  * 
@@ -17,11 +17,8 @@
  * along with PIConGPU.  
  * If not, see <http://www.gnu.org/licenses/>. 
  */ 
- 
 
-
-#ifndef SIMHEADER_HPP
-#define	SIMHEADER_HPP
+#pragma once
 
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
@@ -64,7 +61,3 @@ struct SimHeader
     }
 
 };
-
-
-#endif	/* SIMHEADER_HPP */
-


### PR DESCRIPTION
Some output in non-live visualization (like png, density) did depend on uninitialized values (mainly `DataHeader::byte`).

Running tests right now to validate the valgrind output again.

lwfa with
- density output (-> not fixed, second uninitialized var in `DensityToBinary::operator()` back to #267)
- [x] png output (visualization)
