### PR TITLE
Update splash2txt to require splash 1.2.3+

### DIFF
--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -74,7 +74,7 @@ endif(MPI_CXX_FOUND)
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.2.0 REQUIRED COMPONENTS PARALLEL)
+find_package(Splash 1.2.3 REQUIRED COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -376,18 +376,12 @@ void ToolsSplashParallel::printAvailableDatasets(std::vector< DataCollector::DCE
             matchingLength++;
         }
 
-        // coordinates at the end
-        if (matchingLength == dataName.name.size() - 1)
-            outStream << '/'
-                << dataName.name.substr(matchingLength);
-            // new parameters which differ in more than the coordinate at the end
-        else
-        {
-            outStream << std::string(matchingLength == 0, '\n') << '\n'
-                    << intentation
-                    << std::string(lastMatchingDelimiter, ' ')
-                    << dataName.name.substr(lastMatchingDelimiter);
-        }
+        // additional linebreak for new top-level group
+        outStream << std::string(matchingLength == 0, '\n');
+        // align new entry with last matching group
+        outStream << intentation << std::string(lastMatchingDelimiter, ' ')
+                  << dataName.name.substr(lastMatchingDelimiter)
+                  << std::endl;
 
         lastdataName = dataName.name;
     }


### PR DESCRIPTION
- Up libsplash requirement for splash2txt to 1.2.3 (to be released yet)
- fix print of datasets to cope with new delimiter-free datasets
