### PR TITLE
add laserPolynom as option to `componentsConfig.param`

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/componentsConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -36,6 +36,7 @@ namespace simulation_starter = defaultPIConGPU;
  *                            in 'x' direction
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
  */
 namespace laserProfile = laserPlaneWave;
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/componentsConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -36,6 +36,7 @@ namespace picongpu
      *                            in 'x' direction
      *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
      *  - laserPlaneWave        : a plane wave
+     *  - laserPolynom          : a polynomial laser envelope
      */
     namespace laserProfile = laserNone;
 

--- a/examples/LaserWakefield/include/simulation_defines/param/componentsConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Felix Schmitt,
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.
@@ -37,6 +37,7 @@ namespace simulation_starter = defaultPIConGPU;
  *                            in 'x' direction
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
  */
 namespace laserProfile = laserGaussianBeam;
 

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/componentsConfig.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.
@@ -37,6 +37,7 @@ namespace simulation_starter = singleParticleTest;
  *                            in 'x' direction
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
  */
 namespace laserProfile = laserNone;
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/componentsConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -36,6 +36,7 @@ namespace simulation_starter = radiationTest;
  *                            in 'x' direction
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
  */
 namespace laserProfile = laserPlaneWave;
 

--- a/examples/SingleParticleTest/include/simulation_defines/param/componentsConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -36,6 +36,7 @@ namespace simulation_starter = singleParticleTest;
  *                            in 'x' direction
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
  */
 namespace laserProfile = laserNone;
 

--- a/examples/ThermalTest/include/simulation_defines/param/componentsConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.
@@ -37,6 +37,7 @@ namespace simulation_starter = thermalTestStarter;
  *                            in 'x' direction
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
  */
 namespace laserProfile = laserNone;
 

--- a/examples/WeibelTransverse/include/simulation_defines/param/componentsConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -36,6 +36,7 @@ namespace picongpu
      *                            in 'x' direction
      *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
      *  - laserPlaneWave        : a plane wave
+     *  - laserPolynom          : a polynomial laser envelope
      */
     namespace laserProfile = laserNone;
 

--- a/src/picongpu/include/simulation_defines/param/componentsConfig.param
+++ b/src/picongpu/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Anton Helm, 
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Anton Helm, 
  *                     Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
@@ -37,6 +37,7 @@ namespace simulation_starter = defaultPIConGPU;
  *                            in 'x' direction
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
  */
 namespace laserProfile = laserNone;
 


### PR DESCRIPTION
This pull request adds the missing `laserPolynom` to `componentsConfig.param`. 

@ax3l:
This pull request adjusts `componentsConfig.param`.