### PR TITLE
Close #707 Document Unit Trait for Plain Numbers

### DIFF
--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -34,90 +34,93 @@ namespace traits
 template<typename T_Type>
 struct Unit<position<T_Type> >
 {
-  static std::vector<double> get()
-  {
-      std::vector<double> unit(simDim);
-      /* in-cell position needs two transformations to get to SI:
-         in-cell [0;1) -> dimensionless scaling to grid -> SI*/
-      for(uint32_t i=0;i<simDim;++i)
-        unit[i]=cellSize[i]*UNIT_LENGTH;
+    static std::vector<double> get()
+    {
+        std::vector<double> unit(simDim);
+        /* in-cell position needs two transformations to get to SI:
+           in-cell [0;1) -> dimensionless scaling to grid -> SI */
+        for(uint32_t i=0;i<simDim;++i)
+            unit[i]=cellSize[i]*UNIT_LENGTH;
 
-      return unit;
-  }
+        return unit;
+    }
 };
 
 template<>
 struct Unit<radiationFlag>
 {
-  static std::vector<double> get()
-  {
-      std::vector<double> unit;
-      return unit;
-  }
+    /* zero-sized vector indicating unitless flag for hdf5 and adios output */
+    static std::vector<double> get()
+    {
+        std::vector<double> unit;
+        return unit;
+    }
 };
 
 template<>
 struct Unit<momentum >
 {
-  static std::vector<double> get()
-  {
-      const uint32_t components = GetNComponents<typename momentum::type>::value;
+    static std::vector<double> get()
+    {
+        const uint32_t components = GetNComponents<typename momentum::type>::value;
 
-      std::vector<double> unit(components);
-      for(uint32_t i=0;i<components;++i)
-        unit[i]=UNIT_MASS*UNIT_SPEED;
+        std::vector<double> unit(components);
+        for(uint32_t i=0;i<components;++i)
+            unit[i]=UNIT_MASS*UNIT_SPEED;
 
-      return unit;
-  }
+        return unit;
+    }
 };
 
 template<>
 struct Unit<momentumPrev1>
 {
-  static std::vector<double> get()
-  {
-      const uint32_t components = GetNComponents<typename momentumPrev1::type>::value;
+    static std::vector<double> get()
+    {
+        const uint32_t components = GetNComponents<typename momentumPrev1::type>::value;
 
-      std::vector<double> unit(components);
-      for(uint32_t i=0;i<components;++i)
-        unit[i]=UNIT_MASS*UNIT_SPEED;
+        std::vector<double> unit(components);
+        for(uint32_t i=0;i<components;++i)
+            unit[i]=UNIT_MASS*UNIT_SPEED;
 
-      return unit;
-  }
+        return unit;
+    }
 };
 
 template<>
 struct Unit<weighting >
 {
-  static std::vector<double> get()
-  {
-      std::vector<double> unit;
-      return unit;
-  }
+    /* zero-sized vector indicating unitless flag for hdf5 and adios output */
+    static std::vector<double> get()
+    {
+        std::vector<double> unit;
+        return unit;
+    }
 };
 
 template<typename T_Type>
 struct Unit<globalCellIdx<T_Type> >
 {
-  static std::vector<double> get()
-  {
-      std::vector<double> unit(simDim);
-      for(uint32_t i=0;i<simDim;++i)
-        unit[i]=1.0;
-      return unit;
-  }
+    static std::vector<double> get()
+    {
+        std::vector<double> unit(simDim);
+        for(uint32_t i=0;i<simDim;++i)
+            unit[i]=1.0;
+        return unit;
+    }
 };
 
 template<>
 struct Unit<boundElectrons>
 {
-  static std::vector<double> get()
-  {
-      std::vector<double> unit;
-      return unit;
-  }
+    /* zero-sized vector indicating unitless flag for hdf5 and adios output */
+    static std::vector<double> get()
+    {
+        std::vector<double> unit;
+        return unit;
+    }
 };
 
 
-}//namespace traits
+} //namespace traits
 } //namespace picongpu

--- a/src/picongpu/include/traits/Unit.hpp
+++ b/src/picongpu/include/traits/Unit.hpp
@@ -30,7 +30,10 @@ namespace traits
     /** Get unit of date which are represented by a identifier
      *
      * \tparam T_Identifier any picongpu identifier
-     * \return \p std::vector<double> ::get() as static public methode
+     * \return \p std::vector<double> ::get() as static public method
+     * 
+     * a zero-size vector with no specified unit is valid for unitless items
+     * \see simulation_defines/unitless/speciesAttributes.unitless
      */
     template<typename T_Identifier>
     struct Unit;


### PR DESCRIPTION
Is this small change how the comments on the unitless flags should look like and should the other ones also get more comments? 

I also changed the indents from 2 spaces to our 4 space standard. Was that correct?