### PR TITLE
Fix standard rad observer

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -61,7 +61,7 @@ namespace picongpu
       const numtype2 delta_theta =  2.0 * thetaMax / (parameters::N_observer); 
 
       /* compute angle theta for index */
-      const numtype2 theta(my_theta_id * delta_theta - gamma_times_thetaMax + picongpu::PI); 
+      const numtype2 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI); 
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
@@ -62,7 +62,7 @@ namespace picongpu
       const numtype2 delta_theta =  2.0 * thetaMax / (parameters::N_observer); 
 
       /* compute angle theta for index */
-      const numtype2 theta(my_theta_id * delta_theta - gamma_times_thetaMax + picongpu::PI); 
+      const numtype2 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI); 
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */


### PR DESCRIPTION
I used normalized values for the angle offset. Correct would be radian values.
This pull request fixes this bug.
