### PR TITLE
Fix #609 Restarts with Full/Empty GPUs

### DIFF
--- a/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
@@ -76,7 +76,9 @@ struct LoadParticleAttributesFromHDF5
 
         const std::string name_lookup[] = {"x", "y", "z"};
 
-        ComponentType* tmpArray = new ComponentType[elements];
+        ComponentType* tmpArray = NULL;
+        if( elements > 0 )
+            tmpArray = new ComponentType[elements];
 
         ParallelDomainCollector* dataCollector = params->dataCollector;
         for (uint32_t d = 0; d < components; d++)


### PR DESCRIPTION
- fix #609 particle read during restart hangs if some GPUs have no particles and others do

### To Do
- [x] check at runtime