### PR TITLE
add radiation window function for 2D/3D

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -150,11 +150,7 @@ namespace picongpu
 
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
-// 1 = on  (slower but with noise/ringing reduction)
-// 0 = off (faster but might contain ringing)
-#define PIC_RADWINDOWFUNCTION 0
-
-
+// default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
  * radWindowFunctionRectangle
@@ -162,14 +158,16 @@ namespace picongpu
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
+ * radWindowFunctionNone
  */
 namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }
 namespace radWindowFunctionGauss { }
+namespace radWindowFunctionNone { }
 
-namespace radWindowFunction = radWindowFunctionTriangle;
+namespace radWindowFunction = radWindowFunctionNone;
 
 
 }//namespace picongpu

--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -153,14 +153,12 @@ namespace picongpu
 // default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
- * radWindowFunctionRectangle
  * radWindowFunctionTriangle
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
  * radWindowFunctionNone
  */
-namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -159,14 +159,12 @@ namespace picongpu
 // default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
- * radWindowFunctionRectangle
  * radWindowFunctionTriangle
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
  * radWindowFunctionNone
  */
-namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -156,11 +156,7 @@ namespace picongpu
 
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
-// 1 = on  (slower but with noise/ringing reduction)
-// 0 = off (faster but might contain ringing)
-#define PIC_RADWINDOWFUNCTION 1
-
-
+// default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
  * radWindowFunctionRectangle
@@ -168,12 +164,14 @@ namespace picongpu
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
+ * radWindowFunctionNone
  */
 namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }
 namespace radWindowFunctionGauss { }
+namespace radWindowFunctionNone { }
 
 namespace radWindowFunction = radWindowFunctionTriangle;
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
@@ -150,11 +150,7 @@ namespace picongpu
 
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
-// 1 = on  (slower but with noise/ringing reduction)
-// 0 = off (faster but might contain ringing)
-#define PIC_RADWINDOWFUNCTION 0
-
-
+// default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
  * radWindowFunctionRectangle
@@ -162,14 +158,16 @@ namespace picongpu
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
+ * radWindowFunctionNone
  */
 namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }
 namespace radWindowFunctionGauss { }
+namespace radWindowFunctionNone { }
 
-namespace radWindowFunction = radWindowFunctionTriangle;
+namespace radWindowFunction = radWindowFunctionNone;
 
 
 }//namespace picongpu

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
@@ -153,14 +153,12 @@ namespace picongpu
 // default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
- * radWindowFunctionRectangle
  * radWindowFunctionTriangle
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
  * radWindowFunctionNone
  */
-namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -355,8 +355,6 @@ void kernelRadiationParticles(ParBox pb,
 
                     /* the particle amplitude is used to include the weighting
                      * of the window function filter without needing more memory */
-#if (PIC_RADWINDOWFUNCTION==1)
-
                     const radWindowFunction::radWindowFunction winFkt;
 
                     /* start with a factor of one */
@@ -370,7 +368,6 @@ void kernelRadiationParticles(ParBox pb,
 
                     /* apply window function factor to amplitude */
                     real_amplitude_s[saveParticleAt] *= windowFactor;
-#endif
 
 
 

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -362,25 +362,11 @@ void kernelRadiationParticles(ParBox pb,
                     /* start with a factor of one */
                     float_X windowFactor = 1.0;
 
-                    /* TODO: How to do this for 2D automatically? */
-                    /* window in each  dimension */
-                    /* not supported yet */
-                    /*for (uint32_t d = 0; d < simDim; ++d)
-                      {
-                      windowFactor *= winFkt(particle_locationNow[d],
-                      simBoxSize[d] * cellSize[d]);
-                      }
-                    */
-
-                    /* window in x dimension */
-                    windowFactor *= winFkt(particle_locationNow.x(),
-                                           simBoxSize.x() * CELL_WIDTH);
-                    /* window in y dimension */
-                    windowFactor *= winFkt(particle_locationNow.y(),
-                                           simBoxSize.y() * CELL_HEIGHT);
-                    /* window in z dimension */
-                    windowFactor *= winFkt(particle_locationNow.z(),
-                                           simBoxSize.z() * CELL_DEPTH);
+                    for (uint32_t d = 0; d < simDim; ++d)
+                    {
+                        windowFactor *= winFkt(particle_locationNow[d],
+                        simBoxSize[d] * cellSize[d]);
+                    }
 
                     /* apply window function factor to amplitude */
                     real_amplitude_s[saveParticleAt] *= windowFactor;

--- a/src/picongpu/include/plugins/radiation/windowFunctions.hpp
+++ b/src/picongpu/include/plugins/radiation/windowFunctions.hpp
@@ -184,5 +184,27 @@ namespace picongpu
   } /* namespace radWindowFunctionGauss */
 
 
+  namespace radWindowFunctionNone
+  {
+    struct radWindowFunction
+    {
+      /** 1D Window function according to the no window:
+       *
+       * f(position_x) = always 1.0
+       *
+       * @param position_x = 1D position
+       * @param L_x        = length of the simulated area
+       *                     assuming that the simulation ranges
+       *                     from 0 to L_x in the choosen dimension
+       * @returns 1.0
+       **/
+      HDINLINE float_X operator()(const float_X position_x, const float_X L_x) const
+      {
+        return float_X(1.0);
+      }
+    };
+  } /* namespace radWindowFunctionRectangle */
+
+
 }  /* namespace picongpu */
 

--- a/src/picongpu/include/plugins/radiation/windowFunctions.hpp
+++ b/src/picongpu/include/plugins/radiation/windowFunctions.hpp
@@ -28,41 +28,6 @@ namespace picongpu
   /* several window functions behind namespaces: */
 
 
-  namespace radWindowFunctionRectangle
-  {
-    struct radWindowFunction
-    {
-      /** 1D Window function according to the rectangle window:
-       *
-       * f(position_x) = {1.0     : (0 <= position_x <= L_x )
-       *                 {0.0     : in any other case
-       *
-       * @param position_x = 1D position
-       * @param L_x        = length of the simulated area
-       *                     assuming that the simulation ranges
-       *                     from 0 to L_x in the choosen dimension
-       * @returns weighting factor to reduce ringing effects due to
-       *          sharp spacial boundaries
-       **/
-      HDINLINE float_X operator()(const float_X position_x, const float_X L_x) const
-      {
-        /* an optimized formula is implemented
-         *
-         * transform position to make box symetric:
-         * x_prime = position_x - 1/2 * L_x
-         *
-         * then: f(x_position) = f(x_prime)
-         * f(x_prime) = { 1.0     : -L_x/2 <= x_prime <= +L_x/2
-         *              { 0.0     : in any other case
-         */
-        const float_X x_prime = position_x - L_x*float_X(0.5);
-        return float_X(math::abs(x_prime) <= float_X(0.5) * L_x);
-      }
-    };
-  } /* namespace radWindowFunctionRectangle */
-
-
-
   namespace radWindowFunctionTriangle
   {
     struct radWindowFunction

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -150,11 +150,7 @@ namespace picongpu
 
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
-// 1 = on  (slower but with noise/ringing reduction)
-// 0 = off (faster but might contain ringing)
-#define PIC_RADWINDOWFUNCTION 0
-
-
+// default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
  * radWindowFunctionRectangle
@@ -162,14 +158,16 @@ namespace picongpu
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
+ * radWindowFunctionNone
  */
 namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }
 namespace radWindowFunctionGauss { }
+namespace radWindowFunctionNone { }
 
-namespace radWindowFunction = radWindowFunctionTriangle;
+namespace radWindowFunction = radWindowFunctionNone;
 
 
 }//namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -153,14 +153,12 @@ namespace picongpu
 // default: no window function via `radWindowFunctionNone`
 
 /* Choose different window function in order to get better ringing reduction
- * radWindowFunctionRectangle
  * radWindowFunctionTriangle
  * radWindowFunctionHamming
  * radWindowFunctionTriplett
  * radWindowFunctionGauss
  * radWindowFunctionNone
  */
-namespace radWindowFunctionRectangle { }
 namespace radWindowFunctionTriangle { }
 namespace radWindowFunctionHamming { }
 namespace radWindowFunctionTriplett { }


### PR DESCRIPTION
This pull request:
 - enables using window function in 2D now
 - removes the precompiler flag used to enable the window function
 - replace `radWindowRectangular` with faster `radWindowNone` and use this as default

Needs to be checked:
 - [x] is the window function still working
 - [x] is the slowdown due to avoiding the precompiler flag acceptable
 - [x] check results for 2D simulation
