### PR TITLE
fix k20_autoWait_profile.tpl

### DIFF
--- a/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
@@ -24,6 +24,9 @@ TBG_queue="k20"
 TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 
+# get the ID of the last job of the submitting user waiting in the k20 queue
+TBG_waitJob=`qstat -u $(whoami) | grep $TBG_queue | tail -n 1 | awk '{print $1}'`
+
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 


### PR DESCRIPTION
This pull request fixes a bug introduced with commit ~~[`d0a80a3`](https://github.com/PrometheusPi/picongpu/commit/d0a80a3c043fd83902863ba1f38b998304861483)~~ ff14d8855dd67320fa109f05d78d8df39b769f33.

The `TBG_waitJob` variable was removed and is now added again.

 - [x] check if `k20_autoWait_profile.tpl` still works