### PR TITLE
Radiation Plugin: add unit as attribute to HDF5

### DIFF
--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -551,6 +551,10 @@ private:
 
       splash::Dimensions stride(Amplitude::numComponents,1,1);
 
+      /* get the radiation amplitude unit */
+      Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
+      const numtype2 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
+
       for(uint ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
       {
           splash::Dimensions offset(ampIndex,0,0);
@@ -559,21 +563,28 @@ private:
                                           offset,
                                           stride);
 
+          /* save data for each x/y/z * Re/Im amplitude */
           HDF5dataFile.write(currentStep,
                              radSplashType,
                              3,
                              dataSelection,
                              dataLabels(ampIndex).c_str(),
                              values);
+
+          /* save SI unit as attribute together with data set */
+          HDF5dataFile.writeAttribute(currentStep,
+                                      radSplashType,
+                                      dataLabels(ampIndex).c_str(),
+                                      "unitSI",
+                                      &factor);
       }
 
-      /* get the radiation amplitude unit */ 
-      Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
-      const numtype2 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
-
-      /* save unit in /custom as attribute */
-      const std::string unit = "unit_radiation";
-      HDF5dataFile.writeGlobalAttribute(radSplashType, unit.c_str(), &factor);
+      /* save SI unit as attribute in the Amplitude group (for convenience) */
+      HDF5dataFile.writeAttribute(currentStep,
+                                  radSplashType,
+                                  "Amplitude",
+                                  "unitSI",
+                                  &factor);
 
       HDF5dataFile.close();
     }

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -567,12 +567,15 @@ private:
                              values);
       }
 
-      HDF5dataFile.close();
-
-      /* TODO: will become atribute in HDF5 file later */
+      /* get the radiation amplitude unit */ 
       Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
       const numtype2 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
-      std::cout << "Factor to radiation intensities: " << factor << std::endl;
+
+      /* save unit in /custom as attribute */
+      const std::string unit = "unit_radiation";
+      HDF5dataFile.writeGlobalAttribute(radSplashType, unit.c_str(), &factor);
+
+      HDF5dataFile.close();
     }
 
 


### PR DESCRIPTION
This pull requests removes the text based unit output of the radiation plugin and adds the unit conversion factor as hdf5 attribute.
The attribute is stored in `/custom`.

- [x]  tested with simulation

