### PR TITLE
make the cast from int to bool explicit to prevent a warning

### DIFF
--- a/src/libPMacc/include/memory/dataTypes/Mask.hpp
+++ b/src/libPMacc/include/memory/dataTypes/Mask.hpp
@@ -165,7 +165,7 @@ namespace PMacc
          */
         HDINLINE bool isSet(uint32_t ex) const
         {
-            return ((bitMask & (1u << ex)) != 0);
+            return (bitMask & (1u << ex)) != 0;
         }
 
         /**


### PR DESCRIPTION
MSVC (12, 14) issues a warning for this implicit cast from int to bool
