### PR TITLE
delete white spaces at the end of line

### DIFF
--- a/src/cuda_memtest/cuda_memtest.cu
+++ b/src/cuda_memtest/cuda_memtest.cu
@@ -8,18 +8,18 @@
  *
  * Developed by:
  *
- * Innovative Systems Lab  
- * National Center for Supercomputing Applications  
+ * Innovative Systems Lab
+ * National Center for Supercomputing Applications
  * http://www.ncsa.uiuc.edu/AboutUs/Directorates/ISL.html
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of 
- * this software and associated documentation files (the "Software"), to deal with 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal with
  * the Software without restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the 
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
  * Software, and to permit persons to whom the Software is furnished to do so, subject
  * to the following conditions:
  *
- * * Redistributions of source code must retain the above copyright notice, this list 
+ * * Redistributions of source code must retain the above copyright notice, this list
  * of conditions and the following disclaimers.
  *
  * * Redistributions in binary form must reproduce the above copyright notice, this list
@@ -30,11 +30,11 @@
  * Applications, nor the names of its contributors may be used to endorse or promote products
  * derived from this Software without specific prior written permission.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
  * PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
- * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS WITH THE SOFTWARE.
  */
 
@@ -161,7 +161,7 @@ thread_func(void* _arg)
     }
 
 
-    cudaSetDevice(device); 
+    cudaSetDevice(device);
     cudaThreadSynchronize();
     CUERR;
  
@@ -190,14 +190,14 @@ thread_func(void* _arg)
         }
         else
         {
-            cudaMalloc((void**)&ptr, tot_num_blocks* BLOCKSIZE); 
+            cudaMalloc((void**)&ptr, tot_num_blocks* BLOCKSIZE);
         }
     }while(cudaGetLastError() != cudaSuccess);
     
     PRINTF("Allocated %d MB\n", tot_num_blocks);
 
     atomic_inc(&healthy_threads);
-    run_tests(ptr, tot_num_blocks);	
+    run_tests(ptr, tot_num_blocks);
     
     return NULL;
       
@@ -229,11 +229,11 @@ void
 usage(char** argv)
 {
 
-    char example_usage[] = 
+    char example_usage[] =
 	"run on default setting:       ./cuda_memtest\n"
 	"run on stress test only:      ./cuda_memtest --stress\n";
 	    
-    printf("Usage:%s [options]\n", argv[0]);    
+    printf("Usage:%s [options]\n", argv[0]);
     printf("options:\n");
     printf("--mappedMem                 run all checks with cuda mapped memory instead of native device memory\n");
     printf("--silent                    Do not print out progress message (default)\n");
@@ -255,7 +255,7 @@ usage(char** argv)
     printf("--num_passes <n>            Set the number of test passes (this affects all tests)\n");
     printf("--disable_serial_number     Disable reporting serial number\n");
     printf("--verbose <n>               Setting verbose level\n");
-    printf("                              0 -- Print out test start and end message only (default)\n"); 
+    printf("                              0 -- Print out test start and end message only (default)\n");
     printf("                              1 -- Print out pattern messages in test\n");
     printf("                              2 -- Print out progress messages\n");
     printf("--stress                    Stress test. Equivalent to --disable_all --enable_test 10 --exit_on_error\n");
@@ -292,14 +292,14 @@ main(int argc, char** argv)
 	}
     }
     
-    PRINTF("Running cuda memtest, version %s\n", VERSION);   
+    PRINTF("Running cuda memtest, version %s\n", VERSION);
     int device = -1;
     int num_gpus;
     cudaGetDeviceCount(&num_gpus);CUERR;
     
     if (num_gpus == 0){
 	fprintf(stderr,"ERROR: no GPUs found\n");
-	exit(ERR_GENERAL);	
+	exit(ERR_GENERAL);
     }
     
     
@@ -318,7 +318,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    verbose = atoi(argv[i+1]);	
+	    verbose = atoi(argv[i+1]);
 	    i++;
 	    continue;
 	    
@@ -339,7 +339,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    int idx = atoi(argv[i+1]);	
+	    int idx = atoi(argv[i+1]);
 	    if (idx >= DIM(cuda_memtests)){
 		fprintf(stderr, "Error: invalid test id\n");
 		usage(argv);
@@ -354,7 +354,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    int idx = atoi(argv[i+1]);	
+	    int idx = atoi(argv[i+1]);
 	    if (idx >= DIM(cuda_memtests)){
 		fprintf(stderr, "Error: invalid test id\n");
 		usage(argv);
@@ -376,7 +376,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    device = atoi(argv[i+1]);	    
+	    device = atoi(argv[i+1]);
 	    i++;
 	    num_gpus = 1;
 	    continue;
@@ -386,7 +386,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    max_num_blocks = atoi(argv[i+1]);	    
+	    max_num_blocks = atoi(argv[i+1]);
 	    i++;
 	    continue;
 	}
@@ -401,7 +401,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    monitor_interval = atoi(argv[i+1]);	    
+	    monitor_interval = atoi(argv[i+1]);
 	    i++;
 	    continue;
 	}
@@ -441,7 +441,7 @@ main(int argc, char** argv)
 		fprintf(stderr, "ERROR: email string too long\n");
 		usage(argv);
 	    }
-	    strcpy(emails, argv[i+1]);	    
+	    strcpy(emails, argv[i+1]);
 	    i++;
 	    continue;
 	}
@@ -453,7 +453,7 @@ main(int argc, char** argv)
 	    report_interval = atoi(argv[i+1]);
 	    i++;
 	    continue;
-	}	
+	}
 	
 	if (strcmp(argv[i], "--num_iterations") == 0){
 
@@ -467,7 +467,7 @@ main(int argc, char** argv)
 	    }
 	    i++;
 	    continue;
-	}	
+	}
 	
 	if (strcmp(argv[i], "--num_passes") == 0){
 
@@ -481,12 +481,12 @@ main(int argc, char** argv)
 	    }
 	    i++;
 	    continue;
-	}	
+	}
 
 	if (strcmp(argv[i], "--disable_serial_number") == 0){
 	    disable_serial_number= 1;
 	    continue;
-	}	
+	}
 	
 	if (strcmp(argv[i], "--stress") == 0){
 	    //equal to "--disable_all --enable_test 10 --exit_on_error"
@@ -497,7 +497,7 @@ main(int argc, char** argv)
 	    cuda_memtests[10].enabled = 1;
 	    exit_on_error = 1;
 	    continue;
-	}	
+	}
 	
 	if (strcmp(argv[i], "--list_tests") == 0){
 	    list_tests_info();
@@ -528,7 +528,7 @@ main(int argc, char** argv)
     arg_t args[MAX_NUM_GPUS];
     pthread_t pid[MAX_NUM_GPUS];
     
-    if (device != -1){ //device set, only 1 GPU 
+    if (device != -1){ //device set, only 1 GPU
 	args[0].device = device;
 	pthread_create(&pid[0], NULL, thread_func, (void*)&args[0]);
     }else{//multiple GPUs
@@ -563,7 +563,7 @@ main(int argc, char** argv)
 	fflush(stdout); fflush(stderr);
 	for(i=0;i < num_gpus;i++){
 		pthread_kill(pid[i], SIGTERM);
-	}	    
+	}
 	exit(ERR_BAD_STATE);
     }
     

--- a/src/cuda_memtest/cuda_memtest.h
+++ b/src/cuda_memtest/cuda_memtest.h
@@ -8,18 +8,18 @@
  *
  * Developed by:
  *
- * Innovative Systems Lab  
- * National Center for Supercomputing Applications  
+ * Innovative Systems Lab
+ * National Center for Supercomputing Applications
  * http://www.ncsa.uiuc.edu/AboutUs/Directorates/ISL.html
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of 
- * this software and associated documentation files (the "Software"), to deal with 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal with
  * the Software without restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the 
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
  * Software, and to permit persons to whom the Software is furnished to do so, subject
  * to the following conditions:
  *
- * * Redistributions of source code must retain the above copyright notice, this list 
+ * * Redistributions of source code must retain the above copyright notice, this list
  * of conditions and the following disclaimers.
  *
  * * Redistributions in binary form must reproduce the above copyright notice, this list
@@ -30,11 +30,11 @@
  * Applications, nor the names of its contributors may be used to endorse or promote products
  * derived from this Software without specific prior written permission.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
  * PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
- * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS WITH THE SOFTWARE.
  */
 
@@ -80,7 +80,7 @@ extern void get_driver_info(char* info, unsigned int len);
 	    pthread_mutex_unlock(&mutex);					\
 	}								\
 	fflush(stdout);							\
-    } while(0) 
+    } while(0)
 
 
 #define FPRINTF(fmt,...) do{						\
@@ -91,7 +91,7 @@ extern void get_driver_info(char* info, unsigned int len);
 	    fprintf(stderr, "[%s][%s][%d]:"fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
 	}								\
 	fflush(stderr);							\
-    } while(0) 
+    } while(0)
 
 
 
@@ -113,21 +113,21 @@ extern void get_driver_info(char* info, unsigned int len);
 	    PRINTF("%s: %d out of %d blocks finished\n", msg, num_checked_blocks, tot_num_blocks );  \
 	} \
    }		\
-    fflush(stdout);					
+    fflush(stdout);
 
 
 #define CUERR  do{ cudaError_t cuda_err; \
 	if ((cuda_err = cudaGetLastError()) != cudaSuccess) {		\
 	    FPRINTF("ERROR: CUDA error: %s, line %d, file %s\n", cudaGetErrorString(cuda_err),  __LINE__, __FILE__); \
 	    PRINTF("ERROR: CUDA error: %s, line %d, file %s\n", cudaGetErrorString(cuda_err),  __LINE__, __FILE__); \
-	    exit(cuda_err);}}while(0) 
+	    exit(cuda_err);}}while(0)
 
 #define SYNC_CUERR  do{ cudaError_t cuda_err; \
 	cudaThreadSynchronize(); \
         if ((cuda_err = cudaGetLastError()) != cudaSuccess) {                \
             FPRINTF("ERROR: CUDA error: %s, line %d, file %s\n", cudaGetErrorString(cuda_err),  __LINE__, __FILE__); \
             PRINTF("ERROR: CUDA error: %s, line %d, file %s\n", cudaGetErrorString(cuda_err),  __LINE__, __FILE__); \
-            exit(cuda_err);}}while(0) 
+            exit(cuda_err);}}while(0)
 
 #define TDIFF(tb, ta) (tb.tv_sec - ta.tv_sec + 0.000001*(tb.tv_usec - ta.tv_usec))
 #define DIM(x) (sizeof(x)/sizeof(x[0]))
@@ -141,7 +141,7 @@ typedef  void (*test_func_t)(char* , unsigned int );
 typedef struct cuda_memtest_s{
     test_func_t func;
     char* desc;
-    unsigned int enabled;    
+    unsigned int enabled;
 }cuda_memtest_t;
 
 

--- a/src/cuda_memtest/misc.cpp
+++ b/src/cuda_memtest/misc.cpp
@@ -13,7 +13,7 @@ void update_temperature(void)
 	printf("ERROR: opening pipe failed\n");
 	exit(ERR_GENERAL);
     }
-    unsigned int i = 0;    
+    unsigned int i = 0;
     while(1){
 	char buf[256];
 	char* s;
@@ -36,11 +36,11 @@ void update_temperature(void)
 	
 	intake_temp[i] = t;
 	gpu_temp[2*i]  = gpu_0;
-	gpu_temp[2*i + 1]  = gpu_1;	
+	gpu_temp[2*i + 1]  = gpu_1;
 	i++;
     }
     
-    DEBUG_PRINTF("temperature updated: %d %d %d %d \n", 
+    DEBUG_PRINTF("temperature updated: %d %d %d %d \n",
 		 gpu_temp[0], gpu_temp[1], gpu_temp[2], gpu_temp[3]);
 	
    pclose(file);
@@ -50,7 +50,7 @@ void update_temperature(void)
 
 unsigned long long
 get_serial_number(void)
-{   
+{
     FILE* file= popen("nvidia-smi|/bin/grep \"Serial Number\"|gawk '{print $4}'", "r");
     if (file == NULL){
 	PRINTF("Warning: opening pipe failed for getting serial nubmer\n");

--- a/src/cuda_memtest/ocl_memtest.cpp
+++ b/src/cuda_memtest/ocl_memtest.cpp
@@ -22,11 +22,11 @@ unsigned int exit_on_error = 0;
 
 #define MAX_KERNEL_FILE_SIZE (1024*1024)
 
-char hostname[64];     
+char hostname[64];
 char* kernel_source;
 
 char*
-print_cl_errstring(cl_int err) 
+print_cl_errstring(cl_int err)
 {
   switch (err) {
   case CL_SUCCESS:                          return strdup("Success!");
@@ -77,7 +77,7 @@ print_cl_errstring(cl_int err)
   case CL_INVALID_MIP_LEVEL:                return strdup("Invalid mip-map level");
   default:                                  return strdup("Unknown");
   }
-} 
+}
 
 const char* device_type_str(cl_device_type type)
 {
@@ -163,7 +163,7 @@ allocate_device_mem(memtest_control_t* mc)
   cl_command_queue queue = mc->queue;
   cl_int rc;
   
-  mc->err_count = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_uint), NULL, &rc);CLERR;  
+  mc->err_count = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_uint), NULL, &rc);CLERR;
   mc->err_addr = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_ulong)*MAX_ERR_RECORD_COUNT, NULL, &rc); CLERR;
   mc->err_expect = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_ulong)*MAX_ERR_RECORD_COUNT, NULL, &rc); CLERR;
   mc->err_current = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_ulong)*MAX_ERR_RECORD_COUNT, NULL, &rc); CLERR;
@@ -173,7 +173,7 @@ allocate_device_mem(memtest_control_t* mc)
   cl_ulong err_count= 0;
   rc = clEnqueueWriteBuffer(queue, mc->err_count, CL_TRUE, 0, sizeof(cl_uint), &err_count, 0, NULL, NULL); CLERR;
   
-  cl_ulong msize;  
+  cl_ulong msize;
   rc = clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(msize), &msize, NULL);
   CLERR;
   
@@ -305,7 +305,7 @@ main(const int argc, const char **argv)
   }
 
 
-  cl_platform_id clSelectedPlatformID = NULL; 
+  cl_platform_id clSelectedPlatformID = NULL;
   cl_int rc = oclGetPlatformID (&clSelectedPlatformID);CLERR;
   
   char strbuf[128];
@@ -354,7 +354,7 @@ main(const int argc, const char **argv)
   cl_context contexts[MAX_NUM_DEVICES];
   for(i=starti;i < endi;i++){
     contexts[i]= clCreateContext(0, 1, &devices[i], NULL, NULL, NULL);
-    if (contexts[i] == (cl_context)0){ 
+    if (contexts[i] == (cl_context)0){
       printf("ERROR: creating context from GPU failed\n");
       exit(1);
     }
@@ -363,7 +363,7 @@ main(const int argc, const char **argv)
   
   cl_command_queue queues[MAX_NUM_DEVICES];
   for(i=starti;i < endi;i++){
-    queues[i] = clCreateCommandQueue(contexts[i], devices[i], CL_QUEUE_PROFILING_ENABLE,NULL); 
+    queues[i] = clCreateCommandQueue(contexts[i], devices[i], CL_QUEUE_PROFILING_ENABLE,NULL);
     if (queues[i] == (cl_command_queue)0){
       printf("creating command queue failed\n");
       exit(1);
@@ -389,9 +389,9 @@ main(const int argc, const char **argv)
   for(i=starti;i < endi;i++){
     memtest_ctl[i].context = contexts[i];
     memtest_ctl[i].device_idx = i;
-    memtest_ctl[i].device = devices[i];    
+    memtest_ctl[i].device = devices[i];
     memtest_ctl[i].queue = queues[i];
-    allocate_device_mem(&memtest_ctl[i]);    
+    allocate_device_mem(&memtest_ctl[i]);
     memtest_ctl[i].program= programs[i];
   }
   
@@ -403,9 +403,9 @@ main(const int argc, const char **argv)
   while(loop_count < 2){
     for(i=0;i < device_count; i++){
       memtest_control_t * mc = &memtest_ctl[i];
-      printf("Running tests  in device %d\n", i); 
+      printf("Running tests  in device %d\n", i);
       test10(mc);
-    }//i   
+    }//i
     
     for(i=0;i < device_count; i ++){
       memtest_control_t * mc = &memtest_ctl[i];
@@ -420,7 +420,7 @@ main(const int argc, const char **argv)
   pthread_t pid[MAX_NUM_DEVICES];
   for(i=starti;i < endi;i++){
     int rc;
-    rc = pthread_create(&pid[i], NULL, run_tests, (void*)&memtest_ctl[i]);    
+    rc = pthread_create(&pid[i], NULL, run_tests, (void*)&memtest_ctl[i]);
     if (rc != 0){
       printf("ERROR: create pthread in host failed \n");
       exit(1);
@@ -433,14 +433,14 @@ main(const int argc, const char **argv)
 
   gettimeofday(&t1, NULL);
 
-  for(i=starti;i < endi;i++){    
+  for(i=starti;i < endi;i++){
     memtest_control_t* mc = &memtest_ctl[i];
     clReleaseMemObject(mc->device_mem);
     clReleaseMemObject(mc->err_count);
     clReleaseMemObject(mc->err_addr);
     clReleaseMemObject(mc->err_expect);
     clReleaseMemObject(mc->err_current);
-    clReleaseMemObject(mc->err_second_read);    
+    clReleaseMemObject(mc->err_second_read);
     clFinish(queues[i]);
     clReleaseCommandQueue(queues[i]);
     clReleaseContext(contexts[i]);

--- a/src/cuda_memtest/ocl_memtest_kernels.cpp
+++ b/src/cuda_memtest/ocl_memtest_kernels.cpp
@@ -13,17 +13,17 @@
     err_expect[idx] = (unsigned long)expect;		\
     err_current[idx] = (unsigned long)current;		\
     err_second_read[idx] = (unsigned long)(*p);		\
-  }while(0) 
+  }while(0)
 
 __kernel void
-kernel_modtest_write(__global char* ptr, unsigned long memsize, 
+kernel_modtest_write(__global char* ptr, unsigned long memsize,
 		     unsigned int offset, TYPE p1, TYPE p2)
 {
-  int i;  
+  int i;
   __global TYPE* buf = (__global TYPE*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   
   for(i=idx;i < n; i+= total_num_threads){
     if ( (i+MOD_SZ-offset)%MOD_SZ == 0){
@@ -38,30 +38,30 @@ kernel_modtest_write(__global char* ptr, unsigned long memsize,
 }
 
 __kernel void
-kernel_modtest_read(__global char* ptr, unsigned long memsize, 
-		    unsigned int offset,  TYPE p1, TYPE p2, 
+kernel_modtest_read(__global char* ptr, unsigned long memsize,
+		    unsigned int offset,  TYPE p1, TYPE p2,
 		    volatile __global unsigned int* err_count,
-		    __global unsigned long* err_addr, 
+		    __global unsigned long* err_addr,
 		    __global unsigned long* err_expect,
-		    __global unsigned long* err_current, 
+		    __global unsigned long* err_current,
 		    __global unsigned long* err_second_read)
 {
-  int i;  
+  int i;
   __global TYPE* buf = (__global TYPE*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   
   TYPE localp;
   for(i=idx;i < n; i+= total_num_threads){
     localp = buf[i];
     if ( (i+MOD_SZ-offset)%MOD_SZ == 0){
       if(localp != p1){
-	RECORD_ERR(err_count, &buf[i], p1, localp);     
+	RECORD_ERR(err_count, &buf[i], p1, localp);
       }
     }else{
       if (localp != p2){
-	RECORD_ERR(err_count, &buf[i], p2, localp);     	
+	RECORD_ERR(err_count, &buf[i], p2, localp);
       }
     }
   }
@@ -74,11 +74,11 @@ kernel_modtest_read(__global char* ptr, unsigned long memsize,
 __kernel void
 kernel_write(__global char* ptr, unsigned long memsize, TYPE p1)
 {
-  int i;  
+  int i;
   __global TYPE* buf = (__global TYPE*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   
   for(i=idx;i < n; i+= total_num_threads){
     buf[i] = p1;
@@ -90,11 +90,11 @@ kernel_write(__global char* ptr, unsigned long memsize, TYPE p1)
 
 
 __kernel void
-kernel_readwrite(__global char* ptr, unsigned long memsize, TYPE p1, TYPE p2, 
+kernel_readwrite(__global char* ptr, unsigned long memsize, TYPE p1, TYPE p2,
 		 volatile __global unsigned int* err_count,
-		 __global unsigned long* err_addr, 
+		 __global unsigned long* err_addr,
 		 __global unsigned long* err_expect,
-		 __global unsigned long* err_current, 
+		 __global unsigned long* err_current,
 		 __global unsigned long* err_second_read)
 {
   
@@ -102,7 +102,7 @@ kernel_readwrite(__global char* ptr, unsigned long memsize, TYPE p1, TYPE p2,
   __global TYPE* buf = (__global TYPE*) ptr;
   int idx = get_global_id(0);
   unsigned long n =  memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   TYPE localp;
   
   for(i=idx;i < n;i += total_num_threads){
@@ -110,22 +110,22 @@ kernel_readwrite(__global char* ptr, unsigned long memsize, TYPE p1, TYPE p2,
     localp = buf[i];
     
     if (localp != p1){
-      RECORD_ERR(err_count, &buf[i], p1, localp);      
+      RECORD_ERR(err_count, &buf[i], p1, localp);
     }
     
     buf[i] = p2;
-  }  
+  }
   
 
-}  
+}
 
 
 __kernel void
 kernel_read(__global char* ptr, unsigned long memsize, TYPE p1,
 	    volatile __global unsigned int* err_count,
-	    __global unsigned long* err_addr, 
+	    __global unsigned long* err_addr,
 	    __global unsigned long* err_expect,
-	    __global unsigned long* err_current, 
+	    __global unsigned long* err_current,
 	    __global unsigned long* err_second_read)
 {
   
@@ -133,27 +133,27 @@ kernel_read(__global char* ptr, unsigned long memsize, TYPE p1,
   __global TYPE* buf = (__global TYPE*) ptr;
   int idx = get_global_id(0);
   unsigned long n =  memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   TYPE localp;
   
-  for(i=idx;i < n;i += total_num_threads){    
-    localp = buf[i];    
+  for(i=idx;i < n;i += total_num_threads){
+    localp = buf[i];
     if (localp != p1){
-      RECORD_ERR(err_count, &buf[i], p1, localp);      
-    }    
-  }  
+      RECORD_ERR(err_count, &buf[i], p1, localp);
+    }
+  }
   
 
-}  
+}
 
 __kernel void
 kernel7_write(__global char* ptr, unsigned long memsize)
 {
-  int i;  
+  int i;
   __global TYPE* buf = (__global TYPE*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   int rand_data_num =BLOCKSIZE/sizeof(TYPE);
   
   for(i=idx;i < n; i+= total_num_threads){
@@ -168,11 +168,11 @@ kernel7_write(__global char* ptr, unsigned long memsize)
 }
 
 __kernel void
-kernel7_readwrite(__global char* ptr, unsigned long memsize, 
+kernel7_readwrite(__global char* ptr, unsigned long memsize,
 		 volatile __global unsigned int* err_count,
-		 __global unsigned long* err_addr, 
+		 __global unsigned long* err_addr,
 		 __global unsigned long* err_expect,
-		 __global unsigned long* err_current, 
+		 __global unsigned long* err_current,
 		 __global unsigned long* err_second_read)
 {
   
@@ -180,7 +180,7 @@ kernel7_readwrite(__global char* ptr, unsigned long memsize,
   __global TYPE* buf = (__global TYPE*) ptr;
   int idx = get_global_id(0);
   unsigned long n =  memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   TYPE localp, expected;
   int rand_data_num =BLOCKSIZE/sizeof(TYPE);
   
@@ -191,22 +191,22 @@ kernel7_readwrite(__global char* ptr, unsigned long memsize,
     localp = buf[i];
     expected = buf[i%rand_data_num];
     if (localp != expected){
-      RECORD_ERR(err_count, &buf[i], expected, localp);      
+      RECORD_ERR(err_count, &buf[i], expected, localp);
     }
     
     buf[i] = ~expected;
-  }  
+  }
   
 }
 
 
 
 __kernel void
-kernel7_read(__global char* ptr, unsigned long memsize, 
+kernel7_read(__global char* ptr, unsigned long memsize,
 	     volatile __global unsigned int* err_count,
-	     __global unsigned long* err_addr, 
+	     __global unsigned long* err_addr,
 	     __global unsigned long* err_expect,
-	     __global unsigned long* err_current, 
+	     __global unsigned long* err_current,
 	     __global unsigned long* err_second_read)
 {
   
@@ -214,7 +214,7 @@ kernel7_read(__global char* ptr, unsigned long memsize,
   __global TYPE* buf = (__global TYPE*) ptr;
   int idx = get_global_id(0);
   unsigned long n =  memsize/sizeof(TYPE);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   TYPE localp, expected;
   int rand_data_num =BLOCKSIZE/sizeof(TYPE);
   
@@ -225,10 +225,10 @@ kernel7_read(__global char* ptr, unsigned long memsize,
     localp = buf[i];
     expected = ~(buf[i%rand_data_num]);
     if (localp != expected){
-      RECORD_ERR(err_count, &buf[i], expected, localp);      
+      RECORD_ERR(err_count, &buf[i], expected, localp);
     }
     
-  }  
+  }
   
 }
 
@@ -238,12 +238,12 @@ __kernel void
 kernel_movinv32_write(__global char* ptr, unsigned long memsize, unsigned int pattern,
 		      unsigned int lb, unsigned int sval, unsigned int offset)
 {
-  int i;  
+  int i;
   __global unsigned int* buf = (__global unsigned int*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(unsigned int);
-  int total_num_threads = get_global_size(0);  
-  //assume total_num_threads can be devided by 32, which is true for our purpose 
+  int total_num_threads = get_global_size(0);
+  //assume total_num_threads can be devided by 32, which is true for our purpose
   //then all memories written by this thread will have the same data
   unsigned int pat = pattern;
   unsigned int k=offset;
@@ -272,17 +272,17 @@ __kernel void
 kernel_movinv32_readwrite(__global char* ptr, unsigned long memsize, unsigned int pattern,
 			  unsigned int lb, unsigned int sval, unsigned int offset,
 			  volatile __global unsigned int* err_count,
-			  __global unsigned long* err_addr, 
+			  __global unsigned long* err_addr,
 			  __global unsigned long* err_expect,
-			  __global unsigned long* err_current, 
+			  __global unsigned long* err_current,
 			  __global unsigned long* err_second_read)
 {
-  int i;  
+  int i;
   __global unsigned int* buf = (__global unsigned int*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(unsigned int);
-  int total_num_threads = get_global_size(0);  
-  //assume total_num_threads can be devided by 32, which is true for our purpose 
+  int total_num_threads = get_global_size(0);
+  //assume total_num_threads can be devided by 32, which is true for our purpose
   //then all memories written by this thread will have the same data
   unsigned int pat = pattern;
   unsigned int k=offset;
@@ -299,7 +299,7 @@ kernel_movinv32_readwrite(__global char* ptr, unsigned long memsize, unsigned in
   for(i=idx;i < n; i+= total_num_threads){
     unsigned int localp = buf[i];
     if (localp != pat){
-      RECORD_ERR(err_count, &buf[i], pat, localp);      
+      RECORD_ERR(err_count, &buf[i], pat, localp);
     }
     buf[i] = ~pat;
   }
@@ -315,17 +315,17 @@ __kernel void
 kernel_movinv32_read(__global char* ptr, unsigned long memsize, unsigned int pattern,
 		     unsigned int lb, unsigned int sval, unsigned int offset,
 		     volatile __global unsigned int* err_count,
-		     __global unsigned long* err_addr, 
+		     __global unsigned long* err_addr,
 		     __global unsigned long* err_expect,
-		     __global unsigned long* err_current, 
+		     __global unsigned long* err_current,
 		     __global unsigned long* err_second_read)
 {
-  int i;  
+  int i;
   __global unsigned int* buf = (__global unsigned int*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(unsigned int);
-  int total_num_threads = get_global_size(0);  
-  //assume total_num_threads can be devided by 32, which is true for our purpose 
+  int total_num_threads = get_global_size(0);
+  //assume total_num_threads can be devided by 32, which is true for our purpose
   //then all memories written by this thread will have the same data
   unsigned int pat = pattern;
   unsigned int k=offset;
@@ -342,7 +342,7 @@ kernel_movinv32_read(__global char* ptr, unsigned long memsize, unsigned int pat
   for(i=idx;i < n; i+= total_num_threads){
     unsigned int localp = buf[i];
     if (localp != ~pat){
-      RECORD_ERR(err_count, &buf[i], ~pat, localp);      
+      RECORD_ERR(err_count, &buf[i], ~pat, localp);
     }
   }
   
@@ -356,11 +356,11 @@ kernel_movinv32_read(__global char* ptr, unsigned long memsize, unsigned int pat
 __kernel void
 kernel5_init(__global char* ptr, unsigned long memsize)
 {
-  int i;  
+  int i;
   __global unsigned int * buf = (__global unsigned int*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/64;
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
 
   unsigned int p1 =1;
   unsigned int p2;
@@ -393,10 +393,10 @@ kernel5_init(__global char* ptr, unsigned long memsize)
 __kernel void
 kernel5_move(__global char* ptr, unsigned long memsize)
 {
-  int i, j;  
+  int i, j;
   int idx = get_global_id(0);
   unsigned long n = memsize/BLOCKSIZE;
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   //each thread is responsible for moving within 1 BLOCKSIZE
   unsigned int half_count = BLOCKSIZE/sizeof(unsigned int)/2;
   for(i=idx;i < n; i+= total_num_threads){
@@ -424,16 +424,16 @@ kernel5_move(__global char* ptr, unsigned long memsize)
 __kernel void
 kernel5_check(__global char* ptr, unsigned long memsize,
 	      volatile __global unsigned int* err_count,
-	      __global unsigned long* err_addr, 
+	      __global unsigned long* err_addr,
 	      __global unsigned long* err_expect,
-	      __global unsigned long* err_current, 
+	      __global unsigned long* err_current,
 	      __global unsigned long* err_second_read)
 {
-  int i;  
+  int i;
   __global unsigned int * buf = (__global unsigned int*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/(2*sizeof(unsigned int));
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   
   for(i=idx;i < n; i+= total_num_threads){
     if (buf[2*i] != buf[2*i+1]){
@@ -447,13 +447,13 @@ kernel5_check(__global char* ptr, unsigned long memsize,
 
 
 __kernel void
-kernel1_write(__global char* ptr, unsigned long memsize) 
+kernel1_write(__global char* ptr, unsigned long memsize)
 {
-  int i;  
+  int i;
   __global unsigned long* buf = (__global unsigned long*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(unsigned long);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   
   for(i=idx;i < n; i+= total_num_threads){
     buf[i] = (unsigned long)(buf+i);
@@ -466,16 +466,16 @@ kernel1_write(__global char* ptr, unsigned long memsize)
 __kernel void
 kernel1_read(__global char* ptr, unsigned long memsize,
 	     volatile __global unsigned int* err_count,
-	     __global unsigned long* err_addr, 
+	     __global unsigned long* err_addr,
 	     __global unsigned long* err_expect,
-	     __global unsigned long* err_current, 
-	     __global unsigned long* err_second_read)	     
+	     __global unsigned long* err_current,
+	     __global unsigned long* err_second_read)
 {
-  int i;  
+  int i;
   __global unsigned long* buf = (__global unsigned long*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/sizeof(unsigned long);
-  int total_num_threads = get_global_size(0);  
+  int total_num_threads = get_global_size(0);
   
   for(i=idx;i < n; i+= total_num_threads){
     if( buf[i] != (unsigned long)(buf+i)){
@@ -487,14 +487,14 @@ kernel1_read(__global char* ptr, unsigned long memsize,
     
 }
 
-/*FIXME: 
+/*FIXME:
   when the @myp is replace by p, the write does not go through
   need more investigation on this when you have time
 */
 
 
 __kernel void
-kernel0_global_write(__global char* ptr, unsigned long memsize) 
+kernel0_global_write(__global char* ptr, unsigned long memsize)
 {
   __global unsigned int* p = (__global unsigned int*)ptr;
   __global unsigned int* end_p = (__global unsigned int*)(ptr + memsize);
@@ -521,7 +521,7 @@ kernel0_global_write(__global char* ptr, unsigned long memsize)
     }
     
     *myp = pattern;
-    pattern = pattern <<1;    
+    pattern = pattern <<1;
     mask = (mask << 1);
     if (mask == 0){
       break;
@@ -536,10 +536,10 @@ kernel0_global_write(__global char* ptr, unsigned long memsize)
 __kernel void
 kernel0_global_read(__global char* ptr, unsigned long memsize,
 		    volatile __global unsigned int* err_count,
-		    __global unsigned long* err_addr, 
+		    __global unsigned long* err_addr,
 		    __global unsigned long* err_expect,
-		    __global unsigned long* err_current, 
-		    __global unsigned long* err_second_read)			    
+		    __global unsigned long* err_current,
+		    __global unsigned long* err_second_read)
 {
 
    __global unsigned int* p = (__global unsigned int*)ptr;
@@ -571,7 +571,7 @@ kernel0_global_read(__global char* ptr, unsigned long memsize,
       RECORD_ERR(err_count, p, pattern, *p);
     }
 
-    pattern = pattern <<1;    
+    pattern = pattern <<1;
     mask = (mask << 1);
     if (mask == 0){
       break;
@@ -585,9 +585,9 @@ kernel0_global_read(__global char* ptr, unsigned long memsize,
 
 //each thread is responsible for 1 BLOCKSIZE each time
 __kernel void
-kernel0_local_write(__global char* ptr, unsigned long memsize) 
+kernel0_local_write(__global char* ptr, unsigned long memsize)
 {
-  int i;  
+  int i;
   __global unsigned long* buf = (__global unsigned long*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/BLOCKSIZE;
@@ -619,7 +619,7 @@ kernel0_local_write(__global char* ptr, unsigned long memsize)
       }
       
       *p = pattern;
-      pattern = pattern <<1;    
+      pattern = pattern <<1;
       mask = (mask << 1);
       if (mask == 0){
 	break;
@@ -632,12 +632,12 @@ kernel0_local_write(__global char* ptr, unsigned long memsize)
 __kernel void
 kernel0_local_read(__global char* ptr, unsigned long memsize,
 		   volatile __global unsigned int* err_count,
-		   __global unsigned long* err_addr, 
+		   __global unsigned long* err_addr,
 		   __global unsigned long* err_expect,
-		   __global unsigned long* err_current, 
-		   __global unsigned long* err_second_read)		   
+		   __global unsigned long* err_current,
+		   __global unsigned long* err_second_read)
 {
-  int i;  
+  int i;
   __global unsigned long* buf = (__global unsigned long*)ptr;
   int idx = get_global_id(0);
   unsigned long n = memsize/BLOCKSIZE;
@@ -675,7 +675,7 @@ kernel0_local_read(__global char* ptr, unsigned long memsize,
 	RECORD_ERR(err_count, p, pattern, *p);
       }
 
-      pattern = pattern <<1;    
+      pattern = pattern <<1;
       mask = (mask << 1);
       if (mask == 0){
 	break;

--- a/src/cuda_memtest/ocl_tests.cpp
+++ b/src/cuda_memtest/ocl_tests.cpp
@@ -21,10 +21,10 @@ __thread char time_buf[128];
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 extern unsigned int exit_on_error;
 
-extern char hostname[];  
+extern char hostname[];
 extern char* time_string(void);
 
-unsigned int 
+unsigned int
 error_checking(memtest_control_t* mc)
 {
   int i;
@@ -42,7 +42,7 @@ error_checking(memtest_control_t* mc)
   rc = clEnqueueReadBuffer(queue, mc->err_current, CL_TRUE, 0, sizeof(cl_ulong)*MAX_ERR_RECORD_COUNT, host_err_current, 0, NULL, NULL); CLERR;
   rc = clEnqueueReadBuffer(queue, mc->err_second_read, CL_TRUE, 0, sizeof(cl_ulong)*MAX_ERR_RECORD_COUNT, host_err_second_read, 0, NULL, NULL); CLERR;
   
-  if (host_err_count >0){    
+  if (host_err_count >0){
     PRINTF("ERROR: error_count=%d\n", host_err_count);
     PRINTF("ERROR: the last %d error addresses are:\t", MIN(MAX_ERR_RECORD_COUNT, host_err_count));
     
@@ -58,7 +58,7 @@ error_checking(memtest_control_t* mc)
     }
     
     host_err_count = 0;
-    rc = clEnqueueWriteBuffer(queue, mc->err_count, CL_TRUE, 0, sizeof(cl_uint), &host_err_count, 0, NULL, NULL); CLERR;    
+    rc = clEnqueueWriteBuffer(queue, mc->err_count, CL_TRUE, 0, sizeof(cl_uint), &host_err_count, 0, NULL, NULL); CLERR;
     if (exit_on_error){
       PRINTF("Error Found in Memtest, exiting\n");
       exit(1);
@@ -137,7 +137,7 @@ move_inv_test(memtest_control_t* mc, TYPE p1)
   rc = clSetKernelArg(read_write_kernel, 5, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(read_write_kernel, 6, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(read_write_kernel, 7, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(read_write_kernel, 8, sizeof(cl_mem), &mc->err_second_read); CLERR;    
+  rc = clSetKernelArg(read_write_kernel, 8, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, read_write_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   p1 = p2;
   
@@ -191,13 +191,13 @@ test0(memtest_control_t* mc)
   rc = clSetKernelArg(global_read_kernel, 3, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(global_read_kernel, 4, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(global_read_kernel, 5, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(global_read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(global_read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, global_read_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   clFinish(queue);
   err_count = error_checking(mc);
   
 
-  PRINTF("Test0: local walk test\n");  
+  PRINTF("Test0: local walk test\n");
   cl_kernel local_write_kernel = clCreateKernel(program, "kernel0_local_write", &rc); CLERR;
   cl_kernel local_read_kernel = clCreateKernel(program, "kernel0_local_read", &rc); CLERR;
   global_work_size[0] = 64*1024;
@@ -213,7 +213,7 @@ test0(memtest_control_t* mc)
   rc = clSetKernelArg(local_read_kernel, 3, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(local_read_kernel, 4, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(local_read_kernel, 5, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(local_read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(local_read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, local_read_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   clFinish(queue);
   err_count = error_checking(mc);
@@ -236,7 +236,7 @@ test0(memtest_control_t* mc)
  ********************************************************************************/
 void
 test1(memtest_control_t* mc)
-{  
+{
   cl_int rc;
   int err_count = 0;
   cl_program program=mc->program;
@@ -257,7 +257,7 @@ test1(memtest_control_t* mc)
   rc = clSetKernelArg(read_kernel, 3, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(read_kernel, 4, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(read_kernel, 5, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, read_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   clFinish(queue);
   err_count = error_checking(mc);
@@ -272,7 +272,7 @@ test1(memtest_control_t* mc)
  * ones and zeros.
  *
  ****************************************************************************/
-void 
+void
 test2(memtest_control_t* mc)
 {
   unsigned long p1 = 0;
@@ -287,10 +287,10 @@ test2(memtest_control_t* mc)
  * Test 3 [Moving inversions, 8 bit pat]
  * This is the same as test 1 but uses a 8 bit wide pattern of
  * "walking" ones and zeros.  This test will better detect subtle errors
- * in "wide" memory chips. 
+ * in "wide" memory chips.
  *
  **************************************************************************/
-void 
+void
 test3(memtest_control_t* mc)
 {
   unsigned long p0 = 0x80;
@@ -312,7 +312,7 @@ test3(memtest_control_t* mc)
  *************************************************************************************/
 
 //pretty much the same with test10
-void 
+void
 test4(memtest_control_t* mc)
 {
     int i;
@@ -336,12 +336,12 @@ test4(memtest_control_t* mc)
  * only after the memory moves are completed it is not possible to know
  * where the error occurred.  The addresses reported are only for where the
  * bad pattern was found.
- * 
+ *
  *
  *************************************************************************************/
 
 
-void 
+void
 test5(memtest_control_t* mc)
 {
   cl_int rc;
@@ -369,7 +369,7 @@ test5(memtest_control_t* mc)
   rc = clSetKernelArg(check_kernel, 3, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(check_kernel, 4, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(check_kernel, 5, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(check_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(check_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, check_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   clFinish(queue);
   err_count = error_checking(mc);
@@ -429,7 +429,7 @@ movinv32(memtest_control_t* mc, unsigned int pattern,
   rc = clSetKernelArg(readwrite_kernel, 7, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(readwrite_kernel, 8, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(readwrite_kernel, 9, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(readwrite_kernel, 10, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(readwrite_kernel, 10, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, readwrite_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   
   rc = clSetKernelArg(read_kernel, 0, sizeof(cl_mem), &mc->device_mem); CLERR;
@@ -442,7 +442,7 @@ movinv32(memtest_control_t* mc, unsigned int pattern,
   rc = clSetKernelArg(read_kernel, 7, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(read_kernel, 8, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(read_kernel, 9, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(read_kernel, 10, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(read_kernel, 10, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, read_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   clFinish(queue);
   err_count = error_checking(mc);
@@ -456,7 +456,7 @@ movinv32(memtest_control_t* mc, unsigned int pattern,
 }
 
 
-void 
+void
 test6(memtest_control_t* mc)
 {
   unsigned int i;
@@ -487,7 +487,7 @@ test6(memtest_control_t* mc)
  *******************************************************************************/
 
 
-void 
+void
 test7(memtest_control_t* mc)
 {
   int i;
@@ -523,7 +523,7 @@ test7(memtest_control_t* mc)
   rc = clSetKernelArg(readwrite_kernel, 3, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(readwrite_kernel, 4, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(readwrite_kernel, 5, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(readwrite_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(readwrite_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, readwrite_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   
   rc = clSetKernelArg(read_kernel, 0, sizeof(cl_mem), &mc->device_mem); CLERR;
@@ -532,7 +532,7 @@ test7(memtest_control_t* mc)
   rc = clSetKernelArg(read_kernel, 3, sizeof(cl_mem), &mc->err_addr); CLERR;
   rc = clSetKernelArg(read_kernel, 4, sizeof(cl_mem), &mc->err_expect); CLERR;
   rc = clSetKernelArg(read_kernel, 5, sizeof(cl_mem), &mc->err_current); CLERR;
-  rc = clSetKernelArg(read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;  
+  rc = clSetKernelArg(read_kernel, 6, sizeof(cl_mem), &mc->err_second_read); CLERR;
   rc = clEnqueueNDRangeKernel(queue, read_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
   clFinish(queue);
   err_count = error_checking(mc);
@@ -573,14 +573,14 @@ modtest(memtest_control_t* mc, unsigned int offset,  TYPE p1, TYPE p2)
   
   rc = clSetKernelArg(write_kernel, 0, sizeof(cl_mem), &mc->device_mem); CLERR;
   rc = clSetKernelArg(write_kernel, 1, sizeof(cl_ulong), &mc->mem_size); CLERR;
-  rc = clSetKernelArg(write_kernel, 2, sizeof(unsigned int), &offset); CLERR;  
+  rc = clSetKernelArg(write_kernel, 2, sizeof(unsigned int), &offset); CLERR;
   rc = clSetKernelArg(write_kernel, 3, sizeof(TYPE), &p1); CLERR;
   rc = clSetKernelArg(write_kernel, 4, sizeof(TYPE), &p2); CLERR;
   rc = clEnqueueNDRangeKernel(queue, write_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL); CLERR;
   
   rc = clSetKernelArg(read_kernel, 0, sizeof(cl_mem), &mc->device_mem); CLERR;
   rc = clSetKernelArg(read_kernel, 1, sizeof(cl_ulong), &mc->mem_size); CLERR;
-  rc = clSetKernelArg(read_kernel, 2, sizeof(unsigned int), &offset); CLERR;  
+  rc = clSetKernelArg(read_kernel, 2, sizeof(unsigned int), &offset); CLERR;
   rc = clSetKernelArg(read_kernel, 3, sizeof(TYPE), &p1); CLERR;
   rc = clSetKernelArg(read_kernel, 4, sizeof(TYPE), &p2); CLERR;
   rc = clSetKernelArg(read_kernel, 5, sizeof(cl_mem), &mc->err_count); CLERR;
@@ -720,7 +720,7 @@ test9(memtest_control_t* mc)
  * written as to achieve the maximum bandwidth between the global memory and GPU.
  * This will increase the chance of catching software error. In practice, we found this test quite useful
  * to flush hardware errors as well.
- * 
+ *
  */
   
 void test10(memtest_control_t* mc)
@@ -742,7 +742,7 @@ void test10(memtest_control_t* mc)
   size_t global_work_size[1] = {64*1024};
   size_t local_work_size[1] = {64};
   
-  cl_program program = mc->program;  
+  cl_program program = mc->program;
   cl_kernel write_kernel = clCreateKernel(program, "kernel_write", &rc); CLERR;
   cl_kernel read_write_kernel = clCreateKernel(program, "kernel_readwrite", &rc); CLERR;
   cl_kernel read_kernel = clCreateKernel(program, "kernel_read", &rc); CLERR;
@@ -764,7 +764,7 @@ void test10(memtest_control_t* mc)
     rc = clSetKernelArg(read_write_kernel, 5, sizeof(cl_mem), &mc->err_addr); CLERR;
     rc = clSetKernelArg(read_write_kernel, 6, sizeof(cl_mem), &mc->err_expect); CLERR;
     rc = clSetKernelArg(read_write_kernel, 7, sizeof(cl_mem), &mc->err_current); CLERR;
-    rc = clSetKernelArg(read_write_kernel, 8, sizeof(cl_mem), &mc->err_second_read); CLERR;    
+    rc = clSetKernelArg(read_write_kernel, 8, sizeof(cl_mem), &mc->err_second_read); CLERR;
     rc = clEnqueueNDRangeKernel(queue, read_write_kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL);CLERR;
     p1 = p2;
     p2 = ~p1;
@@ -814,7 +814,7 @@ void* run_tests(void* arg)
   struct timeval t0, t1;
   unsigned int pass = 0;
   int i;
-  while(1){   
+  while(1){
     for (i = 0;i < DIM(cuda_memtests); i++){
       if (cuda_memtests[i].enabled){
 	PRINTF("%s\n", cuda_memtests[i].desc);
@@ -834,6 +834,6 @@ void* run_tests(void* arg)
     if (pass >= num_passes){
       break;
     }
-  }  
+  }
   return NULL;
   }

--- a/src/cuda_memtest/ocl_tests.h
+++ b/src/cuda_memtest/ocl_tests.h
@@ -28,14 +28,14 @@ extern "C" {
     err_expect[idx] = (unsigned long)expect;		\
     err_current[idx] = (unsigned long)current;		\
     err_second_read[idx] = (unsigned long)(*p);		\
-  }while(0) 
+  }while(0)
   
 #define PRINTF(fmt,...) do{                                             \
     pthread_mutex_lock(&mutex);						\
     printf("[%s][%s][%d]:"fmt, time_string(), hostname, mc->device_idx, ##__VA_ARGS__); \
     fflush(stdout);							\
     pthread_mutex_unlock(&mutex);                                       \
-  } while(0) 
+  } while(0)
 
 
   
@@ -46,7 +46,7 @@ extern "C" {
     printf("ERROR: opencl call failed with rc(%d), line %d, file %s\n", rc, __LINE__, __FILE__); \
     printf("Error: %s\n", print_cl_errstring(rc));			\
     exit(1);                                                            \
-  }  
+  }
 
 #define DIM(x) (sizeof(x)/sizeof(x[0]))
   
@@ -63,7 +63,7 @@ extern "C" {
     cl_mem err_second_read;
     cl_ulong mem_size;
     cl_program program;
-    cl_event events[MAX_NUM_KERNELS];    
+    cl_event events[MAX_NUM_KERNELS];
   }memtest_control_t;
   
   void test10(memtest_control_t*);

--- a/src/cuda_memtest/sanity_check.sh
+++ b/src/cuda_memtest/sanity_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script do a quick check if one GPU or all GPUs are in good health.
 # usage: ./sanity_check.sh 0   //check GPU 0
-#        ./sanity_check.sh 1   //check GPU 1 
+#        ./sanity_check.sh 1   //check GPU 1
 #        ./sanity_check.sh     //check All GPUs in the system
 
 

--- a/src/cuda_memtest/tests.cu
+++ b/src/cuda_memtest/tests.cu
@@ -8,18 +8,18 @@
  *
  * Developed by:
  *
- * Innovative Systems Lab  
- * National Center for Supercomputing Applications  
+ * Innovative Systems Lab
+ * National Center for Supercomputing Applications
  * http://www.ncsa.uiuc.edu/AboutUs/Directorates/ISL.html
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of 
- * this software and associated documentation files (the "Software"), to deal with 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal with
  * the Software without restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the 
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
  * Software, and to permit persons to whom the Software is furnished to do so, subject
  * to the following conditions:
  *
- * * Redistributions of source code must retain the above copyright notice, this list 
+ * * Redistributions of source code must retain the above copyright notice, this list
  * of conditions and the following disclaimers.
  *
  * * Redistributions in binary form must reproduce the above copyright notice, this list
@@ -30,11 +30,11 @@
  * Applications, nor the names of its contributors may be used to endorse or promote products
  * derived from this Software without specific prior written permission.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
  * PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
- * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS WITH THE SOFTWARE.
  */
 
@@ -81,7 +81,7 @@ extern char driver_info[MAX_STR_LEN];
 	err_expect[idx] = (unsigned long)expect;	\
 	err_current[idx] = (unsigned long)current;	\
 	err_second_read[idx] = (unsigned long)(*p);	\
-}while(0) 
+}while(0)
 
 
 #endif
@@ -98,14 +98,14 @@ time_string(void)
 	fprintf(stderr, "ERROR: in getting time\n");
 	exit(ERR_GENERAL);
     }
-    sprintf(time_buf, "%02d/%02d/%04d %02d:%02d:%02d", 
-	     tm.tm_mon + 1, tm.tm_mday, tm.tm_year + 1900,tm.tm_hour, tm.tm_min, tm.tm_sec);        
+    sprintf(time_buf, "%02d/%02d/%04d %02d:%02d:%02d",
+	     tm.tm_mon + 1, tm.tm_mday, tm.tm_year + 1900,tm.tm_hour, tm.tm_min, tm.tm_sec);
 
     return time_buf;
 }
 
 
-unsigned int 
+unsigned int
 error_checking(const char* msg, unsigned int blockidx)
 {
     unsigned int err = 0;
@@ -137,22 +137,22 @@ error_checking(const char* msg, unsigned int blockidx)
 	emsg += sprintf(emsg, "ERROR: (%s) %d errors found in block %d\n", msg, err, blockidx);
 	
 	FPRINTF("ERROR: the last %d error addresses are:\t", MIN(MAX_ERR_RECORD_COUNT, err));
-	emsg += sprintf(emsg, "ERROR: the last %d error addresses are:\t", MIN(MAX_ERR_RECORD_COUNT, err));	
+	emsg += sprintf(emsg, "ERROR: the last %d error addresses are:\t", MIN(MAX_ERR_RECORD_COUNT, err));
 	
 	for (i =0;i < MIN(MAX_ERR_RECORD_COUNT, err); i++){
 	    fprintf(stderr, "%p\t", (void*)host_err_addr[i]);
-	    emsg += sprintf(emsg, "%p\t", (void*)host_err_addr[i]);	    
+	    emsg += sprintf(emsg, "%p\t", (void*)host_err_addr[i]);
 	}
 	fprintf(stderr, "\n");
 	emsg += sprintf(emsg, "\n");
 	
 	for (i =0; i < MIN(MAX_ERR_RECORD_COUNT, err); i++){
-	    FPRINTF("ERROR: %dth error, expected value=0x%lx, current value=0x%lx, diff=0x%lx (second_read=0x%lx, expect=0x%lx, diff with expected value=0x%lx)\n", 
-		    i, host_err_expect[i], host_err_current[i], host_err_expect[i] ^ host_err_current[i], 
-		    host_err_second_read[i], host_err_expect[i]  , host_err_expect[i] ^ host_err_second_read[i]); 
-	    emsg += sprintf(emsg, "ERROR: %dth error, expected value=0x%lx, current value=0x%lx, diff=0x%lx (second_read=0x%lx, expect=0x%lx, diff with expected value=0x%lx)\n", 
+	    FPRINTF("ERROR: %dth error, expected value=0x%lx, current value=0x%lx, diff=0x%lx (second_read=0x%lx, expect=0x%lx, diff with expected value=0x%lx)\n",
+		    i, host_err_expect[i], host_err_current[i], host_err_expect[i] ^ host_err_current[i],
+		    host_err_second_read[i], host_err_expect[i]  , host_err_expect[i] ^ host_err_second_read[i]);
+	    emsg += sprintf(emsg, "ERROR: %dth error, expected value=0x%lx, current value=0x%lx, diff=0x%lx (second_read=0x%lx, expect=0x%lx, diff with expected value=0x%lx)\n",
 			    i, host_err_expect[i], host_err_current[i], host_err_expect[i] ^ host_err_current[i],
-			    host_err_second_read[i], host_err_expect[i], host_err_expect[i] ^ host_err_second_read[i]); 			    
+			    host_err_second_read[i], host_err_expect[i], host_err_expect[i] ^ host_err_second_read[i]);
 
 	    
 	}
@@ -165,11 +165,11 @@ error_checking(const char* msg, unsigned int blockidx)
 		
 		FPRINTF("ERROR: reporting this error to %s\n", emails);
 		
-#define CMD_LENGTH (ERR_MSG_LENGTH + 256)	    
+#define CMD_LENGTH (ERR_MSG_LENGTH + 256)
 		char cmd[CMD_LENGTH];
 		error_msg[ERR_MSG_LENGTH -1] = 0;
 		snprintf(cmd, CMD_LENGTH, "echo \"%s cuda_memtest errors found in %s[%d]\n%s\" |%s -s \" cuda_memtest errors found in %s[%d]\" %s",
-			 time_string(), hostname,gpu_idx, error_msg, MAILFILE, hostname,gpu_idx, emails );		
+			 time_string(), hostname,gpu_idx, error_msg, MAILFILE, hostname,gpu_idx, emails );
 		system(cmd);
 		
 		firsttime = 0;
@@ -194,7 +194,7 @@ error_checking(const char* msg, unsigned int blockidx)
     return err;
 }
 
-unsigned int 
+unsigned int
 get_random_num(void)
 {
     struct timeval t0;
@@ -219,7 +219,7 @@ get_random_num_long(void)
     }
     
     unsigned int seed= (unsigned int)t0.tv_sec;
-    srand(seed);    
+    srand(seed);
  
     unsigned int a = rand_r(&seed);
     unsigned int b = rand_r(&seed);
@@ -234,7 +234,7 @@ get_random_num_long(void)
 
 
 
-__global__ void 
+__global__ void
 kernel_move_inv_write(char* _ptr, char* end_ptr, unsigned int pattern)
 {
     unsigned int i;
@@ -247,11 +247,11 @@ kernel_move_inv_write(char* _ptr, char* end_ptr, unsigned int pattern)
 	ptr[i] = pattern;
     }
     
-    return;    
+    return;
 }
 
 
-__global__ void 
+__global__ void
 kernel_move_inv_readwrite(char* _ptr, char* end_ptr, unsigned int p1, unsigned int p2, unsigned int* err,
 			  unsigned long* err_addr, unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
@@ -269,12 +269,12 @@ kernel_move_inv_readwrite(char* _ptr, char* end_ptr, unsigned int p1, unsigned i
 	
     }
     
-    return;    
+    return;
 }
 
 
-__global__ void 
-kernel_move_inv_read(char* _ptr, char* end_ptr,  unsigned int pattern, unsigned int* err, 
+__global__ void
+kernel_move_inv_read(char* _ptr, char* end_ptr,  unsigned int pattern, unsigned int* err,
 		     unsigned long* err_addr, unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read )
 {
     unsigned int i;
@@ -289,7 +289,7 @@ kernel_move_inv_read(char* _ptr, char* end_ptr,  unsigned int pattern, unsigned 
 	}
     }
     
-    return;    
+    return;
 }
 
 
@@ -305,7 +305,7 @@ move_inv_test(char* ptr, unsigned int tot_num_blocks, unsigned int p1, unsigned 
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_move_inv_write<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, p1); SYNC_CUERR;
-	SHOW_PROGRESS("move_inv_write", i, tot_num_blocks);	
+	SHOW_PROGRESS("move_inv_write", i, tot_num_blocks);
     }
     
     
@@ -313,16 +313,16 @@ move_inv_test(char* ptr, unsigned int tot_num_blocks, unsigned int p1, unsigned 
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_move_inv_readwrite<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, p1, p2, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	err += error_checking("move_inv_readwrite",  i);	
-	SHOW_PROGRESS("move_inv_readwrite", i, tot_num_blocks);	
+	err += error_checking("move_inv_readwrite",  i);
+	SHOW_PROGRESS("move_inv_readwrite", i, tot_num_blocks);
     }
     
     for (i=0;i < tot_num_blocks; i+= GRIDSIZE){
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_move_inv_read<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, p2, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	err += error_checking("move_inv_read",  i);	
-	SHOW_PROGRESS("move_inv_read", i, tot_num_blocks);	
+	err += error_checking("move_inv_read",  i);
+	SHOW_PROGRESS("move_inv_read", i, tot_num_blocks);
     }
         
     return err;
@@ -340,9 +340,9 @@ move_inv_test(char* ptr, unsigned int tot_num_blocks, unsigned int p1, unsigned 
 
 
 /*
-__global__ void 
+__global__ void
 kernel_test0_write(char* _ptr, char* end_ptr, unsigned int pattern,
-		   unsigned int* err, unsigned long* err_addr, 
+		   unsigned int* err, unsigned long* err_addr,
 		   unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
     unsigned int i;
@@ -357,13 +357,13 @@ kernel_test0_write(char* _ptr, char* end_ptr, unsigned int pattern,
 	ptr[i] = pattern;
     }
     
-    return;    
+    return;
 }
 
 
-__global__ void 
+__global__ void
 kernel_test0_readwrite(char* _ptr, char* end_ptr, unsigned int pattern, unsigned int prev_pattern,
-	     unsigned int* err, unsigned long* err_addr, 
+	     unsigned int* err, unsigned long* err_addr,
 	     unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
     unsigned int i;
@@ -381,7 +381,7 @@ kernel_test0_readwrite(char* _ptr, char* end_ptr, unsigned int pattern, unsigned
 	ptr[i] = pattern;
     }
     
-    return;    
+    return;
 }
 
 
@@ -408,8 +408,8 @@ test0(char* ptr, unsigned int tot_num_blocks)
 	    prev_pattern = pattern;
 	}
 
-	error_checking(__FUNCTION__,  i);	
-	SHOW_PROGRESS(__FUNCTION__, i, tot_num_blocks);	
+	error_checking(__FUNCTION__,  i);
+	SHOW_PROGRESS(__FUNCTION__, i, tot_num_blocks);
     }
     
     
@@ -418,7 +418,7 @@ test0(char* ptr, unsigned int tot_num_blocks)
 }
 */
 
-__global__ void 
+__global__ void
 kernel_test0_global_write(char* _ptr, char* _end_ptr)
 {
     
@@ -448,13 +448,13 @@ kernel_test0_global_write(char* _ptr, char* _end_ptr)
 	pattern = pattern << 1;
 	mask = mask << 1;
     }
-    return;    
+    return;
 }
 
-__global__ void 
+__global__ void
 kernel_test0_global_read(char* _ptr, char* _end_ptr, unsigned int* err, unsigned long* err_addr,
 			 unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
-{    
+{
     unsigned int* ptr = (unsigned int*)_ptr;
     unsigned int* end_ptr = (unsigned int*)_end_ptr;
     unsigned int* orig_ptr = ptr;
@@ -485,12 +485,12 @@ kernel_test0_global_read(char* _ptr, char* _end_ptr, unsigned int* err, unsigned
 	pattern = pattern << 1;
 	mask = mask << 1;
     }
-    return;    
+    return;
 }
 
 
 
-__global__ void 
+__global__ void
 kernel_test0_write(char* _ptr, char* end_ptr)
 {
     
@@ -498,7 +498,7 @@ kernel_test0_write(char* _ptr, char* end_ptr)
     unsigned int* ptr = orig_ptr;
     if (ptr >= (unsigned int*) end_ptr) {
 	return;
-    }   
+    }
   
     unsigned int* block_end = orig_ptr + BLOCKSIZE/sizeof(unsigned int);
     
@@ -524,11 +524,11 @@ kernel_test0_write(char* _ptr, char* end_ptr)
 	pattern = pattern << 1;
 	mask = mask << 1;
     }
-    return;    
+    return;
 }
 
 
-__global__ void 
+__global__ void
 kernel_test0_read(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* err_addr,
 		  unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
@@ -537,7 +537,7 @@ kernel_test0_read(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* e
     unsigned int* ptr = orig_ptr;
     if (ptr >= (unsigned int*) end_ptr) {
 	return;
-    }   
+    }
     
     unsigned int* block_end = orig_ptr + BLOCKSIZE/sizeof(unsigned int);
     
@@ -566,7 +566,7 @@ kernel_test0_read(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* e
 	pattern = pattern << 1;
 	mask = mask << 1;
     }
-    return;    
+    return;
 }
 
 
@@ -581,23 +581,23 @@ test0(char* ptr, unsigned int tot_num_blocks)
     //test global address
     kernel_test0_global_write<<<1, 1>>>(ptr, end_ptr); SYNC_CUERR;
     kernel_test0_global_read<<<1, 1>>>(ptr, end_ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-    error_checking("test0 on global address",  0);	
+    error_checking("test0 on global address",  0);
 
     for(int ite = 0;ite < num_iterations; ite++){
 	for (i=0;i < tot_num_blocks; i+= GRIDSIZE){
 	    dim3 grid;
 	    grid.x= GRIDSIZE;
 	    kernel_test0_write<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr); SYNC_CUERR;
-	    SHOW_PROGRESS("test0 on writing", i, tot_num_blocks);	
+	    SHOW_PROGRESS("test0 on writing", i, tot_num_blocks);
 	}
 
 	for (i=0;i < tot_num_blocks; i+= GRIDSIZE){
 	    dim3 grid;
 	    grid.x= GRIDSIZE;
 	    kernel_test0_read<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	    error_checking(__FUNCTION__,  i);	
-	    SHOW_PROGRESS("test0 on reading", i, tot_num_blocks);	
-	} 
+	    error_checking(__FUNCTION__,  i);
+	    SHOW_PROGRESS("test0 on reading", i, tot_num_blocks);
+	}
     }
     return;
     
@@ -612,7 +612,7 @@ test0(char* ptr, unsigned int tot_num_blocks)
  *
  ********************************************************************************/
 
-__global__ void 
+__global__ void
 kernel_test1_write(char* _ptr, char* end_ptr, unsigned int* err)
 {
     unsigned int i;
@@ -624,13 +624,13 @@ kernel_test1_write(char* _ptr, char* end_ptr, unsigned int* err)
     
     
     for (i = 0;i < BLOCKSIZE/sizeof(unsigned long); i++){
-	ptr[i] =(unsigned long) & ptr[i];			   	
+	ptr[i] =(unsigned long) & ptr[i];
     }
         
-    return;    
+    return;
 }
 
-__global__ void 
+__global__ void
 kernel_test1_read(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* err_addr,
 		  unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
@@ -648,12 +648,12 @@ kernel_test1_read(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* e
 	}
     }
     
-    return;    
+    return;
 }
 
 
 
-void 
+void
 test1(char* ptr, unsigned int tot_num_blocks)
 {
 
@@ -665,7 +665,7 @@ test1(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test1_write<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, err_count); SYNC_CUERR;
-	SHOW_PROGRESS("test1 on writing", i, tot_num_blocks);	
+	SHOW_PROGRESS("test1 on writing", i, tot_num_blocks);
 	
     }
     
@@ -673,8 +673,8 @@ test1(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test1_read<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	error_checking("test1 on reading",  i);	
-	SHOW_PROGRESS("test1 on reading", i, tot_num_blocks);	
+	error_checking("test1 on reading",  i);
+	SHOW_PROGRESS("test1 on reading", i, tot_num_blocks);
 	
     }
 
@@ -691,7 +691,7 @@ test1(char* ptr, unsigned int tot_num_blocks)
  *
  ****************************************************************************/
 
-void 
+void
 test2(char* ptr, unsigned int tot_num_blocks)
 {
     unsigned int p1 = 0;
@@ -700,7 +700,7 @@ test2(char* ptr, unsigned int tot_num_blocks)
     
     DEBUG_PRINTF("Test2: Moving inversions test, with pattern 0x%x and 0x%x\n", p1, p2);
     move_inv_test(ptr, tot_num_blocks, p1, p2);
-    DEBUG_PRINTF("Test2: Moving inversions test, with pattern 0x%x and 0x%x\n", p2, p1);    
+    DEBUG_PRINTF("Test2: Moving inversions test, with pattern 0x%x and 0x%x\n", p2, p1);
     move_inv_test(ptr, tot_num_blocks, p2, p1);
 
 }
@@ -711,12 +711,12 @@ test2(char* ptr, unsigned int tot_num_blocks)
  * Test 3 [Moving inversions, 8 bit pat]
  * This is the same as test 1 but uses a 8 bit wide pattern of
  * "walking" ones and zeros.  This test will better detect subtle errors
- * in "wide" memory chips. 
+ * in "wide" memory chips.
  *
  **************************************************************************/
 
 
-void 
+void
 test3(char* ptr, unsigned int tot_num_blocks)
 {
     unsigned int p0=0x80;
@@ -725,7 +725,7 @@ test3(char* ptr, unsigned int tot_num_blocks)
     
     DEBUG_PRINTF("Test3: Moving inversions test, with pattern 0x%x and 0x%x\n", p1, p2);
     move_inv_test(ptr, tot_num_blocks, p1, p2);
-    DEBUG_PRINTF("Test3: Moving inversions test, with pattern 0x%x and 0x%x\n", p2, p1);    
+    DEBUG_PRINTF("Test3: Moving inversions test, with pattern 0x%x and 0x%x\n", p2, p1);
     move_inv_test(ptr, tot_num_blocks, p2, p1);
 
 }
@@ -743,7 +743,7 @@ test3(char* ptr, unsigned int tot_num_blocks)
  *
  *************************************************************************************/
 
-void 
+void
 test4(char* ptr, unsigned int tot_num_blocks)
 {
     unsigned int p1;
@@ -765,8 +765,8 @@ test4(char* ptr, unsigned int tot_num_blocks)
     if (err == 0 && iteration == 0){
 	return;
     }
-    if (iteration < MAX_ITERATION){	
-	PRINTF("%dth repeating test4 because there are %d errors found in last run\n", iteration, err);	
+    if (iteration < MAX_ITERATION){
+	PRINTF("%dth repeating test4 because there are %d errors found in last run\n", iteration, err);
 	iteration++;
 	err = 0;
 	goto repeat;
@@ -785,12 +785,12 @@ test4(char* ptr, unsigned int tot_num_blocks)
  * only after the memory moves are completed it is not possible to know
  * where the error occurred.  The addresses reported are only for where the
  * bad pattern was found.
- * 
+ *
  *
  *************************************************************************************/
 
 
-__global__ void 
+__global__ void
 kernel_test5_init(char* _ptr, char* end_ptr)
 {
     unsigned int i;
@@ -798,7 +798,7 @@ kernel_test5_init(char* _ptr, char* end_ptr)
     
     if (ptr >= (unsigned int*) end_ptr) {
 	return;
-    }    
+    }
     
     unsigned int p1 = 1;
     for (i = 0;i < BLOCKSIZE/sizeof(unsigned int); i+=16){
@@ -819,7 +819,7 @@ kernel_test5_init(char* _ptr, char* end_ptr)
 	ptr[i+12] = p1;
 	ptr[i+13] = p1;
 	ptr[i+14] = p2;
-	ptr[i+15] = p2;	
+	ptr[i+15] = p2;
 	
 	p1 = p1<<1;
 	if (p1 == 0){
@@ -827,11 +827,11 @@ kernel_test5_init(char* _ptr, char* end_ptr)
 	}
     }
     
-    return;    
+    return;
 }
 
 
-__global__ void 
+__global__ void
 kernel_test5_move(char* _ptr, char* end_ptr)
 {
     unsigned int i;
@@ -839,7 +839,7 @@ kernel_test5_move(char* _ptr, char* end_ptr)
     
     if (ptr >= (unsigned int*) end_ptr) {
 	return;
-    }    
+    }
     
     unsigned int half_count = BLOCKSIZE/sizeof(unsigned int)/2;
     unsigned int* ptr_mid = ptr + half_count;
@@ -849,18 +849,18 @@ kernel_test5_move(char* _ptr, char* end_ptr)
     }
     
     for (i=0;i < half_count - 8; i++){
-	ptr[i + 8] = ptr_mid[i];	
+	ptr[i + 8] = ptr_mid[i];
     }
     
     for (i=0;i < 8; i++){
 	ptr[i] = ptr_mid[half_count - 8 + i];
     }
     
-    return;    
+    return;
 }
 
 
-__global__ void 
+__global__ void
 kernel_test5_check(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* err_addr,
 		   unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
@@ -869,7 +869,7 @@ kernel_test5_check(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* 
     
     if (ptr >= (unsigned int*) end_ptr) {
 	return;
-    }    
+    }
     
     for (i=0;i < BLOCKSIZE/sizeof(unsigned int); i+=2){
 	if (ptr[i] != ptr[i+1]){
@@ -877,7 +877,7 @@ kernel_test5_check(char* _ptr, char* end_ptr, unsigned int* err, unsigned long* 
 	}
     }
     
-    return;    
+    return;
 }
 
 
@@ -893,7 +893,7 @@ test5(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test5_init<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr); SYNC_CUERR;
-	SHOW_PROGRESS("test5[init]", i, tot_num_blocks);	
+	SHOW_PROGRESS("test5[init]", i, tot_num_blocks);
     }
     
     
@@ -901,7 +901,7 @@ test5(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test5_move<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr); SYNC_CUERR;
-	SHOW_PROGRESS("test5[move]", i, tot_num_blocks);	
+	SHOW_PROGRESS("test5[move]", i, tot_num_blocks);
     }
     
     
@@ -909,9 +909,9 @@ test5(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test5_check<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	error_checking("test5[check]",  i);	
-	SHOW_PROGRESS("test5[check]", i, tot_num_blocks);	
-    }    
+	error_checking("test5[check]",  i);
+	SHOW_PROGRESS("test5[check]", i, tot_num_blocks);
+    }
     
     return;
     
@@ -931,8 +931,8 @@ test5(char* ptr, unsigned int tot_num_blocks)
 
 
 
-__global__ void 
-kernel_movinv32_write(char* _ptr, char* end_ptr, unsigned int pattern, 
+__global__ void
+kernel_movinv32_write(char* _ptr, char* end_ptr, unsigned int pattern,
 		unsigned int lb, unsigned int sval, unsigned int offset)
 {
     unsigned int i;
@@ -956,12 +956,12 @@ kernel_movinv32_write(char* _ptr, char* end_ptr, unsigned int pattern,
 	}
     }
     
-    return;    
+    return;
 }
 
 
-__global__ void 
-kernel_movinv32_readwrite(char* _ptr, char* end_ptr, unsigned int pattern, 
+__global__ void
+kernel_movinv32_readwrite(char* _ptr, char* end_ptr, unsigned int pattern,
 			  unsigned int lb, unsigned int sval, unsigned int offset, unsigned int * err,
 			  unsigned long* err_addr, unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
@@ -991,14 +991,14 @@ kernel_movinv32_readwrite(char* _ptr, char* end_ptr, unsigned int pattern,
 	}
     }
     
-    return;    
+    return;
 }
 
 
 
-__global__ void 
-kernel_movinv32_read(char* _ptr, char* end_ptr, unsigned int pattern, 
-		     unsigned int lb, unsigned int sval, unsigned int offset, unsigned int * err, 
+__global__ void
+kernel_movinv32_read(char* _ptr, char* end_ptr, unsigned int pattern,
+		     unsigned int lb, unsigned int sval, unsigned int offset, unsigned int * err,
 		     unsigned long* err_addr, unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
     unsigned int i;
@@ -1025,15 +1025,15 @@ kernel_movinv32_read(char* _ptr, char* end_ptr, unsigned int pattern,
 	}
     }
     
-    return;    
+    return;
 }
 
 
 
 void
-movinv32(char* ptr, unsigned int tot_num_blocks, unsigned int pattern, 
+movinv32(char* ptr, unsigned int tot_num_blocks, unsigned int pattern,
 	 unsigned int lb, unsigned int sval, unsigned int offset)
-{    
+{
 
     unsigned int i;
 
@@ -1043,23 +1043,23 @@ movinv32(char* ptr, unsigned int tot_num_blocks, unsigned int pattern,
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_movinv32_write<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, pattern, lb,sval, offset); SYNC_CUERR;
-	SHOW_PROGRESS("test6[moving inversion 32 write]", i, tot_num_blocks);	
+	SHOW_PROGRESS("test6[moving inversion 32 write]", i, tot_num_blocks);
     }
     
     for (i=0;i < tot_num_blocks; i+= GRIDSIZE){
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_movinv32_readwrite<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, pattern, lb,sval, offset, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	error_checking("test6[moving inversion 32 readwrite]",  i);	
-	SHOW_PROGRESS("test6[moving inversion 32 readwrite]", i, tot_num_blocks);	
+	error_checking("test6[moving inversion 32 readwrite]",  i);
+	SHOW_PROGRESS("test6[moving inversion 32 readwrite]", i, tot_num_blocks);
     }
     
    for (i=0;i < tot_num_blocks; i+= GRIDSIZE){
        dim3 grid;
        grid.x= GRIDSIZE;
        kernel_movinv32_read<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, pattern, lb,sval, offset, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-       error_checking("test6[moving inversion 32 read]",  i);	
-       SHOW_PROGRESS("test6[moving inversion 32 read]", i, tot_num_blocks);	
+       error_checking("test6[moving inversion 32 read]",  i);
+       SHOW_PROGRESS("test6[moving inversion 32 read]", i, tot_num_blocks);
    }
    
     return;
@@ -1067,7 +1067,7 @@ movinv32(char* ptr, unsigned int tot_num_blocks, unsigned int pattern,
 }
 
 
-void 
+void
 test6(char* ptr, unsigned int tot_num_blocks)
 {
     unsigned int i;
@@ -1079,7 +1079,7 @@ test6(char* ptr, unsigned int tot_num_blocks)
 	DEBUG_PRINTF("Test6[move inversion 32 bits test]: pattern =0x%x, offset=%d\n", pattern, i);
 	movinv32(ptr, tot_num_blocks, pattern, 1, 0, i);
 	DEBUG_PRINTF("Test6[move inversion 32 bits test]: pattern =0x%x, offset=%d\n", ~pattern, i);
-	movinv32(ptr, tot_num_blocks, ~pattern, 0xfffffffe, 1, i);	
+	movinv32(ptr, tot_num_blocks, ~pattern, 0xfffffffe, 1, i);
 	
     }
     
@@ -1102,7 +1102,7 @@ test6(char* ptr, unsigned int tot_num_blocks)
 
 
 
-__global__ void 
+__global__ void
 kernel_test7_write(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int* err)
 {
     unsigned int i;
@@ -1118,13 +1118,13 @@ kernel_test7_write(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int* er
 	ptr[i] = start_ptr[i];
     }
     
-    return;    
+    return;
 }
 
 
 
-__global__ void 
-kernel_test7_readwrite(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int* err, 
+__global__ void
+kernel_test7_readwrite(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int* err,
 		       unsigned long* err_addr, unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
     unsigned int i;
@@ -1143,11 +1143,11 @@ kernel_test7_readwrite(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int
 	ptr[i] = ~(start_ptr[i]);
     }
     
-    return;    
+    return;
 }
 
-__global__ void 
-kernel_test7_read(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int* err, unsigned long* err_addr, 
+__global__ void
+kernel_test7_read(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int* err, unsigned long* err_addr,
 		  unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
     unsigned int i;
@@ -1165,11 +1165,11 @@ kernel_test7_read(char* _ptr, char* end_ptr, char* _start_ptr, unsigned int* err
 	}
     }
     
-    return;    
+    return;
 }
 
 
-void 
+void
 test7(char* ptr, unsigned int tot_num_blocks)
 {
 
@@ -1194,7 +1194,7 @@ test7(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test7_write<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, ptr, err_count); SYNC_CUERR;
-	SHOW_PROGRESS("test7_write", i, tot_num_blocks);	
+	SHOW_PROGRESS("test7_write", i, tot_num_blocks);
     }
     
     
@@ -1202,8 +1202,8 @@ test7(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test7_readwrite<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	err += error_checking("test7_readwrite",  i);	
-	SHOW_PROGRESS("test7_readwrite", i, tot_num_blocks);	
+	err += error_checking("test7_readwrite",  i);
+	SHOW_PROGRESS("test7_readwrite", i, tot_num_blocks);
     }
     
     
@@ -1211,16 +1211,16 @@ test7(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_test7_read<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	err += error_checking("test7_read",  i);	
-	SHOW_PROGRESS("test7_read", i, tot_num_blocks);	
+	err += error_checking("test7_read",  i);
+	SHOW_PROGRESS("test7_read", i, tot_num_blocks);
     }
     
 
     if (err == 0 && iteration == 0){
 	return;
     }
-    if (iteration < MAX_ITERATION){	
-	PRINTF("%dth repeating test7 because there are %d errors found in last run\n", iteration, err);	
+    if (iteration < MAX_ITERATION){
+	PRINTF("%dth repeating test7 because there are %d errors found in last run\n", iteration, err);
 	iteration++;
 	err = 0;
 	goto repeat;
@@ -1241,7 +1241,7 @@ test7(char* ptr, unsigned int tot_num_blocks)
 
 
 
-__global__ void 
+__global__ void
 kernel_modtest_write(char* _ptr, char* end_ptr, unsigned int offset, unsigned int p1, unsigned int p2)
 {
     unsigned int i;
@@ -1251,7 +1251,7 @@ kernel_modtest_write(char* _ptr, char* end_ptr, unsigned int offset, unsigned in
 	return;
     }
     
-    for (i = offset;i < BLOCKSIZE/sizeof(unsigned int); i+=MOD_SZ){	
+    for (i = offset;i < BLOCKSIZE/sizeof(unsigned int); i+=MOD_SZ){
 	ptr[i] =p1;
     }
     
@@ -1261,12 +1261,12 @@ kernel_modtest_write(char* _ptr, char* end_ptr, unsigned int offset, unsigned in
 	}
     }
     
-    return;    
+    return;
 }
 
 
-__global__ void 
-kernel_modtest_read(char* _ptr, char* end_ptr, unsigned int offset, unsigned int p1, unsigned int* err, 
+__global__ void
+kernel_modtest_read(char* _ptr, char* end_ptr, unsigned int offset, unsigned int p1, unsigned int* err,
 		    unsigned long* err_addr, unsigned long* err_expect, unsigned long* err_current, unsigned long* err_second_read)
 {
     unsigned int i;
@@ -1282,10 +1282,10 @@ kernel_modtest_read(char* _ptr, char* end_ptr, unsigned int offset, unsigned int
 	}
     }
     
-    return;    
+    return;
 }
 
-unsigned int 
+unsigned int
 modtest(char* ptr, unsigned int tot_num_blocks, unsigned int offset, unsigned int p1, unsigned int p2)
 {
     
@@ -1297,7 +1297,7 @@ modtest(char* ptr, unsigned int tot_num_blocks, unsigned int offset, unsigned in
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_modtest_write<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, offset, p1, p2); SYNC_CUERR;
-	SHOW_PROGRESS("test8[mod test, write]", i, tot_num_blocks);	
+	SHOW_PROGRESS("test8[mod test, write]", i, tot_num_blocks);
     }
     
     for (i= 0;i < tot_num_blocks; i+= GRIDSIZE){
@@ -1305,14 +1305,14 @@ modtest(char* ptr, unsigned int tot_num_blocks, unsigned int offset, unsigned in
 	grid.x= GRIDSIZE;
 	kernel_modtest_read<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, offset, p1, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
 	err += error_checking("test8[mod test, read", i);
-	SHOW_PROGRESS("test8[mod test, read]", i, tot_num_blocks);	
+	SHOW_PROGRESS("test8[mod test, read]", i, tot_num_blocks);
     }
     
     return err;
     
 }
 
-void 
+void
 test8(char* ptr, unsigned int tot_num_blocks)
 {
     unsigned int i;
@@ -1325,7 +1325,7 @@ test8(char* ptr, unsigned int tot_num_blocks)
     }else{
 	p1= get_random_num();
     }
-    unsigned int p2 = ~p1;    
+    unsigned int p2 = ~p1;
     
  repeat:
     
@@ -1338,7 +1338,7 @@ test8(char* ptr, unsigned int tot_num_blocks)
 	return;
     }
     
-    if (iteration < MAX_ITERATION){	
+    if (iteration < MAX_ITERATION){
 	PRINTF("%dth repeating test8 because there are %d errors found in last run, p1=%x, p2=%x\n", iteration, err, p1, p2);
 	iteration++;
 	err = 0;
@@ -1372,7 +1372,7 @@ test9(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_move_inv_write<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, p1); SYNC_CUERR;
-	SHOW_PROGRESS("test9[bit fade test, write]", i, tot_num_blocks);	
+	SHOW_PROGRESS("test9[bit fade test, write]", i, tot_num_blocks);
     }
     
     DEBUG_PRINTF("sleeping for 90 minutes\n");
@@ -1382,8 +1382,8 @@ test9(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_move_inv_readwrite<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, p1, p2, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	error_checking("test9[bit fade test, readwrite]",  i);	
-	SHOW_PROGRESS("test9[bit fade test, readwrite]", i, tot_num_blocks);	
+	error_checking("test9[bit fade test, readwrite]",  i);
+	SHOW_PROGRESS("test9[bit fade test, readwrite]", i, tot_num_blocks);
     }
     
     DEBUG_PRINTF("sleeping for 90 minutes\n");
@@ -1392,8 +1392,8 @@ test9(char* ptr, unsigned int tot_num_blocks)
 	dim3 grid;
 	grid.x= GRIDSIZE;
 	kernel_move_inv_read<<<grid, 1>>>(ptr + i*BLOCKSIZE, end_ptr, p2, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
-	error_checking("test9[bit fade test, read]",  i);	
-	SHOW_PROGRESS("test9[bit fade test, read]", i, tot_num_blocks);	
+	error_checking("test9[bit fade test, read]",  i);
+	SHOW_PROGRESS("test9[bit fade test, read]", i, tot_num_blocks);
     }
     
     return;
@@ -1409,7 +1409,7 @@ test9(char* ptr, unsigned int tot_num_blocks)
  * written as to achieve the maximum bandwidth between the global memory and GPU.
  * This will increase the chance of catching software error. In practice, we found this test quite useful
  * to flush hardware errors as well.
- * 
+ *
  */
 
 #define TYPE unsigned long
@@ -1498,26 +1498,26 @@ void test10(char* ptr, unsigned int tot_num_blocks)
     int n = num_iterations;
     float elapsedtime;
     dim3 gridDim(STRESS_GRIDSIZE);
-    dim3 blockDim(STRESS_BLOCKSIZE);       
+    dim3 blockDim(STRESS_BLOCKSIZE);
     checkCudaErrors(cudaEventRecord(start, stream));
 
     PRINTF("Test10 with pattern=0x%lx\n", p1);
-    test10_kernel_write<<<gridDim, blockDim, 0, stream>>>(ptr, tot_num_blocks*BLOCKSIZE, p1); SYNC_CUERR;	
+    test10_kernel_write<<<gridDim, blockDim, 0, stream>>>(ptr, tot_num_blocks*BLOCKSIZE, p1); SYNC_CUERR;
     for(int i =0;i < n ;i ++){
 	test10_kernel_readwrite<<<gridDim, blockDim, 0, stream>>>(ptr, tot_num_blocks*BLOCKSIZE, p1, p2,
 								  err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
 	p1 = ~p1;
 	p2 = ~p2;
 	
-    }    
+    }
     cudaEventRecord(stop, stream);
     cudaEventSynchronize(stop);
-    error_checking("test10[Memory stress test]",  0);	
+    error_checking("test10[Memory stress test]",  0);
     cudaEventElapsedTime(&elapsedtime, start, stop);
     DEBUG_PRINTF("test10: elapsedtime=%f, bandwidth=%f GB/s\n", elapsedtime, (2*n+1)*tot_num_blocks/elapsedtime);
     
-   cudaEventDestroy(start);    
-   cudaEventDestroy(stop);    
+   cudaEventDestroy(start);
+   cudaEventDestroy(stop);
    
    cudaStreamDestroy(stream);
 
@@ -1526,7 +1526,7 @@ void test10(char* ptr, unsigned int tot_num_blocks)
     if (host_buf == NULL){
 	printf("ERROR: malloc failed for host_buf\n");
 	exit(ERR_GENERAL);
-    }    
+    }
     memset(host_buf, 0, tot_num_blocks* BLOCKSIZE);
     cudaMemcpy(host_buf, ptr, tot_num_blocks*BLOCKSIZE, cudaMemcpyDeviceToHost);
     for(unsigned long i=0;i < (tot_num_blocks*BLOCKSIZE)/sizeof(TYPE) ;i ++){
@@ -1535,7 +1535,7 @@ void test10(char* ptr, unsigned int tot_num_blocks)
 	    free(host_buf);
 	    exit(ERR_GENERAL);
 	}
-    }    
+    }
     printf("all data match\n");
     free(host_buf);
 #endif
@@ -1546,16 +1546,16 @@ void test10(char* ptr, unsigned int tot_num_blocks)
 
 cuda_memtest_t cuda_memtests[]={
     {test0, "Test0 [Walking 1 bit]",			1},
-    {test1, "Test1 [Own address test]",			1},    
-    {test2, "Test2 [Moving inversions, ones&zeros]",	1},    
-    {test3, "Test3 [Moving inversions, 8 bit pat]",	1},    
-    {test4, "Test4 [Moving inversions, random pattern]",1},    
-    {test5, "Test5 [Block move, 64 moves]",		1},    
-    {test6, "Test6 [Moving inversions, 32 bit pat]",	1},    
-    {test7, "Test7 [Random number sequence]",		1},        
-    {test8, "Test8 [Modulo 20, random pattern]",	1},            
-    {test9, "Test9 [Bit fade test]",			0},            
-    {test10, "Test10 [Memory stress test]",		1}, 
+    {test1, "Test1 [Own address test]",			1},
+    {test2, "Test2 [Moving inversions, ones&zeros]",	1},
+    {test3, "Test3 [Moving inversions, 8 bit pat]",	1},
+    {test4, "Test4 [Moving inversions, random pattern]",1},
+    {test5, "Test5 [Block move, 64 moves]",		1},
+    {test6, "Test6 [Moving inversions, 32 bit pat]",	1},
+    {test7, "Test7 [Random number sequence]",		1},
+    {test8, "Test8 [Modulo 20, random pattern]",	1},
+    {test9, "Test9 [Bit fade test]",			0},
+    {test10, "Test10 [Memory stress test]",		1},
     
 };
 
@@ -1584,7 +1584,7 @@ void
 run_tests(char* ptr, unsigned int tot_num_blocks)
 {
 
-    struct timeval  t0, t1; 
+    struct timeval  t0, t1;
     unsigned int i;
 
     unsigned int pass = 0;
@@ -1596,7 +1596,7 @@ run_tests(char* ptr, unsigned int tot_num_blocks)
 		PRINTF("%s\n", cuda_memtests[i].desc);
 		gettimeofday(&t0, NULL);
 		cuda_memtests[i].func(ptr, tot_num_blocks);
-		gettimeofday(&t1, NULL);	
+		gettimeofday(&t1, NULL);
 		PRINTF("Test%d finished in %.1f seconds\n", i, TDIFF(t1, t0));
 	    }//if
 	}//for
@@ -1608,7 +1608,7 @@ run_tests(char* ptr, unsigned int tot_num_blocks)
 	pass ++;
 	if (pass >= num_passes){
 	    break;
-	}	
+	}
     }//while
     
 }

--- a/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Maximilian Knespel
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -76,7 +76,7 @@ struct GatherSlice
     void finalize()
     {
         if (filteredData != NULL)
-        {  
+        {
             delete[] filteredData;
             filteredData=NULL;
         }

--- a/src/libPMacc/examples/gameOfLife2D/include/PngCreator.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/PngCreator.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef PNGCREATOR_HPP
 #define	PNGCREATOR_HPP

--- a/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -8,7 +8,7 @@
  * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/libPMacc/examples/gameOfLife2D/include/types.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/types.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef TYPES_HPP
 #define	TYPES_HPP

--- a/src/libPMacc/examples/gameOfLife2D/main.cu
+++ b/src/libPMacc/examples/gameOfLife2D/main.cu
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "types.hpp"
 #include <iostream>
@@ -57,7 +57,7 @@ int main( int argc, char **argv )
             ( "help,h", "produce help message" )
             ( "steps,s", po::value<uint32_t > ( &steps ), "simulation steps" )
             ( "rule,r", po::value<std::string > ( &rule ), "simulation rule etc. 23/3" )
-            ( "devices,d", po::value<std::vector<uint32_t> > ( &devices )->multitoken( ), 
+            ( "devices,d", po::value<std::vector<uint32_t> > ( &devices )->multitoken( ),
               "number of devices in each dimension (only 1D or 2D). If you use more than "
               "one device in total, you will need to run mpirun with \"mpirun -n "
               "<DeviceCount.x*DeviceCount.y> ./gameOfLife\"" )

--- a/src/libPMacc/include/algorithms/GlobalReduce.hpp
+++ b/src/libPMacc/include/algorithms/GlobalReduce.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -43,7 +43,7 @@ public:
     {
     }
 
-    /* Activate participation for reduce algorithm. 
+    /* Activate participation for reduce algorithm.
      * Must called from any mpi process. This function use global blocking mpi calls.
      * Don't create a instance befor you have set you cuda device!
      * @param isActive true if mpi rank should be part of reduce operation, else false
@@ -54,12 +54,12 @@ public:
     }
 
     /* Reduce elements in global gpu memeory
-     * 
+     *
      * @param func functor for reduce which takes two arguments, first argument is the source and get the new reduced value.
      * Functor must specialize the function getMPI_Op.
      * @param src a class or a pointer where the reduce algorithm can access the value by operator [] (one dimension access)
      * @param n number of elements to reduce
-     * 
+     *
      * @return reduced value (same on every mpi instance)
      */
     template<class Functor, typename Src>

--- a/src/libPMacc/include/algorithms/PromoteType.hpp
+++ b/src/libPMacc/include/algorithms/PromoteType.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/algorithms/math.hpp
+++ b/src/libPMacc/include/algorithms/math.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013-2014 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -84,9 +84,9 @@ struct Sinc<double>
 
     HDINLINE double operator( )(const double& value )
     {
-      if(::fabs(value) < DBL_EPSILON) 
+      if(::fabs(value) < DBL_EPSILON)
 	return 1.0;
-      else 
+      else
 	return ::sin( value )/value;
     }
 };

--- a/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013-2014 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #pragma once

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -85,9 +85,9 @@ struct Sinc<float>
 
     HDINLINE double operator( )(const float& value )
     {
-      if(::fabsf(value) < FLT_EPSILON) 
+      if(::fabsf(value) < FLT_EPSILON)
 	return 1.0;
-      else 
+      else
 	return ::sinf( value )/value;
     }
 };

--- a/src/libPMacc/include/basicOperations.hpp
+++ b/src/libPMacc/include/basicOperations.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -39,7 +39,7 @@ DINLINE void atomicAddWrapper(float* address, float value)
 #if __CUDA_ARCH__ >= 200 // for Fermi, atomicAdd supports floats
     atomicAdd(address, value);
 #else
-    // float-atomic-add from 
+    // float-atomic-add from
     // [url="http://forums.nvidia.com/index.php?showtopic=158039&view=findpost&p=991561"]http://forums.nvidia.com/index.php?showtop...st&p=991561[/url]
     float old = value;
     while ((old = atomicExch(address, atomicExch(address, 0.0f) + old)) != 0.0f);

--- a/src/libPMacc/include/communication/CommunicatorMPI.hpp
+++ b/src/libPMacc/include/communication/CommunicatorMPI.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _COMMUNICATORMPI_HPP
 #define	_COMMUNICATORMPI_HPP
@@ -237,7 +237,7 @@ protected:
 
     /* Set the first found non charactor or number to 0 (NULL)
      * name like p1223(Pid=1233) is than p1223
-     * in some MPI implementation /mpich) the hostname is uniqu 
+     * in some MPI implementation /mpich) the hostname is uniqu
      */
     void cleanHostname(char* name)
     {

--- a/src/libPMacc/include/communication/ICommunicator.hpp
+++ b/src/libPMacc/include/communication/ICommunicator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _ICOMMUNICATOR_HPP

--- a/src/libPMacc/include/compileTime/accessors/First.hpp
+++ b/src/libPMacc/include/compileTime/accessors/First.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -34,10 +34,10 @@ namespace accessors
 {
 
 /** Get first type of the given type
- * 
+ *
  * \tparam T type from which we return the first held type
- * 
- * T must have defined ::first 
+ *
+ * T must have defined ::first
  */
 template<typename T>
 struct First

--- a/src/libPMacc/include/compileTime/accessors/Second.hpp
+++ b/src/libPMacc/include/compileTime/accessors/Second.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -34,10 +34,10 @@ namespace accessors
 {
 
 /** Get second type of the given type
- * 
+ *
  * \tparam T type from which we return the second held type
- * 
- * T must have defined ::second 
+ *
+ * T must have defined ::second
  */
 template<typename T>
 struct Second

--- a/src/libPMacc/include/compileTime/conversion/TypeToPair.hpp
+++ b/src/libPMacc/include/compileTime/conversion/TypeToPair.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -31,8 +31,8 @@ namespace PMacc
 
 
 
-/** create boost mpl pair 
- * 
+/** create boost mpl pair
+ *
  * @tparam T_Type any type
  * @resturn ::type boost mpl pair where first and second is set to T_Type
  */

--- a/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
@@ -65,7 +65,7 @@ namespace cudaBlock
     }
 
 /** Foreach algorithm that is executed by one cuda thread block
- * 
+ *
  * \tparam BlockDim 3D compile-time vector (PMacc::math::CT::Int) of the size of the cuda blockDim.
  *
  * BlockDim could also be obtained from cuda itself at runtime but
@@ -77,7 +77,7 @@ struct Foreach
 private:
     const int linearThreadIdx;
 public:
-    DINLINE Foreach() 
+    DINLINE Foreach()
      : linearThreadIdx(
         threadIdx.z * BlockDim::x::value * BlockDim::y::value +
         threadIdx.y * BlockDim::x::value +
@@ -85,14 +85,14 @@ public:
     DINLINE Foreach(int linearThreadIdx) : linearThreadIdx(linearThreadIdx) {}
 
     /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
-     * 
+     *
      * \param zone compile-time zone object, see zone::CT::SphericZone. (e.g. ContainerType::Zone())
      * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
      * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 = _2)
-     * 
+     *
      * The functor or lambdaFun is called for each cell within the zone.
      * It is called like functor(*cursor0(cellId), ..., *cursorN(cellId))
-     * 
+     *
      */
     BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), FOREACH_OPERATOR, _)
 };

--- a/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALGORITHM_HOST_FOREACH_HPP
 #define ALGORITHM_HOST_FOREACH_HPP
@@ -112,14 +112,14 @@ namespace detail
 struct Foreach
 {
     /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
-     * 
+     *
      * \param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
      * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
      * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 = _2)
-     * 
+     *
      * The functor or lambdaFun is called for each cell within the zone.
      * It is called like functor(*cursor0(cellId), ..., *cursorN(cellId))
-     * 
+     *
      */
     BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_HOST_MAX_PARAMS), FOREACH_OPERATOR, _)
 };

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALGORITHM_KERNEL_FFT_HPP
 #define ALGORITHM_KERNEL_FFT_HPP

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "math/vector/Size_t.hpp"
 #include "math/Vector.hpp"

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALGORITHM_KERNEL_FOREACH_HPP
 #define ALGORITHM_KERNEL_FOREACH_HPP
@@ -73,7 +73,7 @@ namespace kernel
     }
     
 /** Foreach algorithm that calls a cuda kernel
- * 
+ *
  * \tparam BlockDim 3D compile-time vector (PMacc::math::CT::Int) of the size of the cuda blockDim.
  *
  * blockDim has to fit into the computing volume.
@@ -83,14 +83,14 @@ template<typename BlockDim>
 struct Foreach
 {
     /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
-     * 
+     *
      * \param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
      * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
      * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 = _2)
-     * 
+     *
      * The functor or lambdaFun is called for each cell within the zone.
      * It is called like functor(*cursor0(cellId), ..., *cursorN(cellId))
-     * 
+     *
      */
     BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), FOREACH_OPERATOR, _)
 };

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALGORITHM_KERNEL_FOREACHBLOCK_HPP
 #define ALGORITHM_KERNEL_FOREACHBLOCK_HPP
@@ -97,11 +97,11 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), KERNEL_FOREA
     }
     
 /** Special foreach algorithm that calls a cuda kernel
- * 
+ *
  * Behaves like kernel::Foreach, except that is doesn't shift the cursors cell by cell, but
  * shifts them to the top left (front) corner cell of their corresponding cuda block.
  * So if BlockDim is 4x4x4 it shifts 64 cursors to (0,0,0), 64 to (4,0,0), 64 to (8,0,0), ...
- * 
+ *
  * \tparam BlockDim 3D compile-time vector (PMacc::math::CT::Int) of the size of the cuda blockDim.
  * \tparam ThreadBlock ignored
  */
@@ -109,13 +109,13 @@ template<typename BlockDim, typename ThreadBlock = BlockDim>
 struct ForeachBlock
 {
     /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
-     * 
+     *
      * \param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
      * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
      * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 = _2)
-     * 
+     *
      * It is called like functor(*cursor0(cellId), ..., *cursorN(cellId))
-     * 
+     *
      */
     BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), FOREACH_OPERATOR, _)
 };

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALGORITHM_KERNEL_REDUCE_HPP
 #define ALGORITHM_KERNEL_REDUCE_HPP
@@ -42,9 +42,9 @@ namespace kernel
 {
 
 /** Reduce algorithm that calls a cuda kernel
- * 
+ *
  * \tparam BlockDim compile-time vector (PMacc::math::CT::Int) of the size of the cuda blockDim.
- * 
+ *
  * blockDim has to fit into the volume to be reduced.
  * E.g. (8,8,4) fits into (256, 256, 256)
  */
@@ -55,7 +55,7 @@ struct Reduce
 /* \param destCursor Cursor where the result is stored
  * \param _zone Zone of cells spanning the area of reduce
  * \param srcCursor Cursor located at the origin of the area of reduce
- * \param functor Functor with two arguments which returns the result of the reduce operation. 
+ * \param functor Functor with two arguments which returns the result of the reduce operation.
  *        Can also be a lambda expression.
  */
 template<typename DestCursor, typename Zone, typename SrcCursor, typename Functor>

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "math/vector/Size_t.hpp"
 #include "cuSTL/algorithm/kernel/Foreach.hpp"
@@ -102,7 +102,7 @@ struct ReduceKernel
 
 template<typename BlockDim>
 template<typename DestCursor, typename Zone, typename SrcCursor, typename Functor>
-void Reduce<BlockDim>::operator()(const DestCursor& destCursor, const Zone& _zone, const SrcCursor& srcCursor, const Functor& functor) 
+void Reduce<BlockDim>::operator()(const DestCursor& destCursor, const Zone& _zone, const SrcCursor& srcCursor, const Functor& functor)
 {
     typedef typename boost::remove_reference<typename DestCursor::type>::type type;
     
@@ -120,7 +120,7 @@ void Reduce<BlockDim>::operator()(const DestCursor& destCursor, const Zone& _zon
 
     if(partialSumSize == 1)
     {
-        Foreach<BlockDim>()(_zone, srcCursor, 
+        Foreach<BlockDim>()(_zone, srcCursor,
             expr(detail::ReduceKernel<BlockDim, Zone::dim>(_zone.size.x()))
                 (_destCursor, _1, make_Functor(functor)));
                 

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
  

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALGORITHM_KERNEL_DETAIL_SPHERICMAPPER_HPP
 #define ALGORITHM_KERNEL_DETAIL_SPHERICMAPPER_HPP
@@ -42,7 +42,7 @@ namespace mpl = boost::mpl;
  * \tparam dim dimension
  * \tparam BlockSize compile-time vector of the cuda block size (optional)
  * \tparam dummy neccesary to implement the optional BlockSize parameter
- * 
+ *
  * If BlockSize is given the cuda variable blockDim is not used which is faster.
  */
 template<int dim, typename BlockSize = mpl::void_, typename dummy = mpl::void_>

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALGORITHM_MPI_GATHER_HPP
 #define ALGORITHM_MPI_GATHER_HPP
@@ -61,7 +61,7 @@ private:
     
     template<typename Type, int _dim, int memDim>
     friend class CopyToDest;
-public:    
+public:
     Gather(const zone::SphericZone<dim>& _zone);
     ~Gather();
     

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "mappings/simulation/GridController.hpp"
 #include <iostream>
@@ -43,7 +43,7 @@ Gather<dim>::Gather(const zone::SphericZone<dim>& _zone) : comm(MPI_COMM_NULL)
     int numWorldRanks; MPI_Comm_size(MPI_COMM_WORLD, &numWorldRanks);
     std::vector<Int<dim> > allPositions(numWorldRanks);
     
-    MPI_CHECK(MPI_Allgather((void*)&pos, sizeof(Int<dim>), MPI_CHAR, 
+    MPI_CHECK(MPI_Allgather((void*)&pos, sizeof(Int<dim>), MPI_CHAR,
                   (void*)allPositions.data(), sizeof(Int<dim>), MPI_CHAR,
                   MPI_COMM_WORLD));
                   
@@ -80,7 +80,7 @@ Gather<dim>::~Gather()
 template<int dim>
 bool Gather<dim>::root() const
 {
-    if(!this->m_participate) 
+    if(!this->m_participate)
     {
         std::cerr << "error[mpi::Gather::root()]: this process does not participate in gathering.\n";
         return false;
@@ -92,7 +92,7 @@ bool Gather<dim>::root() const
 template<int dim>
 int Gather<dim>::rank() const
 {
-    if(!this->m_participate) 
+    if(!this->m_participate)
     {
         std::cerr << "error[mpi::Gather::rank()]: this process does not participate in gathering.\n";
         return -1;

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
@@ -3,24 +3,24 @@
 /**
  * Copyright 2013 Heiko Burau
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "mpi.h"
 #include "math/vector/Int.hpp"
@@ -37,17 +37,17 @@ namespace mpi
 {
 
 /** Reduce algorithm for mpi
- * 
+ *
  * \tparam dim dimension of the mpi node volume which has to be reduced.
- * 
+ *
  * This algorithm reduces node-wise. For each node you pass a data container as source
  * and another container of the same size as destination. The result is stored in
  * the destination container of the root node.
- * 
+ *
  * The data values of the container are reduced independently of each other.
- * 
+ *
  * The dimension of the container need not be the same as dim.
- * 
+ *
  */
 template<int dim>
 class Reduce
@@ -57,28 +57,28 @@ private:
     bool m_participate;
 public:
     /** constructor
-     * 
+     *
      * \param zone The zone specifies which mpi-nodes participate in the reduce operation.
      * \param setThisAsRoot Set this node explicitly as root. May only be true for one node.
      *
      * if setThisAsRoot is not set mpi chooses the root node.
-     * 
+     *
      */
     Reduce(const zone::SphericZone<dim>& zone, bool setThisAsRoot = false);
     ~Reduce();
     
     /* execute the algorithm
-     * 
+     *
      * \param dest destination container
      * \param src source container
-     * \param ExprOrFunctor functor with two arguments which returns the result of the reduce operation. 
+     * \param ExprOrFunctor functor with two arguments which returns the result of the reduce operation.
      *        May also be a lambda expression (e.g. _1 + _2).
-     * 
+     *
      * Since only the functor's type is given, the functor must have a standart constructor.
-     * 
+     *
      */
     template<typename Type, int conDim, typename ExprOrFunctor>
-    void operator()(container::HostBuffer<Type, conDim>& dest, 
+    void operator()(container::HostBuffer<Type, conDim>& dest,
                     const container::HostBuffer<Type, conDim>& src,
                     ExprOrFunctor) const;
            

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
@@ -92,7 +92,7 @@ Reduce<dim>::~Reduce()
 template<int dim>
 bool Reduce<dim>::root() const
 {
-    if(!this->m_participate) 
+    if(!this->m_participate)
     {
         std::cerr << "error[mpi::Reduce::root()]: this process does not participate in reducing.\n";
         return false;
@@ -104,7 +104,7 @@ bool Reduce<dim>::root() const
 template<int dim>
 int Reduce<dim>::rank() const
 {
-    if(!this->m_participate) 
+    if(!this->m_participate)
     {
         std::cerr << "error[mpi::Reduce::rank()]: this process does not participate in reducing.\n";
         return -1;
@@ -138,7 +138,7 @@ struct MPI_User_Op
 template<int dim>
 template<typename Type, int conDim, typename ExprOrFunctor>
 void Reduce<dim>::operator()
-                   (container::HostBuffer<Type, conDim>& dest, 
+                   (container::HostBuffer<Type, conDim>& dest,
                     const container::HostBuffer<Type, conDim>& src,
                     ExprOrFunctor) const
 {
@@ -146,7 +146,7 @@ void Reduce<dim>::operator()
     
     typedef typename lambda::result_of::make_Functor<ExprOrFunctor>::type Functor;
     
-    MPI_Op user_op;  
+    MPI_Op user_op;
     MPI_CHECK(MPI_Op_create(&detail::MPI_User_Op<Functor, Type>::callback, 1, &user_op));
     
     MPI_CHECK(MPI_Reduce(&(*src.origin()), &(*dest.origin()), sizeof(Type) * dest.size().productOfComponents(),

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_CARTBUFFER_HPP
 #define CONTAINER_CARTBUFFER_HPP
@@ -53,8 +53,8 @@ namespace container
  * \tparam Copier copies one memory buffer to another
  * \tparam Assigner assigns a value to every datum of a memory buffer
  */
-template<typename Type, int _dim, typename Allocator = allocator::EmptyAllocator, 
-                                  typename Copier = mpl::void_, 
+template<typename Type, int _dim, typename Allocator = allocator::EmptyAllocator,
+                                  typename Copier = mpl::void_,
                                   typename Assigner = mpl::void_>
 class CartBuffer
 {
@@ -87,16 +87,16 @@ public:
     HDINLINE ~CartBuffer();
     
     /* copy another container into this one (hard data copy) */
-    HDINLINE This& 
+    HDINLINE This&
     operator=(const This& rhs);
     /* use the memory from another container and increment the reference counter */
-    HDINLINE This& 
+    HDINLINE This&
     operator=(BOOST_RV_REF(This) rhs);
     
     /* get a view. Views represent a clipped area of the container.
-     * \param a Top left corner of the view, inside the view. 
+     * \param a Top left corner of the view, inside the view.
      * Negative values are remapped, e.g. Int<2>(-1,-2) == Int<2>(width-1, height-2)
-     * \param b Bottom right corner of the view, outside the view. 
+     * \param b Bottom right corner of the view, outside the view.
      * Values are remapped, so that Int<2>(0,0) == Int<2>(width, height)
      */
     HDINLINE View<This>
@@ -111,7 +111,7 @@ public:
     HDINLINE cursor::BufferCursor<Type, dim> origin() const;
     /* get a safe cursor at the container's origin cell */
     HDINLINE cursor::SafeCursor<cursor::BufferCursor<Type, dim> > originSafe() const;
-    /* get a component-twisted cursor at the container's origin cell 
+    /* get a component-twisted cursor at the container's origin cell
      * \param axes x-axis -> axes[0], y-axis -> axes[1], ...
      * */
     HDINLINE cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<dim>, char*>

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "cuSTL/container/allocator/tag.h"
 #include <iostream>
@@ -64,7 +64,7 @@ namespace detail
     template<>
     HDINLINE void notifyEventSystem<allocator::tag::device>()
     {
-#ifndef __CUDA_ARCH__   
+#ifndef __CUDA_ARCH__
         using namespace PMacc;
         __startOperation(ITask::TASK_CUDA);
 #endif
@@ -73,7 +73,7 @@ namespace detail
     template<>
     HDINLINE void notifyEventSystem<allocator::tag::host>()
     {
-#ifndef __CUDA_ARCH__   
+#ifndef __CUDA_ARCH__
         using namespace PMacc;
         __startOperation(ITask::TASK_HOST);
 #endif
@@ -136,7 +136,7 @@ void CartBuffer<Type, _dim, Allocator, Copier, Assigner>::init()
 {
     typename Allocator::Cursor cursor = Allocator::allocate(this->_size);
     this->dataPointer = cursor.getMarker();
-#ifndef __CUDA_ARCH__   
+#ifndef __CUDA_ARCH__
     this->refCount = new int;
 #endif
     *this->refCount = 1;
@@ -158,14 +158,14 @@ void CartBuffer<Type, _dim, Allocator, Copier, Assigner>::exit()
         return;
     Allocator::deallocate(origin());
     this->dataPointer = 0;
-#ifndef __CUDA_ARCH__    
+#ifndef __CUDA_ARCH__
     delete this->refCount;
     this->refCount = 0;
 #endif
 }
 
 template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>& 
+CartBuffer<Type, _dim, Allocator, Copier, Assigner>&
 CartBuffer<Type, _dim, Allocator, Copier, Assigner>::operator=
 (const CartBuffer<Type, _dim, Allocator, Copier, Assigner>& rhs)
 {
@@ -175,7 +175,7 @@ CartBuffer<Type, _dim, Allocator, Copier, Assigner>::operator=
 }
 
 template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>& 
+CartBuffer<Type, _dim, Allocator, Copier, Assigner>&
 CartBuffer<Type, _dim, Allocator, Copier, Assigner>::operator=
 (BOOST_RV_REF(CartBuffer<Type COMMA _dim COMMA Allocator COMMA Copier COMMA Assigner>) rhs)
 {
@@ -253,7 +253,7 @@ CartBuffer<Type, _dim, Allocator, Copier, Assigner>::originCustomAxes(const math
 }
 
 template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-zone::SphericZone<_dim> 
+zone::SphericZone<_dim>
 CartBuffer<Type, _dim, Allocator, Copier, Assigner>::zone() const
 {
     zone::SphericZone<_dim> myZone;

--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_DEVICEBUFFER_HPP
 #define CONTAINER_DEVICEBUFFER_HPP
@@ -44,28 +44,28 @@ namespace container
  */
 template<typename Type, int dim>
 class DeviceBuffer
- : public CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>, 
-                                copier::D2DCopier<dim>, 
+ : public CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>,
+                                copier::D2DCopier<dim>,
                                 assigner::DeviceMemAssigner<dim> >
 {
 private:
-    typedef CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>, 
-                                  copier::D2DCopier<dim>, 
+    typedef CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>,
+                                  copier::D2DCopier<dim>,
                                   assigner::DeviceMemAssigner<dim> > Base;
     typedef DeviceBuffer<Type, dim> This;
     
 ///\todo: make protected
-public:                                  
+public:
     HDINLINE DeviceBuffer() {}
     
     BOOST_COPYABLE_AND_MOVABLE(This)
 public:
     /* constructors
-     * 
+     *
      * \param _size size of the container
-     * 
+     *
      * \param x,y,z convenient wrapper
-     * 
+     *
      */
     HDINLINE DeviceBuffer(const math::Size_t<dim>& _size) : Base(_size) {}
     HDINLINE DeviceBuffer(size_t x) : Base(x) {}
@@ -74,7 +74,7 @@ public:
     HDINLINE DeviceBuffer(const Base& base) : Base(base) {}
     
     template<typename HBuffer>
-    HDINLINE 
+    HDINLINE
     DeviceBuffer<Type, dim>& operator=(const HBuffer& rhs)
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::memoryTag, allocator::tag::host>::value));

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_HOSTBUFFER_HPP
 #define CONTAINER_HOSTBUFFER_HPP
@@ -43,23 +43,23 @@ namespace container
  */
 template<typename Type, int dim>
 class HostBuffer
- : public CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>, 
-                                copier::H2HCopier<dim>, 
+ : public CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>,
+                                copier::H2HCopier<dim>,
                                 assigner::HostMemAssigner<dim> >
 {
 private:
-    typedef CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>, 
-                                  copier::H2HCopier<dim>, 
+    typedef CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>,
+                                  copier::H2HCopier<dim>,
                                   assigner::HostMemAssigner<dim> > Base;
 protected:
     HostBuffer() {}
 public:
     /* constructors
-     * 
+     *
      * \param _size size of the container
-     * 
+     *
      * \param x,y,z convenient wrapper
-     * 
+     *
      */
     HostBuffer(const math::Size_t<dim>& _size) : Base(_size) {}
     HostBuffer(size_t x) : Base(x) {}

--- a/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_INDEXBUFFER_HPP
 #define CONTAINER_INDEXBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/PNGBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/PNGBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_PNGBUFFER_HPP
 #define CONTAINER_PNGBUFFER_HPP
@@ -39,7 +39,7 @@ namespace container
     
 /** Think of a container being a PNG-image
  * offers only write-only access
- */ 
+ */
 class PNGBuffer
 {
 private:

--- a/src/libPMacc/include/cuSTL/container/PseudoBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/PseudoBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_PSEUDOBUFFER_HPP
 #define CONTAINER_PSEUDOBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/PseudoBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/PseudoBuffer.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALLOCATOR_DEVICEMEMALLOCATOR_HPP
 #define ALLOCATOR_DEVICEMEMALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALLOCATOR_DEVICEMEMEVENPITCHALLOCATOR_HPP
 #define ALLOCATOR_DEVICEMEMEVENPITCHALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/allocator/EmptyAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/EmptyAllocator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALLOCATOR_EMPTYALLOCATOR_HPP
 #define ALLOCATOR_EMPTYALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALLOCATOR_HOSTMEMALLOCATOR_HPP
 #define ALLOCATOR_HOSTMEMALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALLOCATOR_SHAREDMEMALLOCATOR_HPP
 #define ALLOCATOR_SHAREDMEMALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/tag.h
+++ b/src/libPMacc/include/cuSTL/container/allocator/tag.h
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ALLOCATOR_TAG_H
 #define ALLOCATOR_TAG_H

--- a/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ASSIGNER_HOSTMEMASSIGNER_HPP
 #define ASSIGNER_HOSTMEMASSIGNER_HPP

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_CT_CTCARTBUFFER_HPP
 #define CONTAINER_CT_CTCARTBUFFER_HPP
@@ -57,7 +57,7 @@ public:
     DINLINE CartBuffer();
     DINLINE CartBuffer(const CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>& other);
     
-    DINLINE CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>& 
+    DINLINE CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>&
     operator=(const CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>& rhs);
     
     DINLINE void assign(const Type& value);

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/compile-time/SharedBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/SharedBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_CT_SHAREDBUFFER_HPP
 #define CONTAINER_CT_SHAREDBUFFER_HPP
@@ -34,12 +34,12 @@ namespace CT
 {
     
 /* typedef version of container::CT::CartBuffer for shared mem on a GPU inside a cuda kernel.
- * \param uid If two containers in one kernel have the same Type and Size, 
+ * \param uid If two containers in one kernel have the same Type and Size,
  * uid has to be different. This is due to a nvcc bug.
  */
 template<typename Type, typename Size, int uid = 0>
-struct SharedBuffer 
- : public CT::CartBuffer<Type, Size, 
+struct SharedBuffer
+ : public CT::CartBuffer<Type, Size,
                          allocator::CT::SharedMemAllocator<Type, Size, Size::dim, uid>, void, void>
 {};
     

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef COPIER_D2DCOPIER_HPP
 #define COPIER_D2DCOPIER_HPP
@@ -42,7 +42,7 @@ struct D2DCopier
     {
         cudaWrapper::Memcopy<dim>()(dest, pitchDest, source, pitchSource,
                                     size, cudaWrapper::flags::Memcopy::deviceToDevice);
-    }         
+    }
 };
 
 } // copier

--- a/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef COPIER_H2HCOPIER_HPP
 #define COPIER_H2HCOPIER_HPP
@@ -42,7 +42,7 @@ struct H2HCopier
     {
         cudaWrapper::Memcopy<dim>()(dest, pitchDest, source, pitchSource,
                                     size, cudaWrapper::flags::Memcopy::hostToHost);
-    }         
+    }
 };
 
 } // copier

--- a/src/libPMacc/include/cuSTL/container/copier/Memcopy.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/Memcopy.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CUDAWRAPPERMEMCOPY_HPP
 #define CUDAWRAPPERMEMCOPY_HPP
@@ -46,21 +46,21 @@ template<>
 struct Memcopy<1>
 {
     template<typename Type>
-    void operator()(Type* dest, const math::Size_t<0>, 
+    void operator()(Type* dest, const math::Size_t<0>,
                     const Type* source, const math::Size_t<0>, const math::Size_t<1>& size,
                     flags::Memcopy::Direction direction)
     {
             const cudaMemcpyKind kind[] = {cudaMemcpyHostToDevice, cudaMemcpyDeviceToHost,
                                      cudaMemcpyHostToHost, cudaMemcpyDeviceToDevice};
             CUDA_CHECK_NO_EXCEP(cudaMemcpy(dest, source, sizeof(Type) * size.x(), kind[direction]));
-    }                 
+    }
 };
 
 template<>
 struct Memcopy<2u>
 {
     template<typename Type>
-    void operator()(Type* dest, const math::Size_t<1> pitchDest, 
+    void operator()(Type* dest, const math::Size_t<1> pitchDest,
                     const Type* source, const math::Size_t<1> pitchSource, const math::Size_t<2u>& size,
                     flags::Memcopy::Direction direction)
     {
@@ -69,14 +69,14 @@ struct Memcopy<2u>
                                      
             CUDA_CHECK_NO_EXCEP(cudaMemcpy2D(dest, pitchDest.x(), source, pitchSource.x(), sizeof(Type) * size.x(), size.y(),
                          kind[direction]));
-    }                    
+    }
 };
 
 template<>
 struct Memcopy<3>
 {
     template<typename Type>
-    void operator()(Type* dest, const math::Size_t<2u> pitchDest, 
+    void operator()(Type* dest, const math::Size_t<2u> pitchDest,
                     Type* source, const math::Size_t<2u> pitchSource, const math::Size_t<3>& size,
                     flags::Memcopy::Direction direction)
     {
@@ -100,7 +100,7 @@ struct Memcopy<3>
             params.extent = make_cudaExtent(size.x() * sizeof(Type), size.y(), size.z());
             params.kind = kind[direction];
             CUDA_CHECK_NO_EXCEP(cudaMemcpy3D(&params));
-    }                    
+    }
 };
     
 } // cudaWrapper

--- a/src/libPMacc/include/cuSTL/container/tag.h
+++ b/src/libPMacc/include/cuSTL/container/tag.h
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CONTAINER_TAG_H
 #define CONTAINER_TAG_H

--- a/src/libPMacc/include/cuSTL/container/view/View.hpp
+++ b/src/libPMacc/include/cuSTL/container/view/View.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -46,7 +46,7 @@ struct View : public Buffer
         *this = other;
     }
     
-    HDINLINE ~View() 
+    HDINLINE ~View()
     {
         /* increment the reference counter because the container's destructor decrements it.
          * We want to compensate this.
@@ -67,7 +67,7 @@ struct View : public Buffer
 
 private:
     // forbid view = container
-    HDINLINE Buffer& 
+    HDINLINE Buffer&
     operator=(const Buffer& rhs);
 };
     

--- a/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_BUFFERCURSOR_HPP
 #define CURSOR_BUFFERCURSOR_HPP
@@ -35,9 +35,9 @@ namespace cursor
 {
     
 /** The most common cursor typedef
- * 
+ *
  * BufferCursor does access and jumping on a cartesian memory buffer.
- * 
+ *
  * \tparam Type type of a single datum
  * \tparam dim dimension of the memory buffer
  */
@@ -52,7 +52,7 @@ struct BufferCursor
      * pitch[1] is the distance in bytes to the incremented z-coordiante
      */
     HDINLINE
-    BufferCursor(Type* pointer, math::Size_t<dim-1> pitch) 
+    BufferCursor(Type* pointer, math::Size_t<dim-1> pitch)
      : Cursor<PointerAccessor<Type>, BufferNavigator<dim>, Type*>
             (PointerAccessor<Type>(), BufferNavigator<dim>(pitch), pointer) {}
             

--- a/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CURSOR_HPP
 #define CURSOR_CURSOR_HPP
@@ -37,7 +37,7 @@ namespace PMacc
 namespace cursor
 {
     
-/** A cursor is used to access a single datum and to jump to another one. 
+/** A cursor is used to access a single datum and to jump to another one.
  * It is always located at a certain datum. Think of a generalized iterator.
  * \tparam _Accessor Policy functor class that is called inside operator*().
  * It typically returns a reference to the current selected datum.
@@ -66,8 +66,8 @@ public:
              const Marker& marker)
                 : Accessor(accessor), Navigator(navigator), marker(marker) {}
 
-    /** access 
-     * \return Accessor's return type. 
+    /** access
+     * \return Accessor's return type.
      * Typically a reference to the current selected single datum.
      */
     HDINLINE
@@ -169,7 +169,7 @@ struct dim< PMacc::cursor::Cursor<_Accessor, _Navigator, _Marker> >
     static const int value = PMacc::cursor::traits::dim<typename Cursor<_Accessor, _Navigator, _Marker>::Navigator >::value;
 };
     
-} // traits           
+} // traits
     
 } // cursor
 } // PMacc

--- a/src/libPMacc/include/cuSTL/cursor/FunctorCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/FunctorCursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_FUNCTORCURSOR_HPP
 #define CURSOR_FUNCTORCURSOR_HPP
@@ -35,17 +35,17 @@ namespace cursor
 {
 
 /** wraps a cursor into a new cursor
- * 
- * On each access of the new cursor the result of the nested cursor access 
+ *
+ * On each access of the new cursor the result of the nested cursor access
  * is filtered through a user-defined functor.
  * e.g.: new_cur = make_FunctorCursor(cur, _1[2]); // access just the z-component
- * 
+ *
  * \param cursor Cursor to be wrapped
  * \param functor User functor acting as a filter. A lambda expression is allowed too.
  */
 template<typename TCursor, typename Functor>
 HDINLINE
-Cursor<FunctorAccessor<typename lambda::result_of::make_Functor<Functor>::type, 
+Cursor<FunctorAccessor<typename lambda::result_of::make_Functor<Functor>::type,
     typename boost::remove_reference<typename TCursor::type>::type>,
     CursorNavigator, TCursor> make_FunctorCursor(const TCursor& cursor, const Functor& functor)
 {

--- a/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_MULTIINDEXCURSOR
 #define CURSOR_MULTIINDEXCURSOR

--- a/src/libPMacc/include/cuSTL/cursor/NestedCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/NestedCursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_NESTEDCURSOR_HPP
 #define CURSOR_NESTEDCURSOR_HPP
@@ -32,7 +32,7 @@ namespace PMacc
 namespace cursor
 {
 
-/** wraps a cursor into a new cursor in a way that accessing on the new cursor 
+/** wraps a cursor into a new cursor in a way that accessing on the new cursor
  * means getting the nested cursor and jumping means jumping on the nested cursor.
  * \param cursor Cursor to be wrapped
  * \return A new cursor which wraps the given cursor

--- a/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_SAVECURSOR_HPP
 #define CURSOR_SAVECURSOR_HPP
@@ -51,11 +51,11 @@ public:
      * \param lowerExtent Top left corner of valid range, inside the range.
      * \param upperExtent Bottom right corner of valid range, inside the range.
      */
-    HDINLINE SafeCursor(const Cursor& cursor, 
+    HDINLINE SafeCursor(const Cursor& cursor,
                         const math::Int<dim>& lowerExtent,
                         const math::Int<dim>& upperExtent)
-        : Cursor(cursor), 
-          lowerExtent(lowerExtent), 
+        : Cursor(cursor),
+          lowerExtent(lowerExtent),
           upperExtent(upperExtent),
           offset(math::Int<dim>(0)),
           enabled(true)
@@ -82,7 +82,7 @@ public:
     HDINLINE
     SafeCursor<Cursor> operator()(const Jump& jump) const
     {
-        SafeCursor<Cursor> result(Cursor::operator()(jump), 
+        SafeCursor<Cursor> result(Cursor::operator()(jump),
                                   this->lowerExtent,
                                   this->upperExtent);
         result.offset = this->offset + jump;
@@ -133,7 +133,7 @@ private:
         {
             if(this->offset[i] < this->lowerExtent[i] ||
                this->offset[i] > this->upperExtent[i])
-                printf("error[cursor]: index %d out of range: %d is not within [%d, %d]\n", 
+                printf("error[cursor]: index %d out of range: %d is not within [%d, %d]\n",
                     i, this->offset[i], this->lowerExtent[i], this->upperExtent[i]);
         }
     }

--- a/src/libPMacc/include/cuSTL/cursor/accessor/CursorAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/CursorAccessor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CURSORACCESSOR_HPP
 #define CURSOR_CURSORACCESSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/accessor/FunctorAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/FunctorAccessor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_FUNCTORACCESSOR_HPP
 #define CURSOR_FUNCTORACCESSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/accessor/MarkerAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/MarkerAccessor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_MARKERACCESSOR_HPP
 #define CURSOR_MARKERACCESSOR_HPP
@@ -33,10 +33,10 @@ struct MarkerAccessor
 {
     typedef const Marker type;
     /** returns the cursor's marker.
-     * 
+     *
      * Here a copy of marker is returned because the cursor object
      * could be a temporary object. Therefore any reference or const-reference
-     * of marker is dangerous. If you want to have a reference to marker use e.g. 
+     * of marker is dangerous. If you want to have a reference to marker use e.g.
      * FunctorAccessor or Cursor::getMarker().
      */
     HDINLINE

--- a/src/libPMacc/include/cuSTL/cursor/accessor/PointerAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/PointerAccessor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_POINTERACCESSOR_HPP
 #define CURSOR_POINTERACCESSOR_HPP
@@ -34,7 +34,7 @@ struct PointerAccessor
     typedef Type& type;
     
     /** Returns the dereferenced pointer of type 'Type'
-     * 
+     *
      * Here a reference is returned because one expects a reference
      * if an ordinary c++ pointer is dereferenced too.
      * There is no danger if the cursor object is temporary.
@@ -45,7 +45,7 @@ struct PointerAccessor
     {
         return *((Type*)data);
     }
-};  
+};
     
 } // cursor
 } // PMacc

--- a/src/libPMacc/include/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -36,8 +36,8 @@ struct TwistAxesAccessor
     typedef typename math::tools::result_of::TwistVectorAxes<
         Axes, typename TCursor::pureType>::type type;
     
-    /** Returns a reference to the result of '*cursor' (with twisted axes). 
-     * 
+    /** Returns a reference to the result of '*cursor' (with twisted axes).
+     *
      * Be aware that the underlying cursor must not be a temporary object if '*cursor'
      * refers to something inside the cursor.
      */

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/BufferCursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CTBUFFERCURSOR_HPP
 #define CURSOR_CTBUFFERCURSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CT_SAVECURSOR_HPP
 #define CURSOR_CT_SAVECURSOR_HPP
@@ -113,14 +113,14 @@ private:
         {
             if(this->offset[i] < LowerExtent().toRT()[i] ||
                this->offset[i] > UpperExtent().toRT()[i])
-                printf("error[cursor]: index %d out of range: %d is not within [%d, %d]\n", 
+                printf("error[cursor]: index %d out of range: %d is not within [%d, %d]\n",
                     i, this->offset[i], LowerExtent().toRT()[i], UpperExtent().toRT()[i]);
         }
     }
 };
 
 template<typename Cursor, typename LowerExtent, typename UpperExtent>
-HDINLINE SafeCursor<Cursor, LowerExtent, UpperExtent> 
+HDINLINE SafeCursor<Cursor, LowerExtent, UpperExtent>
 make_SafeCursor(const Cursor& cursor, LowerExtent, UpperExtent)
 {
     return SafeCursor<Cursor, LowerExtent, UpperExtent>(cursor);

--- a/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_BUFFERNAVIGATOR_HPP
 #define CURSOR_BUFFERNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CARTNAVIGATOR_HPP
 #define CURSOR_CARTNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CursorNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CursorNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CURSORNAVIGATOR_HPP
 #define CURSOR_CURSORNAVIGATOR_HPP
@@ -33,7 +33,7 @@ namespace cursor
 struct CursorNavigator
 {
     template<typename Cursor, typename Jump>
-    HDINLINE 
+    HDINLINE
     Cursor operator()(const Cursor& cursor, const Jump& jump) const
     {
         return cursor(jump);

--- a/src/libPMacc/include/cuSTL/cursor/navigator/EmptyNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/EmptyNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_EMPTYNAVIGATOR_HPP
 #define CURSOR_EMPTYNAVIGATOR_HPP
@@ -31,7 +31,7 @@ namespace cursor
 struct EmptyNavigator
 {
     template<typename Marker, typename Jump>
-    HDINLINE 
+    HDINLINE
     Marker operator()(const Marker& marker, Jump) const
     {
         return marker;

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_MULTIINDEXNAVIGATOR_HPP
 #define CURSOR_MULTIINDEXNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CTBUFFERNAVIGATOR_HPP
 #define CURSOR_CTBUFFERNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
 #define CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
@@ -41,7 +41,7 @@ struct TwistAxesNavigator<Axes, 2>
     static const int dim = 2;
 
     template<typename TCursor>
-    HDINLINE 
+    HDINLINE
     TCursor operator()(const TCursor& cursor, const math::Int<2>& jump) const
     {
         math::Int<2> twistedJump;
@@ -57,7 +57,7 @@ struct TwistAxesNavigator<Axes, 3>
     static const int dim = 3;
 
     template<typename TCursor>
-    HDINLINE 
+    HDINLINE
     TCursor operator()(const TCursor& cursor, const math::Int<3>& jump) const
     {
         math::Int<3> twistedJump;

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
 #define CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
@@ -41,7 +41,7 @@ struct TwistedAxesNavigator<Axes, 2>
     static const int dim = 2;
 
     template<typename TCursor>
-    HDINLINE 
+    HDINLINE
     TCursor operator()(const TCursor& cursor, const math::Int<2>& jump) const
     {
         math::Int<2> twistedJump;
@@ -57,7 +57,7 @@ struct TwistedAxesNavigator<Axes, 3>
     static const int dim = 3;
 
     template<typename TCursor>
-    HDINLINE 
+    HDINLINE
     TCursor operator()(const TCursor& cursor, const math::Int<3>& jump) const
     {
         math::Int<3> twistedJump;

--- a/src/libPMacc/include/cuSTL/cursor/navigator/tag.h
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/tag.h
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_NAVIGATOR_TAG_H
 #define CURSOR_NAVIGATOR_TAG_H

--- a/src/libPMacc/include/cuSTL/cursor/tools/slice.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/slice.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_TOOLS_SLICE_HPP
 #define CURSOR_TOOLS_SLICE_HPP
@@ -43,7 +43,7 @@ template<typename TCursor>
 struct SliceResult<TCursor, tag::BufferNavigator>
 {
     typedef Cursor<
-        typename TCursor::Accessor, 
+        typename TCursor::Accessor,
         BufferNavigator<TCursor::Navigator::dim-1>,
         typename TCursor::Marker> type;
 };
@@ -52,7 +52,7 @@ template<typename TCursor>
 struct SliceResult<TCursor, tag::CartNavigator>
 {
     typedef Cursor<
-        typename TCursor::Accessor, 
+        typename TCursor::Accessor,
         CartNavigator<TCursor::Navigator::dim-1>,
         typename TCursor::Marker> type;
 };
@@ -97,8 +97,8 @@ slice(const TCursor& cur)
 {
     detail::Slice_helper<typename TCursor::Navigator, typename TCursor::Navigator::tag> slice_helper;
     return typename detail::SliceResult<TCursor, typename TCursor::Navigator::tag>::type
-            (cur.getAccessor(), 
-             slice_helper(cur.getNavigator()), 
+            (cur.getAccessor(),
+             slice_helper(cur.getNavigator()),
              cur.getMarker());
 }
     

--- a/src/libPMacc/include/cuSTL/cursor/tools/twistAxes.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/twistAxes.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_TOOLS_TWISTAXIS_HPP
 #define CURSOR_TOOLS_TWISTAXIS_HPP
@@ -35,11 +35,11 @@ namespace tools
 {
 
 /** Returns a new cursor which looks like a rotated version of the one passed.
- * 
+ *
  * The new cursor wraps the one that is passed. In the new cursor's navigator
  * the components of the passed int-vector are reordered according to the Axes
  * parameter and then passed to the nested cursor.
- * 
+ *
  * \tparam Axes compile-time vector (PMacc::math::CT::Int) that descripes the mapping.
  * x-axis -> Axes::at<0>, y-axis -> Axes::at<1>, ...
  */

--- a/src/libPMacc/include/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -47,17 +47,17 @@ struct TwistVectorFieldAxes
 } // result_of
   
 /** Returns a new cursor which looks like a vector field rotated version of the one passed
- * 
+ *
  * When rotating a vector field in physics the coordinate system and the vectors themselves
  * have to be rotated. This is the idea behind this function. It is assuming that the cursor
  * which is passed returns in its access call a vector type of the same dimension as in
  * the jumping call. In other words, the field and the vector have the same dimension.
- * 
+ *
  * e.g.: new_cur = twistVectorFieldAxes<math::CT::Int<1,2,0> >(cur); // x -> y, y -> z, z -> x
- * 
+ *
  * \tparam Axes compile-time vector (PMacc::math::CT::Int) that describes the mapping.
  * x-axis -> Axes::at<0>, y-axis -> Axes::at<1>, ...
- * 
+ *
  */
 template<typename Axes, typename TCursor>
 HDINLINE

--- a/src/libPMacc/include/cuSTL/cursor/traits.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/traits.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CURSOR_TRAITS_HPP
 #define CURSOR_TRAITS_HPP

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ZONE_SPHERICZONE_HPP
 #define ZONE_SPHERICZONE_HPP
@@ -38,11 +38,11 @@ struct SphericZone {};
 }
 
 /* spheric (no holes), cartesian zone
- * 
+ *
  * \tparam _dim dimension of the zone
- * 
+ *
  * This is a zone which is simply described by a size and a offset.
- * 
+ *
  */
 template<int _dim>
 struct SphericZone

--- a/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ZONE_STAGGEREDZONE_HPP
 #define ZONE_STAGGEREDZONE_HPP

--- a/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ZONE_TORICZONE_HPP
 #define ZONE_TORICZONE_HPP

--- a/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
@@ -32,14 +32,14 @@ namespace CT
 {
 
 /* spheric (no holes), cartesian, compile-time zone
- * 
+ *
  * \tparam _Size compile-time vector (PMacc::math::CT::Size_t) of the zone's size.
  * \tparam _Offset compile-time vector (PMacc::math::CT::Size_t) of the zone's offset. default is a zero vector.
- * 
+ *
  * This is a zone which is simply described by a size and a offset.
- * 
+ *
  * Compile-time version of zone::SphericZone
- * 
+ *
  */
 template<typename _Size, typename _Offset = typename math::CT::make_Int<_Size::dim, 0>::type>
 struct SphericZone

--- a/src/libPMacc/include/dataManagement/AbstractInitialiser.hpp
+++ b/src/libPMacc/include/dataManagement/AbstractInitialiser.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Rene Widera, Felix Schmitt
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ABSTRACTINITIALISER_HPP
 #define	ABSTRACTINITIALISER_HPP
@@ -39,7 +39,7 @@ namespace PMacc
         /**
          * Setup this initialiser.
          * Called before any init.
-         * 
+         *
          * @return the next timestep
          */
         virtual uint32_t setup() { return 0;};
@@ -52,7 +52,7 @@ namespace PMacc
         
         /**
          * Initialises simulation data (concrete type of data is described by id).
-         * 
+         *
          * @param data reference to actual simulation data
          * @param currentStep current simulation iteration
          */

--- a/src/libPMacc/include/dataManagement/DataConnector.hpp
+++ b/src/libPMacc/include/dataManagement/DataConnector.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Rene Widera, Felix Schmitt
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -39,7 +39,7 @@ namespace PMacc
      * Helper class for DataConnector.
      * Uses std::map<KeyType, ValType> for storing values and has a
      * IDataSorter for iterating over these values according to their keys.
-     * 
+     *
      * \tparam KeyType type of map keys
      * \tparam ValType type of map values
      */
@@ -50,7 +50,7 @@ namespace PMacc
 
         /**
          * Destructor.
-         * 
+         *
          * Deletes the IDataSorter and clears the mapping.
          */
         ~Mapping()
@@ -93,7 +93,7 @@ namespace PMacc
         /**
          * Initialises all Datasets using initialiser.
          * After initialising, the Datasets will be invalid.
-         * 
+         *
          * @param initialiser class used for initialising Datasets
          * @param currentStep current simulation step
          */
@@ -146,7 +146,7 @@ namespace PMacc
          * Reference to data in Dataset with identifier id and type TYPE is returned.
          * If the Dataset status in invalid, it is automatically synchronized.
          * Increments the reference counter to the dataset specified by id.
-         * This reference has to be released after all read/write operations 
+         * This reference has to be released after all read/write operations
          * before the next synchronize()/getData() on this data are done using releaseData().
          *
          * @tparam TYPE if of the data to load
@@ -173,7 +173,7 @@ namespace PMacc
 
         /**
          * Decrements the reference counter to the data specified by id.
-         * 
+         *
          * @param id id for the dataset previously acquired using getData()
          */
         void releaseData(SimulationDataId)

--- a/src/libPMacc/include/dataManagement/Dataset.hpp
+++ b/src/libPMacc/include/dataManagement/Dataset.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera, Felix Schmitt
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef DATASET_HPP
@@ -54,9 +54,9 @@ namespace PMacc
 
         /**
          * Returns stored data.
-         * Increments the reference counter to this data. 
+         * Increments the reference counter to this data.
          * This reference has to be released
-         * after all read/write operations before the next synchronize()/getData() 
+         * after all read/write operations before the next synchronize()/getData()
          * on this data are done using release().
          *
          * @return reference to internal stored data

--- a/src/libPMacc/include/dataManagement/IDataSorter.hpp
+++ b/src/libPMacc/include/dataManagement/IDataSorter.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera, Felix Schmitt
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef IDATASORTER_HPP
@@ -28,7 +28,7 @@ namespace PMacc
 {
     /**
      * Interface for a simulation data sorting class.
-     * 
+     *
      * Used for traversing IDs in DataConnector's data container while
      * initialising data (DataConnector.initialise()).
      */
@@ -45,14 +45,14 @@ namespace PMacc
 
         /**
          * Adds an ID to this sorter.
-         * 
+         *
          * @param id data id to add
          */
         virtual void add(ID_TYPE id) = 0;
 
         /**
          * Returns the first ID for this sorter.
-         * 
+         *
          * @return first id
          */
         virtual ID_TYPE begin() = 0;
@@ -61,16 +61,16 @@ namespace PMacc
 
         /**
          * Returns if there are more IDs in the sorter.
-         * 
+         *
          * @return whether there are more IDs.
          */
         virtual bool hasNext() = 0;
 
         /**
          * Returns the next ID in the sorter.
-         * 
+         *
          * Check with hasNext() if there are more IDs.
-         * 
+         *
          * @return next ID
          */
         virtual ID_TYPE getNext() = 0;

--- a/src/libPMacc/include/dataManagement/ISimulationData.hpp
+++ b/src/libPMacc/include/dataManagement/ISimulationData.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Rene Widera, Felix Schmitt
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef ISIMULATIONDATA_HPP
 #define	ISIMULATIONDATA_HPP
@@ -44,7 +44,7 @@ namespace PMacc
         
         /**
          * Return the globally unique identifier for this simulation data.
-         * 
+         *
          * @return globally unique identifier
          */
         virtual SimulationDataId getUniqueId() = 0;

--- a/src/libPMacc/include/dataManagement/ListSorter.hpp
+++ b/src/libPMacc/include/dataManagement/ListSorter.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Rene Widera, Felix Schmitt
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LISTSORTER_HPP
 #define	LISTSORTER_HPP
@@ -32,7 +32,7 @@ namespace PMacc
     /**
      * Default sorter for DataConnector.
      * Uses a std::list for managing IDs.
-     * 
+     *
      * FIFO compliant.
      */
     template<typename ID_TYPE>

--- a/src/libPMacc/include/debug/DebugBuffers.hpp
+++ b/src/libPMacc/include/debug/DebugBuffers.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef DEBUGBUFFERS_HPP
@@ -35,7 +35,7 @@ namespace PMacc
 
     /**
      * Helper class for debugging buffers
-     * 
+     *
      * @tparam DIM dimension of the buffer to debug.
      */
     template <unsigned DIM>
@@ -44,7 +44,7 @@ namespace PMacc
     public:
         /**
          * Converts a HostBuffer to a string for debugging.
-         * 
+         *
          * @tparam TYPE datatype stored in the buffer
          * @param hostBuffer the HostBuffer to convert to a string
          * @return a string representing the buffer

--- a/src/libPMacc/include/debug/DebugDataSpace.hpp
+++ b/src/libPMacc/include/debug/DebugDataSpace.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef DEBUGDATASPACE_HPP
@@ -34,7 +34,7 @@ namespace PMacc
 
     /**
      * Helper class for debugging DataSpaces
-     * 
+     *
      * @tparam DIM dimension of the DataSpace to debug.
      */
     template <unsigned DIM>

--- a/src/libPMacc/include/debug/DebugExchangeTypes.hpp
+++ b/src/libPMacc/include/debug/DebugExchangeTypes.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef DEBUGEXCHANGETYPES_HPP
 #define	DEBUGEXCHANGETYPES_HPP
@@ -34,7 +34,7 @@ namespace PMacc
 
     /**
      * Helper class for debugging exchange types.
-     * 
+     *
      */
     class DebugExchangeTypes
     {
@@ -42,7 +42,7 @@ namespace PMacc
         
         /**
          * Converts an exchange type to a string for debugging.
-         * 
+         *
          * @param exchangeType the exchange type to convert
          * @return a string representing the exchange type
          */

--- a/src/libPMacc/include/debug/PMaccVerbose.hpp
+++ b/src/libPMacc/include/debug/PMaccVerbose.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -35,7 +35,7 @@ namespace PMacc
 /*create verbose class*/
 DEFINE_VERBOSE_CLASS(PMaccVerbose)
 (
-    /* define log lvl for later use 
+    /* define log lvl for later use
      * e.g. log<PMaccLogLvl::NOTHING>("TEXT");*/
     DEFINE_LOGLVL(0,NOTHING);
     DEFINE_LOGLVL(1,MEMORY);

--- a/src/libPMacc/include/debug/VerboseLogMakros.hpp
+++ b/src/libPMacc/include/debug/VerboseLogMakros.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/dimensions/DataSpace.tpp
+++ b/src/libPMacc/include/dimensions/DataSpace.tpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013-2014 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/libPMacc/include/dimensions/GridLayout.hpp
+++ b/src/libPMacc/include/dimensions/GridLayout.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _GRIDLAYOUT_HPP
 #define	_GRIDLAYOUT_HPP
@@ -30,7 +30,7 @@ namespace PMacc
 
     /**
      * Describes layout of a DIM-dimensional data grid including the actual grid and optional guards.
-     * 
+     *
      * @tparam DIM dimension of the grid
      */
     template <unsigned DIM>

--- a/src/libPMacc/include/eventSystem/EventSystem.hpp
+++ b/src/libPMacc/include/eventSystem/EventSystem.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _EVENTDATARECEIVE_HPP

--- a/src/libPMacc/include/eventSystem/events/EventNotify.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _EVENTNOTIFY_HPP

--- a/src/libPMacc/include/eventSystem/events/EventNotify.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include <set>
 
@@ -50,7 +50,7 @@ namespace PMacc
              *  delete data;
              **/
 
-        } 
+        }
 
 } //namespace PMacc
 

--- a/src/libPMacc/include/eventSystem/events/EventPool.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventPool.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef EVENTPOOL_HPP

--- a/src/libPMacc/include/eventSystem/events/EventTask.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventTask.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #ifndef _EVENTTASK_HPP
@@ -95,7 +95,7 @@ namespace PMacc
 
         /**
          * Copies attributes from other to this task.
-         * 
+         *
          * This task effectively becomes other.
          */
         EventTask & operator=(const EventTask & other);

--- a/src/libPMacc/include/eventSystem/events/EventTask.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventTask.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #include "eventSystem/EventSystem.hpp"
@@ -80,7 +80,7 @@ namespace PMacc
             return *this;
 
         ITask* myTask = manager.getITaskIfNotFinished(this->taskId);
-        if(myTask==NULL) 
+        if(myTask==NULL)
         {
             this->taskId=other.taskId;
             return *this;

--- a/src/libPMacc/include/eventSystem/events/IEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/IEvent.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _IEVENT_HPP

--- a/src/libPMacc/include/eventSystem/events/IEventData.hpp
+++ b/src/libPMacc/include/eventSystem/events/IEventData.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _IEVENTDATA_HPP
 #define	_IEVENTDATA_HPP

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef KERNELEVENTS_H
 #define KERNELEVENTS_H
@@ -43,9 +43,9 @@ namespace PMacc
 #endif
  
 /** Call activate kernel from taskKernel.
- *  If PMACC_SYNC_KERNEL is 1 cudaThreadSynchronize() is called before 
+ *  If PMACC_SYNC_KERNEL is 1 cudaThreadSynchronize() is called before
  *  and after activation.
- */    
+ */
 #define PMACC_ACTIVATE_KERNEL                                                           \
         CUDA_CHECK_KERNEL_MSG(cudaThreadSynchronize(),"Crash after kernel call");       \
         taskKernel->activateChecks();                                                   \

--- a/src/libPMacc/include/eventSystem/streams/EventStream.hpp
+++ b/src/libPMacc/include/eventSystem/streams/EventStream.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef EVENTSTREAM_HPP
@@ -52,7 +52,7 @@ namespace PMacc
         virtual ~EventStream()
         {
             //wait for all kernels in stream to finish
-            CUDA_CHECK(cudaStreamSynchronize(stream)); 
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             CUDA_CHECK(cudaStreamDestroy(stream));
         }
 

--- a/src/libPMacc/include/eventSystem/tasks/Factory.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _FACTORY_HPP

--- a/src/libPMacc/include/eventSystem/tasks/Factory.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #include "eventSystem/tasks/Factory.hpp"

--- a/src/libPMacc/include/eventSystem/tasks/ITask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/ITask.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _ITASK_HPP
@@ -114,7 +114,7 @@ namespace PMacc
 
         /**
          * Returns a string representation of the task.
-         * 
+         *
          * @return a string naming this task
          */
         virtual std::string toString() = 0;

--- a/src/libPMacc/include/eventSystem/tasks/MPITask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/MPITask.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef MPITASK_HPP
 #define	MPITASK_HPP

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef STREAMTASK_HPP
 #define	STREAMTASK_HPP
@@ -77,7 +77,7 @@ namespace PMacc
 
         /**
          * Returns the EventStream this StreamTask is using.
-         * 
+         *
          * @return pointer to the EventStream
          */
         EventStream* getEventStream();

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include <cuda_runtime.h>
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _TASKCOPYDEVICETODEVICE_HPP
 #define	_TASKCOPYDEVICETODEVICE_HPP

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _TASKCOPYDEVICETOHOST_HPP
 #define	_TASKCOPYDEVICETOHOST_HPP

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _TASKCOPYHOSTTODEVICE_HPP
 #define	_TASKCOPYHOSTTODEVICE_HPP

--- a/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _TASKGETCURRENTSIZEFROMDEVICE_HPP
 #define _TASKGETCURRENTSIZEFROMDEVICE_HPP
@@ -58,7 +58,7 @@ public:
     }
 
     bool executeIntern() throw(std::runtime_error)
-    {   
+    {
         return isFinished();
     }
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #ifndef _TASKKERNEL_HPP

--- a/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef _TASKRECEIVE_HPP
 #define	_TASKRECEIVE_HPP

--- a/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _TASKSEND_HPP

--- a/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef TASKSENDMPI_HPP
 #define	TASKSENDMPI_HPP

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _TASKSETCURRENTSIZEONDEVICE_HPP

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #ifndef TRANSACTION_HPP

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "eventSystem/streams/StreamController.hpp"
 #include "eventSystem/events/EventTask.hpp"

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include <cassert>
 #include "eventSystem/EventSystem.hpp"

--- a/src/libPMacc/include/fields/SimulationFieldHelper.hpp
+++ b/src/libPMacc/include/fields/SimulationFieldHelper.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef SIMULATIONFIELDHELPER_HPP
 #define	SIMULATIONFIELDHELPER_HPP
@@ -52,8 +52,8 @@ public:
     virtual void syncToDevice() = 0;
     
     /**
-     * Start an asynchronous communication. 
-     * 
+     * Start an asynchronous communication.
+     *
      * @param serialEvent an EventTask the method has to wait on
      * @return an EventTask which can be used to wait on completion
      */

--- a/src/libPMacc/include/identifier/identifier.hpp
+++ b/src/libPMacc/include/identifier/identifier.hpp
@@ -52,11 +52,11 @@
 
 /** create a identifier (identifier with arbitrary code as second parameter
  * !! second parameter is optinal and can by any C++ code one can add inside a class
- * 
+ *
  * example: identifier(varname); //create type varname
- * example: identifier(varname,typedef int type;); //create type varname, 
- *          later its possible to use: typedef varname::type type; 
- * 
+ * example: identifier(varname,typedef int type;); //create type varname,
+ *          later its possible to use: typedef varname::type type;
+ *
  * to create a instance of this identifier you can use:
  *      varname();   or varname_
  */

--- a/src/libPMacc/include/lambda/CT/Eval.hpp
+++ b/src/libPMacc/include/lambda/CT/Eval.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_CT_EVAL_HPP
 #define LAMBDA_CT_EVAL_HPP
@@ -196,7 +196,7 @@ struct Eval<CT::Expression<lambda::Expression<exprTypes::terminal, mpl::vector<p
     typedef lambda::Expression<exprTypes::terminal, mpl::vector<placeholder<I> > > Expr;
     
     template<typename TerminalTuple, typename ArgsTuple>
-    HDINLINE 
+    HDINLINE
     typename CT::result_of::Eval<Expr, ArgsTuple>::type
     operator()(TerminalTuple, const ArgsTuple& argsTuple) const
     {
@@ -251,7 +251,7 @@ struct Eval<CT::Expression<lambda::Expression<exprTypes::assign, mpl::vector<Chi
     HDINLINE typename result_of::Eval<Expr, ArgsTuple>::type
     operator()(const TerminalTuple& terminalTuple, const ArgsTuple& argsTuple) const
     {
-        CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple) 
+        CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple)
          = CT::Eval<typename CTExpr::Child1>()(terminalTuple, argsTuple);
          
         return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple);
@@ -269,7 +269,7 @@ struct Eval<CT::Expression<lambda::Expression<exprTypes::plus, mpl::vector<Child
     HDINLINE typename result_of::Eval<Expr, ArgsTuple>::type
     operator()(const TerminalTuple& terminalTuple, const ArgsTuple& argsTuple) const
     {
-        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple) 
+        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple)
          + CT::Eval<typename CTExpr::Child1>()(terminalTuple, argsTuple);
     }
 };
@@ -285,7 +285,7 @@ struct Eval<CT::Expression<lambda::Expression<exprTypes::minus, mpl::vector<Chil
     HDINLINE typename result_of::Eval<Expr, ArgsTuple>::type
     operator()(const TerminalTuple& terminalTuple, const ArgsTuple& argsTuple) const
     {
-        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple) 
+        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple)
          - CT::Eval<typename CTExpr::Child1>()(terminalTuple, argsTuple);
     }
 };
@@ -301,7 +301,7 @@ struct Eval<CT::Expression<lambda::Expression<exprTypes::multiply, mpl::vector<C
     HDINLINE typename result_of::Eval<Expr, ArgsTuple>::type
     operator()(const TerminalTuple& terminalTuple, const ArgsTuple& argsTuple) const
     {
-        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple) 
+        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple)
          * CT::Eval<typename CTExpr::Child1>()(terminalTuple, argsTuple);
     }
 };
@@ -317,7 +317,7 @@ struct Eval<CT::Expression<lambda::Expression<exprTypes::divide, mpl::vector<Chi
     HDINLINE typename result_of::Eval<Expr, ArgsTuple>::type
     operator()(const TerminalTuple& terminalTuple, const ArgsTuple& argsTuple) const
     {
-        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple) 
+        return CT::Eval<typename CTExpr::Child0>()(terminalTuple, argsTuple)
          / CT::Eval<typename CTExpr::Child1>()(terminalTuple, argsTuple);
     }
 };

--- a/src/libPMacc/include/lambda/CT/Expression.hpp
+++ b/src/libPMacc/include/lambda/CT/Expression.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_CT_EXPRESSION_HPP
 #define LAMBDA_CT_EXPRESSION_HPP
@@ -28,7 +28,7 @@
 namespace PMacc
 {
 namespace lambda
-{   
+{
 namespace CT
 {
     

--- a/src/libPMacc/include/lambda/CT/FillTerminalList.hpp
+++ b/src/libPMacc/include/lambda/CT/FillTerminalList.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_CT_FILLTERMINALLIST_HPP
 #define LAMBDA_CT_FILLTERMINALLIST_HPP

--- a/src/libPMacc/include/lambda/CT/TerminalTL.hpp
+++ b/src/libPMacc/include/lambda/CT/TerminalTL.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_CT_TERMINALTL_HPP
 #define LAMBDA_CT_TERMINALTL_HPP

--- a/src/libPMacc/include/lambda/ExprTypes.h
+++ b/src/libPMacc/include/lambda/ExprTypes.h
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_KERNEL_EXPRTYPES_H
 #define LAMBDA_KERNEL_EXPRTYPES_H

--- a/src/libPMacc/include/lambda/Expression.hpp
+++ b/src/libPMacc/include/lambda/Expression.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_EXPRESSION_HPP
 #define LAMBDA_EXPRESSION_HPP
@@ -65,10 +65,10 @@ using mpl::at_c;
 /** Expression is a node in an expression tree
  * \tparam _ExprType see available expression types in ExprTypes.h
  * \tparam _Childs childs notes. This is a mpl typelist
- * 
- * Expression inherits from its childs. They could also be class members but 
+ *
+ * Expression inherits from its childs. They could also be class members but
  * then they would cost one byte extra memory if they are empty.
- * 
+ *
  */
 template<typename _ExprType, typename _Childs>
 struct Expression : public math::Tuple<_Childs>

--- a/src/libPMacc/include/lambda/ProxyClass.hpp
+++ b/src/libPMacc/include/lambda/ProxyClass.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/lambda/is_Expression.hpp
+++ b/src/libPMacc/include/lambda/is_Expression.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_KERNEL_IS_EXPRESSION_HPP
 #define LAMBDA_KERNEL_IS_EXPRESSION_HPP
@@ -29,7 +29,7 @@ namespace mpl = boost::mpl;
 namespace PMacc
 {
 namespace lambda
-{    
+{
 
 template<typename Type>
 struct is_Expression

--- a/src/libPMacc/include/lambda/make_Expr.hpp
+++ b/src/libPMacc/include/lambda/make_Expr.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_KERNEL_MAKE_EXPR_HPP
 #define LAMBDA_KERNEL_MAKE_EXPR_HPP

--- a/src/libPMacc/include/lambda/make_Functor.hpp
+++ b/src/libPMacc/include/lambda/make_Functor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef LAMBDA_MAKE_FUNCTOR_HPP
 #define LAMBDA_MAKE_FUNCTOR_HPP

--- a/src/libPMacc/include/lambda/placeholder.h
+++ b/src/libPMacc/include/lambda/placeholder.h
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/libPMacc/include/mappings/kernel/AreaMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/AreaMapping.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef AREAMAPPING_H
 #define	AREAMAPPING_H

--- a/src/libPMacc/include/mappings/kernel/CudaGridDimRestrictions.hpp
+++ b/src/libPMacc/include/mappings/kernel/CudaGridDimRestrictions.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef CUDAGRIDDIMRESTRICTIONS_HPP
 #define	CUDAGRIDDIMRESTRICTIONS_HPP

--- a/src/libPMacc/include/mappings/kernel/ExchangeMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/ExchangeMapping.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef EXCHANGEMAPPING_H
 #define	EXCHANGEMAPPING_H

--- a/src/libPMacc/include/mappings/kernel/ExchangeMappingMethods.hpp
+++ b/src/libPMacc/include/mappings/kernel/ExchangeMappingMethods.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef EXCHANGEMAPPINGMETHODS_H
 #define	EXCHANGEMAPPINGMETHODS_H

--- a/src/libPMacc/include/mappings/kernel/StrideMappingMethods.hpp
+++ b/src/libPMacc/include/mappings/kernel/StrideMappingMethods.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #ifndef STRIDEMAPPINGMETHODS_H

--- a/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
+++ b/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #ifndef _ENVIRONMENTCONTROLLER_HPP

--- a/src/libPMacc/include/mappings/simulation/Filesystem.hpp
+++ b/src/libPMacc/include/mappings/simulation/Filesystem.hpp
@@ -31,7 +31,7 @@ namespace PMacc
 
         /**
          * Singleton class providing common filesystem operations.
-         * 
+         *
          * @tparam DIM number of dimensions of the simulation
          */
         template<unsigned DIM>

--- a/src/libPMacc/include/mappings/simulation/GridController.hpp
+++ b/src/libPMacc/include/mappings/simulation/GridController.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _GRIDCONTROLLER_HPP
@@ -119,8 +119,8 @@ namespace PMacc
     
             /**
              * Returns the scalar position (rank) of this GPU,
-             * depending on its current grid position 
-             * 
+             * depending on its current grid position
+             *
              * @return current grid position as scalar value
              */
             uint32_t getScalarPosition() const
@@ -169,7 +169,7 @@ namespace PMacc
              * @return true if the position of the calling GPU is switched to the end, false otherwise
              */
             bool slide()
-            {              
+            {
                /* wait that all tasks are finished */
                Environment<DIM>::get().Manager().waitForAllTasks();//
 
@@ -183,7 +183,7 @@ namespace PMacc
     
             /**
              * Slides multiple times.
-             * 
+             *
              * @param[in] numSlides number of slides
              * @return true if the position of gpu is switched to the end, else false
              */
@@ -206,7 +206,7 @@ namespace PMacc
 
             /**
              * Returns the MPI communicator class
-             * 
+             *
              * @return current CommunicatorMPI
              */
             CommunicatorMPI<DIM>& getCommunicator()
@@ -235,7 +235,7 @@ namespace PMacc
     
             /**
              * Sets globalOffset using the current position.
-             * 
+             *
              * (This function is idempotent)
              */
             void updateGlobalOffset()

--- a/src/libPMacc/include/mappings/simulation/SubGrid.hpp
+++ b/src/libPMacc/include/mappings/simulation/SubGrid.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -57,7 +57,7 @@ namespace PMacc
         }
 
         /** get size of global simulation box (in cells)
-        *      
+        *
         */
         HDINLINE Size getGlobalSize() const
         {
@@ -66,7 +66,7 @@ namespace PMacc
 
         /**
          * Get size of local simulation area.
-         * 
+         *
          * @return size of local simulation area
          */
         HDINLINE Size getLocalSize() const
@@ -78,7 +78,7 @@ namespace PMacc
          * Get distance from global origin to local origin (in cells)
          *
          * local null point=Top/Left in 2D, Top/Left/Front in 3D
-         * 
+         *
          * @return offset to local origin of ordinates
          */
         HDINLINE Size getGlobalOffset() const

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -34,7 +34,7 @@
 #endif
 
 /** @see PMACC_CONST_VECTOR documentation, only unique "id" is added
- * 
+ *
  * @param id unique precompiler id to create unique namespaces
  */
 #define PMACC_STATIC_CONST_VECTOR_DIM(id,Name,Type,Dim,count,...)               \
@@ -90,21 +90,21 @@ using namespace PMACC_JOIN(pmacc_static_const_storage,id)
                                                                          
 
 /** Create global constant math::Vector with compile time values which can be
- *  used on device and host 
- * 
+ *  used on device and host
+ *
  * Support all native C/C++ types (e.g. int, float, double,...) and structs with
  * default constructor
- * 
+ *
  * @param type type of vector
  * @param dim count of components of the vector
  * @param name name of created vector instance
  * @param ... values for component x,y,z
- *            If dim is 2 the parameter z is optional 
- * 
+ *            If dim is 2 the parameter z is optional
+ *
  * e.g. PMACC_CONST_VECTOR(float,2,myVector,2.1,4.2);
  *      create math:Vector<float,2> myVector(2.1,4.2); //as global const vector
  *      The type of the created vector is "name_t" -> in this case "myVector_t"
- */                                                          
+ */
 #define PMACC_CONST_VECTOR(type,dim,name,...)                                   \
     PMACC_STATIC_CONST_VECTOR_DIM(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(__VA_ARGS__),__VA_ARGS__)
     

--- a/src/libPMacc/include/math/MapTuple.hpp
+++ b/src/libPMacc/include/math/MapTuple.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/libPMacc/include/math/Tuple.hpp
+++ b/src/libPMacc/include/math/Tuple.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -82,7 +82,7 @@ private:
 public:
     HDINLINE Tuple() {}
     
-    HDINLINE Tuple(Value arg0) : value(arg0) 
+    HDINLINE Tuple(Value arg0) : value(arg0)
     {
         BOOST_STATIC_ASSERT(dim == 1);
     }
@@ -90,14 +90,14 @@ public:
     BOOST_PP_REPEAT_FROM_TO(2, BOOST_PP_INC(TUPLE_MAX_DIM), CONSTRUCTOR, _)
     
     template<int i>
-    HDINLINE 
+    HDINLINE
     typename mpl::at_c<TypeList, i>::type&
     at_c()
     {
         return this->at(mpl::int_<i>());
     }
     template<int i>
-    HDINLINE 
+    HDINLINE
     const typename mpl::at_c<TypeList, i>::type&
     at_c() const
     {
@@ -105,25 +105,25 @@ public:
     }
     
     HDINLINE Value& at(mpl::int_<0>)
-    {    
+    {
         return value;
     }
     HDINLINE Value& at(mpl_::integral_c<int, 0>)
-    {    
+    {
         return value;
     }
     
     HDINLINE const Value& at(mpl::int_<0>) const
-    {    
+    {
         return value;
     }
     HDINLINE const Value& at(mpl_::integral_c<int, 0>) const
-    {    
+    {
         return value;
     }
     
     template<typename Idx>
-    HDINLINE 
+    HDINLINE
     typename mpl::at<TypeList, Idx>::type&
     at(Idx)
     {
@@ -131,7 +131,7 @@ public:
     }
     
     template<typename Idx>
-    HDINLINE 
+    HDINLINE
     const typename mpl::at<TypeList, Idx>::type&
     at(Idx) const
     {

--- a/src/libPMacc/include/math/Vector.hpp
+++ b/src/libPMacc/include/math/Vector.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/math/vector/Float.hpp
+++ b/src/libPMacc/include/math/vector/Float.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/libPMacc/include/math/vector/Size_t.hpp
+++ b/src/libPMacc/include/math/vector/Size_t.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/libPMacc/include/math/vector/UInt.hpp
+++ b/src/libPMacc/include/math/vector/UInt.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/libPMacc/include/math/vector/accessor/StandartAccessor.hpp
+++ b/src/libPMacc/include/math/vector/accessor/StandartAccessor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/math/vector/compile-time/Float.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Float.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/math/vector/compile-time/Int.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Int.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -35,17 +35,17 @@ namespace CT
 {
     
 /** Compile time int vector
- * 
- * 
+ *
+ *
  * @tparam x value for x allowed range [INT_MIN;INT_MAX-1]
  * @tparam y value for y allowed range [INT_MIN;INT_MAX-1]
  * @tparam z value for z allowed range [INT_MIN;INT_MAX-1]
- * 
+ *
  * default parameter is used to distinguish between values given by
  * the user and unset values.
  */
-template<int x = traits::limits::Max<int>::value, 
-         int y = traits::limits::Max<int>::value, 
+template<int x = traits::limits::Max<int>::value,
+         int y = traits::limits::Max<int>::value,
          int z = traits::limits::Max<int>::value>
 struct Int: public CT::Vector<mpl::integral_c<int, x>,
                               mpl::integral_c<int, y>,

--- a/src/libPMacc/include/math/vector/compile-time/Size_t.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Size_t.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -35,17 +35,17 @@ namespace CT
 {
 
 /** Compile time size_t vector
- * 
- * 
+ *
+ *
  * @tparam x value for x allowed range [0;max size_t value -1]
  * @tparam y value for y allowed range [0;max size_t value -1]
  * @tparam z value for z allowed range [0;max size_t value -1]
- * 
+ *
  * default parameter is used to distinguish between values given by
  * the user and unset values.
  */
-template<size_t x = traits::limits::Max<size_t>::value, 
-         size_t y = traits::limits::Max<size_t>::value, 
+template<size_t x = traits::limits::Max<size_t>::value,
+         size_t y = traits::limits::Max<size_t>::value,
          size_t z = traits::limits::Max<size_t>::value>
 struct Size_t : public CT::Vector<mpl::integral_c<size_t, x>,
                               mpl::integral_c<size_t, y>,

--- a/src/libPMacc/include/math/vector/compile-time/UInt.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/UInt.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -35,17 +35,17 @@ namespace CT
 {
 
 /** Compile time uint vector
- * 
- * 
+ *
+ *
  * @tparam x value for x allowed range [0;max uint32_t value -1]
  * @tparam y value for y allowed range [0;max uint32_t value -1]
  * @tparam z value for z allowed range [0;max uint32_t value -1]
- * 
+ *
  * default parameter is used to distinguish between values given by
  * the user and unset values.
  */
-template<uint32_t x = traits::limits::Max<uint32_t>::value, 
-         uint32_t y = traits::limits::Max<uint32_t>::value, 
+template<uint32_t x = traits::limits::Max<uint32_t>::value,
+         uint32_t y = traits::limits::Max<uint32_t>::value,
          uint32_t z = traits::limits::Max<uint32_t>::value>
 struct UInt : public CT::Vector<mpl::integral_c<uint32_t, x>,
                                                    mpl::integral_c<uint32_t, y>,

--- a/src/libPMacc/include/math/vector/math_functor/cosf.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/cosf.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef MATH_FUNCTOR_COSF_HPP
 #define MATH_FUNCTOR_COSF_HPP

--- a/src/libPMacc/include/math/vector/math_functor/max.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/max.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef MATH_FUNCTOR_MAX_HPP
 #define MATH_FUNCTOR_MAX_HPP

--- a/src/libPMacc/include/math/vector/math_functor/min.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/min.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef MATH_FUNCTOR_MIN_HPP
 #define MATH_FUNCTOR_MIN_HPP

--- a/src/libPMacc/include/math/vector/math_functor/sqrtf.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/sqrtf.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef MATH_FUNCTOR_SQRTF_HPP
 #define MATH_FUNCTOR_SQRTF_HPP

--- a/src/libPMacc/include/math/vector/navigator/PermutedNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/PermutedNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/math/vector/navigator/StackedNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/StackedNavigator.hpp
@@ -2,7 +2,7 @@
  * Copyright 2014 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
- * 
+ *
  * libPMacc is free software: you can redistribute it and/or modify
  * it under the terms of of either the GNU General Public License or
  * the GNU Lesser General Public License as published by
@@ -14,7 +14,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License and the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
@@ -28,7 +28,7 @@ namespace math
 {
 
 /* Sticks two navigators together resulting in a new navigator.
- * 
+ *
  * \tparam NaviA first navigator to be called
  * \tparam NaviB second navigator to be called
  */

--- a/src/libPMacc/include/math/vector/navigator/StandartNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/StandartNavigator.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/math/vector/tools/twistVectorAxes.hpp
+++ b/src/libPMacc/include/math/vector/tools/twistVectorAxes.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -56,12 +56,12 @@ struct TwistVectorAxes<T_Axes,math::Vector<T_Type,T_Dim,T_Accessor,T_Navigator,T
 } // result_of
     
 /** Returns a reference of vector with twisted axes.
- * 
- * The axes twist operation is done in place. This means that the result refers to the 
- * memory of the input vector. The input vector's navigator policy is replaced by 
+ *
+ * The axes twist operation is done in place. This means that the result refers to the
+ * memory of the input vector. The input vector's navigator policy is replaced by
  * a new navigator which merely consists of the old navigator plus a twisting navigator.
  * This new navigator does not use any real memory.
- * 
+ *
  * \tparam T_Axes Mapped indices
  * \tparam T_Vector type of vector to be twisted
  * \param vector vector to be twisted

--- a/src/libPMacc/include/memory/boxes/DataBox.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _DATABOX_HPP

--- a/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2014 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -30,7 +30,7 @@ namespace PMacc
 {
 
 /** DataBox which apply a unary functor on every operator () and [] access
- * 
+ *
  * @tparam T_Base base class to inherit from
  * @tparam T_UnaryFunctor unary functor which is applied on every access
  *         - template parameter of functor is the input type for the functor

--- a/src/libPMacc/include/memory/boxes/MultiBox.hpp
+++ b/src/libPMacc/include/memory/boxes/MultiBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #pragma once

--- a/src/libPMacc/include/memory/boxes/PitchedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/PitchedBox.hpp
@@ -1,31 +1,31 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #pragma once
 
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
-#include <cuSTL/cursor/BufferCursor.hpp>      
+#include <cuSTL/cursor/BufferCursor.hpp>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _BUFFER_HPP
@@ -38,7 +38,7 @@ namespace PMacc
 
     /**
      * Minimal function descriptiin of a buffer,
-     * 
+     *
      * @tparam TYPE datatype stored in the buffer
      * @tparam DIM dimension of the buffer (1-3)
      */
@@ -86,7 +86,7 @@ namespace PMacc
             return data_space;
         }
 
-        virtual DataSpace<DIM> getCurrentDataSpace() 
+        virtual DataSpace<DIM> getCurrentDataSpace()
         {
             return getCurrentDataSpace(getCurrentSize());
         }
@@ -96,7 +96,7 @@ namespace PMacc
          * if DIM == DIM2 than return how many lines (y-direction) of memory is used
          * if DIM == DIM3 than return how many slides (z-direction) of memory is used
          */
-        virtual DataSpace<DIM> getCurrentDataSpace(size_t currentSize) 
+        virtual DataSpace<DIM> getCurrentDataSpace(size_t currentSize)
         {
             DataSpace<DIM> tmp;
             int64_t current_size = static_cast<int64_t>(currentSize);
@@ -146,9 +146,9 @@ namespace PMacc
         /*! returns the current size (count of elements)
          * @return current size
          */
-        virtual size_t getCurrentSize() 
+        virtual size_t getCurrentSize()
         {
-            __startOperation(ITask::TASK_HOST);  
+            __startOperation(ITask::TASK_HOST);
             return *current_size;
         }
         
@@ -157,7 +157,7 @@ namespace PMacc
          */
         virtual void setCurrentSize(size_t newsize)
         {
-            __startOperation(ITask::TASK_HOST); 
+            __startOperation(ITask::TASK_HOST);
             assert(static_cast<size_t>(newsize) <= static_cast<size_t>(data_space.productOfComponents()));
             *current_size = newsize;
         }

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _DEVICEBUFFER_HPP
@@ -93,7 +93,7 @@ namespace PMacc
                 result.pitch[0] = cudaData.pitch;
                 result.pitch[1] = cudaData.pitch * result._size.y();
             }
-#ifndef __CUDA_ARCH__ 
+#ifndef __CUDA_ARCH__
             result.refCount = new int;
 #endif
             *result.refCount = 2;
@@ -124,7 +124,7 @@ namespace PMacc
         virtual size_t* getCurrentSizeOnDevicePointer() = 0;
         
         /** Returns host pointer of current size storage
-         * 
+         *
          * @return pointer to stored value on host side
          */
         virtual size_t* getCurrentSizeHostSidePointer()=0;
@@ -148,7 +148,7 @@ namespace PMacc
         virtual const cudaPitchedPtr getCudaPitched() const = 0;
         
         /** get line pitch of memory in byte
-         * 
+         *
          * @return size of one line in memory
          */
         virtual size_t getPitch() const = 0;
@@ -162,7 +162,7 @@ namespace PMacc
 
         /**
          * Copies data from the given DeviceBuffer to this DeviceBuffer.
-         * 
+         *
          * @param other the DeviceBuffer to copy from
          */
         virtual void copyFrom(DeviceBuffer<TYPE, DIM>& other) = 0;

--- a/src/libPMacc/include/memory/buffers/Exchange.hpp
+++ b/src/libPMacc/include/memory/buffers/Exchange.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef _EXCHANGE_HPP

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -102,7 +102,7 @@ public:
     /**
      * Constructor.
      *
-     * @param gridLayout layout of the buffers, including border-cells    
+     * @param gridLayout layout of the buffers, including border-cells
      * @param sizeOnDevice if true, size information exists on device, too.
      */
     GridBuffer(const GridLayout<DIM>& gridLayout, bool sizeOnDevice = false) :
@@ -116,7 +116,7 @@ public:
     /**
      * Constructor.
      *
-     * @param dataSpace DataSpace representing buffer size without border-cells   
+     * @param dataSpace DataSpace representing buffer size without border-cells
      * @param sizeOnDevice if true, size information exists on device, too.
      */
     GridBuffer(DataSpace<DIM>& dataSpace, bool sizeOnDevice = false) :
@@ -131,7 +131,7 @@ public:
      * Constructor.
      *
      * @param otherDeviceBuffer DeviceBuffer which should be used instead of creating own DeviceBuffer
-     * @param gridLayout layout of the buffers, including border-cells     
+     * @param gridLayout layout of the buffers, including border-cells
      * @param sizeOnDevice if true, size information exists on device, too.
      */
     GridBuffer(DeviceBuffer<TYPE, DIM>& otherDeviceBuffer, GridLayout<DIM> gridLayout, bool sizeOnDevice = false) :

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #include "memory/buffers/Buffer.hpp"

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #ifndef _HOSTBUFFERINTERN_HPP

--- a/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
@@ -35,7 +35,7 @@ namespace PMacc
 {
 
 /** Implementation of the DeviceBuffer interface for cuda mapped memory
- * 
+ *
  * For all pmacc tasks and functions this buffer looks like native device buffer
  * but in real it is stored in host memory.
  */
@@ -78,10 +78,10 @@ public:
     }
 
     /*! Get device pointer of memory
-     * 
+     *
      * This pointer is shifted by the offset, if this buffer points to other
      * existing buffer
-     * 
+     *
      * @return device pointer to memory
      */
     TYPE* getPointer()

--- a/src/libPMacc/include/memory/dataTypes/BitData.hpp
+++ b/src/libPMacc/include/memory/dataTypes/BitData.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -38,7 +38,7 @@ namespace PMacc
 
     /**
      * Represents single bits of data.
-     * 
+     *
      * @param TYPE
      * @param NUMBITS
      */

--- a/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
+++ b/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/mpi/MPI_StructAsArray.hpp
+++ b/src/libPMacc/include/mpi/MPI_StructAsArray.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef MPI_STRUCTASARRAY_HPP
 #define	MPI_STRUCTASARRAY_HPP

--- a/src/libPMacc/include/mpi/reduceMethods/AllReduce.hpp
+++ b/src/libPMacc/include/mpi/reduceMethods/AllReduce.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/mpi/reduceMethods/Reduce.hpp
+++ b/src/libPMacc/include/mpi/reduceMethods/Reduce.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/nvidia/functors/Assign.hpp
+++ b/src/libPMacc/include/nvidia/functors/Assign.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ASSIGN_HPP
 #define	ASSIGN_HPP

--- a/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
+++ b/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/libPMacc/include/nvidia/rng/distributions/Normal_float.hpp
+++ b/src/libPMacc/include/nvidia/rng/distributions/Normal_float.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef NORMAL_FLOAT_HPP
@@ -36,7 +36,7 @@ namespace PMacc
             namespace distributions
             {
 
-                /*Return normally distributed floats with mean 0.0f and standard deviation 1.0f 
+                /*Return normally distributed floats with mean 0.0f and standard deviation 1.0f
                  */
                 class Normal_float
                 {

--- a/src/libPMacc/include/nvidia/rng/distributions/Uniform_float.hpp
+++ b/src/libPMacc/include/nvidia/rng/distributions/Uniform_float.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef UNIFORM_FLOAT_HPP

--- a/src/libPMacc/include/nvidia/rng/distributions/Uniform_int32.hpp
+++ b/src/libPMacc/include/nvidia/rng/distributions/Uniform_int32.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/nvidia/rng/methods/Xor.hpp
+++ b/src/libPMacc/include/nvidia/rng/methods/Xor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef XOR_HPP

--- a/src/libPMacc/include/nvidia/traits/GetType.hpp
+++ b/src/libPMacc/include/nvidia/traits/GetType.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/libPMacc/include/particles/Identifier.hpp
+++ b/src/libPMacc/include/particles/Identifier.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -36,12 +36,12 @@ namespace PMacc
 value_identifier(lcellId_t,localCellIdx,0);
 
 /** Is a value to set stages (is particle, is no particle,... of a particle
- * 
+ *
  * if multiMask is set to:
  *  - 0 (zero) it is no particle
  *  - 1 it is a particle
  *  - 2 to 27 is used to define whether a particle leaf a supercell
- *    ExchangeType = value - 1 (e.g. 27 - 1 = 26 means particle leafe supercell 
+ *    ExchangeType = value - 1 (e.g. 27 - 1 = 26 means particle leafe supercell
  *    over FRONT(value=18) TOP(value=6) LEFT(value=2) corner -> 18+6+2=26
  */
 value_identifier(uint8_t,multiMask,0);

--- a/src/libPMacc/include/particles/ParticleDescription.hpp
+++ b/src/libPMacc/include/particles/ParticleDescription.hpp
@@ -29,7 +29,7 @@ namespace PMacc
 {
 
 /** ParticleDescription defines attributes, methods and flags of a particle
- * 
+ *
  * This class holds no runtime data.
  * The class holds information about the name, attributes, flags and methods of a
  * particle.
@@ -39,16 +39,16 @@ namespace PMacc
  * @tparam T_SuperCellSize compile time size of a super cell
  * @tparam T_ValueTypeSeq sequence or single type with value_identifier
  * @tparam T_Flags sequence or single type with identifier to add fags on a frame
- * @tparam T_MethodsList sequence or single class with particle methods 
- *                       (e.g. calculate mass, gamma, ...) 
- *                       (e.g. useSolverXY, calcRadiation, ...) 
+ * @tparam T_MethodsList sequence or single class with particle methods
+ *                       (e.g. calculate mass, gamma, ...)
+ *                       (e.g. useSolverXY, calcRadiation, ...)
  */
 template<
 typename T_Name,
 typename T_SuperCellSize,
 typename T_ValueTypeSeq,
 typename T_Flags = bmpl::vector0<>,
-typename T_MethodsList = bmpl::vector0<> 
+typename T_MethodsList = bmpl::vector0<>
 >
 struct ParticleDescription
 {
@@ -63,7 +63,7 @@ struct ParticleDescription
 
 
 /** Get ParticleDescription with a new ValueTypeSeq
- * 
+ *
  * @tparam T_OldParticleDescription base description
  * @tparam T_NewValueTypeSeq new boost mpl sequence with value types
  * @treturn ::type new ParticleDescription
@@ -73,9 +73,9 @@ struct ReplaceValueTypeSeq
 {
     typedef T_OldParticleDescription OldParticleDescription;
     typedef ParticleDescription<
-        typename OldParticleDescription::Name, 
-        typename OldParticleDescription::SuperCellSize, 
-        typename ToSeq<T_NewValueTypeSeq>::type, 
+        typename OldParticleDescription::Name,
+        typename OldParticleDescription::SuperCellSize,
+        typename ToSeq<T_NewValueTypeSeq>::type,
         typename OldParticleDescription::FlagsList,
         typename OldParticleDescription::MethodsList
     > type;

--- a/src/libPMacc/include/particles/boostExtension/InheritGenerators.hpp
+++ b/src/libPMacc/include/particles/boostExtension/InheritGenerators.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -50,7 +50,7 @@ class LinearInheritFork : public Base1, public Base2
 
 
 /** Rule if head is a class without Base template parameter
- * 
+ *
  * Create a fork an inharid from head and combined classes from Vec
  */
 template <class Head, class Vec,bool isVectorEmpty=bmpl::empty<Vec>::value>
@@ -87,10 +87,10 @@ struct TypelistLinearInherit<Head, Vec ,true>
 
 /** Create a data strcture which inharid lineary
  * \tparam vec_ boost mpl vector with classes
- * 
+ *
  * class A<PMacc::NullFrame>;
  * LinearInherit<mpl::vector<A<>,B> >::type return
- * 
+ *
  * typedef A<B> type;
  */
 template <typename vec_>

--- a/src/libPMacc/include/particles/boostExtension/InheritLinearly.hpp
+++ b/src/libPMacc/include/particles/boostExtension/InheritLinearly.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/libPMacc/include/particles/frame_types.hpp
+++ b/src/libPMacc/include/particles/frame_types.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef FRAME_TYPES_HPP

--- a/src/libPMacc/include/particles/memory/boxes/ExchangePopDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ExchangePopDataBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #ifndef EXCHANGEPOPDATABOX_HPP

--- a/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef EXCHANGEPUSHDATABOX_HPP
 #define	EXCHANGEPUSHDATABOX_HPP

--- a/src/libPMacc/include/particles/memory/boxes/HeapDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/HeapDataBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef HEAPDATABOX_HPP
 #define	HEAPDATABOX_HPP
@@ -76,7 +76,7 @@ public:
 
     /**
      * Computes the index of the VALUE at address old and pushes it to virtual memory.
-     * 
+     *
      * @param old address of VALUE of which the index should be pushed
      */
     HDINLINE void push(VALUE &old)

--- a/src/libPMacc/include/particles/memory/boxes/PopDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PopDataBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef POPDATABOX_HPP
@@ -62,7 +62,7 @@ public:
 
     /**
      * Removes count elements from the stack in an atomic operation.
-     * 
+     *
      * \todo This method unse int32_t and limits the element count to INT_MAX
      *
      * @param count number of elements to pop from stack

--- a/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef PUSHDATABOX_HPP
@@ -81,7 +81,7 @@ namespace PMacc
 
         /**
          * Adds val to the stack in an atomic operation.
-         * 
+         *
          * @param val data of type VALUE to add to the stack
          */
         HDINLINE void push(VALUE val)

--- a/src/libPMacc/include/particles/memory/boxes/RingDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/RingDataBox.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef RINGDATABOX_HPP
 #define	RINGDATABOX_HPP

--- a/src/libPMacc/include/particles/memory/boxes/TileDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/TileDataBox.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -66,7 +66,7 @@ public:
 
 /**
  * Specifies a one-dimensional DataBox for more convenient usage.
- * 
+ *
  * @tparam TYPE type of data represented by the DataBox
  */
 template<class TYPE>

--- a/src/libPMacc/include/particles/memory/buffers/StackExchangeBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/StackExchangeBuffer.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef STACKEXCHANGEBUFFER_HPP
 #define	STACKEXCHANGEBUFFER_HPP

--- a/src/libPMacc/include/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef EXCHANGEMEMORYINDEX_HPP
 #define	EXCHANGEMEMORYINDEX_HPP

--- a/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef SUPERCELL_HPP
 #define	SUPERCELL_HPP

--- a/src/libPMacc/include/particles/memory/frames/NullFrame.hpp
+++ b/src/libPMacc/include/particles/memory/frames/NullFrame.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef NULLFRAME_HPP

--- a/src/libPMacc/include/particles/operations/CopyIdentifier.hpp
+++ b/src/libPMacc/include/particles/operations/CopyIdentifier.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -37,7 +37,7 @@ struct CopyIdentifier
 {
     template<typename T_T1,typename T_T2>
     HDINLINE
-    void operator()(T_T1& dest, const T_T2& src) 
+    void operator()(T_T1& dest, const T_T2& src)
     {
         dest[T_Key()]=src[T_Key()];
     }

--- a/src/libPMacc/include/particles/particleFilter/FilterFactory.hpp
+++ b/src/libPMacc/include/particles/particleFilter/FilterFactory.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef DEFAULTFILTER_HPP
@@ -67,7 +67,7 @@ class DefaultFilter : public Base
 };
 
 template<>
-class DefaultFilter<NullFrame> 
+class DefaultFilter<NullFrame>
 {
     private:
         bool alwaysTrue;

--- a/src/libPMacc/include/particles/particleFilter/system/FalseFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/FalseFilter.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef FALSEFILTER_HPP

--- a/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #ifndef TRUEFILTER_HPP

--- a/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
+++ b/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/particles/tasks/ParticleFactory.tpp
+++ b/src/libPMacc/include/particles/tasks/ParticleFactory.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #pragma once

--- a/src/libPMacc/include/pluginSystem/IPlugin.hpp
+++ b/src/libPMacc/include/pluginSystem/IPlugin.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Rene Widera, Felix Schmitt
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -86,7 +86,7 @@ namespace PMacc
 
         /**
          * Notifies plugins that a (restartable) checkpoint should be created for this timestep.
-         * 
+         *
          * @param currentStep cuurent simulation iteration step
          * @param checkpointDirectory common directory for checkpoints
          */
@@ -94,8 +94,8 @@ namespace PMacc
         
         /**
          * Restart notification callback.
-         * 
-         * 
+         *
+         *
          * @param restartStep simulation iteration step to restart from
          * @param restartDirectory common restart directory (contains checkpoints)
          */
@@ -104,14 +104,14 @@ namespace PMacc
         /**
          * Register command line parameters for this plugin.
          * Parameters are parsed and set prior to plugin load.
-         * 
+         *
          * @param desc boost::program_options description
          */
         virtual void pluginRegisterHelp(po::options_description& desc) = 0;
 
         /**
          * Return the name of this plugin for status messages.
-         * 
+         *
          * @return plugin name
          */
         virtual std::string pluginGetName() const = 0;

--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -3,21 +3,21 @@
  *
  * This file is part of libPMacc.
  *
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/libPMacc/include/ppFunctions.hpp
+++ b/src/libPMacc/include/ppFunctions.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/libPMacc/include/result_of_Functor.hpp
+++ b/src/libPMacc/include/result_of_Functor.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -30,9 +30,9 @@ namespace PMacc
 {
 namespace result_of
 {
-template<typename _Functor, typename Arg0 = mpl::void_, 
-                            typename Arg1 = mpl::void_, 
-                            typename Arg2 = mpl::void_, 
+template<typename _Functor, typename Arg0 = mpl::void_,
+                            typename Arg1 = mpl::void_,
+                            typename Arg2 = mpl::void_,
                             typename Arg3 = mpl::void_,
                             typename Arg4 = mpl::void_,
                             typename Arg5 = mpl::void_,

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -45,10 +45,10 @@ namespace PMacc
 
 /**
  * Abstract base class for simulations.
- * 
+ *
  * Use this helper class to write your own concrete simulations
  * by binding pure virtual methods.
- * 
+ *
  * @tparam DIM base dimension for the simulation (2-3)
  */
 template<unsigned DIM>
@@ -58,7 +58,7 @@ public:
 
     /**
      * Constructor
-     * 
+     *
      */
     SimulationHelper() :
     runSteps(0),
@@ -89,14 +89,14 @@ public:
 
     /**
      * Must describe one iteration (step).
-     * 
+     *
      * This function is called automatically.
      */
     virtual void runOneStep(uint32_t currentStep) = 0;
 
     /**
      * Initializes simulation state.
-     * 
+     *
      * @return returns the first step of the simulation
      */
     virtual uint32_t init() = 0;
@@ -104,18 +104,18 @@ public:
 
     /**
      * Check if moving window work must do
-     * 
+     *
      * If no moving window is needed the implementation of this function can be empty
-     * 
+     *
      * @param currentStep simulation step
      */
     virtual void movingWindowCheck(uint32_t currentStep) = 0;
 
     /**
      * Notifies registered output classes.
-     * 
+     *
      * This function is called automatically.
-     * 
+     *
      *  @param currentStep simulation step
      */
     virtual void dumpOneStep(uint32_t currentStep)
@@ -183,7 +183,7 @@ public:
         TimeIntervall tRound;
         double roundAvg = 0.0;
 
-        /* dump initial step if simulation starts without restart */            
+        /* dump initial step if simulation starts without restart */
         if (currentStep == 0)
             dumpOneStep(currentStep);
         else
@@ -207,7 +207,7 @@ public:
             movingWindowCheck(currentStep);
             /*dump after simulated step*/
             dumpOneStep(currentStep);
-        }       
+        }
 
         //simulatation end
         Environment<>::get().Manager().waitForAllTasks();
@@ -291,7 +291,7 @@ private:
 
     /**
      * Set how often the elapsed time is printed.
-     * 
+     *
      * @param percent percentage difference for printing
      */
     void calcProgress()
@@ -306,7 +306,7 @@ private:
     
     /**
      * Append \p checkpointStep to the master checkpoint file
-     * 
+     *
      * @param checkpointStep current checkpoint step
      */
     void writeCheckpointStep(const uint32_t checkpointStep)

--- a/src/libPMacc/include/simulationControl/TimeInterval.hpp
+++ b/src/libPMacc/include/simulationControl/TimeInterval.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef TIMEINTERVAL_HPP
 #define	TIMEINTERVAL_HPP

--- a/src/libPMacc/include/traits/GetComponentsType.hpp
+++ b/src/libPMacc/include/traits/GetComponentsType.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 
@@ -30,11 +30,11 @@ namespace PMacc
 namespace traits
 {
     /** Get component type of an object
-     *     
+     *
      * \tparam T_Type any type
      * \return \p ::type get result type
      *            If T_Type is fundamental c++ type, the identity is returned
-     * 
+     *
      * Attention: do not defines this trait for structs with different attributes inside
      */
     template<typename T_Type,bool T_IsFundamental=boost::is_fundamental<T_Type>::value >

--- a/src/libPMacc/include/traits/GetFlagType.hpp
+++ b/src/libPMacc/include/traits/GetFlagType.hpp
@@ -29,10 +29,10 @@ namespace traits
 {
 
 /** Get Flag of an Object
- * 
+ *
  * @tparam T_Object any object (class or typename)
  * @tparam T_Key a class which is used as identifier
- * 
+ *
  * @treturn ::type
  */
 template<typename T_Object, typename T_Key>

--- a/src/libPMacc/include/traits/GetNComponents.hpp
+++ b/src/libPMacc/include/traits/GetNComponents.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -30,7 +30,7 @@ namespace PMacc
 namespace traits
 {
 /** C
- * 
+ *
  * \tparam T_Type any type
  * \return \p ::value as public with number of components (uint32_t)
  */

--- a/src/libPMacc/include/traits/GetValueType.hpp
+++ b/src/libPMacc/include/traits/GetValueType.hpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 
 #pragma once

--- a/src/libPMacc/include/traits/GetValueType.tpp
+++ b/src/libPMacc/include/traits/GetValueType.tpp
@@ -1,24 +1,24 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/libPMacc/include/traits/IsSameType.hpp
+++ b/src/libPMacc/include/traits/IsSameType.hpp
@@ -1,34 +1,34 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
 namespace PMacc
 {
     /** IsSameType< typeA, typeB >
-     * 
+     *
      *  Compare two types, IsSameType::result is true if they are equal,
      *  else false.
-     * 
+     *
      *  \tparam T1 first type to compare
      *  \tparam T2 second type to compare
      */

--- a/src/libPMacc/include/traits/Limits.hpp
+++ b/src/libPMacc/include/traits/Limits.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2014 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -32,7 +32,7 @@ namespace traits
 namespace limits
 {
 /** get maximum finite value
- * 
+ *
  * @tparam T_Type any type
  * @result ::value
  */
@@ -40,7 +40,7 @@ template<typename T_Type>
 struct Max;
 
 /** get minimum finite value
- * 
+ *
  * @tparam T_Type any type
  * @result ::value
  */

--- a/src/libPMacc/include/traits/Limits.tpp
+++ b/src/libPMacc/include/traits/Limits.tpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2014 Rene Widera
  *
- * This file is part of libPMacc. 
- * 
- * libPMacc is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * libPMacc is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libPMacc. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/libPMacc/include/traits/NumberOfExchanges.hpp
+++ b/src/libPMacc/include/traits/NumberOfExchanges.hpp
@@ -27,7 +27,7 @@
 namespace PMacc
 {
 
-namespace traits 
+namespace traits
 {
 /** Get number of possible exchanges
  *

--- a/src/picongpu/ArgsParser.cpp
+++ b/src/picongpu/ArgsParser.cpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include <iostream>
 #include <sstream>

--- a/src/picongpu/include/ArgsParser.hpp
+++ b/src/picongpu/include/ArgsParser.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -56,15 +56,15 @@ struct AssignedTrilinearInterpolation
 
     /** Does a 3D trilinear field-to-point interpolation for
      * arbitrary assignment function and arbitrary field_value types.
-     * 
+     *
      * \tparam AssignmentFunction function for assignment
      * \tparam Begin lower margin for interpolation
      * \param End upper margin for interpolation
-     * 
+     *
      * \param cursor cursor pointing to the field
      * \param pos position of the interpolation point
      * \return sum over: field_value * assignment
-     * 
+     *
      * interpolate on grid points in range [Begin;End]
      */
     template<class AssignmentFunction,int Begin,int End,class Cursor >

--- a/src/picongpu/include/algorithms/DifferenceToLower.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToLower.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/picongpu/include/algorithms/DifferenceToUpper.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToUpper.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -31,10 +31,10 @@ namespace picongpu
 {
 
 /** interpolate field which are defined on a grid to a point inside of a grid
- * 
- * interpolate around of a point from -AssignmentFunction::support/2 to 
+ *
+ * interpolate around of a point from -AssignmentFunction::support/2 to
  * (AssignmentFunction::support+1)/2
- * 
+ *
  * \tparam GridShiftMethod functor which shift coordinate system that al value are
  * located on corner
  * \tparam AssignmentFunction AssignmentFunction which is used for interpolation
@@ -64,7 +64,7 @@ struct FieldToParticleInterpolationNative
          * is turned so that E_scalar does the interpolation for the z-component.
          */
 
-        /** _1[mpl::int_<0>()] means: 
+        /** _1[mpl::int_<0>()] means:
          * Create a functor which returns [0] applied on the first paramter.
          * Here it is: return the x-component of the field-vector.
          * _1[mpl::int_<0>()] is equivalent to _1[0] but has no runtime cost.
@@ -94,7 +94,7 @@ namespace traits
 {
 
 /*Get margin of a solver
- * class must define a LowerMargin and UpperMargin 
+ * class must define a LowerMargin and UpperMargin
  */
 template<class AssignMethod, class InterpolationMethod>
 struct GetMargin<picongpu::FieldToParticleInterpolationNative<AssignMethod, InterpolationMethod> >

--- a/src/picongpu/include/algorithms/Gamma.hpp
+++ b/src/picongpu/include/algorithms/Gamma.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/algorithms/Set.hpp
+++ b/src/picongpu/include/algorithms/Set.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/algorithms/ShiftCoordinateSystemNative.hpp
+++ b/src/picongpu/include/algorithms/ShiftCoordinateSystemNative.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -34,7 +34,7 @@ struct ShiftCoordinateSystemNative
 {
 
     /**shift to new coordinat system
-     * 
+     *
      * shift cursor and vector to new coordinate system
      * @param curser curser to memory
      * @param vector short vector with coordinates in old system

--- a/src/picongpu/include/algorithms/Velocity.hpp
+++ b/src/picongpu/include/algorithms/Velocity.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/debug/PIConGPUVerbose.hpp
+++ b/src/picongpu/include/debug/PIConGPUVerbose.hpp
@@ -33,7 +33,7 @@ namespace picongpu
 /*create verbose class*/
 DEFINE_VERBOSE_CLASS(PIConGPUVerbose)
 (
-    /* define log lvl for later use 
+    /* define log lvl for later use
      * e.g. log<PMaccLogLvl::NOTHING>("TEXT");*/
     DEFINE_LOGLVL(0,NOTHING);
     DEFINE_LOGLVL(1,PHYSICS);

--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef FIELDE_KERNEL
@@ -51,16 +51,16 @@ __global__ void kernelLaserE(EBox fieldE, LaserManipulator lMan)
     EFieldOffset.z() = cellOffset.z() + (MappingDesc::SuperCellSize::z::value * GUARD_SIZE);
 #endif
 
-    //uint32_t zOffset 
+    //uint32_t zOffset
 
     /** Calculate how many neighbors to the left we have
      * to initialize the laser in the E-Field
-     * 
+     *
      * Example: Yee needs one neighbor to perform dB = curlE
      *            -> initialize in y=0 plane
      *          A second order solver could need 2 neighbors left:
      *            -> initialize in y=0 and y=1 plane
-     * 
+     *
      * Question: Why do other codes initialize the B-Field instead?
      * Answer:   Because our fields are defined on the lower cell side
      *           (C-Style ftw). Therefore, our curls (for example Yee)
@@ -68,7 +68,7 @@ __global__ void kernelLaserE(EBox fieldE, LaserManipulator lMan)
      *           (in other words: curlLeft <-> curlRight)
      *           for E and B.
      *           For this reason, we have to initialize E instead of B.
-     * 
+     *
      * Problem: that's still not our case. For example our Yee does a
      *          dE = curlLeft(B) - therefor, we should init B, too.
      */
@@ -79,7 +79,7 @@ __global__ void kernelLaserE(EBox fieldE, LaserManipulator lMan)
     {
         /** \todo Right now, the phase could be wrong ( == is cloned)
          *        \See LaserPhysics.hpp
-         * 
+         *
          *  \todo What about the B-Field in the second plane?
          */
         cellOffset.y()=totalOffsetY;

--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/FieldTmp.hpp
+++ b/src/picongpu/include/fields/FieldTmp.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/LaserPhysics.hpp
+++ b/src/picongpu/include/fields/LaserPhysics.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.def
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.def
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -93,7 +93,7 @@ public:
                   twistVectorAxes<Orientation_Y>(gridSize));
            
         __setTransactionEvent(fieldE.asyncCommunication(__getTransactionEvent()));
-        __setTransactionEvent(fieldB.asyncCommunication(__getTransactionEvent()));       
+        __setTransactionEvent(fieldB.asyncCommunication(__getTransactionEvent()));
         
         typedef PMacc::math::CT::Int<2,0,1> Orientation_Z;
         propagate(twistVectorFieldAxes<Orientation_Z>(fieldE_coreBorder.origin()),
@@ -107,7 +107,7 @@ public:
         __setTransactionEvent(fieldB.asyncCommunication(__getTransactionEvent()));
     }
     
-    void update_afterCurrent(uint32_t) const 
+    void update_afterCurrent(uint32_t) const
     {    }
 };
     

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheCurl.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheCurl.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -226,7 +226,7 @@ namespace picongpu
 
                 /** \todo all constants, calculate once at CPU and use as parameter
                  *  \todo cast to double to force high-precision sinus
-                 */  
+                 */
                 const float_X mySin = math::sin( float_X( 0.5 ) * float_X( M_PI ) *
                                                  SPEED_OF_LIGHT * DELTA_T / d_dir );
 

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.def
@@ -1,25 +1,25 @@
 /**
  * Copyright 2013 Axel Huebl, Rémi Lehe
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /* Reference: R. Lehe et al
- *            Phys. Rev. ST Accel. Beams 16, 021301 (2013) 
+ *            Phys. Rev. ST Accel. Beams 16, 021301 (2013)
  */
 
 #pragma once

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.def
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -44,7 +44,7 @@ namespace picongpu
     
             template<uint32_t AREA>
             void updateE()
-            {        
+            {
                 return;
             }
     

--- a/src/picongpu/include/fields/MaxwellSolver/Solvers.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Solvers.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/Curl.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/Curl.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.def
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.def
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.def
@@ -47,7 +47,7 @@ using namespace PMacc;
  * 3. order paper: "High-Order Interpolation Algorithms for Charge Conservation
  *                  in Particle-in-Cell Simulation", Commun. Comput. Phys 13 (2013)
  *                  Jinqing Yu, Xiaolin Jin, Weimin Zhou, Bin Li, Yuqiu Gu
- *                  DOI:10.1109/ICCIS.2012.159 
+ *                  DOI:10.1109/ICCIS.2012.159
  */
 template<typename T_ParticleShape>
 struct ZigZag;

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -32,11 +32,11 @@ namespace picongpu
     {
 
         /**
-         * 
+         *
          * @param currentStep
          * @param subGrid
          * @param phase
-         * @return 
+         * @return
          */
         HINLINE float3_X laserLongitudinal( uint32_t currentStep, float_X& phase )
         {
@@ -80,12 +80,12 @@ namespace picongpu
         }
 
         /**
-         * 
+         *
          * @param elong
          * @param phase
          * @param posX
          * @param posZ
-         * @return 
+         * @return
          */
         HDINLINE float3_X laserTransversal( float3_X elong, float_X phase, const float_X posX, const float_X posZ )
         {

--- a/src/picongpu/include/fields/laserProfiles/laserNone.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserNone.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -29,13 +29,13 @@
 namespace picongpu
 {
     /** No Laser initialization
-     * 
+     *
      */
     namespace laserNone
     {
 
-        /** Compute the 
-         * 
+        /** Compute the
+         *
          */
         HINLINE float3_X laserLongitudinal( uint32_t, float_X& phase )
         {
@@ -47,12 +47,12 @@ namespace picongpu
         }
         
         /**
-         * 
+         *
          * @param elong
          * @param phase
          * @param posX
          * @param posZ
-         * @return 
+         * @return
          */
         HDINLINE float3_X laserTransversal( float3_X elong, const float_X, const float_X, const float_X )
         {

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -29,14 +29,14 @@
 namespace picongpu
 {
     /** plane wave (use periodic boundaries!)
-     * 
-     *  no phase shifts, no spacial envelope   
+     *
+     *  no phase shifts, no spacial envelope
      */
     namespace laserPlaneWave
     {
 
-        /** Compute the 
-         * 
+        /** Compute the
+         *
          */
         HINLINE float3_X laserLongitudinal( uint32_t currentStep, float_X& phase )
         {
@@ -94,12 +94,12 @@ namespace picongpu
         }
         
         /**
-         * 
+         *
          * @param elong
          * @param phase
          * @param posX
          * @param posZ
-         * @return 
+         * @return
          */
         HDINLINE float3_X laserTransversal( float3_X elong, const float_X, const float_X, const float_X )
         {

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -28,7 +28,7 @@
 namespace picongpu
 {
 /** not focusing polynomial laser pulse
- * 
+ *
  *  no phase shifts, just spacial envelope
  */
 namespace laserPolynom
@@ -37,7 +37,7 @@ namespace laserPolynom
 HDINLINE float_64 Tpolynomial(const float_64 tau);
 
 /** Compute the longitudinal enevelope of the laser
- * 
+ *
  */
 HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 {
@@ -46,7 +46,7 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 
     float3_X elong(0.0f, 0.0f, 0.0f);
 
-    // a symmetric pulse will be initialized at position z=0 
+    // a symmetric pulse will be initialized at position z=0
     // the laser amplitude rises  for T_rise
     // and falls for T_rise
     // making the laser pulse 2*T_rise long
@@ -68,8 +68,8 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 }
 
 /**
- * 
- * @param elong E-field without transversal envelope 
+ *
+ * @param elong E-field without transversal envelope
  * @param phase phase of the laser field
  * @param posX location in x (transversal)
  * @param posZ location in y (transversal)

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Anton Helm, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -32,11 +32,11 @@ namespace picongpu
     {
 
         /**
-         * 
+         *
          * @param currentStep
          * @param subGrid
          * @param phase
-         * @return 
+         * @return
          */
         HINLINE float3_X laserLongitudinal( uint32_t currentStep, float_X& phase )
         {
@@ -80,12 +80,12 @@ namespace picongpu
         }
 
         /**
-         * 
+         *
          * @param elong
          * @param phase
          * @param posX
          * @param posZ
-         * @return 
+         * @return
          */
         HDINLINE float3_X laserTransversal( float3_X elong, float_X phase, const float_X posX, const float_X posZ )
         {

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -29,14 +29,14 @@
 namespace picongpu
 {
 /** not focusing wavepaket with spacial gaussian envelope
- * 
+ *
  *  no phase shifts, just spacial envelope
  */
 namespace laserWavepacket
 {
 
-/** Compute the 
- * 
+/** Compute the
+ *
  */
 HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 {
@@ -94,12 +94,12 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 }
 
 /**
- * 
+ *
  * @param elong
  * @param phase
  * @param posX
  * @param posZ
- * @return 
+ * @return
  */
 HDINLINE float3_X laserTransversal(float3_X elong, const float_X, const float_X posX, const float_X posZ)
 {

--- a/src/picongpu/include/fields/numericalCellTypes/AllCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/AllCenteredCell.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/numericalCellTypes/NumericalCellTypes.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/NumericalCellTypes.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/fields/tasks/FieldFactory.hpp
+++ b/src/picongpu/include/fields/tasks/FieldFactory.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/tasks/FieldFactory.tpp
+++ b/src/picongpu/include/fields/tasks/FieldFactory.tpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #include "fields/tasks/FieldFactory.hpp"

--- a/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/initialization/IInitPlugin.hpp
+++ b/src/picongpu/include/initialization/IInitPlugin.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/initialization/InitPluginNone.hpp
+++ b/src/picongpu/include/initialization/InitPluginNone.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/initialization/InitialiserController.hpp
+++ b/src/picongpu/include/initialization/InitialiserController.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -78,7 +78,7 @@ public:
     {
         // restart simulation by loading from persistent data
         // the simulation will start after restartStep
-        log<picLog::SIMULATION_STATE > ("Restarting simulation from timestep %1% in directory '%2%'") % 
+        log<picLog::SIMULATION_STATE > ("Restarting simulation from timestep %1% in directory '%2%'") %
             restartStep % restartDirectory;
 
         Environment<>::get().PluginConnector().restartPlugins(restartStep, restartDirectory);

--- a/src/picongpu/include/initialization/ParserGridDistribution.hpp
+++ b/src/picongpu/include/initialization/ParserGridDistribution.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -102,11 +102,11 @@ private:
     value_type parsedInput;
     
     /** Parses the input string to a vector of pairs
-     *  
+     *
      *  Parses the input string in the form a,b,c{n},d{m},e,f
      *  to a vector of pairs with base number (a,b,c,d,e,f) and multipliers
      *  (1,1,n,m,e,f)
-     * 
+     *
      *  \param[in] s as const std::string in the form a,b{n}
      *  \return std::vector<pair> with uint32_t (base, multiplier)
      */

--- a/src/picongpu/include/initialization/SimStartInitialiser.hpp
+++ b/src/picongpu/include/initialization/SimStartInitialiser.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -34,10 +34,10 @@ namespace picongpu
 
 /**
  * Simulation startup initialiser.
- * 
+ *
  * Initialises a new simulation from default values.
  * DataConnector has to be used with a FIFO compliant IDataSorter.
- * 
+ *
  * @tparam EBuffer type for Electrons (see MySimulation)
  * @tparam IBuffer type for Ions (see MySimulation)
  */

--- a/src/picongpu/include/particles/access/Cell2Particle.hpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef particleAccess_PARTICLE2CELL_HPP
 #define particleAccess_PARTICLE2CELL_HPP

--- a/src/picongpu/include/particles/gasProfiles/gasFreeFormula.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasFreeFormula.hpp
@@ -37,7 +37,7 @@ namespace picongpu
         }
 
         /** Calculate the gas density, divided by the maximum density GAS_DENSITY
-         * 
+         *
          * @param pos as 3D length vector offset to global left top front cell
          * @return float_X between 0.0 and 1.0
          */

--- a/src/picongpu/include/particles/gasProfiles/gasFromHdf5.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasFromHdf5.hpp
@@ -92,7 +92,7 @@ namespace picongpu
                 Dimensions fileAccessOffset(0, 0, 0);
 
                 /* For each dimension, compute how file domain and local simulation domain overlap
-                 * and which sizes and offsets are required for loading data from the file. 
+                 * and which sizes and offsets are required for loading data from the file.
                  **/
                 for (uint32_t d = 0; d < simDim; ++d)
                 {
@@ -194,7 +194,7 @@ namespace picongpu
         }
 
         /** Load the gas density from fieldTmp
-         * 
+         *
          * @param pos as DIM-D length vector offset to global left top front cell
          * @param cellIdx local cell id
          * @param fieldTmp DataBox accessing for fieldTmp

--- a/src/picongpu/include/particles/gasProfiles/gasGaussian.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasGaussian.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -39,7 +39,7 @@ namespace picongpu
         }
         
         /** Calculate the gas density, divided by the maximum density GAS_DENSITY
-         * 
+         *
          * @param pos as 3D length vector offset to global left top front cell
          * @return float_X between 0.0 and 1.0
          */

--- a/src/picongpu/include/particles/gasProfiles/gasGaussianCloud.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasGaussianCloud.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -39,7 +39,7 @@ bool gasSetup( GridBuffer<Type, simDim>&, Window& )
 }
 
 /** Calculate the gas density, divided by the maximum density GAS_DENSITY
- * 
+ *
  * @param y as distance in propagation direction (unit: meters / UNIT_LENGTH)
  * @return float_X between 0.0 and 1.0
  */
@@ -51,7 +51,7 @@ DINLINE float_X calcNormedDensity( floatD_X pos, const DataSpace<DIM>&, FieldBox
     floatD_X exponent  = float_X(math::abs((pos - GAS_CENTER) / GAS_SIGMA));
 
 
-    float_X density=1; 
+    float_X density=1;
     for(uint32_t d=0;d<simDim;++d)
     density *= math::exp(GAS_FACTOR * __powf(exponent[d], GAS_POWER));
     

--- a/src/picongpu/include/particles/gasProfiles/gasHomogenous.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasHomogenous.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -39,7 +39,7 @@ namespace picongpu
         }
 
         /** Calculate the gas density, divided by the maximum density GAS_DENSITY
-         * 
+         *
          * @param pos as 3D length vector offset to global left top front cell
          * @return float_X between 0.0 and 1.0
          */

--- a/src/picongpu/include/particles/gasProfiles/gasLinExp.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasLinExp.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -38,7 +38,7 @@ namespace picongpu
         }
 
         /** Calculate the gas density, divided by the maximum density GAS_DENSITY
-         * 
+         *
          * @param pos as 3D length vector offset to global left top front cell
          * @return float_X between 0.0 and 1.0
          */

--- a/src/picongpu/include/particles/gasProfiles/gasNone.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasNone.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -39,7 +39,7 @@ namespace picongpu
         }
 
         /** Calculate the gas density, divided by the maximum density GAS_DENSITY
-         * 
+         *
          * @return float_X between 0.0 and 1.0
          */
         template<unsigned DIM, typename FieldBox>

--- a/src/picongpu/include/particles/gasProfiles/gasSphereFlanks.hpp
+++ b/src/picongpu/include/particles/gasProfiles/gasSphereFlanks.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -39,7 +39,7 @@ bool gasSetup( GridBuffer<Type, simDim>&, Window& )
 }
         
 /** Calculate the gas density, divided by the maximum density GAS_DENSITY
- * 
+ *
  * @param pos as 3D length vector offset to global left top front cell
  * @return float_X between 0.0 and 1.0
  */

--- a/src/picongpu/include/particles/init/particleInitQuietStart.hpp
+++ b/src/picongpu/include/particles/init/particleInitQuietStart.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -43,7 +43,7 @@ public:
     }
 
     /** Distributes the initial particles lattice-like within the cell.
-     * 
+     *
      * @param rng a reference to an initialized, UNIFORM random number generator
      * @param totalNumParsPerCell the total number of particles to init for this cell
      * @param curParticle the number of this particle: [0, totalNumParsPerCell-1]
@@ -70,10 +70,10 @@ public:
         return floatD_X(precisionCast<float_X>(inCellCoordinate) * spacing + spacing * float_X(0.5));
     }
 
-    /** If the particles to initialize (numParsPerCell) end up with a 
+    /** If the particles to initialize (numParsPerCell) end up with a
      *  related particle weighting (macroWeighting) below MIN_WEIGHTING,
      *  reduce the number of particles if possible to satisfy this condition.
-     * 
+     *
      * @param numParsPerCell the intendet number of particles for this cell
      * @param realElPerCell  the number of real electrons in this cell
      * @return macroWeighting the intended weighting per macro particle

--- a/src/picongpu/include/particles/init/particleInitRandomPos.hpp
+++ b/src/picongpu/include/particles/init/particleInitRandomPos.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -36,7 +36,7 @@ namespace picongpu
         public:
 
             /** Distributes the initial particles uniformly random within the cell.
-             * 
+             *
              * @param rng a reference to an initialized, UNIFORM random number generator
              * @param totalNumParsPerCell the total number of particles to init for this cell
              * @param curParticle the number of this particle: [0, totalNumParsPerCell-1]
@@ -54,10 +54,10 @@ namespace picongpu
                 return result;
             }
 
-            /** If the particles to initialize (numParsPerCell) end up with a 
+            /** If the particles to initialize (numParsPerCell) end up with a
              *  related particle weighting (macroWeighting) below MIN_WEIGHTING,
              *  reduce the number of particles if possible to satisfy this condition.
-             * 
+             *
              * @param numParsPerCell the intendet number of particles for this cell
              * @param realElPerCell  the number of real electrons in this cell
              * @return macroWeighting the intended weighting per macro particle

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -60,7 +60,7 @@ public:
     }
 
     /** return unit for this solver
-     * 
+     *
      * @return solver unit
      */
     HDINLINE float1_64 getUnit() const;

--- a/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -64,8 +64,8 @@ struct Push
 
         for(uint32_t d=0;d<simDim;++d)
         {
-            pos[d] += (vel[d] * deltaT) / cellSize[d]; 
-        }      
+            pos[d] += (vel[d] * deltaT) / cellSize[d];
+        }
 
     }
 };

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -47,8 +47,8 @@ namespace picongpu
 
                 for(uint32_t d=0;d<simDim;++d)
                 {
-                    pos[d] += (vel[d] * DELTA_T) / cellSize[d]; 
-                }   
+                    pos[d] += (vel[d] * DELTA_T) / cellSize[d];
+                }
             }
         };
     } //namespace

--- a/src/picongpu/include/particles/pusher/particlePusherNone.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherNone.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -26,7 +26,7 @@
 namespace picongpu
 {
     namespace particlePusherPhot
-    {   
+    {
         template<class Velocity, class Gamma>
         struct Push
         {
@@ -46,8 +46,8 @@ namespace picongpu
 
                 for(uint32_t d=0;d<simDim;++d)
                 {
-                    pos[d] += (vel[d] * DELTA_T) / cellSize[d]; 
-                }   
+                    pos[d] += (vel[d] * DELTA_T) / cellSize[d];
+                }
             }
         };
     } //namespace

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -43,8 +43,8 @@ struct Push
                                             const ChargeType charge)
     {
 
-        /*   
-             time index in paper is reduced by a half: i=0 --> i=-1/2 so that momenta are 
+        /*
+             time index in paper is reduced by a half: i=0 --> i=-1/2 so that momenta are
              at half time steps and fields and locations are at full time steps
 
      Here the real (PIConGPU) momentum (p) is used, not the momentum from the Vay paper (u)
@@ -83,8 +83,8 @@ struct Push
         
         for(uint32_t d=0;d<simDim;++d)
         {
-            pos[d] += (vel[d] * DELTA_T) / cellSize[d]; 
-        }   
+            pos[d] += (vel[d] * DELTA_T) / cellSize[d];
+        }
     }
 };
 } //namespace particlePusherVay

--- a/src/picongpu/include/particles/shapes.hpp
+++ b/src/picongpu/include/particles/shapes.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/particles/traits/GetCurrentSolver.hpp
+++ b/src/picongpu/include/particles/traits/GetCurrentSolver.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2014 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/picongpu/include/particles/traits/GetInterpolation.hpp
+++ b/src/picongpu/include/particles/traits/GetInterpolation.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2014 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/picongpu/include/particles/traits/GetShape.hpp
+++ b/src/picongpu/include/particles/traits/GetShape.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2014 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/picongpu/include/plugins/CountParticles.hpp
+++ b/src/picongpu/include/plugins/CountParticles.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -228,8 +228,8 @@ private:
             typedef std::numeric_limits< float_64 > dbl;
 
             outFile.precision(dbl::digits10);
-            outFile << currentStep << " " << std::scientific << globalEnergy * UNIT_ENERGY << " " 
-                    << (globalFieldEnergy[0] * UNIT_ENERGY).toString(" ","") << " " 
+            outFile << currentStep << " " << std::scientific << globalEnergy * UNIT_ENERGY << " "
+                    << (globalFieldEnergy[0] * UNIT_ENERGY).toString(" ","") << " "
                     << (globalFieldEnergy[1] * UNIT_ENERGY).toString(" ","") << std::endl;
         }
     }

--- a/src/picongpu/include/plugins/FieldEnergy.hpp
+++ b/src/picongpu/include/plugins/FieldEnergy.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ANALYSIS_FIELDENERGY_HPP
 #define ANALYSIS_FIELDENERGY_HPP

--- a/src/picongpu/include/plugins/FieldEnergy.tpp
+++ b/src/picongpu/include/plugins/FieldEnergy.tpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"
@@ -83,7 +83,7 @@ void FieldEnergy::notify(uint32_t currentStep)
     int localCellZPos = globalCellZPos % fieldE_coreBorder.size().z();
     int gpuZPos = globalCellZPos / fieldE_coreBorder.size().z();
     
-    zone::SphericZone<3> gpuGatheringZone(math::Size_t<3>(gpuDim.x(), gpuDim.y(), 1), 
+    zone::SphericZone<3> gpuGatheringZone(math::Size_t<3>(gpuDim.x(), gpuDim.y(), 1),
                                           PMacc::math::Int<3>(0,0,gpuZPos));
     algorithm::mpi::Gather<3> gather(gpuGatheringZone);
     if(!gather.participate()) return;
@@ -96,7 +96,7 @@ void FieldEnergy::notify(uint32_t currentStep)
         energyDBuffer.zone(), energyDBuffer.origin(),
                               cursor::tools::slice(fieldE_coreBorder.origin()(0,0,localCellZPos)),
                               cursor::tools::slice(fieldB_coreBorder.origin()(0,0,localCellZPos)),
-        _1 = (_abs2(_2) + _abs2(_3) * MUE0_EPS0) * 
+        _1 = (_abs2(_2) + _abs2(_3) * MUE0_EPS0) *
             (float_X(0.5) * EPS0 * UNIT_ENERGY * UNITCONV_Joule_to_keV / (UNIT_LENGTH*UNIT_LENGTH*UNIT_LENGTH)));
             
             

--- a/src/picongpu/include/plugins/ILightweightPlugin.hpp
+++ b/src/picongpu/include/plugins/ILightweightPlugin.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2014 Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/picongpu/include/plugins/ISimulationPlugin.hpp
+++ b/src/picongpu/include/plugins/ISimulationPlugin.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/LiveViewPlugin.hpp
+++ b/src/picongpu/include/plugins/LiveViewPlugin.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/ParticleDensity.hpp
+++ b/src/picongpu/include/plugins/ParticleDensity.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -53,7 +53,7 @@ public:
     std::string pluginGetName() const;
     
 private:
-    void pluginLoad();    
+    void pluginLoad();
 };
 
 }

--- a/src/picongpu/include/plugins/ParticleDensity.tpp
+++ b/src/picongpu/include/plugins/ParticleDensity.tpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"
@@ -135,7 +135,7 @@ void ParticleDensity<ParticlesType>::notify(uint32_t currentStep)
     vec::Size_t<3> planeVec(0); planeVec[plane] = 1;
     vec::Size_t<3> orthoPlaneVec(1); orthoPlaneVec[plane] = 0;
     
-    zone::SphericZone<3> gpuGatheringZone(orthoPlaneVec * gpuDim + planeVec * vec::Size_t<3>(1,1,1), 
+    zone::SphericZone<3> gpuGatheringZone(orthoPlaneVec * gpuDim + planeVec * vec::Size_t<3>(1,1,1),
                                           (vec::Int<3>)planeVec * gpuPos);
     algorithm::mpi::Gather<3> gather(gpuGatheringZone);
     if(!gather.participate()) return;

--- a/src/picongpu/include/plugins/ParticleSpectrum.hpp
+++ b/src/picongpu/include/plugins/ParticleSpectrum.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ANALYSIS_PARTICLESPECTRUM_HPP
 #define ANALYSIS_PARTICLESPECTRUM_HPP

--- a/src/picongpu/include/plugins/SliceFieldPrinter.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/TotalDivJ.hpp
+++ b/src/picongpu/include/plugins/TotalDivJ.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #ifndef ANALYSIS_TOTALDIVJ_HPP
 #define ANALYSIS_TOTALDIVJ_HPP

--- a/src/picongpu/include/plugins/TotalDivJ.tpp
+++ b/src/picongpu/include/plugins/TotalDivJ.tpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"
@@ -88,7 +88,7 @@ void TotalDivJ::notify(uint32_t currentStep)
     //std::cout << coreBorderZone.size << ", " << coreBorderZone.offset << std::endl;
     using namespace lambda;
     algorithm::kernel::Foreach<BlockDim>()
-        (coreBorderZone, fieldDivJ.origin(), cursor::make_NestedCursor(fieldJ.origin()), 
+        (coreBorderZone, fieldDivJ.origin(), cursor::make_NestedCursor(fieldJ.origin()),
             _1 = expr(Div())(_2));
         
     container::DeviceBuffer<float, 1> totalDivJ(1);
@@ -99,7 +99,7 @@ void TotalDivJ::notify(uint32_t currentStep)
     
     static std::ofstream file("totalDivJ.dat");
     
-    file << "step: " << currentStep << ", totalDivJ: " 
+    file << "step: " << currentStep << ", totalDivJ: "
         << *totalDivJ_host.origin() * CELL_VOLUME * UNIT_CHARGE
         << " Coulomb" << std::endl;
 }

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -37,7 +37,7 @@ using namespace PMacc;
 
 
 /** write attribute of a particle to adios file
- * 
+ *
  * @tparam T_Identifier identifier of a particle attribute
  */
 template< typename T_Identifier>
@@ -45,7 +45,7 @@ struct ParticleAttribute
 {
 
     /** write attribute to adios file
-     * 
+     *
      * @param params wrapped params
      * @param elements elements of this attribute
      */

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -51,7 +51,7 @@ public:
 };
 
 
-/** 
+/**
  * Write calculated fields to HDF5 file.
  *
  * @tparam T field class
@@ -95,7 +95,7 @@ public:
  * and write them to hdf5.
  *
  * FieldTmp is calculated on device and than dumped to HDF5.
- * 
+ *
  * @tparam Solver solver class for species
  * @tparam Species species/particles class
  */

--- a/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -141,7 +141,7 @@ public:
 
 /**
  * Hepler class for HDF5Writer (forEach operator) to load a field from HDF5
- * 
+ *
  * @tparam FieldType field class to load
  */
 template< typename FieldType >

--- a/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2013 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -42,7 +42,7 @@ using namespace splash;
 
 
 /** write attribute of a particle to hdf5 file
- * 
+ *
  * @tparam T_Identifier identifier of a particle attribute
  */
 template< typename T_Identifier>
@@ -50,12 +50,12 @@ struct ParticleAttribute
 {
 
     /** write attribute to hdf5 file
-     * 
+     *
      * @param params wrapped params with domainwriter, ...
-     * @param frame frame with all particles 
+     * @param frame frame with all particles
      * @param prefix a name prefix for hdf5 attribute (is combined to: prefix_nameOfAttribute)
      * @param simOffset offset from window origin of thedomain
-     * @param localSize local domain size 
+     * @param localSize local domain size
      */
     template<typename FrameType>
     HINLINE void operator()(
@@ -120,17 +120,17 @@ struct ParticleAttribute
                 tmpArray[i] = ((ComponentValueType*)dataPtr)[i * components + d];
             }
   
-            threadParams->dataCollector->writeDomain(threadParams->currentStep, 
-                                                     splashType, 
-                                                     1u, 
+            threadParams->dataCollector->writeDomain(threadParams->currentStep,
+                                                     splashType,
+                                                     1u,
                                                      splash::Selection(Dimensions(elements, 1, 1)),
-                                                     datasetName.str().c_str(), 
+                                                     datasetName.str().c_str(),
                                                      splash::Domain(
-                                                            splashDomainOffset, 
+                                                            splashDomainOffset,
                                                             splashDomainSize
                                                      ),
                                                      splash::Domain(
-                                                            splashGlobalDomainOffset, 
+                                                            splashGlobalDomainOffset,
                                                             splashGlobalDomainSize
                                                      ),
                                                      DomainCollector::PolyType,

--- a/src/picongpu/include/plugins/output/compression/ZipConnector.hpp
+++ b/src/picongpu/include/plugins/output/compression/ZipConnector.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 
@@ -47,8 +47,8 @@ public:
         strm.avail_out = sizeIn;
         strm.next_out = (Bytef*) out;
         
-        ret = deflate(&strm, Z_FINISH); 
-        assert(ret != Z_STREAM_ERROR); 
+        ret = deflate(&strm, Z_FINISH);
+        assert(ret != Z_STREAM_ERROR);
 
         size_t compressedBytes = strm.total_out;
 
@@ -75,8 +75,8 @@ public:
 
         strm.avail_out = sizeOut;
         strm.next_out = (Bytef*) out;
-        ret = inflate(&strm, Z_FINISH); 
-        assert(ret != Z_STREAM_ERROR); 
+        ret = inflate(&strm, Z_FINISH);
+        assert(ret != Z_STREAM_ERROR);
 
         size_t uncompressedBytes = strm.total_out;
 

--- a/src/picongpu/include/plugins/output/header/ColorHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/ColorHeader.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/output/header/DataHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/DataHeader.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/picongpu/include/plugins/output/header/NodeHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/NodeHeader.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/output/header/SimHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/SimHeader.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/picongpu/include/plugins/output/header/WindowHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/WindowHeader.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/output/images/PngCreator.hpp
+++ b/src/picongpu/include/plugins/output/images/PngCreator.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/radiation/assert.hpp
+++ b/src/picongpu/include/plugins/radiation/assert.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include <iostream>
 
@@ -41,7 +41,7 @@ public:
 
 struct One_minus_beta_times_n
 {
-    /// Class to calculate 1-\beta \times \vec n 
+    /// Class to calculate 1-\beta \times \vec n
     /// using the best suiting method depending on energy
     /// to achieve the best numerical results
     /// it will be used as base class for amplitude calculations
@@ -79,7 +79,7 @@ struct One_minus_beta_times_n
 struct Retarded_time_1
 {
     // interface for combined 'Amplitude_Calc' classes
-    // contains more parameters than needed to have the 
+    // contains more parameters than needed to have the
     // same interface as 'Retarded_time_2'
 
     HDINLINE numtype2 operator()(const numtype2 t,
@@ -145,7 +145,7 @@ public:
 
     HDINLINE vec2 get_vector(const vec2& n) const
     {
-        const vec2 look_direction(n.unit_vec()); // make sure look_direction is a unit vector 
+        const vec2 look_direction(n.unit_vec()); // make sure look_direction is a unit vector
         VecCalc vecC;
         return vecC(look_direction, particle, delta_t);
     }

--- a/src/picongpu/include/plugins/radiation/check_consistency.hpp
+++ b/src/picongpu/include/plugins/radiation/check_consistency.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/plugins/radiation/complex.hpp
+++ b/src/picongpu/include/plugins/radiation/complex.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #include<cmath>
 #include <iostream>

--- a/src/picongpu/include/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
+++ b/src/picongpu/include/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -31,7 +31,7 @@ namespace picongpu
 /*create verbose class*/
 DEFINE_VERBOSE_CLASS(PIConGPUVerboseRadiation)
 (
-    /* define log lvl for later use 
+    /* define log lvl for later use
      * e.g. log<PMaccLogLvl::NOTHING>("TEXT");*/
     DEFINE_LOGLVL(0,NOTHING);
     DEFINE_LOGLVL(1,PHYSICS);

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -66,7 +66,7 @@ namespace picongpu
       }
     };
 
-  }  
+  }
 }
 
 

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -42,8 +42,8 @@ namespace picongpu
     {
     public:
       FreqFunctor(void)
-      {  
-	omega_log_min = math::log(omega_min); 
+      {
+	omega_log_min = math::log(omega_min);
 	delta_omega_log = (math::log(omega_max) - omega_log_min) / float_X(N_omega - 1);
        }
 

--- a/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
+++ b/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -36,7 +36,7 @@ public:
     **/
     __device__ __host__ __forceinline__ NyquistLowPass(const vec2& n, const Particle& particle)
       : omegaNyquist((picongpu::PI - 0.01)/
-	       (picongpu::DELTA_T * 
+	       (picongpu::DELTA_T *
 	        One_minus_beta_times_n()(n, particle)))
     { }
 

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #include <stdint.h>
@@ -34,7 +34,7 @@
 
 class When
 {
-    // a enum to describe all needed times 
+    // a enum to describe all needed times
 public:
 
     enum
@@ -48,7 +48,7 @@ class Particle : protected Taylor // Taylor includes just some methodes (no real
 public:
     //////////////////////////////////////////////////////////////////
     // data:
-    // the first time (in above order) to be stored 
+    // the first time (in above order) to be stored
 
     enum
     {
@@ -61,11 +61,11 @@ public:
 
 public:
     //////////////////////////////////////////////////////////////////
-    // constructors: 
+    // constructors:
   
   HDINLINE Particle(const vec1& locationNow_set, const vec1& momentumOld_set, const vec1& momentumNow_set, const picongpu::float_X mass_set)
     : location_now(locationNow_set), momentum_old(momentumOld_set), momentum_now(momentumNow_set), mass(mass_set)
-    {    
+    {
     
     }
 
@@ -130,7 +130,7 @@ private:
 
     HDINLINE numtype2 calc_gamma_inv_square(const vec1& momentum) const
     {
-        // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2) 
+        // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2)
         const numtype1 Emass = mass * picongpu::SPEED_OF_LIGHT;
         return Emass / (Emass + (util::square<vec1, numtype1 > (momentum)) / Emass);
     }

--- a/src/picongpu/include/plugins/radiation/particles/Momentum_mt1.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/Momentum_mt1.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/radiation/particles/RadiationFlag.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/RadiationFlag.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/plugins/radiation/radFormFactor.hpp
+++ b/src/picongpu/include/plugins/radiation/radFormFactor.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -41,16 +41,16 @@ namespace picongpu
 	 * with observation direction (unit vector) \vec{n} = (n_x, n_y, n_z)
 	 * and with: N     = weighting
 	 *           omega = frequency
-	 *           L_d   = the size of the CIC-particle / cell in dimension d 
+	 *           L_d   = the size of the CIC-particle / cell in dimension d
 	 *
 	 * the Form Factor: sqrt( | \mathcal{F} |^2 ) will be returned
 	 */
 	
-	return sqrt(N + (N*N - N) * util::square( 
-						 math::sinc( observer_unit_vec.x() * CELL_WIDTH/(SPEED_OF_LIGHT*2)  * omega) * 
-						 math::sinc( observer_unit_vec.y() * CELL_HEIGHT/(SPEED_OF_LIGHT*2) * omega) * 
+	return sqrt(N + (N*N - N) * util::square(
+						 math::sinc( observer_unit_vec.x() * CELL_WIDTH/(SPEED_OF_LIGHT*2)  * omega) *
+						 math::sinc( observer_unit_vec.y() * CELL_HEIGHT/(SPEED_OF_LIGHT*2) * omega) *
 						 math::sinc( observer_unit_vec.z() * CELL_DEPTH/(SPEED_OF_LIGHT*2)  * omega)
-						  ) 
+						  )
 		    );
 	
       }

--- a/src/picongpu/include/plugins/radiation/taylor.hpp
+++ b/src/picongpu/include/plugins/radiation/taylor.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/plugins/radiation/utilities.hpp
+++ b/src/picongpu/include/plugins/radiation/utilities.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/plugins/radiation/vector.hpp
+++ b/src/picongpu/include/plugins/radiation/vector.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/plugins/radiation/windowFunctions.hpp
+++ b/src/picongpu/include/plugins/radiation/windowFunctions.hpp
@@ -46,11 +46,11 @@ namespace picongpu
        **/
       HDINLINE float_X operator()(const float_X position_x, const float_X L_x) const
       {
-        /* an optimized formula is implemented 
-         * 
+        /* an optimized formula is implemented
+         *
          * transform position to make box symetric:
          * x_prime = position_x - 1/2 * L_x
-         * 
+         *
          * then: f(x_position) = f(x_prime)
          * f(x_prime) = { 1.0     : -L_x/2 <= x_prime <= +L_x/2
          *              { 0.0     : in any other case
@@ -84,7 +84,7 @@ namespace picongpu
       HDINLINE float_X operator()(const float_X position_x, const float_X L_x) const
       {
         float_X x = position_x - float_X(0.5)*L_x;
-        return float_X(math::abs(x) <= float_X(0.5)*L_x) 
+        return float_X(math::abs(x) <= float_X(0.5)*L_x)
           * (float_X(1.0) - float_X(2.0)/L_x * math::abs(x) );
       }
     };
@@ -115,7 +115,7 @@ namespace picongpu
         const float_X x = position_x - L_x*float_X(0.5);
         const float_X a = 0.08; /* ideal parameter: -43dB reduction */
         const float_X cosinusValue = math::cos(M_PI*x/L_x);
-        return float_X(math::abs(x) <= float_X(0.5)*L_x) 
+        return float_X(math::abs(x) <= float_X(0.5)*L_x)
           * (a + (float_X(1.0)-a)*cosinusValue*cosinusValue);
       }
     };
@@ -130,7 +130,7 @@ namespace picongpu
       /** 1D Window function according to the Triplett window:
        *
        * x      = position_x - L_x/2
-       * lambda = decay parameter of the Triplett window 
+       * lambda = decay parameter of the Triplett window
        * f(x) = {exp(-lambda*|x|)*cos^2(pi*x/L_x) : (-L_x/2 <= x <= +L_x/2 )
        *        {0.0                              : in any other case
        *
@@ -146,7 +146,7 @@ namespace picongpu
         const float_X x = position_x - L_x*float_X(0.5);
         const float_X lambda = float_X(5.0)/L_x; /* larger is better, but too large means no data */
         const float_X cosinusValue = math::cos(M_PI*x/L_x);
-        return float_X(math::abs(x) <= float_X(0.5)*L_x) 
+        return float_X(math::abs(x) <= float_X(0.5)*L_x)
           * (math::exp(float_X(-1.0)*lambda*math::abs(x))*cosinusValue*cosinusValue);
       }
     };
@@ -177,7 +177,7 @@ namespace picongpu
         const float_X x = position_x - L_x*float_X(0.5);
         const float_X sigma = float_X(0.4)*L_x; /* smaller is better, but too small means no data */
         const float_X relativePosition = x/sigma; /* optimization */
-        return float_X(math::abs(x) <= float_X(0.5)*L_x) 
+        return float_X(math::abs(x) <= float_X(0.5)*L_x)
           * (math::exp(float_X(-0.5)*relativePosition*relativePosition));
       }
     };

--- a/src/picongpu/include/pmacc_renamings.hpp
+++ b/src/picongpu/include/pmacc_renamings.hpp
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with PIConGPU.
  * If not, see <http://www.gnu.org/licenses/>.
- */ 
+ */
  
 
 #pragma once

--- a/src/picongpu/include/simulationControl/ISimulationStarter.hpp
+++ b/src/picongpu/include/simulationControl/ISimulationStarter.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -42,10 +42,10 @@ namespace picongpu
         {
         }
         /**Pars progarm parameters
-         *             * 
+         *             *
          * @param argc number of arguments in argv
          * @param argv arguments for programm
-         * 
+         *
          * @return true if no error else false
          */
         virtual bool parseConfigs(int argc, char **argv) = 0;

--- a/src/picongpu/include/simulationControl/Selection.hpp
+++ b/src/picongpu/include/simulationControl/Selection.hpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2014 Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -29,7 +29,7 @@ using namespace PMacc;
 
 /**
  * Any DIM-dimensional selection of a simulation volume with a size and offset.
- * 
+ *
  * @tparam DIM number of dimensions
  */
 template <unsigned DIM>
@@ -48,11 +48,11 @@ public:
             size[i] = 0;
             offset[i] = 0;
         }
-    } 
+    }
    
     /**
      * Copy constructor
-     * 
+     *
      * @param other Selection to copy information from
      */
     Selection(const Selection<DIM>& other) :
@@ -65,7 +65,7 @@ public:
     /**
      * Constructor
      * Offset is initialized to 0.
-     * 
+     *
      * @param size DataSpace for selection size
      */
     Selection(DataSpace<DIM> size) :
@@ -79,7 +79,7 @@ public:
     
     /**
      * Constructor
-     * 
+     *
      * @param size DataSpace for selection size
      * @param offset DataSpace for selection offset
      */
@@ -92,7 +92,7 @@ public:
     
     /**
      * Return a string representation
-     * 
+     *
      * @return string representation
      */
     HINLINE const std::string toString(void) const

--- a/src/picongpu/include/simulationControl/SimulationStarter.hpp
+++ b/src/picongpu/include/simulationControl/SimulationStarter.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/simulation_defines.hpp
+++ b/src/picongpu/include/simulation_defines.hpp
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -34,7 +34,7 @@ namespace picongpu
 
 /* IMPORTANT we need to use #include <...> for local files
  * else we get problems with our EXTENTION_PATH from cmake which
- * overwrites local defined include files. 
+ * overwrites local defined include files.
  */
 
 //##### load param

--- a/src/picongpu/include/simulation_defines/extensionParam.loader
+++ b/src/picongpu/include/simulation_defines/extensionParam.loader
@@ -1,25 +1,25 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 /* this file must be empty
- * 
+ *
  * this file is used to load extensions in own test cases.
  * Write in an include to load extension.
  */

--- a/src/picongpu/include/simulation_defines/extensionUnitless.loader
+++ b/src/picongpu/include/simulation_defines/extensionUnitless.loader
@@ -1,25 +1,25 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 /* this file must be empty
- * 
+ *
  * this file is used to load extensions in own test cases.
  * Write in an include to load extension.
  */

--- a/src/picongpu/include/simulation_defines/param/fieldBackground.param
+++ b/src/picongpu/include/simulation_defines/param/fieldBackground.param
@@ -21,12 +21,12 @@
 #pragma once
 
 /** Load external background fields
- * 
+ *
  */
 namespace picongpu
 {
     class fieldBackgroundE
-    { 
+    {
     public:
         /* Add this additional field for pushing particles */
         static const bool InfluenceParticlePusher = false;
@@ -58,7 +58,7 @@ namespace picongpu
     };
 
     class fieldBackgroundB
-    { 
+    {
     public:
         /* Add this additional field for pushing particles */
         static const bool InfluenceParticlePusher = false;

--- a/src/picongpu/include/simulation_defines/param/fieldSolver.param
+++ b/src/picongpu/include/simulation_defines/param/fieldSolver.param
@@ -1,28 +1,28 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
 #pragma once
 
 /**! Configure the selected field solver method
- * 
+ *
  * You can set/modify Maxwell solver specific options in the
  * section of each "FieldSolver".
  */

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -27,13 +27,13 @@ namespace picongpu
     {
         /** The maximum density in particles per m^3 in the gas distribution
          *  unit: ELEMENTS/m^3
-         * 
+         *
          * He (2e- / Atom ) with 1.e15 He / m^3
          *                      = 2.e15 e- / m^3 */
         const double GAS_DENSITY_SI = 1.e25;
 
         /** height of vacuum area on bottom border
-         *      this vacuum is really important because of the laser initialization, 
+         *      this vacuum is really important because of the laser initialization,
          *      which is done in the first cell of the simulation
          *  unit: meter */
         const double VACUUM_Y_SI = 50.0 * SI::CELL_HEIGHT_SI;
@@ -128,11 +128,11 @@ namespace picongpu
          *                   exponential decreasing flank
          *           ___
          *  1D:  _,./   \.,_   rho(r)
-         * 
+         *
          *  2D:  ..,x,..   density: . low
          *       .,xxx,.            , middle
          *       ..,x,..            x high (constant)
-         * 
+         *
          *  Imagine a ball with a "hard core" and "soft flanks".
          *                 (+1 for using antithetics in a description)
          */

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -53,7 +53,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
-    }; //unit: none  
+    }; //unit: none
     
     const uint32_t ABSORBER_FADE_IN_STEPS = 16;
     
@@ -62,7 +62,7 @@ namespace picongpu
      *  is fired at the begin of the simulation.
      *  When it reaches slide_point % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
-     * 
+     *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -264,11 +264,11 @@ namespace picongpu
             const double AMPLITUDE_SI = 1.738e13;
 
 
-            /** Pulse length: 
+            /** Pulse length:
              *  PULSE_LENGTH_SI = total length of polynamial laser pulse
              *  Rise time = 0.5 * PULSE_LENGTH_SI
              *  Fall time = 0.5 * PULSE_LENGTH_SI
-             *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM} 
+             *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
              *  unit: seconds  */
             const double PULSE_LENGTH_SI = 4.0e-15;
 
@@ -276,7 +276,7 @@ namespace picongpu
              *              decreases to its 1/e^2-th part,
              *              at the focus position of the laser
              *  unit: meter */
-            const double W0x_SI = 4.246e-6; // waist in x-direction 
+            const double W0x_SI = 4.246e-6; // waist in x-direction
             const double W0z_SI = W0x_SI; // waist in z-direction
         }
     }

--- a/src/picongpu/include/simulation_defines/param/particleConfig.param
+++ b/src/picongpu/include/simulation_defines/param/particleConfig.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -59,7 +59,7 @@ namespace picongpu
     //                                  -> cast to float
     // WE DO NOT define "UNIT_ENERGY_keV" or something similar! Never!
     // Stay SI, stay free ;-)
-    // 
+    //
     // example:
     //   // some particle physicist beloved input:
     //   const float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV

--- a/src/picongpu/include/simulation_defines/param/precision.param
+++ b/src/picongpu/include/simulation_defines/param/precision.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -24,7 +24,7 @@
 
   /*
     radiation verbose level:
-    0=nothing, 1=physics, 2=simulation_state, 4=memory, 8=critical 
+    0=nothing, 1=physics, 2=simulation_state, 4=memory, 8=critical
   */
 
 #define PIC_VERBOSE_RADIATION 3
@@ -94,7 +94,7 @@ namespace picongpu
 
 
 /* Choose different form factors in order to consider different  particle shapes for radiation
- * radFormFactor_CIC_3D 
+ * radFormFactor_CIC_3D
  * radFormFactor_CIC_1Dy
  */
 namespace radFormFactor_CIC_3D { }

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once
@@ -25,9 +25,9 @@ namespace picongpu
 {
   namespace radiation_observer
   {
-    /** Compute observation angles 
+    /** Compute observation angles
      *
-     * This function is used in the Radiation plug-in kernel to compute 
+     * This function is used in the Radiation plug-in kernel to compute
      * the observation directions given as a unit vector pointing
      * towards a 'virtual' detector
      *
@@ -37,16 +37,16 @@ namespace picongpu
      *
      * @return   unit vector pointing in observation direction
      *           type: vec2
-     * 
+     *
      */
     DINLINE vec2 observation_direction(const int observation_id_extern)
     {
-      /** compute observation directions for 2D virtual detector field 
+      /** compute observation directions for 2D virtual detector field
        *  pointing toward the +x direction
        *  with observation angles ranging from
        *  theta = [angle_theta_start : angle_theta_end]
        *  phi   = [angle_phi_start   : angle_phi_end  ]
-       *  every block index moves the phi angle from its start value toward 
+       *  every block index moves the phi angle from its start value toward
        *  its end value until the observation_id_extern reaches N_split.
        *  After that the theta angle moves further from its start
        *  value towards its end value while phi is reset to its start
@@ -59,8 +59,8 @@ namespace picongpu
        *  z_value = cos(theta)
        *  These are the standard spherical coordinates.
        *
-       *  The default setup describes an detector array of 
-       *  16x16 detectors ranging from -pi/8= -22.5 degrees 
+       *  The default setup describes an detector array of
+       *  16x16 detectors ranging from -pi/8= -22.5 degrees
        *  to +pi/8= +22.5 degrees for both angles with the center
        *  pointing toward the x-axis (laser propagation direction).
        */
@@ -86,14 +86,14 @@ namespace picongpu
 
       /* compute step with between two angles for range [angle_??_start : angle_??_end] */
       const int N_theta           = parameters::N_observer / N_angle_split;
-      const numtype2 delta_angle_theta =  (angle_theta_start - 
+      const numtype2 delta_angle_theta =  (angle_theta_start -
 					   angle_theta_end) / (N_theta-1.0);
-      const numtype2 delta_angle_phi   =  (angle_phi_start - 
+      const numtype2 delta_angle_phi   =  (angle_phi_start -
 					   angle_phi_end)   / (N_angle_split-1.0);
 
       /* compute observation angles */
       const numtype2 theta(  my_index_theta * delta_angle_theta + angle_theta_start );
-      const numtype2 phi(    my_index_phi   * delta_angle_phi   - angle_phi_start   ); 
+      const numtype2 phi(    my_index_phi   * delta_angle_phi   - angle_phi_start   );
 
       /* compute observation unit vector */
       return vec2( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;

--- a/src/picongpu/include/simulation_defines/param/starter.param
+++ b/src/picongpu/include/simulation_defines/param/starter.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/simulation_defines/param/visColorScales.param
+++ b/src/picongpu/include/simulation_defines/param/visColorScales.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/simulation_defines/param/visualization.param
+++ b/src/picongpu/include/simulation_defines/param/visualization.param
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 #pragma once

--- a/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 

--- a/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -75,7 +75,7 @@ namespace picongpu
     {
         //normed laser parameter
         const float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
-        const float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds 
+        const float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds
         const float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
         const float_X W0x = float_X(SI::W0x_SI / UNIT_LENGTH); // unit: meter
         const float_X W0z = float_X(SI::W0z_SI / UNIT_LENGTH); // unit: meter

--- a/src/picongpu/include/simulation_defines/unitless/particleConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/particleConfig.unitless
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -38,7 +38,7 @@ namespace picongpu
     PMACC_CASSERT_MSG(Drift_velocity_wrong___no_drift_means_gamma_eq_1,
                         (PARTICLE_INIT_DRIFT_GAMMA)>=1.0);
     PMACC_CASSERT_MSG(Drift_velocity_wrong___no_drift_means_gamma_eq_1,
-                        (PARTICLE_INIT_DRIFT_GAMMA_MIDDLE)>=1.0); 
+                        (PARTICLE_INIT_DRIFT_GAMMA_MIDDLE)>=1.0);
     
     namespace particleInitQuietStart
     {

--- a/src/picongpu/include/simulation_defines/unitless/precision.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/precision.unitless
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 #pragma once
 

--- a/src/picongpu/include/simulation_defines/unitless/starter.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/starter.unitless
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
  
 
 
@@ -28,7 +28,7 @@
 #include "simulationControl/SimulationStarter.hpp"
 
 /* Define a starter for the simulation with the name "SimStarter"
- * 
+ *
  * etc.: typedef MyOwnStarterClass SimStarter;
  */
 namespace picongpu

--- a/src/picongpu/include/traits/AdiosToPIC.hpp
+++ b/src/picongpu/include/traits/AdiosToPIC.hpp
@@ -28,7 +28,7 @@ namespace picongpu
 namespace traits
 {
     /** Convert an Adios type to a PIConGPU Type
-     * 
+     *
      * \tparam T_AdiosType Adios data type
      * \return \p ::type as public typedef
      */

--- a/src/picongpu/include/traits/PICToAdios.hpp
+++ b/src/picongpu/include/traits/PICToAdios.hpp
@@ -28,7 +28,7 @@ namespace picongpu
 namespace traits
 {
     /** Convert a PIConGPU Type to an Adios data type
-     * 
+     *
      * \tparam T_Type Typename in PIConGPU
      * \return \p ::type as public typedef of an Adios type
      */

--- a/src/picongpu/include/traits/PICToSplash.hpp
+++ b/src/picongpu/include/traits/PICToSplash.hpp
@@ -28,7 +28,7 @@ namespace picongpu
 namespace traits
 {
     /** Convert a PIConGPU Type to a Splash CollectionType
-     * 
+     *
      * \tparam T_Type Typename in PIConGPU
      * \return \p ::type as public typedef of a Splash CollectionType
      */

--- a/src/picongpu/include/traits/SplashToPIC.hpp
+++ b/src/picongpu/include/traits/SplashToPIC.hpp
@@ -28,7 +28,7 @@ namespace picongpu
 namespace traits
 {
     /** Convert a Splash CollectionType to a PIConGPU Type
-     * 
+     *
      * \tparam T_SplashType Splash CollectionType
      * \return \p ::type as public typedef
      */

--- a/src/picongpu/include/traits/Unit.hpp
+++ b/src/picongpu/include/traits/Unit.hpp
@@ -28,7 +28,7 @@ namespace picongpu
 namespace traits
 {
     /** Get unit of date which are represented by a identifier
-     * 
+     *
      * \tparam T_Identifier any picongpu identifier
      * \return \p std::vector<double> ::get() as static public methode
      */

--- a/src/picongpu/main.cu
+++ b/src/picongpu/main.cu
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/src/picongpu/submit/submitAction.sh
+++ b/src/picongpu/submit/submitAction.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
 ## copy memcheck programs
 cd $TBG_dstPath

--- a/src/tools/bin/BinEnergyPlot.sh
+++ b/src/tools/bin/BinEnergyPlot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2013 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/tools/bin/LineSliceFields.sh
+++ b/src/tools/bin/LineSliceFields.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2013 Axel Huebl
 #
 # This file is part of PIConGPU.

--- a/src/tools/bin/create.sh
+++ b/src/tools/bin/create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2013 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/tools/bin/png2video.sh
+++ b/src/tools/bin/png2video.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2013 Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/tools/bin/position2Trace.sh
+++ b/src/tools/bin/position2Trace.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2013 Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.

--- a/src/tools/bin/splash2vtk.sh
+++ b/src/tools/bin/splash2vtk.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# 
-# Copyright 2013 Axel Huebl             
+#
+# Copyright 2013 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/png2gas/png2gas.cpp
+++ b/src/tools/png2gas/png2gas.cpp
@@ -1,21 +1,21 @@
 /**
  * Copyright 2014 Felix Schmitt
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <iostream>
@@ -75,7 +75,7 @@ bool parseCmdLine(int argc, char **argv, Options &options)
         po::store(po::command_line_parser(argc, argv).options(desc).positional(pos_options_descr).run(), vm);
         po::notify(vm);
 
-        // print help message and return 
+        // print help message and return
         if (vm.count("help"))
         {
             std::cout << desc << std::endl;

--- a/src/tools/splash2txt/include/ITools.hpp
+++ b/src/tools/splash2txt/include/ITools.hpp
@@ -1,22 +1,22 @@
 /*
  * Copyright 2013-2014 Felix Schmitt
  *
- * This file is part of splash2txt. 
- * 
- * splash2txt is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * splash2txt is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with splash2txt. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of splash2txt.
+ *
+ * splash2txt is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * splash2txt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with splash2txt.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef ITOOLS_HPP

--- a/src/tools/splash2txt/include/splash2txt.hpp
+++ b/src/tools/splash2txt/include/splash2txt.hpp
@@ -1,22 +1,22 @@
 /*
  * Copyright 2013-2014 Felix Schmitt, Axel Huebl, Rene Widera
  *
- * This file is part of splash2txt. 
- * 
- * splash2txt is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * splash2txt is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with splash2txt. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of splash2txt.
+ *
+ * splash2txt is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * splash2txt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with splash2txt.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef SPLASH2TXT_HPP
@@ -87,7 +87,7 @@ typedef struct
     std::string delimiter;
     uint32_t step; // simulation iteration
     std::vector<std::string> data; // names of datasets
-    Dims fieldDims; // for field data, dimensions of slice, e.g. xy -> (1, 1, 0) 
+    Dims fieldDims; // for field data, dimensions of slice, e.g. xy -> (1, 1, 0)
     size_t sliceOffset; // offset of slice (fieldDims) in dataset
     bool isReverseSlice; // if one of allowedReverseSlices is used
     bool verbose; // verbose output on stdout

--- a/src/tools/splash2txt/include/tools_splash_parallel.hpp
+++ b/src/tools/splash2txt/include/tools_splash_parallel.hpp
@@ -1,22 +1,22 @@
 /*
  * Copyright 2013-2014 Felix Schmitt
  *
- * This file is part of splash2txt. 
- * 
- * splash2txt is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * splash2txt is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with splash2txt. 
- * If not, see <http://www.gnu.org/licenses/>. 
+ * This file is part of splash2txt.
+ *
+ * splash2txt is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * splash2txt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with splash2txt.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef TOOLS_SPLASH_PARALLEL_HPP

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -28,7 +28,7 @@ ToolsSplashParallel::ToolsSplashParallel(ProgramOptions &options, Dims &mpiTopol
 ITools(options, mpiTopology, outStream),
 dc(MPI_COMM_WORLD, MPI_INFO_NULL, Dimensions(mpiTopology[0], mpiTopology[1], mpiTopology[2]), 100),
 errorStream(std::cerr)
-{    
+{
     DataCollector::FileCreationAttr fattr;
     fattr.enableCompression = false;
     fattr.fileAccType = DataCollector::FAT_READ_MERGED;


### PR DESCRIPTION
I used this command:

``` bash
for i in `find . -type f | egrep "*.def$|*.h$|*.cpp$|*.cu$|*.hpp$|*.tpp$|*.kernel$|*.loader$|*.param$|*.unitless$" ` ;  do grep ^.*[[:space:]]$ $i >/dev/null ; if [ $? -eq 0 ] ; then sed -i 's/\(^.*[^[:space:]]\)[[:space:]]*$/\1/g' $i >/dev/null ;  echo $i ; fi ; done
```
