### PR TITLE
Fix warning sign compare

### DIFF
--- a/src/picongpu/include/plugins/hdf5/restart/RestartParticleLoader.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/RestartParticleLoader.hpp
@@ -276,8 +276,8 @@ public:
             PMacc::lcellId_t localCellId(DataSpaceOperations<simDim>::map(superCellSize, cellPosInSuperCell));
 
             // write to frame
-            assert(localId < (uint32_t)PMacc::math::CT::volume<SuperCellSize>::type::value);
-            assert((uint32_t)localCellId < (uint32_t)PMacc::math::CT::volume<SuperCellSize>::type::value);
+            assert(localId < uint32_t(PMacc::math::CT::volume<SuperCellSize>::type::value));
+            assert(uint32_t(localCellId) < uint32_t(PMacc::math::CT::volume<SuperCellSize>::type::value));
 
             PMACC_AUTO(particle, ((*frame)[localId]));
 


### PR DESCRIPTION
Fix a signed/unsigned warning in RestartParticleLoader

`localCellId` is unsigned (16 or 32 bit) while `PMacc::math::CT::volume<SuperCellSize>::type::value` is an `int`

Found on joker with gcc/4.6.2 and gcc/4.7.1.
