### PR TITLE
add electron momentum initialization

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
@@ -32,7 +32,8 @@ namespace picongpu
  * the functors are called in order (from first to last functor)
  */
 typedef mpl::vector<
-    particles::CreateGas<gasProfiles::GaussianCloud,particles::startPosition::Random,PIC_Electrons>
+    particles::CreateGas<gasProfiles::GaussianCloud,particles::startPosition::Random,PIC_Electrons>,
+    particles::Manipulate<particles::manipulators::AssignYDriftNegative,PIC_Electrons>
 > InitPipeline;
 
 } //namespace picongpu


### PR DESCRIPTION
With the new particle initialization scheme #730, the electrons of the `Bunch` example were missing their non-zero momentum.

This pull request fixes the missing momentum initialization.