### PR TITLE
remove superfluous CUDA includes

### DIFF
--- a/src/libPMacc/include/eventSystem/events/EventPool.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventPool.hpp
@@ -26,7 +26,6 @@
 #include "types.h"
 #include "eventSystem/events/CudaEvent.hpp"
 #include <vector>
-#include <cuda_runtime.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
@@ -22,11 +22,8 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
-
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/events/CudaEvent.hpp"
-
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
@@ -20,7 +20,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <cuda_runtime.h>
 
 #include "Environment.hpp"
 //#include "eventSystem/EventSystem.hpp"

--- a/src/libPMacc/include/mappings/kernel/MappingDescription.hpp
+++ b/src/libPMacc/include/mappings/kernel/MappingDescription.hpp
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include <builtin_types.h>
 #include <stdexcept>
 #include "dimensions/DataSpace.hpp"
 #include "dimensions/DataSpaceOperations.hpp"

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
 #include <iostream>
 #include <iomanip>
 
@@ -84,7 +83,6 @@ public:
                 tSimulation.printInterval() << " = " <<
                 (uint64_t) (tSimulation.getInterval() / 1000.) << " sec" << std::endl;
         }
-        //CUDA_CHECK(cudaGetLastError());
     }
 
     /**


### PR DESCRIPTION
The CUDA includes in these files are not necessary because those classes neither use any CUDA methods nor data types.