### PR TITLE
fix memory bug in Visualisation.hpp

### DIFF
--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -605,7 +605,7 @@ public:
 
         //create image particles
         __picKernelArea((kernelPaintParticles3D), *cellDescription, CORE + BORDER)
-            (SuperCellSize::toRT().toDim3(), blockSize2D.productOfComponents() * sizeof (int))
+            (SuperCellSize::toRT().toDim3(), blockSize2D.productOfComponents() * sizeof (float_X))
             (particles->getDeviceParticlesBox(),
              img->getDeviceBuffer().getDataBox(),
              transpose,


### PR DESCRIPTION
- set extern shared memory to float_X

this bug only effect runs with double precision