### PR TITLE
Hypnos: grcat, fermi, mails

### DIFF
--- a/src/picongpu/submit/bash/bash_mpirun.tpl
+++ b/src/picongpu/submit/bash/bash_mpirun.tpl
@@ -23,7 +23,7 @@
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-    
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
@@ -39,17 +39,17 @@ cd !TBG_dstPath
 export MODULES_NO_OUTPUT=1
 . ~/picongpu.profile
 unset MODULES_NO_OUTPUT
-    
+
 #set user rights to u=rwx;g=r-x;o=---
-umask 0027 
-    
+umask 0027
+
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-mpirun --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
+mpirun --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpirun  -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpirun  -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
 fi
 
 mpirun  -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos/fermi_profile.tpl
+++ b/src/picongpu/submit/hypnos/fermi_profile.tpl
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tesla C2070 queue on kepler018 & kepler019
+
+## calculation are done by tbg ##
+TBG_queue="k20f"
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+
+# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+
+#number of cores per parallel node / default is 2 cores per gpu on k20 queue
+TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
+
+# PIConGPU batch script for hypnos PBS batch system
+
+#PBS -q !TBG_queue
+#PBS -l walltime=!TBG_wallTime
+# Sets batch job's name
+#PBS -N !TBG_jobName
+#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
+# send me a mail on (b)egin, (e)nd, (a)bortion
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
+#PBS -d !TBG_dstPath
+
+#PBS -o stdout
+#PBS -e stderr
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source ~/picongpu.profile
+if [ $? -ne 0 ] ; then
+  echo "Error: ~/picongpu.profile not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+#wait that all nodes see ouput folder
+sleep 1
+
+mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
+
+if [ $? -eq 0 ] ; then
+  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+fi
+
+mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
@@ -17,20 +17,16 @@
 # along with PIConGPU.  
 # If not, see <http://www.gnu.org/licenses/>. 
 # 
- 
 
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
-
-TBG_waitJob=`qstat -u $(whoami) | grep $TBG_queue | tail -n 1 | awk '{print $1}'`
-
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-    
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
@@ -46,7 +42,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
 # send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m !TBG_mailSettings -M !TBG_mailAdress
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 
 #PBS -W depend=afterany:!TBG_waitJob
@@ -60,12 +56,15 @@ cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
 source ~/picongpu.profile
+if [ $? -ne 0 ] ; then
+  echo "Error: ~/picongpu.profile not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
-                   
-                    
+
 #set user rights to u=rwx;g=r-x;o=---
-umask 0027 
-    
+umask 0027
+
 mkdir simOutput 2> /dev/null
 cd simOutput
 

--- a/src/picongpu/submit/hypnos/k20_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_profile.tpl
@@ -17,17 +17,16 @@
 # along with PIConGPU.  
 # If not, see <http://www.gnu.org/licenses/>. 
 # 
- 
 
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-    
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
@@ -43,7 +42,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
 # send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m !TBG_mailSettings -M !TBG_mailAdress
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 
 #PBS -o stdout
@@ -55,11 +54,15 @@ cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
 source ~/picongpu.profile
+if [ $? -ne 0 ] ; then
+  echo "Error: ~/picongpu.profile not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
-    
+
 #set user rights to u=rwx;g=r-x;o=---
-umask 0027 
-    
+umask 0027
+
 mkdir simOutput 2> /dev/null
 cd simOutput
 

--- a/src/picongpu/submit/hypnos/k20_vampir_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_vampir_profile.tpl
@@ -17,13 +17,12 @@
 # along with PIConGPU.  
 # If not, see <http://www.gnu.org/licenses/>. 
 # 
- 
 
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -43,7 +42,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
 # send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m !TBG_mailSettings -M !TBG_mailAdress
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 
 #PBS -o stdout
@@ -55,6 +54,10 @@ cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
 source ~/picongpu.profile
+if [ $? -ne 0 ] ; then
+  echo "Error: ~/picongpu.profile not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
 
 export VT_MPI_IGNORE_FILTER=yes

--- a/src/picongpu/submit/hypnos/k20_wait_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_wait_profile.tpl
@@ -17,20 +17,16 @@
 # along with PIConGPU.  
 # If not, see <http://www.gnu.org/licenses/>. 
 # 
- 
 
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
-
-TBG_waitJob="0"
-
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-    
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
@@ -46,7 +42,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
 # send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m !TBG_mailSettings -M !TBG_mailAdress
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 
 #PBS -W depend=afterany:!TBG_waitJob
@@ -60,12 +56,15 @@ cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
 source ~/picongpu.profile
+if [ $? -ne 0 ] ; then
+  echo "Error: ~/picongpu.profile not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
-                   
-                    
+
 #set user rights to u=rwx;g=r-x;o=---
-umask 0027 
-    
+umask 0027
+
 mkdir simOutput 2> /dev/null
 cd simOutput
 

--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -35,6 +35,10 @@ alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
 export PICSRC=/home/`whoami`/src/picongpu
 
+# send me a mails on job (b)egin, (e)nd, (a)bortion or (n)o mails
+export MY_MAIL="someone@example.com"
+export MY_MAILNOTIFY="n"
+
 export PATH=$PATH:$PICSRC/src/splash2txt/build
 export PATH=$PATH:$PICSRC/src/tools/bin
 

--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -38,6 +38,14 @@ export PICSRC=/home/`whoami`/src/picongpu
 export PATH=$PATH:$PICSRC/src/splash2txt/build
 export PATH=$PATH:$PICSRC/src/tools/bin
 
+# Development #################################################################
+#
+#function make
+#{
+#  real_make=`which make`
+#  $real_make $* 2>&1 | $HOME/grcat/usr/bin/grcat conf.gcc
+#}
+
 # "tbg" default options #######################################################
 #   - PBS/Torque (qsub)
 #   - "k20" queue

--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -13,6 +13,7 @@ then
         module load openmpi/1.6.3
         module load boost/1.54.0
         module load cuda/6.5
+        module load mallocmc/2.0.1
 
         # Plugins (optional)
         module load pngwriter/0.5.4


### PR DESCRIPTION
`Hypnos` environment updates:

- add `grcat` example (picongpu.profile: development) 	
- add `export MY_MAIL` for email delivery (picongpu.profile)	
- add `k20f` queue (2x4 C2070)
- add `mallocmc/2.0.1` (picongpu.profile: development)

`Bash` environment update:

- forward `LD_LIBRARY_PATH` in `mpirun` template, too

**Note:** we might add `mallocMC` later on via [git subtree](http://blogs.atlassian.com/2013/05/alternatives-to-git-submodule-git-subtree/) directly in `libPMacc` to keep the dependencies/install barriers low.