### PR TITLE
cuSTL Kernel 2D Container Support

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
@@ -63,8 +63,8 @@ namespace kernel
         /* ... */                                                                                           \
         BOOST_PP_REPEAT(N, SHIFT_CURSOR_ZONE, _)                                                            \
                                                                                                             \
-        dim3 blockDim(BlockDim::x::value, BlockDim::y::value, BlockDim::z::value);                          \
-        detail::SphericMapper<Zone::dim, BlockDim> mapper; \
+        dim3 blockDim(BlockDim::toRT().toDim3());                                                           \
+        detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace PMacc;                                                                              \
         __cudaKernel(detail::kernelForeach)(mapper.cudaGridDim(_zone.size), blockDim)                       \
                   /* c0_shifted, c1_shifted, ... */                                                         \

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -87,7 +87,7 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), KERNEL_FOREA
         /* ... */                                                                                           \
         BOOST_PP_REPEAT(N, SHIFT_CURSOR_ZONE, _)                                                            \
                                                                                                             \
-        dim3 blockDim(ThreadBlock::x::value, ThreadBlock::y::value, ThreadBlock::z::value);                 \
+        dim3 blockDim(ThreadBlock::toRT().toDim3());                                                        \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace PMacc;                                                                              \
         __cudaKernel(detail::kernelForeachBlock)(mapper.cudaGridDim(_zone.size), blockDim)                  \

--- a/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
@@ -23,6 +23,7 @@
 #define CURSOR_MULTIINDEXCURSOR
 
 #include "Cursor.hpp"
+#include "accessor/MarkerAccessor.hpp"
 #include "navigator/MultiIndexNavigator.hpp"
 #include "math/vector/Int.hpp"
 


### PR DESCRIPTION
Adds more support for kernels and cuda building blocks on 2D containers.

Minor flaws detected during the upgrade of the Phase Space plugin to support 2D simulations.

Btw: makros obfuscate error messages pretty hard (find the error in one of the ~15 generated lines).
