### PR TITLE
Parse gridDist: Avoid Out-of-Bounce Access

### DIFF
--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -167,7 +167,7 @@ public:
 
         // calculate the number of local grid cells and
         // the local cell offset to the global box
-        for (uint32_t dim = 0; dim < gridDistribution.size(); ++dim)
+        for (uint32_t dim = 0; dim < gridDistribution.size() && dim < simDim; ++dim)
         {
             // parse string
             ParserGridDistribution parserGD(gridDistribution.at(dim));


### PR DESCRIPTION
- still allows to specify *less* arguments
- avoids segfault on "too many" arguments (more are ignored)

related to #637 but does not cause the issue