### PR TITLE
Refactor libPMacc UInt Vectors

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
@@ -24,7 +24,6 @@
 #define ALGORITHM_KERNEL_REDUCE_HPP
 
 #include "math/vector/Int.hpp"
-#include "math/vector/UInt.hpp"
 #include "cuSTL/container/CartBuffer.hpp"
 #include "cuSTL/container/DeviceBuffer.hpp"
 #include "cuSTL/zone/SphericZone.hpp"

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
@@ -25,7 +25,6 @@
 
 #include "mpi.h"
 #include "math/vector/Int.hpp"
-#include "math/vector/UInt.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
 #include "cuSTL/zone/SphericZone.hpp"
 #include <vector>

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
@@ -24,7 +24,6 @@
 
 #include "mpi.h"
 #include "math/vector/Int.hpp"
-#include "math/vector/UInt.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
 #include "cuSTL/zone/SphericZone.hpp"
 #include <vector>

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include "types.h"
 #include "math/vector/Size_t.hpp"
-#include "math/vector/UInt.hpp"
+#include "math/vector/UInt32.hpp"
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include "cuSTL/cursor/navigator/CartNavigator.hpp"
 #include "cuSTL/cursor/accessor/PointerAccessor.hpp"
@@ -115,7 +115,7 @@ public:
      * \param axes x-axis -> axes[0], y-axis -> axes[1], ...
      * */
     HDINLINE cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<dim>, char*>
-    originCustomAxes(const math::UInt<dim>& axes) const;
+    originCustomAxes(const math::UInt32<dim>& axes) const;
 
     /* get a zone spanning the whole container */
     HDINLINE zone::SphericZone<dim> zone() const;

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -234,7 +234,7 @@ CartBuffer<Type, _dim, Allocator, Copier, Assigner>::originSafe() const
 
 template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
 cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<_dim>, char*>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::originCustomAxes(const math::UInt<_dim>& axes) const
+CartBuffer<Type, _dim, Allocator, Copier, Assigner>::originCustomAxes(const math::UInt32<_dim>& axes) const
 {
     math::Size_t<dim> factor;
     factor[0] = sizeof(Type);

--- a/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
@@ -24,7 +24,7 @@
 #define CONTAINER_INDEXBUFFER_HPP
 
 #include <stdint.h>
-#include "../vector/UInt.hpp"
+#include "../vector/UInt32.hpp"
 #include "../vector/Int.hpp"
 #include "../vector/Size_t.hpp"
 #include "../cursor/Cursor.hpp"
@@ -41,9 +41,9 @@ template<int dim>
 class IndexBuffer
 {
 private:
-    math::UInt<dim> _size;
+    math::UInt32<dim> _size;
 public:
-    IndexBuffer(const math::UInt<dim>& _size) : _size(_size) {}
+    IndexBuffer(const math::UInt32<dim>& _size) : _size(_size) {}
     IndexBuffer(uint32_t x) : _size(x) {}
     IndexBuffer(uint32_t x, uint32_t y) : _size(x,y) {}
     IndexBuffer(uint32_t x, uint32_t y, uint32_t z) : _size(x,y,z) {}
@@ -69,7 +69,7 @@ public:
     cursor::Cursor<cursor::MarkerAccessor<math::Int<dim> >,
                    cursor::CartNavigator<dim>,
                    math::Int<dim> >
-    originCustomAxes(const math::UInt<dim>& axes) const
+    originCustomAxes(const math::UInt32<dim>& axes) const
     {
         math::Int<dim> factor;
         factor[0] = 1; factor[1] = this->_size.x();

--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -39,9 +39,9 @@ template<typename Type, typename Size, int uid>
 struct SharedMemAllocator<Type, Size, 1, uid>
 {
     typedef Type type;
-    typedef math::CT::UInt<> Pitch;
+    typedef math::CT::UInt32<> Pitch;
     static const int dim = 1;
-    typedef cursor::CT::BufferCursor<type, math::CT::UInt<> > Cursor;
+    typedef cursor::CT::BufferCursor<type, math::CT::UInt32<> > Cursor;
 
     __device__ static Cursor allocate()
     {
@@ -55,7 +55,7 @@ template<typename Type, typename Size, int uid>
 struct SharedMemAllocator<Type, Size, 2, uid>
 {
     typedef Type type;
-    typedef math::CT::UInt<sizeof(Type) * Size::x::value> Pitch;
+    typedef math::CT::UInt32<sizeof(Type) * Size::x::value> Pitch;
     static const int dim = 2;
     typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
@@ -71,7 +71,7 @@ template<typename Type, typename Size, int uid>
 struct SharedMemAllocator<Type, Size, 3, uid>
 {
     typedef Type type;
-    typedef math::CT::UInt<sizeof(Type) * Size::x::value,
+    typedef math::CT::UInt32<sizeof(Type) * Size::x::value,
                              sizeof(Type) * Size::x::value * Size::y::value> Pitch;
     static const int dim = 3;
     typedef cursor::CT::BufferCursor<type, Pitch> Cursor;

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -66,7 +66,7 @@ public:
     DINLINE cursor::CT::BufferCursor<Type, Pitch> origin() const;
     /*
     HDINLINE Cursor<PointerAccessor<Type>, CartNavigator<dim>, char*>
-    originCustomAxes(const math::UInt<dim>& axes) const;
+    originCustomAxes(const math::UInt32<dim>& axes) const;
     */
     DINLINE math::Size_t<dim> size() const {return math::Size_t<dim>(Size());}
 

--- a/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -23,8 +23,7 @@
 #ifndef CURSOR_BUFFERNAVIGATOR_HPP
 #define CURSOR_BUFFERNAVIGATOR_HPP
 
-#include <math/vector/Int.hpp>
-#include <math/vector/Size_t.hpp>
+#include "math/Vector.hpp"
 #include "tag.h"
 #include <boost/type_traits/remove_pointer.hpp>
 #include "CartNavigator.hpp"

--- a/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
@@ -24,7 +24,7 @@
 #define ZONE_STAGGEREDZONE_HPP
 
 #include <stdint.h>
-#include "../vector/Size_t.hpp"
+#include "vector/Vector.hpp"
 #include "SphericZone.hpp"
 
 namespace PMacc
@@ -40,8 +40,8 @@ template<int _dim>
 struct StaggeredZone : public SphericZone<_dim>
 {
     typedef tag::StaggeredZone tag;
-    math::UInt<dim> staggered;
-    math::UInt<dim> staggeredOffset;
+    math::UInt32<dim> staggered;
+    math::UInt32<dim> staggeredOffset;
 };
 
 } // zone

--- a/src/libPMacc/include/math/Vector.hpp
+++ b/src/libPMacc/include/math/Vector.hpp
@@ -24,13 +24,13 @@
 
 #include "math/vector/Vector.hpp"
 #include "math/vector/Int.hpp"
-#include "math/vector/UInt.hpp"
+#include "math/vector/UInt32.hpp"
 #include "math/vector/Size_t.hpp"
 #include "math/vector/Float.hpp"
 #include "math/ConstVector.hpp"
 #include "math/vector/compile-time/Vector.hpp"
 #include "math/vector/compile-time/Int.hpp"
 #include "math/vector/compile-time/Size_t.hpp"
-#include "math/vector/compile-time/UInt.hpp"
+#include "math/vector/compile-time/UInt32.hpp"
 
 #include "math/vector/Vector.tpp"

--- a/src/libPMacc/include/math/Vector.hpp
+++ b/src/libPMacc/include/math/Vector.hpp
@@ -25,6 +25,7 @@
 #include "math/vector/Vector.hpp"
 #include "math/vector/Int.hpp"
 #include "math/vector/UInt32.hpp"
+#include "math/vector/UInt64.hpp"
 #include "math/vector/Size_t.hpp"
 #include "math/vector/Float.hpp"
 #include "math/ConstVector.hpp"
@@ -32,5 +33,6 @@
 #include "math/vector/compile-time/Int.hpp"
 #include "math/vector/compile-time/Size_t.hpp"
 #include "math/vector/compile-time/UInt32.hpp"
+#include "math/vector/compile-time/UInt64.hpp"
 
 #include "math/vector/Vector.tpp"

--- a/src/libPMacc/include/math/vector/UInt32.hpp
+++ b/src/libPMacc/include/math/vector/UInt32.hpp
@@ -30,23 +30,23 @@ namespace math
 {
 
 template<int dim>
-struct UInt : public Vector<uint32_t, dim>
+struct UInt32 : public Vector<uint32_t, dim>
 {
     typedef Vector<uint32_t, dim> BaseType;
 
-    HDINLINE UInt()
+    HDINLINE UInt32()
     {
     }
 
-    HDINLINE UInt(uint32_t x) : BaseType(x)
+    HDINLINE UInt32(uint32_t x) : BaseType(x)
     {
     }
 
-    HDINLINE UInt(uint32_t x, uint32_t y) : BaseType(x, y)
+    HDINLINE UInt32(uint32_t x, uint32_t y) : BaseType(x, y)
     {
     }
 
-    HDINLINE UInt(uint32_t x, uint32_t y, uint32_t z) : BaseType(x, y, z)
+    HDINLINE UInt32(uint32_t x, uint32_t y, uint32_t z) : BaseType(x, y, z)
     {
     }
 
@@ -56,12 +56,12 @@ struct UInt : public Vector<uint32_t, dim>
     typename T_OtherAccessor,
     typename T_OtherNavigator,
     template <typename, int> class T_OtherStorage>
-    HDINLINE explicit UInt(const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec) :
+    HDINLINE explicit UInt32(const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec) :
     BaseType(vec)
     {
     }
 
-    HDINLINE UInt(const BaseType& vec) :
+    HDINLINE UInt32(const BaseType& vec) :
     BaseType(vec)
     {
     }

--- a/src/libPMacc/include/math/vector/UInt64.hpp
+++ b/src/libPMacc/include/math/vector/UInt64.hpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Axel Huebl
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Vector.hpp"
+
+namespace PMacc
+{
+namespace math
+{
+
+template<int dim>
+struct UInt64 : public Vector<uint64_t, dim>
+{
+    typedef Vector<uint64_t, dim> BaseType;
+
+    HDINLINE UInt64()
+    {
+    }
+
+    HDINLINE UInt64(uint64_t x) : BaseType(x)
+    {
+    }
+
+    HDINLINE UInt64(uint64_t x, uint64_t y) : BaseType(x, y)
+    {
+    }
+
+    HDINLINE UInt64(uint64_t x, uint64_t y, uint64_t z) : BaseType(x, y, z)
+    {
+    }
+
+    /*! only allow explicit cast*/
+    template<
+    typename T_OtherType,
+    typename T_OtherAccessor,
+    typename T_OtherNavigator,
+    template <typename, int> class T_OtherStorage>
+    HDINLINE explicit UInt64(const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec) :
+    BaseType(vec)
+    {
+    }
+
+    HDINLINE UInt64(const BaseType& vec) :
+    BaseType(vec)
+    {
+    }
+};
+
+} // math
+} // PMacc

--- a/src/libPMacc/include/math/vector/compile-time/UInt32.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/UInt32.hpp
@@ -47,21 +47,21 @@ namespace CT
 template<uint32_t x = traits::limits::Max<uint32_t>::value,
          uint32_t y = traits::limits::Max<uint32_t>::value,
          uint32_t z = traits::limits::Max<uint32_t>::value>
-struct UInt : public CT::Vector<mpl::integral_c<uint32_t, x>,
+struct UInt32 : public CT::Vector<mpl::integral_c<uint32_t, x>,
                                                    mpl::integral_c<uint32_t, y>,
                                                    mpl::integral_c<uint32_t, z> >
 {};
 
 template<>
-struct UInt<> : public CT::Vector<>
+struct UInt32<> : public CT::Vector<>
 {};
 
 template<uint32_t x>
-struct UInt<x> : public CT::Vector< mpl::integral_c<uint32_t, x> >
+struct UInt32<x> : public CT::Vector< mpl::integral_c<uint32_t, x> >
 {};
 
 template<uint32_t x, uint32_t y>
-struct UInt<x, y> : public CT::Vector<mpl::integral_c<uint32_t, x>,
+struct UInt32<x, y> : public CT::Vector<mpl::integral_c<uint32_t, x>,
                                                 mpl::integral_c<uint32_t, y> >
 {};
 

--- a/src/libPMacc/include/math/vector/compile-time/UInt64.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/UInt64.hpp
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Axel Huebl
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "math/Vector.hpp"
+#include <boost/mpl/integral_c.hpp>
+#include "traits/Limits.hpp"
+
+namespace PMacc
+{
+namespace math
+{
+namespace CT
+{
+
+/** Compile time uint vector
+ *
+ *
+ * @tparam x value for x allowed range [0;max uint64_t value -1]
+ * @tparam y value for y allowed range [0;max uint64_t value -1]
+ * @tparam z value for z allowed range [0;max uint64_t value -1]
+ *
+ * default parameter is used to distinguish between values given by
+ * the user and unset values.
+ */
+template<uint64_t x = traits::limits::Max<uint64_t>::value,
+         uint64_t y = traits::limits::Max<uint64_t>::value,
+         uint64_t z = traits::limits::Max<uint64_t>::value>
+struct UInt64 : public CT::Vector<mpl::integral_c<uint64_t, x>,
+                                  mpl::integral_c<uint64_t, y>,
+                                  mpl::integral_c<uint64_t, z> >
+{};
+
+template<>
+struct UInt64<> : public CT::Vector<>
+{};
+
+template<uint64_t x>
+struct UInt64<x> : public CT::Vector< mpl::integral_c<uint64_t, x> >
+{};
+
+template<uint64_t x, uint64_t y>
+struct UInt64<x, y> : public CT::Vector<mpl::integral_c<uint64_t, x>,
+                                        mpl::integral_c<uint64_t, y> >
+{};
+
+
+
+} // CT
+} // math
+} // PMacc

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -22,8 +22,6 @@
 
 #include "simulation_defines.hpp"
 #include "types.h"
-#include "math/vector/UInt.hpp"
-#include "types.h"
 #include "cuSTL/cursor/Cursor.hpp"
 #include "basicOperations.hpp"
 #include <cuSTL/cursor/tools/twistVectorFieldAxes.hpp>

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -22,8 +22,6 @@
 
 #include "simulation_defines.hpp"
 #include "types.h"
-#include "math/vector/UInt.hpp"
-#include "types.h"
 #include "cuSTL/cursor/Cursor.hpp"
 #include "basicOperations.hpp"
 #include <cuSTL/cursor/tools/twistVectorFieldAxes.hpp>

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -22,8 +22,6 @@
 
 #include "simulation_defines.hpp"
 #include "types.h"
-#include "math/vector/UInt.hpp"
-#include "types.h"
 #include "dimensions/DataSpace.hpp"
 #include "math/Vector.hpp"
 #include "cuSTL/cursor/Cursor.hpp"

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -90,7 +90,7 @@ namespace picongpu
 
             /* cell id in this block */
             const int linearCellIdx = particle[localCellIdx_];
-            const PMacc::math::UInt<simDim> cellIdx(
+            const PMacc::math::UInt32<simDim> cellIdx(
                 PMacc::math::MapToPos<simDim>()( SuperCellSize(), linearCellIdx ) );
 
             const uint32_t r_bin    = cellIdx[r_dir];

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -144,11 +144,11 @@ void SliceFieldPrinter<Field>::printSlice(const TField& field, int nAxis, float 
     if(!gather.participate()) return;
 
     using namespace lambda;
-    vec::UInt<3> twistedVector((nAxis+1)%3, (nAxis+2)%3, nAxis);
+    vec::UInt32<3> twistedVector((nAxis+1)%3, (nAxis+2)%3, nAxis);
 
     /* convert data to higher precision and to SI units */
     SliceFieldPrinterHelper::ConversionFunctor<Field> cf;
-    algorithm::kernel::Foreach<vec::CT::UInt<4,4,1> >()(
+    algorithm::kernel::Foreach<vec::CT::UInt32<4,4,1> >()(
       dBuffer_SI->zone(), dBuffer_SI->origin(),
       cursor::tools::slice(field.originCustomAxes(twistedVector)(0,0,localPlane)),
       cf );


### PR DESCRIPTION
The libPMacc vectors such as `Int` and `UInt` use implicit (machine-dependent) vector sizes.

This pull tries to refactor that.

### To Do
- [x] remove `[WIP]`/work-in-process
- [x] compile tests on jetson & hypnos