### PR TITLE
fix broken restart

### DIFF
--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -330,11 +330,10 @@ public:
             else
             {
                 initialiserController->init();
+                ForEach<InitPipeline, particles::CallFunctor<bmpl::_1> > initSpecies;
+                initSpecies(forward(particleStorage), step);
             }
         }
-
-        ForEach<InitPipeline, particles::CallFunctor<bmpl::_1> > initSpecies;
-        initSpecies(forward(particleStorage), step);
 
         Environment<>::get().EnvMemoryInfo().getMemoryInfo(&freeGpuMem);
         log<picLog::MEMORY > ("free mem after all particles are initialized %1% MiB") % (freeGpuMem / 1024 / 1024);


### PR DESCRIPTION
fix that restart loads particle from hdf5 and use `InitPipeline` to create particles

This bug only applies `dev` since #730 *add multi species gas functors*

Thanks to @BeyondEspresso 