### PR TITLE
fix logic behind fill color of numerical heating tool

### DIFF
--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -169,8 +169,7 @@ else:
 
 
 ## get values ##
-startEnergy = Energies[0][0]
-
+startEnergy = Energies[:][0]
 
 ## plot numerical heating ##
 
@@ -183,30 +182,30 @@ else:
 if not args.boolDiff:
     # plot energy evolution
     plt.plot(Times[0][:time_limit], 
-             (Energies[0][:time_limit]-startEnergy)*norm, 
+             (Energies[0][:time_limit]-startEnergy[0])*norm, 
              color="green", lw=3, label=args.label1)
     if numDir == 2:
         # True is deviation of branch to init energy is less than of dev
-        branch_better = (np.abs(Energies[0][:time_limit]-startEnergy)
-                         > np.abs(Energies[1][:time_limit]-startEnergy))
+        branch_better = (np.abs(Energies[0][:time_limit]-startEnergy[0])
+                         > np.abs(Energies[1][:time_limit]-startEnergy[1]))
 
         # branch is closer to initial energy than dev
         plt.fill_between(Times[1][:time_limit], 
-                         (Energies[0][:time_limit]-startEnergy)*norm, 
-                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         (Energies[0][:time_limit]-startEnergy[0])*norm, 
+                         (Energies[1][:time_limit]-startEnergy[0])*norm, 
                          where=branch_better,
                          color="orange", alpha=0.8)
 
         # dev is closer to initial energy than branch
         plt.fill_between(Times[1][:time_limit], 
-                         (Energies[0][:time_limit]-startEnergy)*norm, 
-                         (Energies[1][:time_limit]-startEnergy)*norm, 
+                         (Energies[0][:time_limit]-startEnergy[0])*norm, 
+                         (Energies[1][:time_limit]-startEnergy[0])*norm, 
                          where=np.logical_not(branch_better),
                          color="red", alpha=0.7)
 
         # plot second energy evolution
         plt.plot(Times[1][:time_limit], 
-                 (Energies[1][:time_limit]-startEnergy)*norm, 
+                 (Energies[1][:time_limit]-startEnergy[0])*norm, 
                  color="blue",  lw=2, label=args.label2)
     if args.boolRelative:
         plt.ylabel(r"$\frac{E}{E_0}-1\,[\%]$", fontsize=24)

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -186,36 +186,22 @@ if not args.boolDiff:
              (Energies[0][:time_limit]-startEnergy)*norm, 
              color="green", lw=3, label=args.label1)
     if numDir == 2:
-        # dev is less than start value and branch is closer to initial energy
-        plt.fill_between(Times[1][:time_limit], 
-                         (Energies[0][:time_limit]-startEnergy)*norm, 
-                         (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], 
-                                              Energies[0][:time_limit] < startEnergy),
-                         color="orange", alpha=0.8) 
+        # True is deviation of branch to init energy is less than of dev
+        branch_better = (np.abs(Energies[0][:time_limit]-startEnergy)
+                         > np.abs(Energies[1][:time_limit]-startEnergy))
 
-        # dev is less than start value and branch is worse than initial energy
+        # branch is closer to initial energy than dev
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], 
-                                              Energies[0][:time_limit] < startEnergy),
-                         color="red", alpha=0.7)
-
-        # dev is greater than start value and branch is closer to initial energy
-        plt.fill_between(Times[1][:time_limit], 
-                         (Energies[0][:time_limit]-startEnergy)*norm, 
-                         (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] > Energies[1][:time_limit], 
-                                              Energies[0][:time_limit] > startEnergy),
+                         where=branch_better,
                          color="orange", alpha=0.8)
 
-        # dev is greater than start value and branch is worse than initial energy
+        # dev is closer to initial energy than branch
         plt.fill_between(Times[1][:time_limit], 
                          (Energies[0][:time_limit]-startEnergy)*norm, 
                          (Energies[1][:time_limit]-startEnergy)*norm, 
-                         where=np.logical_and(Energies[0][:time_limit] < Energies[1][:time_limit], 
-                                              Energies[0][:time_limit] > startEnergy),
+                         where=np.logical_not(branch_better),
                          color="red", alpha=0.7)
 
         # plot second energy evolution


### PR DESCRIPTION
This pull request fixes a bug found by @psychocoderHPC in the `plotNumericalHeating` tool. It occures, when `dev` and `branch` energies deviate strongly.

With this fix, the **following rules** are applied for coloring:
 - `red` ... means *worse* energy conservation in `branch` than in `dev`
 - `orange` ... means *better* energy conservation in `branch` than in `dev`

**Example 1:**
**`dev`:**
![numheating_newgraphics5_dev](https://cloud.githubusercontent.com/assets/5121158/6843584/c02780b6-d3a4-11e4-9960-593cdec4ff0e.png)

**`pull request`:**
![numheating_newgraphics5](https://cloud.githubusercontent.com/assets/5121158/6843591/d04978e6-d3a4-11e4-9468-6d53743f2b89.png)

**Example 2:**
**`dev`:**
![numheating_newgraphics6_dev](https://cloud.githubusercontent.com/assets/5121158/6843599/dbe5aaee-d3a4-11e4-8903-4b2ea00b106b.png)

**`pull request`:**
![numheating_newgraphics6](https://cloud.githubusercontent.com/assets/5121158/6843604/e7169a4a-d3a4-11e4-900f-7110697e2155.png)
