### PR TITLE
change internal `particle` representation

### DIFF
--- a/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
@@ -53,7 +53,8 @@ namespace pmacc = PMacc;
 
 /** A single particle of a @see Frame
  *
- * A instance of this Particle is only a reference to a dataset of @see Frame
+ * A instance of this Particle is a representaion ("pointer") to the memory
+ * where the frame is stored.
  *
  * @tparam T_FrameType type of the parent frame
  * @tparam T_ValueTypeSeq sequence with all attribute identifiers
@@ -76,16 +77,17 @@ struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
      * in this case sizeof(uint32_t)>sizeof(reference)
      */
     /** index of particle inside the Frame*/
-    const uint32_t idx;
-    /** reference to parent frame where this particle is from*/
-    FrameType& frame;
+    PMACC_ALIGN(idx, const uint32_t);
+
+    /** pointer to parent frame where this particle is from*/
+    PMACC_ALIGN(frame, FrameType* const);
 
     /** create particle
      *
      * @param frame reference to parent frame
      * @param idx index of particle inside the frame
      */
-    HDINLINE Particle(FrameType& frame, uint32_t idx) : frame(frame), idx(idx)
+    HDINLINE Particle(FrameType& frame, uint32_t idx) : frame(&frame), idx(idx)
     {
     }
 
@@ -109,7 +111,7 @@ struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
     >::type
     operator[](const T_Key key)
     {
-        return frame.getIdentifier(key)[idx];
+        return frame->getIdentifier(key)[idx];
     }
 
     /** const version of method operator(const T_Key) */
@@ -123,7 +125,7 @@ struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
     operator[](const T_Key key) const
     {
 
-        return frame.getIdentifier(key)[idx];
+        return frame->getIdentifier(key)[idx];
     }
 private:
     /* we disallow to assign this class*/


### PR DESCRIPTION
This change allow to store a particle in global/shared memory.

- store pointer to the parent frame instead of a reference
- add alignment for member variables

**There is no disadvantage in simulation runtime or register usage**