### PR TITLE
Fix #743 moving window out of mem

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -137,6 +137,10 @@ public:
      */
     void deleteGuardParticles(uint32_t exchangeType);
 
+    /* Delete all particle in an area*/
+    template<uint32_t T_area>
+    void deleteParticlesInArea();
+
     /* Bash particles in a direction.
      * Copy all particles from the guard of a direction to the device exchange buffer
      */

--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -164,6 +164,10 @@ public:
      * asynchron.
      */
     EventTask asyncCommunication(EventTask event);
+
+    /* set all internal objects to initial state*/
+    virtual void reset(uint32_t currentStep);
+
 };
 
 } //namespace PMacc

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -46,6 +46,12 @@ namespace PMacc
     }
 
     template<typename T_ParticleDescription, class MappingDesc>
+    void ParticlesBase<T_ParticleDescription, MappingDesc>::reset(uint32_t )
+    {
+        particlesBuffer->reset( );
+    }
+
+    template<typename T_ParticleDescription, class MappingDesc>
     void ParticlesBase<T_ParticleDescription, MappingDesc>::bashParticles(uint32_t exchangeType)
     {
         if (particlesBuffer->hasSendExchange(exchangeType))
@@ -97,5 +103,3 @@ namespace PMacc
     }
 
 } //namespace PMacc
-
-

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -46,8 +46,22 @@ namespace PMacc
     }
 
     template<typename T_ParticleDescription, class MappingDesc>
+    template<uint32_t T_area>
+    void ParticlesBase<T_ParticleDescription, MappingDesc>::deleteParticlesInArea()
+    {
+
+        AreaMapping<T_area, MappingDesc> mapper(this->cellDescription);
+        dim3 grid(mapper.getGridDim());
+
+        __cudaKernel(kernelDeleteParticles)
+                (grid, TileSize)
+                (particlesBuffer->getDeviceParticleBox(), mapper);
+    }
+
+    template<typename T_ParticleDescription, class MappingDesc>
     void ParticlesBase<T_ParticleDescription, MappingDesc>::reset(uint32_t )
     {
+        deleteParticlesInArea<CORE+BORDER+GUARD>();
         particlesBuffer->reset( );
     }
 

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -53,9 +53,6 @@ public:
 
     void createParticleBuffer();
 
-
-    virtual void reset(uint32_t currentStep);
-
     void init(FieldE &fieldE, FieldB &fieldB, FieldJ &fieldJ, FieldTmp &fieldTmp);
 
     void update(uint32_t currentStep);

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -181,12 +181,6 @@ void Particles<T_ParticleDescription>::update(uint32_t )
 }
 
 template< typename T_ParticleDescription>
-void Particles<T_ParticleDescription>::reset( uint32_t )
-{
-    this->particlesBuffer->reset( );
-}
-
-template< typename T_ParticleDescription>
 void Particles<T_ParticleDescription>::initFill( uint32_t currentStep )
 {
     Window window = MovingWindow::getInstance( ).getWindow( currentStep );


### PR DESCRIPTION
fix #743 *MovingWindow: out of memory after slide*

- move `picongpu::Particles::reset()` to `PMacc::ParticlesBase`
- `ParticlesBase`: add method `deleteParticlesInArea`

Tests:

- [x] LWFA with sliding window