### PR TITLE
Fix #719 Restart HDF5: Avoid 32bit Downcast

### DIFF
--- a/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
@@ -62,8 +62,8 @@ struct LoadParticleAttributesFromHDF5
                             ThreadParams* params,
                             FrameType& frame,
                             const std::string subGroup,
-                            const size_t particlesOffset,
-                            const size_t elements)
+                            const uint64_t particlesOffset,
+                            const uint64_t elements)
     {
 
         typedef T_Identifier Identifier;


### PR DESCRIPTION
- `particlesOffset` are element offsets in the *global* particle attribute array (that can be more than `uint32_t` / `size_t`)
- `elements` are promoted to `uint64_t` too for convenience
- very similar to the unholy #666 bug