### PR TITLE
Fix #631 Allocation Of Memory On Jetson Boards

### DIFF
--- a/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
+++ b/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
@@ -83,15 +83,16 @@ public:
 
         getMemoryInfo(&freeAtStart);
 
-        // allocating 100% is a bit risky on a SoC-like device
+        /* alloc 90%, since allocating 100% is a bit risky on a SoC-like device */
         size_t allocSth = size_t( 0.9 * double(freeAtStart) );
-        char* c = new char[allocSth];
-        memset(c,'-',allocSth);
-        // cudaDeviceSynchronize();
+        uint8_t* c = new uint8_t[allocSth];
+        memset(c, 0, allocSth);
 
         getMemoryInfo(&freeInternal);
         delete [] c;
 
+        /* if we allocated 90% of available mem, we should have "lost" more
+         * than 50% of memory, even with fluctuations from the OS */
         if( double(freeInternal)/double(freeAtStart) < 0.5 )
             return true;
 

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -272,6 +272,8 @@ public:
         size_t freeGpuMem(0);
         Environment<>::get().EnvMemoryInfo().getMemoryInfo(&freeGpuMem);
         freeGpuMem -= totalFreeGpuMemory;
+        if( Environment<>::get().EnvMemoryInfo().isSharedMemoryPool() )
+            freeGpuMem /= 2;
 
         ForEach<VectorAllSpecies, particles::CallCreateParticleBuffer<bmpl::_1>, MakeIdentifier<bmpl::_1> > createParticleBuffer;
         createParticleBuffer(forward(particleStorage), freeGpuMem);

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -272,8 +272,14 @@ public:
         size_t freeGpuMem(0);
         Environment<>::get().EnvMemoryInfo().getMemoryInfo(&freeGpuMem);
         freeGpuMem -= totalFreeGpuMemory;
+
         if( Environment<>::get().EnvMemoryInfo().isSharedMemoryPool() )
+        {
             freeGpuMem /= 2;
+            log<picLog::MEMORY > ("Shared RAM between GPU and host detected - using only half of the 'device' memory.");
+        }
+        else
+            log<picLog::MEMORY > ("RAM is NOT shared between GPU and host.");
 
         ForEach<VectorAllSpecies, particles::CallCreateParticleBuffer<bmpl::_1>, MakeIdentifier<bmpl::_1> > createParticleBuffer;
         createParticleBuffer(forward(particleStorage), freeGpuMem);


### PR DESCRIPTION
SoC-like boards share the same memory for the device and host. Since we still do double buffering, we should only reserve *half* of the available "device" memory for particles.

Add `8` for `MEMORY` to `PIC_VERBOSE`, e.g.:
```bash
$PICSRC/configure -a sm_35 -c"-DPIC_VERBOSE=9" ../paramSets/lwfa
```

Still needs run time testing:
  - [x] jetson
  - [x] k20, fermi, k80, ...

Also:
  - [x] add a `MEMORY` `log` output about the selected choice