### PR TITLE
Flag for proton and neutron number

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/species.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/species.param
@@ -40,6 +40,11 @@
 
 #define ENABLE_IONS PARAM_IONS
 
+/*enable (1) or disable (0) ionization*/
+#ifndef PARAM_IONIZATION
+#define PARAM_IONIZATION 0
+#endif
+
 
 namespace picongpu
 {

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -102,12 +102,30 @@ typedef Particles<ParticleDescription<
 
 /*--------------------------- ions -------------------------------------------*/
 
+/*! Specify (chemical) element
+ * 
+ * Proton and neutron numbers define the chemical element that the ion species
+ * is based on. This value can be non-integer for physical models taking  
+ * charge shielding effects into account. 
+ * @see http://en.wikipedia.org/wiki/Effective_nuclear_charge
+ * 
+ * It is wrapped into a struct because of C++ restricting floats from being 
+ * template arguments. 
+ * 
+ * Do not forget to set the correct mass of the atom in 
+ * @see physicalConstants.param !
+ */
+struct Helium
+{
+    static const float_X numberOfProtons  = 2.0;
+    static const float_X numberOfNeutrons = 2.0;
+};
+
 /*! Ionization Model Configuration ----------------------------------------
  * 
  * For development purposes: ---------------------------------------------
  * - None : no particle is ionized
  * - BSI : simple barrier suppression ionization
- *      (particles can only be ionized once from charge state 1 to 2)
  * 
  * Usage: Add a flag to the list of particle flags that has the following structure
  * 
@@ -119,10 +137,11 @@ typedef bmpl::vector<
     particlePusher<UsedParticlePusher>,
     shape<UsedParticleShape>,
     interpolation<UsedField2Particle>,
-    current<UsedParticleCurrentSolver>
-    #if(PARAM_IONIZATION==1)
-    ,ionizer<particles::ionization::BSI<PIC_Electrons> >
+    current<UsedParticleCurrentSolver>, 
+    #if(PARAM_IONIZATION == 1)
+    ionizer<particles::ionization::BSI<PIC_Electrons> >,
     #endif
+    atomicNumbers<Helium>
 > ParticleFlagsIons;
 
 /* define species: ions */

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -22,6 +22,7 @@
 
 #include "types.h"
 #include "particles/ionization/ionizationEnergies.param"
+#include "particles/traits/GetAtomicNumbers.hpp"
 
 /** IONIZATION ALGORITHM 
  * - implements the calculation of ionization probability and changes charge states
@@ -53,11 +54,13 @@ namespace ionization
         operator()( const BType bField, const EType eField, ParticleType& parentIon )
         {
 
+            const float_X protonNumber = GetAtomicNumbers<ParticleType>::type::numberOfProtons;
+            
             /* ionization condition */
-            if (math::abs(eField)*UNIT_EFIELD >= SI::IONIZATION_EFIELD && parentIon[chargeState_] < SI::PROTON_NUMBER)
+            if (math::abs(eField)*UNIT_EFIELD >= SI::IONIZATION_EFIELD && parentIon[chargeState_] < protonNumber)
             {
                 /* set new particle charge state */
-                parentIon[chargeState_] = 1 + parentIon[chargeState_];
+                parentIon[chargeState_] += float_X(1.0);
             }
 
         }

--- a/src/picongpu/include/particles/ionization/ionizationEnergies.param
+++ b/src/picongpu/include/particles/ionization/ionizationEnergies.param
@@ -40,7 +40,5 @@ namespace SI
     /* ionization field strength (E-field) for -""-: in Volt / meter */
     const double IONIZATION_EFIELD = 5.14e11;
 
-    /* \todo add a new attribute protonNumber and introduce it wherever needed */
-    const int PROTON_NUMBER = 2;
 } // namespace SI
 } // namespace picongpu

--- a/src/picongpu/include/particles/traits/GetAtomicNumbers.hpp
+++ b/src/picongpu/include/particles/traits/GetAtomicNumbers.hpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 Marco Garten, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "static_assert.hpp"
+#include "traits/GetFlagType.hpp"
+#include "traits/Resolve.hpp"
+#include "particles/memory/frames/Frame.hpp"
+
+namespace picongpu
+{
+namespace traits
+{
+template<typename T_Species>
+struct GetAtomicNumbers
+{
+    typedef typename T_Species::FrameType FrameType;
+    
+    typedef typename HasFlag<FrameType, atomicNumbers<> >::type hasAtomicNumbers;
+    /* throw static assert if species has no protons or neutrons */
+    PMACC_CASSERT_MSG(This_species_has_no_atomic_numbers,hasAtomicNumbers::value==true);
+            
+    typedef typename GetFlagType<FrameType,atomicNumbers<> >::type FoundAtomicNumbersAlias;
+    typedef typename PMacc::traits::Resolve<FoundAtomicNumbersAlias >::type type;
+};
+} //namespace traits
+
+}// namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -59,7 +59,8 @@ value_identifier(bool, radiationFlag, false);
  *
  * value type is float_X to avoid casts during the runtime
  *
- * - only reasonable for ion species if ionization is enabled*/
+ * - only reasonable for ion species if ionization is enabled 
+ * - \todo calculate from new attribute boundElectrons */
 value_identifier(float_X,chargeState,float_X(1.0));
 
 /** specialization global position inside a domain (relative to origin of the
@@ -81,6 +82,10 @@ alias(interpolation);
 
 /*! alias for particle current solver @see species.param */
 alias(current);
+
+/*! alias for particle flag: atomic numbers @see speciesDefinition.param
+ * - only reasonable for atoms / ions / nuclei */
+alias(atomicNumbers);
 
 template<uint32_t T_commTag>
 struct CommunicationId


### PR DESCRIPTION
Here is another topic concerning **multiple species** and **ionization**. 
This PR adds a ***flag for proton and neutron number*** of the ion species.

In detail:
- flags `protonNumber` and `neutronNumber`
- traits `GetProtonNumber` and `GetNeutronNumber`   
  (these contain a `static_assert` which is thrown if someone tries to get these numbers from, say, electrons)
- ionization algorithm has been edited to ionize until `chargeState` = `protonNumber`
- ionization is now always active if ions are enabled (deactivate by deleting the flags)

### The last commit has not been runtime-tested due to the current maintenance
(everything until *Make proton/neutronNumber a float* is safe)