### PR TITLE
Definition of Insitu<Plugin> class and use in MySimulation class

### DIFF
--- a/src/picongpu/include/plugins/InsituBinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/InsituBinEnergyParticles.hpp
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2013-2015 Anshuman Goswami
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+
+#include "types.h"
+#include "simulation_defines.hpp"
+#include "simulation_types.hpp"
+#include "basicOperations.hpp"
+#include "dimensions/DataSpace.hpp"
+
+#include "simulation_classTypes.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "plugins/ISimulationPlugin.hpp"
+
+#include "mpi/reduceMethods/Reduce.hpp"
+#include "mpi/MPIReduce.hpp"
+#include "nvidia/functors/Add.hpp"
+
+#include "algorithms/Gamma.hpp"
+
+#include <boost/filesystem.hpp>
+
+namespace picongpu
+{
+using namespace PMacc;
+using namespace boost::filesystem;
+
+namespace po = boost::program_options;
+
+template<class ParticlesType>
+class InsituBinEnergyParticles : public ISimulationPlugin
+{
+private:
+
+    typedef MappingDesc::SuperCellSize SuperCellSize;
+
+    ParticlesType *particles;
+
+    double *gBins; //This is now on host memory, so not a GridBuffer
+    MappingDesc *cellDescription;
+
+    double * binReduced;
+
+    int numBins;
+    int realNumBins;
+
+    mpi::MPIReduce reduce;
+
+public:
+
+    InsituBinEnergyParticles() :
+    particles(NULL),
+    gBins(NULL),
+    cellDescription(NULL)
+    {
+    }
+
+    virtual ~InsituBinEnergyParticles()
+    {
+
+    }
+
+    void load()
+    {
+       pluginLoad();
+    }
+
+    void unload()
+    {
+       pluginUnload();
+    }
+
+    void notify(uint32_t currentStep)
+    {
+        DataConnector &dc = Environment<>::get().DataConnector();
+        particles = &(dc.getData<ParticlesType > (ParticlesType::FrameType::getName(), true));
+
+	//Serialize superCells
+
+	//frames
+
+        //Submit serialized particle data to the transport library
+    }
+
+    void pluginRegisterHelp(po::options_description& desc)
+    {
+	//No cmdline interface now
+    }
+
+    std::string pluginGetName() const
+    {
+        return NULL;
+    }
+
+    void setMappingDescription(MappingDesc *cellDescription)
+    {
+        this->cellDescription = cellDescription;
+    }
+
+    void pluginLoad()
+    {
+            realNumBins = numBins + 2;
+
+	    gBins = new double[realNumBins];
+	    binReduced = new double[realNumBins];
+	    for (int i = 0; i < realNumBins; ++i)
+	    {
+		    binReduced[i] = 0.0;
+	    }
+	    //Also setup transport library
+    }
+
+    void pluginUnload()
+    {
+	    __delete(gBins);
+	    __deleteArray(binReduced);
+	    //Also teardown transport library
+    }
+
+    void restart(uint32_t restartStep, const std::string restartDirectory)
+    {
+	//Not implemented
+    }
+
+    void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
+    {
+	//Not implemented
+    }
+
+    //calBinEnergyParticles is now run in a different address space
+};
+
+}

--- a/src/picongpu/include/plugins/InsituBinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/InsituBinEnergyParticles.hpp
@@ -57,26 +57,15 @@ class InsituBinEnergyParticles : public ISimulationPlugin
 {
 private:
 
-    typedef MappingDesc::SuperCellSize SuperCellSize;
-
     ParticlesType *particles;
-
-    double *gBins; //This is now on host memory, so not a GridBuffer
-    MappingDesc *cellDescription;
-
-    double * binReduced;
 
     int numBins;
     int realNumBins;
-
-    mpi::MPIReduce reduce;
 
 public:
 
     InsituBinEnergyParticles() :
     particles(NULL),
-    gBins(NULL),
-    cellDescription(NULL)
     {
     }
 
@@ -85,24 +74,12 @@ public:
 
     }
 
-    void load()
-    {
-       pluginLoad();
-    }
-
-    void unload()
-    {
-       pluginUnload();
-    }
-
     void notify(uint32_t currentStep)
     {
         DataConnector &dc = Environment<>::get().DataConnector();
         particles = &(dc.getData<ParticlesType > (ParticlesType::FrameType::getName(), true));
 
-	//Serialize superCells
-
-	//frames
+	//Serialize particles::superCells
 
         //Submit serialized particle data to the transport library
     }
@@ -117,28 +94,13 @@ public:
         return NULL;
     }
 
-    void setMappingDescription(MappingDesc *cellDescription)
-    {
-        this->cellDescription = cellDescription;
-    }
-
     void pluginLoad()
     {
-            realNumBins = numBins + 2;
-
-	    gBins = new double[realNumBins];
-	    binReduced = new double[realNumBins];
-	    for (int i = 0; i < realNumBins; ++i)
-	    {
-		    binReduced[i] = 0.0;
-	    }
 	    //Also setup transport library
     }
 
     void pluginUnload()
     {
-	    __delete(gBins);
-	    __deleteArray(binReduced);
 	    //Also teardown transport library
     }
 

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -33,6 +33,7 @@
 #include "plugins/SumCurrents.hpp"
 #include "plugins/PositionsParticles.hpp"
 #include "plugins/BinEnergyParticles.hpp"
+#include "plugins/InsituBinEnergyParticles.hpp"
 #if(ENABLE_HDF5 == 1)
 #include "plugins/PhaseSpace/PhaseSpaceMulti.hpp"
 #endif
@@ -137,6 +138,7 @@ private:
     typedef EnergyParticles<PIC_Electrons> EnergyElectrons;
     typedef PositionsParticles<PIC_Electrons> PositionElectrons;
     typedef BinEnergyParticles<PIC_Electrons> BinEnergyElectrons;
+    typedef InsituBinEnergyParticles<PIC_Electrons> InsituBinEnergyElectrons;
 #if(ENABLE_RADIATION == 1)
     typedef Radiation<PIC_Electrons> RadiationElectrons;
 #endif
@@ -157,6 +159,7 @@ private:
     typedef CountParticles<PIC_Ions> IonCounter;
     typedef EnergyParticles<PIC_Ions> EnergyIons;
     typedef BinEnergyParticles<PIC_Ions> BinEnergyIons;
+    typedef InsituBinEnergyParticles<PIC_Ions> InsituBinEnergyIons;
 #endif
 
 #if (ENABLE_HDF5 == 1)
@@ -210,6 +213,7 @@ private:
 #endif
         plugins.push_back(new BinDensityElectrons("BinDensityElectrons", "binDensity_e"));
         plugins.push_back(new BinEnergyElectrons("BinEnergyElectrons", "bin_e"));
+        plugins.push_back(new InsituBinEnergyElectrons("InsituBinEnergyElectrons", "insitu_bin_e"));
         plugins.push_back(new ElectronCounter("ElectronsCount", "elec_cnt"));
         plugins.push_back(new EnergyElectrons("EnergyElectrons", "energy_e"));
         plugins.push_back(new PositionElectrons("PositionsElectrons", "pos_e"));
@@ -225,6 +229,7 @@ private:
 #endif
         plugins.push_back(new BinDensityIons("BinDensityIons", "binDensity_i"));
         plugins.push_back(new BinEnergyIons("BinEnergyIons", "bin_i"));
+        plugins.push_back(new InsituBinEnergyIons("InsituBinEnergyIons", "insitu_bin_i"));
         plugins.push_back(new IonCounter("IonsCount", "ions_cnt"));
         plugins.push_back(new EnergyIons("EnergyIons", "energy_i"));
 #endif

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Richard Pausch, Alexander Debus, Marco Garten
+ *                     Richard Pausch, Alexander Debus, Marco Garten, Anshuman Goswami
  *
  * This file is part of PIConGPU.
  *
@@ -59,7 +59,7 @@
 #include "algorithms/ForEach.hpp"
 #include "particles/ParticlesFunctors.hpp"
 #include <boost/mpl/int.hpp>
-
+#include "plugins/InsituBinEnergyParticles.hpp"
 namespace picongpu
 {
 using namespace PMacc;
@@ -220,6 +220,10 @@ public:
                 assert((int) ABSORBER_CELLS[i][1] <= (int) cellDescription->getGridLayout().getDataSpaceWithoutGuarding()[i]);
             }
         }
+        //Insitu analysis
+	insituPlugin = new InsituBinEnergyElectrons();
+	insituPlugin->setMappingDescription(cellDescription);
+	insituPlugin->load();
 
     }
 
@@ -244,6 +248,10 @@ public:
         __delete(pushBGField);
         __delete(currentBGField);
         __delete(cellDescription);
+        
+        //Insitu analysis
+        insituPlugin->unload();
+	__delete(insituPlugin);
     }
 
     void notify(uint32_t)
@@ -415,6 +423,8 @@ public:
 #endif
 
         this->myFieldSolver->update_afterCurrent(currentStep);
+	//Insitu analysis
+	insituPlugin->notify(currentStep);
     }
 
     virtual void movingWindowCheck(uint32_t currentStep)
@@ -573,6 +583,9 @@ protected:
     std::vector<std::string> gridDistribution;
 
     bool slidingWindow;
+    //Insitu analysis
+    ISimulationPlugin* insituPlugin;
+    typedef InsituBinEnergyParticles<PIC_Electrons> InsituBinEnergyElectrons;
 };
 } /* namespace picongpu */
 

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -59,7 +59,7 @@
 #include "algorithms/ForEach.hpp"
 #include "particles/ParticlesFunctors.hpp"
 #include <boost/mpl/int.hpp>
-#include "plugins/InsituBinEnergyParticles.hpp"
+
 namespace picongpu
 {
 using namespace PMacc;
@@ -220,10 +220,6 @@ public:
                 assert((int) ABSORBER_CELLS[i][1] <= (int) cellDescription->getGridLayout().getDataSpaceWithoutGuarding()[i]);
             }
         }
-        //Insitu analysis
-	insituPlugin = new InsituBinEnergyElectrons();
-	insituPlugin->setMappingDescription(cellDescription);
-	insituPlugin->load();
 
     }
 
@@ -249,9 +245,6 @@ public:
         __delete(currentBGField);
         __delete(cellDescription);
         
-        //Insitu analysis
-        insituPlugin->unload();
-	__delete(insituPlugin);
     }
 
     void notify(uint32_t)
@@ -423,8 +416,6 @@ public:
 #endif
 
         this->myFieldSolver->update_afterCurrent(currentStep);
-	//Insitu analysis
-	insituPlugin->notify(currentStep);
     }
 
     virtual void movingWindowCheck(uint32_t currentStep)
@@ -583,9 +574,6 @@ protected:
     std::vector<std::string> gridDistribution;
 
     bool slidingWindow;
-    //Insitu analysis
-    ISimulationPlugin* insituPlugin;
-    typedef InsituBinEnergyParticles<PIC_Electrons> InsituBinEnergyElectrons;
 };
 } /* namespace picongpu */
 


### PR DESCRIPTION
This branch's purpose is to serialize PIConGPU's particle data for delivery to a separate analysis application (not running in PIConGPU's address space).

- InsituBinEnergyParticles class cloned from BinEnergyParticles class
- load, unload and notify called from MySimulation class's load, unload and runOneStep respectively
 