### PR TITLE
fix #616 typo TGB -> TBG

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -1,4 +1,4 @@
-# Copyright 2014 Felix Schmitt, Axel Huebl
+# Copyright 2014-2015 Felix Schmitt, Axel Huebl, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -130,11 +130,11 @@ TBG_iBin="--bin_i.period 500 --bin_i.binCount 1024 --bin_i.minEnergy 0 --bin_i.m
 # Calculate a 2D phase space
 # - requires parallel libSplash for HDF5 output
 # - momentum range in m_e c
-TGB_ePSxpx="--ps_e.period 10 --ps_e.space x --ps_e.momentum px --ps_e.min -1.0 --ps_e.max 1.0"
-TGB_ePSxpz="--ps_e.period 10 --ps_e.space x --ps_e.momentum pz --ps_e.min -1.0 --ps_e.max 1.0"
-TGB_ePSypx="--ps_e.period 10 --ps_e.space y --ps_e.momentum px --ps_e.min -1.0 --ps_e.max 1.0"
-TGB_ePSypy="--ps_e.period 10 --ps_e.space y --ps_e.momentum py --ps_e.min -1.0 --ps_e.max 1.0"
-TGB_ePSypz="--ps_e.period 10 --ps_e.space y --ps_e.momentum pz --ps_e.min -1.0 --ps_e.max 1.0"
+TBG_ePSxpx="--ps_e.period 10 --ps_e.space x --ps_e.momentum px --ps_e.min -1.0 --ps_e.max 1.0"
+TBG_ePSxpz="--ps_e.period 10 --ps_e.space x --ps_e.momentum pz --ps_e.min -1.0 --ps_e.max 1.0"
+TBG_ePSypx="--ps_e.period 10 --ps_e.space y --ps_e.momentum px --ps_e.min -1.0 --ps_e.max 1.0"
+TBG_ePSypy="--ps_e.period 10 --ps_e.space y --ps_e.momentum py --ps_e.min -1.0 --ps_e.max 1.0"
+TBG_ePSypz="--ps_e.period 10 --ps_e.space y --ps_e.momentum pz --ps_e.min -1.0 --ps_e.max 1.0"
 
 
 # Binary density output for slides every .period steps over axis .axis [yx,yz]


### PR DESCRIPTION
Fixed typo: `TGB` to `TBG`
found by @dengshuan #616 