### PR TITLE
Close #584 Memtest Without External Tools

### DIFF
--- a/src/cuda_memtest/CMakeLists.txt
+++ b/src/cuda_memtest/CMakeLists.txt
@@ -18,6 +18,9 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # set helper pathes to find libraries and packages
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/" "$ENV{CUDA_ROOT}")
 
+# own modules for find_packages
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
+
 
 ################################################################################
 # Find CUDA 
@@ -42,6 +45,22 @@ if(SAME_NVCC_FLAGS_IN_SUBPROJECTS)
     make_directory("${PROJECT_BINARY_DIR}/nvcc_tmp")
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --keep --keep-dir "${PROJECT_BINARY_DIR}/nvcc_tmp")
   endif()
+endif()
+
+
+################################################################################
+# Find NVML
+################################################################################
+
+set(GPU_DEPLOYMENT_KIT_ROOT_DIR "$ENV{GDK_ROOT}")
+find_package(NVML)
+
+if(NVML_FOUND)
+    include_directories(${NVML_INCLUDE_DIR})
+    list(APPEND LIBS ${NVML_LIBRARY})
+    add_definitions(-DENABLE_NVML=1)
+else()
+    add_definitions(-DENABLE_NVML=0)
 endif()
 
 

--- a/src/cuda_memtest/cmake/FindNVML.cmake
+++ b/src/cuda_memtest/cmake/FindNVML.cmake
@@ -1,0 +1,81 @@
+#.rst:
+# FindNVML
+# --------
+#
+# Find the NVIDIA Management Library (NVML) includes and library. NVML documentation
+# is available at: http://docs.nvidia.com/deploy/nvml-api/index.html 
+#
+# NVML is part of the GPU Deployment Kit (GDK) and GPU_DEPLOYMENT_KIT_ROOT_DIR can
+# be specified if the GPU Deployment Kit is not installed in a default location.
+#
+# FindNVML defines the following variables: 
+#
+#   NVML_INCLUDE_DIR, where to find nvml.h, etc.
+#   NVML_LIBRARY, the libraries needed to use NVML.
+#   NVML_FOUND, If false, do not try to use NVML.
+#
+
+#   Jiri Kraus, NVIDIA Corp (nvidia.com - jkraus)
+#
+#   Copyright (c) 2008 - 2014 NVIDIA Corporation.  All rights reserved.
+#
+#   This code is licensed under the MIT License.  See the FindNVML.cmake script
+#   for the text of the license.
+
+# The MIT License
+#
+# License for the specific language governing rights and limitations under
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+#
+###############################################################################
+
+if( CMAKE_SYSTEM_NAME STREQUAL "Windows"  )
+  set( NVML_LIB_PATHS "C:/Program Files/NVIDIA Corporation/GDK/nvml/lib" )
+  if(GPU_DEPLOYMENT_KIT_ROOT_DIR)
+    list(APPEND NVML_LIB_PATHS "${GPU_DEPLOYMENT_KIT_ROOT_DIR}/nvml/lib")
+  endif()
+  set(NVML_NAMES nvml)
+  
+  set( NVML_INC_PATHS "C:/Program Files/NVIDIA Corporation/GDK/nvml/include" )
+  if(GPU_DEPLOYMENT_KIT_ROOT_DIR)
+    list(APPEND NVML_INC_PATHS "${GPU_DEPLOYMENT_KIT_ROOT_DIR}/nvml/include")
+  endif()
+else()
+  set( NVML_LIB_PATHS /usr/lib64 )
+  if(GPU_DEPLOYMENT_KIT_ROOT_DIR)
+    list(APPEND NVML_LIB_PATHS "${GPU_DEPLOYMENT_KIT_ROOT_DIR}/src/gdk/nvml/lib")
+  endif()
+  set(NVML_NAMES nvidia-ml)
+  
+  set( NVML_INC_PATHS /usr/include/nvidia/gdk/ /usr/include )
+  if(GPU_DEPLOYMENT_KIT_ROOT_DIR)
+    list(APPEND NVML_INC_PATHS "${GPU_DEPLOYMENT_KIT_ROOT_DIR}/include/nvidia/gdk")
+  endif()
+endif()
+
+find_library(NVML_LIBRARY NAMES ${NVML_NAMES} PATHS ${NVML_LIB_PATHS} )
+
+find_path(NVML_INCLUDE_DIR nvml.h PATHS ${NVML_INC_PATHS})
+
+# handle the QUIETLY and REQUIRED arguments and set NVML_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(NVML DEFAULT_MSG NVML_LIBRARY NVML_INCLUDE_DIR)
+
+mark_as_advanced(NVML_LIBRARY NVML_INCLUDE_DIR)

--- a/src/cuda_memtest/cuda_memtest.h
+++ b/src/cuda_memtest/cuda_memtest.h
@@ -44,6 +44,14 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <pthread.h>
+#include <iostream>
+#include <stdexcept>
+
+#include <cuda.h>
+#include <cublas.h>
+#if (ENABLE_NVML==1)
+#include <nvml.h>
+#endif
 
 #define VERSION "1.2.3"
 
@@ -130,6 +138,19 @@ extern void get_driver_info(char* info, unsigned int len);
             PRINTF("ERROR: CUDA error: %s, line %d, file %s\n", cudaGetErrorString(cuda_err),  __LINE__, __FILE__); \
             exit(cuda_err);}}while(0)
 
+#if (ENABLE_NVML==1)
+/**
+ * Captures NVML errors and prints messages to stdout, including line number and file.
+ *
+ * @param cmd command with nvmlReturn_t return value to check
+ */
+#define NVML_CHECK(cmd) {nvmlReturn_t returnVal = cmd; if(returnVal!=NVML_SUCCESS){std::cerr<<"<"<<__FILE__<<">:"<<__LINE__<<std::endl; throw std::runtime_error(std::string("[NVML] Error: ") + std::string(nvmlErrorString(returnVal)));}}
+
+#define NVML_CHECK_MSG(cmd,msg) {nvmlReturn_t returnVal = cmd; if(returnVal!=NVML_SUCCESS){std::cerr<<"<"<<__FILE__<<">:"<<__LINE__<<msg<<std::endl; throw std::runtime_error(std::string("[NVML] Error: ") + std::string(nvmlErrorString(returnVal)));}}
+
+#define NVML_CHECK_NO_EXCEP(cmd) {nvmlReturn_t returnVal = cmd; if(returnVal!=NVML_SUCCESS){printf("[NVML] Error: <%s>:%i ",__FILE__,__LINE__);}}
+#endif
+
 #define TDIFF(tb, ta) (tb.tv_sec - ta.tv_sec + 0.000001*(tb.tv_usec - ta.tv_usec))
 #define DIM(x) (sizeof(x)/sizeof(x[0]))
 #define MIN(x,y) (x < y? x: y)
@@ -144,7 +165,5 @@ typedef struct cuda_memtest_s{
     char* desc;
     unsigned int enabled;
 }cuda_memtest_t;
-
-
 
 #endif

--- a/src/cuda_memtest/cuda_memtest.h
+++ b/src/cuda_memtest/cuda_memtest.h
@@ -148,7 +148,7 @@ extern void get_driver_info(char* info, unsigned int len);
 
 #define NVML_CHECK_MSG(cmd,msg) {nvmlReturn_t returnVal = cmd; if(returnVal!=NVML_SUCCESS){std::cerr<<"<"<<__FILE__<<">:"<<__LINE__<<msg<<std::endl; throw std::runtime_error(std::string("[NVML] Error: ") + std::string(nvmlErrorString(returnVal)));}}
 
-#define NVML_CHECK_NO_EXCEP(cmd) {nvmlReturn_t returnVal = cmd; if(returnVal!=NVML_SUCCESS){printf("[NVML] Error: <%s>:%i ",__FILE__,__LINE__);}}
+#define NVML_CHECK_NO_EXCEP(cmd) {nvmlReturn_t returnVal = cmd; if(returnVal!=NVML_SUCCESS){std::cerr<<"[NVML] Error: <"<<__FILE__<<">:"<<__LINE__<<std::endl;}}
 #endif
 
 #define TDIFF(tb, ta) (tb.tv_sec - ta.tv_sec + 0.000001*(tb.tv_usec - ta.tv_usec))

--- a/src/cuda_memtest/misc.cpp
+++ b/src/cuda_memtest/misc.cpp
@@ -1,84 +1,40 @@
+#include "misc.h"
 
-#include <stdlib.h>
-#include <assert.h>
-#include "cuda_memtest.h"
-
-volatile int intake_temp[MAX_GPU_NUM/2];
 volatile int gpu_temp[MAX_GPU_NUM];
 
 void update_temperature(void)
 {
-    FILE* file= popen("nvidia-smi|/bin/grep Temperature|gawk '{print $3 $4}'", "r");
-    if (file == NULL){
-	printf("ERROR: opening pipe failed\n");
-	exit(ERR_GENERAL);
+#if (ENABLE_NVML==1)
+    unsigned int deviceCount;
+    NVML_CHECK(nvmlDeviceGetCount( &deviceCount ));
+
+    for( unsigned int devIdx = 0; devIdx < deviceCount; ++devIdx )
+    {
+        nvmlDevice_t devHandle;
+        NVML_CHECK(nvmlDeviceGetHandleByIndex( devIdx, &devHandle ));
+
+        unsigned int devTemperature;
+        NVML_CHECK(nvmlDeviceGetTemperature( devHandle, NVML_TEMPERATURE_GPU, &devTemperature ));
+        gpu_temp[devIdx] = devTemperature;
+
+        DEBUG_PRINTF("temperature updated: (gpu %d) %d \n", devIdx, devTemperature);
     }
-    unsigned int i = 0;
-    while(1){
-	char buf[256];
-	char* s;
-	int t;
-	int gpu_0,  gpu_1;
-
-	s = fgets(buf, 256, file);
-	if (s == NULL){
-	    break;
-	}
-	sscanf(buf, ":%d", &t);
-
-	s = fgets(buf, 256, file);
-	assert(s);
-	sscanf(buf, "%dC", &gpu_0);
-
-	s = fgets(buf, 256, file);
-	assert(s);
-	sscanf(buf, "%dC", &gpu_1);
-
-	intake_temp[i] = t;
-	gpu_temp[2*i]  = gpu_0;
-	gpu_temp[2*i + 1]  = gpu_1;
-	i++;
-    }
-
-    DEBUG_PRINTF("temperature updated: %d %d %d %d \n",
-		 gpu_temp[0], gpu_temp[1], gpu_temp[2], gpu_temp[3]);
-
-   pclose(file);
-
+#endif
 }
 
 
-unsigned long long
-get_serial_number(void)
+void get_serial_number(unsigned int devIdx, char* serial)
 {
-    FILE* file= popen("nvidia-smi|/bin/grep \"Serial Number\"|gawk '{print $4}'", "r");
-    if (file == NULL){
-	PRINTF("Warning: opening pipe failed for getting serial nubmer\n");
-	return 0;
-    }
+#if (ENABLE_NVML==1)
+    nvmlDevice_t devHandle;
+    NVML_CHECK(nvmlDeviceGetHandleByIndex( devIdx, &devHandle ));
 
-    char buf[256];
-    char* s;
-    int t;
-    unsigned long long sn;
-
-    s = fgets(buf, 256, file);
-    if (s == NULL){
-	PRINTF("Warning: Getting serial number failed\n");
-	pclose(file);
-	return 0;
-    }
-    sscanf(buf, "%llu", &sn);
-
-    PRINTF("Unit serial number: %llu\n", sn);
-
-    pclose(file);
-
-    return sn;
+    unsigned int serialLength = NVML_DEVICE_SERIAL_BUFFER_SIZE;
+    NVML_CHECK(nvmlDeviceGetSerial( devHandle, serial, serialLength ));
+#endif
 }
 
 
-#define NV_DRIVER_VER_FILE "/proc/driver/nvidia/version"
 void
 get_driver_info(char* info, unsigned int len)
 {

--- a/src/cuda_memtest/misc.h
+++ b/src/cuda_memtest/misc.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdlib.h>
+#include <assert.h>
+#include "cuda_memtest.h"
+
+void update_temperature(void);
+
+void get_serial_number(unsigned int devIdx, char* serial);
+
+#define NV_DRIVER_VER_FILE "/proc/driver/nvidia/version"
+void get_driver_info(char* info, unsigned int len);

--- a/src/cuda_memtest/tests.cu
+++ b/src/cuda_memtest/tests.cu
@@ -39,7 +39,7 @@
  */
 
 #include <stdio.h>
-#include "cuda_memtest.h"
+#include "misc.h"
 #include <cuda.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -60,7 +60,6 @@ extern unsigned int email_notification;
 extern char emails[];
 extern unsigned int global_pattern;
 extern unsigned long global_pattern_long;
-extern unsigned long long serial_number;
 extern unsigned int num_iterations;
 extern unsigned int num_passes;
 extern char driver_info[MAX_STR_LEN];
@@ -130,8 +129,14 @@ error_checking(const char* msg, unsigned int blockidx)
 	FPRINTF("ERROR: %s",  driver_info);
 	emsg += sprintf(emsg, "ERROR: %s", driver_info);
 
-	FPRINTF("ERROR: The unit serial number is %llu\n",  serial_number);
-	emsg += sprintf(emsg, "ERROR: The unit serial number is %llu\n",  serial_number);
+#if !defined(NVML_DEVICE_SERIAL_BUFFER_SIZE)
+    char devSerialNum[] = "unknown (no NVML found)";
+#else
+    char devSerialNum[NVML_DEVICE_SERIAL_BUFFER_SIZE];
+    get_serial_number( gpu_idx, devSerialNum );
+#endif
+	FPRINTF("ERROR: The unit serial number is %s\n", devSerialNum);
+	emsg += sprintf(emsg, "ERROR: The unit serial number is %s\n", devSerialNum);
 
 	FPRINTF("ERROR: (%s) %d errors found in block %d\n", msg, err, blockidx);
 	emsg += sprintf(emsg, "ERROR: (%s) %d errors found in block %d\n", msg, err, blockidx);

--- a/src/cuda_memtest/tests.cu
+++ b/src/cuda_memtest/tests.cu
@@ -130,10 +130,10 @@ error_checking(const char* msg, unsigned int blockidx)
 	emsg += sprintf(emsg, "ERROR: %s", driver_info);
 
 #if !defined(NVML_DEVICE_SERIAL_BUFFER_SIZE)
-    char devSerialNum[] = "unknown (no NVML found)";
+	char devSerialNum[] = "unknown (no NVML found)";
 #else
-    char devSerialNum[NVML_DEVICE_SERIAL_BUFFER_SIZE];
-    get_serial_number( gpu_idx, devSerialNum );
+	char devSerialNum[NVML_DEVICE_SERIAL_BUFFER_SIZE];
+	get_serial_number( gpu_idx, devSerialNum );
 #endif
 	FPRINTF("ERROR: The unit serial number is %s\n", devSerialNum);
 	emsg += sprintf(emsg, "ERROR: The unit serial number is %s\n", devSerialNum);


### PR DESCRIPTION
Close #584

- removes the "nvidia-smi", "grep" and "gawk" calls
- adds optional support for `libnvidia-ml` ([NVML](https://developer.nvidia.com/nvidia-management-library-nvml)) which is either part of the driver or the `gdk` ([GPU Deployment Kit](https://developer.nvidia.com/gpu-deployment-kit)) to:
  - measure the device temperature
  - get the device serial number (by `index`, let's hope it is the same index as in cuda for now - else we have to use the [PIC bus id](http://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1gcfea8661435e6a8f26485c5c42eadd2f) if that works for 2-chip cards like K80)
- adds initial support for 8 GPUs/node (previous config was 4 GPUs) but needs additional testing
- thanks to @jirikraus for the support and initial hint to use NVML