### PR TITLE
avoid non zero E-field integral in plane wave

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -19,9 +19,7 @@
  */
 
 
-
-#ifndef LASERPLANEWAVE_HPP
-#define	LASERPLANEWAVE_HPP
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -135,8 +133,4 @@ namespace picongpu
 
     }
 }
-
-#endif	/* LASERPLANEWAVE_HPP */
-
-
 

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -42,7 +42,9 @@ namespace picongpu
      *  t = x/c and (x-x_0)/sigma = (t-t_0)/tau and k*(x-x_0) = omega*(t-t_0) with omega/k = c and tau * c = sigma
      *  and get:
      *  E = Phi_0*omega/c * exp(0.5 * (t-t_0)^2 / tau^2) * [sin(omega*(t - t_0) - phi) + t/(omega*tau^2) * cos(omega*(t - t_0) - phi)]
-     *  and define Phi_0*omega/c = E_0
+     *  and define:
+     *    E_0 = Phi_0*omega/c
+     *    integrationCorrectionFactor = t/(omega*tau^2)
      *
      *  Please consider:
      *  The above formulae does only apply to a Gaussian envelope. If the plateau length is
@@ -81,14 +83,14 @@ namespace picongpu
                     ( ( runTime - startDownramp )
                       / PULSE_LENGTH / sqrt( 2.0 ) );
                 envelope *= exp( -0.5 * exponent * exponent );
-                integrationCorrectionFactor = ( runTime - startDownramp )/ (2.0*PULSE_LENGTH*PULSE_LENGTH);
+                integrationCorrectionFactor = ( runTime - startDownramp )/ (w*2.0*PULSE_LENGTH*PULSE_LENGTH);
             }
             else if ( runTime < endUpramp )
             {
                 // upramp = start
                 const double exponent = ( ( runTime - endUpramp ) / PULSE_LENGTH / sqrt( 2.0 ) );
                 envelope *= exp( -0.5 * exponent * exponent );
-                integrationCorrectionFactor = ( runTime - endUpramp )/ (2.0*PULSE_LENGTH*PULSE_LENGTH);
+                integrationCorrectionFactor = ( runTime - endUpramp )/ (w*2.0*PULSE_LENGTH*PULSE_LENGTH);
             }
 
             const double timeOszi = runTime - endUpramp;

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -57,7 +57,7 @@ namespace picongpu
             const double endUpramp = mue;
             const double startDownramp = mue + LASER_NOFOCUS_CONSTANT;
 
-
+            double integrationCorrectionFactor = 0.0;
 
             if( runTime > startDownramp )
             {
@@ -66,28 +66,34 @@ namespace picongpu
                     ( ( runTime - startDownramp )
                       / PULSE_LENGTH / sqrt( 2.0 ) );
                 envelope *= exp( -0.5 * exponent * exponent );
+                integrationCorrectionFactor = ( runTime - startDownramp )/ (2.0*PULSE_LENGTH*PULSE_LENGTH);
             }
             else if ( runTime < endUpramp )
             {
                 // upramp = start
                 const double exponent = ( ( runTime - endUpramp ) / PULSE_LENGTH / sqrt( 2.0 ) );
                 envelope *= exp( -0.5 * exponent * exponent );
-
+                integrationCorrectionFactor = ( runTime - endUpramp )/ (2.0*PULSE_LENGTH*PULSE_LENGTH);
             }
 
             const double timeOszi = runTime - endUpramp;
+            const double t_and_phase = w * timeOszi + LASER_PHASE;
             if( Polarisation == LINEAR_X )
             {
-                elong.x() = float_X( envelope * math::sin( w * timeOszi + LASER_PHASE));
+              elong.x() = float_X( envelope * (math::sin(t_and_phase)
+                          + math::cos(t_and_phase) * integrationCorrectionFactor));
             }
             else if( Polarisation == LINEAR_Z)
             {
-                elong.z() = float_X( envelope * math::sin( w * timeOszi + LASER_PHASE));
+              elong.z() = float_X( envelope * (math::sin(t_and_phase)
+                          + math::cos(t_and_phase) * integrationCorrectionFactor));
             }
             else if( Polarisation == CIRCULAR )
             {
-                elong.x() = float_X( envelope / sqrt(2.0)  * math::sin( w * timeOszi + LASER_PHASE));
-                elong.z() = float_X( envelope / sqrt(2.0)  * math::cos( w * timeOszi + LASER_PHASE));
+                elong.x() = float_X( envelope / sqrt(2.0) * (math::sin(t_and_phase)
+                            + math::cos(t_and_phase) * integrationCorrectionFactor));
+                elong.z() = float_X( envelope / sqrt(2.0) * (math::cos(t_and_phase)
+                            - math::sin(t_and_phase) * integrationCorrectionFactor));
             }
 
 

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -30,16 +30,26 @@ namespace picongpu
 {
     /** plane wave (use periodic boundaries!)
      *
-     *  no transversal spacial envelope
+     *  no transverse spacial envelope
      *  based on the electric potential
-     *  Phi = E_0 * exp(0.5 * (t-t_0)^2 / tau^2) * cos(t - t_0 - phi)
-     *  by applying t = x/c, the spatial derivative can be interchanged by the temporal derivative
-     *  resulting in:
-     *  E = E_0 * exp(...) * [sin(...) + t/tau^2 * cos(...)]
-     *  This ensures int_{-infinty}^{+infinty} E(x) = 0 for any phase.
+     *  Phi = Phi_0 * exp(0.5 * (x-x_0)^2 / sigma^2) * cos(k*(x - x_0) - phi)
+     *  by applying grad Phi = d/dx Phi = E(x)
+     *  we get:
+     *  E = Phi_0 * exp(0.5 * (x-x_0)^2 / sigma^2) * [k*sin(k*(x - x_0) - phi) + x/sigma^2 * cos(k*(x - x_0) - phi)]
      *
-     *  The plateau length needs to be set to a multiple of the wavelength,
-     *  otherwise the integral will not vanish. 
+     *  This approach ensures that int_{-infinity}^{+infinity} E(x) = 0 for any phase
+     *  if we have no transverse profile as we have with this plane wave train
+     *
+     *  Since PIConGPU requires a temporally defined electric field, we use:
+     *  t = x/c and (x-x_0)/sigma = (t-t_0)/tau and k*(x-x_0) = omega*(t-t_0) with omega/k = c and tau * c = sigma
+     *  and get:
+     *  E = Phi_0*omega/c * exp(0.5 * (t-t_0)^2 / tau^2) * [sin(omega*(t - t_0) - phi) + t/(omega*tau^2) * cos(omega*(t - t_0) - phi)]
+     *  and define Phi_0*omega/c = E_0
+     *
+     *  Please consider:
+     *  The above formulae does only apply to a Gaussian envelope. If the plateau length is
+     *  not zero, the integral over the volume will only vanish if the plateau length is
+     *  a multiple of the wavelength,
      */
     namespace laserPlaneWave
     {
@@ -110,7 +120,7 @@ namespace picongpu
             return elong;
         }
 
-        /** calculates transversal field distribution
+        /** calculates transverse field distribution
          *
          * @param elong
          * @param phase

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -47,9 +47,11 @@ namespace picongpu
      *    integrationCorrectionFactor = t/(omega*tau^2)
      *
      *  Please consider:
-     *  The above formulae does only apply to a Gaussian envelope. If the plateau length is
-     *  not zero, the integral over the volume will only vanish if the plateau length is
-     *  a multiple of the wavelength,
+     *   1) The above formulae does only apply to a Gaussian envelope. If the plateau length is
+     *      not zero, the integral over the volume will only vanish if the plateau length is
+     *      a multiple of the wavelength.
+     *   2) Since we define our envelope by a sigma of the laser intensity, 
+     *      tau = PULSE_LENGTH / sqrt(2)
      */
     namespace laserPlaneWave
     {
@@ -70,6 +72,7 @@ namespace picongpu
             const double mue = 0.5 * RAMP_INIT * PULSE_LENGTH;
 
             const double w = 2.0 * PI * f;
+            const double tau = PULSE_LENGTH / sqrt( 2.0 );
 
             const double endUpramp = mue;
             const double startDownramp = mue + LASER_NOFOCUS_CONSTANT;
@@ -79,18 +82,16 @@ namespace picongpu
             if( runTime > startDownramp )
             {
                 // downramp = end
-                const double exponent =
-                    ( ( runTime - startDownramp )
-                      / PULSE_LENGTH / sqrt( 2.0 ) );
+                const double exponent = (runTime - startDownramp) / tau;
                 envelope *= exp( -0.5 * exponent * exponent );
-                integrationCorrectionFactor = ( runTime - startDownramp )/ (w*2.0*PULSE_LENGTH*PULSE_LENGTH);
+                integrationCorrectionFactor = ( runTime - startDownramp )/ (w*tau*tau);
             }
             else if ( runTime < endUpramp )
             {
                 // upramp = start
-                const double exponent = ( ( runTime - endUpramp ) / PULSE_LENGTH / sqrt( 2.0 ) );
+                const double exponent = (runTime - endUpramp) / tau;
                 envelope *= exp( -0.5 * exponent * exponent );
-                integrationCorrectionFactor = ( runTime - endUpramp )/ (w*2.0*PULSE_LENGTH*PULSE_LENGTH);
+                integrationCorrectionFactor = ( runTime - endUpramp )/ (w*tau*tau);
             }
 
             const double timeOszi = runTime - endUpramp;

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -31,9 +31,9 @@ namespace picongpu
      *  no transverse spacial envelope
      *  based on the electric potential
      *  Phi = Phi_0 * exp(0.5 * (x-x_0)^2 / sigma^2) * cos(k*(x - x_0) - phi)
-     *  by applying grad Phi = d/dx Phi = E(x)
+     *  by applying -grad Phi = -d/dx Phi = E(x)
      *  we get:
-     *  E = Phi_0 * exp(0.5 * (x-x_0)^2 / sigma^2) * [k*sin(k*(x - x_0) - phi) + x/sigma^2 * cos(k*(x - x_0) - phi)]
+     *  E = -Phi_0 * exp(0.5 * (x-x_0)^2 / sigma^2) * [k*sin(k*(x - x_0) - phi) + x/sigma^2 * cos(k*(x - x_0) - phi)]
      *
      *  This approach ensures that int_{-infinity}^{+infinity} E(x) = 0 for any phase
      *  if we have no transverse profile as we have with this plane wave train
@@ -41,9 +41,9 @@ namespace picongpu
      *  Since PIConGPU requires a temporally defined electric field, we use:
      *  t = x/c and (x-x_0)/sigma = (t-t_0)/tau and k*(x-x_0) = omega*(t-t_0) with omega/k = c and tau * c = sigma
      *  and get:
-     *  E = Phi_0*omega/c * exp(0.5 * (t-t_0)^2 / tau^2) * [sin(omega*(t - t_0) - phi) + t/(omega*tau^2) * cos(omega*(t - t_0) - phi)]
+     *  E = -Phi_0*omega/c * exp(0.5 * (t-t_0)^2 / tau^2) * [sin(omega*(t - t_0) - phi) + t/(omega*tau^2) * cos(omega*(t - t_0) - phi)]
      *  and define:
-     *    E_0 = Phi_0*omega/c
+     *    E_0 = -Phi_0*omega/c
      *    integrationCorrectionFactor = t/(omega*tau^2)
      *
      *  Please consider:


### PR DESCRIPTION
Due to the arbitary length of our laser envelope and the arbitary phase, the integral along the propagation direction of the plane wave might not be zero.

By deriving the electric field from a scalar potential, this pull request ensures that the electric field vanishes if integrated from -infinty to +infinity.

Thanks @ssstuvz for telling us about this error.

![f1](https://cloud.githubusercontent.com/assets/1353258/7417907/d17b3016-ef69-11e4-8bcc-e2eae6e2c937.png)
with ![f2](https://cloud.githubusercontent.com/assets/1353258/7417908/d5555630-ef69-11e4-9008-1695a992a7f7.png)



