### PR TITLE
fix MessageHeader, wrong array deletion

### DIFF
--- a/src/picongpu/include/plugins/output/header/MessageHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/MessageHeader.hpp
@@ -148,7 +148,7 @@ struct MessageHeader
 
     static void destroy(MessageHeader * obj)
     {
-        __delete(obj);
+        __deleteArray(obj);
     }
 
     DataHeader data;


### PR DESCRIPTION
use `__deleteArray` to free memory