### PR TITLE
close #177 assign `float3_X = float_X`

### DIFF
--- a/examples/SingleParticleCurrent/include/CheckCurrent.hpp
+++ b/examples/SingleParticleCurrent/include/CheckCurrent.hpp
@@ -1,23 +1,23 @@
 /**
  * Copyright 2013 Heiko Burau, Rene Widera
  *
- * This file is part of PIConGPU. 
- * 
- * PIConGPU is free software: you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * 
- * PIConGPU is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * along with PIConGPU.  
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "fields/FieldJ.hpp"
@@ -29,22 +29,22 @@
 
 namespace picongpu
 {
-    
+
 struct CheckCurrent
 {
     struct PrintNonZeroComponents
     {
         typedef void type;
         float3_X totalJ;
-        
-        PrintNonZeroComponents() : totalJ(0.0) {}
+
+        PrintNonZeroComponents() : totalJ(float3_X::create(0.0)) {}
         ~PrintNonZeroComponents()
         {
             const float_X unit_current = UNIT_CHARGE / (UNIT_LENGTH * UNIT_LENGTH * UNIT_TIME);
             totalJ *= unit_current;
             printf("totalJ: (%g, %g, %g) A/m²\n", totalJ.x(), totalJ.y(), totalJ.z());
         }
-        
+
         HDINLINE void operator()(float3_X data, PMacc::math::Int<3> cellIdx)
         {
 
@@ -55,7 +55,7 @@ struct CheckCurrent
                 printf("j_y = %g at %d, %d, %d\n", data.y() * unit_current, cellIdx.x(), cellIdx.y(), cellIdx.z());
             if(data.z() != 0.0f)
                 printf("j_z = %g at %d, %d, %d\n", data.z() * unit_current, cellIdx.x(), cellIdx.y(), cellIdx.z());
-                
+
             this->totalJ += data;
         }
     };
@@ -63,28 +63,28 @@ struct CheckCurrent
     {
 
         typedef SuperCellSize GuardDim;
-    
+
         // Get fieldJ without guards
-        BOOST_AUTO(fieldJ_device, 
+        BOOST_AUTO(fieldJ_device,
             _fieldJ_device.getGridBuffer().getDeviceBuffer().cartBuffer());
 
         container::HostBuffer<float3_X, 3> fieldJ_with_guards(fieldJ_device.size());
         fieldJ_with_guards = fieldJ_device;
         container::View<container::HostBuffer<float3_X, 3> > fieldJ(fieldJ_with_guards.view(GuardDim::toRT(), -GuardDim::toRT()));
-        
+
         float3_X beta(BETA0_X, BETA0_Y, BETA0_Z);
-        
+
         std::cout << "\nsingle P A R T I C L E facts:\n\n";
         std::cout << "position: (" << float3_X(LOCAL_POS_X, LOCAL_POS_Y, LOCAL_POS_Z)
             << ") at cell " << fieldJ.size()/size_t(2) << std::endl;
         std::cout << "velocity: (" << beta << ") * c\n";
         std::cout << "delta_pos: (" << beta * SPEED_OF_LIGHT / float3_X(CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH) << ") * cellSize\n";
-        
+
         const double j = Q_EL / CELL_VOLUME * abs(beta) * SPEED_OF_LIGHT;
         const double unit_current = UNIT_CHARGE / (UNIT_LENGTH * UNIT_LENGTH * UNIT_TIME);
         std::cout << "j = rho * abs(velocity) = " << std::setprecision(6) << j * unit_current << " A/m²" << std::endl;
         std::cout << "------------------------------------------\n\n";
-    
+
         std::cout << "fieldJ facts:\n\n";
 //        std::cout << "zone: " << fieldJ.zone().size << ", " << fieldJ.zone().offset << std::endl;
 //        std::cout << "index: " << *cursor::make_MultiIndexCursor<3>()(math::Int<3>(1,2,3)) << std::endl;
@@ -98,6 +98,6 @@ struct CheckCurrent
         std::cout << "------------------------------------------\n\n";
     }
 };
-    
-    
+
+
 }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.tpp
@@ -135,7 +135,7 @@ void Reduce<BlockDim>::operator()(const DestCursor& destCursor, const Zone& p_zo
     while(partialSumSize > 1)
     {
         int numBlocks = ceil((float)partialSumSize / 512.0f);
-        zone::SphericZone<1> p_zone1D = zone::SphericZone<1>(math::Size_t<1>(numBlocks*512));
+        zone::SphericZone<1> p_zone1D = zone::SphericZone<1>(math::Size_t<1>((size_t)(numBlocks*512)));
         curDestBuffer ^= 1;
         if(numBlocks == 1)
         {

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -70,8 +70,8 @@ struct SphericMapper<1, BlockSize>
     HDINLINE
     math::Int<1> operator()(const dim3& _blockIdx, const dim3& _threadIdx = dim3(0,0,0)) const
     {
-        return operator()(math::Int<1>(_blockIdx.x),
-                          math::Int<1>(_threadIdx.x));
+        return operator()(math::Int<1>((int)_blockIdx.x),
+                          math::Int<1>((int)_threadIdx.x));
     }
 };
 
@@ -151,8 +151,8 @@ struct SphericMapper<1, mpl::void_>
     DINLINE
     math::Int<1> operator()(const dim3& _blockIdx, const dim3& _threadIdx = dim3(0,0,0)) const
     {
-        return operator()(math::Int<1>(_blockIdx.x),
-                          math::Int<1>(_threadIdx.x));
+        return operator()(math::Int<1>((int)_blockIdx.x),
+                          math::Int<1>((int)_threadIdx.x));
     }
 };
 

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -199,7 +199,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::view
 {
     a = (a + (math::Int<T_dim>)this->size()) % (math::Int<T_dim>)this->size();
     b = (b + (math::Int<T_dim>)this->size())
-            % ((math::Int<T_dim>)this->size() + math::Int<T_dim>(math::Int<T_dim>::create(1)));
+            % ((math::Int<T_dim>)this->size() + math::Int<T_dim>::create(1));
 
     View<CartBuffer<Type, T_dim, Allocator, Copier, Assigner> > result;
 
@@ -228,7 +228,7 @@ cursor::SafeCursor<cursor::BufferCursor<Type, T_dim> >
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::originSafe() const
 {
     return cursor::make_SafeCursor(this->origin(),
-                                   math::Int<T_dim>(math::Int<T_dim>::create(0)),
+                                   math::Int<T_dim>::create(0),
                                    math::Int<T_dim>(size()));
 }
 
@@ -257,7 +257,7 @@ zone::SphericZone<T_dim>
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::zone() const
 {
     zone::SphericZone<T_dim> myZone;
-    myZone.offset = math::Int<T_dim>(math::Int<T_dim>::create(0));
+    myZone.offset = math::Int<T_dim>::create(0);
     myZone.size = this->_size;
     return myZone;
 }

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -44,7 +44,7 @@ namespace detail
         template<typename TCursor>
         HDINLINE math::Size_t<1> operator()(const TCursor& cursor)
         {
-            return math::Size_t<1>((char*)cursor(0, 1).getMarker() - (char*)cursor.getMarker());
+            return math::Size_t<1>(size_t((char*)cursor(0, 1).getMarker() - (char*)cursor.getMarker()));
         }
     };
     template<>
@@ -53,8 +53,8 @@ namespace detail
         template<typename TCursor>
         HDINLINE math::Size_t<2> operator()(const TCursor& cursor)
         {
-            return math::Size_t<2>((char*)cursor(0, 1, 0).getMarker() - (char*)cursor.getMarker(),
-                                     (char*)cursor(0, 0, 1).getMarker() - (char*)cursor.getMarker());
+            return math::Size_t<2>((size_t)((char*)cursor(0, 1, 0).getMarker() - (char*)cursor.getMarker()),
+                                   (size_t)((char*)cursor(0, 0, 1).getMarker() - (char*)cursor.getMarker()));
         }
     };
 
@@ -199,7 +199,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::view
 {
     a = (a + (math::Int<T_dim>)this->size()) % (math::Int<T_dim>)this->size();
     b = (b + (math::Int<T_dim>)this->size())
-            % ((math::Int<T_dim>)this->size() + math::Int<T_dim>(1));
+            % ((math::Int<T_dim>)this->size() + math::Int<T_dim>(math::Int<T_dim>::create(1)));
 
     View<CartBuffer<Type, T_dim, Allocator, Copier, Assigner> > result;
 
@@ -228,7 +228,7 @@ cursor::SafeCursor<cursor::BufferCursor<Type, T_dim> >
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::originSafe() const
 {
     return cursor::make_SafeCursor(this->origin(),
-                                   math::Int<T_dim>(0),
+                                   math::Int<T_dim>(math::Int<T_dim>::create(0)),
                                    math::Int<T_dim>(size()));
 }
 
@@ -257,7 +257,7 @@ zone::SphericZone<T_dim>
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::zone() const
 {
     zone::SphericZone<T_dim> myZone;
-    myZone.offset = math::Int<T_dim>(0);
+    myZone.offset = math::Int<T_dim>(math::Int<T_dim>::create(0));
     myZone.size = this->_size;
     return myZone;
 }

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -60,7 +60,7 @@ struct DeviceMemAssigner
          * and a certain power of two value gives the best suitable block size
          */
         boost::math::gcd_evaluator<size_t> gcd; // greatest common divisor
-        math::Size_t<3> blockDim(1);
+        math::Size_t<3> blockDim(math::Size_t<3>::create(1));
         int maxValues[] = {16, 16, 4}; // maximum values for each dimension
         for(int i = 0; i < dim; i++)
             blockDim[i] = gcd(size[i], maxValues[dim-1]);

--- a/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
@@ -43,7 +43,7 @@ template<int dim>
 HDINLINE
 cursor::Cursor<cursor::MarkerAccessor<math::Int<dim> >, MultiIndexNavigator<dim>,
                math::Int<dim> >
-               make_MultiIndexCursor(const math::Int<dim>& idx = math::Int<dim>(0))
+               make_MultiIndexCursor(const math::Int<dim>& idx = math::Int<dim>(math::Int<dim>::create(0)))
 {
     return make_Cursor(cursor::MarkerAccessor<math::Int<dim> >(),
                        MultiIndexNavigator<dim>(),

--- a/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
@@ -43,7 +43,7 @@ template<int dim>
 HDINLINE
 cursor::Cursor<cursor::MarkerAccessor<math::Int<dim> >, MultiIndexNavigator<dim>,
                math::Int<dim> >
-               make_MultiIndexCursor(const math::Int<dim>& idx = math::Int<dim>(math::Int<dim>::create(0)))
+               make_MultiIndexCursor(const math::Int<dim>& idx = math::Int<dim>::create(0))
 {
     return make_Cursor(cursor::MarkerAccessor<math::Int<dim> >(),
                        MultiIndexNavigator<dim>(),

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -53,7 +53,7 @@ struct SphericZone
     math::Int<dim> offset;
 
     HDINLINE SphericZone() {}
-    HDINLINE SphericZone(const math::Size_t<dim>& size) : size(size), offset(math::Int<dim>(math::Int<dim>::create(0))) {}
+    HDINLINE SphericZone(const math::Size_t<dim>& size) : size(size), offset(math::Int<dim>::create(0)) {}
     HDINLINE SphericZone(const math::Size_t<dim>& size,
                          const math::Int<dim>& offset) : size(size), offset(offset) {}
 

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -53,7 +53,7 @@ struct SphericZone
     math::Int<dim> offset;
 
     HDINLINE SphericZone() {}
-    HDINLINE SphericZone(const math::Size_t<dim>& size) : size(size), offset(math::Int<dim>(0)) {}
+    HDINLINE SphericZone(const math::Size_t<dim>& size) : size(size), offset(math::Int<dim>(math::Int<dim>::create(0))) {}
     HDINLINE SphericZone(const math::Size_t<dim>& size,
                          const math::Int<dim>& offset) : size(size), offset(offset) {}
 

--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -22,12 +22,10 @@
 
 #pragma once
 
+#include "types.h"
 #include "result_of_Functor.hpp"
-#include <builtin_types.h>
-#include <cuda_runtime.h>
 #include <boost/static_assert.hpp>
 #include <boost/mpl/size.hpp>
-#include <types.h>
 #include <iostream>
 #include <lambda/Expression.hpp>
 #include <math/vector/accessor/StandartAccessor.hpp>
@@ -105,6 +103,13 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
     }
 
     HDINLINE
+    Vector(const type x)
+    {
+        PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM1,dim == 1);
+        (*this)[0] = x;
+    }
+
+    HDINLINE
     Vector(const type x, const type y)
     {
         PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM2,dim == 2);
@@ -119,13 +124,6 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
         (*this)[0] = x;
         (*this)[1] = y;
         (*this)[2] = z;
-    }
-
-    HDINLINE
-    Vector(const T_Type& value)
-    {
-        for (int i = 0; i < dim; i++)
-            (*this)[i] = value;
     }
 
     HDINLINE Vector(const This& other)
@@ -150,6 +148,22 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
     {
         for (int i = 0; i < dim; i++)
             (*this)[i] = static_cast<type> (other[i]);
+    }
+
+    /**
+     * Give a Vector<...> were all dimensions were set to the same value
+     *
+     * @param value value which is set for all dimensions
+     * @return new Vector<...>
+     */
+    HDINLINE
+    static This create(const type& value)
+    {
+        This result;
+        for (int i = 0; i < dim; i++)
+            result[i] = value;
+
+        return result;
     }
 
     HDINLINE const This& toRT() const

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -87,7 +87,7 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
 
     __syncthreads();
 
-    Set<typename JBox::ValueType > set(float3_X(0.0, 0.0, 0.0));
+    Set<typename JBox::ValueType > set(float3_X::create(0.0));
     ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectivSet(linearThreadIdx);
     collectivSet(set, cachedJ);
 

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -184,7 +184,7 @@ void FieldJ::reset( uint32_t )
 
 void FieldJ::clear( )
 {
-    ValueType tmp = float3_X( 0. );
+    ValueType tmp(ValueType::create(0.));
     fieldJ.getDeviceBuffer( ).setValue( tmp );
     //fieldJ.reset(false);
 }

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -44,7 +44,7 @@ namespace templates
 namespace twts
 {
     namespace pmMath = PMacc::algorithms::math;
-    
+
     HINLINE
     EField::EField( const float_64 focus_y_SI,
                     const float_64 wavelength_SI,
@@ -65,23 +65,23 @@ namespace twts
                  on host (see fieldBackground.param), this is no problem. */
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         halfSimSize = subGrid.getGlobalDomain().size / 2;
-        tdelay = detail::getInitialTimeDelay_SI(auto_tdelay, tdelay_user_SI, 
+        tdelay = detail::getInitialTimeDelay_SI(auto_tdelay, tdelay_user_SI,
                                                 halfSimSize, pulselength_SI,
                                                 focus_y_SI, phi, beta_0);
     }
-    
+
     template<>
     HDINLINE float3_X
     EField::getTWTSEfield_Normalized<DIM3>(
                 const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
                 const float_64 time) const
     {
-        float3_64 pos(0.0);
+        float3_64 pos(float3_64::create(0.0));
         for (uint32_t i = 0; i<simDim;++i) pos[i] = eFieldPositions_SI[0][i];
         return float3_X( float_X( calcTWTSEx(pos,time) ),
                          float_X(0.), float_X(0.) );
     }
-    
+
     template<>
     HDINLINE float3_X
     EField::getTWTSEfield_Normalized<DIM2>(
@@ -89,23 +89,23 @@ namespace twts
         const float_64 time) const
     {
         /* Ex->Ez, so also the grid cell offset for Ez has to be used. */
-        float3_64 pos(0.0);
+        float3_64 pos(float3_64::create(0.0));
         /* 2D (y,z) vectors are mapped on 3D (x,y,z) vectors. */
         for (uint32_t i = 0; i<simDim;++i) pos[i+1] = eFieldPositions_SI[2][i];
         return float3_X( float_X(0.), float_X(0.),
                          float_X( calcTWTSEx(pos,time) ) );
     }
-    
+
     HDINLINE float3_X
     EField::operator()( const DataSpace<simDim>& cellIdx,
                             const uint32_t currentStep ) const
     {
         const float_64 time_SI = float_64(currentStep) * dt - tdelay;
-        
+
         const PMacc::math::Vector<floatD_64,detail::numComponents> eFieldPositions_SI =
               detail::getFieldPositions_SI(cellIdx,halfSimSize,
                 fieldSolver::NumericalCellType::getEFieldPosition(),unit_length,focus_y_SI,phi);
-        
+
         /* Single TWTS-Pulse */
         return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI);
     }
@@ -125,7 +125,7 @@ namespace twts
         const double UNIT_TIME = SI::DELTA_T_SI;
         /** Unit of length */
         const double UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
-    
+
         /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
         const float_T phiReal = float_T(phi);
@@ -140,11 +140,11 @@ namespace twts
          * the dispersion will (although physically correct) be slightly off the ideal TWTS
          * pulse for beta0 != 1.0. This only shows that this TWTS pulse is primarily designed for
          * scenarios close to beta0 = 1. */
-        
+
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = (PI / 2) - (phiReal - alphaTilt); */
-        
+
         const float_T cspeed = float_T(1.0);
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
         const float_T om0 = float_T(2.0*PI*cspeed / lambda0*UNIT_TIME);
@@ -160,14 +160,14 @@ namespace twts
         const float_T y = float_T(pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
         const float_T t = float_T(time / UNIT_TIME);
-        
+
         /* Calculating shortcuts for speeding up field calculation */
         const float_T sinPhi = pmMath::sin(phiT);
         const float_T cosPhi = pmMath::cos(phiT);
         const float_T sinPhi2 = pmMath::sin(phiT / float_T(2.0));
         const float_T cosPhi2 = pmMath::cos(phiT / float_T(2.0));
         const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
-        
+
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
          * thus help with formal code verification through manual code inspection. */
         const complex_T helpVar1 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
@@ -178,7 +178,7 @@ namespace twts
 
         const complex_T helpVar4 = (
             -(cspeed*cspeed*k*om0*tauG*tauG*wy*wy*x*x)
-            - float_T(2.0)*cspeed*cspeed*om0*t*t*wy*wy*rho0 
+            - float_T(2.0)*cspeed*cspeed*om0*t*t*wy*wy*rho0
             + complex_T(0,2)*cspeed*cspeed*om0*om0*t*tauG*tauG*wy*wy*rho0
             - float_T(2.0)*cspeed*cspeed*om0*tauG*tauG*y*y*rho0
             + float_T(4.0)*cspeed*om0*t*wy*wy*z*rho0
@@ -230,7 +230,7 @@ namespace twts
             )
         ) / (float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2);
 
-        const complex_T helpVar5 = cspeed*om0*tauG*tauG 
+        const complex_T helpVar5 = cspeed*om0*tauG*tauG
             - complex_T(0,8)*y*pmMath::tan( float_T(PI / 2)-phiT )
                                 / sinPhi / sinPhi*sinPhi2*sinPhi2*sinPhi2*sinPhi2
             - complex_T(0,2)*z*tanPhi2*tanPhi2;

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -43,7 +43,7 @@ namespace picongpu
             const double runTime = DELTA_T*currentStep;
             const double f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
-            float3_X elong = float3_X(float3_X::create(0.0));
+            float3_X elong(float3_X::create(0.0));
 
             // a symmetric pulse will be initialized at position z=0 for
             // a time of PULSE_INIT * PULSE_LENGTH = INIT_TIME.

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -43,7 +43,7 @@ namespace picongpu
             const double runTime = DELTA_T*currentStep;
             const double f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
-            float3_X elong = float3_X(float_X(0.0), float_X(0.0), float_X(0.0));
+            float3_X elong = float3_X(float3_X::create(0.0));
 
             // a symmetric pulse will be initialized at position z=0 for
             // a time of PULSE_INIT * PULSE_LENGTH = INIT_TIME.

--- a/src/picongpu/include/fields/laserProfiles/laserNone.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserNone.hpp
@@ -39,7 +39,7 @@ namespace picongpu
          */
         HINLINE float3_X laserLongitudinal( uint32_t, float_X& phase )
         {
-            float3_X elong = float3_X(float_X(0.0), float_X(0.0), float_X(0.0));
+            float3_X elong = float3_X(float3_X::create(0.0));
 
             phase = float_X(0.0);
 

--- a/src/picongpu/include/fields/laserProfiles/laserNone.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserNone.hpp
@@ -39,7 +39,7 @@ namespace picongpu
          */
         HINLINE float3_X laserLongitudinal( uint32_t, float_X& phase )
         {
-            float3_X elong = float3_X(float3_X::create(0.0));
+            const float3_X elong(float3_X::create(0.0));
 
             phase = float_X(0.0);
 

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -44,7 +44,7 @@ namespace picongpu
             const double f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
             double envelope = double(AMPLITUDE );
-            float3_X elong = float3_X(float3_X::create(0.0));
+            float3_X elong(float3_X::create(0.0));
 
             // a NON-symmetric (starting with phase=0) pulse will be initialized at position z=0 for
             // a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -44,7 +44,7 @@ namespace picongpu
             const double f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
             double envelope = double(AMPLITUDE );
-            float3_X elong = float3_X(float_X(0.0), float_X(0.0), float_X(0.0));
+            float3_X elong = float3_X(float3_X::create(0.0));
 
             // a NON-symmetric (starting with phase=0) pulse will be initialized at position z=0 for
             // a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
@@ -58,7 +58,7 @@ namespace picongpu
             const double startDownramp = mue + LASER_NOFOCUS_CONSTANT;
 
 
-            
+
             if( runTime > startDownramp )
             {
                 // downramp = end

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -44,7 +44,7 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
     const float_X runTime = DELTA_T*currentStep;
     const float_X f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
-    float3_X elong(0.0f, 0.0f, 0.0f);
+    float3_X elong(float3_X::create(0.0));
 
     // a symmetric pulse will be initialized at position z=0
     // the laser amplitude rises  for T_rise

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -43,7 +43,7 @@ namespace picongpu
             const double runTime = DELTA_T*currentStep;
             const double f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
-            float3_X elong = float3_X(float3_X::create(0.0));
+            float3_X elong(float3_X::create(0.0));
 
             // a symmetric pulse will be initialized at position z=0 for
             // a time of PULSE_INIT * PULSE_LENGTH = INIT_TIME.

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -43,7 +43,7 @@ namespace picongpu
             const double runTime = DELTA_T*currentStep;
             const double f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
-            float3_X elong = float3_X(float_X(0.0), float_X(0.0), float_X(0.0));
+            float3_X elong = float3_X(float3_X::create(0.0));
 
             // a symmetric pulse will be initialized at position z=0 for
             // a time of PULSE_INIT * PULSE_LENGTH = INIT_TIME.

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -40,7 +40,7 @@ namespace laserWavepacket
 HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 {
     float_X envelope = float_X(AMPLITUDE);
-    float3_X elong = float3_X(float_X(0.0), float_X(0.0), float_X(0.0));
+    float3_X elong = float3_X(float3_X::create(0.0));
 
     // a symmetric pulse will be initialized at position z=0 for
     // a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -40,7 +40,7 @@ namespace laserWavepacket
 HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 {
     float_X envelope = float_X(AMPLITUDE);
-    float3_X elong = float3_X(float3_X::create(0.0));
+    float3_X elong(float3_X::create(0.0));
 
     // a symmetric pulse will be initialized at position z=0 for
     // a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.

--- a/src/picongpu/include/particles/gasProfiles/GaussianCloudImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/GaussianCloudImpl.hpp
@@ -64,13 +64,13 @@ struct GaussianCloudImpl : public T_ParamClass
 
         if (globalCellPos.y() < vacuum_y) return float_X(0.0);
 
-        floatD_X exponent = float_X(math::abs((globalCellPos - center) / sigma));
-
-
-        float_X density = 1;
+        float_X density(1.0);
         const float_X power = ParamClass::power;
         for (uint32_t d = 0; d < simDim; ++d)
-            density *= math::exp(ParamClass::factor * math::pow(exponent[d], power));
+        {
+            const float_X exponent(math::abs((globalCellPos[d] - center[d]) / sigma[d]));
+            density *= math::exp(ParamClass::factor * math::pow(exponent, power));
+        }
 
         return density;
     }

--- a/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
@@ -115,7 +115,7 @@ namespace picongpu
                     mom += eField * charge * deltaT;
                 }
 
-                float3_X dr = float3_X( float_X(0.0), float_X(0.0), float_X(0.0) );
+                float3_X dr(float3_X::create(0.0));
 
                 // old spacial change calculation: linear step
                 if( TrajectoryInterpolation == LINEAR )

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -216,8 +216,8 @@ private:
          * idx == 1 -> fieldE
          */
         EneVectorType globalFieldEnergy[2];
-        globalFieldEnergy[0]=EneVectorType(0.0);
-        globalFieldEnergy[1]=EneVectorType(0.0);
+        globalFieldEnergy[0]=EneVectorType::create(0.0);
+        globalFieldEnergy[1]=EneVectorType::create(0.0);
 
         EneVectorType localReducedFieldEnergy[2];
         localReducedFieldEnergy[0] = reduceField(fieldB);

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
@@ -90,7 +90,7 @@ namespace picongpu
             /* my plane means: the offset for the transversal plane to my r_element
              * should be zero
              */
-            PMacc::math::Int<simDim> longOffset(0);
+            PMacc::math::Int<simDim> longOffset(PMacc::math::Int<simDim>::create(0));
             longOffset[this->axis_element.space] = planePos;
 
             zone::SphericZone<simDim> zoneTransversalPlane( sizeTransversalPlane, longOffset );
@@ -102,7 +102,7 @@ namespace picongpu
             {
                 PMacc::math::Int<simDim> inPlaneGPU(gpuPos);
                 inPlaneGPU[this->axis_element.space] = 0;
-                if( inPlaneGPU == PMacc::math::Int<simDim>(0) )
+                if( inPlaneGPU == PMacc::math::Int<simDim>::create(0) )
                     isGroupRoot = true;
             }
 

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -50,7 +50,7 @@ struct SglParticle
     float_X charge;
     float_X gamma;
 
-    SglParticle() : position(0.0), momentum(0.0), mass(0.0),
+    SglParticle() : position(FloatPos::create(0.0)), momentum(float3_X::create(0.0)), mass(0.0),
         weighting(0.0), charge(0.0), gamma(0.0)
     {
     }

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -133,7 +133,7 @@ void SliceFieldPrinter<Field>::printSlice(const TField& field, int nAxis, float 
     int localPlane = globalPlane % field.size()[nAxis];
     int gpuPlane = globalPlane / field.size()[nAxis];
 
-    vec::Int<3> nVector(0);
+    vec::Int<3> nVector(vec::Int<3>::create(0));
     nVector[nAxis] = 1;
 
     zone::SphericZone<3> gpuGatheringZone(vec::Size_t<3>(gpuDim.x(), gpuDim.y(), gpuDim.z()),

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -58,7 +58,7 @@ __global__ void kernelSumCurrents(J_DataBox fieldJ, float3_X* gCurrent, Mapping 
 
     if (linearThreadIdx == 0)
     {
-        sh_sumJ = float3_X(float_X(0.0), float_X(0.0), float_X(0.0));
+        sh_sumJ = float3_X::create(0.0);
     }
 
     __syncthreads();
@@ -185,7 +185,7 @@ private:
 
     float3_X getSumCurrents()
     {
-        sumcurrents->getDeviceBuffer().setValue(float3_X(float_X(0.0), float_X(0.0), float_X(0.0)));
+        sumcurrents->getDeviceBuffer().setValue(float3_X::create(0.0));
         dim3 block(MappingDesc::SuperCellSize::toRT().toDim3());
 
         __picKernelArea(kernelSumCurrents, *cellDescription, CORE + BORDER)

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -227,7 +227,7 @@ private:
             /*load particle without copy particle data to host*/
             Species* speciesTmp = &(dc.getData<Species >(Species::FrameType::getName(), true));
 
-            fieldTmp->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
+            fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType::create(0.0));
             /*run algorithm*/
             fieldTmp->computeValue < CORE + BORDER, Solver > (*speciesTmp, params->currentStep);
 

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -59,7 +59,7 @@ public:
 
         const PMacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
-        field.getHostBuffer().setValue(float3_X(0.));
+        field.getHostBuffer().setValue(float3_X::create(0.0));
 
         DataSpace<simDim> domain_offset = localDomain.offset;
 

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -152,7 +152,7 @@ private:
         /*load particle without copy particle data to host*/
         Species* speciesTmp = &(dc.getData<Species >(Species::FrameType::getName(), true));
 
-        fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType(0.0));
+        fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType::create(0.0));
         /*run algorithm*/
         fieldTmp->computeValue < CORE + BORDER, Solver > (*speciesTmp, params->currentStep);
 

--- a/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -55,7 +55,7 @@ public:
         const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
         const PMacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
-        field.getHostBuffer().setValue(float3_X(0.));
+        field.getHostBuffer().setValue(float3_X::create(0.0));
 
         const std::string name_lookup[] = {"x", "y", "z"};
 

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -410,7 +410,7 @@ __global__ void channelsToRGB(Mem mem, uint32_t n)
     uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= n) return;
 
-    float3_X rgb = float3_X(float_X(0.0), float_X(0.0), float_X(0.0));
+    float3_X rgb(float3_X::create(0.0));
 
     visPreview::preChannel1Col::addRGB(rgb,
                                        mem[tid].x(),

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -45,11 +45,11 @@ alias(position);
 alias(globalCellIdx);
 
 /** specialization for the relative in-cell position */
-value_identifier(floatD_X,position_pic,floatD_X(0.));
+value_identifier(floatD_X,position_pic,floatD_X::create(0.));
 /** momentum at timestep t */
-value_identifier(float3_X,momentum,float3_X(0.));
+value_identifier(float3_X,momentum,float3_X::create(0.));
 /** momentum at (previous) timestep t-1 */
-value_identifier(float3_X,momentumPrev1,float3_X(0.));
+value_identifier(float3_X,momentumPrev1,float3_X::create(0.));
 /** weighting of the macro particle */
 value_identifier(float_X, weighting, 0.0);
 /** use this particle for radiation diagnostics */
@@ -60,7 +60,7 @@ value_identifier(bool, radiationFlag, false);
  * value type is float_X to avoid casts during the runtime
  * - float is also reasonable because effective charge numbers are possible
  * - only reasonable for ion species if ionization is enabled
- * 
+ *
  * \todo connect default to proton number
  */
 value_identifier(float_X,boundElectrons,float_X(0.0));


### PR DESCRIPTION
close #177 **Assign `float3_X = float_X` should not be allowed**

- add method to create vector were all components were set
to the same value `math::vector<...>`
- remove ambiguous `vector<T_Type,...>(T_Type value)` constructor
- add new constructor for one dimensional vectors
- fix dependencies

**Do not merge before #807**