### PR TITLE
fileOutput.param: Sort file and add Hints

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -23,6 +23,8 @@
 #pragma once
 
 #include "simulation_defines.hpp"
+#include "fields/Fields.def"
+#include "particles/traits/GetShape.hpp"
 
 namespace picongpu
 {
@@ -73,6 +75,75 @@ public:
                             const TVecSuperCell superCell,
                             BoxTmp& tmpBox);
 };
+
+/** Predefined Calculations for \see fieldOutput.param
+ */
+
+/* Density */
+template<typename T_Species>
+struct CreateDensityOperation
+{
+    typedef typename GetShape<T_Species>::type shapeType;
+    typedef ComputeGridValuePerFrame<
+        shapeType,
+        ComputeGridValueOptions::calcDensity
+    > ParticleDensity;
+
+    typedef FieldTmpOperation< ParticleDensity, T_Species > type;
+};
+
+/* ParticleCounter */
+template<typename T_Species>
+struct CreateCounterOperation
+{
+    typedef ComputeGridValuePerFrame<
+        particles::shapes::Counter,
+        ComputeGridValueOptions::calcCounter
+    > ParticleCounter;
+
+    typedef FieldTmpOperation< ParticleCounter, T_Species > type;
+};
+
+/* EnergyDensity */
+template<typename T_Species>
+struct CreateEnergyDensityOperation
+{
+    typedef typename GetShape<T_Species>::type shapeType;
+    typedef ComputeGridValuePerFrame<
+        shapeType,
+        ComputeGridValueOptions::calcEnergyDensity
+    > ParticleEnergyDensity;
+
+    typedef FieldTmpOperation< ParticleEnergyDensity, T_Species > type;
+};
+
+/* Energy */
+template<typename T_Species>
+struct CreateEnergyOperation
+{
+    typedef typename GetShape<T_Species>::type shapeType;
+    typedef ComputeGridValuePerFrame<
+        shapeType,
+        ComputeGridValueOptions::calcEnergy
+    > ParticleEnergy;
+
+    typedef FieldTmpOperation< ParticleEnergy, T_Species > type;
+};
+
+#if(ENABLE_RADIATION == 1)
+template<typename T_Species>
+struct CreateLarmorEnergyOperation
+{
+    typedef typename GetShape<T_Species>::type shapeType;
+    typedef ComputeGridValuePerFrame<
+        shapeType,
+        ComputeGridValueOptions::calcLarmorEnergy
+    > ParticleLarmorEnergy;
+
+    typedef FieldTmpOperation< ParticleLarmorEnergy, T_Species > type;
+};
+#endif
+
 
 } // namespace particleToGrid
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -30,65 +30,33 @@
 /** some forward declarations we need */
 #include "fields/Fields.def"
 #include "particles/particleToGrid/ComputeGridValuePerFrame.def"
-#include "particles/traits/GetShape.hpp"
 
 namespace picongpu
 {
     /** FieldTmp output (calculated at runtime) *******************************
+     *
+     * you can choose any of these particle to grid projections:
+     *   - CreateDensityOperation: particle position + shape on the grid
+     *   - CreateCounterOperation: counts point like particles per cell
+     *   - CreateEnergyDensityOperation: particle energy density with respect to shape
+     *   - CreateEnergyOperation: particle energy with respect to shape
+     *   - CreateLarmorEnergyOperation: radiated larmor energy (needs ENABLE_RADIATION)
      */
     using namespace particleToGrid;
 
-    /* ParticleDensity section */
-
-    template<typename T_Species>
-    struct CreateDensityOperation
-    {
-        typedef typename GetShape<T_Species>::type shapeType;
-        typedef ComputeGridValuePerFrame<
-            shapeType,
-            ComputeGridValueOptions::calcDensity
-        > ParticleDensity;
-
-        typedef FieldTmpOperation< ParticleDensity, T_Species > type;
-    };
-
+    /* Density section */
     typedef typename bmpl::transform<
             VectorAllSpecies,
             CreateDensityOperation<bmpl::_1>
             >::type Density_Seq;
 
     /* ParticleCounter section */
-
-    template<typename T_Species>
-    struct CreateCounterOperation
-    {
-        typedef ComputeGridValuePerFrame<
-            particles::shapes::Counter,
-            ComputeGridValueOptions::calcCounter
-        > ParticleCounter;
-
-        typedef FieldTmpOperation< ParticleCounter, T_Species > type;
-    };
-
     typedef typename bmpl::transform<
             VectorAllSpecies,
             CreateCounterOperation<bmpl::_1>
             >::type Counter_Seq;
 
-    /* ParticleCounter section */
-
-    template<typename T_Species>
-    struct CreateEnergyDensityOperation
-    {
-        typedef typename GetShape<T_Species>::type shapeType;
-        typedef ComputeGridValuePerFrame<
-            shapeType,
-            ComputeGridValueOptions::calcEnergyDensity
-        > ParticleEnergyDensity;
-
-        typedef FieldTmpOperation< ParticleEnergyDensity, T_Species > type;
-    };
-
+    /* EnergyDensity section */
     typedef typename bmpl::transform<
             VectorAllSpecies,
             CreateEnergyDensityOperation<bmpl::_1>
@@ -106,7 +74,7 @@ namespace picongpu
     >::type FieldTmpSolvers;
 
 
-    /** FileOutputFields: Groups all Fields that shall be dumped **************
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
 
     /** Possible native fields: FieldE, FieldB, FieldJ
      */


### PR DESCRIPTION
This pull request:
- Adds a small comment on how to disable particle output
- formats the file to be sorted by priority and useful groups
- removes all auxiliary defines of `bmpl` to let the user focus on the options that he is actually allowed to set

**Misc:**

Added a note in the [wiki](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-HDF5) that `fileOutput.param` controls HDF5.

Adios is controlled by the same file I guess?
- [x] update [adios page](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-ADIOS), too
