### PR TITLE
fix and refactor CUDA bugs in Esirkepov

### DIFF
--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -136,12 +136,9 @@ struct Esirkepov<T_ParticleShape, DIM3>
          * If previous position was greater than current position we change our interval
          * from [begin,end) to [begin+1,end+1).
          */
-        /** \todo -(-int(bool)) is a workaround for a nvcc bug
-         * @see https://devtalk.nvidia.com/default/topic/752200/cuda-programming-and-performance/nvcc-loop-bug-since-cuda-5-5/
-         */
-        const int offset_i = -(-int(line.pos0.x() > line.pos1.x()));
-        const int offset_j = -(-int(line.pos0.y() > line.pos1.y()));
-        const int offset_k = -(-int(line.pos0.z() > line.pos1.z()));
+        const int offset_i = line.pos0.x() > line.pos1.x() ? 1 : 0;
+        const int offset_j = line.pos0.y() > line.pos1.y() ? 1 : 0;
+        const int offset_k = line.pos0.z() > line.pos1.z() ? 1 : 0;
 
         /* pick every cell in the xy-plane that is overlapped by particle's
          * form factor and deposit the current for the cells above and beneath

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -142,11 +142,8 @@ struct Esirkepov<T_ParticleShape, DIM2>
          * If previous position was greater than current position we change our interval
          * from [begin,end) to [begin+1,end+1).
          */
-        /** \todo -(-int(bool)) is a workaround for a nvcc bug
-         * @see https://devtalk.nvidia.com/default/topic/752200/cuda-programming-and-performance/nvcc-loop-bug-since-cuda-5-5/
-         */
-        const int offset_i = -(-int(line.pos0.x() > line.pos1.x()));
-        const int offset_j = -(-int(line.pos0.y() > line.pos1.y()));
+        const int offset_i = line.pos0.x() > line.pos1.x() ? 1 : 0;
+        const int offset_j = line.pos0.y() > line.pos1.y() ? 1 : 0;
 
 
         for (int j = begin + offset_j; j < end + offset_j; ++j)
@@ -181,11 +178,8 @@ struct Esirkepov<T_ParticleShape, DIM2>
          * If previous position was greater than current position we change our interval
          * from [begin,end) to [begin+1,end+1).
          */
-        /** \todo -(-int(bool)) is a workaround for a nvcc bug
-         * @see https://devtalk.nvidia.com/default/topic/752200/cuda-programming-and-performance/nvcc-loop-bug-since-cuda-5-5/
-         */
-        const int offset_i = -(-int(line.pos0.x() > line.pos1.x()));
-        const int offset_j = -(-int(line.pos0.y() > line.pos1.y()));
+        const int offset_i = line.pos0.x() > line.pos1.x() ? 1 : 0;
+        const int offset_j = line.pos0.y() > line.pos1.y() ? 1 : 0;
 
 
         for (int j = begin + offset_j; j < end + offset_j; ++j)


### PR DESCRIPTION
This pull request fixes the CUDA 6.5 `int(bool)` bug in the Esirkepov current deposition scheme.

The changes applied also changed a workaround of a [CUDA5.5+ bug](https://devtalk.nvidia.com/default/topic/752200/cuda-programming-and-performance/nvcc-loop-bug-sin%5Cce-cuda-5-5) found and implemented by @psychocoderHPC. Therefore, we have to carefull check if the *CUDA5.5+ unroll bug* is now in again. 

Between `dev` and `fix-04boolBugCUDA6.5` for both `2D` and `3D` we need to:
 - [x] check simulation time
 - [x] check numerical heating
 - [x] verify that the *CUDA5.5+ unroll bug* is avoided as well @(psychocoderHPC Should we go through the `ptx`code again or are the tests above enough?)

Full list of current work arounds for CUDA bugs: #652