### PR TITLE
TBG: Add Defaults via Env for -s|-t

### DIFF
--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -160,9 +160,10 @@ help()
     echo "TBG (template batch generator)"
     echo "create a new folder for a batch job and copy in all important files"
     echo ""
-    echo "usage: tbg -c cfgFile [-s [submitsystem]] [-t [templateFile]] [-p project] [-o \"VARNAME1=10 VARNAME2=5\"] [-h] destinationPath"
+    echo "usage: tbg -c [cfgFile] [-s [submitsystem]] [-t [templateFile]] [-p project] [-o \"VARNAME1=10 VARNAME2=5\"] [-h] destinationPath"
     echo ""
-    echo "-c | --cfg      file           - Configuration file to set up batch file."
+    echo "-c | --cfg      [file]         - Configuration file to set up batch file."
+    echo "                                 Default: [cfgFile] via export TBG_CFGFILE"
     echo "-s | --submit   [command]      - Submit command (qsub, \"qsub -h\", sbatch, ...)"
     echo "                                 Default: [submitsystem] via export TBG_SUBMIT"
     echo "-t | --tpl      [file]         - Template to create a batch file from."
@@ -203,10 +204,10 @@ if [ $? -ne 0 ] ; then
     exit 1
 fi
 
-# options may be followed by 
+# options may be followed by
 # - one colon to indicate they has a required argument
 # - two colons to indicate they has a optional argument
-OPTS=`$egetoptTool -o p:t::c:s::o:h -l project:,tpl::,cfg:,submit::,help -n tbg ++ "$@"`
+OPTS=`$egetoptTool -o p:t::c::s::o:h -l project:,tpl::,cfg::,submit::,help -n tbg ++ "$@"`
 if [ $? != 0 ] ; then
     # something went wrong, egetopt will put out an error message for us
     exit 1
@@ -230,7 +231,7 @@ while true ; do
             shift
             ;;
        -c|--cfg)
-            cfg_file="$2"
+            cfg_file=${2:-$TBG_CFGFILE}
             shift
             ;;
        -o)
@@ -254,19 +255,24 @@ done
 # tpl file was set - does it also exist?
 #   if a tpl file was not set, try stdin later on
 if [ -n "$tooltpl_file" ] && [ ! -f "$tooltpl_file" ] ; then
-    echo "The given tpl file \"$tooltpl_file\" does not exist." >&2
+    echo "The given tpl file \"$tooltpl_file\" does not exist (-t|--tpl)." >&2
     exit 1;
 fi
 
 outDir="$*"
 
 if [ -z "$outDir" ] ; then
-    echo "No output directory is set" >&2
+    echo "No output directory is set (last tbg parameter)." >&2
     exit 1;
 fi
 
-if [ ! -f $cfg_file ] ; then
-    echo "No cfg file given." >&2
+if [ -z "$cfg_file" ] ; then
+    echo "No cfg file given (-c|--cfg)." >&2
+    exit 1;
+fi
+
+if [ ! -f "$cfg_file" ] ; then
+    echo "The given cfg file \"$cfg_file\" does not exist (-c|--cfg)." >&2
     exit 1;
 fi
 

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -164,8 +164,10 @@ help()
     echo ""
     echo "-c | --cfg      file           - Configuration file to set up batch file."
     echo "-s | --submit   command        - Submit command (qsub, \"qsub -h\", sbatch, ...)"
+    echo "                                 Default: via export TBG_SUBMIT"
     echo "-t | --tpl      file           - Template to create a batch file from."
     echo "                                 tbg will use stdin, if no file is specified."
+    echo "                                 Default: via export TBG_TPLFILE"
     echo "-p | --project  folder         - Project folder containing sourcecode and binaries"
     echo "                                 Default: current directory"
     echo "-o                             - Overwrite any template variable:"
@@ -197,9 +199,13 @@ fi
 
 eval set -- "$OPTS"
 
+# default parameters from environment variables (e.g. in a .profile file)
+#   -s | --submit
+submit_command=${TBG_SUBMIT:-""}
+#   -t | --tpl
+tooltpl_file=${TBG_TPLFILE:-""}
 
-
-
+# parser
 while true ; do
     case "$1" in
         -s|--submit)
@@ -220,10 +226,6 @@ while true ; do
             ;;
        -t|--tpl)
             tooltpl_file="$2"
-            if [ ! -f $tooltpl_file ] ; then
-                echo "The given tpl file \"$tooltpl_file\" does not exist." >&2
-                exit 1;
-            fi
             shift
             ;;
         -h|--help)
@@ -235,6 +237,11 @@ while true ; do
     esac
     shift
 done
+
+if [ ! -f $tooltpl_file ] ; then
+    echo "The given tpl file \"$tooltpl_file\" does not exist." >&2
+    exit 1;
+fi
 
 outDir="$*"
 

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -238,7 +238,9 @@ while true ; do
     shift
 done
 
-if [ ! -f $tooltpl_file ] ; then
+# tpl file was set - does it also exist?
+#   if a tpl file was not set, try stdin later on
+if [ -n "$tooltpl_file" ] && [ ! -f "$tooltpl_file" ] ; then
     echo "The given tpl file \"$tooltpl_file\" does not exist." >&2
     exit 1;
 fi


### PR DESCRIPTION
This feature shortens the `tbg` call dramatically without harming its generality.

The `-s | --submit` option is the batch system and unique for each machine. That is a perfect candidate for a `picongpu.profile` or a general `.profile` setting (as a default).

The `-t | --tpl` file is useful if you have various queues or debug templates. 99% of the users always submit to the same queue and would love a default, too. Developers or power users with varying queues can still use `-t` to overwrite the default.

If `TBG_SUBMIT` or `TBG_TPLFILE` are not set, the default values are still `""` which will result in a standard error from `tbg`.