### PR TITLE
Add BG Fields in Plugins

### DIFF
--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus
  *
  * This file is part of libPMacc.
  *
@@ -190,13 +190,20 @@ public:
         TimeIntervall tRound;
         double roundAvg = 0.0;
 
-        /* dump initial step if simulation starts without restart */
-        if (currentStep == 0)
-            dumpOneStep(currentStep);
-        else
-            currentStep--; //we dump before calculation, thus we must go on step back if we do a restart
-
-        movingWindowCheck(currentStep); //if we restart at any step check if we must slide
+	/* dump initial step if simulation starts without restart */
+	if (currentStep == 0)
+	{
+	    /* Since in the main loop movingWindow is called always before the dump, we also call it here for consistency.
+	    This becomes only important, if movingWindowCheck does more than merely checking for a slide.
+	    TO DO in a new feature: Turn this into a general hook for pre-checks (window slides are just one possible action). */
+	    movingWindowCheck(currentStep);
+	    dumpOneStep(currentStep);
+	}
+	else
+	{
+	    currentStep--; //We dump before calculation, thus we must go one step back when doing a restart.
+	    movingWindowCheck(currentStep); //If we restart at any step check if we must slide.
+	}
 
         /* dump 0% output */
         dumpTimes(tSimCalculation, tRound, roundAvg, currentStep);

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Richard Pausch
+ *                     Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -410,7 +410,7 @@ public:
             slide(currentStep);
         }
 
-        /** add background field: the movingWindowCheck ist just at the start
+        /** add background field: the movingWindowCheck is just at the start
          * of a time step before all the plugins are called (and the step
          * itself is performed for this time step).
          * Hence the background field is visible for all plugins


### PR DESCRIPTION
Part of @BeyondEspresso changes for the TWTS implementation in the original pull #597.

The bg fields are now still available during the plugin/output phase for easier debugging.

A follow up could write the background fields to an independent output field.