### PR TITLE
adjust DELTA_T_SI depending on SIMDIM to improve the CFL condition

### DIFF
--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -27,6 +27,9 @@ namespace picongpu
 
     namespace SI
     {
+        /** Duration of one timestep
+         *  unit: seconds */
+        const double DELTA_T_SI = 1.79e-16;
         /** equals X
          *  unit: meter */
         const double CELL_WIDTH_SI = 9.34635e-8;
@@ -36,14 +39,6 @@ namespace picongpu
         /** equals Z
          *  unit: meter */
         const double CELL_DEPTH_SI = CELL_WIDTH_SI;
-
-        /** Duration of one timestep
-         *  unit: seconds */
-#if (SIMDIM==DIM3)
-        const double DELTA_T_SI = 1.79e-16;
-#elif (SIMDIM==DIM2)
-        const double DELTA_T_SI = 2.20e-16;
-#endif
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 
@@ -27,18 +27,23 @@ namespace picongpu
 
     namespace SI
     {
-        /** Duration of one timestep
-         *  unit: seconds */
-        const double DELTA_T_SI = 1.5e-16;
         /** equals X
          *  unit: meter */
         const double CELL_WIDTH_SI = 9.34635e-8;
         /** equals Y - the propagation direction
          *  unit: meter */
-        const double CELL_HEIGHT_SI = 9.34635e-8;
+        const double CELL_HEIGHT_SI = CELL_WIDTH_SI;
         /** equals Z
          *  unit: meter */
-        const double CELL_DEPTH_SI = 9.34635e-8;
+        const double CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Duration of one timestep
+         *  unit: seconds */
+#if (SIMDIM==DIM3)
+        const double DELTA_T_SI = 1.79e-16;
+#elif (SIMDIM==DIM2)
+        const double DELTA_T_SI = 2.20e-16;
+#endif
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)


### PR DESCRIPTION
This pull request adjusts `DELTA_T_SI` to improve the Courant-Friedrichs-Lewy condition depending on the dimension of the simulation `SIMDIM`. It closes issue #763. 

For 2D we now get:
```
PIConGPUVerbose PHYSICS(1) | Courant c*dt <= 1.00204 ? 1
```

For 3D we now get:
```
PIConGPUVerbose PHYSICS(1) | Courant c*dt <= 1.00556 ? 1
```

