### PR TITLE
Fix #609 Splash NULL Reads

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -91,7 +91,7 @@ Some of our examples will also need **libSplash**.
       [PNGWRITER\_ROOT](#additional-required-environment-variables-for-optional-libraries)
       to `$HOME/lib/pngwriter`
 
-- **libSplash** >= 1.2.3 (requires *hdf5*, *boost program-options*)
+- **libSplash** >= 1.2.4 (requires *hdf5*, *boost program-options*)
     - *Debian/Ubuntu dependencies:* `sudo apt-get install libhdf5-openmpi-dev libboost-program-options-dev`
     - *Arch Linux dependencies:* `sudo pacman --sync hdf5-openmpi boost`
     - example:

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -392,7 +392,7 @@ include_directories(${PMACC_ROOT_DIR}/include)
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.2.3 COMPONENTS PARALLEL)
+find_package(Splash 1.2.4 COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})

--- a/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
@@ -79,17 +79,6 @@ struct LoadParticleAttributesFromHDF5
         ComponentType* tmpArray = NULL;
         if( elements > 0 )
             tmpArray = new ComponentType[elements];
-        else
-        {
-            /** This is a workaround to avoid the bug that processes hangs
-             *  if some call `DataCollector::read()` where elements to read is
-             *  zero and the destination pointer for the read data is set to `NULL`.
-             *  see: - `PIconGPU`  issu: https://github.com/ComputationalRadiationPhysics/picongpu/pull/611
-             *       - `libSplash` issu: https://github.com/ComputationalRadiationPhysics/libSplash/issues/148
-             * \todo: please remove this workaround after the libsplash bug is fixed
-             */
-            tmpArray = new ComponentType[1];
-        }
 
         ParallelDomainCollector* dataCollector = params->dataCollector;
         for (uint32_t d = 0; d < components; d++)

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -78,7 +78,7 @@ set(LIBS ${LIBS} ${Boost_LIBRARIES})
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.2.3 REQUIRED COMPONENTS PARALLEL)
+find_package(Splash 1.2.4 REQUIRED COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -86,7 +86,7 @@ endif(MPI_CXX_FOUND)
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.2.3 REQUIRED COMPONENTS PARALLEL)
+find_package(Splash 1.2.4 REQUIRED COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})


### PR DESCRIPTION
Remove work-around introduced with #611 and force fixed libSplash version
- the work around was valid but is not needed any more (as of [libSplash 1.2.4](https://github.com/ComputationalRadiationPhysics/libSplash/pull/150))
- simplify code-base again

the update of all CMake files (even for tools) is a bit opportunistic of me, sry for that.

### to do

- [x] [release](https://github.com/ComputationalRadiationPhysics/libSplash/pull/150) `libSplash 1.2.4` (~Sunday)
- [x] add libSplash 1.2.4 to [compile node](https://github.com/ComputationalRadiationPhysics/compileNode) (~next week)
- [ ] ~~cherry-pick changes into~~ rebase `release-beta-rc7` branch (~next week)