### PR TITLE
improve graphics of numerical heating tool

### DIFF
--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -189,7 +189,25 @@ if not args.boolDiff:
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
-                         color="red", alpha=0.5)
+                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], Energies[0][:time_limit] < startEnergy),
+                         color="red", alpha=0.4) # dev is less than start value and branch is closer to initial energy 
+        plt.fill_between(Times[1][:time_limit], 
+                         (Energies[0][:time_limit]-startEnergy)*norm, 
+                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], Energies[0][:time_limit] < startEnergy),
+                         color="red", alpha=0.6)# dev is less than start value and branch is worse than initial energy 
+
+        plt.fill_between(Times[1][:time_limit], 
+                         (Energies[0][:time_limit]-startEnergy)*norm, 
+                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], Energies[0][:time_limit] > startEnergy),
+                         color="red", alpha=0.4) # dev is greater than start value and branch is closer to initial energy 
+        plt.fill_between(Times[1][:time_limit], 
+                         (Energies[0][:time_limit]-startEnergy)*norm, 
+                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], Energies[0][:time_limit] > startEnergy),
+                         color="red", alpha=0.6)# dev is greater than start value and branch is worse than initial energy 
+
         plt.plot(Times[1][:time_limit], 
                  (Energies[1][:time_limit]-startEnergy)*norm, 
                  color="blue",  lw=2, label=args.label2)

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -181,33 +181,44 @@ else:
     norm = 1.0 # absolute values
 
 if not args.boolDiff:
-    # plot energy evolution side by side
+    # plot energy evolution
     plt.plot(Times[0][:time_limit], 
              (Energies[0][:time_limit]-startEnergy)*norm, 
              color="green", lw=3, label=args.label1)
     if numDir == 2:
+        # dev is less than start value and branch is closer to initial energy
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], Energies[0][:time_limit] < startEnergy),
-                         color="red", alpha=0.4, hatch="--", edgecolor="white") # dev is less than start value and branch is closer to initial energy 
-        plt.fill_between(Times[1][:time_limit], 
-                         (Energies[0][:time_limit]-startEnergy)*norm, 
-                         (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], Energies[0][:time_limit] < startEnergy),
-                         color="red", alpha=0.7, hatch="++", edgecolor="black")# dev is less than start value and branch is worse than initial energy 
+                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], 
+                                              Energies[0][:time_limit] < startEnergy),
+                         color="orange", alpha=0.8) 
 
+        # dev is less than start value and branch is worse than initial energy
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], Energies[0][:time_limit] > startEnergy),
-                         color="red", alpha=0.4, hatch="--", edgecolor="white") # dev is greater than start value and branch is closer to initial energy 
-        plt.fill_between(Times[1][:time_limit], 
-                         (Energies[0][:time_limit]-startEnergy)*norm, 
-                         (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], Energies[0][:time_limit] > startEnergy),
-                         color="red", alpha=0.7, hatch="++", edgecolor="black")# dev is greater than start value and branch is worse than initial energy 
+                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], 
+                                              Energies[0][:time_limit] < startEnergy),
+                         color="red", alpha=0.7)
 
+        # dev is greater than start value and branch is closer to initial energy
+        plt.fill_between(Times[1][:time_limit], 
+                         (Energies[0][:time_limit]-startEnergy)*norm, 
+                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], 
+                                              Energies[0][:time_limit] > startEnergy),
+                         color="orange", alpha=0.8)
+
+        # dev is greater than start value and branch is worse than initial energy
+        plt.fill_between(Times[1][:time_limit], 
+                         (Energies[0][:time_limit]-startEnergy)*norm, 
+                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], 
+                                              Energies[0][:time_limit] > startEnergy),
+                         color="red", alpha=0.7)
+
+        # plot second energy evolution
         plt.plot(Times[1][:time_limit], 
                  (Energies[1][:time_limit]-startEnergy)*norm, 
                  color="blue",  lw=2, label=args.label2)

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -190,23 +190,23 @@ if not args.boolDiff:
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
                          where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], Energies[0][:time_limit] < startEnergy),
-                         color="red", alpha=0.4) # dev is less than start value and branch is closer to initial energy 
+                         color="red", alpha=0.4, hatch="--", edgecolor="white") # dev is less than start value and branch is closer to initial energy 
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
                          where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], Energies[0][:time_limit] < startEnergy),
-                         color="red", alpha=0.6)# dev is less than start value and branch is worse than initial energy 
+                         color="red", alpha=0.7, hatch="++", edgecolor="black")# dev is less than start value and branch is worse than initial energy 
 
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
                          where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], Energies[0][:time_limit] > startEnergy),
-                         color="red", alpha=0.4) # dev is greater than start value and branch is closer to initial energy 
+                         color="red", alpha=0.4, hatch="--", edgecolor="white") # dev is greater than start value and branch is closer to initial energy 
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
                          where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], Energies[0][:time_limit] > startEnergy),
-                         color="red", alpha=0.6)# dev is greater than start value and branch is worse than initial energy 
+                         color="red", alpha=0.7, hatch="++", edgecolor="black")# dev is greater than start value and branch is worse than initial energy 
 
         plt.plot(Times[1][:time_limit], 
                  (Energies[1][:time_limit]-startEnergy)*norm, 

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -186,9 +186,13 @@ if not args.boolDiff:
              (Energies[0][:time_limit]-startEnergy)*norm, 
              color="green", lw=3, label=args.label1)
     if numDir == 2:
+        plt.fill_between(Times[1][:time_limit], 
+                         (Energies[0][:time_limit]-startEnergy)*norm, 
+                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         color="red", alpha=0.5)
         plt.plot(Times[1][:time_limit], 
                  (Energies[1][:time_limit]-startEnergy)*norm, 
-                 "--", color="blue",  lw=5, label=args.label2)
+                 color="blue",  lw=2, label=args.label2)
     if args.boolRelative:
         plt.ylabel(r"$\frac{E}{E_0}-1\,[\%]$", fontsize=24)
     else:


### PR DESCRIPTION
This pull requests improves the graphics of the `plotNumericalHeating` tool as suggested by @psychocoderHPC .

The new look can be seen here:
![numheating_newgraphics](https://cloud.githubusercontent.com/assets/5121158/6487890/1aaddd72-c294-11e4-873e-c6720f27c586.png)

Compare this to [the following plot](https://github.com/ComputationalRadiationPhysics/picongpu/pull/730#issuecomment-77185517) where the small scale oscillation of `branch` is not visible due to the dashed line.
