### PR TITLE
Fix GameOfLife compile errors

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
@@ -132,7 +132,7 @@ endif(PNGwriter_FOUND)
 # Boost from system
 ###############################################################################
 
-FIND_PACKAGE(Boost REQUIRED COMPONENTS program_options regex)
+FIND_PACKAGE(Boost REQUIRED COMPONENTS program_options regex system)
 INCLUDE_DIRECTORIES(AFTER ${Boost_INCLUDE_DIRS})
 LINK_DIRECTORIES(${Boost_LIBRARY_DIR})
 SET(LIBS ${LIBS} ${Boost_LIBRARIES})

--- a/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -111,7 +111,7 @@ public:
         /* subGrid holds global and*
          * local SimulationSize and where the local SimArea is in the greater *
          * scheme using Offsets from global LEFT, TOP, FRONT                  */
-        const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
+        const SubGrid<DIM2>& subGrid = Environment<DIM2>::get().SubGrid();
 
         /* Recall that in types.hpp the following is defined:                 *
          *     typedef MappingDescription<DIM2, math::CT::Int<16,16> > MappingDesc;    *

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -30,6 +30,7 @@
 #include "mpi/GetMPI_StructAsArray.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
+#include "algorithms/PromoteType.hpp"
 
 namespace PMacc
 {


### PR DESCRIPTION
- missing include
- replace simDim with DIM2
- add missing system dep for boost in CMake
