### PR TITLE
Fix #543 FieldTmp Algorithms

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -136,11 +136,11 @@ ComputeGridValuePerFrame<T_ParticleShape, calcType>::operator()
     const DataSpace<simDim> lowMargin(LowerMargin().toRT());
     const DataSpace<simDim> upMargin(UpperMargin().toRT());
 
-    const DataSpace<simDim> marginSpace(upMargin + lowMargin);
+    const DataSpace<simDim> marginSpace(upMargin + lowMargin + 1);
 
     const int numWriteCells = marginSpace.productOfComponents();
 
-    for (int i = 0; i <= numWriteCells; ++i)
+    for (int i = 0; i < numWriteCells; ++i)
     {
         /* multidimensionalIndex is only positive: defined range = [0,LowerMargin+UpperMargin]*/
         const DataSpace<simDim> multidimensionalIndex = DataSpaceOperations<simDim>::map(marginSpace, i);

--- a/src/picongpu/include/particles/shapes/Counter.hpp
+++ b/src/picongpu/include/particles/shapes/Counter.hpp
@@ -39,7 +39,7 @@ namespace shapes
              * width of the support of this form_factor. This is the area where the function
              * is non-zero.
              */
-            static const int support = 1;
+            static const int support = 0;
         };
 
     } // namespace shared_Counter
@@ -53,14 +53,14 @@ namespace shapes
             HDINLINE float_X operator()(const float_X x)
             {
                 /*       -
-                 *       |  1               if 0<=x<1
+                 *       | -1               if -1<x<=0
                  * W(x)=<|
                  *       |  0               otherwise
                  *       -
                  */
 
-                const bool in_cell = ( float_X(0.0) <= x &&
-                                                       x < float_X(1.0) );
+                const bool in_cell = ( float_X(-1.0) < x &&
+                                                       x <= float_X(0.0) );
 
                 return float_X(in_cell);
             }


### PR DESCRIPTION
Fix #543
- the `particleToGrid` algorithms forgot a small fraction of _all_ algorithms since `beta-rc5`
- the algorithm `ParticleCounter` was broken completely due to this

The correction of the defintion of the "Counter" Shape (NOT a real shape such as NGP) and the loop that calculates the values for the affected cells fixes that.
