### PR TITLE
blocking/sync_kernel: getLastError

### DIFF
--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -47,9 +47,10 @@ namespace PMacc
  *  and after activation.
  */
 #define PMACC_ACTIVATE_KERNEL                                                           \
-        CUDA_CHECK_KERNEL_MSG(cudaThreadSynchronize(),"Crash after kernel call");       \
+        CUDA_CHECK_KERNEL_MSG(cudaGetLastError( ),"Last error after kernel launch");    \
+        CUDA_CHECK_KERNEL_MSG(cudaThreadSynchronize(),"Crash after kernel launch");     \
         taskKernel->activateChecks();                                                   \
-        CUDA_CHECK_KERNEL_MSG(cudaThreadSynchronize(),"Crash after kernel activation"); \
+        CUDA_CHECK_KERNEL_MSG(cudaThreadSynchronize(),"Crash after kernel activation");
 
 /**
  * Appends kernel arguments to generated code and activates kernel task.


### PR DESCRIPTION
I found `PMACC_BLOCKING_KERNEL` to be way more useful when adding that line.

Probably it should be added above with `CUDA_CHECK_KERNEL_MSG` instead but this pull is a reminder that useful CUDA error message may not be delivered directly but only at the end of the sim.


Example:

```
picongpu/include/fields/FieldJ.tpp>:247
[1,0]<stderr>:terminate called after throwing an instance of
'std::runtime_error'
[1,0]<stderr>:  what():  [CUDA] Error: too many resources requested for
launch
```
-> btw: the `FieldJ` error can not be reproduced by me or @psychocoderHPC any more. so no need to open an issue.