### PR TITLE
add analyzer tool for numerical heating

### DIFF
--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -68,6 +68,11 @@ parser.add_argument("--label2",
                     default="branch",
                     help='label second simulation (default: branch)')
 
+parser.add_argument("--diff",
+                    dest="boolDiff",
+                    action='store_true',
+                    help='show difference between both simulations')
+
 args = parser.parse_args()
 
 
@@ -156,13 +161,20 @@ E_total_2 = E_fields_2[:,1] + E_electrons_2[:,1] + E_ions_2[:,1]
 startEnergy = E_total_1[0]
 
 ## plot numerical heating ##
-plt.plot(timestep, (1-E_total_1/startEnergy)*100., color="green", lw=3, label=args.label1)
-plt.plot(timestep, (1-E_total_2/startEnergy)*100., "--", color="blue",  lw=5, label=args.label2)
 
-plt.legend(loc=2)
+if not args.boolDiff:
+    # plot energy evolution side by side
+    plt.plot(timestep, (1-E_total_1/startEnergy)*100., color="green", lw=3, label=args.label1)
+    plt.plot(timestep, (1-E_total_2/startEnergy)*100., "--", color="blue",  lw=5, label=args.label2)
+    plt.ylabel(r"$1-\frac{E}{E_0}\,[\%]$", fontsize=24)
+else:
+    # plot difference in energy evolution
+    plt.plot(timestep, ((E_total_1-E_total_2)/startEnergy)*100., color="green", lw=3, label=args.label1)
+    plt.ylabel(r"$\frac{E_1 - E_2}{E_1(t=0)}\,[\%]$", fontsize=24)
+
+plt.legend(loc=0)
 
 plt.xlabel("time step", fontsize=20)
-plt.ylabel(r"$1-\frac{E}{E_0}\,[\%]$", fontsize=24)
 
 plt.xticks(fontsize=16)
 plt.yticks(fontsize=16)

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -175,21 +175,22 @@ else:
 
 if not args.boolDiff:
     # plot energy evolution side by side
-    plt.plot(timestep, (startEnergy-E_total_1)*norm, color="green", lw=3, label=args.label1)
-    plt.plot(timestep, (startEnergy-E_total_2)*norm, "--", color="blue",  lw=5, label=args.label2)
+    plt.plot(timestep, (E_total_1-startEnergy)*norm, color="green", lw=3, label=args.label1)
+    plt.plot(timestep, (E_total_2-startEnergy)*norm, "--", color="blue",  lw=5, label=args.label2)
     if args.boolRelative:
-        plt.ylabel(r"$1-\frac{E}{E_0}\,[\%]$", fontsize=24)
+        plt.ylabel(r"$\frac{E}{E_0}-1\,[\%]$", fontsize=24)
     else:
-        plt.ylabel(r"$E_0-E(t)$", fontsize=24)
+        plt.ylabel(r"$E(t)-E_0$", fontsize=24)
+    plt.legend(loc=0)
 else:
     # plot difference in energy evolution
-    plt.plot(timestep, (E_total_1-E_total_2)*norm, color="green", lw=3, label=args.label1)
+    plt.plot(timestep, (E_total_1-E_total_2)*norm, color="red", lw=3)
     if args.boolRelative:
         plt.ylabel(r"$\frac{E_1 - E_2}{E_1(t=0)}\,[\%]$", fontsize=24)
     else:
         plt.ylabel(r"$E_1 - E_2$", fontsize=24)
 
-plt.legend(loc=0)
+
 
 plt.xlabel("time step", fontsize=20)
 

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Richard Pausch
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+
+__doc__ = '''
+This program compares the energy evolution of two PIConGPU runs.
+Just give the directory of two PIConGPU runs and this program will
+get all values needed if they are available.
+You need to activate `--energy_fields`, `--energy_e` and `--energy_i`
+for both simulation runs with the same dumping period. 
+Plotted are:
+x-axis: time steps,
+y-axis: change in total energy.
+Developer: Richard Pausch
+'''
+
+import argparse
+import os
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+## set up argument parser ##
+parser = argparse.ArgumentParser(
+    description=__doc__,
+    epilog='For further questions please contact Richard Pausch.'
+    )
+
+parser.add_argument(metavar="[directory]",
+                    dest="dir_run1",
+                    help='directory with reference PIConGPU run',
+                    action='store')
+
+parser.add_argument(metavar='[directory]',
+                    dest="dir_run2",
+                    help='directory with PIConGPU run to compare with',
+                    action='store')
+
+parser.add_argument("--label1",
+                    metavar='[string]',
+                    dest="label1",
+                    default="dev",
+                    help='label first simulation (default: dev)')
+
+parser.add_argument("--label2",
+                    metavar='[string]',
+                    dest="label2",
+                    default="branch",
+                    help='label second simulation (default: branch)')
+
+args = parser.parse_args()
+
+
+## get directories from parser ##
+directory1 = args.dir_run1
+directory2 = args.dir_run2
+
+
+## check if directories exit ###
+simDir = "/simOutput/"
+
+warningText1 = "The {} directory ({}) does not exist." 
+if not os.path.isdir(directory1):
+    sys.exit(warningText1.format("first", directory1))
+
+if not os.path.isdir(directory2):
+    sys.exit(warningText1.format("second", directory2))
+
+warningText2 = "The {} directory does not contain {} yet."
+if not os.path.isdir(directory1+simDir):
+    sys.exit(warningText2.format("first", simDir))
+
+if not os.path.isdir(directory2+simDir):
+    sys.exit(warningText2.format("second", simDir))
+
+if directory1 == directory2:
+    sys.exit("We do not allow cheating! Compare two different runs.")
+
+
+## load files ##
+fileNameFields = "EnergyFields.dat"
+fileNameElectrons = "EnergyElectrons.dat"
+fileNameIons = "EnergyIons.dat"
+
+warningText3 = "The file {} does not exist."
+
+# first run
+path = directory1+simDir+fileNameFields
+if os.path.exists(path):
+    E_fields_1 = np.loadtxt(path)
+else:
+    sys.exit(warningText3.format(path))
+    
+path = directory1+simDir+fileNameElectrons
+if os.path.exists(path):
+    E_electrons_1 = np.loadtxt(path)
+else:
+    sys.exit(warningText3.format(path))
+
+path = directory1+simDir+fileNameIons
+if os.path.exists(path):
+    E_ions_1 = np.loadtxt(path)
+else:
+    sys.exit(warningText3.format(path))
+
+# second run
+path = directory2+simDir+fileNameFields
+if os.path.exists(path):
+    E_fields_2 = np.loadtxt(path)
+else:
+    sys.exit(warningText3.format(path))
+    
+path = directory2+simDir+fileNameElectrons
+if os.path.exists(path):
+    E_electrons_2 = np.loadtxt(path)
+else:
+    sys.exit(warningText3.format(path))
+
+path = directory2+simDir+fileNameIons
+if os.path.exists(path):
+    E_ions_2 = np.loadtxt(path)
+else:
+    sys.exit(warningText3.format(path))
+
+
+## check time steps ##
+for other in [E_electrons_1, E_ions_1, E_fields_2, E_electrons_2, E_ions_2]:
+    if not np.array_equal(E_fields_1[:,0], other[:,0]):
+        sys.exit("Time steps differ.")
+
+
+## get values ##
+timestep = E_fields_1[:,0]
+E_total_1 = E_fields_1[:,1] + E_electrons_1[:,1] + E_ions_1[:,1]
+E_total_2 = E_fields_2[:,1] + E_electrons_2[:,1] + E_ions_2[:,1]
+startEnergy = E_total_1[0]
+
+## plot numerical heating ##
+plt.plot(timestep, (1-E_total_1/startEnergy)*100., color="green", lw=3, label=args.label1)
+plt.plot(timestep, (1-E_total_2/startEnergy)*100., "--", color="blue",  lw=5, label=args.label2)
+
+plt.legend(loc=2)
+
+plt.xlabel("time step", fontsize=20)
+plt.ylabel(r"$1-\frac{E}{E_0}\,[\%]$", fontsize=24)
+
+plt.xticks(fontsize=16)
+plt.yticks(fontsize=16)
+
+plt.tight_layout()
+plt.show()
+

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -73,6 +73,11 @@ parser.add_argument("--diff",
                     action='store_true',
                     help='show difference between both simulations')
 
+parser.add_argument("--noRelative",
+                    dest="boolRelative",
+                    action="store_false",
+                    help="do not plot evolution relative to initial value")
+
 args = parser.parse_args()
 
 
@@ -162,15 +167,27 @@ startEnergy = E_total_1[0]
 
 ## plot numerical heating ##
 
+# choose normalization
+if args.boolRelative:
+    norm = 100. / startEnergy # relative to startEnergy in percent
+else:
+    norm = 1.0 # absolute values
+
 if not args.boolDiff:
     # plot energy evolution side by side
-    plt.plot(timestep, (1-E_total_1/startEnergy)*100., color="green", lw=3, label=args.label1)
-    plt.plot(timestep, (1-E_total_2/startEnergy)*100., "--", color="blue",  lw=5, label=args.label2)
-    plt.ylabel(r"$1-\frac{E}{E_0}\,[\%]$", fontsize=24)
+    plt.plot(timestep, (startEnergy-E_total_1)*norm, color="green", lw=3, label=args.label1)
+    plt.plot(timestep, (startEnergy-E_total_2)*norm, "--", color="blue",  lw=5, label=args.label2)
+    if args.boolRelative:
+        plt.ylabel(r"$1-\frac{E}{E_0}\,[\%]$", fontsize=24)
+    else:
+        plt.ylabel(r"$E_0-E(t)$", fontsize=24)
 else:
     # plot difference in energy evolution
-    plt.plot(timestep, ((E_total_1-E_total_2)/startEnergy)*100., color="green", lw=3, label=args.label1)
-    plt.ylabel(r"$\frac{E_1 - E_2}{E_1(t=0)}\,[\%]$", fontsize=24)
+    plt.plot(timestep, (E_total_1-E_total_2)*norm, color="green", lw=3, label=args.label1)
+    if args.boolRelative:
+        plt.ylabel(r"$\frac{E_1 - E_2}{E_1(t=0)}\,[\%]$", fontsize=24)
+    else:
+        plt.ylabel(r"$E_1 - E_2$", fontsize=24)
 
 plt.legend(loc=0)
 


### PR DESCRIPTION
This pull request adds a python program that can compare the energy evolution and thus the numerical heating of two PIConGPU simulation runs.

Writing a seperate tool for this task was suggested by @ax3l in #657.

The program has the following features:
 - help via `--help` or `-h`
 - auto check existence of directories and files
 - checks that dump period is equal for all output files
 - creates a plot with labels, legend, etc.
 - optional: use other lables as `dev` and `branch`
 - forbids *cheating* by comparing the same results :smiling_imp:  

I tested it with the last numerical heating run and it works fine with `python/2.7.8` on `hypnos`.

 - [x] add absolute energy plot (suggested by @psychocoderHPC )
 - [x] add difference plot