### PR TITLE
add phase to all laser implementations

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -176,6 +176,8 @@ const double PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
 const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+const double laser_phase = 0.0;
 
 enum PolarisationType
   {

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -72,6 +72,9 @@ const double FOCUS_POS_SI = 4.62e-5;
  *  unit: none */
 const double PULSE_INIT = 20.0;
 
+/* laser phase shift (no shift: 0.0) */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
 enum PolarisationType
 {
     LINEAR_X = 1u,

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -126,6 +126,9 @@ const double TILT_X_SI = 0;
 *  unit: none */
 const double PULSE_INIT = 20.0;
 
+/* laser phase shift (no shift: 0.0) */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
 enum PolarisationType
 {
 LINEAR_X = 1u,

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -179,6 +179,7 @@ const double PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
 const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
 const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Anton Helm, Richard Pausch
+ * Copyright 2013-2015 Anton Helm, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -177,7 +177,7 @@ const double PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741
  *  unit: none */
 const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-const double laser_phase = 0.0;
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
   {

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -248,6 +248,9 @@ and half at the end of the plateau
  *  unit: none */
 const double RAMP_INIT = 20.0;
 
+/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
 enum PolarisationType
 {
     LINEAR_X = 1u,

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -297,6 +297,9 @@ const double PULSE_LENGTH_SI = 4.0e-15;
 const double W0x_SI = 4.246e-6; // waist in x-direction 
 const double W0z_SI = W0x_SI; // waist in z-direction
 }
+
+/* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 }
 
 namespace laserNone

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -71,7 +71,10 @@ namespace picongpu
         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
          *  unit: none */
         const double PULSE_INIT = 15.0;
-        
+
+        /* laser phase shift (no shift: 0.0) */
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
         enum PolarisationType
         {
             LINEAR_X = 1u,

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -179,6 +179,7 @@ namespace picongpu
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
         const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
         const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -249,6 +249,9 @@ namespace picongpu
          *  unit: none */
         const double RAMP_INIT = 20.0;
 
+        /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
         enum PolarisationType
         {
             LINEAR_X = 1u,

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -298,6 +298,9 @@ namespace picongpu
 	    const double W0x_SI = 4.246e-6; // waist in x-direction 
    	    const double W0z_SI = W0x_SI;   // waist in z-direction
         }
+
+        /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
     }
 
     namespace laserNone

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -126,6 +126,9 @@ namespace picongpu
          *  unit: none */
         const double PULSE_INIT = 20.0;
 
+        /* laser phase shift (no shift: 0.0) */
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
         enum PolarisationType
         {
             LINEAR_X = 1u,

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -176,6 +176,8 @@ namespace picongpu
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
         const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+        /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+        const double laser_phase = 0.0;
 
         enum PolarisationType
         {

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -177,7 +177,7 @@ namespace picongpu
          *  unit: none */
         const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-        const double laser_phase = 0.0;
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -308,6 +308,9 @@ const double PULSE_LENGTH_SI = 4.0e-15;
 const double W0x_SI = 4.246e-6; // waist in x-direction 
 const double W0z_SI = W0x_SI; // waist in z-direction
 }
+
+/* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 }
 
 namespace laserNone

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -187,6 +187,8 @@ const double PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
 const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+const double laser_phase = 0.0;
 
 enum PolarisationType
   {

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -72,6 +72,9 @@ const double FOCUS_POS_SI = 4.62e-5;
  *  unit: none */
 const double PULSE_INIT = 20.0;
 
+/* laser phase shift (no shift: 0.0) */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
 enum PolarisationType
 {
     LINEAR_X = 1u,

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -190,6 +190,7 @@ const double PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
 const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
 const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -188,7 +188,7 @@ const double PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741
  *  unit: none */
 const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-const double laser_phase = 0.0;
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
   {

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -137,6 +137,9 @@ const double TILT_X_SI = 0;
 *  unit: none */
 const double PULSE_INIT = 20.0;
 
+/* laser phase shift (no shift: 0.0) */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
 enum PolarisationType
 {
     LINEAR_X = 1u,

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -259,6 +259,9 @@ const double W0_Z_SI = W0_X_SI;
  *  unit: none */
 const double RAMP_INIT = 20.0;
 
+/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
 enum PolarisationType
 {
     LINEAR_X = 1u,

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -74,7 +74,7 @@ namespace picongpu
                 elong.z() = float_X( envelope / sqrt(2.0) );
             }
 
-            phase = 2.0f * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - FOCUS_POS / SPEED_OF_LIGHT );
+            phase = 2.0f * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - FOCUS_POS / SPEED_OF_LIGHT) + LASER_PHASE;
 
             return elong;
         }

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -77,16 +77,16 @@ namespace picongpu
 
             if( Polarisation == LINEAR_X )
             {
-                elong.x() = float_X( envelope * math::sin( w * runTime ));
+                elong.x() = float_X( envelope * math::sin( w * runTime + LASER_PHASE));
             }
             else if( Polarisation == LINEAR_Z)
             {
-                elong.z() = float_X( envelope * math::sin( w * runTime ));
+                elong.z() = float_X( envelope * math::sin( w * runTime + LASER_PHASE));
             }
             else if( Polarisation == CIRCULAR )
             {
-                elong.x() = float_X( envelope / sqrt(2.0)  * math::sin( w * runTime ));
-                elong.z() = float_X( envelope / sqrt(2.0)  * math::cos( w * runTime ));
+                elong.x() = float_X( envelope / sqrt(2.0)  * math::sin( w * runTime + LASER_PHASE));
+                elong.z() = float_X( envelope / sqrt(2.0)  * math::cos( w * runTime + LASER_PHASE));
             }
 
 

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -75,18 +75,19 @@ namespace picongpu
 
             }
 
+            const double timeOszi = runTime - endUpramp;
             if( Polarisation == LINEAR_X )
             {
-                elong.x() = float_X( envelope * math::sin( w * runTime + LASER_PHASE));
+                elong.x() = float_X( envelope * math::sin( w * timeOszi + LASER_PHASE));
             }
             else if( Polarisation == LINEAR_Z)
             {
-                elong.z() = float_X( envelope * math::sin( w * runTime + LASER_PHASE));
+                elong.z() = float_X( envelope * math::sin( w * timeOszi + LASER_PHASE));
             }
             else if( Polarisation == CIRCULAR )
             {
-                elong.x() = float_X( envelope / sqrt(2.0)  * math::sin( w * runTime + LASER_PHASE));
-                elong.z() = float_X( envelope / sqrt(2.0)  * math::cos( w * runTime + LASER_PHASE));
+                elong.x() = float_X( envelope / sqrt(2.0)  * math::sin( w * timeOszi + LASER_PHASE));
+                elong.z() = float_X( envelope / sqrt(2.0)  * math::cos( w * timeOszi + LASER_PHASE));
             }
 
 

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -59,7 +59,7 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
     elong.x() = float_X(
                        float_64(AMPLITUDE) *
                        Tpolynomial(tau)
-                       * math::sin(omegaLaser * (runTime - T_rise))
+                       * math::sin(omegaLaser * (runTime - T_rise) + LASER_PHASE)
                        );
 
     phase = 0.0f;

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -59,7 +59,7 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
     elong.x() = float_X(
                        float_64(AMPLITUDE) *
                        Tpolynomial(tau)
-                       * math::sin(omegaLaser * (runTime - T_rise) + LASER_PHASE)
+                       * math::sin(omegaLaser * (runTime - T_rise) + float_64(LASER_PHASE))
                        );
 
     phase = 0.0f;

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Anton Helm, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -74,7 +74,7 @@ namespace picongpu
                 elong.z() = float_X( envelope / sqrt(2.0) );
             }
 
-            phase = 2.0f * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - FOCUS_POS / SPEED_OF_LIGHT );
+            phase = 2.0f * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - FOCUS_POS / SPEED_OF_LIGHT ) + LASER_PHASE;
 
             return elong;
         }

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -72,7 +72,7 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
         envelope *= math::exp(-0.5 * exponent * exponent);
     }
 
-    phase = float_X(w * runTime + LASER_PHASE);
+    phase += float_X(w * runTime) + LASER_PHASE;
 
     if( Polarisation == LINEAR_X )
     {

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -72,22 +72,21 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
         envelope *= math::exp(-0.5 * exponent * exponent);
     }
 
+    phase = float_X(w * runTime + LASER_PHASE);
+
     if( Polarisation == LINEAR_X )
     {
-        elong.x() = envelope * math::sin(w * runTime);
+        elong.x() = envelope * math::sin(phase);
     }
     else if( Polarisation == LINEAR_Z )
     {
-        elong.z() = envelope * math::sin(w * runTime);
+        elong.z() = envelope * math::sin(phase);
     }
     else if( Polarisation == CIRCULAR )
     {
-        elong.x() = envelope / sqrt(2.0) * math::sin(w * runTime);
-        elong.z() = envelope / sqrt(2.0) * math::cos(w * runTime);
+        elong.x() = envelope / sqrt(2.0) * math::sin(phase);
+        elong.z() = envelope / sqrt(2.0) * math::cos(phase);
     }
-
-
-    phase = float_X(0.0);
 
     return elong;
 }

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -179,6 +179,7 @@ namespace picongpu
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
         const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
         const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -298,6 +298,9 @@ namespace picongpu
             const double W0x_SI = 4.246e-6; // waist in x-direction
             const double W0z_SI = W0x_SI; // waist in z-direction
         }
+
+        /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
     }
 
     namespace laserNone

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -68,9 +68,12 @@ namespace picongpu
              *  unit: meter */
             const double FOCUS_POS_SI = 4.62e-5;
         }
-    /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
-     *  unit: none */
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+         *  unit: none */
         const double PULSE_INIT = 20.0;
+
+        /* laser phase shift (no shift: 0.0) */
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -249,6 +249,9 @@ namespace picongpu
      *  unit: none */
     const double RAMP_INIT = 20.0;
 
+    /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+    const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
     enum PolarisationType
     {
         LINEAR_X = 1u,

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -176,6 +176,8 @@ namespace picongpu
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
         const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+        /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+        const double laser_phase = 0.0;
 
         enum PolarisationType
         {

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -126,6 +126,9 @@ namespace picongpu
         *  unit: none */
         const double PULSE_INIT = 20.0;
 
+        /* laser phase shift (no shift: 0.0) */
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
         enum PolarisationType
         {
             LINEAR_X = 1u,

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -177,7 +177,7 @@ namespace picongpu
          *  unit: none */
         const double RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-        const double laser_phase = 0.0;
+        const float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {

--- a/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
@@ -57,7 +57,6 @@ namespace picongpu
         const float_X LASER_NOFOCUS_CONSTANT = float_X (SI::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); //unit: seconds
         const float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
         const float_X INIT_TIME = float_X ((RAMP_INIT*SI::PULSE_LENGTH_SI + SI::LASER_NOFOCUS_CONSTANT_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
-        const float_X LASER_PHASE = float_X(laser_phase); // unit: None
     }
 
     namespace laserWavepacket

--- a/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
@@ -57,6 +57,7 @@ namespace picongpu
         const float_X LASER_NOFOCUS_CONSTANT = float_X (SI::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); //unit: seconds
         const float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
         const float_X INIT_TIME = float_X ((RAMP_INIT*SI::PULSE_LENGTH_SI + SI::LASER_NOFOCUS_CONSTANT_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
+        const float_X LASER_PHASE = float_X(laser_phase); // unit: None
     }
 
     namespace laserWavepacket


### PR DESCRIPTION
This pull request adds a **phase** to **all laser** implementation thus allowing to run simulations suggested by @ssstuvz.

**ToDo:**
check if setting phase works for:
 - [x] laserGaussianBeam
 - [x] laserPlaneWave
 - [x] laserPolynom
 - [x] laserPulseFrontTilt
 - [x] laserWavepacket

@ax3l:
This pull request adjusts:
- `laserConfig.unitless`
- `laserConfig.param`

and thus needs an entry to the `CHANGELOG.md` after it is merged to `master`.
