### PR TITLE
fix message header allocation

### DIFF
--- a/src/picongpu/include/plugins/output/header/MessageHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/MessageHeader.hpp
@@ -143,7 +143,7 @@ struct MessageHeader
 
     static MessageHeader * create()
     {
-        return (MessageHeader*) new uint8_t(bytes);
+        return (MessageHeader*) new uint8_t[bytes];
     }
 
     static void destroy(MessageHeader * obj)


### PR DESCRIPTION
fix wrong usage of operator new, caused by pull https://github.com/ComputationalRadiationPhysics/picongpu/pull/439
