### PR TITLE
FindPNGwriter: Fix misleading Not-Found Message

### DIFF
--- a/src/cmake/FindPNGwriter.cmake
+++ b/src/cmake/FindPNGwriter.cmake
@@ -135,7 +135,7 @@ if(PNGwriter_FOUND)
     set(PNGwriter_VERSION "0.5.4")
 
 else(PNGwriter_FOUND)
-    message(STATUS "Can NOT find PNGwriter - set PNGwriter_ROOT")
+    message(STATUS "Can NOT find PNGwriter - set PNGWRITER_ROOT")
 endif(PNGwriter_FOUND)
 
 


### PR DESCRIPTION
The message on PNGwriter "NOT FOUND" was wrong, this fixes it.

**As a background information:**
Traditionally, the environment vars controlling a cmake module are all upper case, such as PNGWRITER_ROOT, BOOST_ROOT.
On the other hand cmake variables are internally used case sensitive, such as PNGwriter, Boost, ...