### PR TITLE
Close #398 CMake Use Execute Stripping

### DIFF
--- a/src/cmake/FindADIOS.cmake
+++ b/src/cmake/FindADIOS.cmake
@@ -92,20 +92,17 @@ endif(ADIOS_CONFIG)
 if(ADIOS_FOUND)
     execute_process(COMMAND ${ADIOS_CONFIG} -l
                     OUTPUT_VARIABLE ADIOS_LINKFLAGS
-                    RESULT_VARIABLE ADIOS_CONFIG_RETURN)
+                    RESULT_VARIABLE ADIOS_CONFIG_RETURN
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT ADIOS_CONFIG_RETURN EQUAL 0)
         set(ADIOS_FOUND FALSE)
         message(STATUS "Can NOT execute 'adios_config' - check file permissions")
-    else()
-        # trim trailing newlines
-        string(REGEX REPLACE "(\r?\n)+$" "" ADIOS_LINKFLAGS "${ADIOS_LINKFLAGS}")
     endif()
 
     # find ADIOS_ROOT_DIR
     execute_process(COMMAND ${ADIOS_CONFIG} -d
-                    OUTPUT_VARIABLE ADIOS_ROOT_DIR)
-    # trim trailing newlines
-    string(REGEX REPLACE "(\r?\n)+$" "" ADIOS_ROOT_DIR "${ADIOS_ROOT_DIR}")
+                    OUTPUT_VARIABLE ADIOS_ROOT_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT IS_DIRECTORY "${ADIOS_ROOT_DIR}")
         set(ADIOS_FOUND FALSE)
         message(STATUS "The directory provided by 'adios_config -d' does not exist: ${ADIOS_ROOT_DIR}")
@@ -176,9 +173,8 @@ if(ADIOS_FOUND)
 
     # add the version string
     execute_process(COMMAND ${ADIOS_CONFIG} -v
-                    OUTPUT_VARIABLE ADIOS_VERSION)
-    # trim trailing newlines
-    string(REGEX REPLACE "(\r?\n)+$" "" ADIOS_VERSION "${ADIOS_VERSION}")
+                    OUTPUT_VARIABLE ADIOS_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 endif(ADIOS_FOUND)
 

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -108,17 +108,15 @@ if(VAMPIR_ENABLE)
     # compile flags
     execute_process(COMMAND $ENV{VT_ROOT}/bin/vtc++ -vt:hyb -vt:showme-compile
                     OUTPUT_VARIABLE VT_COMPILEFLAGS
-                    RESULT_VARIABLE VT_CONFIG_RETURN)
+                    RESULT_VARIABLE VT_CONFIG_RETURN
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT VT_CONFIG_RETURN EQUAL 0)
         message(FATAL_ERROR "Can NOT execute 'vtc++' at $ENV{VT_ROOT}/bin/vtc++ - check file permissions")
-    else()
-        # trim trailing newlines
-        string(REGEX REPLACE "(\r?\n)+$" "" VT_COMPILEFLAGS "${VT_COMPILEFLAGS}")
     endif()
     # link flags
     execute_process(COMMAND $ENV{VT_ROOT}/bin/vtc++ -vt:hyb -vt:showme-link
-                    OUTPUT_VARIABLE VT_LINKFLAGS)
-    string(REGEX REPLACE "(\r?\n)+$" "" VT_LINKFLAGS "${VT_LINKFLAGS}")
+                    OUTPUT_VARIABLE VT_LINKFLAGS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     # bugfix showme
     string(REPLACE "--as-needed" "--no-as-needed" VT_LINKFLAGS "${VT_LINKFLAGS}")
@@ -160,22 +158,25 @@ if(SCOREP_ENABLE)
     # compile flags
     execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --nocompiler --cflags
                     OUTPUT_VARIABLE SCOREP_COMPILEFLAGS
-                    RESULT_VARIABLE SCOREP_CONFIG_RETURN)
+                    RESULT_VARIABLE SCOREP_CONFIG_RETURN
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT SCOREP_CONFIG_RETURN EQUAL 0)
         message(FATAL_ERROR "Can NOT execute 'scorep-config' at $ENV{SCOREP_ROOT}/bin/scorep-config - check file permissions")
     endif()
 
     # link flags
     execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --ldflags
-                    OUTPUT_VARIABLE SCOREP_LINKFLAGS)
+                    OUTPUT_VARIABLE SCOREP_LINKFLAGS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     # libraries
     execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --libs
-                    OUTPUT_VARIABLE SCOREP_LIBFLAGS)
-    string(STRIP "${SCOREP_LIBFLAGS}" SCOREP_LIBFLAGS)
+                    OUTPUT_VARIABLE SCOREP_LIBFLAGS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     # subsystem iniialization file
     execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --adapter-init
-                    OUTPUT_VARIABLE SCOREP_INIT_FILE)
+                    OUTPUT_VARIABLE SCOREP_INIT_FILE
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     file(WRITE ${CMAKE_BINARY_DIR}/scorep_init.c "${SCOREP_INIT_FILE}")
 
     if(SCOREP_ENABLE)


### PR DESCRIPTION
Use trim functions of `execute_process` in CMake instead of regex-ing the trailing white spaces and newlines away ourself.
