### PR TITLE
Topic pic2xdmf namebug fix

### DIFF
--- a/src/tools/bin/pic2xdmf.py
+++ b/src/tools/bin/pic2xdmf.py
@@ -418,6 +418,8 @@ def main():
             splash_files.append(s_filename)
     else:
         splash_files.append(splashFilename)
+        tmp = splashFilename.rfind(".h5")
+        splashFilename = splashFilename[:tmp]
         
     output_filename = "{}.xmf".format(splashFilename)
     


### PR DESCRIPTION
Fix the single timestep name bug. Refers to [libsplash #123](https://github.com/ComputationalRadiationPhysics/libSplash/pull/123)
