### PR TITLE
Forward declarations for std::stack are not standard conformant.

### DIFF
--- a/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
@@ -22,7 +22,7 @@
 
 
 #ifndef TRANSACTION_HPP
-#define	TRANSACTION_HPP
+#define    TRANSACTION_HPP
 
 #include "eventSystem/EventSystem.hpp"
 
@@ -85,5 +85,5 @@ private:
 }
 
 
-#endif	/* TRANSACTION_HPP */
+#endif    /* TRANSACTION_HPP */
 

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
@@ -44,7 +44,7 @@ public:
     /**
      * Destructor.
      */
-	virtual ~TransactionManager() noexcept(false);
+    virtual ~TransactionManager() throw(std::runtime_error);
 
     /**
      * Adds a new transaction to the stack.

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
@@ -26,12 +26,12 @@
 namespace PMacc
 {
 
-inline TransactionManager::~TransactionManager() noexcept(false)
+inline TransactionManager::~TransactionManager() throw(std::runtime_error)
 {
-	if(transactions.size() == 0)
-		throw std::runtime_error("Missing transaction on the stack!");
-	else if(transactions.size() > 1)
-		throw std::runtime_error("Unfinished transactions on the stack");
+    if(transactions.size() == 0)
+        throw std::runtime_error("Missing transaction on the stack!");
+    else if(transactions.size() > 1)
+        throw std::runtime_error("Unfinished transactions on the stack");
     transactions.pop( );
 }
 


### PR DESCRIPTION
Forward declarations for std::stack are not standard conformant. Implementations (like the one I am using) are allowed to require complete types.

'if ( !transactions.size( ) > 1 )' is useless because it always returns false. Even the correct version without the ! does not catch the case of the missing last transaction.
