### PR TITLE
TBG Macros: Add Restart Dir

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -185,8 +185,11 @@ TBG_adios="--adios.period 100 --adios.file simData"
 TBG_checkpoints="--checkpoints 1000"
 
 # Restart the simulation from checkpoints created using TBG_checkpoints
-TBG_restart="--restart --restart-step 1000"
-
+TBG_restart="--restart"
+# By default, the last checkpoint is restarted if not specified via
+#   --restart-step 1000
+# To restart in a new run directory point to the old run where to start from
+#   --restart-directory /path/to/simOutput/checkpoints
 
 # Connect to a live-view server (start the server in advance)
 TBG_liveViewYX="--live_e.period 1 --live_e.slicePoint 0.5 --live_e.ip 10.0.2.254 \

--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -97,7 +97,6 @@ TBG_movingWindow="-m"
 #--radiation_e.omegaList 	If spectrum frequencies are taken from a file, this gives the path to this list
 #--radiation_e.radPerGPU 	If set to 1, each GPU stores its own spectra without summing the entire simulation area
 #--radiation_e.folderRadPerGPU 	Folder where the GPU specific spectras are stored
-#--radiation_e.restart 	If set to 1, stored amplitudes are used to initialize the spectra
 TBG_radiation="--radiation_e.period 1 --radiation_e.dump 2 --radiation_e.totalRadiation 1 \
                --radiation_e.lastRadiation 0 --radiation_e.start 2800 --radiation_e.end 3000"
 


### PR DESCRIPTION
That flag is needed pretty often and it should be documented at `doc/TBG_macros.cfg` too that it needs to point to `<run>/simOutput/checkpoints`.

Wiki article, as linked some lines above in that file: http://git.io/PToFYg