### PR TITLE
PNG Plugin: Use less compression

### DIFF
--- a/src/picongpu/include/plugins/output/images/PngCreator.hpp
+++ b/src/picongpu/include/plugins/output/images/PngCreator.hpp
@@ -99,8 +99,13 @@ namespace picongpu
         std::string filename(name + "_" + step.str() + ".png");
 
         pngwriter png(size.x(), size.y(), 0, filename.c_str());
-        //PngWriter coordinate system begin with 1,1
 
+        /* default compression: 6
+         * zlib level 1 is ~12% bigger but ~2.3x faster in write_png()
+         */
+        png.setcompressionlevel(1);
+
+        //PngWriter coordinate system begin with 1,1
         for (int y = 0; y < size.y(); ++y)
         {
             for (int x = 0; x < size.x(); ++x)


### PR DESCRIPTION
- increases file by about 12%
- decreases time for write_png() call by ~2.3x
- part of optimizations in #693