### PR TITLE
Fix #663 ADIOS Avoid 32bit Down-Cast

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Felix Schmitt
+ * Copyright 2014-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -41,6 +41,7 @@
 #include "plugins/output/WriteSpeciesCommon.hpp"
 #include "plugins/kernel/CopySpecies.kernel"
 #include "mappings/kernel/AreaMapping.hpp"
+#include "math/Vector.hpp"
 
 #include "traits/PICToAdios.hpp"
 #include "plugins/adios/writer/ParticleAttributeSize.hpp"
@@ -133,19 +134,20 @@ public:
 
         /* define adios var for species index/info table */
         {
-            const size_t localTableSize = 5;
+            const uint64_t localTableSize = 5;
             traits::PICToAdios<uint64_t> adiosIndexType;
 
-            int64_t adiosSpeciesIndexVar = defineAdiosVar(
+            const char* path = NULL;
+            int64_t adiosSpeciesIndexVar = defineAdiosVar<DIM1>(
                 params->adiosGroupHandle,
                 (params->adiosBasePath + std::string(ADIOS_PATH_PARTICLES) +
                     FrameType::getName() + std::string("/") + subGroup +
                     std::string("particles_info")).c_str(),
-                NULL,
+                path,
                 adiosIndexType.type,
-                DataSpace<DIM1>(localTableSize),
-                DataSpace<DIM1>(localTableSize * gc.getGlobalSize()),
-                DataSpace<DIM1>(localTableSize * gc.getGlobalRank()),
+                PMacc::math::UInt64<DIM1>(localTableSize),
+                PMacc::math::UInt64<DIM1>(localTableSize * uint64_t(gc.getGlobalSize()) ),
+                PMacc::math::UInt64<DIM1>(localTableSize * uint64_t(gc.getGlobalRank()) ),
                 true,
                 params->adiosCompression);
 

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Felix Schmitt
+ * Copyright 2014-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -18,14 +18,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include <adios.h>
 #include <list>
 
 #include "types.h"
+#include "math/Vector.hpp"
 #include "simulation_types.hpp"
 #include "particles/frame_types.hpp"
 #include "simulationControl/MovingWindow.hpp"
@@ -36,7 +35,6 @@ namespace picongpu
 namespace adios
 {
 using namespace PMacc;
-
 
 
 namespace po = boost::program_options;
@@ -84,9 +82,9 @@ struct ThreadParams
     std::string adiosBasePath;              /* base path for the current step */
     std::string adiosCompression;           /* ADIOS data transform compression method */
 
-    DataSpace<simDim> fieldsSizeDims;
-    DataSpace<simDim> fieldsGlobalSizeDims;
-    DataSpace<simDim> fieldsOffsetDims;
+    PMacc::math::UInt64<simDim> fieldsSizeDims;
+    PMacc::math::UInt64<simDim> fieldsGlobalSizeDims;
+    PMacc::math::UInt64<simDim> fieldsOffsetDims;
 
     std::list<int64_t> adiosFieldVarIds;        /* var IDs for fields in order of appearance */
     std::list<int64_t> adiosParticleAttrVarIds; /* var IDs for particle attributes in order of appearance */
@@ -131,9 +129,9 @@ int64_t defineAdiosVar(int64_t group_id,
                        const char * name,
                        const char * path,
                        enum ADIOS_DATATYPES type,
-                       DataSpace<DIM> dimensions,
-                       DataSpace<DIM> globalDimensions,
-                       DataSpace<DIM> offset,
+                       PMacc::math::UInt64<DIM> dimensions,
+                       PMacc::math::UInt64<DIM> globalDimensions,
+                       PMacc::math::UInt64<DIM> offset,
                        bool compression,
                        std::string compressionMethod);
 

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2014-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -82,9 +82,9 @@ int64_t defineAdiosVar(int64_t group_id,
                        const char * name,
                        const char * path,
                        enum ADIOS_DATATYPES type,
-                       DataSpace<DIM> dimensions,
-                       DataSpace<DIM> globalDimensions,
-                       DataSpace<DIM> offset,
+                       PMacc::math::UInt64<DIM> dimensions,
+                       PMacc::math::UInt64<DIM> globalDimensions,
+                       PMacc::math::UInt64<DIM> offset,
                        bool compression,
                        std::string compressionMethod)
 {
@@ -291,10 +291,11 @@ private:
                 datasetName << "/" << name_lookup_tpl[c];
 
             /* define adios var for field, e.g. field_FieldE_y */
-            int64_t adiosFieldVarId = defineAdiosVar(
+            const char* path = NULL;
+            int64_t adiosFieldVarId = defineAdiosVar<simDim>(
                     params->adiosGroupHandle,
                     datasetName.str().c_str(),
-                    NULL,
+                    path,
                     adiosType,
                     params->fieldsSizeDims,
                     params->fieldsGlobalSizeDims,
@@ -775,7 +776,7 @@ private:
         /* write created variable values */
         for (uint32_t d = 0; d < simDim; ++d)
         {
-            int offset = threadParams->window.localDimensions.offset[d];
+            uint64_t offset = threadParams->window.localDimensions.offset[d];
 
             /* dimension 1 is y and is the direction of the moving window (if any) */
             if (1 == d)

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Felix Schmitt
+ * Copyright 2014-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -52,9 +52,9 @@ struct ParticleAttributeSize
     HINLINE void operator()(
                             ThreadParams* params,
                             const std::string subGroup,
-                            const size_t elements,
-                            const size_t globalElements,
-                            const size_t globalOffset)
+                            const uint64_t elements,
+                            const uint64_t globalElements,
+                            const uint64_t globalOffset)
     {
 
         typedef T_Identifier Identifier;
@@ -78,14 +78,15 @@ struct ParticleAttributeSize
             if (components > 1)
                 datasetName << "/" << name_lookup[d];
 
-            int64_t adiosParticleAttrId = defineAdiosVar(
+            const char* path = NULL;
+            int64_t adiosParticleAttrId = defineAdiosVar<DIM1>(
                 params->adiosGroupHandle,
                 datasetName.str().c_str(),
-                NULL,
+                path,
                 adiosType.type,
-                DataSpace<DIM1>(elements),
-                DataSpace<DIM1>(globalElements),
-                DataSpace<DIM1>(globalOffset),
+                PMacc::math::UInt64<DIM1>(elements),
+                PMacc::math::UInt64<DIM1>(globalElements),
+                PMacc::math::UInt64<DIM1>(globalOffset),
                 true,
                 params->adiosCompression);
 


### PR DESCRIPTION
`defineAdiosVar` caused a down-cast to 32bit for counter attributes such as offsets.
That caused problems with counters and offsets for particles, that are traditionally stored in a long 1D array and can exceed the size of uint32_t (the base type of `DataSpace<DIM>`) easily.

First spotted by @psychocoderHPC - thanks!

### To Do

- [x] depends on the merge of #665
- [x] rebase on `dev`