### PR TITLE
close #487 deprecated literal char* conversion

### DIFF
--- a/src/libPMacc/include/identifier/alias.hpp
+++ b/src/libPMacc/include/identifier/alias.hpp
@@ -24,6 +24,7 @@
 
 #include "types.h"
 #include "identifier/identifier.hpp"
+#include <string>
 
 namespace PMacc
 {
@@ -35,12 +36,12 @@ identifier(pmacc_isAlias);
 #define PMACC_alias(name,id)                                                   \
     namespace PMACC_JOIN(placeholder_definition,id) {                          \
         template<typename T_Type=PMacc::pmacc_void,typename T_IsAlias=PMacc::pmacc_isAlias> \
-        struct name:public T_Type                                                   \
+        struct name:public T_Type                                              \
         {                                                                      \
-            typedef T_Type ThisType;                                                \
-            static HDINLINE char* getName()                                    \
+            typedef T_Type ThisType;                                           \
+            static std::string getName()                                       \
             {                                                                  \
-                     return #name;                                             \
+                return std::string(#name);                                     \
             }                                                                  \
         };                                                                     \
     }                                                                          \

--- a/src/libPMacc/include/identifier/named_type.hpp
+++ b/src/libPMacc/include/identifier/named_type.hpp
@@ -24,34 +24,35 @@
 
 #include "types.h"
 #include "identifier/identifier.hpp"
+#include <string>
 
 /* No namespace is needed because we only have defines*/
 
 /** define a unique identifier with name, type and a default value
  * @param in_type type of the value
  * @param name name of identifier
- * 
+ *
  * The created identifier has the following options:
  *          getName()         - return the name of the identifier
  *          ::type            - get contained type
  *          ::ThisType        - get type of the created class by it self
- * 
+ *
  * e.g. named_type(float,length)
  *      typedef length::type value_type; // is float
  *      typedef length::ThisType X;  // is class length
  *      printf("Identifier name: %s",length::getName()); //print Identifier name: length
- * 
+ *
  * to create a instance of this value_identifier you can use:
  *      length();   or length_
- * 
+ *
  */
 #define named_type(in_type,name,...)                                           \
         identifier(name,                                                       \
         typedef name ThisType;                                                 \
         typedef in_type type;                                                  \
-        static HDINLINE char* getName()                                        \
+        static std::string getName()                                           \
         {                                                                      \
-                return #name;                                                  \
+                return std::string(#name);                                     \
         }                                                                      \
         __VA_ARGS__                                                            \
     )

--- a/src/libPMacc/include/identifier/value_identifier.hpp
+++ b/src/libPMacc/include/identifier/value_identifier.hpp
@@ -24,6 +24,7 @@
 
 #include "types.h"
 #include "identifier/identifier.hpp"
+#include <string>
 
 /* No namespace is needed because we only have defines*/
 
@@ -31,20 +32,20 @@
  * @param in_type type of the value
  * @param name name of identifier
  * @param in_default default value of in_type (can be a constructor of a class)
- * 
+ *
  * The created identifier has the following options:
  *          getDefaultValue() - return the default value
  *          getName()         - return the name of the identifier
- *          ::type            - get type of the value 
- * 
+ *          ::type            - get type of the value
+ *
  * e.g. value_identifier(float,length,0.0f)
  *      typedef length::type value_type; // is float
  *      value_type x= length::getDefault();  //set x to 0.f
  *      printf("Identifier name: %s",length::getName()); //print Identifier name: length
- * 
+ *
  * to create a instance of this value_identifier you can use:
  *      length();   or length_
- * 
+ *
  */
 #define value_identifier(in_type,name,in_default)                              \
         identifier(name,                                                       \
@@ -54,8 +55,8 @@
         {                                                                      \
                 return in_default;                                             \
         }                                                                      \
-        static HDINLINE char* getName()                                        \
+        static std::string getName()                                           \
         {                                                                      \
-                return #name;                                                  \
+                return std::string(#name);                                     \
         }                                                                      \
     )


### PR DESCRIPTION
Issue #487 
- change interface that `getName()` return std::string instead of char*
- change methode qualifier from HDINLINE to host only
