### PR TITLE
Fix Race Condition in Particle Box

### DIFF
--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ * 
  * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the


### PR DESCRIPTION
- fix bug that memory writes in `setAsLastFrame` and `setAsFirstFrame` are not in order

This bug was not triggered by the current `dev` or `master` branch.

~~**PLEASE do not merge, I think our compile suite isn't working.**~~
