### PR TITLE
fix wrong return type in Float2int_rd

### DIFF
--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -47,9 +47,9 @@ struct Floor<double>
 template<>
 struct Float2int_rd<double>
 {
-    typedef double result;
+    typedef int result;
 
-    HDINLINE result operator( )(result value)
+    HDINLINE result operator( )(double value)
     {
 #if __CUDA_ARCH__
         return ::__double2int_rd( value );

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -25,7 +25,6 @@
 
 #include "types.h"
 
-#include <boost/predef.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -25,6 +25,7 @@
 
 #include "types.h"
 
+#include <boost/predef.h>
 
 namespace PMacc
 {
@@ -47,9 +48,9 @@ struct Floor<float>
 template<>
 struct Float2int_rd<float>
 {
-    typedef float result;
+    typedef int result;
 
-    HDINLINE result operator( )(result value)
+    HDINLINE result operator( )(float value)
     {
 #if __CUDA_ARCH__
         return ::__float2int_rd( value );


### PR DESCRIPTION
The operator() of struct Float2int_rd<float> is used to convert the incoming float to an integer.
This should be reflected by the code.