### PR TITLE
ADIOS Checkpoint/Restart Capability

### DIFF
--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -162,6 +162,15 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
         return *this;
     }
 
+    HDINLINE This revert()
+    {
+        This invertedVector;
+        for (int i = 0; i < dim; i++)
+            invertedVector[dim-1-i] = (*this)[i];
+
+        return invertedVector;
+    }
+
     template<
     typename T_OtherAccessor,
     typename T_OtherNavigator,

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -89,10 +89,8 @@
 #include "plugins/makroParticleCounter/PerSuperCell.hpp"
 #endif
 
-#if(SIMDIM==DIM3)
 #if (ENABLE_ADIOS == 1)
 #include "plugins/adios/ADIOSWriter.hpp"
-#endif
 #endif
 
 namespace picongpu
@@ -177,10 +175,8 @@ private:
         plugins.push_back(new hdf5::HDF5Writer());
 #endif
 
-#if(SIMDIM==DIM3)
 #if (ENABLE_ADIOS == 1)
         plugins.push_back(new adios::ADIOSWriter());
-#endif
 #endif
 
         plugins.push_back(new EnergyFields("EnergyFields", "energy_fields"));

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -92,7 +92,6 @@ struct ThreadParams
     std::list<int64_t> adiosFieldVarIds;        /* var IDs for fields in order of appearance */
     std::list<int64_t> adiosParticleAttrVarIds; /* var IDs for particle attributes in order of appearance */
     std::list<int64_t> adiosSpeciesIndexVarIds; /* var IDs for species index tables in order of appearance */
-    std::list<int64_t> adiosMetaAttrVarIds;     /* var IDs for scalar meta attributes */
 
     GridLayout<simDim> gridLayout;
     MappingDesc *cellDescription;

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -55,16 +55,16 @@ namespace po = boost::program_options;
 {                                                                              \
     int _err_code = _cmd;                                                      \
     if (_err_code != ADIOS_SUCCESS)                                            \
-        log<picLog::INPUT_OUTPUT > ("ADIOS: error at cmd '%1%': '%2%'") %      \
-            #_cmd % _err_code;                                                 \
+        log<picLog::INPUT_OUTPUT > ("ADIOS: error at cmd '%1%': '%2%' %3%") %  \
+            #_cmd % _err_code % adios_errmsg();                                \
 }
 
 #define ADIOS_CMD_EXPECT_NONZERO(_cmd)                                         \
 {                                                                              \
     int _err_code = _cmd;                                                      \
     if (_err_code == 0)                                                        \
-        log<picLog::INPUT_OUTPUT > ("ADIOS: error at cmd '%1%': '%2%'") %      \
-            #_cmd % _err_code;                                                 \
+        log<picLog::INPUT_OUTPUT > ("ADIOS: error at cmd '%1%': '%2%' %3%") %  \
+            #_cmd % _err_code % adios_errmsg();                                \
 }
 
 struct ThreadParams

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -24,12 +24,16 @@
 #include <adios_read.h>
 
 #include <list>
+#include <limits>
+#include <sstream>
+#include <string>
 
 #include "types.h"
 #include "math/Vector.hpp"
 #include "simulation_types.hpp"
 #include "particles/frame_types.hpp"
 #include "simulationControl/MovingWindow.hpp"
+#include "traits/PICToAdios.hpp"
 
 namespace picongpu
 {
@@ -112,6 +116,31 @@ struct ThreadParams
  */
 
 class ADIOSWriter;
+
+/** Default ADIOS types we will use */
+typedef PICToAdios<uint32_t> AdiosUInt32Type;
+typedef PICToAdios<float_X> AdiosFloatXType;
+typedef PICToAdios<double> AdiosDoubleType;
+
+/** Attribute conversation: values to c-strings in ADIOS C-API <= 1.8.0 */
+template<typename T>
+static std::string flt2str( T val )
+{
+    typedef std::numeric_limits< T > fltLimit;
+
+    std::stringstream s;
+    s.precision(fltLimit::digits10);
+    s << std::scientific << val;
+    return s.str();
+}
+
+template<typename T>
+static std::string int2str( T val )
+{
+    std::stringstream s;
+    s << val;
+    return s.str();
+}
 
 /**
  * Wrapper for adios_define_var that sets data transform method

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -21,6 +21,8 @@
 #pragma once
 
 #include <adios.h>
+#include <adios_read.h>
+
 #include <list>
 
 #include "types.h"
@@ -74,6 +76,7 @@ struct ThreadParams
 
     /** current dump is a checkpoint */
     bool isCheckpoint;
+    ADIOS_FILE* fp;                          /* file pointer for checkpoint file */
 
     MPI_Comm adiosComm;                     /* MPI communicator for adios lib */
     bool adiosBufferInitialized;            /* set if ADIOS buffer has been allocated */

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -72,6 +72,9 @@ struct ThreadParams
     uint32_t currentStep;                   /** current simulation step */
     std::string fullFilename;
 
+    /** current dump is a checkpoint */
+    bool isCheckpoint;
+
     MPI_Comm adiosComm;                     /* MPI communicator for adios lib */
     bool adiosBufferInitialized;            /* set if ADIOS buffer has been allocated */
     int64_t adiosFileHandle;                /* ADIOS file handle */

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -27,6 +27,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <iostream> // std::cerr
 
 #include "types.h"
 #include "math/Vector.hpp"
@@ -61,16 +62,18 @@ namespace po = boost::program_options;
 {                                                                              \
     int _err_code = _cmd;                                                      \
     if (_err_code != ADIOS_SUCCESS)                                            \
-        log<picLog::INPUT_OUTPUT > ("ADIOS: error at cmd '%1%': '%2%' %3%") %  \
-            #_cmd % _err_code % adios_errmsg();                                \
+        std::cerr << "ADIOS: error at cmd '" << #_cmd                          \
+                  << "' (" << _err_code << ") in "                             \
+                  << __FILE__ << ":" << __LINE__ << adios_errmsg();            \
 }
 
 #define ADIOS_CMD_EXPECT_NONZERO(_cmd)                                         \
 {                                                                              \
     int _err_code = _cmd;                                                      \
     if (_err_code == 0)                                                        \
-        log<picLog::INPUT_OUTPUT > ("ADIOS: error at cmd '%1%': '%2%' %3%") %  \
-            #_cmd % _err_code % adios_errmsg();                                \
+        std::cerr << "ADIOS: error at cmd '" << #_cmd                          \
+                  << "' (" << _err_code << ") in "                             \
+                  << __FILE__ << ":" << __LINE__ << adios_errmsg();            \
 }
 
 struct ThreadParams

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -561,10 +561,7 @@ public:
 
         /* set window for restart, complete global domain */
         mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);
-        for (uint32_t d = 0; d < simDim; ++d)
-        {
-            mThreadParams.localWindowToDomainOffset[d] = 0;
-        }
+        mThreadParams.localWindowToDomainOffset = DataSpace<simDim>::create(0);
 
         /* load all fields */
         ForEach<FileCheckpointFields, LoadFields<bmpl::_1> > forEachLoadFields;
@@ -1007,7 +1004,6 @@ private:
     MappingDesc *cellDescription;
 
     uint32_t notifyPeriod;
-    int64_t lastCheckpoint;
     std::string filename;
     std::string checkpointFilename;
     std::string restartFilename;

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -566,17 +566,17 @@ public:
         log<picLog::INPUT_OUTPUT > ("ADIOS: Setting slide count for moving window to %1%") % slides;
         MovingWindow::getInstance().setSlideCounter(slides, restartStep);
 
+        /* re-distribute the local offsets in y-direction */
+        GridController<simDim> &gc = Environment<simDim>::get().GridController();
+        if( MovingWindow::getInstance().isSlidingWindowActive() )
+            gc.setStateAfterSlides(slides);
+
         /* set window for restart, complete global domain */
         mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);
         for (uint32_t d = 0; d < simDim; ++d)
         {
             mThreadParams.localWindowToDomainOffset[d] = 0;
         }
-
-        /* re-distribute the local offsets in y-direction */
-        GridController<simDim> &gc = Environment<simDim>::get().GridController();
-        if( MovingWindow::getInstance().isSlidingWindowActive() )
-            gc.setStateAfterSlides(slides);
 
         /* load all fields */
         ForEach<FileCheckpointFields, LoadFields<bmpl::_1> > forEachLoadFields;

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -111,9 +111,9 @@ int64_t defineAdiosVar(int64_t group_id,
     } else {
         var_id = adios_define_var(
             group_id, name, path, type,
-            dimensions.toString(",", "").c_str(),
-            globalDimensions.toString(",", "").c_str(),
-            offset.toString(",", "").c_str());
+            dimensions.revert().toString(",", "").c_str(),
+            globalDimensions.revert().toString(",", "").c_str(),
+            offset.revert().toString(",", "").c_str());
     }
 
     if (compression && canCompress)

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -755,13 +755,18 @@ private:
             const size_t plane_full_size = field_full[1] * field_full[0] * nComponents;
             const size_t plane_no_guard_size = field_no_guard[1] * field_no_guard[0];
 
-            /* copy strided data from source to temporary buffer */
-            for (int z = 0; z < field_no_guard[2]; ++z)
+            /* copy strided data from source to temporary buffer
+             *
+             * \todo use d1Access as in `include/plugins/hdf5/writer/Field.hpp`
+             */
+            const int maxZ = simDim == DIM3 ? field_no_guard[2] : 1;
+            const int guardZ = simDim == DIM3 ? field_guard[2] : 0;
+            for (int z = 0; z < maxZ; ++z)
             {
                 for (int y = 0; y < field_no_guard[1]; ++y)
                 {
                     const size_t base_index_src =
-                                (z + field_guard[2]) * plane_full_size +
+                                (z + guardZ) * plane_full_size +
                                 (y + field_guard[1]) * field_full[0] * nComponents;
 
                     const size_t base_index_dst =

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -519,12 +519,6 @@ public:
             throw std::runtime_error("ADIOS: Error opening stream: " +
                                      std::string(adios_errmsg()) );
 
-        /* create adios group: not rly necessary but required to restore our IDs */
-        ADIOS_CMD(adios_declare_group(&(mThreadParams.adiosGroupHandle),
-                ADIOS_GROUP_NAME,
-                (mThreadParams.adiosBasePath + std::string("iteration")).c_str(),
-                adios_flag_no));
-
         /* ADIOS types */
         AdiosUInt32Type adiosUInt32Type;
         //AdiosFloatXType adiosFloatXType;
@@ -995,14 +989,16 @@ private:
         if (threadParams->adiosFileHandle == ADIOS_INVALID_HANDLE)
             throw std::runtime_error("ADIOS: Failed to open file.");
 
-        /* set adios group size (total size of all data to be written) */
+        /* attributes written here are pure meta data */
+        writeMetaAttributes(threadParams);
+
+        /* set adios group size (total size of all data to be written)
+         * besides the number of bytes for variables, this call also
+         * calculates the overhead of meta data
+         */
         uint64_t adiosTotalSize;
         ADIOS_CMD(adios_group_size(threadParams->adiosFileHandle,
                 threadParams->adiosGroupSize, &adiosTotalSize));
-
-        writeMetaAttributes(threadParams);
-
-
 
         /* write fields */
         log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) writing fields.");

--- a/src/picongpu/include/plugins/adios/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/WriteSpecies.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera, Felix Schmitt
+ * Copyright 2014-2015 Rene Widera, Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -94,38 +94,37 @@ public:
         ThisSpecies* speciesTmp = &(dc.getData<ThisSpecies >(ThisSpecies::FrameType::getName(), true));
 
         /* count total number of particles on the device */
-        log<picLog::INPUT_OUTPUT > ("ADIOS:  (begin) count particles: %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) count particles: %1%") % AdiosFrameType::getName();
         uint64_cu totalNumParticles = 0;
         totalNumParticles = PMacc::CountParticles::countOnDevice < CORE + BORDER > (
                                                                                     *speciesTmp,
                                                                                     *(params->cellDescription),
                                                                                     params->localWindowToDomainOffset,
                                                                                     params->window.localDimensions.size);
-        log<picLog::INPUT_OUTPUT > ("ADIOS:  ( end ) count particles: %1% = %2%") % AdiosFrameType::getName() % totalNumParticles;
-
+        log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) count particles: %1% = %2%") % AdiosFrameType::getName() % totalNumParticles;
 
         AdiosFrameType hostFrame;
-        log<picLog::INPUT_OUTPUT > ("ADIOS:  (begin) malloc mapped memory: %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) malloc mapped memory: %1%") % AdiosFrameType::getName();
 
         /* malloc mapped memory */
         ForEach<typename AdiosFrameType::ValueTypeSeq, MallocMemory<bmpl::_1> > mallocMem;
         mallocMem(forward(hostFrame), totalNumParticles);
-        log<picLog::INPUT_OUTPUT > ("ADIOS:  ( end ) malloc mapped memory: %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) malloc mapped memory: %1%") % AdiosFrameType::getName();
 
         if (totalNumParticles > 0)
         {
-            log<picLog::INPUT_OUTPUT > ("ADIOS:  (begin) get mapped memory device pointer: %1%") % AdiosFrameType::getName();
+            log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) get mapped memory device pointer: %1%") % AdiosFrameType::getName();
             /* load device pointer of mapped memory */
             AdiosFrameType deviceFrame;
             ForEach<typename AdiosFrameType::ValueTypeSeq, GetDevicePtr<bmpl::_1> > getDevicePtr;
             getDevicePtr(forward(deviceFrame), forward(hostFrame));
-            log<picLog::INPUT_OUTPUT > ("ADIOS:  ( end ) get mapped memory device pointer: %1%") % AdiosFrameType::getName();
+            log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) get mapped memory device pointer: %1%") % AdiosFrameType::getName();
 
-            log<picLog::INPUT_OUTPUT > ("ADIOS:  (begin) copy particle to host: %1%") % AdiosFrameType::getName();
+            log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) copy particle to host: %1%") % AdiosFrameType::getName();
             typedef bmpl::vector< typename GetPositionFilter<simDim>::type > usedFilters;
             typedef typename FilterFactory<usedFilters>::FilterType MyParticleFilter;
             MyParticleFilter filter;
-            /* activeate filter pipeline if moving window is activated */
+            /* activate filter pipeline if moving window is activated */
             filter.setStatus(MovingWindow::getInstance().isSlidingWindowActive());
             filter.setWindowPosition(params->localWindowToDomainOffset,
                                      params->window.localDimensions.size);
@@ -144,9 +143,9 @@ public:
                  mapper
                  );
             counterBuffer.deviceToHost();
-            log<picLog::INPUT_OUTPUT > ("ADIOS:  ( end ) copy particle to host: %1%") % AdiosFrameType::getName();
+            log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) copy particle to host: %1%") % AdiosFrameType::getName();
             __getTransactionEvent().waitForFinished();
-            log<picLog::INPUT_OUTPUT > ("ADIOS:  all events are finished: %1%") % AdiosFrameType::getName();
+            log<picLog::INPUT_OUTPUT > ("ADIOS:   all events are finished: %1%") % AdiosFrameType::getName();
             /* this costs a little bit of time but adios writing is slower */
             assert((uint64_cu) counterBuffer.getHostBuffer().getDataBox()[0] == totalNumParticles);
         }
@@ -160,7 +159,7 @@ public:
         log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) writing species: %1%") % AdiosFrameType::getName();
 
         /* write species counter table to adios file */
-        log<picLog::INPUT_OUTPUT > ("ADIOS:  (begin) writing particle index table for %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) writing particle index table for %1%") % AdiosFrameType::getName();
         {
             GridController<simDim>& gc = Environment<simDim>::get().GridController();
 
@@ -182,7 +181,7 @@ public:
             params->adiosSpeciesIndexVarIds.pop_front();
             ADIOS_CMD(adios_write_byid(params->adiosFileHandle, adiosIndexVarId, particlesMetaInfo));
         }
-        log<picLog::INPUT_OUTPUT > ("ADIOS:  ( end ) writing particle index table for %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) writing particle index table for %1%") % AdiosFrameType::getName();
     }
 };
 

--- a/src/picongpu/include/plugins/adios/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/WriteSpecies.hpp
@@ -44,6 +44,9 @@
 #include "compileTime/conversion/RemoveFromSeq.hpp"
 #include "particles/ParticleDescription.hpp"
 
+#include "particles/particleFilter/FilterFactory.hpp"
+#include "particles/particleFilter/PositionFilter.hpp"
+
 namespace picongpu
 {
 

--- a/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#pragma once
+
+
+#include "types.h"
+#include "simulation_types.hpp"
+#include "plugins/adios/ADIOSWriter.def"
+#include "traits/PICToAdios.hpp"
+#include "traits/GetComponentsType.hpp"
+#include "traits/GetNComponents.hpp"
+#include "traits/Resolve.hpp"
+
+
+namespace picongpu
+{
+
+namespace adios
+{
+using namespace PMacc;
+
+/** Load attribute of a species from ADIOS checkpoint file
+ *
+ * @tparam T_Identifier identifier of species attribute
+ */
+template< typename T_Identifier>
+struct LoadParticleAttributesFromADIOS
+{
+
+    /** read attributes from ADIOS file
+     *
+     * @param params thread params with ADIOS_FILE, ...
+     * @param frame frame with all particles
+     * @param particlePath path to the group in the ADIOS file
+     * @param particlesOffset read offset in the attribute array
+     * @param elements number of elements which should be read the attribute array
+     */
+    template<typename FrameType>
+    HINLINE void operator()(
+                            ThreadParams* params,
+                            FrameType& frame,
+                            const std::string particlePath,
+                            const uint64_t particlesOffset,
+                            const uint64_t elements)
+    {
+
+        typedef T_Identifier Identifier;
+        typedef typename PMacc::traits::Resolve<Identifier>::type::type ValueType;
+        const uint32_t components = GetNComponents<ValueType>::value;
+        typedef typename GetComponentsType<ValueType>::type ComponentType;
+
+        log<picLog::INPUT_OUTPUT > ("ADIOS: ( begin ) load species attribute: %1%") % Identifier::getName();
+
+        const std::string name_lookup[] = {"x", "y", "z"};
+
+        ComponentType* tmpArray = NULL;
+        if( elements > 0 )
+            tmpArray = new ComponentType[elements];
+
+        // dev assert!
+        if( elements > 0 )
+            assert(tmpArray);
+
+        for (uint32_t n = 0; n < components; ++n)
+        {
+            std::stringstream datasetName;
+            datasetName << particlePath << T_Identifier::getName();
+            if (components > 1)
+                datasetName << "/" << name_lookup[n];
+
+            ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer();
+
+            ADIOS_VARINFO* varInfo = adios_inq_var( params->fp, datasetName.str().c_str() );
+            // it's possible to aquire the local block with that call again and
+            // the local elements to-be-read, but the block-ID must be known (MPI rank?)
+            //ADIOS_CMD(adios_inq_var_blockinfo( params->fp, varInfo ));
+
+            ADIOS_SELECTION* sel = adios_selection_boundingbox( 1, &particlesOffset, &elements );
+            ADIOS_CMD(adios_schedule_read( params->fp,
+                                           sel,
+                                           datasetName.str().c_str(),
+                                           0,
+                                           1,
+                                           (void*)tmpArray ));
+
+            /* start a blocking read of all scheduled variables */
+            ADIOS_CMD(adios_perform_reads( params->fp, 1 ));
+
+            log<picLog::INPUT_OUTPUT > ("ADIOS:  Did read %1% local of %2% global elements for %3%") %
+                elements % varInfo->dims[0] % datasetName.str();
+
+            /* copy component from temporary array to array of structs */
+            for (size_t i = 0; i < elements; ++i)
+            {
+                ComponentType& ref = ((ComponentType*) dataPtr)[i * components + n];
+                ref = tmpArray[i];
+            }
+
+            adios_selection_delete( sel );
+            adios_free_varinfo( varInfo );
+        }
+        __deleteArray(tmpArray);
+
+        log<picLog::INPUT_OUTPUT > ("ADIOS:  ( end ) load species attribute: %1%") %
+            Identifier::getName();
+    }
+
+};
+
+} /* namespace adios */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -104,8 +104,8 @@ struct LoadParticleAttributesFromADIOS
                 ADIOS_CMD(adios_schedule_read( params->fp,
                                                sel,
                                                datasetName.str().c_str(),
-                                               0,
-                                               1,
+                                               0, /* from_step (not used in streams) */
+                                               1, /* nsteps to read (must be 1 for stream) */
                                                (void*)tmpArray ));
             }
 

--- a/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -26,7 +26,6 @@
 #include "types.h"
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
-#include "traits/PICToAdios.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
 #include "traits/Resolve.hpp"

--- a/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_types.hpp"
+
+#include "plugins/adios/ADIOSWriter.def"
+#include "plugins/ISimulationPlugin.hpp"
+
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/find.hpp>
+#include <boost/type_traits.hpp>
+
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "compileTime/conversion/RemoveFromSeq.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "particles/ParticleDescription.hpp"
+
+#include "plugins/output/WriteSpeciesCommon.hpp"
+#include "plugins/kernel/CopySpeciesGlobal2Local.kernel"
+#include "plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp"
+
+namespace picongpu
+{
+
+namespace adios
+{
+using namespace PMacc;
+
+/** Load species from ADIOS checkpoint file
+ *
+ * @tparam T_Species type of species
+ *
+ */
+template< typename T_Species >
+struct LoadSpecies
+{
+public:
+
+    typedef T_Species ThisSpecies;
+    typedef typename ThisSpecies::FrameType FrameType;
+    typedef typename FrameType::ParticleDescription ParticleDescription;
+    typedef typename FrameType::ValueTypeSeq ParticleAttributeList;
+
+
+    /* delete multiMask and localCellIdx in adios particle*/
+    typedef bmpl::vector2<multiMask, localCellIdx> TypesToDelete;
+    typedef typename RemoveFromSeq<ParticleAttributeList, TypesToDelete>::type ParticleCleanedAttributeList;
+
+    /* add globalCellIdx for adios particle*/
+    typedef typename MakeSeq<
+    ParticleCleanedAttributeList,
+    globalCellIdx<globalCellIdx_pic>
+    >::type ParticleNewAttributeList;
+
+    typedef
+    typename ReplaceValueTypeSeq<ParticleDescription, ParticleNewAttributeList>::type
+    NewParticleDescription;
+
+    typedef Frame<OperatorCreateVectorBox, NewParticleDescription> AdiosFrameType;
+
+    /** Load species from ADIOS checkpoint file
+     *
+     * @param params thread params with ADIOS_FILE, ...
+     * @param restartChunkSize number of particles processed in one kernel call
+     */
+    HINLINE void operator()(ThreadParams* params, const uint32_t restartChunkSize)
+    {
+
+        log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) load species: %1%") % AdiosFrameType::getName();
+        DataConnector &dc = Environment<>::get().DataConnector();
+        GridController<simDim> &gc = Environment<simDim>::get().GridController();
+
+        std::string particlePath = params->adiosBasePath + std::string(ADIOS_PATH_PARTICLES) +
+                                   FrameType::getName() + std::string("/");
+        const PMacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+
+        /* load particle without copying particle data to host */
+        ThisSpecies* speciesTmp = &(dc.getData<ThisSpecies >(ThisSpecies::FrameType::getName(), true));
+
+        /* count total number of particles on the device */
+        uint64_cu totalNumParticles = 0;
+
+        /* load particles info table entry for this process
+           particlesInfo is (part-count, scalar pos, x, y, z) */
+        typedef uint64_t uint64Quint[5];
+        uint64Quint particlesInfo[gc.getGlobalSize()];
+
+        ADIOS_CMD(adios_schedule_read( params->fp,
+                                       NULL,       /* read full data set */
+                                       (particlePath + std::string("particles_info")).c_str(),
+                                       0,
+                                       1,
+                                       particlesInfo ));
+
+        /* start a blocking read of all scheduled variables */
+        ADIOS_CMD(adios_perform_reads( params->fp, 1 ));
+
+        /* search my entry (using my scalar position) in particlesInfo */
+        uint64_t particleOffset = 0;
+        uint64_t myScalarPos = gc.getScalarPosition();
+
+        for (size_t i = 0; i < gc.getGlobalSize(); ++i)
+        {
+            if (particlesInfo[i][1] == myScalarPos)
+            {
+                totalNumParticles = particlesInfo[i][0];
+                break;
+            }
+
+            particleOffset += particlesInfo[i][0];
+        }
+
+        log<picLog::INPUT_OUTPUT > ("ADIOS: Loading %1% particles from offset %2%") %
+            (long long unsigned) totalNumParticles % (long long unsigned) particleOffset;
+
+        AdiosFrameType hostFrame;
+        log<picLog::INPUT_OUTPUT > ("ADIOS: malloc mapped memory: %1%") % AdiosFrameType::getName();
+        /*malloc mapped memory*/
+        ForEach<typename AdiosFrameType::ValueTypeSeq, MallocMemory<bmpl::_1> > mallocMem;
+        mallocMem(forward(hostFrame), totalNumParticles);
+
+        log<picLog::INPUT_OUTPUT > ("ADIOS: get mapped memory device pointer: %1%") % AdiosFrameType::getName();
+        /*load device pointer of mapped memory*/
+        AdiosFrameType deviceFrame;
+        ForEach<typename AdiosFrameType::ValueTypeSeq, GetDevicePtr<bmpl::_1> > getDevicePtr;
+        getDevicePtr(forward(deviceFrame), forward(hostFrame));
+
+        ForEach<typename AdiosFrameType::ValueTypeSeq, LoadParticleAttributesFromADIOS<bmpl::_1> > loadAttributes;
+        loadAttributes(forward(params), forward(hostFrame), particlePath, particleOffset, totalNumParticles);
+
+        if (totalNumParticles != 0)
+        {
+            dim3 block(PMacc::math::CT::volume<SuperCellSize>::type::value);
+
+            /* counter is used to apply for work, count used frames and count loaded particles
+             * [0] -> offset for loading particles
+             * [1] -> number of loaded particles
+             * [2] -> number of used frames
+             *
+             * all values are zero after initialization
+             */
+            GridBuffer<uint32_t, DIM1> counterBuffer(DataSpace<DIM1>(3));
+
+            const uint32_t cellsInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
+
+            const uint32_t iterationsForLoad = ceil(double(totalNumParticles) / double(restartChunkSize));
+            uint32_t leftOverParticles = totalNumParticles;
+
+            __startAtomicTransaction(__getTransactionEvent());
+
+            for (uint32_t i = 0; i < iterationsForLoad; ++i)
+            {
+                /* only load a chunk of particles per iteration to avoid blow up of frame usage
+                 */
+                uint32_t currentChunkSize = std::min(leftOverParticles, restartChunkSize);
+                log<picLog::INPUT_OUTPUT > ("ADIOS: load particles on device chunk offset=%1%; chunk size=%2%; left particles %3%") %
+                    (i * restartChunkSize) % currentChunkSize % leftOverParticles;
+                __cudaKernel(copySpeciesGlobal2Local)
+                    (ceil(double(currentChunkSize) / double(cellsInSuperCell)), cellsInSuperCell)
+                    (counterBuffer.getDeviceBuffer().getDataBox(),
+                     speciesTmp->getDeviceParticlesBox(), deviceFrame,
+                     (int) totalNumParticles,
+                     localDomain.offset, /*relative to data domain (not to physical domain)*/
+                     *(params->cellDescription)
+                     );
+                speciesTmp->fillAllGaps();
+                leftOverParticles -= currentChunkSize;
+            }
+            __setTransactionEvent(__endTransaction());
+            counterBuffer.deviceToHost();
+            log<picLog::INPUT_OUTPUT > ("ADIOS: wait for last processed chunk: %1%") % AdiosFrameType::getName();
+            __getTransactionEvent().waitForFinished();
+
+            log<picLog::INPUT_OUTPUT > ("ADIOS: used frames to load particles: %1%") % counterBuffer.getHostBuffer().getDataBox()[2];
+
+            if ((uint64_cu) counterBuffer.getHostBuffer().getDataBox()[1] != totalNumParticles)
+            {
+                log<picLog::INPUT_OUTPUT >("ADIOS: error load species | counter is %1% but should %2%") % counterBuffer.getHostBuffer().getDataBox()[1] % totalNumParticles;
+                throw std::runtime_error("ADIOS: Failed to load expected number of particles to GPU.");
+            }
+            assert((uint64_cu) counterBuffer.getHostBuffer().getDataBox()[1] == totalNumParticles);
+
+            /*free host memory*/
+            ForEach<typename AdiosFrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;
+            freeMem(forward(hostFrame));
+            log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) load species: %1%") % AdiosFrameType::getName();
+        }
+    }
+};
+
+
+} /* namespace adios */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -105,8 +105,9 @@ public:
             uint64_t count[varInfo->ndim];
             for(int d = 0; d < varInfo->ndim; ++d)
             {
-                start[d] = domain_offset[d];
-                count[d] = local_domain_size[d];
+                /* \see adios_define_var: z,y,x in C-order */
+                start[d] = domain_offset.revert()[d];
+                count[d] = local_domain_size.revert()[d];
             }
 
             ADIOS_SELECTION* fSel = adios_selection_boundingbox( varInfo->ndim, start, count );

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -132,27 +132,6 @@ public:
         log<picLog::INPUT_OUTPUT > ("ADIOS: Finished loading field '%1%'") % objectName;
     }
 
-    template<class Data>
-    static void cloneField(Data& fieldDest, Data& fieldSrc, std::string objectName)
-    {
-        log<picLog::INPUT_OUTPUT > ("ADIOS: Begin cloning field '%1%'") % objectName;
-        DataSpace<simDim> field_grid = fieldDest.getGridLayout().getDataSpace();
-
-        size_t elements = field_grid.productOfComponents();
-        float3_X *ptrDest = fieldDest.getHostBuffer().getDataBox().getPointer();
-        float3_X *ptrSrc = fieldSrc.getHostBuffer().getDataBox().getPointer();
-
-        for (size_t k = 0; k < elements; ++k)
-        {
-            ptrDest[k] = ptrSrc[k];
-        }
-
-        fieldDest.hostToDevice();
-
-        __getTransactionEvent().waitForFinished();
-
-        log<picLog::INPUT_OUTPUT > ("ADIOS: Finished cloning field '%1%'") % objectName;
-    }
 };
 
 /**

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -57,30 +57,13 @@ public:
         const std::string name_lookup_tpl[] = {"x", "y", "z", "w"};
         const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
 
-        const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
         const PMacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
         field.getHostBuffer().setValue(float3_X(0.));
 
-        //const std::string name_lookup[] = {"x", "y", "z"};
+        DataSpace<simDim> domain_offset = localDomain.offset;
 
-        /* globalSlideOffset due to gpu slides between origin at time step 0
-         * and origin at current time step
-         * ATTENTION: splash offset are globalSlideOffset + picongpu offsets
-         */
-        DataSpace<simDim> globalSlideOffset;
-        globalSlideOffset.y() = numSlides * localDomain.size.y();
-
-        DataSpace<simDim> domain_offset;
-        for (uint32_t d = 0; d < simDim; ++d)
-            domain_offset[d] = localDomain.offset[d] + globalSlideOffset[d];
-
-        if (Environment<simDim>::get().GridController().getPosition().y() == 0)
-            domain_offset[1] += params->window.globalDimensions.offset.y();
-
-        DataSpace<simDim> local_domain_size;
-        for (uint32_t d = 0; d < simDim; ++d)
-            local_domain_size[d] = params->window.localDimensions.size[d];
+        DataSpace<simDim> local_domain_size = params->window.localDimensions.size;
 
         PMACC_AUTO(destBox, field.getHostBuffer().getDataBox());
         for (uint32_t n = 0; n < numComponents; ++n)

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2014-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <adios.h>
+#include <adios_read.h>
+#include <adios_error.h>
+
+#include <string>
+#include <sstream>
+
+#include "types.h"
+#include "simulation_defines.hpp"
+#include "plugins/adios/ADIOSWriter.def"
+
+#include "particles/frame_types.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "dimensions/DataSpace.hpp"
+#include "dimensions/GridLayout.hpp"
+#include "fields/FieldE.hpp"
+#include "fields/FieldB.hpp"
+#include "simulationControl/MovingWindow.hpp"
+
+namespace picongpu
+{
+
+namespace adios
+{
+
+/**
+ * Helper class for ADIOS plugin to load fields from parallel ADIOS BP files.
+ */
+class RestartFieldLoader
+{
+public:
+    template<class Data>
+    static void loadField(Data& field, const uint32_t numComponents, std::string objectName, ThreadParams *params)
+    {
+        log<picLog::INPUT_OUTPUT > ("Begin loading field '%1%'") % objectName;
+
+        const std::string name_lookup_tpl[] = {"x", "y", "z", "w"};
+        const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
+
+        const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
+        const PMacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+
+        field.getHostBuffer().setValue(float3_X(0.));
+
+        //const std::string name_lookup[] = {"x", "y", "z"};
+
+        /* globalSlideOffset due to gpu slides between origin at time step 0
+         * and origin at current time step
+         * ATTENTION: splash offset are globalSlideOffset + picongpu offsets
+         */
+        DataSpace<simDim> globalSlideOffset;
+        globalSlideOffset.y() = numSlides * localDomain.size.y();
+
+        DataSpace<simDim> domain_offset;
+        for (uint32_t d = 0; d < simDim; ++d)
+            domain_offset[d] = localDomain.offset[d] + globalSlideOffset[d];
+
+        if (Environment<simDim>::get().GridController().getPosition().y() == 0)
+            domain_offset[1] += params->window.globalDimensions.offset.y();
+
+        DataSpace<simDim> local_domain_size;
+        for (uint32_t d = 0; d < simDim; ++d)
+            local_domain_size[d] = params->window.localDimensions.size[d];
+
+        PMACC_AUTO(destBox, field.getHostBuffer().getDataBox());
+        for (uint32_t n = 0; n < numComponents; ++n)
+        {
+            // Read the subdomain which belongs to our mpi position.
+            // The total grid size must match the grid size of the stored data.
+            log<picLog::INPUT_OUTPUT > ("ADIOS: Read from domain: offset=%1% size=%2%") %
+                domain_offset % local_domain_size;
+
+            std::stringstream datasetName;
+            datasetName << params->adiosBasePath << ADIOS_PATH_FIELDS << objectName;
+            if (numComponents > 1)
+                datasetName << "/" << name_lookup_tpl[n];
+
+            log<picLog::INPUT_OUTPUT > ("ADIOS: Read from field '%1%'") %
+                datasetName.str();
+
+            ADIOS_VARINFO* varInfo = adios_inq_var( params->fp, datasetName.str().c_str() );
+            uint64_t start[varInfo->ndim];
+            uint64_t count[varInfo->ndim];
+            for(int d = 0; d < varInfo->ndim; ++d)
+            {
+                start[d] = domain_offset[d];
+                count[d] = local_domain_size[d];
+            }
+
+            ADIOS_SELECTION* fSel = adios_selection_boundingbox( varInfo->ndim, start, count );
+
+            /* specify what we want to read, but start reading at below at
+             * `adios_perform_reads` */
+            log<picLog::INPUT_OUTPUT > ("ADIOS: Allocate %1% elements") %
+                local_domain_size.productOfComponents();
+
+            /// \todo float_X should be some kind of gridBuffer's GetComponentsType<ValueType>::type
+            float_X* field_container = new float_X[local_domain_size.productOfComponents()];
+            ADIOS_CMD(adios_schedule_read( params->fp, fSel, datasetName.str().c_str(), 0, 1, (void*)field_container ));
+
+            /* start a blocking read of all scheduled variables */
+            ADIOS_CMD(adios_perform_reads( params->fp, 1 ));
+
+            int elementCount = params->window.localDimensions.size.productOfComponents();
+
+            for (int linearId = 0; linearId < elementCount; ++linearId)
+            {
+                /* calculate index inside the moving window domain which is located on the local grid*/
+                DataSpace<simDim> destIdx = DataSpaceOperations<simDim>::map(params->window.localDimensions.size, linearId);
+                /* jump over guard and local sliding window offset*/
+                destIdx += field_guard + params->localWindowToDomainOffset;
+
+                destBox(destIdx)[n] = field_container[linearId];
+            }
+
+            __deleteArray(field_container);
+            adios_selection_delete(fSel);
+            adios_free_varinfo(varInfo);
+        }
+
+        field.hostToDevice();
+
+        __getTransactionEvent().waitForFinished();
+
+        log<picLog::INPUT_OUTPUT > ("ADIOS: Read from domain: offset=%1% size=%2%") %
+            domain_offset % local_domain_size;
+        log<picLog::INPUT_OUTPUT > ("ADIOS: Finished loading field '%1%'") % objectName;
+    }
+
+    template<class Data>
+    static void cloneField(Data& fieldDest, Data& fieldSrc, std::string objectName)
+    {
+        log<picLog::INPUT_OUTPUT > ("ADIOS: Begin cloning field '%1%'") % objectName;
+        DataSpace<simDim> field_grid = fieldDest.getGridLayout().getDataSpace();
+
+        size_t elements = field_grid.productOfComponents();
+        float3_X *ptrDest = fieldDest.getHostBuffer().getDataBox().getPointer();
+        float3_X *ptrSrc = fieldSrc.getHostBuffer().getDataBox().getPointer();
+
+        for (size_t k = 0; k < elements; ++k)
+        {
+            ptrDest[k] = ptrSrc[k];
+        }
+
+        fieldDest.hostToDevice();
+
+        __getTransactionEvent().waitForFinished();
+
+        log<picLog::INPUT_OUTPUT > ("ADIOS: Finished cloning field '%1%'") % objectName;
+    }
+};
+
+/**
+ * Hepler class for ADIOSWriter (forEach operator) to load a field from ADIOS
+ *
+ * @tparam FieldType field class to load
+ */
+template< typename FieldType >
+struct LoadFields
+{
+public:
+
+    HDINLINE void operator()(ThreadParams* params)
+    {
+#ifndef __CUDA_ARCH__
+        DataConnector &dc = Environment<>::get().DataConnector();
+        ThreadParams *tp = params;
+
+        /* load field without copying data to host */
+        FieldType* field = &(dc.getData<FieldType > (FieldType::getName(), true));
+
+        /* load from ADIOS */
+        RestartFieldLoader::loadField(
+                field->getGridBuffer(),
+                (uint32_t)FieldType::numComponents,
+                FieldType::getName(),
+                tp);
+
+        dc.releaseData(FieldType::getName());
+#endif
+    }
+
+};
+
+using namespace PMacc;
+
+} /* namespace adios */
+} /* namespace picongpu */

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -35,8 +35,6 @@
 #include "dataManagement/DataConnector.hpp"
 #include "dimensions/DataSpace.hpp"
 #include "dimensions/GridLayout.hpp"
-#include "fields/FieldE.hpp"
-#include "fields/FieldB.hpp"
 #include "simulationControl/MovingWindow.hpp"
 
 namespace picongpu
@@ -119,6 +117,7 @@ public:
 
             /// \todo float_X should be some kind of gridBuffer's GetComponentsType<ValueType>::type
             float_X* field_container = new float_X[local_domain_size.productOfComponents()];
+            /* magic parameters (0, 1): `from_step` (not used in streams), `nsteps` to read (must be 1 for stream) */
             ADIOS_CMD(adios_schedule_read( params->fp, fSel, datasetName.str().c_str(), 0, 1, (void*)field_container ));
 
             /* start a blocking read of all scheduled variables */

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
@@ -23,7 +23,6 @@
 #include "types.h"
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
-#include "traits/PICToAdios.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
 #include "traits/Resolve.hpp"

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
@@ -78,7 +78,12 @@ struct ParticleAttribute
 
             int64_t adiosAttributeVarId = *(params->adiosParticleAttrVarIds.begin());
             params->adiosParticleAttrVarIds.pop_front();
-            ADIOS_CMD(adios_write_byid(params->adiosFileHandle, adiosAttributeVarId, tmpBfr));
+
+            /** We skip this part due to a bug in ADIOS 1.8.0 where
+             *  read with *compressed* data sets fail on zero-size data sets.
+             *  Note: adios_write commands are not collective (for most methods, except the PHDF5 transport) */
+            if (elements > 0)
+                ADIOS_CMD(adios_write_byid(params->adiosFileHandle, adiosAttributeVarId, tmpBfr));
         }
 
         __deleteArray(tmpBfr);

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -70,6 +70,8 @@ struct ParticleAttributeSize
         AdiosType adiosType;
         const std::string name_lookup[] = {"x", "y", "z"};
 
+        std::vector<double> unit = Unit<Identifier>::get();
+
         for (uint32_t d = 0; d < components; d++)
         {
             std::stringstream datasetName;
@@ -91,6 +93,16 @@ struct ParticleAttributeSize
                 params->adiosCompression);
 
             params->adiosParticleAttrVarIds.push_back(adiosParticleAttrId);
+
+            /* already add the sim_unit attribute so `adios_group_size` calculates
+             * the reservation for the buffer correctly */
+            AdiosDoubleType adiosDoubleType;
+
+            /* check if this attribute actually has a unit (unit.size() == 0 is no unit) */
+            if (unit.size() >= (d + 1))
+                ADIOS_CMD(adios_define_attribute(params->adiosGroupHandle,
+                          "sim_unit", datasetName.str().c_str(), adiosDoubleType.type,
+                          flt2str(unit.at(d)).c_str(), ""));
         }
 
 

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -143,13 +143,20 @@ public:
 
     void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
     {
+#if(ENABLE_ADIOS == 1)
+        log<picLog::INPUT_OUTPUT > ("HDF5: Checkpoint skipped since ADIOS is enabled.");
+#else
         this->checkpointDirectory = checkpointDirectory;
 
         notificationReceived(currentStep, true);
+#endif
     }
 
     void restart(uint32_t restartStep, const std::string restartDirectory)
     {
+#if(ENABLE_ADIOS == 1)
+        log<picLog::INPUT_OUTPUT > ("HDF5: Restart skipped since ADIOS is enabled.");
+#else
         const uint32_t maxOpenFilesPerNode = 4;
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
         mThreadParams.dataCollector = new ParallelDomainCollector(
@@ -221,6 +228,7 @@ public:
             mThreadParams.dataCollector->finalize();
 
         __delete(mThreadParams.dataCollector);
+#endif
     }
 
 private:


### PR DESCRIPTION
Close a point from #56.

- adds checkpointing and restart via ADIOS
- prefers ADIOS over HDF5 if both are found (for checkpointing/restarting)
- ~~unifies some logs to be coherent with HDF5/ADIOS~~

### To Do
- [x] still based on ~~#661~~, rebase on `dev`
- [x] add restart methods
- [x] clean up new code (a little), add `ADIOS_CMD` wrappers, ...
- [x] test in 2D
- [x] test in 3D
- [x] test `--gridDist`
- [x] test multiple species (lwfa with e- and ions) with nx!=ny!=nz
- [x] test with/without particles, bunch (partial empty) -> ~~still problems during read with zlib~~ (ADIOS bug report sent on 9th of Mar) -> work around applied
- [x] test moving window setups
- [x] move HDF5 changes in "log syntax" to separate pull request
- [x] should `ADIOS_CMD` fails be critical / throw? -> looks ok for now, errors are visible this way
- [x] add `dataSet` attributes such as `sim_unit`
- [x] ~~write RFE: `chunk_size` should be set-able via `adios_read_init_method` not only via export https://github.com/ornladios/ADIOS/issues/46~~ we use `ADIOS_READ_METHOD_BP` now