### PR TITLE
Taurus/Hypnos: Update Examples with new TBG Hints

### DIFF
--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -1,4 +1,5 @@
-export PICSRC=/home/`whoami`/src/picongpu
+# Modules #####################################################################
+#
 
 if [ -f /etc/profile.modules ]
 then
@@ -8,17 +9,17 @@ then
 
         # Core Dependencies
         module load gcc/4.6.2
-        module load cmake/2.8.10
+        module load cmake/3.0.1
         module load openmpi/1.6.3
         module load boost/1.54.0
         module load cuda/6.5
 
         # Plugins (optional)
         module load pngwriter/0.5.4
-        module load hdf5-parallel/1.8.11 libsplash/1.2.2
+        module load hdf5-parallel/1.8.14 libsplash/1.2.3
 
         # either use libSplash or ADIOS for file I/O
-        #module load libmxml/2.8 filelib/adios/1.6.0
+        #module load libmxml/2.8 filelib/adios/1.7.0
 
         # Debug Tools
         #module load valgrind/3.8.1
@@ -27,8 +28,18 @@ then
 #       unset MODULES_NO_OUTPUT
 fi
 
+# Environment #################################################################
+#
 alias getk20='qsub -I -q k20 -lwalltime=00:30:00 -lnodes=1:ppn=8'
 alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
+export PICSRC=/home/`whoami`/src/picongpu
+
 export PATH=$PATH:$PICSRC/src/splash2txt/build
 export PATH=$PATH:$PICSRC/src/tools/bin
+
+# "tbg" default options #######################################################
+#   - PBS/Torque (qsub)
+#   - "k20" queue
+export TBG_SUBMIT="qsub"
+export TBG_TPLFILE="submit/hypnos/k20_profile.tpl"

--- a/src/picongpu/submit/taurus/picongpu.profile.example
+++ b/src/picongpu/submit/taurus/picongpu.profile.example
@@ -35,3 +35,9 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
 
 export PICSRC=$HOME/src/picongpu
 export PATH=$PATH:$PICSRC/src/tools/bin
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "gpu" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="submit/taurus/k20x_profile.tpl"

--- a/src/picongpu/submit/taurus/picongpu.profile.example
+++ b/src/picongpu/submit/taurus/picongpu.profile.example
@@ -14,6 +14,9 @@ module load gcc/4.8.0 boost/1.55.0-gnu4.8
 ### ICC
 #module load intel/2013-sp1 boost/1.57.0-intel2013-sp1
 ### PGI
+#export BOOST_ROOT=$HOME/lib/boost_1_54_pgi_13_6
+#export BOOST_INC=$BOOST_ROOT/include
+#export BOOST_LIB=$BOOST_ROOT/lib
 # must be set in `which <pgiDir>/bin/localrc`:
 #   set NOSWITCHERROR=YES;
 #module load pgi/14.1 boost/1.55.0-pgi14.1

--- a/src/picongpu/submit/taurus/picongpu.profile.example
+++ b/src/picongpu/submit/taurus/picongpu.profile.example
@@ -4,18 +4,15 @@ module purge
 #
 module load oscar-modules llview
 module load cmake/2.8.11 git
-module load cuda/5.0.35
+module load cuda/6.5.14  # gcc 4.8, intel 14.0 == 2013-sp1
 module load bullxmpi
 module load gnuplot/4.6.1
 
 # Compilers ###################################################################
 ### GCC
-#module load gcc/4.6.2 boost/1.54.0-gnu4.6
+module load gcc/4.8.0 boost/1.55.0-gnu4.8
 ### ICC
-module load intel/12.1 boost/1.54.0-intel12.1
-#export BOOST_ROOT=$HOME/lib/boost_1_54_intel_12_1
-#export BOOST_INC=$BOOST_ROOT/include
-#export BOOST_LIB=$BOOST_ROOT/lib
+#module load intel/2013-sp1 boost/1.57.0-intel2013-sp1
 ### PGI
 # must be set in `which <pgiDir>/bin/localrc`:
 #   set NOSWITCHERROR=YES;


### PR DESCRIPTION
- use `TBG_` environent variables for `-s` and `-t` (feature from #613)
- update hypnos modules to recent `libSplash`/`HDF5` und `cmake 3.0.1`