### PR TITLE
Fix ADIOS: Zero Writes, Collects and Buffers

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
@@ -124,13 +124,10 @@ public:
                 myParticleOffset += allNumParticles[i];
         }
 
-        if (myNumParticles > 0)
-        {
-            /* iterate over all attributes of this species */
-            ForEach<typename AdiosFrameType::ValueTypeSeq, adios::ParticleAttributeSize<bmpl::_1> > attributeSize;
-            attributeSize(params, (FrameType::getName() + std::string("/") + subGroup).c_str(),
-                    myNumParticles, globalNumParticles, myParticleOffset);
-        }
+        /* iterate over all attributes of this species */
+        ForEach<typename AdiosFrameType::ValueTypeSeq, adios::ParticleAttributeSize<bmpl::_1> > attributeSize;
+        attributeSize(params, (FrameType::getName() + std::string("/") + subGroup).c_str(),
+                myNumParticles, globalNumParticles, myParticleOffset);
 
         /* define adios var for species index/info table */
         {

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
@@ -35,8 +35,6 @@ namespace adios
 {
 using namespace PMacc;
 
-
-
 /** write attribute of a particle to adios file
  *
  * @tparam T_Identifier identifier of a particle attribute
@@ -64,7 +62,10 @@ struct ParticleAttribute
 
         log<picLog::INPUT_OUTPUT > ("ADIOS:  (begin) write species attribute: %1%") % Identifier::getName();
 
-        ComponentType* tmpBfr = new ComponentType[elements];
+        ComponentType* tmpBfr = NULL;
+
+        if (elements > 0)
+            tmpBfr = new ComponentType[elements];
 
         for (uint32_t d = 0; d < components; d++)
         {
@@ -73,7 +74,7 @@ struct ParticleAttribute
             /* copy strided data from source to temporary buffer */
             for (size_t i = 0; i < elements; ++i)
             {
-                tmpBfr[i] = ((ComponentType*)dataPtr)[d + i * components];
+                tmpBfr[i] = ((ComponentType*) dataPtr)[d + i * components];
             }
 
             int64_t adiosAttributeVarId = *(params->adiosParticleAttrVarIds.begin());

--- a/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
+++ b/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
@@ -93,7 +93,10 @@ struct FreeMemory
 
         type* ptr = value.getIdentifier(T_Type()).getPointer();
         if (ptr != NULL)
+        {
             CUDA_CHECK(cudaFreeHost(ptr));
+            ptr=NULL;
+        }
     }
 };
 


### PR DESCRIPTION
If some of the processes write zero amount of data with
adios they hang.

Changes:
- take care that all processes call collective adios write methods
- all processes calculate it's adios index table
- set freed memory to `NULL`
- move calculation of domain sizes before `forEachCollectFieldsSizes` and `adiosCountParticles`

Tests:
- [x] dump Bunch (no data verification) 

Why is this pull request blocked:
- ~~during the third dumps we got a warning: `adios_group_size (data): Not buffering. needs: 314532206 available: 114294784.`~~
- ~~during the third dump the adios plugin hangs ( 2 of 8 processes)~~