### PR TITLE
CompileSuite: Use libSplash 1.2.3

### DIFF
--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -95,7 +95,7 @@ cd $cnf_gitdir
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=sm_35"
             . /etc/profile
-            module load gcc/4.6.4 boost/1.55.0 cmake/2.8.12.2 cuda/6.0 openmpi/1.6.5 libSplash/1.2.3 adios/1.6.0 pngwriter/0.5.4
+            module load gcc/4.6.4 boost/1.55.0 cmake/2.8.12.2 cuda/6.0 openmpi/1.6.5 mallocmc/2.0.0 libSplash/1.2.3 adios/1.7.0 pngwriter/0.5.4
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/compile -l -q -j $cnf_numParallel \


### PR DESCRIPTION
I installed the latest libSplash version already in the compile suite.

This update triggers the new builds to run against it (well, not  really. I have to update it on the machine by hand for now.)
