### PR TITLE
fix linker failure

### DIFF
--- a/src/libPMacc/include/debug/VerboseLog.hpp
+++ b/src/libPMacc/include/debug/VerboseLog.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <sstream>
@@ -36,13 +36,16 @@ namespace PMacc
 
 
 /** get the name of a verbose lvl
- * 
+ *
  * this function is defined as friend function for every log lvl
  * @param dummy instance of LogClass to find name
  * @return name of LogClass
  */
 template<class LogClass>
-std::string getLogName(const LogClass& dummy);
+std::string getLogName(const LogClass& dummy)
+{
+    return std::string("UNDEFINED_LVL");
+}
 
 
 namespace verboseLog_detail
@@ -98,7 +101,7 @@ public:
     {
         typedef LogLvl<(logLvl & LogParent::log_level), LogParent> LogClass;
         /* check if a bit in the mask is set
-         * If you get an linker error in the next two lines you have not used 
+         * If you get an linker error in the next two lines you have not used
          * DEFINE_LOGLVL makro to define a named logLvl
          */
         if (logLvl & LogParent::log_level) /*compiletime check*/


### PR DESCRIPTION
if PMACC_VERBOSE=16777215 (HEX: 0xFFFFFF) than we get a linker error

```
src/libPMacc/include/debug/VerboseLog.hpp:106:
  undefined reference to
        std::basic_string<char, std::char_traits<char>, std::allocator<char> >
        PMacc::getLogName<PMacc::LogLvl<17ul, PMacc::PMaccVerbose> >
        (PMacc::LogLvl<17ul, PMacc::PMaccVerbose> const&)
```
