### PR TITLE
Add Restart For CountParticles, EnergyFields & EnergyParticles

### DIFF
--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -26,7 +26,6 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-#include <sstream>
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -44,12 +43,11 @@
 
 #include "algorithms/Gamma.hpp"
 
-#include <boost/filesystem.hpp>
+#include "common/txtFileHandling.hpp"
 
 namespace picongpu
 {
 using namespace PMacc;
-using namespace boost::filesystem;
 
 namespace po = boost::program_options;
 
@@ -374,47 +372,21 @@ private:
         if( !writeToFile )
             return;
 
-        if( outFile.is_open() )
-            outFile.close();
-
-        std::stringstream sStep;
-        sStep << restartStep;
-
-        path src( restartDirectory + std::string("/") + filename +
-                  std::string(".") + sStep.str() );
-        path dst( filename );
-
-        copy_file( src,
-                   dst,
-                   copy_option::overwrite_if_exists );
-
-        outFile.open( filename.c_str(), std::ofstream::out | std::ostream::app );
-        if( !outFile )
-        {
-            std::cerr << "[Plugin] [" << analyzerPrefix
-                      << "] Can't open file '" << filename
-                      << "', output disabled" << std::endl;
-            writeToFile = false;
-        }
+        writeToFile = restoreTxtFile( outFile,
+                                      filename,
+                                      restartStep,
+                                      restartDirectory );
     }
 
     void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
     {
-        if( writeToFile )
-        {
-            outFile.flush();
+        if( !writeToFile )
+            return;
 
-            std::stringstream sStep;
-            sStep << currentStep;
-
-            path src( filename );
-            path dst( checkpointDirectory + std::string("/") + filename +
-                      std::string(".") + sStep.str() );
-
-            copy_file( src,
-                       dst,
-                       copy_option::overwrite_if_exists );
-        }
+        checkpointTxtFile( outFile,
+                           filename,
+                           currentStep,
+                           checkpointDirectory );
     }
 
     template< uint32_t AREA>

--- a/src/picongpu/include/plugins/CountParticles.hpp
+++ b/src/picongpu/include/plugins/CountParticles.hpp
@@ -31,7 +31,6 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-#include <sstream>
 
 #include "plugins/ISimulationPlugin.hpp"
 
@@ -44,12 +43,11 @@
 
 #include "particles/operations/CountParticles.hpp"
 
-#include <boost/filesystem.hpp>
+#include "common/txtFileHandling.hpp"
 
 namespace picongpu
 {
 using namespace PMacc;
-using namespace boost::filesystem;
 
 template<class ParticlesType>
 class CountParticles : public ISimulationPlugin
@@ -160,28 +158,10 @@ private:
         if( !writeToFile )
             return;
 
-        if( outFile.is_open() )
-            outFile.close();
-
-        std::stringstream sStep;
-        sStep << restartStep;
-
-        path src( restartDirectory + std::string("/") + filename +
-                  std::string(".") + sStep.str() );
-        path dst( filename );
-
-        copy_file( src,
-                   dst,
-                   copy_option::overwrite_if_exists );
-
-        outFile.open( filename.c_str(), std::ofstream::out | std::ostream::app );
-        if( !outFile )
-        {
-            std::cerr << "[Plugin] [" << analyzerPrefix
-                      << "] Can't open file '" << filename
-                      << "', output disabled" << std::endl;
-            writeToFile = false;
-        }
+        writeToFile = restoreTxtFile( outFile,
+                                      filename,
+                                      restartStep,
+                                      restartDirectory );
     }
 
     void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
@@ -189,18 +169,10 @@ private:
         if( !writeToFile )
             return;
 
-        outFile.flush();
-
-        std::stringstream sStep;
-        sStep << currentStep;
-
-        path src( filename );
-        path dst( checkpointDirectory + std::string("/") + filename +
-        std::string(".") + sStep.str() );
-
-        copy_file( src,
-                   dst,
-                   copy_option::overwrite_if_exists );
+        checkpointTxtFile( outFile,
+                           filename,
+                           currentStep,
+                           checkpointDirectory );
     }
 
     template< uint32_t AREA>

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -35,7 +35,7 @@
 
 #include "basicOperations.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
-#include "plugins/ILightweightPlugin.hpp"
+#include "plugins/ISimulationPlugin.hpp"
 
 #include "mpi/reduceMethods/Reduce.hpp"
 #include "mpi/MPIReduce.hpp"
@@ -43,6 +43,8 @@
 #include "nvidia/reduce/Reduce.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
 #include "memory/boxes/DataBoxUnaryTransform.hpp"
+
+#include "common/txtFileHandling.hpp"
 
 namespace picongpu
 {
@@ -77,7 +79,7 @@ struct squareComponentWise
 
 }
 
-class EnergyFields : public ILightweightPlugin
+class EnergyFields : public ISimulationPlugin
 {
 private:
     FieldE* fieldE;
@@ -184,6 +186,28 @@ private:
             }
             __delete(localReduce);
         }
+    }
+
+    void restart(uint32_t restartStep, const std::string restartDirectory)
+    {
+        if( !writeToFile )
+            return;
+
+        writeToFile = restoreTxtFile( outFile,
+                                      filename,
+                                      restartStep,
+                                      restartDirectory );
+    }
+
+    void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
+    {
+        if( !writeToFile )
+            return;
+
+        checkpointTxtFile( outFile,
+                           filename,
+                           currentStep,
+                           checkpointDirectory );
     }
 
     void getEnergyFields(uint32_t currentStep)

--- a/src/picongpu/include/plugins/common/txtFileHandling.hpp
+++ b/src/picongpu/include/plugins/common/txtFileHandling.hpp
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <sstream>
+
+#include <boost/filesystem.hpp>
+
+namespace picongpu
+{
+using namespace boost::filesystem;
+
+    /** Restore a txt file from the checkpoint dir
+     *
+     * Restores a txt file from the checkpoint dir and starts appending to it.
+     * Opened files in \see outFile are closed and a valid handle is opened again.
+     *
+     * \param outFile std::ofstream file handle to regular file that shall be restored
+     * \param filename the file's name
+     * \param restartStep the file's version in time to restore
+     * \param restartDirectory path to the checkpoint directory
+     *
+     * \return operation was successful or not
+     */
+    bool restoreTxtFile( std::ofstream& outFile, std::string filename,
+                         uint32_t restartStep, const std::string restartDirectory )
+    {
+        if( outFile.is_open() )
+            outFile.close();
+
+        std::stringstream sStep;
+        sStep << restartStep;
+
+        path src( restartDirectory + std::string("/") + filename +
+                  std::string(".") + sStep.str() );
+        path dst( filename );
+
+        copy_file( src,
+                   dst,
+                   copy_option::overwrite_if_exists );
+
+        outFile.open( filename.c_str(), std::ofstream::out | std::ostream::app );
+        if( !outFile )
+        {
+            std::cerr << "[Plugin] Can't open file '" << filename
+                      << "', output disabled" << std::endl;
+            return false;
+        }
+        return true;
+    }
+
+    /** Checkpoints a txt file
+     *
+     * The file is flushed, copied to the checkpoint dir with extension fileName.step
+     *
+     * \param outFile std::ofstream file handle to regular file that shall be checkpointed
+     * \param filename the file's name
+     * \param currentStep the current time step
+     * \param checkpointDirectory path to the checkpoint directory
+     */
+    void checkpointTxtFile( std::ofstream& outFile, std::string filename,
+                            uint32_t currentStep, const std::string checkpointDirectory )
+    {
+        outFile.flush();
+
+        std::stringstream sStep;
+        sStep << currentStep;
+
+        path src( filename );
+        path dst( checkpointDirectory + std::string("/") + filename +
+        std::string(".") + sStep.str() );
+
+        copy_file( src,
+                   dst,
+                   copy_option::overwrite_if_exists );
+    }
+
+} /* namespace picongpu */


### PR DESCRIPTION
This avoids loosing the data before the restart, basically the same implementation as #540.

### Minors

- code clean up: "frequency" is a period, `#pragma once`
- refactored common code, also in `BinEnergyParticles`

### To Do

- [x] run time test
- [x] update [wiki](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-Plugins) (remove the note where implemented)