### PR TITLE
Slide Log: SIMULATION_STATE and only of affected

### DIFF
--- a/src/picongpu/include/debug/PIConGPUVerbose.hpp
+++ b/src/picongpu/include/debug/PIConGPUVerbose.hpp
@@ -1,27 +1,24 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2014 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
-
-#ifndef PICONGPUVERBOSELOG_HPP
-#define	PICONGPUVERBOSELOG_HPP
+#pragma once
 
 #include <stdint.h>
 #include "debug/VerboseLog.hpp"
@@ -50,7 +47,4 @@ DEFINE_VERBOSE_CLASS(PIConGPUVerbose)
 (NOTHING::lvl|PIC_VERBOSE_LVL);
 
 
-}// namespace picongpu
-
-#endif	/* PICONGPUVERBOSELOG_HPP */
-
+} /* namespace picongpu */

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -1,27 +1,25 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef MYSIMULATION_HPP
-#define	MYSIMULATION_HPP
+#pragma once
 
 #include <cassert>
 #include <string>
@@ -428,7 +426,6 @@ public:
         if (MovingWindow::getInstance().getVirtualWindow(currentStep).doSlide)
         {
             slide(currentStep);
-            log<picLog::PHYSICS > ("slide in step %1%") % currentStep;
         }
     }
 
@@ -453,7 +450,7 @@ public:
 
         if (gc.slide())
         {
-
+            log<picLog::SIMULATION_STATE > ("slide in step %1%") % currentStep;
             resetAll(currentStep);
             initialiserController->slide(currentStep);
         }
@@ -535,7 +532,4 @@ protected:
 
     bool slidingWindow;
 };
-}
-
-#endif	/* MYSIMULATION_HPP */
-
+} /* namespace picongpu */


### PR DESCRIPTION
This change reduces some noise in stdout.
- use `SIMULATION_STATE` for output log class
- only trigger log if performing a slide (last plane)

I removed some end-of-line white spaces, too. You might enjoy the [minimal diff](https://github.com/ComputationalRadiationPhysics/picongpu/pull/354/files?w=1).
