### PR TITLE
Fix #571 libPMacc limits: 32 bit host

### DIFF
--- a/src/libPMacc/include/traits/Limits.tpp
+++ b/src/libPMacc/include/traits/Limits.tpp
@@ -34,12 +34,6 @@ namespace limits
 {
 
 template<>
-struct Max<size_t>
-{
-    static const size_t value=static_cast<size_t>(-1);
-};
-
-template<>
 struct Max<int>
 {
     static const int value=INT_MAX;
@@ -49,6 +43,12 @@ template<>
 struct Max<uint32_t>
 {
     static const uint32_t value=static_cast<uint32_t>(-1);
+};
+
+template<>
+struct Max<uint64_t>
+{
+    static const uint64_t value=static_cast<uint64_t>(-1);
 };
 
 } //namespace limits


### PR DESCRIPTION
Fix for #571: on 32bit hosts, size_t is the same as uint32_t (hopefully) which declares the `max` for it twice.

Reported by @sigkill on github, thanks!

@psychocoderHPC @f-schmitt-zih can one of you please review that? :)
- [x] @ax3l needs to be cherry-picked in `release-beta-rc6` afterwards
