### PR TITLE
fix stack frame usage in Esirkepov solver

### DIFF
--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -183,7 +183,7 @@ struct Esirkepov<T_ParticleShape, DIM3>
      * @param d dimension range {0,1,2} means {x,y,z}
      *          different to Esirkepov paper, here we use C style
      */
-    DINLINE float_X S0(const Line<float3_X>& line, const float_X gridPoint, const float_X d)
+    DINLINE float_X S0(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
     {
         return ParticleAssign()(gridPoint - line.pos0[d]);
     }
@@ -194,7 +194,7 @@ struct Esirkepov<T_ParticleShape, DIM3>
      * @param d dimension range {0,1,2} means {x,y,z}]
      *          different to Esirkepov paper, here we use C style
      */
-    DINLINE float_X DS(const Line<float3_X>& line, const float_X gridPoint, const float_X d)
+    DINLINE float_X DS(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
     {
         return ParticleAssign()(gridPoint - line.pos1[d]) - ParticleAssign()(gridPoint - line.pos0[d]);
     }

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -213,7 +213,7 @@ struct Esirkepov<T_ParticleShape, DIM2>
      * @param d dimension range {0,1} means {x,y}
      *          different to Esirkepov paper, here we use C style
      */
-    DINLINE float_X S0(const Line<float2_X>& line, const float_X gridPoint, const float_X d)
+    DINLINE float_X S0(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
     {
         return ParticleAssign()(gridPoint - line.pos0[d]);
     }
@@ -224,7 +224,7 @@ struct Esirkepov<T_ParticleShape, DIM2>
      * @param d dimension range {0,1} means {x,y}
      *          different to Esirkepov paper, here we use C style
      */
-    DINLINE float_X DS(const Line<float2_X>& line, const float_X gridPoint, const float_X d)
+    DINLINE float_X DS(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
     {
         return ParticleAssign()(gridPoint - line.pos1[d]) - ParticleAssign()(gridPoint - line.pos0[d]);
     }


### PR DESCRIPTION
- old version used `float` to access a `floatD_X` array, this end in  stack frames usage

```
[0mptxas info    : Function properties for _ZN8picongpu20kernelComputeCurrentILi2EN5PMacc20SuperCellDescriptionINS1_4math2CT6VectorIN4mpl_10integral_cIiLi8EEES8_NS7_IiLi4EEEEENS4_3IntILi2ELi2ELi2EEENSB_ILi3ELi3ELi3EEEEELj3ENS1_7DataBoxINS1_10PitchedBoxINS3_6VectorIfLi3ENS3_16StandartAccessorENS3_17StandartNavigatorENS3_6detail17Vector_componentsEEELj3EEEEENS1_12ParticlesBoxINS1_5FrameINS1_15ParticlesBufferINS1_19ParticleDescriptionIN5boost3mpl6stringILi101ELi0ELi0ELi0ELi0ELi0ELi0ELi0EEESA_NSU_6v_itemINS_24placeholder_definition179weightingENSX_INS_24placeholder_definition158momentumENSX_INS_24placeholder_definition128positionINS_24placeholder_definition1412position_picENS1_24placeholder_definition1113pmacc_isAliasEEENSU_7vector0INS6_2naEEELi0EEELi0EEELi0EEENSU_6vectorINS_24placeholder_definition2114particlePusherINS_9particles6pusher5BorisES17_EENS_24placeholder_definition205shapeINS1I_6shapes3TSCES17_EENS_24placeholder_definition2213interpolationINS_28FieldToParticleInterpolationIS1P_NS_30AssignedTrilinearInterpolationEEES17_EENS_24placeholder_definition237currentINS_13currentSolver9EsirkepovIS1P_Lj3EEES17_EES1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_EENSX_INS_12MemoryFactorILm2EEENSX_INS_15CommunicationIdILj5EEES1B_Li0EEELi0EEEEESA_Lj3EE29OperatorCreatePairStaticArrayILj256EEENSS_ISW_SA_NSX_INS1_23placeholder_definition99multiMaskENSX_INS1_23placeholder_definition812localCellIdxES1E_Li0EEELi0EEES23_S29_EEEELj3EEENS1_13StrideMappingILj3ELj3ENS1_18MappingDescriptionILj3ESA_EEEENS_22ComputeCurrentPerFrameIS21_NS_8VelocityESA_EEEEvT2_T3_T5_T4_[0m
[0m    72 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads[0m
[0mptxas info    : Used 64 registers, 18256 bytes smem, 496 bytes cmem[0], 24 bytes cmem[2][0m
```
- change `const float` index to `const uint32_t` to solve the problem

```
[0mptxas info    : Function properties for _ZN8picongpu20kernelComputeCurrentILi2EN5PMacc20SuperCellDescriptionINS1_4math2CT6VectorIN4mpl_10integral_cIiLi8EEES8_NS7_IiLi4EEEEENS4_3IntILi2ELi2ELi2EEENSB_ILi3ELi3ELi3EEEEELj3ENS1_7DataBoxINS1_10PitchedBoxINS3_6VectorIfLi3ENS3_16StandartAccessorENS3_17StandartNavigatorENS3_6detail17Vector_componentsEEELj3EEEEENS1_12ParticlesBoxINS1_5FrameINS1_15ParticlesBufferINS1_19ParticleDescriptionIN5boost3mpl6stringILi101ELi0ELi0ELi0ELi0ELi0ELi0ELi0EEESA_NSU_6v_itemINS_24placeholder_definition179weightingENSX_INS_24placeholder_definition158momentumENSX_INS_24placeholder_definition128positionINS_24placeholder_definition1412position_picENS1_24placeholder_definition1113pmacc_isAliasEEENSU_7vector0INS6_2naEEELi0EEELi0EEELi0EEENSU_6vectorINS_24placeholder_definition2114particlePusherINS_9particles6pusher5BorisES17_EENS_24placeholder_definition205shapeINS1I_6shapes3TSCES17_EENS_24placeholder_definition2213interpolationINS_28FieldToParticleInterpolationIS1P_NS_30AssignedTrilinearInterpolationEEES17_EENS_24placeholder_definition237currentINS_13currentSolver9EsirkepovIS1P_Lj3EEES17_EES1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_S1A_EENSX_INS_12MemoryFactorILm2EEENSX_INS_15CommunicationIdILj5EEES1B_Li0EEELi0EEEEESA_Lj3EE29OperatorCreatePairStaticArrayILj256EEENSS_ISW_SA_NSX_INS1_23placeholder_definition99multiMaskENSX_INS1_23placeholder_definition812localCellIdxES1E_Li0EEELi0EEES23_S29_EEEELj3EEENS1_13StrideMappingILj3ELj3ENS1_18MappingDescriptionILj3ESA_EEEENS_22ComputeCurrentPerFrameIS21_NS_8VelocityESA_EEEEvT2_T3_T5_T4_[0m
[0m    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads[0m
[0mptxas info    : Used 60 registers, 18256 bytes smem, 496 bytes cmem[0], 24 bytes cmem[2][0m
```
