### PR TITLE
enable compression for radiation hdf5 output

### DIFF
--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -610,7 +610,6 @@ private:
       splash::DataCollector::initFileCreationAttr(fAttr);
 
       fAttr.fileAccType = splash::DataCollector::FAT_READ;
-      fAttr.enableCompression = compressionOn;
 
       std::ostringstream filename;
       /* add to standard ending added by libSpash for SerialDataCollector */

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -127,6 +127,7 @@ private:
     std::string pathRestart;
 
     mpi::MPIReduce reduce;
+    bool compressionOn;
 
 public:
 
@@ -146,7 +147,8 @@ public:
     isMaster(false),
     currentStep(0),
     radPerGPU(false),
-    lastStep(0)
+    lastStep(0),
+    compressionOn(false)
     {
         Environment<>::get().PluginConnector().registerPlugin(this);
     }
@@ -201,7 +203,8 @@ public:
             ((analyzerPrefix + ".end").c_str(), po::value<uint32_t > (&radEnd)->default_value(0), "time index when radiation should end with calculation")
             ((analyzerPrefix + ".omegaList").c_str(), po::value<std::string > (&pathOmegaList)->default_value("_noPath_"), "path to file containing all frequencies to calculate")
             ((analyzerPrefix + ".radPerGPU").c_str(), po::value<bool > (&radPerGPU)->default_value(false), "enable(1)/disable(0) radiation output from each GPU individually")
-          ((analyzerPrefix + ".folderRadPerGPU").c_str(), po::value<std::string > (&folderRadPerGPU)->default_value("radPerGPU"), "folder in which the radiation of each GPU is written");
+            ((analyzerPrefix + ".folderRadPerGPU").c_str(), po::value<std::string > (&folderRadPerGPU)->default_value("radPerGPU"), "folder in which the radiation of each GPU is written")
+            ((analyzerPrefix + ".compression").c_str(), po::value<bool > (&compressionOn)->default_value(false), "enable(1)/disable(0) compression of hdf5 output");
     }
 
 
@@ -532,7 +535,7 @@ private:
       splash::DataCollector::FileCreationAttr fAttr;
 
       splash::DataCollector::initFileCreationAttr(fAttr);
-      fAttr.enableCompression = true;
+      fAttr.enableCompression = compressionOn;
 
       std::ostringstream filename;
       filename << name << currentStep;
@@ -607,7 +610,7 @@ private:
       splash::DataCollector::initFileCreationAttr(fAttr);
 
       fAttr.fileAccType = splash::DataCollector::FAT_READ;
-      fAttr.enableCompression = true;
+      fAttr.enableCompression = compressionOn;
 
       std::ostringstream filename;
       /* add to standard ending added by libSpash for SerialDataCollector */

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -532,6 +532,7 @@ private:
       splash::DataCollector::FileCreationAttr fAttr;
 
       splash::DataCollector::initFileCreationAttr(fAttr);
+      fAttr.enableCompression = true;
 
       std::ostringstream filename;
       filename << name << currentStep;
@@ -606,6 +607,7 @@ private:
       splash::DataCollector::initFileCreationAttr(fAttr);
 
       fAttr.fileAccType = splash::DataCollector::FAT_READ;
+      fAttr.enableCompression = true;
 
       std::ostringstream filename;
       /* add to standard ending added by libSpash for SerialDataCollector */


### PR DESCRIPTION
This pull request enables compression vor the hdf5 ouput created by the radiation plugin.
Since it is using the `serialDataCollector` of `libSplash`, using compression is possible.

Still to test/decide:
 - [x] are compressed hdf5 files created
 - [x] is the compression worth the effort