### PR TITLE
Fix compile warnings (signage comparison) in splash2txt

### DIFF
--- a/src/tools/splash2txt/splash2txt.cpp
+++ b/src/tools/splash2txt/splash2txt.cpp
@@ -124,7 +124,7 @@ throw (std::runtime_error )
         {
             bool sliceFound = false;
             options.fieldDims.set( 0, 0, 0 );
-            for ( int i = 0; i < numAllowedSlices; ++i )
+            for ( size_t i = 0; i < numAllowedSlices; ++i )
             {
                 if ( slice_string.compare( allowedSlices[i] ) == 0 )
                 {

--- a/src/tools/splash2txt/tools_adios_parallel.cpp
+++ b/src/tools/splash2txt/tools_adios_parallel.cpp
@@ -47,7 +47,7 @@ void ToolsAdiosParallel::convertToText()
     if(options.data.size() == 0)
         throw std::runtime_error("No datasets requested");
 
-    for (int i = 0; i < options.data.size(); ++i)
+    for (size_t i = 0; i < options.data.size(); ++i)
     {
         ADIOS_VARINFO *pVarInfo;
 

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -409,7 +409,7 @@ void ToolsSplashParallel::listAvailableDatasets()
             << std::endl;
 
     outStream << "available time steps:";
-    for (int i = 0; i < num_entries; ++i)
+    for (size_t i = 0; i < num_entries; ++i)
         outStream << " " << entries[i];
     outStream << std::endl;
 


### PR DESCRIPTION
Fix for #551 
