### PR TITLE
Restart for Plugin BinEnergyParticles

### DIFF
--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -400,18 +400,21 @@ private:
 
     void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
     {
-        outFile.flush();
+        if( writeToFile )
+        {
+            outFile.flush();
 
-        std::stringstream sStep;
-        sStep << currentStep;
+            std::stringstream sStep;
+            sStep << currentStep;
 
-        path src( filename );
-        path dst( checkpointDirectory + std::string("/") + filename +
-                  std::string(".") + sStep.str() );
+            path src( filename );
+            path dst( checkpointDirectory + std::string("/") + filename +
+                      std::string(".") + sStep.str() );
 
-        copy_file( src,
-                   dst,
-                   copy_option::overwrite_if_exists );
+            copy_file( src,
+                       dst,
+                       copy_option::overwrite_if_exists );
+        }
     }
 
     template< uint32_t AREA>


### PR DESCRIPTION
The old text file is opened, filtered for previous values and pre-pended to the new file during restarts.

The old implementation made a manual copy-and-join of the output necessary (see note <sup>1</sup> in the [wiki](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-Plugins)).
### To Do
- [x] perform a run time test (again; after #541 was merged)
