### PR TITLE
add python module to read sliced fields

### DIFF
--- a/src/tools/share/python/sliceFieldReader.py
+++ b/src/tools/share/python/sliceFieldReader.py
@@ -1,3 +1,23 @@
+# Copyright 2014 Richard Pausch
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
 import numpy as _numpy
 import StringIO as _StringIO
 


### PR DESCRIPTION
adds a function that reads out the field slices generated by the **SliceFieldPrinter**
