### PR TITLE
Remove attribute chargeState, add boundElectrons

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -74,7 +74,7 @@ AttributRadiationFlag
 typedef
 typename MakeSeq<
 DefaultParticleAttributes,
-chargeState
+boundElectrons
 >::type AttributeSeqIons;
 
 /*########################### end particle attributes ########################*/

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -23,9 +23,11 @@
 #include "types.h"
 #include "particles/ionization/ionizationEnergies.param"
 #include "particles/traits/GetAtomicNumbers.hpp"
+#include "traits/attribute/GetChargeState.hpp"
 
 /** IONIZATION ALGORITHM 
  * - implements the calculation of ionization probability and changes charge states
+ *   by decreasing the number of bound electrons
  * - is called with the IONIZATION MODEL, specifically by setting the flag in @see speciesDefinition.param */
 
 namespace picongpu
@@ -55,12 +57,13 @@ namespace ionization
         {
 
             const float_X protonNumber = GetAtomicNumbers<ParticleType>::type::numberOfProtons;
+            float_X chargeState = attribute::getChargeState(parentIon);
             
             /* ionization condition */
-            if (math::abs(eField)*UNIT_EFIELD >= SI::IONIZATION_EFIELD && parentIon[chargeState_] < protonNumber)
+            if (math::abs(eField)*UNIT_EFIELD >= SI::IONIZATION_EFIELD && chargeState < protonNumber)
             {
                 /* set new particle charge state */
-                parentIon[chargeState_] += float_X(1.0);
+                parentIon[boundElectrons_] -= float_X(1.0);
             }
 
         }

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -96,8 +96,8 @@ struct IonizeParticlesPerFrame
         float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass(weighting,particle);
         
-        /* define charge state before ionization */
-        float_X prevChState = particle[chargeState_];
+        /* define number of bound macro electrons before ionization */
+        float_X prevBoundElectrons = particle[boundElectrons_];
  
         /* this is the point where actual ionization takes place */
         IonizeAlgo ionizeAlgo;
@@ -109,7 +109,7 @@ struct IonizeParticlesPerFrame
         particle[momentum_] = mom;
         particle[position_] = pos;
         /* determine number of new macro electrons to be created */
-        newMacroElectrons = particle[chargeState_] - prevChState;
+        newMacroElectrons = prevBoundElectrons - particle[boundElectrons_];
         /*calculate one dimensional cell index*/
         particle[localCellIdx_] = DataSpaceOperations<TVec::dim>::template map<TVec > (localCell);
     }

--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -62,7 +62,7 @@ namespace ionization
              * some attributes:
              * - multiMask: reading from global memory takes longer than just setting it again explicitly
              * - momentum: because the electron would get a higher energy because of the ion mass 
-             * - chargeState: because electrons cannot have a charge state other than 1 
+             * - boundElectrons: because species other than ions or atoms do not have them
              * (gets AUTOMATICALLY deselected because electrons do not have this attribute) */
             PMACC_AUTO(targetElectronClone, partOp::deselect<bmpl::vector2<multiMask, momentum> >(childElectron));
 

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -63,7 +63,7 @@ value_identifier(bool, radiationFlag, false);
  * 
  * \todo connect default to proton number
  */
-value_identifier(float_X,boundElectrons,float_X(2.0));
+value_identifier(float_X,boundElectrons,float_X(0.0));
 
 /** specialization global position inside a domain (relative to origin of the
  * moving window) and is loaded after all other param files)

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -55,13 +55,15 @@ value_identifier(float_X, weighting, 0.0);
 /** use this particle for radiation diagnostics */
 value_identifier(bool, radiationFlag, false);
 
-/** charge state of the particle
+/** number of electrons bound to the atom / ion
  *
  * value type is float_X to avoid casts during the runtime
- *
+ * - float is also reasonable because effective charge numbers are possible
  * - only reasonable for ion species if ionization is enabled 
- * - \todo calculate from new attribute boundElectrons */
-value_identifier(float_X,chargeState,float_X(1.0));
+ * 
+ * \todo connect default to proton number
+ */
+value_identifier(float_X,boundElectrons,float_X(2.0));
 
 /** specialization global position inside a domain (relative to origin of the
  * moving window) and is loaded after all other param files)

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -109,7 +109,7 @@ struct Unit<globalCellIdx<T_Type> >
 };
 
 template<>
-struct Unit<chargeState >
+struct Unit<boundElectrons>
 {
   static std::vector<double> get()
   {

--- a/src/picongpu/include/simulation_defines/unitless/speciesDefinition.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesDefinition.unitless
@@ -24,6 +24,7 @@
 #include "traits/frame/GetCharge.hpp"
 #include "traits/frame/GetMass.hpp"
 #include "traits/attribute/GetCharge.hpp"
+#include "traits/attribute/GetChargeState.hpp"
 #include "traits/attribute/GetMass.hpp"
 #include "fields/currentDeposition/Solver.hpp"
 #include "particles/Particles.tpp"

--- a/src/picongpu/include/traits/attribute/GetCharge.hpp
+++ b/src/picongpu/include/traits/attribute/GetCharge.hpp
@@ -38,32 +38,50 @@ namespace detail
  *
  * use attribute `boundElectrons` and the proton number from 
  * flag `atomicNumbers` to calculate the charge
+ * 
+ * \tparam T_HasBoundElectrons boolean that describes if species allows multiple charge states
+ * due to bound electrons
  */
 template<bool T_HasBoundElectrons>
 struct LoadBoundElectrons
 {
-
+    /** Functor implementation 
+     * 
+     * \tparam T_Particle particle type
+     * \param singlyChargedResult charge resulting from multiplying a single 
+     * electron charge (positive OR negative) by the macro particle weighting
+     * \param particle particle reference
+     */
     template<typename T_Particle>
-    HDINLINE float_X operator()(const float_X partialResult, const T_Particle& particle)
+    HDINLINE float_X operator()(const float_X singlyChargedResult, const T_Particle& particle)
     {
         const float_X protonNumber = GetAtomicNumbers<T_Particle>::type::numberOfProtons;
         
-        return partialResult * (protonNumber - particle[boundElectrons_]);
+        return singlyChargedResult * (protonNumber - particle[boundElectrons_]);
     }
 };
 
 /**  Calculate the real charge of a particle
  *
  * This is the fallback implementation if no `boundElectrons` are available for a particle
+ * 
+ * \tparam T_HasBoundElectrons boolean that describes if species allows multiple charge states
+ * due to bound electrons
  */
 template<>
 struct LoadBoundElectrons<false>
 {
-
+    /** Functor implementation 
+     * 
+     * \tparam T_Particle particle type
+     * \param singlyChargedResult charge resulting from multiplying a single 
+     * electron charge (positive OR negative) by the macro particle weighting
+     * \param particle particle reference
+     */
     template<typename T_Particle>
-    HDINLINE float_X operator()(const float_X partialResult, const T_Particle& particle)
+    HDINLINE float_X operator()(const float_X singlyChargedResult, const T_Particle& particle)
     {
-        return partialResult;
+        return singlyChargedResult;
     }
 };
 } // namespace detail

--- a/src/picongpu/include/traits/attribute/GetChargeState.hpp
+++ b/src/picongpu/include/traits/attribute/GetChargeState.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -41,7 +41,10 @@ namespace detail
 template<bool T_HasBoundElectrons>
 struct LoadChargeState
 {
-
+    /** Functor implementation
+     * 
+     * \return chargeState = number of electrons in neutral atom - number of currently bound electrons
+     */
     template<typename T_Particle>
     HDINLINE float_X operator()(const T_Particle& particle)
     {
@@ -52,7 +55,8 @@ struct LoadChargeState
 
 /**  Calculate charge state of an atom / ion
  *
- * This is the fallback implementation if no `boundElectrons` are available for a particle
+ * This is the fallback implementation to throw an error if no `boundElectrons` 
+ * are available for a species.
  */
 template<>
 struct LoadChargeState<false>
@@ -61,7 +65,7 @@ struct LoadChargeState<false>
     template<typename T_Particle>
     HDINLINE void operator()(const T_Particle& particle)
     {
-        PMACC_CASSERT_MSG(This_species_has_no_different_charge_states,1==2);
+        PMACC_CASSERT_MSG(This_species_has_only_one_charge_state,1==2);
     }
 };
 } // namespace detail
@@ -69,7 +73,7 @@ struct LoadChargeState<false>
 /** get the charge state of a macro particle
  *
  * This function trait considers the `boundElectrons` attribute if it is set. 
- * Charge states do not add up and also the different particles in a macro particle 
+ * Charge states do not add up and also the various particles in a macro particle 
  * do NOT have different charge states where one would average over them.
  *
  * @param particle a reference to a particle


### PR DESCRIPTION
In this PR the following has been refactored:
- remove attribute `chargeState`, add `boundElectrons`
- add trait `GetChargeState.hpp`
- replace all uses of `chargeState` with `boundElectrons`