### PR TITLE
Fix Race Condition: Field Update and Pusher

### DIFF
--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -363,6 +363,8 @@ public:
         ForEach<VectorAllSpecies, particles::CallUpdate<bmpl::_1>, MakeIdentifier<bmpl::_1> > particleUpdate;
         particleUpdate(forward(particleStorage), currentStep, initEvent, forward(updateEvent), forward(commEvent));
 
+        __setTransactionEvent(updateEvent);
+
         /** remove background field for particle pusher */
         (*pushBGField)(fieldE, nvfct::Sub(), fieldBackgroundE(fieldE->getUnit()),
                        currentStep, fieldBackgroundE::InfluenceParticlePusher);
@@ -373,7 +375,7 @@ public:
 
         fieldJ->clear();
 
-        __setTransactionEvent(updateEvent + commEvent);
+        __setTransactionEvent(commEvent);
         (*currentBGField)(fieldJ, nvfct::Add(), fieldBackgroundJ(fieldJ->getUnit()),
                           currentStep, fieldBackgroundJ::activated);
 #if (ENABLE_CURRENT == 1)


### PR DESCRIPTION
- fix race condition that field update `update_beforeCurrent` run in parallel to the particle pusher
- fix race condition that field background is removed in parallel to the particle pusher

The `update_beforeCurrent` race condition is older than our github history, but might not have occurred yet since the particle push is rather heavy in register consumption (and seldom run in parallel to an other kernel).
