### PR TITLE
Add Missing <iostream> include

### DIFF
--- a/src/mpiInfo/main.cpp
+++ b/src/mpiInfo/main.cpp
@@ -20,6 +20,7 @@
 
 #include <mpi.h>
 #include <cstdlib>
+#include <iostream> // std::cerr
 
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>


### PR DESCRIPTION
- errored on Titan (ORNL) with GCC 4.8.2 in cross-compile mode