### PR TITLE
add missing const in method override

### DIFF
--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -155,7 +155,7 @@ namespace PMacc
         /*! sets the current size (count of elements)
          * @param newsize new current size
          */
-        virtual void setCurrentSize(size_t newsize)
+        virtual void setCurrentSize(const size_t newsize)
         {
             __startOperation(ITask::TASK_HOST);
             assert(static_cast<size_t>(newsize) <= static_cast<size_t>(data_space.productOfComponents()));


### PR DESCRIPTION
The override of 'PMacc::Buffer<...>::setCurrentSize' in 'PMacc::DeviceBuffer<...>::setCurrentSize' differs by a const from the base class method declaration.
