### PR TITLE
close #630 cuda 7.0 compile crash

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
@@ -46,7 +46,7 @@ namespace host
 #define FOREACH_HOST_MAX_PARAMS 4
 #endif
 
-#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (_zone.offset);
+#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (p_zone.offset);
 #define SHIFTACCESS_SHIFTEDCURSOR(Z, N, _) forward(c ## N ## _shifted [cellIndex])
 
 namespace detail
@@ -59,45 +59,45 @@ namespace detail
     struct GetRange<3u>
     {
         template<typename Zone>
-        const math::Int<3u> operator()(const Zone _zone) const
+        const math::Int<3u> operator()(const Zone p_zone) const
         {
-            return math::Int<3u>(_zone.size.x(), _zone.size.y(), _zone.size.z());
+            return math::Int<3u>(p_zone.size.x(), p_zone.size.y(), p_zone.size.z());
         }
     };
     template<>
     struct GetRange<2u>
     {
         template<typename Zone>
-        const math::Int<3u> operator()(const Zone _zone) const
+        const math::Int<3u> operator()(const Zone p_zone) const
         {
-            return math::Int<3u>(_zone.size.x(), _zone.size.y(), 1);
+            return math::Int<3u>(p_zone.size.x(), p_zone.size.y(), 1);
         }
     };
     template<>
     struct GetRange<1u>
     {
         template<typename Zone>
-        const math::Int<3u> operator()(const Zone _zone) const
+        const math::Int<3u> operator()(const Zone p_zone) const
         {
-            return math::Int<3u>(_zone.size.x(), 1, 1);
+            return math::Int<3u>(p_zone.size.x(), 1, 1);
         }
     };
 } // namespace detail
 
 #define FOREACH_OPERATOR(Z, N, _)                                              \
     template<typename Zone, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor> \
-    void operator()(const Zone& _zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor) \
+    void operator()(const Zone& p_zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor) \
     {                                                                          \
         BOOST_PP_REPEAT(N, SHIFT_CURSOR_ZONE, _)                               \
                                                                                \
         typename lambda::result_of::make_Functor<Functor>::type fun            \
             = lambda::make_Functor(functor);                                   \
         detail::GetRange<Zone::dim> getRange;                                  \
-        for(int z = 0; z < getRange(_zone).z(); z++)                           \
+        for(int z = 0; z < getRange(p_zone).z(); z++)                           \
         {                                                                      \
-            for(int y = 0; y < getRange(_zone).y(); y++)                       \
+            for(int y = 0; y < getRange(p_zone).y(); y++)                       \
             {                                                                  \
-                for(int x = 0; x < getRange(_zone).x(); x++)                   \
+                for(int x = 0; x < getRange(p_zone).x(); x++)                   \
                 {                                                              \
                     math::Int<Zone::dim> cellIndex =                           \
                         math::Int<3u>(x, y, z).shrink<Zone::dim>();            \

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
@@ -34,7 +34,7 @@ template<int dim>
 struct FFT
 {
     template<typename Zone, typename DestCursor, typename SrcCursor>
-    void operator()(const Zone& _zone, const DestCursor& destCursor, const SrcCursor& srcCursor);
+    void operator()(const Zone& p_zone, const DestCursor& destCursor, const SrcCursor& srcCursor);
 };
 
 } // kernel

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
@@ -34,13 +34,13 @@ namespace kernel
 
 template<>
 template<typename Zone, typename DestCursor, typename SrcCursor>
-void FFT<2>::operator()(const Zone& _zone, const DestCursor& destCursor, const SrcCursor& srcCursor)
+void FFT<2>::operator()(const Zone& p_zone, const DestCursor& destCursor, const SrcCursor& srcCursor)
 {
     cufftHandle plan;
-    CUFFT_CHECK(cufftPlan2d(&plan, _zone.size.x(), _zone.size.y(), CUFFT_R2C));
+    CUFFT_CHECK(cufftPlan2d(&plan, p_zone.size.x(), p_zone.size.y(), CUFFT_R2C));
 
-    CUFFT_CHECK(cufftExecR2C(plan, (cufftReal*)&(*(srcCursor(_zone.offset))),
-                        (cufftComplex*)&(*destCursor(_zone.offset))));
+    CUFFT_CHECK(cufftExecR2C(plan, (cufftReal*)&(*(srcCursor(p_zone.offset))),
+                        (cufftComplex*)&(*destCursor(p_zone.offset))));
 
     CUFFT_CHECK(cufftDestroy(plan));
 }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
@@ -50,24 +50,24 @@ namespace kernel
 #ifndef FOREACH_KERNEL_MAX_PARAMS
 #define FOREACH_KERNEL_MAX_PARAMS 4
 #endif
-#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (_zone.offset);
+#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (p_zone.offset);
 #define SHIFTED_CURSOR(Z, N, _) c ## N ## _shifted
 
 #define FOREACH_OPERATOR(Z, N, _)                                                                           \
                          /* typename C0, typename C1, ... */                                                \
     template<typename Zone, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor>                          \
                                     /* C0 c0, C1 c1, ... */                                                 \
-    void operator()(const Zone& _zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor)        \
+    void operator()(const Zone& p_zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor)        \
     {                                                                                                       \
-        /* C0 c0_shifted = c0(_zone.offset); */                                                             \
-        /* C1 c1_shifted = c1(_zone.offset); */                                                             \
+        /* C0 c0_shifted = c0(p_zone.offset); */                                                             \
+        /* C1 c1_shifted = c1(p_zone.offset); */                                                             \
         /* ... */                                                                                           \
         BOOST_PP_REPEAT(N, SHIFT_CURSOR_ZONE, _)                                                            \
                                                                                                             \
         dim3 blockDim(BlockDim::toRT().toDim3());                                                           \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace PMacc;                                                                              \
-        __cudaKernel(detail::kernelForeach)(mapper.cudaGridDim(_zone.size), blockDim)                       \
+        __cudaKernel(detail::kernelForeach)(mapper.cudaGridDim(p_zone.size), blockDim)                       \
                   /* c0_shifted, c1_shifted, ... */                                                         \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                   \
     }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -74,24 +74,24 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), KERNEL_FOREA
 
 }
 
-#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (_zone.offset);
+#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (p_zone.offset);
 #define SHIFTED_CURSOR(Z, N, _) c ## N ## _shifted
 
 #define FOREACH_OPERATOR(Z, N, _)                                                                           \
                          /* typename C0, typename C1, ... */                                                \
     template<typename Zone, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor>                          \
                                      /* C0 c0, C1 c1, ... */                                                \
-    void operator()(const Zone& _zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor)        \
+    void operator()(const Zone& p_zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor)        \
     {                                                                                                       \
-        /* C0 c0_shifted = c0(_zone.offset); */                                                             \
-        /* C1 c1_shifted = c1(_zone.offset); */                                                             \
+        /* C0 c0_shifted = c0(p_zone.offset); */                                                             \
+        /* C1 c1_shifted = c1(p_zone.offset); */                                                             \
         /* ... */                                                                                           \
         BOOST_PP_REPEAT(N, SHIFT_CURSOR_ZONE, _)                                                            \
                                                                                                             \
         dim3 blockDim(ThreadBlock::toRT().toDim3());                                                        \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace PMacc;                                                                              \
-        __cudaKernel(detail::kernelForeachBlock)(mapper.cudaGridDim(_zone.size), blockDim)                  \
+        __cudaKernel(detail::kernelForeachBlock)(mapper.cudaGridDim(p_zone.size), blockDim)                  \
                     /* c0_shifted, c1_shifted, ... */                                                       \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                   \
     }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
@@ -52,13 +52,13 @@ struct Reduce
 {
 
 /* \param destCursor Cursor where the result is stored
- * \param _zone Zone of cells spanning the area of reduce
+ * \param p_zone Zone of cells spanning the area of reduce
  * \param srcCursor Cursor located at the origin of the area of reduce
  * \param functor Functor with two arguments which returns the result of the reduce operation.
  *        Can also be a lambda expression.
  */
 template<typename DestCursor, typename Zone, typename SrcCursor, typename Functor>
-void operator()(const DestCursor& destCursor, const Zone& _zone, const SrcCursor& srcCursor, const Functor& functor);
+void operator()(const DestCursor& destCursor, const Zone& p_zone, const SrcCursor& srcCursor, const Functor& functor);
 };
 
 } // kernel

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -55,16 +55,16 @@ namespace RT
 #define FOREACH_KERNEL_MAX_PARAMS 4
 #endif
 
-#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (_zone.offset);
+#define SHIFT_CURSOR_ZONE(Z, N, _) C ## N c ## N ## _shifted = c ## N (p_zone.offset);
 #define SHIFTED_CURSOR(Z, N, _) c ## N ## _shifted
 
 #define FOREACH_OPERATOR(Z, N, _)                                                                                   \
     /*                      typename C0, ..., typename CN            */                                             \
     template<typename Zone, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor>                                  \
                                 /*     C0 c0, ..., CN cN  */                                                        \
-    void operator()(const Zone& _zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor)                \
+    void operator()(const Zone& p_zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor)                \
     {                                                                                                               \
-        /* C0 c0_shifted = c0(_zone.offset); ...; CN cN_shifted = cN(_zone.offset); */                              \
+        /* C0 c0_shifted = c0(p_zone.offset); ...; CN cN_shifted = cN(p_zone.offset); */                              \
         BOOST_PP_REPEAT(N, SHIFT_CURSOR_ZONE, _)                                                                    \
                                                                                                                     \
         /* the maximum number of threads per block for devices with                                                 \
@@ -75,7 +75,7 @@ namespace RT
         dim3 blockDim(this->_blockDim.x(), this->_blockDim.y(), this->_blockDim.z());                               \
         kernel::detail::SphericMapper<Zone::dim> mapper;                                                            \
         using namespace PMacc;                                                                                      \
-        __cudaKernel(kernel::detail::kernelForeach)(mapper.cudaGridDim(_zone.size, this->_blockDim), blockDim)      \
+        __cudaKernel(kernel::detail::kernelForeach)(mapper.cudaGridDim(p_zone.size, this->_blockDim), blockDim)      \
                 /*   c0_shifted, ..., cN_shifted    */                                                              \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                           \
     }

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
@@ -46,7 +46,7 @@ private:
     std::vector<math::Int<dim> > positions;
     bool m_participate;
 
-    template<typename Type, int _dim, int memDim>
+    template<typename Type, int T_dim, int memDim>
     struct CopyToDest;
 
     template<typename Type>
@@ -58,10 +58,10 @@ private:
                         container::HostBuffer<Type, 2>& source, int dir) const;
     };
 
-    template<typename Type, int _dim, int memDim>
+    template<typename Type, int T_dim, int memDim>
     friend class CopyToDest;
 public:
-    Gather(const zone::SphericZone<dim>& _zone);
+    Gather(const zone::SphericZone<dim>& p_zone);
     ~Gather();
 
     template<typename Type, int memDim>

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
@@ -33,7 +33,7 @@ namespace mpi
 {
 
 template<int dim>
-Gather<dim>::Gather(const zone::SphericZone<dim>& _zone) : comm(MPI_COMM_NULL)
+Gather<dim>::Gather(const zone::SphericZone<dim>& p_zone) : comm(MPI_COMM_NULL)
 {
     using namespace PMacc::math;
 
@@ -54,7 +54,7 @@ Gather<dim>::Gather(const zone::SphericZone<dim>& _zone) : comm(MPI_COMM_NULL)
     for(int i = 0; i < (int)allPositions.size(); i++)
     {
         Int<dim> pos = allPositions[i];
-        if(!_zone.within(pos)) continue;
+        if(!p_zone.within(pos)) continue;
 
         new_ranks.push_back(i);
         this->positions.push_back(allPositions[i]);

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
@@ -22,6 +22,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "mpi.h"
 #include "math/vector/Int.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
@@ -65,7 +67,7 @@ public:
      */
     Reduce(const zone::SphericZone<dim>& zone, bool setThisAsRoot = false);
     ~Reduce();
-    
+
     /* execute the algorithm
      *
      * \param dest destination container
@@ -80,7 +82,7 @@ public:
     void operator()(container::HostBuffer<Type, conDim>& dest,
                     const container::HostBuffer<Type, conDim>& src,
                     ExprOrFunctor) const;
-           
+
     // Returns whether this node is within the zone.
     inline bool participate() const {return m_participate;}
     // Returns whether this node is the root node.
@@ -88,7 +90,7 @@ public:
     // Returns the mpi rank of this node.
     inline int rank() const;
 };
-    
+
 } // mpi
 } // algorithm
 } // PMacc

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -62,13 +62,13 @@ public:
     typedef Type type;
     typedef CartBuffer<Type, T_dim, Allocator, Copier, Assigner> This;
     static const int dim = T_dim;
-    typedef cursor::BufferCursor<Type, dim> Cursor;
+    typedef cursor::BufferCursor<Type, T_dim> Cursor;
     typedef typename Allocator::tag memoryTag;
 public:
     Type* dataPointer;
     int* refCount;
-    math::Size_t<dim> _size;
-    math::Size_t<dim-1> pitch;
+    math::Size_t<T_dim> _size;
+    math::Size_t<T_dim-1> pitch;
     HDINLINE void init();
     HDINLINE void exit();
     HDINLINE CartBuffer() {}
@@ -76,7 +76,7 @@ private:
     /* makes this class able to emulate a r-value reference */
     BOOST_COPYABLE_AND_MOVABLE(This)
 public:
-    HDINLINE CartBuffer(const math::Size_t<dim>& size);
+    HDINLINE CartBuffer(const math::Size_t<T_dim>& size);
     HDINLINE CartBuffer(size_t x);
     HDINLINE CartBuffer(size_t x, size_t y);
     HDINLINE CartBuffer(size_t x, size_t y, size_t z);
@@ -100,29 +100,29 @@ public:
      * Values are remapped, so that Int<2>(0,0) == Int<2>(width, height)
      */
     HDINLINE View<This>
-        view(math::Int<dim> a = math::Int<dim>(0),
-             math::Int<dim> b = math::Int<dim>(0)) const;
+        view(math::Int<T_dim> a = math::Int<T_dim>(0),
+             math::Int<T_dim> b = math::Int<T_dim>(0)) const;
 
     /* assign value to each datum */
     PMACC_NO_NVCC_HDWARNING
     HDINLINE void assign(const Type& value);
 
     /* get a cursor at the container's origin cell */
-    HDINLINE cursor::BufferCursor<Type, dim> origin() const;
+    HDINLINE cursor::BufferCursor<Type, T_dim> origin() const;
     /* get a safe cursor at the container's origin cell */
-    HDINLINE cursor::SafeCursor<cursor::BufferCursor<Type, dim> > originSafe() const;
+    HDINLINE cursor::SafeCursor<cursor::BufferCursor<Type, T_dim> > originSafe() const;
     /* get a component-twisted cursor at the container's origin cell
      * \param axes x-axis -> axes[0], y-axis -> axes[1], ...
      * */
-    HDINLINE cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<dim>, char*>
-    originCustomAxes(const math::UInt32<dim>& axes) const;
+    HDINLINE cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<T_dim>, char*>
+    originCustomAxes(const math::UInt32<T_dim>& axes) const;
 
     /* get a zone spanning the whole container */
-    HDINLINE zone::SphericZone<dim> zone() const;
+    HDINLINE zone::SphericZone<T_dim> zone() const;
 
     HDINLINE Type* getDataPointer() const {return dataPointer;}
-    HDINLINE math::Size_t<dim> size() const {return this->_size;}
-    HDINLINE math::Size_t<dim-1> getPitch() const {return this->pitch;}
+    HDINLINE math::Size_t<T_dim> size() const {return this->_size;}
+    HDINLINE math::Size_t<T_dim-1> getPitch() const {return this->pitch;}
 };
 
 } // container

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -48,20 +48,20 @@ namespace container
  * The way memory gets allocated, copied and assigned is
  * fully controlled by three policy classes.
  * \tparam Type type of a single value
- * \tparam _dim dimension of the container
+ * \tparam T_dim dimension of the container
  * \tparam Allocator allocates and releases memory
  * \tparam Copier copies one memory buffer to another
  * \tparam Assigner assigns a value to every datum of a memory buffer
  */
-template<typename Type, int _dim, typename Allocator = allocator::EmptyAllocator,
+template<typename Type, int T_dim, typename Allocator = allocator::EmptyAllocator,
                                   typename Copier = mpl::void_,
                                   typename Assigner = mpl::void_>
 class CartBuffer
 {
 public:
     typedef Type type;
-    typedef CartBuffer<Type, _dim, Allocator, Copier, Assigner> This;
-    static const int dim = _dim;
+    typedef CartBuffer<Type, T_dim, Allocator, Copier, Assigner> This;
+    static const int dim = T_dim;
     typedef cursor::BufferCursor<Type, dim> Cursor;
     typedef typename Allocator::tag memoryTag;
 public:

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -111,7 +111,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
-(const CartBuffer<Type, dim, Allocator, Copier, Assigner>& other)
+(const CartBuffer<Type, T_dim, Allocator, Copier, Assigner>& other)
 {
     this->dataPointer = other.dataPointer;
     this->refCount = other.refCount;
@@ -124,7 +124,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
-(BOOST_RV_REF(CartBuffer<Type COMMA dim COMMA Allocator COMMA Copier COMMA Assigner>) other)
+(BOOST_RV_REF(CartBuffer<Type COMMA T_dim COMMA Allocator COMMA Copier COMMA Assigner>) other)
 {
     this->dataPointer = 0;
     this->refCount = 0;

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -80,37 +80,37 @@ namespace detail
     }
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
-(const math::Size_t<_dim>& _size)
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
+(const math::Size_t<T_dim>& _size)
 {
     this->_size = _size;
     init();
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 (size_t x)
 {
     this->_size = math::Size_t<1>(x); init();
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 (size_t x, size_t y)
 {
     this->_size = math::Size_t<2>(x, y); init();
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 (size_t x, size_t y, size_t z)
 {
     this->_size = math::Size_t<3>(x, y, z); init();
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 (const CartBuffer<Type, dim, Allocator, Copier, Assigner>& other)
 {
     this->dataPointer = other.dataPointer;
@@ -122,8 +122,8 @@ CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
 
 #define COMMA ,
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 (BOOST_RV_REF(CartBuffer<Type COMMA dim COMMA Allocator COMMA Copier COMMA Assigner>) other)
 {
     this->dataPointer = 0;
@@ -131,8 +131,8 @@ CartBuffer<Type, _dim, Allocator, Copier, Assigner>::CartBuffer
     *this = other;
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-void CartBuffer<Type, _dim, Allocator, Copier, Assigner>::init()
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+void CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::init()
 {
     typename Allocator::Cursor cursor = Allocator::allocate(this->_size);
     this->dataPointer = cursor.getMarker();
@@ -140,17 +140,17 @@ void CartBuffer<Type, _dim, Allocator, Copier, Assigner>::init()
     this->refCount = new int;
 #endif
     *this->refCount = 1;
-    this->pitch = detail::PitchHelper<_dim>()(cursor);
+    this->pitch = detail::PitchHelper<T_dim>()(cursor);
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::~CartBuffer()
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::~CartBuffer()
 {
     exit();
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-void CartBuffer<Type, _dim, Allocator, Copier, Assigner>::exit()
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+void CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::exit()
 {
     if(!this->refCount) return;
     (*(this->refCount))--;
@@ -164,20 +164,20 @@ void CartBuffer<Type, _dim, Allocator, Copier, Assigner>::exit()
 #endif
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>&
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::operator=
-(const CartBuffer<Type, _dim, Allocator, Copier, Assigner>& rhs)
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>&
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::operator=
+(const CartBuffer<Type, T_dim, Allocator, Copier, Assigner>& rhs)
 {
     if(this->dataPointer == rhs.dataPointer) return *this;
     Copier::copy(this->dataPointer, this->pitch, rhs.dataPointer, rhs.pitch, rhs._size);
     return *this;
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>&
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::operator=
-(BOOST_RV_REF(CartBuffer<Type COMMA _dim COMMA Allocator COMMA Copier COMMA Assigner>) rhs)
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>&
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::operator=
+(BOOST_RV_REF(CartBuffer<Type COMMA T_dim COMMA Allocator COMMA Copier COMMA Assigner>) rhs)
 {
     if(this->dataPointer == rhs.dataPointer) return *this;
 
@@ -192,49 +192,49 @@ CartBuffer<Type, _dim, Allocator, Copier, Assigner>::operator=
 
 #undef COMMA
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-View<CartBuffer<Type, _dim, Allocator, Copier, Assigner> >
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::view
-(math::Int<_dim> a, math::Int<_dim> b) const
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+View<CartBuffer<Type, T_dim, Allocator, Copier, Assigner> >
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::view
+(math::Int<T_dim> a, math::Int<T_dim> b) const
 {
-    a = (a + (math::Int<_dim>)this->size()) % (math::Int<_dim>)this->size();
-    b = (b + (math::Int<_dim>)this->size())
-            % ((math::Int<_dim>)this->size() + math::Int<_dim>(1));
+    a = (a + (math::Int<T_dim>)this->size()) % (math::Int<T_dim>)this->size();
+    b = (b + (math::Int<T_dim>)this->size())
+            % ((math::Int<T_dim>)this->size() + math::Int<T_dim>(1));
 
-    View<CartBuffer<Type, _dim, Allocator, Copier, Assigner> > result;
+    View<CartBuffer<Type, T_dim, Allocator, Copier, Assigner> > result;
 
     result.dataPointer = &(*origin()(a));
-    result._size = (math::Size_t<_dim>)(b - a);
+    result._size = (math::Size_t<T_dim>)(b - a);
     result.pitch = this->pitch;
     result.refCount = this->refCount;
     return result;
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-void CartBuffer<Type, _dim, Allocator, Copier, Assigner>::assign(const Type& value)
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+void CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::assign(const Type& value)
 {
     Assigner::assign(this->dataPointer, this->pitch, value, this->_size);
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-cursor::BufferCursor<Type, _dim> CartBuffer<Type, _dim, Allocator, Copier, Assigner>::origin() const
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+cursor::BufferCursor<Type, T_dim> CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::origin() const
 {
     detail::notifyEventSystem<typename Allocator::tag>();
-    return cursor::BufferCursor<Type, _dim>(this->dataPointer, this->pitch);
+    return cursor::BufferCursor<Type, T_dim>(this->dataPointer, this->pitch);
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-cursor::SafeCursor<cursor::BufferCursor<Type, _dim> >
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::originSafe() const
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+cursor::SafeCursor<cursor::BufferCursor<Type, T_dim> >
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::originSafe() const
 {
     return cursor::make_SafeCursor(this->origin(),
-                                   math::Int<_dim>(0),
-                                   math::Int<_dim>(size()));
+                                   math::Int<T_dim>(0),
+                                   math::Int<T_dim>(size()));
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<_dim>, char*>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::originCustomAxes(const math::UInt32<_dim>& axes) const
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<T_dim>, char*>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::originCustomAxes(const math::UInt32<T_dim>& axes) const
 {
     math::Size_t<dim> factor;
     factor[0] = sizeof(Type);
@@ -252,12 +252,12 @@ CartBuffer<Type, _dim, Allocator, Copier, Assigner>::originCustomAxes(const math
             (cursor::PointerAccessor<Type>(), navi, (char*)this->dataPointer);
 }
 
-template<typename Type, int _dim, typename Allocator, typename Copier, typename Assigner>
-zone::SphericZone<_dim>
-CartBuffer<Type, _dim, Allocator, Copier, Assigner>::zone() const
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+zone::SphericZone<T_dim>
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::zone() const
 {
-    zone::SphericZone<_dim> myZone;
-    myZone.offset = math::Int<_dim>(0);
+    zone::SphericZone<T_dim> myZone;
+    myZone.offset = math::Int<T_dim>(0);
     myZone.size = this->_size;
     return myZone;
 }

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -32,16 +32,16 @@ namespace PMacc
 namespace allocator
 {
 
-template<typename Type, int _dim>
+template<typename Type, int T_dim>
 struct DeviceMemAllocator
 {
     typedef Type type;
-    static const int dim = _dim;
+    static const int dim = T_dim;
     typedef cursor::BufferCursor<type, dim> Cursor;
     typedef allocator::tag::device tag;
 
     HDINLINE
-    static cursor::BufferCursor<type, _dim> allocate(const math::Size_t<_dim>& size);
+    static cursor::BufferCursor<type, T_dim> allocate(const math::Size_t<T_dim>& size);
     template<typename TCursor>
     HDINLINE
     static void deallocate(const TCursor& cursor);

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
@@ -25,13 +25,13 @@ namespace PMacc
 namespace allocator
 {
 
-template<typename Type, int _dim>
-cursor::BufferCursor<Type, _dim>
-DeviceMemAllocator<Type, _dim>::allocate(const math::Size_t<_dim>& size)
+template<typename Type, int T_dim>
+cursor::BufferCursor<Type, T_dim>
+DeviceMemAllocator<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
 {
 #ifndef __CUDA_ARCH__
     Type* dataPointer;
-    math::Size_t<_dim-1> pitch;
+    math::Size_t<T_dim-1> pitch;
     cudaPitchedPtr cudaData;
 
     cudaData.ptr = NULL;
@@ -58,13 +58,13 @@ DeviceMemAllocator<Type, _dim>::allocate(const math::Size_t<_dim>& size)
     }
     dataPointer = (Type*)cudaData.ptr;
 
-    return cursor::BufferCursor<Type, _dim>(dataPointer, pitch);
+    return cursor::BufferCursor<Type, T_dim>(dataPointer, pitch);
 #endif
 
 #ifdef __CUDA_ARCH__
     Type* dataPointer = 0;
-    math::Size_t<_dim-1> pitch;
-    return cursor::BufferCursor<Type, _dim>(dataPointer, pitch);
+    math::Size_t<T_dim-1> pitch;
+    return cursor::BufferCursor<Type, T_dim>(dataPointer, pitch);
 #endif
 }
 
@@ -86,9 +86,9 @@ DeviceMemAllocator<Type, 1>::allocate(const math::Size_t<1>& size)
 #endif
 }
 
-template<typename Type, int _dim>
+template<typename Type, int T_dim>
 template<typename TCursor>
-void DeviceMemAllocator<Type, _dim>::deallocate(const TCursor& cursor)
+void DeviceMemAllocator<Type, T_dim>::deallocate(const TCursor& cursor)
 {
 #ifndef __CUDA_ARCH__
     CUDA_CHECK_NO_EXCEP(cudaFree(cursor.getMarker()));

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
@@ -32,15 +32,15 @@ namespace PMacc
 namespace allocator
 {
 
-template<typename Type, int _dim>
+template<typename Type, int T_dim>
 struct DeviceMemEvenPitch
 {
     typedef Type type;
-    static const int dim = _dim;
+    static const int dim = T_dim;
     typedef cursor::BufferCursor<type, dim> Cursor;
     typedef allocator::tag::device tag;
 
-    static cursor::BufferCursor<type, _dim> allocate(const math::Size_t<_dim>& size);
+    static cursor::BufferCursor<type, T_dim> allocate(const math::Size_t<T_dim>& size);
     template<typename TCursor>
     static void deallocate(const TCursor& cursor);
 };

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -25,12 +25,12 @@ namespace PMacc
 namespace allocator
 {
 
-template<typename Type, int _dim>
-cursor::BufferCursor<Type, _dim>
-DeviceMemEvenPitch<Type, _dim>::allocate(const math::Size_t<_dim>& size)
+template<typename Type, int T_dim>
+cursor::BufferCursor<Type, T_dim>
+DeviceMemEvenPitch<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
 {
     Type* dataPointer;
-    math::Size_t<_dim-1> pitch;
+    math::Size_t<T_dim-1> pitch;
 
     CUDA_CHECK(cudaMalloc((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
 
@@ -44,7 +44,7 @@ DeviceMemEvenPitch<Type, _dim>::allocate(const math::Size_t<_dim>& size)
         pitch[1] = pitch[0] * size[1];
     }
 
-    return cursor::BufferCursor<Type, _dim>(dataPointer, pitch);
+    return cursor::BufferCursor<Type, T_dim>(dataPointer, pitch);
 }
 
 template<typename Type>
@@ -58,9 +58,9 @@ DeviceMemEvenPitch<Type, 1>::allocate(const math::Size_t<1>& size)
     return cursor::BufferCursor<Type, 1>(dataPointer, math::Size_t<0>());
 }
 
-template<typename Type, int _dim>
+template<typename Type, int T_dim>
 template<typename TCursor>
-void DeviceMemEvenPitch<Type, _dim>::deallocate(const TCursor& cursor)
+void DeviceMemEvenPitch<Type, T_dim>::deallocate(const TCursor& cursor)
 {
     CUDA_CHECK(cudaFree(cursor.getMarker()));
 }

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -33,11 +33,11 @@ namespace PMacc
 namespace allocator
 {
 
-template<typename Type, int _dim>
+template<typename Type, int T_dim>
 struct HostMemAllocator
 {
     typedef Type type;
-    static const int dim = _dim;
+    static const int dim = T_dim;
     typedef cursor::BufferCursor<type, dim> Cursor;
     typedef allocator::tag::host tag;
 

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -38,11 +38,11 @@ struct HostMemAllocator
 {
     typedef Type type;
     static const int dim = T_dim;
-    typedef cursor::BufferCursor<type, dim> Cursor;
+    typedef cursor::BufferCursor<type, T_dim> Cursor;
     typedef allocator::tag::host tag;
 
     HDINLINE
-    static cursor::BufferCursor<type, dim> allocate(const math::Size_t<dim>& size);
+    static cursor::BufferCursor<type, T_dim> allocate(const math::Size_t<T_dim>& size);
     template<typename TCursor>
     HDINLINE
     static void deallocate(const TCursor& cursor);

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -25,13 +25,13 @@ namespace PMacc
 namespace allocator
 {
 
-template<typename Type, int _dim>
-cursor::BufferCursor<Type, _dim>
-HostMemAllocator<Type, _dim>::allocate(const math::Size_t<_dim>& size)
+template<typename Type, int T_dim>
+cursor::BufferCursor<Type, T_dim>
+HostMemAllocator<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
 {
 #ifndef __CUDA_ARCH__
     Type* dataPointer;
-    math::Size_t<_dim-1> pitch;
+    math::Size_t<T_dim-1> pitch;
 
     CUDA_CHECK_NO_EXCEP(cudaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
     if(dim == 2u)
@@ -44,13 +44,13 @@ HostMemAllocator<Type, _dim>::allocate(const math::Size_t<_dim>& size)
         pitch[1] = pitch[0] * size[1];
     }
 
-    return cursor::BufferCursor<Type, _dim>(dataPointer, pitch);
+    return cursor::BufferCursor<Type, T_dim>(dataPointer, pitch);
 #endif
 
 #ifdef __CUDA_ARCH__
     Type* dataPointer = 0;
-    math::Size_t<_dim-1> pitch;
-    return cursor::BufferCursor<Type, _dim>(dataPointer, pitch);
+    math::Size_t<T_dim-1> pitch;
+    return cursor::BufferCursor<Type, T_dim>(dataPointer, pitch);
 #endif
 }
 
@@ -74,9 +74,9 @@ HostMemAllocator<Type, 1>::allocate(const math::Size_t<1>& size)
 #endif
 }
 
-template<typename Type, int _dim>
+template<typename Type, int T_dim>
 template<typename TCursor>
-void HostMemAllocator<Type, _dim>::deallocate(const TCursor& cursor)
+void HostMemAllocator<Type, T_dim>::deallocate(const TCursor& cursor)
 {
 #ifndef __CUDA_ARCH__
     CUDA_CHECK_NO_EXCEP(cudaFreeHost(cursor.getMarker()));

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -43,10 +43,10 @@ namespace assigner
 
 namespace mpl = boost::mpl;
 
-template<int _dim>
+template<int T_dim>
 struct DeviceMemAssigner
 {
-    static const int dim = _dim;
+    static const int dim = T_dim;
     template<typename Type>
     static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
                        const math::Size_t<dim>& size)

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -31,10 +31,10 @@ namespace PMacc
 namespace copier
 {
 
-template<int _dim>
+template<int T_dim>
 struct D2DCopier
 {
-    static const int dim = _dim;
+    static const int dim = T_dim;
     template<typename Type>
     static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
          Type* source, const math::Size_t<dim-1>& pitchSource,

--- a/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
@@ -31,10 +31,10 @@ namespace PMacc
 namespace copier
 {
 
-template<int _dim>
+template<int T_dim>
 struct H2HCopier
 {
-    static const int dim = _dim;
+    static const int dim = T_dim;
     template<typename Type>
     static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
          Type* source, const math::Size_t<dim-1>& pitchSource,

--- a/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
@@ -65,11 +65,11 @@ namespace traits
 {
 
 /* type trait to get the BufferCursor's dimension if it has one */
-template<typename Type, int _dim>
-struct dim<BufferCursor<Type, _dim> >
+template<typename Type, int T_dim>
+struct dim<BufferCursor<Type, T_dim> >
 {
     static const int value = PMacc::cursor::traits::dim<
-        Cursor<PointerAccessor<Type>, BufferNavigator<_dim>, Type*> >::value;
+        Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*> >::value;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -34,12 +34,12 @@ namespace PMacc
 namespace cursor
 {
 
-template<int _dim>
+template<int T_dim>
 class BufferNavigator
 {
 public:
     typedef tag::BufferNavigator tag;
-    static const int dim = _dim;
+    static const int dim = T_dim;
 private:
     math::Size_t<dim-1> pitch;
 public:
@@ -85,10 +85,10 @@ public:
 namespace traits
 {
 
-template<int _dim>
-struct dim<BufferNavigator<_dim> >
+template<int T_dim>
+struct dim<BufferNavigator<T_dim> >
 {
-    static const int value = _dim;
+    static const int value = T_dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -32,12 +32,12 @@ namespace PMacc
 namespace cursor
 {
 
-template<int _dim>
+template<int T_dim>
 class CartNavigator
 {
 public:
     typedef tag::CartNavigator tag;
-    static const int dim = _dim;
+    static const int dim = T_dim;
 private:
     math::Int<dim> factor;
 public:
@@ -60,10 +60,10 @@ public:
 namespace traits
 {
 
-template<int _dim>
-struct dim<CartNavigator<_dim> >
+template<int T_dim>
+struct dim<CartNavigator<T_dim> >
 {
-    static const int value = _dim;
+    static const int value = T_dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -32,11 +32,11 @@ namespace PMacc
 namespace cursor
 {
 
-template<int _dim>
+template<int T_dim>
 struct MultiIndexNavigator
 {
     typedef tag::MultiIndexNavigator tag;
-    static const int dim = _dim;
+    static const int dim = T_dim;
 
     template<typename MultiIndex>
     HDINLINE
@@ -49,10 +49,10 @@ struct MultiIndexNavigator
 namespace traits
 {
 
-template<int _dim>
-struct dim<MultiIndexNavigator<_dim> >
+template<int T_dim>
+struct dim<MultiIndexNavigator<T_dim> >
 {
-    static const int value = _dim;
+    static const int value = T_dim;
 };
 
 }

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -39,16 +39,16 @@ struct SphericZone {};
 
 /* spheric (no holes), cartesian zone
  *
- * \tparam _dim dimension of the zone
+ * \tparam T_dim dimension of the zone
  *
  * This is a zone which is simply described by a size and a offset.
  *
  */
-template<int _dim>
+template<int T_dim>
 struct SphericZone
 {
     typedef tag::SphericZone tag;
-    static const int dim = _dim;
+    static const int dim = T_dim;
     math::Size_t<dim> size;
     math::Int<dim> offset;
 
@@ -58,10 +58,10 @@ struct SphericZone
                          const math::Int<dim>& offset) : size(size), offset(offset) {}
 
     /* Returns whether pos is within the zone */
-    HDINLINE bool within(const PMacc::math::Int<_dim>& pos) const
+    HDINLINE bool within(const PMacc::math::Int<T_dim>& pos) const
     {
         bool result = true;
-        for(int i = 0; i < _dim; i++)
+        for(int i = 0; i < T_dim; i++)
             if((pos[i] < offset[i]) || (pos[i] >= offset[i] + (int)size[i])) result = false;
         return result;
     }

--- a/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
@@ -36,8 +36,8 @@ namespace tag
 struct StaggeredZone {};
 }
 
-template<int _dim>
-struct StaggeredZone : public SphericZone<_dim>
+template<int T_dim>
+struct StaggeredZone : public SphericZone<T_dim>
 {
     typedef tag::StaggeredZone tag;
     math::UInt32<dim> staggered;

--- a/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
@@ -35,11 +35,11 @@ namespace tag
 struct ToricZone {};
 }
 
-template<int _dim>
+template<int T_dim>
 struct ToricZone
 {
     typedef tag::ToricZone tag;
-    static const int dim = _dim;
+    static const int dim = T_dim;
     math::Size_t<dim> offset;
     math::Size_t<dim> size;
     uint32_t thickness;

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
@@ -80,7 +80,7 @@ namespace picongpu
         container::DeviceBuffer<float_PS, 2>* dBuffer;
 
         /** reduce functor to a single host per plane */
-        algorithm::mpi::Reduce<simDim>* planeReduce;
+        PMacc::algorithm::mpi::Reduce<simDim>* planeReduce;
         bool isPlaneReduceRoot;
         /** MPI communicator that contains the root ranks of the \p planeReduce
          */


### PR DESCRIPTION
close #630

- rename `cuSTL` variables with beginning `_`
- CartBuffer.hpp: use `T_dim`  instead of `dim` inside definitions

With this pull request we had still an open warning: #749
