### PR TITLE
CMake: 2.8.12 Warning and External Projects

### DIFF
--- a/src/cuda_memtest/CMakeLists.txt
+++ b/src/cuda_memtest/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/" "$ENV{CUDA_ROOT}")
 
 find_package(CUDA REQUIRED)
 
+if(SAME_NVCC_FLAGS_IN_SUBPROJECTS)
   set(CUDA_ARCH sm_13 CACHE STRING "set GPU architecture" )
   set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} ${nvcc_flags} -arch=${CUDA_ARCH})
 
@@ -41,6 +42,7 @@ find_package(CUDA REQUIRED)
     make_directory("${PROJECT_BINARY_DIR}/nvcc_tmp")
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --keep --keep-dir "${PROJECT_BINARY_DIR}/nvcc_tmp")
   endif()
+endif()
 
 
 ################################################################################

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -233,13 +233,6 @@ endif(PARAM_OVERWRITES)
 
 
 ################################################################################
-# Add External Projects
-################################################################################
-
-include(ExternalProject)
-
-
-################################################################################
 # load cuda_memtest project
 ################################################################################
 
@@ -250,11 +243,8 @@ find_path(CUDA_MEMTEST_DIR
         DOC "path to cuda_memtest"
         )
 
-ExternalProject_Add(cuda_memtest
-  DOWNLOAD_COMMAND ""
-  PREFIX "${CUDA_MEMTEST_DIR}/../../"
-  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/build_cuda_memtest"
-  CMAKE_ARGS "CUDA_ARCH=${CUDA_ARCH}")
+add_subdirectory(${CUDA_MEMTEST_DIR}
+                 "${CMAKE_CURRENT_BINARY_DIR}/build_cuda_memtest")
 
 
 ################################################################################
@@ -267,10 +257,8 @@ find_path(MPI_INFO_DIR
         DOC "path to mpiInfo"
         )
 
-ExternalProject_Add(mpiInfo
-        DOWNLOAD_COMMAND ""
-        PREFIX "${MPI_INFO_DIR}/../../"
-        BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/build_mpiInfo")
+add_subdirectory(${MPI_INFO_DIR}
+                 "${CMAKE_CURRENT_BINARY_DIR}/build_mpiInfo")
 
 
 ################################################################################


### PR DESCRIPTION
- Put some projects in ExternalProjects _(optional, 119b659)_
- Fix warning for CMake 2.8.12-2:
  - addition of `\"` against whitespace warning (mind the whitespace near the end of line 205)
  - CUDA_NVCC_FLAGS instead of CMAKE_CXX_FLAGS against undefined symbol error
  - remove the whitespace inside to get rid of the `'` characters which cause errors
