### PR TITLE
fix 2D zigzag z-flux calculation

### DIFF
--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -281,11 +281,11 @@ struct ZigZag
                 inCellPos[d] = calc_InCellPos(pos_tmp, tmpRelayPoint, I[parId][d]);
                 flux[d] = sign * calc_chargeFlux(pos_tmp, tmpRelayPoint, deltaTime, charge) * volume_reci * cellSize[d];
             }
-            
+
             /* this loop is only needed for 2D, we need a flux in z direction */
             for (uint32_t d = simDim; d < 3; ++d)
             {
-                flux[d] = charge * velocity[d] * volume_reci;
+                flux[d] = float_X(0.5) *  charge * velocity[d] * volume_reci;
             }
 
             PMACC_AUTO(cursorJ, dataBoxJ.shift(precisionCast<int>(I[parId])).toCursor());


### PR DESCRIPTION
- fix wrong velocity for for z-flux calculation

The zigzag implementation split all particle trajectories for any direction in two independent trajectories.
The current implementation also need to does it for the z-direction in 2D, therefore the velocity must halved.

affects simulations only **all** of the following applies:
- 2D3V simulations with a *relevant* component **v.z** (e.g., a warm plasma)
- `ZigZag` solver was used for charged species