### PR TITLE
Fix checkpointing in HDF5Writer

### DIFF
--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -92,11 +92,10 @@ class HDF5Writer : public ISimulationPlugin
 public:
 
     HDF5Writer() :
-    filename("h5"),
-    checkpointFilename(""),
-    restartFilename(""),
-    notifyFrequency(0),
-    lastCheckpoint(-1)
+    filename("h5_data"),
+    checkpointFilename("h5_checkpoint"),
+    restartFilename(""), /* set to checkpointFilename by default */
+    notifyPeriod(0)
     {
         Environment<>::get().PluginConnector().registerPlugin(this);
     }
@@ -109,7 +108,7 @@ public:
     void pluginRegisterHelp(po::options_description& desc)
     {
         desc.add_options()
-            ("hdf5.period", po::value<uint32_t > (&notifyFrequency)->default_value(0),
+            ("hdf5.period", po::value<uint32_t > (&notifyPeriod)->default_value(0),
              "enable HDF5 IO [for each n-th step]")
             ("hdf5.file", po::value<std::string > (&filename)->default_value(filename),
              "HDF5 output filename (prefix)")
@@ -132,14 +131,12 @@ public:
 
     __host__ void notify(uint32_t currentStep)
     {
-        if ((int64_t)currentStep > lastCheckpoint)
-            notificationReceived(currentStep, false);
+        notificationReceived(currentStep, false);
     }
     
     void checkpoint(uint32_t currentStep)
     {
         notificationReceived(currentStep, true);
-        lastCheckpoint = currentStep;
     }
     
     void restart(uint32_t restartStep)
@@ -268,35 +265,36 @@ private:
 
     void pluginLoad()
     {
-        if (notifyFrequency > 0)
+        mThreadParams.gridPosition =
+            Environment<simDim>::get().SubGrid().getSimulationBox().getGlobalOffset();
+
+        GridController<simDim> &gc = Environment<simDim>::get().GridController();
+        /* It is important that we never change the mpi_pos after this point 
+         * because we get problems with the restart.
+         * Otherwise we do not know which gpu must load the ghost parts around
+         * the sliding window.
+         */
+        mpi_pos = gc.getPosition();
+        mpi_size = gc.getGpuNodes();
+
+        splashMpiPos.set(0, 0, 0);
+        splashMpiSize.set(1, 1, 1);
+
+        for (uint32_t i = 0; i < simDim; ++i)
         {
-            mThreadParams.gridPosition =
-                Environment<simDim>::get().SubGrid().getSimulationBox().getGlobalOffset();
+            splashMpiPos[i] = mpi_pos[i];
+            splashMpiSize[i] = mpi_size[i];
+        }
 
-            GridController<simDim> &gc = Environment<simDim>::get().GridController();
-            /* It is important that we never change the mpi_pos after this point 
-             * because we get problems with the restart.
-             * Otherwise we do not know which gpu must load the ghost parts around
-             * the sliding window.
-             */
-            mpi_pos = gc.getPosition();
-            mpi_size = gc.getGpuNodes();
-
-            splashMpiPos.set(0, 0, 0);
-            splashMpiSize.set(1, 1, 1);
-
-            for (uint32_t i = 0; i < simDim; ++i)
-            {
-                splashMpiPos[i] = mpi_pos[i];
-                splashMpiSize[i] = mpi_size[i];
-            }
-
-            Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyFrequency);
+        /* only register for notify callback when .period is set on command line */
+        if (notifyPeriod > 0)
+        {
+            Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
         }
         
         if (restartFilename == "")
         {
-            restartFilename = filename;
+            restartFilename = checkpointFilename;
         }
 
         loaded = true;
@@ -304,8 +302,7 @@ private:
 
     void pluginUnload()
     {
-        if (notifyFrequency > 0)
-            __delete(mThreadParams.dataCollector);
+        __delete(mThreadParams.dataCollector);
     }
 
     typedef PICToSplash<float_X>::type SplashFloatXType;
@@ -394,7 +391,7 @@ private:
 
     MappingDesc *cellDescription;
 
-    uint32_t notifyFrequency;
+    uint32_t notifyPeriod;
     int64_t lastCheckpoint;
     std::string filename;
     std::string checkpointFilename;


### PR DESCRIPTION
Fix for issue #358 
- rename default data file
- new default name for checkpoint files
- create both data and checkpoint if triggered for the same timestep

Tested with 2 GPUs with
`--checkpoints 256` and `--restart --restart-step 256` (creates only checkpoints) and
`--checkpoints 256 --hdf5.period 256` (creates both checkpoints and data)
