### PR TITLE
fix CUDA6.5 int(bool) bug in algorithms

### DIFF
--- a/src/picongpu/include/algorithms/ShiftCoordinateSystem.hpp
+++ b/src/picongpu/include/algorithms/ShiftCoordinateSystem.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -140,7 +140,7 @@ struct GetOffsetToStaticShapeSystem<false>
     template<typename T_Type>
     HDINLINE int operator()(const T_Type& pos)
     {
-        return int(pos >= T_Type(0.5));
+        return pos >= T_Type(0.5) ? 1 : 0;
     }
 };
 


### PR DESCRIPTION
This pull request ~~fixes~~ avoids the CUDA6.5 int(bool) #570 bug in `src/picongpu/include/algorithms`.

- [x] check numerical heating
- [x] check simulation time

(as suggested by @psychocoderHPC, the CUDA6.5 fixes will come in seperate pull requests depending on the code they affect.)