### PR TITLE
fix CUDA6.5 int(bool) bug in PhaseSpace

### DIFF
--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -103,12 +103,9 @@ namespace picongpu
                                   / (axis_p_range.second - axis_p_range.first);
             int p_bin = int( rel_bin * float_X(num_pbins) );
 
-            /* out-of-range bins back to min/max
-             * p_bin < 0 ? p_bin = 0;
-             * p_bin > (num_pbins-1) ? p_bin = num_pbins-1;
-             */
-            p_bin *= int(p_bin >= 0);
-            p_bin += int(p_bin >= num_pbins) * (num_pbins - 1 - p_bin);
+            /* out-of-range bins back to min/max */
+            p_bin >= 0 ? /* do not change p_bin */ : p_bin=0;
+            p_bin < num_pbins ? /* do not change p_bin */ : p_bin=num_pbins-1;
 
             /** \todo take particle shape into account */
             atomicAddWrapper( &(*curDBufferOriginInBlock( p_bin, r_bin )),


### PR DESCRIPTION
This pull request fixes the **CUDA 6.5 int(bool) bug**(#570) in the **phase space plugin**.

It uses *short if notation* (`bool condition ? true return : false return`) to avoid the `int` cast of bool values bug in CUDA 6.5.