### PR TITLE
Fix Radiation: No HDF5

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -71,8 +71,9 @@ Requirements
 
 ### Optional Libraries
 
-If you do not install the optional libraries, you will not have the full amount of PIConGPU online analysers.
+If you do not install the optional libraries, you will not have the full amount of PIConGPU plugins.
 We recomment to install at least **pngwriter**.
+Some of our examples will also need **libSplash**.
 
 - **pngwriter** >= 0.5.5
     - download our modified version from

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -140,7 +140,9 @@ private:
     typedef PositionsParticles<PIC_Electrons> PositionElectrons;
     typedef BinEnergyParticles<PIC_Electrons> BinEnergyElectrons;
 #if(ENABLE_RADIATION == 1)
+#if(ENABLE_HDF5 == 1)
     typedef Radiation<PIC_Electrons> RadiationElectrons;
+#endif
 #endif
 #endif
 
@@ -232,7 +234,9 @@ private:
 #endif
 
 #if(ENABLE_RADIATION == 1)
+#if(ENABLE_HDF5 == 1)
         plugins.push_back(new RadiationElectrons("RadiationElectrons", "radiation_e"));
+#endif
 #endif
 
 #if (ENABLE_INSITU_VOLVIS == 1)

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -42,10 +42,8 @@
 #endif
 
 #if(ENABLE_RADIATION == 1)
-#if(ENABLE_HDF5 == 1)
 #include "plugins/radiation/parameters.hpp"
 #include "plugins/radiation/Radiation.hpp"
-#endif
 #endif
 
 #include "simulation_classTypes.hpp"
@@ -140,9 +138,7 @@ private:
     typedef PositionsParticles<PIC_Electrons> PositionElectrons;
     typedef BinEnergyParticles<PIC_Electrons> BinEnergyElectrons;
 #if(ENABLE_RADIATION == 1)
-#if(ENABLE_HDF5 == 1)
     typedef Radiation<PIC_Electrons> RadiationElectrons;
-#endif
 #endif
 #endif
 
@@ -234,9 +230,7 @@ private:
 #endif
 
 #if(ENABLE_RADIATION == 1)
-#if(ENABLE_HDF5 == 1)
         plugins.push_back(new RadiationElectrons("RadiationElectrons", "radiation_e"));
-#endif
 #endif
 
 #if (ENABLE_INSITU_VOLVIS == 1)

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#if(ENABLE_HDF5 != 1)
+#error The activated radiation plugin (radiationConfig.param) requires HDF5
+#endif
+
 #include <string>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
Radiation causes a compile error since it is not consequently disabled on missing hdf5.