### PR TITLE
add `*.pyc` (python byte code) to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 /*.cbp
 /*.layout
 
-# python object code
+# python byte code
 *.pyc
+


### PR DESCRIPTION
`*.pyc` are produced if python based tools are used in `src/tools/bin`
If one uses the python tools there, the directory gets cluttered with these files.
