### PR TITLE
fix extended friend syntax

### DIFF
--- a/src/libPMacc/include/dataManagement/DataConnector.hpp
+++ b/src/libPMacc/include/dataManagement/DataConnector.hpp
@@ -182,9 +182,9 @@ namespace PMacc
 
     private:
 
-        friend Environment<DIM1>;
-        friend Environment<DIM2>;
-        friend Environment<DIM3>;
+        friend class Environment<DIM1>;
+        friend class Environment<DIM2>;
+        friend class Environment<DIM3>;
 
         static DataConnector& getInstance()
         {

--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -80,9 +80,9 @@ namespace PMacc
 
     private:
 
-        friend Environment<DIM1>;
-        friend Environment<DIM2>;
-        friend Environment<DIM3>;
+        friend class Environment<DIM1>;
+        friend class Environment<DIM2>;
+        friend class Environment<DIM3>;
 
         inline ITask* getPassiveITaskIfNotFinished(id_t taskId) const;
 

--- a/src/libPMacc/include/eventSystem/streams/StreamController.hpp
+++ b/src/libPMacc/include/eventSystem/streams/StreamController.hpp
@@ -109,9 +109,9 @@ namespace PMacc
 
     private:
 
-        friend Environment<DIM1>;
-        friend Environment<DIM2>;
-        friend Environment<DIM3>;
+        friend class Environment<DIM1>;
+        friend class Environment<DIM2>;
+        friend class Environment<DIM3>;
 
         /**
          * Constructor.

--- a/src/libPMacc/include/eventSystem/tasks/Factory.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.hpp
@@ -166,9 +166,9 @@ namespace PMacc
 
     private:
 
-        friend Environment<DIM1>;
-        friend Environment<DIM2>;
-        friend Environment<DIM3>;
+        friend class Environment<DIM1>;
+        friend class Environment<DIM2>;
+        friend class Environment<DIM3>;
 
         Factory() {};
 

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
@@ -94,9 +94,9 @@ public:
 
 private:
 
-    friend Environment<DIM1>;
-    friend Environment<DIM2>;
-    friend Environment<DIM3>;
+    friend class Environment<DIM1>;
+    friend class Environment<DIM2>;
+    friend class Environment<DIM3>;
 
     TransactionManager();
 

--- a/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
+++ b/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
@@ -46,7 +46,7 @@ public:
         return *comm;
     }
 
-    
+
 
     /*! Get Mask with all GPU neighbar
      * @return Mask with neighbar
@@ -66,15 +66,15 @@ public:
     }
 
 private:
-    
-    friend Environment<DIM1>;
-    friend Environment<DIM2>;
-    friend Environment<DIM3>;
-    
+
+    friend class Environment<DIM1>;
+    friend class Environment<DIM2>;
+    friend class Environment<DIM3>;
+
     /*! Default constructor.
      */
     EnvironmentController() {}
-    
+
     static EnvironmentController& getInstance()
     {
         static EnvironmentController instance;
@@ -86,7 +86,7 @@ private:
     /*! Pointer to MPI communicator.
      */
     ICommunicator* comm;
-    
+
 };
 
 } //namespace PMacc

--- a/src/libPMacc/include/mappings/simulation/Filesystem.hpp
+++ b/src/libPMacc/include/mappings/simulation/Filesystem.hpp
@@ -86,7 +86,7 @@ namespace PMacc
 
         private:
 
-            friend Environment<DIM>;
+            friend class Environment<DIM>;
 
             /**
              * Constructor

--- a/src/libPMacc/include/mappings/simulation/GridController.hpp
+++ b/src/libPMacc/include/mappings/simulation/GridController.hpp
@@ -222,7 +222,7 @@ namespace PMacc
 
         private:
 
-            friend Environment<DIM>;
+            friend class Environment<DIM>;
             /**
              * Constructor
              */

--- a/src/libPMacc/include/mappings/simulation/SubGrid.hpp
+++ b/src/libPMacc/include/mappings/simulation/SubGrid.hpp
@@ -109,7 +109,7 @@ namespace PMacc
 
     private:
 
-        friend Environment<DIM>;
+        friend class Environment<DIM>;
 
         /** total simulation volume, including active and inactive subvolumes */
         Selection<DIM> totalDomain;

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -512,7 +512,7 @@ public:
 
 private:
     
-    friend Environment<DIM>;
+    friend class Environment<DIM>;
 
     void init(bool sizeOnDevice, bool buildDeviceBuffer = true, bool buildHostBuffer = true)
     {

--- a/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
+++ b/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
@@ -108,9 +108,9 @@ protected:
     size_t reservedMem;
 
 private:
-    friend Environment<DIM1>;
-    friend Environment<DIM2>;
-    friend Environment<DIM3>;
+    friend class Environment<DIM1>;
+    friend class Environment<DIM2>;
+    friend class Environment<DIM3>;
 
     static MemoryInfo& getInstance()
     {

--- a/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
+++ b/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
@@ -69,9 +69,9 @@ namespace PMacc
 
     private:
 
-        friend Environment<DIM1>;
-        friend Environment<DIM2>;
-        friend Environment<DIM3>;
+        friend class Environment<DIM1>;
+        friend class Environment<DIM2>;
+        friend class Environment<DIM3>;
 
         /**
          * returns the instance of this factory

--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -184,9 +184,9 @@ namespace PMacc
 
     private:
 
-        friend Environment<DIM1>;
-        friend Environment<DIM2>;
-        friend Environment<DIM3>;
+        friend class Environment<DIM1>;
+        friend class Environment<DIM2>;
+        friend class Environment<DIM3>;
 
         static PluginConnector& getInstance()
         {


### PR DESCRIPTION
fix `warning: extended friend syntax is a C++11 feature` by adding class key word

This warning was announced from @ax3l in #630.

Reverence:
https://www.ibm.com/developerworks/community/blogs/5894415f-be62-4bc0-81c5-3956e82276f3/entry/introduction_to_the_c_11_feature_extended_friend_declaration3?lang=en