### PR TITLE
Hypnos: Add picongpu.profile Example File

### DIFF
--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -9,9 +9,8 @@ then
         module load devel/cmake/2.8.10
         module load tools/infiniband/2.0.0
         module load mpi/openmpi/1.6.3
-        module load devel/boost/1.49.0
-        module load devel/cuda/5.0
-        module load devel/llvm/3.1 devel/ocelot/2.1.2181
+        module load devel/boost/1.54.0
+        module load devel/cuda/6.0
         module load filelib/hdf5-parallel/1.8.11
         module load filelib/libsplash/1.2.0
         module load devel/subversion/1.6.6
@@ -24,7 +23,7 @@ then
 fi
 
 alias getk20='qsub -I -q k20 -lwalltime=00:30:00 -lnodes=1:ppn=8'
-alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=64'
+alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
 export PATH=$PATH:$PICSRC/src/splash2txt/build
 export PATH=$PATH:$PICSRC/src/tools/bin


### PR DESCRIPTION
Adds the usual `submit/<cluster>/picongpu.profile.example` file.
