### PR TITLE
add charge conservation plugin

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Felix Schmitt, Axel Huebl, Richard Pausch
+# Copyright 2014-2015 Felix Schmitt, Axel Huebl, Richard Pausch, Heiko Burau
 # 
 # This file is part of PIConGPU. 
 # 
@@ -181,6 +181,9 @@ TBG_liveViewYX="--<species>_liveView.period 1 --<species>_liveView.slicePoint 0.
 TBG_liveViewYZ="--<species>_liveView.period 1 --<species>_liveView.slicePoint 0.5 --<species>_liveView.ip 10.0.2.254 \
                 --<species>_liveView.port 2021 --<species>_liveView.axis yz"
 
+
+# Print the maximum charge deviation between particles and div E to textfile 'chargeConservation.dat':
+TBG_chargeConservation="--chargeConservation.period 100"
 
 ################################################################################
 ## Section: Program Parameters

--- a/src/picongpu/include/plugins/ChargeConservation.hpp
+++ b/src/picongpu/include/plugins/ChargeConservation.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2013-2015 Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "plugins/ILightweightPlugin.hpp"
+
+namespace picongpu
+{
+using namespace PMacc;
+
+namespace po = boost::program_options;
+
+template<typename Species>
+class ChargeConservation : public ILightweightPlugin
+{
+private:
+    std::string name;
+    std::string prefix;
+    uint32_t notifyFrequency;
+
+    void pluginLoad();
+public:
+    ChargeConservation();
+    virtual ~ChargeConservation() {}
+
+    void notify(uint32_t currentStep);
+    void setMappingDescription(MappingDesc*) {}
+    void pluginRegisterHelp(po::options_description& desc);
+    std::string pluginGetName() const;
+};
+
+}
+
+#include "ChargeConservation.tpp"

--- a/src/picongpu/include/plugins/ChargeConservation.hpp
+++ b/src/picongpu/include/plugins/ChargeConservation.hpp
@@ -28,12 +28,19 @@ using namespace PMacc;
 
 namespace po = boost::program_options;
 
+/**
+ * @class ChargeConservation
+ * @brief maximum difference between electron charge density and div E
+ *
+ * WARNING: This plugin assumes a Yee-cell!
+ * Do not use it together with other field solvers like `directional splitting` or `Lehe`
+ */
 class ChargeConservation : public ILightweightPlugin
 {
 private:
     std::string name;
     std::string prefix;
-    uint32_t notifyFrequency;
+    uint32_t notifyPeriod;
 
     void pluginLoad();
 public:

--- a/src/picongpu/include/plugins/ChargeConservation.hpp
+++ b/src/picongpu/include/plugins/ChargeConservation.hpp
@@ -20,7 +20,9 @@
 
 #pragma once
 
-#include "plugins/ILightweightPlugin.hpp"
+#include "plugins/ISimulationPlugin.hpp"
+#include <boost/shared_ptr.hpp>
+#include "cuSTL/algorithm/mpi/Reduce.hpp"
 
 namespace picongpu
 {
@@ -35,12 +37,21 @@ namespace po = boost::program_options;
  * WARNING: This plugin assumes a Yee-cell!
  * Do not use it together with other field solvers like `directional splitting` or `Lehe`
  */
-class ChargeConservation : public ILightweightPlugin
+class ChargeConservation : public ISimulationPlugin
 {
 private:
     std::string name;
     std::string prefix;
     uint32_t notifyPeriod;
+    const std::string filename;
+    MappingDesc* cellDescription;
+    std::ofstream output_file;
+
+    typedef boost::shared_ptr<PMacc::algorithm::mpi::Reduce<simDim> > AllGPU_reduce;
+    AllGPU_reduce allGPU_reduce;
+
+    void restart(uint32_t restartStep, const std::string restartDirectory);
+    void checkpoint(uint32_t currentStep, const std::string checkpointDirectory);
 
     void pluginLoad();
 public:
@@ -48,7 +59,7 @@ public:
     virtual ~ChargeConservation() {}
 
     void notify(uint32_t currentStep);
-    void setMappingDescription(MappingDesc*) {}
+    void setMappingDescription(MappingDesc*);
     void pluginRegisterHelp(po::options_description& desc);
     std::string pluginGetName() const;
 };

--- a/src/picongpu/include/plugins/ChargeConservation.hpp
+++ b/src/picongpu/include/plugins/ChargeConservation.hpp
@@ -28,7 +28,6 @@ using namespace PMacc;
 
 namespace po = boost::program_options;
 
-template<typename Species>
 class ChargeConservation : public ILightweightPlugin
 {
 private:

--- a/src/picongpu/include/plugins/ChargeConservation.tpp
+++ b/src/picongpu/include/plugins/ChargeConservation.tpp
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "math/vector/Int.hpp"
+#include "math/vector/Float.hpp"
+#include "math/vector/Size_t.hpp"
+#include "math/vector/math_functor/abs.hpp"
+#include "math/vector/math_functor/max.hpp"
+#include "cuSTL/container/PseudoBuffer.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "fields/FieldJ.hpp"
+#include "math/Vector.hpp"
+#include "cuSTL/algorithm/mpi/Gather.hpp"
+#include "cuSTL/algorithm/mpi/Reduce.hpp"
+#include "cuSTL/container/DeviceBuffer.hpp"
+#include "cuSTL/container/HostBuffer.hpp"
+#include "cuSTL/algorithm/kernel/Foreach.hpp"
+#include "cuSTL/algorithm/host/Foreach.hpp"
+#include "lambda/Expression.hpp"
+#include <sstream>
+
+#include "cuSTL/algorithm/kernel/Reduce.hpp"
+
+namespace picongpu
+{
+
+template<typename Species>
+ChargeConservation<Species>::ChargeConservation()
+    : name("print the maximum charge derivation between particles and div E"), 
+      prefix("electronChargeConservation")
+{
+    Environment<>::get().PluginConnector().registerPlugin(this);
+}
+
+template<typename Species>
+void ChargeConservation<Species>::pluginRegisterHelp(po::options_description& desc)
+{
+    desc.add_options()
+        ((this->prefix + "_frequency").c_str(),
+        po::value<uint32_t > (&this->notifyFrequency)->default_value(0), "notifyFrequency");
+}
+
+template<typename Species>
+std::string ChargeConservation<Species>::pluginGetName() const {return this->name;}
+
+template<typename Species>
+void ChargeConservation<Species>::pluginLoad()
+{
+    Environment<>::get().PluginConnector().setNotificationPeriod(this, this->notifyFrequency);
+}
+
+template<typename ValueType>
+struct Div
+{
+    typedef ValueType result_type;
+
+    template<typename Field>
+    HDINLINE ValueType operator()(Field field) const
+    {
+        const ValueType reciWidth = float_X(1.0) / CELL_WIDTH;
+        const ValueType reciHeight = float_X(1.0) / CELL_HEIGHT;
+        const ValueType reciDepth = float_X(1.0) / CELL_DEPTH;
+        return ((*field(1,0,0)).x() - (*field).x()) * reciWidth +
+               ((*field(0,1,0)).y() - (*field).y()) * reciHeight +
+               ((*field(0,0,1)).z() - (*field).z()) * reciDepth;
+    }
+};
+
+template<typename Species>
+void ChargeConservation<Species>::notify(uint32_t currentStep)
+{
+    typedef SuperCellSize BlockDim;
+
+    DataConnector &dc = Environment<>::get().DataConnector();
+
+    /*## update field tmp with charge information ##*/
+    /*load FieldTmp without copy data to host*/
+    FieldTmp* fieldTmp = &(dc.getData<FieldTmp > (FieldTmp::getName(), true));
+    /*load particle without copy particle data to host*/
+    Species* speciesTmp = &(dc.getData<Species >(Species::FrameType::getName(), true));
+
+    fieldTmp->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
+    /*run algorithm*/
+    typedef typename CreateDensityOperation<Species>::type::Solver DensitySolver;
+
+    fieldTmp->computeValue < CORE + BORDER, DensitySolver > (*speciesTmp, currentStep);
+
+    EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
+    __setTransactionEvent(fieldTmpEvent);
+    dc.releaseData(Species::FrameType::getName());
+    
+    /* cast libPMacc Buffer to cuSTL Buffer */
+    BOOST_AUTO(fieldTmp_coreBorder,
+                 fieldTmp->getGridBuffer().
+                 getDeviceBuffer().cartBuffer().
+                 view(BlockDim::toRT(), -BlockDim::toRT()));
+    
+    /* cast libPMacc Buffer to cuSTL Buffer */
+    BOOST_AUTO(fieldE_coreBorder,
+                 dc.getData<FieldE > (FieldE::getName(), true).getGridBuffer().
+                 getDeviceBuffer().cartBuffer().
+                 view(BlockDim::toRT(), -BlockDim::toRT()));
+
+    /* run calculation: fieldTmp = | div E - rho / eps_0 | */
+    using namespace lambda;
+    using namespace PMacc::math::math_functor;
+    typedef Div<typename FieldTmp::ValueType> myDiv;
+    algorithm::kernel::Foreach<BlockDim>()
+        (fieldTmp_coreBorder.zone(), fieldTmp_coreBorder.origin(), 
+        cursor::make_NestedCursor(fieldE_coreBorder.origin()),
+            _1 = _abs(expr(myDiv())(_2) - _1 / EPS0));
+            
+    /* reduce charge derivation (fieldTmp) to get the maximum value */
+    container::DeviceBuffer<typename FieldTmp::ValueType, 1> maxChargeDiff(1);
+    algorithm::kernel::Reduce<BlockDim>()
+        (maxChargeDiff.origin(), fieldTmp_coreBorder.zone(), fieldTmp_coreBorder.origin(), _max(_1, _2));
+    container::HostBuffer<typename FieldTmp::ValueType, 1> maxChargeDiff_host(1);
+    maxChargeDiff_host = maxChargeDiff;
+    
+    /* reduce again across mpi cluster */
+    PMacc::GridController<3>& con = PMacc::Environment<3>::get().GridController();
+    using namespace PMacc::math;
+    Size_t<3> gpuDim = (Size_t<3>)con.getGpuNodes();
+    zone::SphericZone<3> zone_allGPUs(Size_t<3>(gpuDim.x(), gpuDim.y(), gpuDim.z()));
+    PMacc::algorithm::mpi::Reduce<3> allGPU_reduce(zone_allGPUs);
+    container::HostBuffer<typename FieldTmp::ValueType, 1> maxChargeDiff_cluster(1);
+    allGPU_reduce(maxChargeDiff_cluster, maxChargeDiff_host, _max(_1, _2));
+
+    if(!allGPU_reduce.root()) return;
+
+    static std::ofstream file("chargeConservation.dat");
+
+    file << "step: " << currentStep << ", max charge derivation: "
+        << *maxChargeDiff_cluster.origin() * CELL_VOLUME << " * " << UNIT_CHARGE
+        << " Coulomb" << std::endl;
+}
+
+} // namespace picongpu

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -67,7 +67,6 @@
 
 #if(SIMDIM==DIM3)
 #include "plugins/IntensityPlugin.hpp"
-#include "plugins/ChargeConservation.hpp"
 #endif
 #include "plugins/SliceFieldPrinterMulti.hpp"
 

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -34,6 +34,7 @@
 #include "plugins/SumCurrents.hpp"
 #include "plugins/PositionsParticles.hpp"
 #include "plugins/BinEnergyParticles.hpp"
+#include "plugins/ChargeConservation.hpp"
 #if(ENABLE_HDF5 == 1)
 #include "plugins/PhaseSpace/PhaseSpaceMulti.hpp"
 #endif
@@ -66,6 +67,7 @@
 
 #if(SIMDIM==DIM3)
 #include "plugins/IntensityPlugin.hpp"
+#include "plugins/ChargeConservation.hpp"
 #endif
 #include "plugins/SliceFieldPrinterMulti.hpp"
 
@@ -163,7 +165,8 @@ private:
         EnergyParticles<bmpl::_1>,
         BinEnergyParticles<bmpl::_1>,
         LiveViewPlugin<bmpl::_1>,
-        PositionsParticles<bmpl::_1>
+        PositionsParticles<bmpl::_1>,
+        ChargeConservation<bmpl::_1>
 #if(ENABLE_RADIATION == 1)
       , Radiation<bmpl::_1>
 #endif

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -125,7 +125,8 @@ private:
     /* define stand alone plugins*/
     typedef bmpl::vector<
         EnergyFields,
-        SumCurrents
+        SumCurrents,
+        ChargeConservation
 #if(SIMDIM==DIM3)
       , IntensityPlugin
 #endif
@@ -164,8 +165,7 @@ private:
         EnergyParticles<bmpl::_1>,
         BinEnergyParticles<bmpl::_1>,
         LiveViewPlugin<bmpl::_1>,
-        PositionsParticles<bmpl::_1>,
-        ChargeConservation<bmpl::_1>
+        PositionsParticles<bmpl::_1>
 #if(ENABLE_RADIATION == 1)
       , Radiation<bmpl::_1>
 #endif


### PR DESCRIPTION
adding --chargeConservation.period <frequency> option to picongpu now returns the maximum charge deviation between particles and div E in a separate output file chargeConservation.dat:
```
#timestep max-charge-deviation unit[As]
0 7.59718e-06 5.23234e-17
100 8.99187e-05 5.23234e-17
200 0.000113926 5.23234e-17
300 0.00014836 5.23234e-17
400 0.000154502 5.23234e-17
500 0.000164952 5.23234e-17
```
### To Do

- [x] update the `TBG_macros.cfg`
- [x] provide easily gnuplot-able output format (e.g., write a `# header for the columns`)
- [x] use common plugin syntax on cmd line (e.g., `name.period`)
- [x] prefer structured variables over single consts: `cellSize` over 3x `CELL_...`
- [x] update the [wiki](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-ChargeConservation)