### PR TITLE
fix #538 traverse frame list

### DIFF
--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -128,7 +128,7 @@ __global__ void kernelAddTemperature(ParticlesBox<FRAME, simDim> pb, float_X ene
         return; //end kernel if we have no frames
 
     /* BUGFIX to issue #538
-     * volatile prohibit that the compiler creates wrong code*/
+     * volatile prohibits that the compiler creates wrong code*/
     volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
 
 
@@ -237,7 +237,7 @@ __global__ void kernelSetDrift(ParBox pb,
         return; //end kernel if we have no frames
 
     /* BUGFIX to issue #538
-     * volatile prohibit that the compiler creates wrong code*/
+     * volatile prohibits that the compiler creates wrong code*/
     volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
 
     while (isValid)

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -87,7 +87,7 @@ __global__ void kernelEnergyParticles(ParticlesBox<FRAME, simDim> pb,
     /* this checks if the data loaded by a thread is filled with a particle
      * or not. Only applies to the first loaded frame (=last frame) */
     /* BUGFIX to issue #538
-     * volatile prohibit that the compiler creates wrong code*/
+     * volatile prohibits that the compiler creates wrong code*/
     volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
 
     while (isValid)

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -122,7 +122,7 @@ __global__ void kernelPositionsParticles(ParticlesBox<FRAME, simDim> pb,
         return; //end kernel if we have no frames
 
     /* BUGFIX to issue #538
-     * volatile prohibit that the compiler creates wrong code*/
+     * volatile prohibits that the compiler creates wrong code*/
     volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
 
     while (isValid)


### PR DESCRIPTION
workaround for #538
- given momentum in `kernelSetDrift` was not correct set
- nvcc optimize out variable `isParticle` (workaround: set isParticle volatile)
