### PR TITLE
Bunch example: change start and end of radiation calculation

### DIFF
--- a/examples/Bunch/submit/bunch_0032.cfg
+++ b/examples/Bunch/submit/bunch_0032.cfg
@@ -47,8 +47,8 @@ TBG_periodic="--periodic 1 0 1"
 ## Section: Optional Variables ##
 #################################s
 
-TBG_radiation="--radiation_e.period 1 --radiation_e.dump 2 --radiation_e.totalRadiation 1 \
-               --radiation_e.lastRadiation 0 --radiation_e.start 2800 --radiation_e.end 3000"
+TBG_radiation="--radiation_e.period 1 --radiation_e.dump 1 --radiation_e.totalRadiation 1 \
+               --radiation_e.lastRadiation 0 --radiation_e.start 5600 --radiation_e.end 5920"
 
 TBG_pngYX="--png_e.period 100 --png_e.axis yx --png_e.slicePoint 0.5 --png_e.folder pngElectronsYX"
 


### PR DESCRIPTION
Since the initial commit, the start end end of the radiation calculation is during a time, were no electrons interact with the laser.

By default, radiation shoud accure without changing the settings.

 - [ ] check if new range works