### PR TITLE
ParaView: Request Exclusive Nodes

### DIFF
--- a/src/tools/share/paraview.pvsc
+++ b/src/tools/share/paraview.pvsc
@@ -31,6 +31,7 @@
 \#PBS -l walltime=T_WALLTIME\\n
 \#PBS -N pvserver\\n
 \#PBS -l nodes=NUM_NODES:ppn=NUM_PPN\\n
+\#PBS -W x=NACCESSPOLICY:SINGLETASK\\n
 \#PBS -d .\\n
 \#PBS -o stdout\\n
 \#PBS -e stderr\\n


### PR DESCRIPTION
Request exclusive nodes on `hypnos`.

Note: I saw some multi-node problems unrelated to that pull today. Seems like some environment settings changed in the last month. Right now only 1-node jobs run by default.
