### PR TITLE
adjust example to work on hypnos

### DIFF
--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -7,7 +7,7 @@ then
 #       export MODULES_NO_OUTPUT=1
 
         # Core Dependencies
-        module load gcc/4.6.2
+        module load gcc/4.8.2
         module load cmake/2.8.10
         module load openmpi/1.6.3
         module load boost/1.54.0


### PR DESCRIPTION
This fixes an error with `gcc/4.6.2` and `cmake on hypnos, where`/src/configure` stops working because a default gcc test creats an error.

See HZDR support ticket `4414` for more details.   
