### PR TITLE
move member pointer to end of the class

### DIFF
--- a/src/libPMacc/include/memory/boxes/MultiBox.hpp
+++ b/src/libPMacc/include/memory/boxes/MultiBox.hpp
@@ -57,8 +57,8 @@ public:
     }
 
 private:
-    const PMACC_ALIGN(ptr, char*);
     const PMACC_ALIGN(offset, size_t);
+    const PMACC_ALIGN(ptr, char*);
 };
 
 }//namespace MutiBoxAccass
@@ -127,8 +127,8 @@ public:
 
 protected:
 
-    PMACC_ALIGN(fixedPointer, Type*);
     PMACC_ALIGN(attributePitch, size_t);
+    PMACC_ALIGN(fixedPointer, Type*);
 };
 
 template<typename Type>
@@ -195,9 +195,9 @@ public:
 
 protected:
 
-    PMACC_ALIGN(fixedPointer, Type*);
     PMACC_ALIGN(pitch, size_t);
     PMACC_ALIGN(attributePitch, size_t);
+    PMACC_ALIGN(fixedPointer, Type*);
 };
 
 template<typename Type>
@@ -255,10 +255,10 @@ public:
     }
 
 
-    PMACC_ALIGN(fixedPointer, Type*);
     PMACC_ALIGN(pitch, size_t);
     PMACC_ALIGN(pitch2D, size_t);
     PMACC_ALIGN(attributePitch, size_t);
+    PMACC_ALIGN(fixedPointer, Type*);
 
 };
 

--- a/src/libPMacc/include/memory/boxes/PitchedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/PitchedBox.hpp
@@ -156,8 +156,8 @@ public:
 
 protected:
 
-    PMACC_ALIGN(fixedPointer, TYPE*);
     PMACC_ALIGN(pitch, size_t);
+    PMACC_ALIGN(fixedPointer, TYPE*);
 
 };
 
@@ -213,7 +213,7 @@ public:
     {
         return fixedPointer;
     }
-    
+
     HDINLINE PMacc::cursor::BufferCursor<TYPE, DIM3>
     toCursor() const
     {
@@ -232,9 +232,9 @@ protected:
     }
 
 
-    PMACC_ALIGN(fixedPointer, TYPE*);
     PMACC_ALIGN(pitch, size_t);
     PMACC_ALIGN(pitch2D, size_t);
+    PMACC_ALIGN(fixedPointer, TYPE*);
 
 };
 

--- a/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -86,8 +86,8 @@ public:
 
 protected:
     PMACC_ALIGN8(virtualMemory, PushDataBox<TYPE, PushType >);
-    PMACC_ALIGN(currentSizePointer, TYPE*);
     PMACC_ALIGN(maxSize, TYPE);
+    PMACC_ALIGN(currentSizePointer, TYPE*);
 };
 
 }

--- a/src/libPMacc/include/particles/memory/boxes/PopDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PopDataBox.hpp
@@ -111,9 +111,10 @@ public:
 
 
 protected:
+
+    PMACC_ALIGN(maxSize, TYPE);
     // ptr must be in device-memory
     PMACC_ALIGN(currentSize, TYPE*);
-    PMACC_ALIGN(maxSize, TYPE);
 };
 
 }

--- a/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
@@ -95,8 +95,8 @@ namespace PMacc
         }
 
     protected:
-        PMACC_ALIGN(currentSize,TYPE*);
         PMACC_ALIGN(maxSize,TYPE);
+        PMACC_ALIGN(currentSize,TYPE*);
     };
 }
 

--- a/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
@@ -82,11 +82,13 @@ public:
         sizeLastFrame = size;
     }
 
-    PMACC_ALIGN(firstFramePtr, TYPE*);
-    PMACC_ALIGN(lastFramePtr, TYPE*);
+
 private:
     PMACC_ALIGN(mustShiftVal, bool);
     PMACC_ALIGN(sizeLastFrame, lcellId_t);
+public:
+    PMACC_ALIGN(firstFramePtr, TYPE*);
+    PMACC_ALIGN(lastFramePtr, TYPE*);
 };
 
 } //end namespace


### PR DESCRIPTION
In some cases were a pointer is equivalent to a reference the nvcc compiler can better optimize the code if the aligned pointer is defined as last member in a class/struct.

This pull request reduce the register and stack frames in some kernel e.g.
before:
```
[0mptxas info    : Function properties for _ZN5PMacc14kernelSetValueINS_7DataBoxINS_10PitchedBoxINS_9SuperCellINS_5FrameINS_15ParticlesBufferINS_19ParticleDescriptionIN5boost3mpl6stringILi101ELi0ELi0ELi0ELi0ELi0ELi0ELi0EEENS_4math2CT6VectorIN4mpl_10integral_cIiLi8EEESG_NSF_IiLi4EEEEENS8_6v_itemIN8picongpu24placeholder_definition179weightingENSJ_INSK_24placeholder_definition158momentumENSJ_INSK_24placeholder_definition128positionINSK_24placeholder_definition1412position_picENS_24placeholder_definition1113pmacc_isAliasEEENS8_7vector0INSE_2naEEELi0EEELi0EEELi0EEENS8_6vectorINSK_24placeholder_definition2214particlePusherINSK_9particles6pusher5BorisESU_EENSK_24placeholder_definition215shapeINS15_6shapes3TSCESU_EENSK_24placeholder_definition2413interpolationINSK_28FieldToParticleInterpolationIS1C_NSK_30AssignedTrilinearInterpolationEEESU_EENSK_24placeholder_definition257currentINSK_13currentSolver9EsirkepovIS1C_Lj3EEESU_EESX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_EENSJ_INSK_15CommunicationIdILj5EEESY_Li0EEEEESI_Lj3EE29OperatorCreatePairStaticArrayILj256EEENS6_ISA_SI_NSJ_INS_23placeholder_definition99multiMaskENSJ_INS_23placeholder_definition812localCellIdxES11_Li0EEELi0EEES1Q_S1T_EEEEEELj3EEEEES26_NS_9DataSpaceILj3EEEEEvT_T0_T1_[0m
[0m    24 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads[0m
[0mptxas info    : Used 24 registers, 380 bytes cmem[0][0m
```
and after:
```
[0mptxas info    : Function properties for _ZN5PMacc14kernelSetValueINS_7DataBoxINS_10PitchedBoxINS_9SuperCellINS_5FrameINS_15ParticlesBufferINS_19ParticleDescriptionIN5boost3mpl6stringILi101ELi0ELi0ELi0ELi0ELi0ELi0ELi0EEENS_4math2CT6VectorIN4mpl_10integral_cIiLi8EEESG_NSF_IiLi4EEEEENS8_6v_itemIN8picongpu24placeholder_definition179weightingENSJ_INSK_24placeholder_definition158momentumENSJ_INSK_24placeholder_definition128positionINSK_24placeholder_definition1412position_picENS_24placeholder_definition1113pmacc_isAliasEEENS8_7vector0INSE_2naEEELi0EEELi0EEELi0EEENS8_6vectorINSK_24placeholder_definition2214particlePusherINSK_9particles6pusher5BorisESU_EENSK_24placeholder_definition215shapeINS15_6shapes3TSCESU_EENSK_24placeholder_definition2413interpolationINSK_28FieldToParticleInterpolationIS1C_NSK_30AssignedTrilinearInterpolationEEESU_EENSK_24placeholder_definition257currentINSK_13currentSolver9EsirkepovIS1C_Lj3EEESU_EESX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_SX_EENSJ_INSK_15CommunicationIdILj5EEESY_Li0EEEEESI_Lj3EE29OperatorCreatePairStaticArrayILj256EEENS6_ISA_SI_NSJ_INS_23placeholder_definition99multiMaskENSJ_INS_23placeholder_definition812localCellIdxES11_Li0EEELi0EEES1Q_S1T_EEEEEELj3EEEEES26_NS_9DataSpaceILj3EEEEEvT_T0_T1_[0m
[0m    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads[0m
[0mptxas info    : Used 11 registers, 380 bytes cmem[0][0m
```