### PR TITLE
Close #775: laser polynom - convert float_64 to float_X

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -34,15 +34,15 @@ namespace picongpu
 namespace laserPolynom
 {
 
-HDINLINE float_64 Tpolynomial(const float_64 tau);
+HDINLINE float_X Tpolynomial(const float_X tau);
 
 /** Compute the longitudinal enevelope of the laser
  *
  */
 HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 {
-    const float_64 runTime = DELTA_T*currentStep;
-    const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+    const float_X runTime = DELTA_T*currentStep;
+    const float_X f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
     float3_X elong(0.0f, 0.0f, 0.0f);
 
@@ -51,16 +51,13 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
     // and falls for T_rise
     // making the laser pulse 2*T_rise long
 
-    const float_64 T_rise = 0.5 * PULSE_LENGTH;
-    const float_64 tau = runTime / T_rise;
+    const float_X T_rise = 0.5 * PULSE_LENGTH;
+    const float_X tau = runTime / T_rise;
 
-    const float_64 omegaLaser = 2.0 * PI * f;
+    const float_X omegaLaser = 2.0 * PI * f;
 
-    elong.x() = float_X(
-                       float_64(AMPLITUDE) *
-                       Tpolynomial(tau)
-                       * math::sin(omegaLaser * (runTime - T_rise) + float_64(LASER_PHASE))
-                       );
+    elong.x() = AMPLITUDE * Tpolynomial(tau)
+                * math::sin(omegaLaser * (runTime - T_rise) + LASER_PHASE);
 
     phase = 0.0f;
 
@@ -77,13 +74,13 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
  */
 HDINLINE float3_X laserTransversal(float3_X elong, const float_X, const float_X posX, const float_X posZ)
 {
-    const float_64 exponent = (posX / W0x)*(posX / W0x) + (posZ / W0z)*(posZ / W0z);
+    const float_X exponent = (posX / W0x)*(posX / W0x) + (posZ / W0z)*(posZ / W0z);
 
-    return elong * precisionCast<float_X > (math::exp(-exponent));
+    return elong * math::exp(-exponent);
 
 }
 
-HDINLINE float_64 Tpolynomial(const float_64 tau)
+HDINLINE float_X Tpolynomial(const float_X tau)
 {
     if (tau >= 0.0 && tau <= 1.0)
         return tau * tau * tau * (10.0 - 15.0 * tau + 6.0 * tau * tau);


### PR DESCRIPTION
This pull request unifies the float types used in `laserPolynomial`.
It closes issue #775.

 - [x] Compare `dev` with new `branch`

Differences are in the float precission.