### PR TITLE
Add support for `math::tan`

### DIFF
--- a/src/libPMacc/include/algorithms/math/defines/trigo.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/trigo.hpp
@@ -1,24 +1,24 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 
@@ -36,6 +36,9 @@ struct Sin;
 template<typename Type>
 struct Cos;
 
+template<typename Type>
+struct Tan;
+
 template<typename ArgType, typename SinType, typename CosType>
 struct SinCos;
 
@@ -44,29 +47,45 @@ struct Sinc;
 
 
 template<typename T1>
-HDINLINE static typename Sin< T1 >::result sin(const T1& value)
+HDINLINE static
+typename Sin< T1 >::result
+sin(const T1& value)
 {
     return Sin< T1 > ()(value);
 }
 
 template<typename T1>
-HDINLINE static typename Cos<T1>::result cos(const T1& value)
+HDINLINE static
+typename Cos<T1>::result
+cos(const T1& value)
 {
     return Cos< T1 > ()(value);
 }
 
+template<typename T1>
+HDINLINE static
+typename Tan<T1>::result
+tan(const T1& value)
+{
+    return Tan< T1 > ()(value);
+}
+
 template<typename ArgType, typename SinType, typename CosType>
-HDINLINE static typename SinCos< ArgType, SinType, CosType >::result sincos(ArgType arg, SinType& sinValue, CosType& cosValue)
+HDINLINE static
+typename SinCos< ArgType, SinType, CosType >::result
+sincos(ArgType arg, SinType& sinValue, CosType& cosValue)
 {
     return SinCos< ArgType, SinType, CosType > ()(arg, sinValue, cosValue);
 }
 
 template<typename T1>
-HDINLINE static typename Sinc<T1>::result sinc(const T1& value)
+HDINLINE static
+typename Sinc<T1>::result
+sinc(const T1& value)
 {
     return Sinc< T1 > ()(value);
 }
 
-} //namespace math
-} //namespace algorithms
-}//namespace PMacc
+} /* namespace math */
+} /* namespace algorithms */
+} /* namespace PMacc */

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -1,24 +1,24 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 
@@ -51,6 +51,17 @@ struct Cos<double>
     HDINLINE double operator( )(const double& value )
     {
         return ::cos( value );
+    }
+};
+
+template<>
+struct Tan<double>
+{
+    typedef double result;
+
+    HDINLINE double operator( )(const double& value )
+    {
+        return ::tan( value );
     }
 };
 

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -1,24 +1,25 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "types.h"
@@ -50,6 +51,17 @@ struct Cos<float>
     HDINLINE float operator( )(const float& value )
     {
         return ::cosf( value );
+    }
+};
+
+template<>
+struct Tan<float>
+{
+    typedef float result;
+
+    HDINLINE float operator( )(const float& value )
+    {
+        return ::tanf( value );
     }
 };
 


### PR DESCRIPTION
Add libPMacc suport for `math::tan`.

Contains minor formatting updates (license header and newlines for function types).
