### PR TITLE
fix typo in W0_Z_SI definition

### DIFF
--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -226,7 +226,7 @@ namespace picongpu
          *              if both values are equal, the laser has a circular shape in x-z
          *  unit: meter */
         const double W0_X_SI = 4.246e-6;
-        const double W0_Z_SI = W0_Z_SI;
+        const double W0_Z_SI = W0_X_SI;
 
     }
     /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau


### PR DESCRIPTION
This fixes a typo in `src/picongpu/include/simulation_defines/param/laserConfig.param` that creates a non-intuitive compile error:

```
/net/cns/projects/HPL/xray/pausch/PIConGPU/picongpu/src/picongpu/include/fields/FieldE.kernel(87): error: identifier "_ZN8picongpu15laserWavepacket4W0_ZE" is undefined
```
