### PR TITLE
Updated wrong link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please note that this is an Open
 release for **developers** and **power users** [only](#users).
 
 **Users** *should wait* for our 
-[Open Beta](https://github.com/ComputationalRadiationPhysics/picongpu/issues/milestones)
+[Open Beta](https://github.com/ComputationalRadiationPhysics/picongpu/issues?milestone=2)
 release!
 
 ********************************************************************************
@@ -104,7 +104,7 @@ Users
 
 Dear User, please [beware](#open-alpha) that this is a **developer and
 power user only release**! We hereby emphasize that you should wait for our
-[Beta](https://github.com/ComputationalRadiationPhysics/picongpu/issues/milestones)
+[Beta](https://github.com/ComputationalRadiationPhysics/picongpu/issues?milestone=2)
 release.
 
 Visit [picongpu.hzdr.de](http://picongpu.hzdr.de) to learn more about PIC

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please note that this is an Open
 release for **developers** and **power users** [only](#users).
 
 **Users** *should wait* for our 
-[Open Beta](https://github.com/ComputationalRadiationPhysics/picongpu/issues?milestone=2)
+[Open Beta](https://github.com/ComputationalRadiationPhysics/picongpu/milestones)
 release!
 
 ********************************************************************************
@@ -104,7 +104,7 @@ Users
 
 Dear User, please [beware](#open-alpha) that this is a **developer and
 power user only release**! We hereby emphasize that you should wait for our
-[Beta](https://github.com/ComputationalRadiationPhysics/picongpu/issues?milestone=2)
+[Beta](https://github.com/ComputationalRadiationPhysics/picongpu/milestones)
 release.
 
 Visit [picongpu.hzdr.de](http://picongpu.hzdr.de) to learn more about PIC


### PR DESCRIPTION
 - The 2 links that were supposed to point to the milestones resulted in a 404-Error.
 - Links now to the same place as the entry in [`CHANGELOG.md`](https://github.com/ComputationalRadiationPhysics/picongpu/blob/dev/CHANGELOG.md)
 - alternatively, could link to [all milestones](https://github.com/ComputationalRadiationPhysics/picongpu/milestones)