### PR TITLE
assignment shape piecewise biqudratic spline `P4S`

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/species.param
+++ b/examples/Bunch/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -45,6 +45,7 @@ namespace picongpu
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order (requires CUDA_ARCH>=sm_20)
  *  - particles::shapes::PCS : 3rd order (requires CUDA_ARCH>=sm_20)
+ *  - particles::shapes::P4S : 4th order (requires CUDA_ARCH>=sm_20)
  *
  *  example:             typedef particles::shapes::CIC CICShape;
  */
@@ -54,9 +55,9 @@ typedef particles::shapes::CIC UsedParticleShape;
 typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
 
 /*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS , P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -44,6 +44,7 @@ namespace picongpu
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order (requires CUDA_ARCH>=sm_20)
  *  - particles::shapes::PCS : 3rd order (requires CUDA_ARCH>=sm_20)
+ *  - particles::shapes::P4S : 4th order (requires CUDA_ARCH>=sm_20)
  *
  *  example:             typedef particles::shapes::CIC CICShape;
  */
@@ -56,9 +57,9 @@ typedef particles::shapes::PARAM_PARTICLESHAPE UsedParticleShape;
 typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
 
 /*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov

--- a/examples/LaserWakefield/include/simulation_defines/param/species.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -54,6 +54,7 @@ namespace picongpu
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order (requires CUDA_ARCH>=sm_20)
  *  - particles::shapes::PCS : 3rd order (requires CUDA_ARCH>=sm_20)
+ *  - particles::shapes::P4S : 4th order (requires CUDA_ARCH>=sm_20)
  *
  *  example:             typedef particles::shapes::CIC CICShape;
  */
@@ -66,9 +67,9 @@ typedef particles::shapes::PARAM_PARTICLESHAPE UsedParticleShape;
 typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
 
 /*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -45,6 +45,7 @@ namespace picongpu
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order (requires CUDA_ARCH>=sm_20)
  *  - particles::shapes::PCS : 3rd order (requires CUDA_ARCH>=sm_20)
+ *  - particles::shapes::P4S : 4th order (requires CUDA_ARCH>=sm_20)
  *
  *  example:             typedef particles::shapes::CIC CICShape;
  */
@@ -54,9 +55,9 @@ typedef particles::shapes::CIC UsedParticleShape;
 typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
 
 /*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -45,6 +45,7 @@ namespace picongpu
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order (requires CUDA_ARCH>=sm_20)
  *  - particles::shapes::PCS : 3rd order (requires CUDA_ARCH>=sm_20)
+ *  - particles::shapes::P4S : 4th order (requires CUDA_ARCH>=sm_20)
  *
  *  example:             typedef particles::shapes::CIC CICShape;
  */
@@ -54,9 +55,9 @@ typedef particles::shapes::CIC UsedParticleShape;
 typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
 
 /*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov

--- a/examples/SingleParticleTest/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -45,6 +45,7 @@ namespace picongpu
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order (requires CUDA_ARCH>=sm_20)
  *  - particles::shapes::PCS : 3rd order (requires CUDA_ARCH>=sm_20)
+ *  - particles::shapes::P4S : 4th order (requires CUDA_ARCH>=sm_20)
  *
  *  example:             typedef particles::shapes::CIC CICShape;
  */
@@ -54,9 +55,9 @@ typedef particles::shapes::CIC UsedParticleShape;
 typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
 
 /*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -69,6 +69,66 @@ struct EvalAssignmentFunction
  * - Even Support: parPos [0.0;1.0)
  * - Odd Support:  parPos [-0.5;0.5)
  */
+template<>
+struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, 0> >
+{
+    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+
+    HDINLINE float_X
+    operator()(const float_X parPos)
+    {
+
+        return ParticleAssign::ff_1st_radius(parPos);
+    }
+};
+
+template<>
+struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, 1> >
+{
+    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+
+    HDINLINE float_X
+    operator()(const float_X parPos)
+    {
+        return ParticleAssign::ff_2nd_radius(float_X(1.0)-parPos);
+    }
+};
+
+template<>
+struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, -1 > >
+{
+    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+
+    HDINLINE float_X
+    operator()(const float_X parPos)
+    {
+        return ParticleAssign::ff_2nd_radius(algorithms::math::abs(float_X(-1.0)-parPos));
+    }
+};
+
+template<>
+struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, 2> >
+{
+    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+
+    HDINLINE float_X
+    operator()(const float_X parPos)
+    {
+        return ParticleAssign::ff_3rd_radius(float_X(2.0)-parPos);
+    }
+};
+
+template<>
+struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, -2 > >
+{
+    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+
+    HDINLINE float_X
+    operator()(const float_X parPos)
+    {
+        return ParticleAssign::ff_3rd_radius(algorithms::math::abs(float_X(-2.0)-parPos));
+    }
+};
 
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c<int, 0> >

--- a/src/picongpu/include/particles/shapes.hpp
+++ b/src/picongpu/include/particles/shapes.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -29,3 +29,4 @@
 #include "particles/shapes/CIC.hpp"
 #include "particles/shapes/TSC.hpp"
 #include "particles/shapes/PCS.hpp"
+#include "particles/shapes/P4S.hpp"

--- a/src/picongpu/include/particles/shapes/P4S.hpp
+++ b/src/picongpu/include/particles/shapes/P4S.hpp
@@ -39,30 +39,33 @@ struct P4S
     HDINLINE static float_X ff_1st_radius(const float_X x)
     {
         /*
-         * W(x)=115/192 - 5/8*x^2 + 1/4*x^4
+         * W(x)= 115/192 - 5/8 * x^2 + 1/4 * x^4
+         *     = 115/192 + x^2 * (-5/8 + 1/4 * x^2)
          */
         const float_X square_x = x * x;
-        const float_X biquadratic_x = square_x * square_x;
         return float_X(115. / 192.)
-             - float_X(5. / 8.) * square_x
-             + float_X(1.0 / 4.0) * biquadratic_x;
+            + square_x
+            * (
+               float_X(-5. / 8.)
+               + float_X(1.0 / 4.0) * square_x
+               );
     }
 
     HDINLINE static float_X ff_2nd_radius(const float_X x)
     {
         /*
-         * W(x)=1/96 * (55 + 20*x - 120*x^2 + 80*x^3 - 16*x^4)
+         * W(x)= 1/96 * (55 + 20 * x - 120 * x^2 + 80 * x^3 - 16 * x^4)
+         *     = 1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x))))
          */
-        const float_X square_x = x * x;
-        const float_X cubic_x = square_x * x;
-        const float_X biquadratic_x = square_x * square_x;
-
-        return float_X(1. / 96.)*(
-                                    float_X(55.)
-                                  + float_X(20.) * x
-                                  - float_X(120.) * square_x
-                                  + float_X(80.) * cubic_x
-                                  - float_X(16.) * biquadratic_x);
+        return float_X(1. / 96.)*
+            (
+             float_X(55.) + float_X(4.) * x
+             * (float_X(5.) - float_X(2.) * x
+                * (float_X(15.) + float_X(2.) * x
+                   * (float_X(-5.) + x)
+                   )
+                )
+             );
     }
 
     HDINLINE static float_X ff_3rd_radius(const float_X x)
@@ -80,7 +83,6 @@ struct P4S
 
 } //namespace shared_P4S
 
-
 /** particle assignment shape `piecewise biquadratic spline`
  */
 struct P4S : public shared_P4S::P4S
@@ -93,11 +95,11 @@ struct P4S : public shared_P4S::P4S
         HDINLINE float_X operator()(const float_X x)
         {
             /*       -
-             *       |  115/192 - 5/8*x^2 + 1/4*x^4                    if -1/2 < x < 1/2
+             *       |  115/192 + x^2 * (-5/8 + 1/4 * x^2)                          if -1/2 < x < 1/2
              * W(x)=<|
-             *       |  1/96 * (55 + 20*x - 120*x^2 + 80*x^3 - 16*x^4) if 1/2 <= |x| < 3/2
+             *       |  1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x)))) if 1/2 <= |x| < 3/2
              *       |
-             *       |  1/384 * (5 - 2*x)^4                            if 3/2 <= |x| < 5/2
+             *       |  1/384 * (5 - 2 * x)^4                                       if 3/2 <= |x| < 5/2
              *       -
              */
             float_X abs_x = algorithms::math::abs(x);
@@ -124,13 +126,13 @@ struct P4S : public shared_P4S::P4S
         {
 
             /*       -
-             *       |  115/192 - 5/8*x^2 + 1/4*x^4                    if -1/2 < x < 1/2
+             *       |  115/192 + x^2 * (-5/8 + 1/4 * x^2)                          if -1/2 < x < 1/2
              * W(x)=<|
-             *       |  1/96 * (55 + 20*x - 120*x^2 + 80*x^3 - 16*x^4) if 1/2 <= |x| < 3/2
+             *       |  1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x)))) if 1/2 <= |x| < 3/2
              *       |
-             *       |  1/384 * (5 - 2*x)^4                            if 3/2 <= |x| < 5/2
+             *       |  1/384 * (5 - 2*x)^4                                         if 3/2 <= |x| < 5/2
              *       |
-             *       |  0                                              otherwise
+             *       |  0                                                           otherwise
              *       -
              */
             float_X abs_x = algorithms::math::abs(x);

--- a/src/picongpu/include/particles/shapes/P4S.hpp
+++ b/src/picongpu/include/particles/shapes/P4S.hpp
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2015 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace shapes
+{
+
+namespace shared_P4S
+{
+
+struct P4S
+{
+    static const int support = 5;
+
+    HDINLINE static float_X ff_1st_radius(const float_X x)
+    {
+        /*
+         * W(x)=115/192 - 5/8*x^2 + 1/4*x^4
+         */
+        const float_X square_x = x * x;
+        const float_X biquadratic_x = square_x * square_x;
+        return float_X(115. / 192.)
+             - float_X(5. / 8.) * square_x
+             + float_X(1.0 / 4.0) * biquadratic_x;
+    }
+
+    HDINLINE static float_X ff_2nd_radius(const float_X x)
+    {
+        /*
+         * W(x)=1/96 * (55 + 20*x - 120*x^2 + 80*x^3 - 16*x^4)
+         */
+        const float_X square_x = x * x;
+        const float_X cubic_x = square_x * x;
+        const float_X biquadratic_x = square_x * square_x;
+
+        return float_X(1. / 96.)*(
+                                    float_X(55.)
+                                  + float_X(20.) * x
+                                  - float_X(120.) * square_x
+                                  + float_X(80.) * cubic_x
+                                  - float_X(16.) * biquadratic_x);
+    }
+
+    HDINLINE static float_X ff_3rd_radius(const float_X x)
+    {
+        /*
+         * W(x)=1/384 * (5 - 2*x)^4
+         */
+        const float_X tmp = (float_X(5.) - float_X(2.) * x);
+        const float_X square_tmp = tmp * tmp;
+        const float_X biquadratic_tmp = square_tmp*square_tmp;
+
+        return float_X(1. / 384.) * biquadratic_tmp;
+    }
+};
+
+} //namespace shared_P4S
+
+
+/** particle assignment shape `piecewise biquadratic spline`
+ */
+struct P4S : public shared_P4S::P4S
+{
+    typedef picongpu::particles::shapes::PCS CloudShape;
+
+    struct ChargeAssignmentOnSupport : public shared_P4S::P4S
+    {
+
+        HDINLINE float_X operator()(const float_X x)
+        {
+            /*       -
+             *       |  115/192 - 5/8*x^2 + 1/4*x^4                    if -1/2 < x < 1/2
+             * W(x)=<|
+             *       |  1/96 * (55 + 20*x - 120*x^2 + 80*x^3 - 16*x^4) if 1/2 <= |x| < 3/2
+             *       |
+             *       |  1/384 * (5 - 2*x)^4                            if 3/2 <= |x| < 5/2
+             *       -
+             */
+            float_X abs_x = algorithms::math::abs(x);
+
+            const bool below_3rd_radius = (abs_x < float_X(1.5));
+            if (below_3rd_radius)
+            {
+                const bool below_2rd_radius = (abs_x < float_X(0.5));
+                if (below_2rd_radius)
+                    return ff_1st_radius(abs_x);
+                else
+                    return ff_2nd_radius(abs_x);
+            }
+            else
+                return ff_3rd_radius(abs_x);
+        }
+
+    };
+
+    struct ChargeAssignment : public shared_P4S::P4S
+    {
+
+        HDINLINE float_X operator()(const float_X x)
+        {
+
+            /*       -
+             *       |  115/192 - 5/8*x^2 + 1/4*x^4                    if -1/2 < x < 1/2
+             * W(x)=<|
+             *       |  1/96 * (55 + 20*x - 120*x^2 + 80*x^3 - 16*x^4) if 1/2 <= |x| < 3/2
+             *       |
+             *       |  1/384 * (5 - 2*x)^4                            if 3/2 <= |x| < 5/2
+             *       |
+             *       |  0                                              otherwise
+             *       -
+             */
+            float_X abs_x = algorithms::math::abs(x);
+
+            const bool below_max = (abs_x < float_X(2.5));
+
+            if (below_max)
+                return ChargeAssignmentOnSupport()(abs_x);
+            else
+                return float_X(0.);
+        }
+    };
+};
+
+} // namespace shapes
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -47,6 +47,7 @@ namespace picongpu
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order (requires CUDA_ARCH>=sm_20)
  *  - particles::shapes::PCS : 3rd order (requires CUDA_ARCH>=sm_20)
+ *  - particles::shapes::P4S : 4th order (requires CUDA_ARCH>=sm_20)
  *
  *  example:             typedef particles::shapes::CIC CICShape;
  */
@@ -56,9 +57,9 @@ typedef particles::shapes::TSC UsedParticleShape;
 typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
 
 /*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS (1st to 3rd order)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov


### PR DESCRIPTION
- add assignment shape P4S called *piecewise biqudratic spline*
- add explicit rules for the shape `P4S` evaluation for the current solver `ZigZag`

**Tests:**
- [x] KHI electrons/positrons  TSC (Esirkepov) vs. P4S (Esirkepov)
- [x] KHI electrons/positrons  TSC (Esirkepov) vs. P4S (ZigZag)

thx @PrometheusPi for giving me a lesson in `mathematica`