### PR TITLE
Add meta attributes for ADIOS as in HDF5

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -91,6 +91,7 @@ struct ThreadParams
     std::list<int64_t> adiosFieldVarIds;        /* var IDs for fields in order of appearance */
     std::list<int64_t> adiosParticleAttrVarIds; /* var IDs for particle attributes in order of appearance */
     std::list<int64_t> adiosSpeciesIndexVarIds; /* var IDs for species index tables in order of appearance */
+    std::list<int64_t> adiosMetaAttrVarIds;     /* var IDs for scalar meta attributes */
 
     GridLayout<simDim> gridLayout;
     MappingDesc *cellDescription;


### PR DESCRIPTION
Add meta attributes for ADIOS which are already in HDF5.
Attributes are written as scalar ADIOS variables (instead of ADIOS attributes) as the latter only support strings. Main difference (I assume) is that attributes are written by root only while variables are effectively written by all processes.
