### PR TITLE
close #749 warning in `PhaseSpace` plugin

### DIFF
--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
@@ -220,7 +220,7 @@ namespace picongpu
         container::HostBuffer<float_PS, 2> hReducedBuffer( hBuffer.size() );
         hReducedBuffer.assign( float_PS(0.0) );
 
-        (*this->planeReduce)( /* parameters: dest, source */
+        planeReduce->template operator()( /* parameters: dest, source */
                              hReducedBuffer,
                              hBuffer,
                              /* the functors return value will be written to dst */


### PR DESCRIPTION
fix #749

solve warning by explicit call of `operator()` with the hint (for the compiler) that it uses template

**~~Do not merge before~~ #748**