### PR TITLE
Fix #637 Restart y-direction --gridDist

### DIFF
--- a/src/libPMacc/include/communication/CommunicatorMPI.hpp
+++ b/src/libPMacc/include/communication/CommunicatorMPI.hpp
@@ -212,7 +212,7 @@ public:
         return false;
     }
 
-    bool setNumSlides(size_t numSlides)
+    bool setStateAfterSlides(size_t numSlides)
     {
         bool result = false;
 

--- a/src/libPMacc/include/communication/ICommunicator.hpp
+++ b/src/libPMacc/include/communication/ICommunicator.hpp
@@ -52,7 +52,7 @@ public:
      * @param[in] numSlides number of slides
      * @return true if the position of gpu is switched to the end, else false
      */
-    virtual bool setNumSlides(size_t numSlides) = 0;
+    virtual bool setStateAfterSlides(size_t numSlides) = 0;
 
     //!\todo Interface should not depend on MPI!
 

--- a/src/libPMacc/include/mappings/simulation/GridController.hpp
+++ b/src/libPMacc/include/mappings/simulation/GridController.hpp
@@ -183,6 +183,9 @@ namespace PMacc
             /**
              * Slides multiple times.
              *
+             * Restores the state of the communicator and the domain offsets as
+             * if the simulation has been slided for numSlides times.
+             *
              * \warning you are not allowed to call this method if moving
              *          the simulation does not use a moving window,
              *          else static load balancing will break in y-direction
@@ -190,9 +193,9 @@ namespace PMacc
              * @param[in] numSlides number of slides
              * @return true if the position of gpu is switched to the end, else false
              */
-            bool setNumSlides(size_t numSlides)
+            bool setStateAfterSlides(size_t numSlides)
             {
-                bool result = comm.setNumSlides(numSlides);
+                bool result = comm.setStateAfterSlides(numSlides);
                 updateLocalDomainOffset();
                 return result;
             }

--- a/src/libPMacc/include/mappings/simulation/GridController.hpp
+++ b/src/libPMacc/include/mappings/simulation/GridController.hpp
@@ -183,6 +183,10 @@ namespace PMacc
             /**
              * Slides multiple times.
              *
+             * \warning you are not allowed to call this method if moving
+             *          the simulation does not use a moving window,
+             *          else static load balancing will break in y-direction
+             *
              * @param[in] numSlides number of slides
              * @return true if the position of gpu is switched to the end, else false
              */
@@ -236,6 +240,9 @@ namespace PMacc
              * Sets localDomain.offset (formerly named globalOffset) using the current position.
              *
              * (This function is idempotent)
+             *
+             * \warning the implementation of this method is not compatible with
+             *          static load balancing in y-direction
              */
             void updateLocalDomainOffset()
             {

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -191,7 +191,10 @@ public:
         /* apply slides to set gpus to last/written configuration */
         log<picLog::INPUT_OUTPUT > ("Setting slide count for moving window to %1%") % slides;
         MovingWindow::getInstance().setSlideCounter(slides, restartStep);
-        gc.setNumSlides(slides);
+
+        /* re-distribute the local offsets in y-direction */
+        if( MovingWindow::getInstance().isSlidingWindowActive() )
+            gc.setNumSlides(slides);
 
         /* set window for restart, complete global domain */
         mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -194,7 +194,7 @@ public:
 
         /* re-distribute the local offsets in y-direction */
         if( MovingWindow::getInstance().isSlidingWindowActive() )
-            gc.setNumSlides(slides);
+            gc.setStateAfterSlides(slides);
 
         /* set window for restart, complete global domain */
         mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);


### PR DESCRIPTION
- call `setNumSlides(...)` only if movingWindow is active, since this function redistributes the y-offsets (intentionally)