### PR TITLE
Fix Particle2Grid: Non-Relativistic Particle Energy

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/physicalConstants.param
+++ b/examples/Bunch/include/simulation_defines/param/physicalConstants.param
@@ -26,6 +26,11 @@ namespace picongpu
 {
     const float_64 PI = 3.141592653589793238462643383279502884197169399;
 
+    /** Threshold used for calculations that want to separate between
+     *  high-precision formulas for relativistic and non-relativistic
+     *  use-cases, e.g. energy-binning algorithms. */
+    const float_X GAMMA_THRESH = float_X(1.005);
+
     namespace SI
     {
         /** unit: m / s */

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/physicalConstants.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/physicalConstants.param
@@ -26,6 +26,11 @@ namespace picongpu
 {
     const float_64 PI = 3.141592653589793238462643383279502884197169399;
 
+    /** Threshold used for calculations that want to separate between
+     *  high-precision formulas for relativistic and non-relativistic
+     *  use-cases, e.g. energy-binning algorithms. */
+    const float_X GAMMA_THRESH = float_X(1.005);
+
     namespace SI
     {
         /** unit: m / s */

--- a/examples/LaserWakefield/include/simulation_defines/param/physicalConstants.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/physicalConstants.param
@@ -26,6 +26,11 @@ namespace picongpu
 {
     const float_64 PI = 3.141592653589793238462643383279502884197169399;
 
+    /** Threshold used for calculations that want to separate between
+     *  high-precision formulas for relativistic and non-relativistic
+     *  use-cases, e.g. energy-binning algorithms. */
+    const float_X GAMMA_THRESH = float_X(1.005);
+
     namespace SI
     {
         /** unit: m / s */

--- a/examples/WeibelTransverse/include/simulation_defines/param/physicalConstants.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/physicalConstants.param
@@ -26,6 +26,11 @@ namespace picongpu
 {
     const float_64 PI = 3.141592653589793238462643383279502884197169399;
 
+    /** Threshold used for calculations that want to separate between
+     *  high-precision formulas for relativistic and non-relativistic
+     *  use-cases, e.g. energy-binning algorithms. */
+    const float_X GAMMA_THRESH = float_X(1.005);
+
     namespace SI
     {
         /** unit: m / s */

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -116,7 +116,9 @@ ComputeGridValuePerFrame<T_ParticleShape, calcType>::operator()
     const typename Gamma<float_X>::valueType gamma = calcGamma(mom, mass);
     const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
 
-    const float_X energy = (gamma - float_X(1.0)) * mass * c2;
+    const float_X energy = ( gamma <= float_X(GAMMA_THRESH) ) ?
+        math::abs2(mom) / ( float_X(2.0) * mass ) :   /* non-relativistic */
+        (gamma - float_X(1.0)) * mass * c2;           /* relativistic     */
 #if(ENABLE_RADIATION == 1)
     const float_X el_factor = charge * charge
         / (6.0 * PI * EPS0 *

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -140,7 +140,7 @@ __global__ void kernelBinEnergyParticles(ParticlesBox<FRAME, simDim> pb,
 
                 float_X _local_energy;
 
-                if (gamma < 1.005f)
+                if (gamma < GAMMA_THRESH)
                 {
                     _local_energy = mom2 / (2.0f * mass); /* not relativistic use equation with more precision */
                 }

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -109,7 +109,7 @@ __global__ void kernelEnergyParticles(ParticlesBox<FRAME, simDim> pb,
             Gamma<> calcGamma; /* functor for computing relativistic gamma factor */
             const float_X gamma = calcGamma(mom, mass); /* compute relativistic gamma */
 
-            if (gamma < 1.005f) /* if particle energy is low enough: */
+            if (gamma < GAMMA_THRESH) /* if particle energy is low enough: */
             {
                 /* not relativistic: use equation with more precision */
                 _local_energyKin += mom2 / (2.0f * mass);

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -26,6 +26,11 @@ namespace picongpu
 {
     const float_64 PI = 3.141592653589793238462643383279502884197169399;
 
+    /** Threshold used for calculations that want to separate between
+     *  high-precision formulas for relativistic and non-relativistic
+     *  use-cases, e.g. energy-binning algorithms. */
+    const float_X GAMMA_THRESH = float_X(1.005);
+
     namespace SI
     {
         /** unit: m / s */


### PR DESCRIPTION
Energy for particles with only non-relativistic energies was zero.

since the magic number `1.005` for gamma values "close to 1.0" is used the third time now, I exposed that number in `physicalConstants.param` now (second commit).

also: we still have that ugly "bump" in `BinEnergyParticles` since the round-off around `1.005` is hard to control for adjacent bins.

 - [x] check Argon droplet run from @MSPIC 
 - [x] fix typo