### PR TITLE
extend particle assign specialization 

### DIFF
--- a/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
@@ -32,7 +32,7 @@
 #include "dimensions/DataSpaceOperations.hpp"
 
 #include "plugins/radiation/parameters.hpp"
-#include "particles/ParticlesInit.kernel"
+#include "particles/operations/SetAttributeToDefault.hpp"
 
 namespace picongpu
 {
@@ -73,7 +73,7 @@ __global__ void kernelAddOneParticle(ParBox pb,
             typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
 
             algorithms::forEach::ForEach<ParticleCleanedAttrList,
-                SetToDefault<bmpl::_1> > setToDefault;
+                SetAttributeToDefault<bmpl::_1> > setToDefault;
             setToDefault(forward(par));
         }
         float3_X pos = float3_X(LOCAL_POS_X, LOCAL_POS_Y, LOCAL_POS_Z);

--- a/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
@@ -32,7 +32,7 @@
 #include "dimensions/DataSpaceOperations.hpp"
 
 #include "plugins/radiation/parameters.hpp"
-#include "particles/ParticlesInit.kernel"
+#include "particles/operations/SetAttributeToDefault.hpp"
 
 namespace picongpu
 {
@@ -72,7 +72,7 @@ __global__ void kernelAddOneParticle(ParBox pb,
             typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
 
             algorithms::forEach::ForEach<ParticleCleanedAttrList,
-                SetToDefault<bmpl::_1> > setToDefault;
+                SetAttributeToDefault<bmpl::_1> > setToDefault;
             setToDefault(forward(par));
         }
 

--- a/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
@@ -32,7 +32,7 @@
 #include "dimensions/DataSpaceOperations.hpp"
 
 #include "plugins/radiation/parameters.hpp"
-#include "particles/ParticlesInit.kernel"
+#include "particles/operations/SetAttributeToDefault.hpp"
 
 namespace picongpu
 {
@@ -72,7 +72,7 @@ __global__ void kernelAddOneParticle(ParBox pb,
             typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
 
             algorithms::forEach::ForEach<ParticleCleanedAttrList,
-                SetToDefault<bmpl::_1> > setToDefault;
+                SetAttributeToDefault<bmpl::_1> > setToDefault;
             setToDefault(forward(par));
         }
 

--- a/src/libPMacc/include/particles/operations/SetAttributeToDefault.hpp
+++ b/src/libPMacc/include/particles/operations/SetAttributeToDefault.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2014 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "traits/Resolve.hpp"
+
+namespace PMacc
+{
+
+/** set an attribute of a particle to their default value
+ *
+ * @tparam  T_Attribute value_identifier or alias which is a value_identifier
+ */
+template<typename T_Attribute>
+struct SetAttributeToDefault
+{
+    typedef T_Attribute Attribute;
+
+    /** set an attribute to their default value
+     *
+     * @tparam T_Partcile particle type
+     */
+    template<typename T_Particle>
+    HDINLINE
+    void operator()(T_Particle& particle)
+    {
+        typedef typename PMacc::traits::Resolve<Attribute>::type ResolvedAttr;
+        particle[Attribute()] = ResolvedAttr::getDefaultValue();
+    }
+};
+
+
+}//namespace PMacc

--- a/src/libPMacc/include/particles/operations/SetAttributeToDefault.hpp
+++ b/src/libPMacc/include/particles/operations/SetAttributeToDefault.hpp
@@ -28,7 +28,7 @@
 namespace PMacc
 {
 
-/** set an attribute of a particle to their default value
+/** set an attribute of a particle to its default value
  *
  * @tparam  T_Attribute value_identifier or alias which is a value_identifier
  */

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -35,6 +35,7 @@
 #include "nvidia/rng/distributions/Uniform_float.hpp"
 #include "particles/init/particleInitRandomPos.hpp"
 
+#include "particles/operations/SetAttributeToDefault.hpp"
 #include "compileTime/conversion/ResolveAndRemoveFromSeq.hpp"
 
 
@@ -64,28 +65,6 @@ DINLINE float_X calcRealDensity(const DataSpace<Dim>& offset,
     const float_X value = gasProfile::calcNormedDensity(physicalCellPosition, localCellIdx, fieldTmp) * GAS_DENSITY;
     return value;
 }
-
-/** Set a particle attribute to the default value
- *
- * @tparam T_Attribute attribute type (pmacc alias is allowed)
- */
-template<typename T_Attribute>
-struct SetToDefault
-{
-    typedef T_Attribute Attribute;
-
-    /** set attribute to the default value
-     *
-     * @tparam T_Partcile particle type
-     */
-    template<typename T_Particle>
-    HDINLINE
-    void operator()(T_Particle& particle)
-    {
-        typedef typename PMacc::traits::Resolve<Attribute>::type ResolvedAttr;
-        particle[Attribute()] = ResolvedAttr::getDefaultValue();
-    }
-};
 
 template< typename ParBox, typename FieldBox, class Mapping>
 __global__ void kernelFillGridWithParticles(ParBox pb,
@@ -219,7 +198,7 @@ __global__ void kernelFillGridWithParticles(ParBox pb,
                 typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
 
                 algorithms::forEach::ForEach<ParticleCleanedAttrList,
-                    SetToDefault<bmpl::_1> > setToDefault;
+                    SetAttributeToDefault<bmpl::_1> > setToDefault;
                 setToDefault(forward(particle));
             }
             particle[position_] = pos;


### PR DESCRIPTION
- add functor to set an attribute of a particle to their default value
- extend the particle assign definition (set attributes which are not defined in the source particle to their default value)  [discussion](https://github.com/ComputationalRadiationPhysics/picongpu/pull/595#discussion_r22087654)
- remove old usage of `SetValueToDefault` with the new PMacc functor


**Tests**
- [x] runtime: KHI
- [x] compile time: check subset and complementary sequence with various configurations