### PR TITLE
libPMacc: Code Clean-Up

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Maximilian Knespel
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, 
+ *                     Maximilian Knespel, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,18 +21,15 @@
  */
 
 
-#ifndef GATHERSLICE_HPP
-#define	GATHERSLICE_HPP
+#pragma once
 
-#include "types.h"
 
 
 #include <mpi.h>
 #include "mappings/simulation/GridController.hpp"
-
-//c includes
 #include "memory/boxes/PitchedBox.hpp"
 #include "dimensions/DataSpace.hpp"
+#include "types.h"                                  // DIM*
 
 namespace gol
 {
@@ -227,5 +225,4 @@ private:
 
 }//namespace
 
-#endif	/* GATHERSLICE_HPP */
 

--- a/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -20,16 +20,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-
-
-#include <mpi.h>
 #include "mappings/simulation/GridController.hpp"
 #include "memory/boxes/PitchedBox.hpp"
 #include "dimensions/DataSpace.hpp"
 #include "types.h"                                  // DIM*
+
+#include <mpi.h>
 
 namespace gol
 {

--- a/src/libPMacc/include/communication/CommunicatorMPI.hpp
+++ b/src/libPMacc/include/communication/CommunicatorMPI.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera, 
+ *                     Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -89,7 +90,7 @@ public:
      *
      * \warning throws invalid argument if cx*cy*cz != totalnodes
      */
-    void init(DataSpace<DIM3> numberProcesses, DataSpace<DIM3> periodic) throw (std::invalid_argument)
+    void init(DataSpace<DIM3> numberProcesses, DataSpace<DIM3> periodic)
     {
         this->periodic = periodic;
 

--- a/src/libPMacc/include/communication/CommunicatorMPI.hpp
+++ b/src/libPMacc/include/communication/CommunicatorMPI.hpp
@@ -21,20 +21,19 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _COMMUNICATORMPI_HPP
-#define	_COMMUNICATORMPI_HPP
-
-#include <mpi.h>
-#include <vector>
-#include <utility>
-#include <map>
-
-#include "types.h"
-#include "memory/dataTypes/Mask.hpp"
-#include "dimensions/DataSpace.hpp"
+#pragma once
 
 #include "communication/ICommunicator.hpp"
 #include "communication/manager_common.h"
+#include "dimensions/DataSpace.hpp"
+#include "memory/dataTypes/Mask.hpp"
+#include "types.h"
+
+#include <mpi.h>
+
+#include <vector>
+#include <utility>
+#include <map>
 
 namespace PMacc
 {
@@ -71,7 +70,6 @@ public:
     {
         return mpiSize;
     }
-
 
     MPI_Comm getMPIComm() const
     {
@@ -394,8 +392,6 @@ protected:
         return ranks[type];
     }
 
-
-
 private:
     //! coordinates in GPU-Grid [0:cx-1,0:cy-1,0:cz-1]
     DataSpace<DIM> coordinates;
@@ -418,8 +414,4 @@ private:
     int mpiSize;
 };
 
-
 } //namespace PMacc
-
-#endif	/* _COMMUNICATORMPI_HPP */
-

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,22 +20,23 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_CARTBUFFER_HPP
-#define CONTAINER_CARTBUFFER_HPP
+#pragma once
 
-#include <stdint.h>
-#include "types.h"
-#include "math/vector/Size_t.hpp"
-#include "math/vector/UInt32.hpp"
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include "cuSTL/cursor/navigator/CartNavigator.hpp"
 #include "cuSTL/cursor/accessor/PointerAccessor.hpp"
 #include "cuSTL/cursor/SafeCursor.hpp"
 #include "cuSTL/zone/SphericZone.hpp"
+#include "cuSTL/container/view/View.hpp"
 #include "allocator/EmptyAllocator.hpp"
+#include "math/vector/Size_t.hpp"
+#include "math/vector/UInt32.hpp"
+#include "types.h"
+
+#include <stdint.h>
+
 #include <boost/mpl/void.hpp>
 #include <boost/move/move.hpp>
-#include "cuSTL/container/view/View.hpp"
 
 namespace PMacc
 {
@@ -129,5 +130,3 @@ public:
 } // PMacc
 
 #include "CartBuffer.tpp"
-
-#endif // CONTAINER_CARTBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -22,21 +22,21 @@
 
 #pragma once
 
+#include "allocator/EmptyAllocator.hpp"
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include "cuSTL/cursor/navigator/CartNavigator.hpp"
 #include "cuSTL/cursor/accessor/PointerAccessor.hpp"
 #include "cuSTL/cursor/SafeCursor.hpp"
 #include "cuSTL/zone/SphericZone.hpp"
 #include "cuSTL/container/view/View.hpp"
-#include "allocator/EmptyAllocator.hpp"
 #include "math/vector/Size_t.hpp"
 #include "math/vector/UInt32.hpp"
 #include "types.h"
 
-#include <stdint.h>
-
 #include <boost/mpl/void.hpp>
 #include <boost/move/move.hpp>
+
+#include <stdint.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -21,8 +21,9 @@
  */
 
 #include "cuSTL/container/allocator/tag.h"
+#include "eventSystem/EventSystem.hpp"
+
 #include <iostream>
-#include <eventSystem/EventSystem.hpp>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -31,7 +31,9 @@ namespace container
 
 namespace detail
 {
-    template<int dim> struct PitchHelper;
+    template<int dim>
+    struct PitchHelper;
+
     template<>
     struct PitchHelper<1>
     {

--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_DEVICEBUFFER_HPP
-#define CONTAINER_DEVICEBUFFER_HPP
+#pragma once
 
 #include <cuSTL/container/allocator/DeviceMemAllocator.hpp>
 #include <cuSTL/container/copier/D2DCopier.hpp>
@@ -93,5 +92,3 @@ public:
 
 } // container
 } // PMacc
-
-#endif // CONTAINER_DEVICEBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -25,14 +25,14 @@
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include "cuSTL/zone/SphericZone.hpp"
 #include "cuSTL/algorithm/kernel/run-time/Foreach.hpp"
-#include "math/vector/Size_t.hpp"
 #include "lambda/Expression.hpp"
+#include "math/vector/Size_t.hpp"
 #include "types.h"
+
+#include <boost/math/common_factor.hpp>
 
 #include <cassert>
 #include <stdint.h>
-
-#include <boost/math/common_factor.hpp>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,61 +20,58 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ASSIGNER_DEVICEMEMASSIGNER_HPP
-#define ASSIGNER_DEVICEMEMASSIGNER_HPP
+#pragma once
 
-#include <stdint.h>
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include "cuSTL/zone/SphericZone.hpp"
-#include "math/vector/Size_t.hpp"
 #include "cuSTL/algorithm/kernel/run-time/Foreach.hpp"
+#include "math/vector/Size_t.hpp"
 #include "lambda/Expression.hpp"
-#include "math/Vector.hpp"
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/at.hpp>
 #include "types.h"
-#include <boost/math/common_factor.hpp>
+
 #include <cassert>
+#include <stdint.h>
+
+#include <boost/math/common_factor.hpp>
 
 namespace PMacc
 {
 namespace assigner
 {
 
-namespace mpl = boost::mpl;
-
 template<int T_dim>
 struct DeviceMemAssigner
 {
     static const int dim = T_dim;
-    template<typename Type>
-    static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
-                       const math::Size_t<dim>& size)
-    {
 
-        using namespace math;
-        cursor::BufferCursor<Type, dim> cursor(data, pitch);
+    template<
+        typename Type>
+    static void assign(
+        Type* data, 
+        const math::Size_t<dim-1>& pitch, 
+        const Type& value,
+        const math::Size_t<dim>& size)
+    {
         zone::SphericZone<dim> myZone(size);
+        cursor::BufferCursor<Type, dim> cursor(data, pitch);
 
         /* The greatest common divisor of each component of the volume size
-         * and a certain power of two value gives the best suitable block size
-         */
+         * and a certain power of two value gives the best suitable block size */
         boost::math::gcd_evaluator<size_t> gcd; // greatest common divisor
         math::Size_t<3> blockDim(1);
         int maxValues[] = {16, 16, 4}; // maximum values for each dimension
         for(int i = 0; i < dim; i++)
+        {
             blockDim[i] = gcd(size[i], maxValues[dim-1]);
+        }
         /* the maximum number of threads per block for devices with
          * compute capability > 2.0 is 1024 */
-        assert(blockDim.productOfComponents()<=1024);
+        assert(blockDim.productOfComponents() <= 1024);
 
-        using namespace lambda;
         algorithm::kernel::RT::Foreach foreach(blockDim);
-        foreach(myZone, cursor, _1 = value);
+        foreach(myZone, cursor, lambda::_1 = value);
     }
 };
 
 } // assigner
 } // PMacc
-
-#endif // ASSIGNER_DEVICEMEMASSIGNER_HPP

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -44,8 +44,7 @@ struct DeviceMemAssigner
 {
     static const int dim = T_dim;
 
-    template<
-        typename Type>
+    template<typename Type>
     static void assign(
         Type* data, 
         const math::Size_t<dim-1>& pitch, 

--- a/src/libPMacc/include/debug/VerboseLog.hpp
+++ b/src/libPMacc/include/debug/VerboseLog.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,15 +22,14 @@
 
 #pragma once
 
-#include <sstream>
-#include <boost/format.hpp>
-#include <iostream>
-
-#include "types.h"
-#include <string>
-
 #include "debug/VerboseLogMakros.hpp"
+#include "types.h"
 
+#include <boost/format.hpp>
+
+#include <string>
+#include <iostream>
+#include <sstream>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/dimensions/DataSpace.hpp
+++ b/src/libPMacc/include/dimensions/DataSpace.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera, 
+ *                     Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -28,9 +29,8 @@
 #include <math.h>
 #include <iostream>
 
-#include "types.h"
 #include "math/Vector.hpp"
-
+#include "types.h"
 
 namespace PMacc
 {
@@ -122,7 +122,7 @@ namespace PMacc
         }
 
         /**
-         * Give DataSpace were all dimensions set to init value
+         * Give DataSpace where all dimensions set to init value
          *
          * @param value value which is setfor all dimensions
          * @return the new DataSpace

--- a/src/libPMacc/include/dimensions/DataSpace.hpp
+++ b/src/libPMacc/include/dimensions/DataSpace.hpp
@@ -23,12 +23,6 @@
 
 #pragma once
 
-#include <cassert>
-#include <stdexcept>
-#include <stdio.h>
-#include <math.h>
-#include <iostream>
-
 #include "math/Vector.hpp"
 #include "types.h"
 
@@ -162,8 +156,6 @@ namespace PMacc
             }
             return false;
         }
-
-
 
         HDINLINE operator math::Size_t<DIM>() const
         {

--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,12 +23,12 @@
 
 #pragma once
 
-#include <map>
-#include <cassert>
 
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/events/EventPool.hpp"
 
+#include <map>
+#include <set>
 
 namespace PMacc
 {
@@ -74,9 +75,7 @@ namespace PMacc
 
         EventPool& getEventPool();
 
-        int getCount();
-
-
+        std::size_t getCount();
 
     private:
 

--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -23,7 +23,6 @@
 
 #pragma once
 
-
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/events/EventPool.hpp"
 

--- a/src/libPMacc/include/eventSystem/Manager.tpp
+++ b/src/libPMacc/include/eventSystem/Manager.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -203,7 +203,7 @@ inline EventPool& Manager::getEventPool( )
     return *eventPool;
 }
 
-inline int Manager::getCount( )
+inline std::size_t Manager::getCount( )
 {
     for ( TaskMap::iterator iter = tasks.begin( ); iter != tasks.end( ); ++iter )
     {

--- a/src/libPMacc/include/eventSystem/Manager.tpp
+++ b/src/libPMacc/include/eventSystem/Manager.tpp
@@ -20,14 +20,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "eventSystem/streams/StreamController.hpp"
+#include "eventSystem/EventSystem.hpp"
+#include "eventSystem/Manager.hpp"
+
+#include <cstdlib>
+#include <cstdio>
 #include <set>
 #include <iostream>
 
-#include "eventSystem/EventSystem.hpp"
-#include "eventSystem/streams/StreamController.hpp"
-#include "eventSystem/Manager.hpp"
-#include <stdlib.h>
-#include <stdio.h>
 //#define DEBUG_EVENTS
 
 namespace PMacc

--- a/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
@@ -21,7 +21,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "eventSystem/events/IEventData.hpp"

--- a/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,8 +22,7 @@
  */
 
 
-#ifndef _EVENTDATARECEIVE_HPP
-#define	_EVENTDATARECEIVE_HPP
+#pragma once
 
 #include "eventSystem/events/IEventData.hpp"
 
@@ -32,13 +32,10 @@ namespace PMacc
     class EventDataReceive : public IEventData
     {
     public:
-
         EventDataReceive(EventNotify *task, size_t recv_count) :
-        IEventData(task),
-        recv_count(recv_count)
-        {
-
-        }
+            IEventData(task),
+            recv_count(recv_count)
+        {}
 
         size_t getReceivedCount() const
         {
@@ -51,6 +48,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _EVENTDATARECEIVE_HPP */
-

--- a/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
@@ -32,8 +32,8 @@ namespace PMacc
     {
     public:
         EventDataReceive(EventNotify *task, size_t recv_count) :
-            IEventData(task),
-            recv_count(recv_count)
+        IEventData(task),
+        recv_count(recv_count)
         {}
 
         size_t getReceivedCount() const

--- a/src/libPMacc/include/eventSystem/events/EventNotify.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.hpp
@@ -21,12 +21,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include "types.h"
-
 #include <set>
+
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/events/EventNotify.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,19 +22,18 @@
  */
 
 
-#ifndef _EVENTNOTIFY_HPP
-#define	_EVENTNOTIFY_HPP
+#pragma once
+
+#include "types.h"
 
 #include <set>
-#include "types.h"
-#include "eventSystem/events/IEvent.hpp"
-
-
 
 namespace PMacc
 {
 
     class IEventData;
+    class IEvent;
+
     /**
      * Implements an observable.
      */
@@ -77,7 +77,4 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _EVENTNOTIFY_HPP */
 

--- a/src/libPMacc/include/eventSystem/events/EventNotify.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -26,6 +26,7 @@
 #include "eventSystem/events/EventNotify.hpp"
 #include "eventSystem/events/IEventData.hpp"
 
+#include "eventSystem/events/IEvent.hpp"
 
 namespace PMacc
 {
@@ -53,6 +54,3 @@ namespace PMacc
         }
 
 } //namespace PMacc
-
-
-

--- a/src/libPMacc/include/eventSystem/events/EventNotify.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.tpp
@@ -20,13 +20,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <set>
-
-#include "types.h"
 #include "eventSystem/events/EventNotify.hpp"
 #include "eventSystem/events/IEventData.hpp"
-
 #include "eventSystem/events/IEvent.hpp"
+#include "types.h"
+
+#include <set>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/events/EventPool.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventPool.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -23,8 +23,10 @@
 
 #pragma once
 
-#include "types.h"
 #include "eventSystem/events/CudaEvent.hpp"
+#include "debug/VerboseLog.hpp"
+#include "types.h"
+
 #include <vector>
 
 namespace PMacc

--- a/src/libPMacc/include/eventSystem/events/EventTask.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventTask.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,15 +20,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef _EVENTTASK_HPP
-#define	_EVENTTASK_HPP
+#include "types.h"
 
-
-#include <set>
-#include "eventSystem/tasks/ITask.hpp"
-
-
+#include <string>
 
 namespace PMacc
 {
@@ -110,5 +106,3 @@ namespace PMacc
 } //namespace PMacc
 
 
-
-#endif	/* _EVENTTASK_HPP */

--- a/src/libPMacc/include/eventSystem/events/EventTask.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventTask.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -30,15 +30,12 @@ namespace PMacc
 {
 
     inline EventTask::EventTask(id_t taskId) :
-    taskId(taskId)
-    {
-    }
+        taskId(taskId)
+    {}
 
     inline EventTask::EventTask() :
-    taskId(0)
-    {
-
-    }
+        taskId(0)
+    {}
 
     inline std::string EventTask::toString()
     {
@@ -107,8 +104,5 @@ namespace PMacc
         return *this;
     }
 
-
-
 }
-
 

--- a/src/libPMacc/include/eventSystem/events/IEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/IEvent.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _IEVENT_HPP
-#define	_IEVENT_HPP
+#pragma once
 
 #include "types.h"
 
@@ -56,6 +55,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _IEVENT_HPP */
-

--- a/src/libPMacc/include/eventSystem/events/IEventData.hpp
+++ b/src/libPMacc/include/eventSystem/events/IEventData.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _IEVENTDATA_HPP
-#define	_IEVENTDATA_HPP
+#pragma once
 
 #include "eventSystem/events/EventNotify.hpp"
 
@@ -39,13 +39,10 @@ namespace PMacc
 
         IEventData(EventNotify *task) :
         task(task)
-        {
-
-        }
+        {}
 
         virtual ~IEventData()
-        {
-        }
+        {}
 
         EventNotify* getEventNotify()
         {
@@ -58,6 +55,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _IEVENTDATA_HPP */
-

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -22,11 +22,12 @@
 
 #pragma once
 
-#include "types.h"
-#include "ppFunctions.hpp"
-#include <boost/preprocessor/control/if.hpp>
 #include "dimensions/DataSpace.hpp"
 #include "eventSystem/EventSystem.hpp"
+#include "ppFunctions.hpp"
+#include "types.h"
+
+#include <boost/preprocessor/control/if.hpp>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KERNELEVENTS_H
-#define KERNELEVENTS_H
+#pragma once
 
 #include "types.h"
 #include "ppFunctions.hpp"
@@ -84,7 +83,3 @@ namespace PMacc
     kernelname PMACC_CUDAKERNELCONFIG
 
 }
-
-
-#endif //KERNELEVENTS_H
-

--- a/src/libPMacc/include/eventSystem/streams/EventStream.hpp
+++ b/src/libPMacc/include/eventSystem/streams/EventStream.hpp
@@ -20,12 +20,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <cuda_runtime.h>
 #include "eventSystem/events/CudaEvent.hpp"
 #include "types.h"
+
+#include <cuda_runtime.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/streams/EventStream.hpp
+++ b/src/libPMacc/include/eventSystem/streams/EventStream.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -25,6 +25,7 @@
 
 #include <cuda_runtime.h>
 #include "eventSystem/events/CudaEvent.hpp"
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/streams/StreamController.hpp
+++ b/src/libPMacc/include/eventSystem/streams/StreamController.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,15 +22,16 @@
  */
 
 
-#ifndef _STREAMCONTROLLER_HPP
-#define	_STREAMCONTROLLER_HPP
+#pragma once
 
+#include "eventSystem/streams/EventStream.hpp"
 #include <cuda_runtime.h>
-#include <vector>
 
 #include "types.h"
 
-#include "eventSystem/streams/EventStream.hpp"
+#include <string>
+#include <stdexcept>
+#include <vector>
 
 namespace PMacc
 {
@@ -138,7 +140,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _ENVIRONMENTCONTROLLER_HPP */
-

--- a/src/libPMacc/include/eventSystem/streams/StreamController.hpp
+++ b/src/libPMacc/include/eventSystem/streams/StreamController.hpp
@@ -25,9 +25,9 @@
 #pragma once
 
 #include "eventSystem/streams/EventStream.hpp"
-#include <cuda_runtime.h>
-
 #include "types.h"
+
+#include <cuda_runtime.h>
 
 #include <string>
 #include <stdexcept>

--- a/src/libPMacc/include/eventSystem/tasks/Factory.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,11 +21,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef _FACTORY_HPP
-#define	_FACTORY_HPP
+#include <string>
 
-#include <iostream>
+#include "types.h"  // DIM*
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/streams/EventStream.hpp"
 
@@ -43,7 +44,7 @@ namespace PMacc
 
     /**
      * Singleton Factory-pattern class for creation of several types of EventTasks.
-     * Tasks are not actually 'returned' but immediately initialised and
+     * Tasks are not actually 'returned' but immediately initialized and
      * added to the Manager's queue. An exception is TaskKernel.
      */
     class Factory
@@ -183,7 +184,4 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _FACTORY_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/Factory.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.hpp
@@ -23,11 +23,11 @@
 
 #pragma once
 
-#include <string>
-
-#include "types.h"  // DIM*
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/streams/EventStream.hpp"
+#include "types.h"
+
+#include <string>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/Factory.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -37,9 +37,9 @@
 #include "eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp"
 #include "eventSystem/tasks/TaskSendMPI.hpp"
 #include "eventSystem/tasks/TaskReceiveMPI.hpp"
+#include "eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp"
 #include "eventSystem/streams/EventStream.hpp"
 #include "eventSystem/streams/StreamController.hpp"
-#include "eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/ITask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/ITask.hpp
@@ -21,9 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _ITASK_HPP
-#define	_ITASK_HPP
+#pragma once
 
 #include "eventSystem/events/EventNotify.hpp"
 #include "eventSystem/events/IEvent.hpp"
@@ -126,6 +124,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _ITASK_HPP */
-

--- a/src/libPMacc/include/eventSystem/tasks/ITask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/ITask.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -24,14 +25,13 @@
 #ifndef _ITASK_HPP
 #define	_ITASK_HPP
 
-#include <iostream>
-#include <typeinfo>
-#include <set>
-#include <cassert>
-
 #include "eventSystem/events/EventNotify.hpp"
 #include "eventSystem/events/IEvent.hpp"
 #include "types.h"
+
+#include <string>
+#include <set>
+#include <cassert>
 
 namespace PMacc
 {
@@ -76,7 +76,7 @@ namespace PMacc
         }
 
         /**
-         * Initialises the task.
+         * Initializes the task.
          * Must be called before adding the task to the Manager's queue.
          */
         virtual void init()=0;

--- a/src/libPMacc/include/eventSystem/tasks/MPITask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/MPITask.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,13 +20,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MPITASK_HPP
-#define	MPITASK_HPP
-
-#include <mpi.h>
+#pragma once
 
 #include "eventSystem/tasks/ITask.hpp"
-#include "eventSystem/transactions/TransactionManager.hpp"
+
+#include <mpi.h>
 
 namespace PMacc
 {
@@ -79,6 +77,3 @@ namespace PMacc
         bool finished;
     };
 }
-
-#endif	/* MPITASK_HPP */
-

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ * Copyright 2013 Felix Schmitt, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -25,8 +25,6 @@
 //#include "eventSystem/EventSystem.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
 #include "eventSystem/streams/EventStream.hpp"
-
-
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TASKCOPYDEVICETODEVICE_HPP
-#define	_TASKCOPYDEVICETODEVICE_HPP
+#pragma once
 
 #include <cuda_runtime_api.h>
 
@@ -54,7 +54,7 @@ namespace PMacc
             notify(this->myId, COPYDEVICE2DEVICE, NULL);
         }
 
-        bool executeIntern() throw (std::runtime_error)
+        bool executeIntern()
         {
             return isFinished();
         }
@@ -199,7 +199,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _TASKCOPYDEVICETODEVICE_HPP */
-

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
@@ -23,13 +23,12 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
-
-#include "types.h"
-
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/streams/EventStream.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
+#include "types.h"
+
+#include <cuda_runtime_api.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TASKCOPYDEVICETOHOST_HPP
-#define	_TASKCOPYDEVICETOHOST_HPP
+#pragma once
 
 
 #include <cuda_runtime_api.h>
@@ -205,7 +205,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _TASKCOPYDEVICETOHOST_HPP */
-

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
@@ -23,14 +23,13 @@
 
 #pragma once
 
-
-#include <cuda_runtime_api.h>
-#include <iomanip>
-
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/streams/EventStream.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
 
+#include <cuda_runtime_api.h>
+
+#include <iomanip>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TASKCOPYHOSTTODEVICE_HPP
-#define	_TASKCOPYHOSTTODEVICE_HPP
+#pragma once
 
 #include <cuda_runtime_api.h>
 
@@ -193,7 +193,3 @@ namespace PMacc
 
 
 } //namespace PMacc
-
-
-#endif	/* _TASKCOPYHOSTTODEVICE_HPP */
-

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
@@ -23,11 +23,11 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
-
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/streams/EventStream.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
+
+#include <cuda_runtime_api.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TASKGETCURRENTSIZEFROMDEVICE_HPP
-#define _TASKGETCURRENTSIZEFROMDEVICE_HPP
+#pragma once
 
 #include <cuda_runtime_api.h>
 #include <cuda.h>
@@ -87,7 +86,3 @@ private:
 };
 
 } //namespace PMacc
-
-
-#endif	/* _TASKGETCURRENTSIZEFROMDEVICE_HPP */
-

--- a/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -22,16 +22,14 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
-#include <cuda.h>
-
-
-#include "dimensions/DataSpace.hpp"
-#include "types.h"
-
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/streams/EventStream.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
+#include "dimensions/DataSpace.hpp"
+#include "types.h"
+
+#include <cuda_runtime_api.h>
+#include <cuda.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,11 +21,7 @@
  */
 
 
-#ifndef _TASKKERNEL_HPP
-#define _TASKKERNEL_HPP
-
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#pragma once
 
 #include "eventSystem/tasks/StreamTask.hpp"
 #include "eventSystem/streams/EventStream.hpp"
@@ -87,7 +83,4 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _TASKKERNEL_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,15 +22,11 @@
  */
 
 
-#ifndef _TASKLOGICALAND_HPP
-#define	_TASKLOGICALAND_HPP
+#pragma once
 
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
 #include "eventSystem/EventSystem.hpp"
-#include <exception>
-
-#include <set>
 
 namespace PMacc
 {
@@ -152,6 +149,4 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _TASKLOGICALAND_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TASKRECEIVE_HPP
-#define	_TASKRECEIVE_HPP
+#pragma once
 
 #include "memory/buffers/Exchange.hpp"
 
@@ -146,7 +146,4 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _TASKRECEIVE_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
@@ -23,14 +23,13 @@
 
 #pragma once
 
-#include "memory/buffers/Exchange.hpp"
-
-#include "mappings/simulation/EnvironmentController.hpp"
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/tasks/MPITask.hpp"
 #include "eventSystem/tasks/TaskCopyHostToDevice.hpp"
 #include "eventSystem/events/EventDataReceive.hpp"
 #include "eventSystem/tasks/Factory.hpp"
+#include "mappings/simulation/EnvironmentController.hpp"
+#include "memory/buffers/Exchange.hpp"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskReceiveMPI.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskReceiveMPI.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,15 +21,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TASKRECEIVEMPI_HPP
-#define	TASKRECEIVEMPI_HPP
-
-#include <mpi.h>
-
+#pragma once
 #include "memory/buffers/Exchange.hpp"
 
 #include "eventSystem/tasks/MPITask.hpp"
 
+#include <mpi.h>
 #include "communication/manager_common.h"
 #include "communication/ICommunicator.hpp"
 
@@ -113,6 +111,4 @@ private:
 };
 
 } //namespace PMacc
-
-#endif	/* TASKRECEIVEMPI_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskReceiveMPI.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskReceiveMPI.hpp
@@ -22,14 +22,13 @@
  */
 
 #pragma once
-#include "memory/buffers/Exchange.hpp"
 
-#include "eventSystem/tasks/MPITask.hpp"
-
-#include <mpi.h>
 #include "communication/manager_common.h"
 #include "communication/ICommunicator.hpp"
+#include "eventSystem/tasks/MPITask.hpp"
+#include "memory/buffers/Exchange.hpp"
 
+#include <mpi.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _TASKSEND_HPP
-#define	_TASKSEND_HPP
+#pragma once
 
 #include <cuda_runtime_api.h>
 
@@ -132,9 +131,7 @@ namespace PMacc
             DeviceToHostFinished,
             SendDone,
             Finish
-
         };
-
 
         Exchange<TYPE, DIM> *exchange;
         EventTask& copyEvent;
@@ -142,6 +139,4 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _TASKSEND_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
@@ -23,16 +23,15 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
-
-#include "memory/buffers/Exchange.hpp"
-#include "eventSystem/EventSystem.hpp"
-
+#include "eventSystem/tasks/Factory.hpp"
 #include "eventSystem/tasks/ITask.hpp"
 #include "eventSystem/tasks/TaskReceive.hpp"
 #include "eventSystem/tasks/TaskCopyDeviceToHost.hpp"
+#include "eventSystem/EventSystem.hpp"
 #include "mappings/simulation/EnvironmentController.hpp"
-#include "eventSystem/tasks/Factory.hpp"
+#include "memory/buffers/Exchange.hpp"
+
+#include <cuda_runtime_api.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,15 +21,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TASKSENDMPI_HPP
-#define	TASKSENDMPI_HPP
-
-#include <mpi.h>
+#pragma once
 
 #include "memory/buffers/Exchange.hpp"
 
 #include "eventSystem/tasks/MPITask.hpp"
 
+#include <mpi.h>
 #include "communication/manager_common.h"
 #include "communication/ICommunicator.hpp"
 
@@ -102,6 +101,4 @@ private:
 };
 
 } //namespace PMacc
-
-#endif	/* TASKSENDMPI_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
@@ -23,13 +23,12 @@
 
 #pragma once
 
-#include "memory/buffers/Exchange.hpp"
-
-#include "eventSystem/tasks/MPITask.hpp"
-
-#include <mpi.h>
 #include "communication/manager_common.h"
 #include "communication/ICommunicator.hpp"
+#include "eventSystem/tasks/MPITask.hpp"
+#include "memory/buffers/Exchange.hpp"
+
+#include <mpi.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -22,16 +22,14 @@
 
 #pragma once
 
-
-#include <cuda_runtime_api.h>
-#include <cuda.h>
-
-#include "dimensions/DataSpace.hpp"
-
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/streams/EventStream.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
 #include "eventSystem/events/kernelEvents.hpp"
+#include "dimensions/DataSpace.hpp"
+
+#include <cuda_runtime_api.h>
+#include <cuda.h>
 
 __global__ void kernelSetValueOnDeviceMemory(size_t* pointer, const size_t size)
 {

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef _TASKSETCURRENTSIZEONDEVICE_HPP
-#define _TASKSETCURRENTSIZEONDEVICE_HPP
 
 #include <cuda_runtime_api.h>
 #include <cuda.h>
@@ -97,7 +96,4 @@ private:
 };
 
 } //namespace PMacc
-
-
-#endif	/* _TASKSETCURRENTSIZEONDEVICE_HPP */
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera, 
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,20 +23,18 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
-#include <cuda.h>
-
-#include "memory/buffers/DeviceBuffer.hpp"
 #include "dimensions/DataSpace.hpp"
-#include "memory/boxes/DataBox.hpp"
-
-#include "eventSystem/EventSystem.hpp"
-#include "memory/buffers/DeviceBuffer.hpp"
-#include "eventSystem/tasks/StreamTask.hpp"
 #include "mappings/simulation/EnvironmentController.hpp"
+#include "memory/buffers/DeviceBuffer.hpp"
+#include "memory/boxes/DataBox.hpp"
+#include "eventSystem/EventSystem.hpp"
+#include "eventSystem/tasks/StreamTask.hpp"
 
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits.hpp>
+
+#include <cuda_runtime_api.h>
+#include <cuda.h>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,8 +21,7 @@
  */
 
 
-#ifndef TRANSACTION_HPP
-#define    TRANSACTION_HPP
+#pragma once
 
 #include "eventSystem/EventSystem.hpp"
 
@@ -83,7 +82,4 @@ private:
 };
 
 }
-
-
-#endif    /* TRANSACTION_HPP */
 

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
@@ -20,12 +20,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "eventSystem/EventSystem.hpp"
-
-
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -19,12 +19,12 @@
  * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+ 
+#include "Transaction.hpp"
 
 #include "eventSystem/streams/StreamController.hpp"
 #include "eventSystem/events/EventTask.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
-#include "Transaction.hpp"
-
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
@@ -20,7 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include "Transaction.hpp"
+#include "eventSystem/transactions/Transaction.hpp"
 
 #include "eventSystem/streams/StreamController.hpp"
 #include "eventSystem/events/EventTask.hpp"

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,9 +22,10 @@
 
 #pragma once
 
-#include <stack>
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/transactions/Transaction.hpp"
+
+#include <stack>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -19,9 +19,10 @@
  * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+ 
+#include "eventSystem/EventSystem.hpp"
 
 #include <cassert>
-#include "eventSystem/EventSystem.hpp"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/boxes/SharedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/SharedBox.hpp
@@ -22,13 +22,10 @@
 
 #pragma once
 
-#include "types.h"
-#include "math/Vector.hpp"
-
-
 #include <cuSTL/cursor/compile-time/BufferCursor.hpp>
 #include <math/vector/Float.hpp>
-
+#include "math/Vector.hpp"
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/boxes/SharedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/SharedBox.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -56,8 +56,8 @@ public:
     typedef T_TYPE ValueType;
     typedef ValueType& RefValueType;
     typedef T_Vector Size;
-    typedef SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id > ReducedType;
-    typedef SharedBox<ValueType, T_Vector, T_id,DIM1 > This;
+    typedef SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id> ReducedType;
+    typedef SharedBox<ValueType, T_Vector, T_id, DIM1> This;
 
     HDINLINE RefValueType operator[](const int idx)
     {

--- a/src/libPMacc/include/memory/boxes/SharedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/SharedBox.hpp
@@ -24,7 +24,7 @@
 
 #include <cuSTL/cursor/compile-time/BufferCursor.hpp>
 #include <math/vector/Float.hpp>
-#include "math/Vector.hpp"
+#include <math/Vector.hpp>
 #include "types.h"
 
 namespace PMacc

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -22,14 +22,14 @@
 
 #pragma once
 
-#include <cassert>
-#include <limits>
-
-#include "types.h"
 #include "dimensions/DataSpace.hpp"
 #include "memory/boxes/DataBox.hpp"
 #include "memory/boxes/PitchedBox.hpp"
 #include "Environment.hpp"
+#include "types.h"
+
+#include <cassert>
+#include <limits>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _BUFFER_HPP
-#define	_BUFFER_HPP
+#pragma once
 
 #include <cassert>
 #include <limits>
@@ -193,6 +191,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _BUFFER_HPP */
-

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,23 +20,22 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef _DEVICEBUFFER_HPP
-#define	_DEVICEBUFFER_HPP
 
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
-#include <stdexcept>
 
 
 #include "memory/buffers/Buffer.hpp"
 
 
 #include <cuSTL/container/DeviceBuffer.hpp>
-#include <types.h>
 #include <math/vector/Int.hpp>
 #include <math/vector/Size_t.hpp>
+#include <types.h>
 #include "cuSTL/container/view/View.hpp"
+#include <stdexcept>
 
 
 namespace PMacc
@@ -170,6 +169,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _DEVICEBUFFER_HPP */

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -22,21 +22,17 @@
 
 #pragma once
 
+#include <cuSTL/container/view/View.hpp>
+#include <cuSTL/container/DeviceBuffer.hpp>
+#include <math/vector/Int.hpp>
+#include <math/vector/Size_t.hpp>
+#include <memory/buffers/Buffer.hpp>
+#include <types.h>
 
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
 
-
-#include "memory/buffers/Buffer.hpp"
-
-
-#include <cuSTL/container/DeviceBuffer.hpp>
-#include <math/vector/Int.hpp>
-#include <math/vector/Size_t.hpp>
-#include <types.h>
-#include "cuSTL/container/view/View.hpp"
 #include <stdexcept>
-
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -22,13 +22,12 @@
 
 #pragma once
 
-#include <cassert>
-
 #include "dimensions/DataSpace.hpp"
+#include "eventSystem/tasks/Factory.hpp"
 #include "memory/buffers/DeviceBuffer.hpp"
 #include "memory/boxes/DataBox.hpp"
 
-#include "eventSystem/tasks/Factory.hpp"
+#include <cassert>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _DEVICEBUFFERINTERN_HPP
-#define	_DEVICEBUFFERINTERN_HPP
+#pragma once
 
 #include <cassert>
 
@@ -327,5 +325,3 @@ private:
 };
 
 } //namespace PMacc
-
-#endif	/* _DEVICEBUFFERINTERN_HPP */

--- a/src/libPMacc/include/memory/buffers/Exchange.hpp
+++ b/src/libPMacc/include/memory/buffers/Exchange.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _EXCHANGE_HPP
-#define	_EXCHANGE_HPP
+#pragma once
 
 #include "memory/buffers/DeviceBuffer.hpp"
 #include "memory/buffers/HostBuffer.hpp"
@@ -98,6 +96,3 @@ namespace PMacc
     };
 
 }
-
-#endif	/* _EXCHANGE_HPP */
-

--- a/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,10 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef _EXCHANGEINTERN_HPP
-#define	_EXCHANGEINTERN_HPP
+#pragma once
 
 #include <assert.h>
 
@@ -241,6 +238,3 @@ namespace PMacc
     };
 
 }
-
-#endif	/* _EXCHANGEINTERN_HPP */
-

--- a/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
@@ -22,19 +22,19 @@
 
 #pragma once
 
-#include <assert.h>
-
-#include "types.h"
-#include "memory/buffers/Exchange.hpp"
-#include "memory/dataTypes/Mask.hpp"
 #include "dimensions/GridLayout.hpp"
 #include "mappings/simulation/GridController.hpp"
+#include "memory/buffers/Exchange.hpp"
+#include "memory/dataTypes/Mask.hpp"
+#include "memory/buffers/DeviceBufferIntern.hpp"
+#include "memory/buffers/HostBufferIntern.hpp"
 
 #include "eventSystem/tasks/Factory.hpp"
 #include "eventSystem/tasks/TaskReceive.hpp"
 
-#include "memory/buffers/DeviceBufferIntern.hpp"
-#include "memory/buffers/HostBufferIntern.hpp"
+#include "types.h"
+
+#include <cassert>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -24,7 +24,6 @@
 #ifndef _GRIDBUFFER_HPP
 #define	_GRIDBUFFER_HPP
 
-#include <algorithm>
 
 #include "eventSystem/EventSystem.hpp"
 #include "dimensions/GridLayout.hpp"
@@ -37,6 +36,7 @@
 
 #include <sstream>
 #include <stdexcept>
+#include <algorithm>
 
 #include <set>
 

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -20,16 +20,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef _GRIDBUFFER_HPP
-#define	_GRIDBUFFER_HPP
-
-
-#include "eventSystem/EventSystem.hpp"
 #include "dimensions/GridLayout.hpp"
-#include "memory/dataTypes/Mask.hpp"
-
+#include "eventSystem/EventSystem.hpp"
 #include "mappings/simulation/EnvironmentController.hpp"
+#include "memory/dataTypes/Mask.hpp"
 #include "memory/buffers/ExchangeIntern.hpp"
 #include "memory/buffers/HostBufferIntern.hpp"
 #include "memory/buffers/DeviceBufferIntern.hpp"
@@ -37,7 +33,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <algorithm>
-
 #include <set>
 
 namespace PMacc
@@ -557,6 +552,3 @@ protected:
 };
 
 }
-
-#endif	/* _GRIDBUFFER_HPP */
-

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,13 +20,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include "memory/buffers/Buffer.hpp"
 #include "dimensions/DataSpace.hpp"
-
-
-#ifndef _HOSTBUFFER_HPP
-#define	_HOSTBUFFER_HPP
 
 namespace PMacc
 {
@@ -86,6 +83,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif	/* _HOSTBUFFER_HPP */

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -22,12 +22,11 @@
 
 #pragma once
 
-#include <cassert>
-
 #include "memory/buffers/Buffer.hpp"
+#include "eventSystem/tasks/Factory.hpp"
 #include "eventSystem/EventSystem.hpp"
 
-#include "eventSystem/tasks/Factory.hpp"
+#include <cassert>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _HOSTBUFFERINTERN_HPP
-#define	_HOSTBUFFERINTERN_HPP
+#pragma once
 
 #include <cassert>
 
@@ -129,6 +127,3 @@ private:
 };
 
 }
-
-#endif	/* _HOSTBUFFERINTERN_HPP */
-

--- a/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera, Axel Huebl
+ * Copyright 2014-2015 Rene Widera, Axel Huebl, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,16 +20,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <cassert>
-
+#include "eventSystem/EventSystem.hpp"
+#include "eventSystem/tasks/Factory.hpp"
 #include "memory/buffers/Buffer.hpp"
 #include "memory/buffers/DeviceBuffer.hpp"
-#include "eventSystem/EventSystem.hpp"
 
-#include "eventSystem/tasks/Factory.hpp"
+#include <cassert>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,22 +20,20 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <algorithm>
-
 #include "dimensions/DataSpace.hpp"
-#include "eventSystem/EventSystem.hpp"
 #include "dimensions/GridLayout.hpp"
-#include "memory/dataTypes/Mask.hpp"
-
+#include "eventSystem/EventSystem.hpp"
 #include "mappings/simulation/EnvironmentController.hpp"
+#include "memory/dataTypes/Mask.hpp"
 #include "memory/buffers/ExchangeIntern.hpp"
 #include "memory/buffers/HostBufferIntern.hpp"
 #include "memory/buffers/DeviceBufferIntern.hpp"
 #include "memory/buffers/GridBuffer.hpp"
 #include "memory/boxes/MultiBox.hpp"
+
+#include <algorithm>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera, Felix Schmitt, Axel Huebl
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Axel Huebl, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -49,7 +49,6 @@ namespace PMacc
          * @param plugin plugin to register
          */
         void registerPlugin(IPlugin *plugin)
-        throw (PluginException)
         {
             if (plugin != NULL)
             {
@@ -63,7 +62,6 @@ namespace PMacc
          * Calls load on all registered, not loaded plugins
          */
         void loadPlugins()
-        throw (PluginException)
         {
             // load all plugins
             for (std::list<IPlugin*>::reverse_iterator iter = plugins.rbegin();
@@ -80,7 +78,6 @@ namespace PMacc
          * Unloads all registered, loaded plugins
          */
         void unloadPlugins()
-        throw (PluginException)
         {
             // unload all plugins
             for (std::list<IPlugin*>::reverse_iterator iter = plugins.rbegin();

--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -22,10 +22,10 @@
 
 #pragma once
 
-#include <list>
-
 #include "pluginSystem/INotify.hpp"
 #include "pluginSystem/IPlugin.hpp"
+
+#include <list>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/types.h
+++ b/src/libPMacc/include/types.h
@@ -24,20 +24,19 @@
 #pragma once
 
 #include "debug/PMaccVerbose.hpp"
+
+#define BOOST_MPL_LIMIT_VECTOR_SIZE 20
+#define BOOST_MPL_LIMIT_MAP_SIZE 20
+#include <boost/typeof/std/utility.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/filesystem.hpp>
+
 #include <builtin_types.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
 
-#include <boost/typeof/std/utility.hpp>
-#include <boost/mpl/placeholders.hpp>
-#include <boost/filesystem.hpp>
 #include <stdint.h>
 #include <stdexcept>
-
-#define BOOST_MPL_LIMIT_VECTOR_SIZE 20
-#define BOOST_MPL_LIMIT_MAP_SIZE 20
-
-
 
 #define PMACC_AUTO_TPL(var,...) BOOST_AUTO_TPL(var,(__VA_ARGS__))
 #define PMACC_AUTO(var,...) BOOST_AUTO(var,(__VA_ARGS__))

--- a/src/libPMacc/include/types.h
+++ b/src/libPMacc/include/types.h
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera, 
+ *                     Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,16 +23,16 @@
 
 #pragma once
 
-#include <stdint.h>
+#include "debug/PMaccVerbose.hpp"
 #include <builtin_types.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
-#include <stdexcept>
 
 #include <boost/typeof/std/utility.hpp>
-#include "debug/PMaccVerbose.hpp"
 #include <boost/mpl/placeholders.hpp>
 #include <boost/filesystem.hpp>
+#include <stdint.h>
+#include <stdexcept>
 
 #define BOOST_MPL_LIMIT_VECTOR_SIZE 20
 #define BOOST_MPL_LIMIT_MAP_SIZE 20


### PR DESCRIPTION
- replace header guards with #pragma once
- remove deprecated throw(...) declarations
- reorder/sort header includes
- remove unnecessary includes