### PR TITLE
close #753 add out of memory message

### DIFF
--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -73,15 +73,27 @@ public:
      */
     DINLINE FRAME &getEmptyFrame()
     {
-        FrameType* tmp = (FrameType*) mallocMC::malloc(sizeof (FrameType));
-
-        if (tmp != NULL)
+        FrameType* tmp = NULL;
+        const int maxTries = 13; //magic number is not performance critical
+        for (int numTries = 0; numTries < maxTries; ++numTries)
         {
-            /* disable all particles since we can not assume that newly allocated memory contains zeros */
-            for (int i = 0; i < (int) math::CT::volume<typename FrameType::SuperCellSize>::type::value; ++i)
-                (*tmp)[i][multiMask_] = 0;
-            /* takes care that changed values are visible to all threads inside this block*/
-            __threadfence_block();
+            tmp = (FrameType*) mallocMC::malloc(sizeof (FrameType));
+            if (tmp != NULL)
+            {
+                /* disable all particles since we can not assume that newly allocated memory contains zeros */
+                for (int i = 0; i < (int) math::CT::volume<typename FrameType::SuperCellSize>::type::value; ++i)
+                    (*tmp)[i][multiMask_] = 0;
+                /* takes care that changed values are visible to all threads inside this block*/
+                __threadfence_block();
+                break;
+            }
+            else
+            {
+                printf("%s: mallocMC out of memory (try %i of %i)\n",
+                       (numTries+1)==maxTries?"WARNING":"ERROR",
+                       numTries+1,
+                       maxTries);
+            }
         }
 
         return *(FramePtr(tmp));
@@ -94,7 +106,7 @@ public:
      */
     DINLINE void removeFrame(FRAME &frame)
     {
-        mallocMC::free((void*)&frame);
+        mallocMC::free((void*) &frame);
     }
 
     /**


### PR DESCRIPTION
- if `mallocMC::malloc` return NULL, retry 13 times to allocate memory
- write warning/error if we detect out of memory

If we can not allocate memory after 13 tries *bad things will happen* :-)

close #753
This pull request not implement the detection with a mallocMC OOM-Policy because retry the malloc call is not possible in a OOM-Policy.

**Tests:**

- [x] KHI with to few heap memory
- [x] KHI with enough heap memory
