### PR TITLE
fix #796 wrong PMacc path detection

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -392,11 +392,7 @@ endif()
 
 # libPMacc
 
-find_path(PMACC_ROOT_DIR
-  NAMES include/types.h
-  PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../libPMacc"
-  DOC "libPMacc root location"
-  )
+set(PMACC_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../libPMacc")
 include_directories(${PMACC_ROOT_DIR}/include)
 
 


### PR DESCRIPTION
close #769 **Ubuntu: libPMacc not found by CMake (system `types.h`)**

use hard coded path to `PMacc` to avoid wrong detection by using cmake `find_path`