### PR TITLE
add threshold radiation gamma to params 

### DIFF
--- a/examples/WeibelTransverse/include/simulation_defines/param/physicalConstants.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/physicalConstants.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013, 2015 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 
@@ -30,7 +30,12 @@ namespace picongpu
      *  high-precision formulas for relativistic and non-relativistic
      *  use-cases, e.g. energy-binning algorithms. */
     const float_X GAMMA_THRESH = float_X(1.005);
-    /* with 0.18 the relativ error will be below 0.001% for Taylor series of order 5 */
+
+    /** This limit is used to decide between a pure 1-sqrt(1-x) calculation 
+     *  and a 5th order Taylor approximation of 1-sqrt(1-x) to avoid halving
+     *  of significant digits due to the sqrt() evaluation at x = 1/gamma^2 near 0.0.
+     *  With 0.18 the relative error between Taylor approximation and real value
+     *  will be below 0.001% = 1e-5 * for x=1/gamma^2 < 0.18 */
     const float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
 
     namespace SI

--- a/examples/WeibelTransverse/include/simulation_defines/param/physicalConstants.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/physicalConstants.param
@@ -30,6 +30,8 @@ namespace picongpu
      *  high-precision formulas for relativistic and non-relativistic
      *  use-cases, e.g. energy-binning algorithms. */
     const float_X GAMMA_THRESH = float_X(1.005);
+    /* with 0.18 the relativ error will be below 0.001% for Taylor series of order 5 */
+    const float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
 
     namespace SI
     {

--- a/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -60,9 +60,9 @@ struct One_minus_beta_times_n
         // chose a Taylor approximation to to better calculate 1-\beta \times \vec n (which is close to 1-1)
         // is energy is low, then the Appriximation will acuse a larger error, therfor calculate
         // 1-\beta \times \vec n directly
-        if (gamma_inv_square < picongpu::GAMMA_INV_SQUARE_RAD_THRESH) // with 0.18 the relativ error will be below 0.001% for Taylor series of order 5
+        // with 0.18 the relativ error will be below 0.001% for a Taylor series of 1-sqrt(1-x) of 5th order
+        if (gamma_inv_square < picongpu::GAMMA_INV_SQUARE_RAD_THRESH) 
         {
-
             const numtype2 cos_theta(particle.get_cos_theta<When::now > (n)); // cosinus between looking vector and momentum of particle
             const numtype2 taylor_approx(cos_theta * Taylor()(gamma_inv_square) + (1.0 - cos_theta));
             return  (taylor_approx);

--- a/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
@@ -60,7 +60,7 @@ struct One_minus_beta_times_n
         // chose a Taylor approximation to to better calculate 1-\beta \times \vec n (which is close to 1-1)
         // is energy is low, then the Appriximation will acuse a larger error, therfor calculate
         // 1-\beta \times \vec n directly
-        if (gamma_inv_square < 0.18) // with 0.18 the relativ error will be below 0.001% for Taylor series of order 5
+        if (gamma_inv_square < picongpu::GAMMA_INV_SQUARE_RAD_THRESH) // with 0.18 the relativ error will be below 0.001% for Taylor series of order 5
         {
 
             const numtype2 cos_theta(particle.get_cos_theta<When::now > (n)); // cosinus between looking vector and momentum of particle

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -30,6 +30,8 @@ namespace picongpu
      *  high-precision formulas for relativistic and non-relativistic
      *  use-cases, e.g. energy-binning algorithms. */
     const float_X GAMMA_THRESH = float_X(1.005);
+    /* with 0.18 the relativ error will be below 0.001% for Taylor series of order 5 */
+    const float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
 
     namespace SI
     {

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -30,7 +30,12 @@ namespace picongpu
      *  high-precision formulas for relativistic and non-relativistic
      *  use-cases, e.g. energy-binning algorithms. */
     const float_X GAMMA_THRESH = float_X(1.005);
-    /* with 0.18 the relativ error will be below 0.001% for Taylor series of order 5 */
+
+    /** This limit is used to decide between a pure 1-sqrt(1-x) calculation 
+     *  and a 5th order Taylor approximation of 1-sqrt(1-x) to avoid halving
+     *  of significant digits due to the sqrt() evaluation at x = 1/gamma^2 near 0.0.
+     *  With 0.18 the relative error between Taylor approximation and real value
+     *  will be below 0.001% = 1e-5 * for x=1/gamma^2 < 0.18 */
     const float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
 
     namespace SI


### PR DESCRIPTION
This pull requests moves the threshold *magic number* used in `calc_amplitude.hpp` to `physicsConstants.param` where we started to store numerical thresholds since #669.

