### PR TITLE
close #697: fix radiation types

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 

--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -36,10 +36,10 @@ namespace picongpu
      *           to compute the observation direction
      *
      * @return   unit vector pointing in observation direction
-     *           type: vec2
+     *           type: vector_64
      * 
      */
-    DINLINE vec2 observation_direction(const int observation_id_extern)
+    DINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** Computes observation angles along the x-y plane.
        *  Assuming electron(s) fly in -x direction and the laser
@@ -65,7 +65,7 @@ namespace picongpu
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */
-      return vec2(sinf(theta), cosf(theta), 0.0);
+      return vector_64(sinf(theta), cosf(theta), 0.0);
       
     }
     

--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -53,15 +53,15 @@ namespace picongpu
       const int my_theta_id = observation_id_extern;
 
       /* set up: */
-      const numtype2 gamma_times_thetaMax = 1.5; /* max normalized angle */
-      const numtype2 gamma = 5.0;                /* relativistic gamma */
-      const numtype2 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
+      const picongpu::float_64 gamma_times_thetaMax = 1.5; /* max normalized angle */
+      const picongpu::float_64 gamma = 5.0;                /* relativistic gamma */
+      const picongpu::float_64 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
 
       /* stepwith of theta for from [-thetaMax : +thetaMax] */
-      const numtype2 delta_theta =  2.0 * thetaMax / (parameters::N_observer); 
+      const picongpu::float_64 delta_theta =  2.0 * thetaMax / (parameters::N_observer); 
 
       /* compute angle theta for index */
-      const numtype2 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI); 
+      const picongpu::float_64 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI); 
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
@@ -36,10 +36,10 @@ namespace picongpu
      *           to compute the observation direction
      *
      * @return   unit vector pointing in observation direction
-     *           type: vec2
+     *           type: vector_64
      * 
      */
-    DINLINE vec2 observation_direction(const int observation_id_extern)
+    DINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** This computes observation directions for one octant 
        *  of a sphere around the simulation area.
@@ -65,7 +65,7 @@ namespace picongpu
       const picongpu::float_64 phi(    my_index_phi   * delta_angle  ); 
       
       /* compute unit vector */
-      return vec2( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;
+      return vector_64( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;
 
     }
     

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
@@ -55,14 +55,14 @@ namespace picongpu
       const int my_index_phi = observation_id_extern % N_angle_split;
 
       /*  range for BOTH angles */
-      const numtype2 angle_range= picongpu::PI/2.0;
+      const picongpu::float_64 angle_range= picongpu::PI/2.0;
 
       /* angle stepwidth for BOTH angles */
-      const numtype2 delta_angle =  1.0 * angle_range / (N_angle_split-1);
+      const picongpu::float_64 delta_angle =  1.0 * angle_range / (N_angle_split-1);
 
       /* compute both angles */
-      const numtype2 theta(  my_index_theta * delta_angle  + 0.5*picongpu::PI ); 
-      const numtype2 phi(    my_index_phi   * delta_angle  ); 
+      const picongpu::float_64 theta(  my_index_theta * delta_angle  + 0.5*picongpu::PI ); 
+      const picongpu::float_64 phi(    my_index_phi   * delta_angle  ); 
       
       /* compute unit vector */
       return vec2( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU. 
  * 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
@@ -36,10 +36,10 @@ namespace picongpu
      *           to compute the observation direction
      *
      * @return   unit vector pointing in observation direction
-     *           type: vec2
+     *           type: vector_64
      * 
      */
-    DINLINE vec2 observation_direction(const int observation_id_extern)
+    DINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** Computes observation angles along the x-y plane.
        *  Assuming electron(s) fly in -x direction and the laser
@@ -66,7 +66,7 @@ namespace picongpu
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */
-      return vec2(sinf(theta), cosf(theta), 0.0);
+      return vector_64(sinf(theta), cosf(theta), 0.0);
       
     }
     

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
@@ -54,15 +54,15 @@ namespace picongpu
       const int my_theta_id = observation_id_extern;
 
       /* set up: */
-      const numtype2 gamma_times_thetaMax = 1.5; /* max normalized angle */
-      const numtype2 gamma = 5.0;                /* relativistic gamma */
-      const numtype2 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
+      const picongpu::float_64 gamma_times_thetaMax = 1.5; /* max normalized angle */
+      const picongpu::float_64 gamma = 5.0;                /* relativistic gamma */
+      const picongpu::float_64 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
 
       /* stepwith of theta for from [-thetaMax : +thetaMax] */
-      const numtype2 delta_theta =  2.0 * thetaMax / (parameters::N_observer); 
+      const picongpu::float_64 delta_theta =  2.0 * thetaMax / (parameters::N_observer); 
 
       /* compute angle theta for index */
-      const numtype2 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI); 
+      const picongpu::float_64 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI); 
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -553,7 +553,7 @@ private:
 
       /* get the radiation amplitude unit */
       Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
-      const numtype2 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
+      const picongpu::float_64 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
 
       for(uint ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
       {
@@ -627,7 +627,7 @@ private:
                                            parameters::N_observer);
 
           const int N_tmpBuffer = radiation_frequencies::N_omega * parameters::N_observer;
-          numtype2* tmpBuffer = new numtype2[N_tmpBuffer];
+          picongpu::float_64* tmpBuffer = new picongpu::float_64[N_tmpBuffer];
 
           for(uint ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
           {
@@ -639,7 +639,7 @@ private:
               for(int copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
               {
                   /* convert data directly because Amplutude is just 6 double */
-                  ((numtype2*)values)[ampIndex + Amplitude::numComponents*copyIndex] = tmpBuffer[copyIndex];
+                  ((picongpu::float_64*)values)[ampIndex + Amplitude::numComponents*copyIndex] = tmpBuffer[copyIndex];
               }
 
           }

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -128,7 +128,7 @@ void kernelRadiationParticles(ParBox pb,
 
     const int blockSize=PMacc::math::CT::volume<Block>::type::value;
     // vectorial part of the integrand in the Jackson formula
-    __shared__ vec2 real_amplitude_s[blockSize];
+    __shared__ vector_64 real_amplitude_s[blockSize];
 
     // retarded time
     __shared__ picongpu::float_64 t_ret_s[blockSize];
@@ -162,7 +162,7 @@ void kernelRadiationParticles(ParBox pb,
     const picongpu::float_64 t((picongpu::float_64) currentStep * (picongpu::float_64) DELTA_T);
 
     // looking direction (needed for observer) used in the thread
-    const vec2 look = radiation_observer::observation_direction(theta_idx);
+    const vector_64 look = radiation_observer::observation_direction(theta_idx);
 
     // get extent of guarding super cells (needed to ignore them)
     const int guardingSuperCells = mapper.getGuardingSuperCells();
@@ -440,13 +440,13 @@ void kernelRadiationParticles(ParBox pb,
                         // is considered
                         // the form factor influences the real amplitude
 #if (__COHERENTINCOHERENTWEIGHTING__==1)
-                        const vec2 weighted_real_amp = real_amplitude_s[j] * precisionCast<float_64 >
+                        const vector_64 weighted_real_amp = real_amplitude_s[j] * precisionCast<float_64 >
                           (myRadFormFactor(radWeighting_s[j], omega, look));
 #else
                         // if coherent/incoherent radiation of single macro-particle
                         // is NOT considered
                         // no change on real amplitude is performed
-                        const vec2 weighted_real_amp = real_amplitude_s[j];
+                        const vector_64 weighted_real_amp = real_amplitude_s[j];
 #endif
 
                         // complex amplitude for j-th particle

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Klaus Steiniger,
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Klaus Steiniger,
  * Felix Schmitt
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -131,7 +131,7 @@ void kernelRadiationParticles(ParBox pb,
     __shared__ vec2 real_amplitude_s[blockSize];
 
     // retarded time
-    __shared__ numtype2 t_ret_s[blockSize];
+    __shared__ picongpu::float_64 t_ret_s[blockSize];
 
     // storage for macro particle weighting needed if
     // the coherent and incoherent radiation of a single
@@ -159,7 +159,7 @@ void kernelRadiationParticles(ParBox pb,
 
 
     // simulation time (needed for retarded time)
-    const numtype2 t((numtype2) currentStep * (numtype2) DELTA_T);
+    const picongpu::float_64 t((picongpu::float_64) currentStep * (picongpu::float_64) DELTA_T);
 
     // looking direction (needed for observer) used in the thread
     const vec2 look = radiation_observer::observation_direction(theta_idx);
@@ -330,7 +330,7 @@ void kernelRadiationParticles(ParBox pb,
                     // a single electron
                     real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
                       particle_charge *
-                      (numtype2) DELTA_T;
+                      (picongpu::float_64) DELTA_T;
 #else
                     // if coherent and incoherent of single macro-particle is NOT considered
 
@@ -340,7 +340,7 @@ void kernelRadiationParticles(ParBox pb,
                     // compute real amplitude of macro-particle
                     real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
                       particle_charge *
-                      (numtype2) DELTA_T;
+                      (picongpu::float_64) DELTA_T;
 #endif
 
                     // retarded time stored in shared memory
@@ -406,7 +406,7 @@ void kernelRadiationParticles(ParBox pb,
                 Amplitude amplitude = Amplitude::zero();
 
                 // compute frequency "omega" using for-loop-index "o"
-                const numtype2 omega = freqFkt(o);
+                const picongpu::float_64 omega = freqFkt(o);
 
 
                 // if coherent and incoherent radiation of a single macro-particle

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -267,7 +267,7 @@ void kernelRadiationParticles(ParBox pb,
                                                       (cellIdx));
 
                     // add global position of cell with local position of particle in cell
-                    vec1 particle_locationNow;
+                    vector_32 particle_locationNow;
                     // set z component to zero in case of simDim==DIM2
                     particle_locationNow[2] = 0.0;
                     // run over all components and compute gobal position
@@ -276,8 +276,8 @@ void kernelRadiationParticles(ParBox pb,
 
 
                     // get old and new particle momenta
-                    const vec1 particle_momentumNow = vec1(par[momentum_]);
-                    const vec1 particle_momentumOld = vec1(par[momentumPrev1_]);
+                    const vector_32 particle_momentumNow = vector_32(par[momentum_]);
+                    const vector_32 particle_momentumOld = vector_32(par[momentumPrev1_]);
 
 
                     /* get macro-particle weighting

--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -24,15 +24,15 @@
 #include "parameters.hpp"
 #include "mpi/GetMPI_StructAsArray.hpp"
 
-typedef PMacc::math::Complex<numtype2> complex_64;
+typedef PMacc::math::Complex<picongpu::float_64> complex_64;
 
 /** class to store 3 complex numbers for the radiated amplitude
  */
 class Amplitude
 {
 public:
-  // number of scalars of type numtype2 in Amplitude = 3 (3D) * 2 (complex) = 6
-  static const uint numComponents = 3 * sizeof(complex_64) / sizeof(numtype2);
+  // number of scalars of type picongpu::float_64 in Amplitude = 3 (3D) * 2 (complex) = 6
+  static const uint numComponents = 3 * sizeof(complex_64) / sizeof(picongpu::float_64);
 
   /** constructor 
    * 
@@ -44,9 +44,9 @@ public:
       picongpu::float_X cosValue;
       picongpu::float_X sinValue;
       picongpu::math::sincos(phase, sinValue, cosValue);
-      amp_x=PMacc::algorithms::math::euler(vec.x(), picongpu::precisionCast<numtype2>(sinValue), picongpu::precisionCast<numtype2>(cosValue) );
-      amp_y=PMacc::algorithms::math::euler(vec.y(), picongpu::precisionCast<numtype2>(sinValue), picongpu::precisionCast<numtype2>(cosValue) );
-      amp_z=PMacc::algorithms::math::euler(vec.z(), picongpu::precisionCast<numtype2>(sinValue), picongpu::precisionCast<numtype2>(cosValue) );
+      amp_x=PMacc::algorithms::math::euler(vec.x(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
+      amp_y=PMacc::algorithms::math::euler(vec.y(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
+      amp_z=PMacc::algorithms::math::euler(vec.z(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
   }
 
 
@@ -63,9 +63,9 @@ public:
    * 
    * Arguments:
    * - 6x float: Re(x), Im(x), Re(y), Im(y), Re(z), Im(z) */
-  HDINLINE Amplitude(const numtype2 x_re, const numtype2 x_im, 
-                     const numtype2 y_re, const numtype2 y_im, 
-                     const numtype2 z_re, const numtype2 z_im)
+  HDINLINE Amplitude(const picongpu::float_64 x_re, const picongpu::float_64 x_im, 
+                     const picongpu::float_64 y_re, const picongpu::float_64 y_im, 
+                     const picongpu::float_64 z_re, const picongpu::float_64 z_im)
       : amp_x(x_re, x_im), amp_y(y_re, y_im), amp_z(z_re, z_im)
   {
 
@@ -107,10 +107,10 @@ public:
   /** calculate radiation from *this amplitude
    *
    * Returns: \frac{d^2 I}{d \Omega d \omega} = const*Amplitude^2 */
-  HDINLINE numtype2 calc_radiation(void)
+  HDINLINE picongpu::float_64 calc_radiation(void)
   {
       // const SI factor radiation
-      const numtype2 factor = 1.0 /
+      const picongpu::float_64 factor = 1.0 /
         (16. * util::cube(M_PI) * picongpu::EPS0 * picongpu::SPEED_OF_LIGHT); 
 
       return factor * (PMacc::algorithms::math::abs2(amp_x) + PMacc::algorithms::math::abs2(amp_y) + PMacc::algorithms::math::abs2(amp_z));
@@ -120,7 +120,7 @@ public:
   /** debugging method
    * 
    * Returns: real-x-value */
-  HDINLINE numtype2 debug(void)
+  HDINLINE picongpu::float_64 debug(void)
   {
       return amp_x.get_real();
   }

--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -37,9 +37,9 @@ public:
   /** constructor 
    * 
    * Arguments:
-   * - vec2: real 3D vector 
+   * - vector_64: real 3D vector 
    * - float: complex phase */
-  DINLINE Amplitude(vec2 vec, picongpu::float_X phase)
+  DINLINE Amplitude(vector_64 vec, picongpu::float_X phase)
   {
       picongpu::float_X cosValue;
       picongpu::float_X sinValue;

--- a/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
@@ -48,7 +48,7 @@ struct One_minus_beta_times_n
 
     //  Taylor just includes a method, When includes just enum
 
-    HDINLINE numtype1 operator()(const vec2& n, const Particle & particle) const
+    HDINLINE picongpu::float_32 operator()(const vec2& n, const Particle & particle) const
     {
         // 1/gamma^2:
 

--- a/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
@@ -48,7 +48,7 @@ struct One_minus_beta_times_n
 
     //  Taylor just includes a method, When includes just enum
 
-    HDINLINE picongpu::float_32 operator()(const vec2& n, const Particle & particle) const
+    HDINLINE picongpu::float_32 operator()(const vector_64& n, const Particle & particle) const
     {
         // 1/gamma^2:
 
@@ -69,7 +69,7 @@ struct One_minus_beta_times_n
         }
         else
         {
-            const vec2 beta(particle.get_beta<When::now > ()); // calc v/c=beta
+            const vector_64 beta(particle.get_beta<When::now > ()); // calc v/c=beta
             return  (1.0 - beta * n);
         }
 
@@ -83,9 +83,9 @@ struct Retarded_time_1
     // same interface as 'Retarded_time_2'
 
     HDINLINE picongpu::float_64 operator()(const picongpu::float_64 t,
-                                const vec2& n, const Particle & particle) const
+                                const vector_64& n, const Particle & particle) const
     {
-        const vec2 r(particle.get_location<When::now > ()); // location
+        const vector_64 r(particle.get_location<When::now > ()); // location
         return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
     }
 
@@ -99,10 +99,10 @@ struct Old_Method
     /// with Exponent=Cube the integration over t_ret will be assumed (old FFT)
     /// with Exponent=Square the integration over t_sim will be assumed (old DFT)
 
-    HDINLINE vec2 operator()(const vec2& n, const Particle& particle, const picongpu::float_64 delta_t) const
+    HDINLINE vector_64 operator()(const vector_64& n, const Particle& particle, const picongpu::float_64 delta_t) const
     {
-        const vec2 beta(particle.get_beta<When::now > ()); // beta = v/c
-        const vec2 beta_dot((beta - particle.get_beta < When::now + 1 > ()) / delta_t); // numeric differentiation (backward difference)
+        const vector_64 beta(particle.get_beta<When::now > ()); // beta = v/c
+        const vector_64 beta_dot((beta - particle.get_beta < When::now + 1 > ()) / delta_t); // numeric differentiation (backward difference)
         const Exponent exponent; // instance of the Exponent class // ???is a static class and no instance possible???
          //const One_minus_beta_times_n one_minus_beta_times_n;
         const picongpu::float_64 factor(exponent(1.0 / (One_minus_beta_times_n()(n, particle))));
@@ -143,21 +143,21 @@ public:
 
     // get real vector part of amplitude
 
-    HDINLINE vec2 get_vector(const vec2& n) const
+    HDINLINE vector_64 get_vector(const vector_64& n) const
     {
-        const vec2 look_direction(n.unit_vec()); // make sure look_direction is a unit vector
+        const vector_64 look_direction(n.unit_vec()); // make sure look_direction is a unit vector
         VecCalc vecC;
         return vecC(look_direction, particle, delta_t);
     }
 
     // get retarded time
 
-    HDINLINE picongpu::float_64 get_t_ret(const vec2 look_direction) const
+    HDINLINE picongpu::float_64 get_t_ret(const vector_64 look_direction) const
     {
         TimeCalc timeC;
         return timeC(t_sim, look_direction, particle);
 
-        //  const vec2 r = particle.get_location<When::now > (); // location
+        //  const vector_64 r = particle.get_location<When::now > (); // location
         //  return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
     }
 

--- a/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
@@ -52,9 +52,9 @@ struct One_minus_beta_times_n
     {
         // 1/gamma^2:
 
-        const numtype2 gamma_inv_square(particle.get_gamma_inv_square<When::now > ());
+        const picongpu::float_64 gamma_inv_square(particle.get_gamma_inv_square<When::now > ());
 
-        //numtype2 value; // storage for 1-\beta \times \vec n
+        //picongpu::float_64 value; // storage for 1-\beta \times \vec n
 
         // if energy is high enough to cause numerical errors ( equals if 1/gamma^2 is closs enought to zero)
         // chose a Taylor approximation to to better calculate 1-\beta \times \vec n (which is close to 1-1)
@@ -63,8 +63,8 @@ struct One_minus_beta_times_n
         // with 0.18 the relativ error will be below 0.001% for a Taylor series of 1-sqrt(1-x) of 5th order
         if (gamma_inv_square < picongpu::GAMMA_INV_SQUARE_RAD_THRESH) 
         {
-            const numtype2 cos_theta(particle.get_cos_theta<When::now > (n)); // cosinus between looking vector and momentum of particle
-            const numtype2 taylor_approx(cos_theta * Taylor()(gamma_inv_square) + (1.0 - cos_theta));
+            const picongpu::float_64 cos_theta(particle.get_cos_theta<When::now > (n)); // cosinus between looking vector and momentum of particle
+            const picongpu::float_64 taylor_approx(cos_theta * Taylor()(gamma_inv_square) + (1.0 - cos_theta));
             return  (taylor_approx);
         }
         else
@@ -82,11 +82,11 @@ struct Retarded_time_1
     // contains more parameters than needed to have the
     // same interface as 'Retarded_time_2'
 
-    HDINLINE numtype2 operator()(const numtype2 t,
+    HDINLINE picongpu::float_64 operator()(const picongpu::float_64 t,
                                 const vec2& n, const Particle & particle) const
     {
         const vec2 r(particle.get_location<When::now > ()); // location
-        return (numtype2) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
+        return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
     }
 
 };
@@ -99,21 +99,21 @@ struct Old_Method
     /// with Exponent=Cube the integration over t_ret will be assumed (old FFT)
     /// with Exponent=Square the integration over t_sim will be assumed (old DFT)
 
-    HDINLINE vec2 operator()(const vec2& n, const Particle& particle, const numtype2 delta_t) const
+    HDINLINE vec2 operator()(const vec2& n, const Particle& particle, const picongpu::float_64 delta_t) const
     {
         const vec2 beta(particle.get_beta<When::now > ()); // beta = v/c
         const vec2 beta_dot((beta - particle.get_beta < When::now + 1 > ()) / delta_t); // numeric differentiation (backward difference)
         const Exponent exponent; // instance of the Exponent class // ???is a static class and no instance possible???
          //const One_minus_beta_times_n one_minus_beta_times_n;
-        const numtype2 factor(exponent(1.0 / (One_minus_beta_times_n()(n, particle))));
+        const picongpu::float_64 factor(exponent(1.0 / (One_minus_beta_times_n()(n, particle))));
         // factor=1/(1-beta*n)^g   g=2 for DFT and g=3 for FFT
         return (n % ((n - beta) % beta_dot)) * factor;
     }
 };
 
 // typedef of all possible forms of Old_Method
-//typedef Old_Method<util::Cube<numtype2> > Old_FFT;
-typedef Old_Method<util::Square<numtype2> > Old_DFT;
+//typedef Old_Method<util::Cube<picongpu::float_64> > Old_FFT;
+typedef Old_Method<util::Square<picongpu::float_64> > Old_DFT;
 
 
 
@@ -135,8 +135,8 @@ public:
     // of base classes
 
     HDINLINE Calc_Amplitude(const Particle& particle,
-                           const numtype2 delta_t,
-                           const numtype2 t_sim)
+                           const picongpu::float_64 delta_t,
+                           const picongpu::float_64 t_sim)
     : particle(particle), delta_t(delta_t), t_sim(t_sim)
     {
     }
@@ -152,20 +152,20 @@ public:
 
     // get retarded time
 
-    HDINLINE numtype2 get_t_ret(const vec2 look_direction) const
+    HDINLINE picongpu::float_64 get_t_ret(const vec2 look_direction) const
     {
         TimeCalc timeC;
         return timeC(t_sim, look_direction, particle);
 
         //  const vec2 r = particle.get_location<When::now > (); // location
-        //  return (numtype2) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
+        //  return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
     }
 
 private:
     // data:
     const Particle& particle; // one particle
-    const numtype2 delta_t; // length of one timestep in simulation
-    const numtype2 t_sim; // simulation time (for methods not using index*delta_t )
+    const picongpu::float_64 delta_t; // length of one timestep in simulation
+    const picongpu::float_64 t_sim; // simulation time (for methods not using index*delta_t )
 
 
 };

--- a/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
+++ b/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
@@ -34,7 +34,7 @@ public:
      * omega_{Nyquist} = (\pi - \epsilon )/(\delta t * (1 - \vec(\beta) * \vec(n)))
      * so that all Amplitudes for higher frequencies can be ignored
     **/
-    __device__ __host__ __forceinline__ NyquistLowPass(const vec2& n, const Particle& particle)
+    __device__ __host__ __forceinline__ NyquistLowPass(const vector_64& n, const Particle& particle)
       : omegaNyquist((picongpu::PI - 0.01)/
 	       (picongpu::DELTA_T *
 	        One_minus_beta_times_n()(n, particle)))

--- a/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
+++ b/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
@@ -50,12 +50,12 @@ public:
     /**
      * checks if frequency omega is below Nyquist frequency
     **/
-    __device__ __host__ __forceinline__ bool check(const numtype1 omega)
+    __device__ __host__ __forceinline__ bool check(const picongpu::float_32 omega)
     {
         return omega < omegaNyquist * picongpu::radiationNyquist::NyquistFactor;
     }
 
 private:
-    numtype1 omegaNyquist; // Nyquist frequency for a particle (at a certain timestep) for one direction
+    picongpu::float_32 omegaNyquist; // Nyquist frequency for a particle (at a certain timestep) for one direction
 };
 

--- a/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
+++ b/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -25,7 +25,7 @@
 #include "simulation_defines.hpp"
 
 
-typedef /*__align__(16)*/ cuda_vec<picongpu::float3_X, picongpu::float_X> vec1;
+typedef /*__align__(16)*/ cuda_vec<picongpu::float3_X, picongpu::float_X> vector_32;
 typedef /*__align__(32)*/ cuda_vec<picongpu::float3_64, picongpu::float_64> vector_64;
 
 

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -25,8 +25,6 @@
 #include "simulation_defines.hpp"
 
 
-typedef picongpu::float_32 numtype1;
-
 typedef /*__align__(16)*/ cuda_vec<picongpu::float3_X, picongpu::float_X> vec1;
 typedef /*__align__(32)*/ cuda_vec<picongpu::float3_64, picongpu::float_64> vec2;
 

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -26,7 +26,6 @@
 
 
 typedef picongpu::float_32 numtype1;
-typedef __align__(8) picongpu::float_64 numtype2;
 
 typedef /*__align__(16)*/ cuda_vec<picongpu::float3_X, picongpu::float_X> vec1;
 typedef /*__align__(32)*/ cuda_vec<picongpu::float3_64, picongpu::float_64> vec2;

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -26,6 +26,6 @@
 
 
 typedef /*__align__(16)*/ cuda_vec<picongpu::float3_X, picongpu::float_X> vec1;
-typedef /*__align__(32)*/ cuda_vec<picongpu::float3_64, picongpu::float_64> vec2;
+typedef /*__align__(32)*/ cuda_vec<picongpu::float3_64, picongpu::float_64> vector_64;
 
 

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -74,15 +74,15 @@ public:
     // getters:
 
     template<unsigned int when>
-    HDINLINE vec2 get_location(void) const;
+    HDINLINE vector_64 get_location(void) const;
     // get location at time when
 
     template<unsigned int when>
-    HDINLINE vec2 get_momentum(void) const;
+    HDINLINE vector_64 get_momentum(void) const;
     // get momentum at time when
 
     template<unsigned int when>
-    HDINLINE vec2 get_beta(void) const
+    HDINLINE vector_64 get_beta(void) const
     {
         return calc_beta(get_momentum<when > ());
     } // get beta at time when except:
@@ -101,10 +101,10 @@ public:
     } // get 1/gamma^2
 
     template< unsigned int when>
-    HDINLINE picongpu::float_64 get_cos_theta(const vec2& n) const
+    HDINLINE picongpu::float_64 get_cos_theta(const vector_64& n) const
     {
         // get cos(theta) at time when
-        const vec2 beta = get_beta<when > ();
+        const vector_64 beta = get_beta<when > ();
         return calc_cos_theta(n, beta);
     }
 
@@ -113,7 +113,7 @@ private:
     //////////////////////////////////////////////////////////////////
     // private methods:
 
-    HDINLINE vec2 calc_beta(const vec1& momentum) const
+    HDINLINE vector_64 calc_beta(const vec1& momentum) const
     {
         // returns beta=v/c
         const picongpu::float_32 gamma1 = calc_gamma(momentum);
@@ -135,7 +135,7 @@ private:
         return Emass / (Emass + (util::square<vec1, picongpu::float_32 > (momentum)) / Emass);
     }
 
-    HDINLINE picongpu::float_64 calc_cos_theta(const vec2& n, const vec2& beta) const
+    HDINLINE picongpu::float_64 calc_cos_theta(const vector_64& n, const vector_64& beta) const
     {
         // return cos of angle between looking and flight direction
         return (n * beta) / (std::sqrt(beta * beta));
@@ -156,19 +156,19 @@ private:
 
 
 template<>
-HDINLINE vec2 Particle::get_location<When::now>(void) const
+HDINLINE vector_64 Particle::get_location<When::now>(void) const
 {
     return location_now;
 } // get location at time when
 
 template<>
-HDINLINE vec2 Particle::get_momentum<When::now>(void) const
+HDINLINE vector_64 Particle::get_momentum<When::now>(void) const
 {
     return momentum_now;
 } // get momentum at time when
 
 template<>
-HDINLINE vec2 Particle::get_momentum<When::old>(void) const
+HDINLINE vector_64 Particle::get_momentum<When::old>(void) const
 {
     return momentum_old;
 } // get momentum at time when

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -54,16 +54,16 @@ public:
     {
         location_begin = When::now, momentum_begin = When::now, beta_begin = When::first
     };
-    const vec1 momentum_now;
-    const vec1 momentum_old;
-    const vec1 location_now;
+    const vector_32 momentum_now;
+    const vector_32 momentum_old;
+    const vector_32 location_now;
     const picongpu::float_X mass;
 
 public:
     //////////////////////////////////////////////////////////////////
     // constructors:
 
-  HDINLINE Particle(const vec1& locationNow_set, const vec1& momentumOld_set, const vec1& momentumNow_set, const picongpu::float_X mass_set)
+  HDINLINE Particle(const vector_32& locationNow_set, const vector_32& momentumOld_set, const vector_32& momentumNow_set, const picongpu::float_X mass_set)
     : location_now(locationNow_set), momentum_old(momentumOld_set), momentum_now(momentumNow_set), mass(mass_set)
     {
 
@@ -113,26 +113,26 @@ private:
     //////////////////////////////////////////////////////////////////
     // private methods:
 
-    HDINLINE vector_64 calc_beta(const vec1& momentum) const
+    HDINLINE vector_64 calc_beta(const vector_32& momentum) const
     {
         // returns beta=v/c
         const picongpu::float_32 gamma1 = calc_gamma(momentum);
         return momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT * gamma1));
     }
 
-    HDINLINE picongpu::float_64 calc_gamma(const vec1& momentum) const
+    HDINLINE picongpu::float_64 calc_gamma(const vector_32& momentum) const
     {
         // return gamma = E/(mc^2)
-        const picongpu::float_32 x = util::square<vec1, picongpu::float_32 > (momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT)));
+        const picongpu::float_32 x = util::square<vector_32, picongpu::float_32 > (momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT)));
         return picongpu::math::sqrt(1.0 + x);
 
     }
 
-    HDINLINE picongpu::float_64 calc_gamma_inv_square(const vec1& momentum) const
+    HDINLINE picongpu::float_64 calc_gamma_inv_square(const vector_32& momentum) const
     {
         // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2)
         const picongpu::float_32 Emass = mass * picongpu::SPEED_OF_LIGHT;
-        return Emass / (Emass + (util::square<vec1, picongpu::float_32 > (momentum)) / Emass);
+        return Emass / (Emass + (util::square<vector_32, picongpu::float_32 > (momentum)) / Emass);
     }
 
     HDINLINE picongpu::float_64 calc_cos_theta(const vector_64& n, const vector_64& beta) const

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -89,19 +89,19 @@ public:
     // first --> is specialized below
 
     template<unsigned int when>
-    HDINLINE numtype2 get_gamma(void) const
+    HDINLINE picongpu::float_64 get_gamma(void) const
     {
         return calc_gamma(get_momentum<when > ());
     } // get gamma at time when
 
     template<unsigned int when>
-    HDINLINE numtype2 get_gamma_inv_square(void) const
+    HDINLINE picongpu::float_64 get_gamma_inv_square(void) const
     {
         return calc_gamma_inv_square(get_momentum<when > ());
     } // get 1/gamma^2
 
     template< unsigned int when>
-    HDINLINE numtype2 get_cos_theta(const vec2& n) const
+    HDINLINE picongpu::float_64 get_cos_theta(const vec2& n) const
     {
         // get cos(theta) at time when
         const vec2 beta = get_beta<when > ();
@@ -120,7 +120,7 @@ private:
         return momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT * gamma1));
     }
 
-    HDINLINE numtype2 calc_gamma(const vec1& momentum) const
+    HDINLINE picongpu::float_64 calc_gamma(const vec1& momentum) const
     {
         // return gamma = E/(mc^2)
         const numtype1 x = util::square<vec1, numtype1 > (momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT)));
@@ -128,14 +128,14 @@ private:
 
     }
 
-    HDINLINE numtype2 calc_gamma_inv_square(const vec1& momentum) const
+    HDINLINE picongpu::float_64 calc_gamma_inv_square(const vec1& momentum) const
     {
         // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2)
         const numtype1 Emass = mass * picongpu::SPEED_OF_LIGHT;
         return Emass / (Emass + (util::square<vec1, numtype1 > (momentum)) / Emass);
     }
 
-    HDINLINE numtype2 calc_cos_theta(const vec2& n, const vec2& beta) const
+    HDINLINE picongpu::float_64 calc_cos_theta(const vec2& n, const vec2& beta) const
     {
         // return cos of angle between looking and flight direction
         return (n * beta) / (std::sqrt(beta * beta));
@@ -144,10 +144,10 @@ private:
 
     // setters:
 
-    HDINLINE numtype2 summand(void) const
+    HDINLINE picongpu::float_64 summand(void) const
     {
         // return \vec n independend summand (next value to add to \vec n independend sum)
-        const numtype2 x = get_gamma_inv_square<When::now > ();
+        const picongpu::float_64 x = get_gamma_inv_square<When::now > ();
         return Taylor()(x);
     }
 

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -116,14 +116,14 @@ private:
     HDINLINE vec2 calc_beta(const vec1& momentum) const
     {
         // returns beta=v/c
-        const numtype1 gamma1 = calc_gamma(momentum);
+        const picongpu::float_32 gamma1 = calc_gamma(momentum);
         return momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT * gamma1));
     }
 
     HDINLINE picongpu::float_64 calc_gamma(const vec1& momentum) const
     {
         // return gamma = E/(mc^2)
-        const numtype1 x = util::square<vec1, numtype1 > (momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT)));
+        const picongpu::float_32 x = util::square<vec1, picongpu::float_32 > (momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT)));
         return picongpu::math::sqrt(1.0 + x);
 
     }
@@ -131,8 +131,8 @@ private:
     HDINLINE picongpu::float_64 calc_gamma_inv_square(const vec1& momentum) const
     {
         // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2)
-        const numtype1 Emass = mass * picongpu::SPEED_OF_LIGHT;
-        return Emass / (Emass + (util::square<vec1, numtype1 > (momentum)) / Emass);
+        const picongpu::float_32 Emass = mass * picongpu::SPEED_OF_LIGHT;
+        return Emass / (Emass + (util::square<vec1, picongpu::float_32 > (momentum)) / Emass);
     }
 
     HDINLINE picongpu::float_64 calc_cos_theta(const vec2& n, const vec2& beta) const

--- a/src/picongpu/include/plugins/radiation/radFormFactor.hpp
+++ b/src/picongpu/include/plugins/radiation/radFormFactor.hpp
@@ -32,7 +32,7 @@ namespace picongpu
       HDINLINE radFormFactor(void)
       { }
 
-      HDINLINE float_X operator()(const float_X N, const float_X omega, const vec1 observer_unit_vec) const
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_32 observer_unit_vec) const
       {
 
 	/* Form Factor for CIC charge distribution of N discrete electrons:
@@ -67,7 +67,7 @@ namespace picongpu
       HDINLINE radFormFactor(void)
       { }
 
-      HDINLINE float_X operator()(const float_X N, const float_X omega, const vec1 observer_unit_vec) const
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_32 observer_unit_vec) const
       {
 
 	/* Form Factor for 1D CIC charge distribution of N discrete electrons:
@@ -91,7 +91,7 @@ namespace picongpu
       HDINLINE radFormFactor(void)
       { }
 
-      HDINLINE float_X operator()(const float_X N, const float_X omega, const vec1 observer_unit_vec) const
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_32 observer_unit_vec) const
       {
 
 	/* Form Factor for 1D CIC charge distribution of N discrete electrons:

--- a/src/picongpu/include/plugins/radiation/radFormFactor.hpp
+++ b/src/picongpu/include/plugins/radiation/radFormFactor.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/taylor.hpp
+++ b/src/picongpu/include/plugins/radiation/taylor.hpp
@@ -27,11 +27,11 @@ struct Taylor
 {
     // a Taylor development for 1-sqrt(1-x)
 
-    HDINLINE numtype2 operator()(numtype2 x) const
+    HDINLINE picongpu::float_64 operator()(picongpu::float_64 x) const
     {
         // Taylor series of 1-sqrt(1-x) till 5th order
         //same like 0.5*x + 0.125*x*x + 0.0625 * x*x*x + 0.0390625 * x*x*x*x + 0.02734375 *x*x*x*x*x;
-        const numtype2 x2 = (x * x);
+        const picongpu::float_64 x2 = (x * x);
         return x * ((0.5 + 0.125 * x) + x2 * (0.0625 + (0.0390625 * x + 0.02734375 * x2)));
     }
 

--- a/src/picongpu/include/plugins/radiation/taylor.hpp
+++ b/src/picongpu/include/plugins/radiation/taylor.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -36,10 +36,10 @@ namespace picongpu
      *           to compute the observation direction
      *
      * @return   unit vector pointing in observation direction
-     *           type: vec2
+     *           type: vector_64
      *
      */
-    DINLINE vec2 observation_direction(const int observation_id_extern)
+    DINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** compute observation directions for 2D virtual detector field
        *  pointing toward the +x direction
@@ -96,7 +96,7 @@ namespace picongpu
       const picongpu::float_64 phi(    my_index_phi   * delta_angle_phi   - angle_phi_start   );
 
       /* compute observation unit vector */
-      return vec2( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;
+      return vector_64( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;
 
     }
 

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -75,25 +75,25 @@ namespace picongpu
 
       /* set up observation angle range */
       /* angles range for theta */
-      const numtype2 angle_theta_start = - picongpu::PI/8.0
+      const picongpu::float_64 angle_theta_start = - picongpu::PI/8.0
 	                                         + 0.5*picongpu::PI; /* [rad] */
-      const numtype2 angle_theta_end   = + picongpu::PI/8.0
+      const picongpu::float_64 angle_theta_end   = + picongpu::PI/8.0
 	                                         + 0.5*picongpu::PI; /* [rad] */
       /* angles range for phi */
-      const numtype2 angle_phi_start = - picongpu::PI/8.0; /* [rad] */
-      const numtype2 angle_phi_end   = + picongpu::PI/8.0; /* [rad] */
+      const picongpu::float_64 angle_phi_start = - picongpu::PI/8.0; /* [rad] */
+      const picongpu::float_64 angle_phi_end   = + picongpu::PI/8.0; /* [rad] */
 
 
       /* compute step with between two angles for range [angle_??_start : angle_??_end] */
       const int N_theta           = parameters::N_observer / N_angle_split;
-      const numtype2 delta_angle_theta =  (angle_theta_start -
+      const picongpu::float_64 delta_angle_theta =  (angle_theta_start -
 					   angle_theta_end) / (N_theta-1.0);
-      const numtype2 delta_angle_phi   =  (angle_phi_start -
+      const picongpu::float_64 delta_angle_phi   =  (angle_phi_start -
 					   angle_phi_end)   / (N_angle_split-1.0);
 
       /* compute observation angles */
-      const numtype2 theta(  my_index_theta * delta_angle_theta + angle_theta_start );
-      const numtype2 phi(    my_index_phi   * delta_angle_phi   - angle_phi_start   );
+      const picongpu::float_64 theta(  my_index_theta * delta_angle_theta + angle_theta_start );
+      const picongpu::float_64 phi(    my_index_phi   * delta_angle_phi   - angle_phi_start   );
 
       /* compute observation unit vector */
       return vec2( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -51,7 +51,7 @@ namespace picongpu
   {
     const float_X omega_min = (SI::omega_min*UNIT_TIME);
     const float_X omega_max = (SI::omega_max*UNIT_TIME);
-    //const numtype2 delta_omega_log = (numtype2) ((omega_log_max - omega_log_min) / (double) (N_omega - 1)); // difference beween two omega
+    //const picongpu::float_64 delta_omega_log = (picongpu::float_64) ((omega_log_max - omega_log_min) / (double) (N_omega - 1)); // difference beween two omega
 
     const unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     const unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -51,7 +51,6 @@ namespace picongpu
   {
     const float_X omega_min = (SI::omega_min*UNIT_TIME);
     const float_X omega_max = (SI::omega_max*UNIT_TIME);
-    //const picongpu::float_64 delta_omega_log = (picongpu::float_64) ((omega_log_max - omega_log_min) / (double) (N_omega - 1)); // difference beween two omega
 
     const unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     const unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation


### PR DESCRIPTION
This pull request **replaces** the float types used in the radiation plugin by standard PIConGPU types and it **renames** the vector classes  as suggested by @psychocoderHPC in issue #697. 

 - `numtype1` -> `picongpu::float_32`
 - `numtype2` -> `picongpu::float_64`
 - `vec1` -> `vector_32` 
 - `vec2` -> `vector_64`

**ToDo:**
 - [x] check `SingleParticleRadiationWithLaser`

**Notice:**
@ax3l This pull request adjusts `*.param` and `*.unitless` files.