### PR TITLE
adjust cell size to fit 5 KHI vortices into sim box

### DIFF
--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 


### PR DESCRIPTION
This adjust the cell size in the KHI example to fit exactly 5 vortices into the simulation box.
Previously, only space for 4.68 vortices was available.
