### PR TITLE
Titan: Update picongpu.profile to ADIOS 1.7.0

### DIFF
--- a/src/picongpu/submit/jaguar/picongpu.profile.example
+++ b/src/picongpu/submit/jaguar/picongpu.profile.example
@@ -43,6 +43,9 @@ export HDF5_ROOT=$HDF5_DIR
 export SPLASH_ROOT=$MEMBERWORK/$proj/lib/splash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SPLASH_ROOT/lib
 
+#export T3PIO_ROOT=$MEMBERWORK/$proj/lib/t3pio
+#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$T3PIO_ROOT/lib
+
 # download libpng.h and compile yourself with
 #   http://www.libpng.org/pub/png/libpng.html
 #   tar -xvf libpng-1.6.9.tar.gz


### PR DESCRIPTION
Update picongpu.profile to ADIOS 1.7.0 for **Titan** (ORNL).

Also adds [T3PIO](https://github.com/TACC/t3pio) hints.
