### PR TITLE
Fix Segfault Checkpointing Radiation Plugin

### DIFF
--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Klaus Steiniger,
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Klaus Steiniger,
  * Felix Schmitt
  *
  * This file is part of PIConGPU.
@@ -217,19 +217,27 @@ public:
 
     void restart(uint32_t timeStep, const std::string restartDirectory)
     {
-      if(isMaster)
-      {
-          // this will lead to wrong lastRad output right after the checkpoint if the restart point is
-          // not a dump point. The correct lastRad data can be reconstructed from hdf5 data
-          // since text based lastRad output will be obsolete soon, this is not a problem
-          readHDF5file(timeSumArray, restartDirectory + "/" + std::string("radRestart_"), timeStep);
-          std::cout << "Radiation: loaded radiation restart data" << std::endl;
-      }
+        // only load backup if radiation is calculated:
+        if(notifyFrequency == 0)
+            return;
+
+        if(isMaster)
+        {
+            // this will lead to wrong lastRad output right after the checkpoint if the restart point is
+            // not a dump point. The correct lastRad data can be reconstructed from hdf5 data
+            // since text based lastRad output will be obsolete soon, this is not a problem
+            readHDF5file(timeSumArray, restartDirectory + "/" + std::string("radRestart_"), timeStep);
+            std::cout << "Radiation: loaded radiation restart data" << std::endl;
+        }
     }
 
 
     void checkpoint(uint32_t timeStep, const std::string restartDirectory)
     {
+        // only write backup if radiation is calculated:
+        if(notifyFrequency == 0)
+            return;
+
         // collect data GPU -> CPU -> Master
         copyRadiationDeviceToHost();
         collectRadiationOnMaster();


### PR DESCRIPTION
This pull request fixes a bug caused by the *radiation plugin* if:
 - the radiation plugin is active: `#define ENABLE_RADIATION 1`
 - the plugin is not used: no `--radiation_e.period 1`
 - checkpoints are created: `--checkpoints 5000`

Under these conditions, a checkpoint for the radiation should be written, but no memory for the data is allocated causing a **segfault**.

This pull request now **checks if the radiation plugin is called before writing and reading checkpoints**.

*The code has been tested and is running fine with radiation and checkpoints on, but no radiation calculation active.*

Thanks to @psychocoderHPC and @ax3l for pointing in the right direction. :+1:

Background information:
This bug was introduced with #419 and is in `dev` since 2014-12-21. It does not affect the `master`.