### PR TITLE
Fix #702 Activate new plugins after restart

### DIFF
--- a/src/picongpu/include/plugins/common/txtFileHandling.hpp
+++ b/src/picongpu/include/plugins/common/txtFileHandling.hpp
@@ -60,10 +60,8 @@ using namespace boost::filesystem;
         if( !boost::filesystem::exists( src ) )
         {
             /* restart file does not exists */
-            log<picLog::INPUT_OUTPUT> ("Plugin restart file:");
-            log<picLog::INPUT_OUTPUT> ("\t %1%") % src ;
-            log<picLog::INPUT_OUTPUT> ("was not found.");
-            log<picLog::INPUT_OUTPUT> ("--> Starting plugin from current time step.");
+            log<picLog::INPUT_OUTPUT> ("Plugin restart file: %1% was not found. \
+                                       --> Starting plugin from current time step.") % src;
             return true;
         }
         else

--- a/src/picongpu/include/plugins/common/txtFileHandling.hpp
+++ b/src/picongpu/include/plugins/common/txtFileHandling.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Axel Huebl
+ * Copyright 2015 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -34,7 +34,8 @@ using namespace boost::filesystem;
     /** Restore a txt file from the checkpoint dir
      *
      * Restores a txt file from the checkpoint dir and starts appending to it.
-     * Opened files in \see outFile are closed and a valid handle is opened again.
+     * Opened files in \see outFile are closed and a valid handle is opened again
+     * if a restart file is found. Otherwise new output file stays untouched.
      *
      * \param outFile std::ofstream file handle to regular file that shall be restored
      * \param filename the file's name
@@ -46,28 +47,46 @@ using namespace boost::filesystem;
     bool restoreTxtFile( std::ofstream& outFile, std::string filename,
                          uint32_t restartStep, const std::string restartDirectory )
     {
-        if( outFile.is_open() )
-            outFile.close();
-
+        /* get restart time step as string */
         std::stringstream sStep;
         sStep << restartStep;
 
+        /* set location of restart file and output file */
         path src( restartDirectory + std::string("/") + filename +
                   std::string(".") + sStep.str() );
         path dst( filename );
 
-        copy_file( src,
-                   dst,
-                   copy_option::overwrite_if_exists );
-
-        outFile.open( filename.c_str(), std::ofstream::out | std::ostream::app );
-        if( !outFile )
+        /* check whether restart file exists */
+        std::ifstream restartFile(src.c_str());
+        if(! restartFile.good())
         {
-            std::cerr << "[Plugin] Can't open file '" << filename
-                      << "', output disabled" << std::endl;
-            return false;
+            /* restart file does not exists */
+            restartFile.close();
+            std::cerr << "Plugin restart file: \n \t" << src << "\n was not found." << std::endl;
+            std::cerr << "Starting plugin from current time step." << std::endl;
+            return true;
         }
-        return true;
+        else
+        {
+            /* restart file found - fix output file created at restart */
+            restartFile.close();
+
+            if( outFile.is_open() )
+                outFile.close();
+
+            copy_file( src,
+                       dst,
+                       copy_option::overwrite_if_exists );
+
+            outFile.open( filename.c_str(), std::ofstream::out | std::ostream::app );
+            if( !outFile )
+            {
+                std::cerr << "[Plugin] Can't open file '" << filename
+                          << "', output disabled" << std::endl;
+                return false;
+            }
+            return true;
+        }
     }
 
     /** Checkpoints a txt file

--- a/src/picongpu/include/plugins/common/txtFileHandling.hpp
+++ b/src/picongpu/include/plugins/common/txtFileHandling.hpp
@@ -57,20 +57,18 @@ using namespace boost::filesystem;
         path dst( filename );
 
         /* check whether restart file exists */
-        std::ifstream restartFile(src.c_str());
-        if(! restartFile.good())
+        if( !boost::filesystem::exists( src ) )
         {
             /* restart file does not exists */
-            restartFile.close();
-            std::cerr << "Plugin restart file: \n \t" << src << "\n was not found." << std::endl;
-            std::cerr << "Starting plugin from current time step." << std::endl;
+            log<picLog::INPUT_OUTPUT> ("Plugin restart file:");
+            log<picLog::INPUT_OUTPUT> ("\t %1%") % src ;
+            log<picLog::INPUT_OUTPUT> ("was not found.");
+            log<picLog::INPUT_OUTPUT> ("--> Starting plugin from current time step.");
             return true;
         }
         else
         {
             /* restart file found - fix output file created at restart */
-            restartFile.close();
-
             if( outFile.is_open() )
                 outFile.close();
 


### PR DESCRIPTION
This pull request solves issue #702:
If we add plugin calls via command line after a restart, checkpoint files for the plugin do not exists thus crashing PIConGPU during the attempt to copy checkpoint files to output files.
This pull request now checks whether a checkpoint file exists. If it does, everthing is handled as before. If the required checkpoint file does not exist, a warning is printed and we just start with data output from the restart point. PIConGPU does not crash anymore.

**To Do:**
- [x] verify that this pull request solves the restart crash 
- [x] verify that standard restart still works
