### PR TITLE
close #811: numerical heating tool wrong normalization 

### DIFF
--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -159,9 +159,9 @@ if numDir == 2:
                 time_limit = i+1
             else:
                 break
-            if time_limit == 0:
-                # if no time step is equal stop program
-                sys.exit("Time steps between sim1 and sim2 differ from start.")
+        if time_limit == 0:
+            # if no time step is equal stop program
+            sys.exit("Time steps between sim1 and sim2 differ from start.")
 elif numDir == 1:
     time_limit = len(Times[0])
 else:

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -175,7 +175,7 @@ startEnergy = Energies[:][0]
 
 # choose normalization
 if args.boolRelative:
-    norm = 100. / startEnergy # relative to startEnergy in percent
+    norm = 100. / startEnergy[0] # relative to startEnergy in percent
 else:
     norm = 1.0 # absolute values
 


### PR DESCRIPTION
This pull request
 - fixes #811 which was caused due to an array like structure of the normalization after adjusting the start energy introduced with #779
 - fixes a wrong indentation introduced from start