### PR TITLE
Prevent splash2txt exception on no-domain files

### DIFF
--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -238,7 +238,7 @@ void ToolsSplashParallel::convertToText()
     } catch (DCException)
     {
         errorStream << "Error: No domain information for dataset '" << options.data[0] << "' available." << std::endl;
-        errorStream << "This might not be a valid PIConGPU libSplash file." << std::endl;
+        errorStream << "This might not be a valid libSplash domain." << std::endl;
         return;
     }
 


### PR DESCRIPTION
Prevent that splash2txt throws an exception if the splash input file does not contain domain information. Instead, print an information or error message and exit.
