### PR TITLE
Avoid mkdir and allocs if disabled

### DIFF
--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceMulti.tpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceMulti.tpp
@@ -58,6 +58,9 @@ namespace picongpu
     {
         this->numChildren = this->notifyPeriod.size();
 
+        if( this->numChildren == 0 )
+            return;
+
         this->children.reserve( this->numChildren );
         for(uint32_t i = 0; i < this->numChildren; i++)
         {


### PR DESCRIPTION
Follow up to #347
This basically prevents the creation of an empty directory if the plugin is disabled.
