### PR TITLE
use intrinsics in CUDA code with MSVC

### DIFF
--- a/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
@@ -50,7 +50,7 @@ struct RSqrt<double>
 
     HDINLINE double operator( )(const double& value )
     {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
         return 1.0/::sqrt(value);
 #else
         return ::rsqrt(value);

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -72,7 +72,7 @@ struct SinCos<double, double, double>
 
     HDINLINE void operator( )(double arg, double& sinValue, double& cosValue )
     {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
         sinValue = ::sin(arg);
         cosValue = ::cos(arg);
 #else

--- a/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
@@ -50,7 +50,7 @@ struct RSqrt<float>
 
     HDINLINE float operator( )(const float& value )
     {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
         return 1.0f/::sqrtf(value);
 #else
         return ::rsqrtf(value);

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -73,7 +73,7 @@ struct SinCos<float, float, float>
 
     HDINLINE void operator( )(float arg, float& sinValue, float& cosValue )
     {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
         sinValue = ::sinf(arg);
         cosValue = ::cosf(arg);
 #else


### PR DESCRIPTION
change MSVC compatibility for host and device
```C++
#if defined(_MSC_VER)
```
to host only
```C++
#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
```

Discussion see #816.