### PR TITLE
add mem-per-cpu to still be able to work with changed taurus config

### DIFF
--- a/src/picongpu/submit/taurus/k20x_profile.tpl
+++ b/src/picongpu/submit/taurus/k20x_profile.tpl
@@ -48,6 +48,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-cpu=3000
 #SBATCH --gres=gpu:!TBG_gpusPerNode
 # send me a mail on (b)egin, (e)nd, (a)bortion
 #SBATCH --mail-type=!TBG_mailSettings


### PR DESCRIPTION
The taurus default memory limit for GPU jobs has been the maximum memory available (3000MB per core) - till now. 
Due to an update, this has changed to 300MB per core by default, but can be set to 3000MB per core manually.

This pull-request adds this configuration to the `*.tpl`.

Info:
`--mem-per-cpu` actually means _memory per cpu-core_ in MB.
