### PR TITLE
Fix LWFA Example: Keep Hydrogen

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -115,10 +115,10 @@ typedef Particles<ParticleDescription<
  * Do not forget to set the correct mass of the atom in 
  * @see physicalConstants.param !
  */
-struct Helium
+struct Hydrogen
 {
-    static const float_X numberOfProtons  = 2.0;
-    static const float_X numberOfNeutrons = 2.0;
+    static const float_X numberOfProtons  = 1.0;
+    static const float_X numberOfNeutrons = 0.0;
 };
 
 /*! Ionization Model Configuration ----------------------------------------
@@ -141,7 +141,7 @@ typedef bmpl::vector<
     #if(PARAM_IONIZATION == 1)
     ionizer<particles::ionization::BSI<PIC_Electrons> >,
     #endif
-    atomicNumbers<Helium>
+    atomicNumbers<Hydrogen>
 > ParticleFlagsIons;
 
 /* define species: ions */


### PR DESCRIPTION
In #687 I did not prevent the introduction of ~~Hydrogen~~"Helium" for the LWFA example.

That is actually wrong so far, since correct ~~hydrogen~~helium would require to increase either the number of initialized electrons or their weighting. Also, the constants in `physicalConstants.param` do not agree for that species.

So far, the proton/neutron number is only an attribute - partly used for the BSI models - but it should be still consistent for each example.