### PR TITLE
Fix #688 2D Restart Fields

### DIFF
--- a/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -47,7 +47,7 @@ class RestartFieldLoader
 {
 public:
     template<class Data>
-    static void loadField(Data& field, std::string objectName, ThreadParams *params)
+    static void loadField(Data& field, const uint32_t numComponents, std::string objectName, ThreadParams *params)
     {
         log<picLog::INPUT_OUTPUT > ("Begin loading field '%1%'") % objectName;
         const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
@@ -78,7 +78,7 @@ public:
             local_domain_size[d] = params->window.localDimensions.size[d];
 
         PMACC_AUTO(destBox, field.getHostBuffer().getDataBox());
-        for (uint32_t i = 0; i < simDim; ++i)
+        for (uint32_t i = 0; i < numComponents; ++i)
         {
             // Read the subdomain which belongs to our mpi position.
             // The total grid size must match the grid size of the stored data.
@@ -161,6 +161,7 @@ public:
         /* load from HDF5 */
         RestartFieldLoader::loadField(
                 field->getGridBuffer(),
+                (uint32_t)FieldType::numComponents,
                 FieldType::getName(),
                 tp);
 


### PR DESCRIPTION
**Fix #688 2D Restart Fields**: in 2D simulations, the last component (z) of FieldE and FieldB was not initialized again (default: zero).

- [x] verify with 2D KHI simulation and check `EnergyFields.dat` before/after restart (especially `B_z`)

**unrelated:**
- wrong docs string and index names in `hdf5/writer/Field.hpp` -> extra pull #690

the index names in `hdf5/writer/Field.hpp` are not ideal (even if the implementation is correct): once `d` is used as an index `[0; simDim]` and once as an index `[0; nComponents]` and same mixed with `i`.