### PR TITLE
[BG fields] Add in-plane polarization to TWTS laser

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/fieldBackground.param
+++ b/examples/Bunch/include/simulation_defines/param/fieldBackground.param
@@ -35,7 +35,7 @@ namespace picongpu
     class FieldBackgroundE
     {
     public:
-    
+
         /* Add this additional field for pushing particles */
         static const bool InfluenceParticlePusher = PARAM_INCLUDE_FIELDBACKGROUND;
 
@@ -45,10 +45,10 @@ namespace picongpu
         /* TWTS E-fields need to be initialized on host,
          *  so they can look up global grid dimensions. */
         const templates::twts::EField twtsFieldE;
-        
+
         /* Constructor is host-only, because of subGrid and halfSimSize initialization */
         HINLINE FieldBackgroundE( const float3_64 unitField ) : unitField(unitField),
-        
+
             twtsFieldE(
                 /* focus_y [m], the distance to the laser focus in y-direction */
                 30.0e-6,
@@ -81,7 +81,7 @@ namespace picongpu
             /* example 1: TWTS background pulse */
             /** unit: meter */
             const double WAVE_LENGTH_SI = 0.8e-6;
-            
+
             /** UNITCONV */
             /* const double UNITCONV_Intens_to_A0 = SI::ELECTRON_CHARGE_SI
                 * SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI
@@ -105,9 +105,9 @@ namespace picongpu
             const float3_64 invUnitField = float3_64(1.0 / unitField[0],
                                                      1.0 / unitField[1],
                                                      1.0 / unitField[2] );
-            
+
             /* laser amplitude in picongpu units [ unit: (Volt /meter) / unitField-factor ]
-             * Note: the laser amplitude is included in all field components 
+             * Note: the laser amplitude is included in all field components
              * polarization and other properties are established by the peak amplitude
              * normalized twtsFieldE(...) */
             const float3_X amplitude = precisionCast<float_X>(
@@ -127,12 +127,12 @@ namespace picongpu
         /* TWTS B-fields need to be initialized on host,
          * so they can look up global grid dimensions. */
         const templates::twts::BField twtsFieldB;
-        
+
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(unitField, const float3_64);
-        
+
         HINLINE FieldBackgroundB( const float3_64 unitField ) : unitField(unitField),
-        
+
             twtsFieldB(
                 /* focus_y [m], the distance to the laser focus in y-direction */
                 30.0e-6,
@@ -164,7 +164,7 @@ namespace picongpu
         {
             /** unit: meter */
             const double WAVE_LENGTH_SI = 0.8e-6;
-            
+
             /** UNITCONV */
             /* const double UNITCONV_Intens_to_A0 = SI::ELECTRON_CHARGE_SI
                 * SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI
@@ -187,14 +187,14 @@ namespace picongpu
             const float3_64 invUnitField = float3_64( 1.0 / unitField[0],
                                                       1.0 / unitField[1],
                                                       1.0 / unitField[2] );
-            
+
             /* laser amplitude in picongpu units [ unit: (Volt/meter) / unitField-factor ]
-             * Note: the laser amplitude is included in all field components 
+             * Note: the laser amplitude is included in all field components
              * polarization and other properties are established by the peak amplitude
              * normalized twtsFieldB(...) */
             const float3_X amplitude = precisionCast<float_X>(
                     float_64(_A0 * UNITCONV_A0_to_Amplitude_SI) * invUnitField );
-            
+
             /* Note: twtsFieldB(...) is normalized, such that peak amplitude equals unity. */
             return amplitude * twtsFieldB( cellIdx, currentStep );
         }
@@ -208,7 +208,7 @@ namespace picongpu
 
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(unitField, const float3_64);
-        
+
         HDINLINE FieldBackgroundJ( const float3_64 unitField ) : unitField(unitField)
         {}
 

--- a/examples/Bunch/include/simulation_defines/param/fieldBackground.param
+++ b/examples/Bunch/include/simulation_defines/param/fieldBackground.param
@@ -43,11 +43,17 @@ namespace picongpu
         PMACC_ALIGN(unitField, const float3_64);
 
         /* TWTS E-fields need to be initialized on host,
-         *  so they can look up global grid dimensions. */
+         * so they can look up global grid dimensions.
+         *
+         * Note: No PMACC_ALIGN(...) used, since this *additional* memory alignment would require
+         *       roughly double the number of registers in the corresponding kernel on the device.
+         */
         const templates::twts::EField twtsFieldE;
 
         /* Constructor is host-only, because of subGrid and halfSimSize initialization */
-        HINLINE FieldBackgroundE( const float3_64 unitField ) : unitField(unitField),
+        HINLINE FieldBackgroundE( const float3_64 unitField ) :
+
+            unitField(unitField),
 
             twtsFieldE(
                 /* focus_y [m], the distance to the laser focus in y-direction */
@@ -78,8 +84,7 @@ namespace picongpu
         operator()( const DataSpace<simDim>& cellIdx,
                     const uint32_t currentStep ) const
         {
-            /* example 1: TWTS background pulse */
-            /** unit: meter */
+            /* unit: meter */
             const double WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
@@ -92,16 +97,18 @@ namespace picongpu
                 * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
                 * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
 
-            /** unit: W / m^2 */
-            /* const double _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4; */
-            /** unit: none */
-            /* const double _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0; */
+            /* unit: W / m^2
+             * const double _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
+             * unit: none
+             * const double _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+             */
 
-            /** unit: none */
+            /* unit: none */
             const double _A0  = 1.0;
 
-            /** unit: Volt /meter */
-            /*\todo #738 implement math::vector, native type operations */
+            /* unit: Volt /meter
+             *\todo #738 implement math::vector, native type operations
+             */
             const float3_64 invUnitField = float3_64(1.0 / unitField[0],
                                                      1.0 / unitField[1],
                                                      1.0 / unitField[2] );
@@ -109,7 +116,8 @@ namespace picongpu
             /* laser amplitude in picongpu units [ unit: (Volt /meter) / unitField-factor ]
              * Note: the laser amplitude is included in all field components
              * polarization and other properties are established by the peak amplitude
-             * normalized twtsFieldE(...) */
+             * normalized twtsFieldE(...)
+             */
             const float3_X amplitude = precisionCast<float_X>(
                                 float_64(_A0 * UNITCONV_A0_to_Amplitude_SI) * invUnitField );
 
@@ -125,13 +133,19 @@ namespace picongpu
         static const bool InfluenceParticlePusher = PARAM_INCLUDE_FIELDBACKGROUND;
 
         /* TWTS B-fields need to be initialized on host,
-         * so they can look up global grid dimensions. */
+         * so they can look up global grid dimensions.
+         *
+         * Note: No PMACC_ALIGN(...) used, since this *additional* memory alignment would require
+         *       roughly double the number of registers in the corresponding kernel on the device.
+         */
         const templates::twts::BField twtsFieldB;
 
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(unitField, const float3_64);
 
-        HINLINE FieldBackgroundB( const float3_64 unitField ) : unitField(unitField),
+        HINLINE FieldBackgroundB( const float3_64 unitField ) :
+
+            unitField(unitField),
 
             twtsFieldB(
                 /* focus_y [m], the distance to the laser focus in y-direction */
@@ -162,7 +176,7 @@ namespace picongpu
         operator()( const DataSpace<simDim>& cellIdx,
                     const uint32_t currentStep ) const
         {
-            /** unit: meter */
+            /* unit: meter */
             const double WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
@@ -175,10 +189,11 @@ namespace picongpu
                 * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
                 * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
 
-            /** unit: W / m^2 */
-            /* const double _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4; */
-            /** unit: none */
-            /* const double _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0; */
+            /* unit: W / m^2
+             * const double _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
+             * unit: none
+             * const double _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+             */
 
             /** unit: none */
             const double _A0  = 1.0;
@@ -191,7 +206,8 @@ namespace picongpu
             /* laser amplitude in picongpu units [ unit: (Volt/meter) / unitField-factor ]
              * Note: the laser amplitude is included in all field components
              * polarization and other properties are established by the peak amplitude
-             * normalized twtsFieldB(...) */
+             * normalized twtsFieldB(...)
+             */
             const float3_X amplitude = precisionCast<float_X>(
                     float_64(_A0 * UNITCONV_A0_to_Amplitude_SI) * invUnitField );
 

--- a/examples/Bunch/include/simulation_defines/param/fieldBackground.param
+++ b/examples/Bunch/include/simulation_defines/param/fieldBackground.param
@@ -44,7 +44,7 @@ namespace picongpu
 
         /* TWTS E-fields need to be initialized on host,
          *  so they can look up global grid dimensions. */
-        PMACC_ALIGN(twtsFieldE, const templates::twts::EField);
+        const templates::twts::EField twtsFieldE;
         
         /* Constructor is host-only, because of subGrid and halfSimSize initialization */
         HINLINE FieldBackgroundE( const float3_64 unitField ) : unitField(unitField),
@@ -126,7 +126,7 @@ namespace picongpu
 
         /* TWTS B-fields need to be initialized on host,
          * so they can look up global grid dimensions. */
-        PMACC_ALIGN(twtsFieldB, const templates::twts::BField);
+        const templates::twts::BField twtsFieldB;
         
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(unitField, const float3_64);

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -39,7 +39,7 @@ namespace twts
 class BField
 {
 public:
-    typedef float_64 float_T;
+    typedef float_X float_T;
     
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -39,7 +39,7 @@ namespace twts
 class BField
 {
 public:
-    typedef float_X float_T;
+    typedef float_64 float_T;
     
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -110,7 +110,7 @@ public:
             const float_X phi               = 90.*(PI / 180.),
             const float_X beta_0            = 1.0,
             const float_64 tdelay_user_SI   = 0.0,
-            const bool auto_tdelay          = true
+            const bool auto_tdelay          = true,
             const PolarizationType pol      = NORMAL_TO_TILTPLANE );
     
     
@@ -165,6 +165,16 @@ public:
     template<unsigned T_dim>
     HDINLINE float3_X
     getTWTSBfield_Normalized(
+            const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
+            const float_64 time) const;
+    
+    /** Calculate the B-field vector of the "in-plane" polarized TWTS laser in SI units.
+     * \tparam T_dim Specializes for the simulation dimension
+     * \param cellIdx The total cell id counted from the start at timestep 0
+     * \return B-field vector of the rotated TWTS field in SI units */
+    template<unsigned T_dim>
+    HDINLINE float3_X
+    getTWTSBfield_Normalized_Ey(
             const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
             const float_64 time) const;
     

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -109,7 +109,8 @@ public:
     operator()( const DataSpace<simDim>& cellIdx,
                 const uint32_t currentStep ) const;
 
-    /** Calculate the By(r,t) field here
+    /** Calculate the By(r,t) field, when electric field vector (Ex,0,0)
+     *  is normal to the pulse-front-tilt plane (y,z)
      *
      * \param pos Spatial position of the target field.
      * \param time Absolute time (SI, including all offsets and transformations)
@@ -117,14 +118,33 @@ public:
     HDINLINE float_T
     calcTWTSBy( const float3_64& pos, const float_64 time ) const;
 
-    /** Calculate the Bz(r,t) field here
+    /** Calculate the Bz(r,t) field, when electric field vector (Ex,0,0)
+     *  is normal to the pulse-front-tilt plane (y,z)
      *
      * \param pos Spatial position of the target field.
      * \param time Absolute time (SI, including all offsets and transformations)
      *  for calculating the field */
     HDINLINE float_T
-    calcTWTSBz( const float3_64& pos, const float_64 time ) const;
+    calcTWTSBz_Ex( const float3_64& pos, const float_64 time ) const;
 
+    /** Calculate the By(r,t) field, when electric field vector (0,Ey,0)
+     *  lies within the pulse-front-tilt plane (y,z)
+     *
+     * \param pos Spatial position of the target field.
+     * \param time Absolute time (SI, including all offsets and transformations)
+     *  for calculating the field */
+    HDINLINE float_T
+    calcTWTSBx( const float3_64& pos, const float_64 time ) const;
+
+    /** Calculate the Bz(r,t) field here (electric field vector (0,Ey,0)
+     *  lies within the pulse-front-tilt plane (y,z)
+     *
+     * \param pos Spatial position of the target field.
+     * \param time Absolute time (SI, including all offsets and transformations)
+     *  for calculating the field */
+    HDINLINE float_T
+    calcTWTSBz_Ey( const float3_64& pos, const float_64 time ) const;
+    
     /** Calculate the B-field vector of the TWTS laser in SI units.
      * \tparam T_dim Specializes for the simulation dimension
      * \param cellIdx The total cell id counted from the start at timestep 0

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -40,15 +40,21 @@ class BField
 {
 public:
     typedef float_X float_T;
-    
+
     enum PolarizationType
     {
         /* The linear polarization of the TWTS laser is defined
-         * relative to the plane of the pulse front tilt. */
-        NORMAL_TO_TILTPLANE = 1u, /* use Ex-fields in TWTS laser internal coordinate system */
-        WITHIN_TILTPLANE = 2u,    /* use Ey-fields in TWTS laser internal coordinate system */
+         * relative to the plane of the pulse front tilt (reference plane). */
+        /* Polarisation is normal to the reference plane.
+         * Use Ex-fields (and corresponding B-fields) in TWTS laser internal coordinate system.
+         */
+        LINEAR_X = 1u,
+        /* Polarization lies within the reference plane.
+         * Use Ey-fields (and corresponding B-fields) in TWTS laser internal coordinate system.
+         */
+        LINEAR_YZ = 2u,
     };
-    
+
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);
     /* y-position of TWTS coordinate origin inside the simulation coordinates [meter]
@@ -81,12 +87,12 @@ public:
     const PMACC_ALIGN(auto_tdelay,bool);
     /* Polarization of TWTS laser */
     const PMACC_ALIGN(pol,PolarizationType);
-    
+
     /** Magnetic field of the TWTS laser
      *
      * \param focus_y_SI the distance to the laser focus in y-direction [m]
      * \param wavelength_SI central wavelength [m]
-     * \param pulselength_SI sigma of std. gauss for intensity (E^2), 
+     * \param pulselength_SI sigma of std. gauss for intensity (E^2),
      *  pulselength_SI = FWHM_of_Intensity / 2.35482 [seconds (sigma)]
      * \param w_x beam waist: distance from the axis where the pulse electric field
      *  decreases to its 1/e^2-th part at the focus position of the laser [m]
@@ -99,7 +105,7 @@ public:
      * \param auto_tdelay calculate the time delay such that the TWTS pulse is not
      *  inside the simulation volume at simulation start timestep = 0 [default = true]
      * \param pol determines the TWTS laser polarization, which is either normal or parallel
-     *  to the laser pulse front tilt plane [ default= NORMAL_TO_TILTPLANE , WITHIN_TILTPLANE ]
+     *  to the laser pulse front tilt plane [ default= LINEAR_X , LINEAR_YZ ]
      */
     HINLINE
     BField( const float_64 focus_y_SI,
@@ -111,9 +117,9 @@ public:
             const float_X beta_0            = 1.0,
             const float_64 tdelay_user_SI   = 0.0,
             const bool auto_tdelay          = true,
-            const PolarizationType pol      = NORMAL_TO_TILTPLANE );
-    
-    
+            const PolarizationType pol      = LINEAR_X );
+
+
     /** Specify your background field B(r,t) here
      *
      * \param cellIdx The total cell id counted from the start at t=0
@@ -157,7 +163,7 @@ public:
      *  for calculating the field */
     HDINLINE float_T
     calcTWTSBz_Ey( const float3_64& pos, const float_64 time ) const;
-    
+
     /** Calculate the B-field vector of the TWTS laser in SI units.
      * \tparam T_dim Specializes for the simulation dimension
      * \param cellIdx The total cell id counted from the start at timestep 0
@@ -167,7 +173,7 @@ public:
     getTWTSBfield_Normalized(
             const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
             const float_64 time) const;
-    
+
     /** Calculate the B-field vector of the "in-plane" polarized TWTS laser in SI units.
      * \tparam T_dim Specializes for the simulation dimension
      * \param cellIdx The total cell id counted from the start at timestep 0
@@ -177,7 +183,7 @@ public:
     getTWTSBfield_Normalized_Ey(
             const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
             const float_64 time) const;
-    
+
 };
 
 } /* namespace twts */

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -41,6 +41,14 @@ class BField
 public:
     typedef float_X float_T;
     
+    enum PolarizationType
+    {
+        /* The linear polarization of the TWTS laser is defined
+         * relative to the plane of the pulse front tilt. */
+        NORMAL_TO_TILTPLANE = 1u, /* use Ex-fields in TWTS laser internal coordinate system */
+        WITHIN_TILTPLANE = 2u,    /* use Ey-fields in TWTS laser internal coordinate system */
+    };
+    
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);
     /* y-position of TWTS coordinate origin inside the simulation coordinates [meter]
@@ -71,6 +79,8 @@ public:
     /* Should the TWTS laser time delay be chosen automatically, such that
     the laser gradually enters the simulation volume? [Default: TRUE] */
     const PMACC_ALIGN(auto_tdelay,bool);
+    /* Polarization of TWTS laser */
+    const PMACC_ALIGN(pol,PolarizationType);
     
     /** Magnetic field of the TWTS laser
      *
@@ -88,6 +98,8 @@ public:
      * \param tdelay_user manual time delay if auto_tdelay is false
      * \param auto_tdelay calculate the time delay such that the TWTS pulse is not
      *  inside the simulation volume at simulation start timestep = 0 [default = true]
+     * \param pol determines the TWTS laser polarization, which is either normal or parallel
+     *  to the laser pulse front tilt plane [ default= NORMAL_TO_TILTPLANE , WITHIN_TILTPLANE ]
      */
     HINLINE
     BField( const float_64 focus_y_SI,
@@ -98,7 +110,8 @@ public:
             const float_X phi               = 90.*(PI / 180.),
             const float_X beta_0            = 1.0,
             const float_64 tdelay_user_SI   = 0.0,
-            const bool auto_tdelay          = true );
+            const bool auto_tdelay          = true
+            const PolarizationType pol      = NORMAL_TO_TILTPLANE );
     
     
     /** Specify your background field B(r,t) here

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -29,10 +29,10 @@
 
 namespace picongpu
 {
-/** Load pre-defined background field */
+/* Load pre-defined background field */
 namespace templates
 {
-/** Traveling-wave Thomson scattering laser pulse */
+/* Traveling-wave Thomson scattering laser pulse */
 namespace twts
 {
 
@@ -44,8 +44,9 @@ public:
     enum PolarizationType
     {
         /* The linear polarization of the TWTS laser is defined
-         * relative to the plane of the pulse front tilt (reference plane). */
-        /* Polarisation is normal to the reference plane.
+         * relative to the plane of the pulse front tilt (reference plane).
+         *
+         * Polarisation is normal to the reference plane.
          * Use Ex-fields (and corresponding B-fields) in TWTS laser internal coordinate system.
          */
         LINEAR_X = 1u,
@@ -58,8 +59,9 @@ public:
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);
     /* y-position of TWTS coordinate origin inside the simulation coordinates [meter]
-       The other origin coordinates (x and z) default to globally centered values
-       with respect to the simulation volume. */
+     * The other origin coordinates (x and z) default to globally centered values
+     * with respect to the simulation volume.
+     */
     const PMACC_ALIGN(focus_y_SI,float_64);
     /* Laser wavelength [meter] */
     const PMACC_ALIGN(wavelength_SI,float_64);
@@ -83,7 +85,8 @@ public:
     /* TWTS laser time delay */
     PMACC_ALIGN(tdelay,float_64);
     /* Should the TWTS laser time delay be chosen automatically, such that
-    the laser gradually enters the simulation volume? [Default: TRUE] */
+     * the laser gradually enters the simulation volume? [Default: TRUE]
+     */
     const PMACC_ALIGN(auto_tdelay,bool);
     /* Polarization of TWTS laser */
     const PMACC_ALIGN(pol,PolarizationType);

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -522,6 +522,7 @@ namespace twts
     BField::calcTWTSBz_Ey( const float3_64& pos, const float_64 time ) const
     {
         typedef PMacc::math::Complex<float_T> complex_T;
+        typedef PMacc::math::Complex<float_64> complex_64;
         /** Unit of Speed */
         const double UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /** Unit of time */
@@ -575,12 +576,11 @@ namespace twts
          * thus help with formal code verification through manual code inspection. */
         const complex_T helpVar1 = 
             complex_T(0,-1)*cspeed*om0*tauG*tauG
-            - y*cosPhi / pmMath::cos(phiT / float_T(2.0)) / pmMath::cos(phiT / float_T(2.0))*tanPhi2
-            - 2*z*tanPhi2*tanPhi2;
+            - y*cosPhi / cosPhi2 / cosPhi2 * tanPhi2
+            - float_T(2.0)*z*tanPhi2*tanPhi2;
         const complex_T helpVar2 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
-        const complex_T helpVar3 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
         
-        const complex_T helpVar4 = (
+        const complex_T helpVar3 = (
             - cspeed*cspeed*k*om0*tauG*tauG*wy*wy*x*x
             - float_T(2.0)*cspeed*cspeed*om0*t*t*wy*wy*rho0
             + complex_T(0,2)*cspeed*cspeed*om0*om0*t*tauG*tauG*wy*wy*rho0
@@ -589,14 +589,14 @@ namespace twts
             - complex_T(0,2)*cspeed*om0*om0*tauG*tauG*wy*wy*z*rho0
             - float_T(2.0)*om0*wy*wy*z*z*rho0
             - complex_T(0,8)*om0*wy*wy*y*(cspeed*t - z)*z*sinPhi2*sinPhi2
-            + complex_T(0,8) / pmMath::sin(phiT)*(
+            + complex_T(0,8) / sinPhi *(
                 float_T(2.0)*z*z*(cspeed*om0*t*wy*wy + complex_T(0,1)*cspeed*y*y - om0*wy*wy*z)
                 + y*(
                     cspeed*k*wy*wy*x*x
                     - complex_T(0,2)*cspeed*om0*t*wy*wy*rho0
                     + float_T(2.0)*cspeed*y*y*rho0
                     + complex_T(0,2)*om0*wy*wy*z*rho0
-                )*tan(float_T(PI) / float_T(2.0)-phiT) / pmMath::sin(phiT)
+                )*tan(float_T(PI) / float_T(2.0)-phiT) / sinPhi
             )*sinPhi2*sinPhi2*sinPhi2*sinPhi2
             - complex_T(0,2)*cspeed*cspeed*om0*t*t*wy*wy*z*sinPhi
             - float_T(2.0)*cspeed*cspeed*om0*om0*t*tauG*tauG*wy*wy*z*sinPhi
@@ -610,15 +610,14 @@ namespace twts
                 cspeed*om0*t*wy*wy
                 + complex_T(0,1)*cspeed*y*y
                 - om0*wy*wy*z
-            )*cosPhi2*cosPhi2 / pmMath::cos(phiT / float_T(2.0)) / pmMath::cos(phiT / float_T(2.0))
-                *tanPhi2
+            )*cosPhi*cosPhi / cosPhi2 / cosPhi2 * tanPhi2
             + complex_T(0,2)*cspeed*k*wy*wy*x*x*z*tanPhi2*tanPhi2
             - float_T(2.0)*om0*wy*wy*y*y*rho0*tanPhi2*tanPhi2
             + float_T(4.0)*cspeed*om0*t*wy*wy*z*rho0*tanPhi2*tanPhi2
             + complex_T(0,4)*cspeed*y*y*z*rho0*tanPhi2*tanPhi2
             - float_T(4.0)*om0*wy*wy*z*z*rho0*tanPhi2*tanPhi2
             - complex_T(0,2)*om0*wy*wy*y*y*z*sinPhi*tanPhi2*tanPhi2
-            - float_T(2.0)*y*cos(phiT)*(
+            - float_T(2.0)*y*cosPhi*(
                 om0*(
                     cspeed*cspeed*(complex_T(0,1)*t*t*wy*wy
                     + om0*t*tauG*tauG*wy*wy
@@ -626,29 +625,30 @@ namespace twts
                     - cspeed*(complex_T(0,2)*t + om0*tauG*tauG)*wy*wy*z
                     + complex_T(0,1)*wy*wy*z*z
                 )
-                + complex_T(0,2)*om0*wy*wy*y*(cspeed*t - z)*pmMath::tan( phiT / float_T(2.0) )
+                + complex_T(0,2)*om0*wy*wy*y*(cspeed*t - z)*tanPhi2
                 + complex_T(0,1)*(
-                    complex_T(0,-4)*cspeed*y*y*z 
+                    complex_T(0,-4)*cspeed*y*y*z
                     + om0*wy*wy*(y*y - float_T(4.0)*(cspeed*t - z)*z)
                 )*tanPhi2*tanPhi2
             )
-        ) / (float_T(2.0)*cspeed*wy*wy*helpVar2*helpVar1);
+        /* The "round-trip" conversion in the line below fixes a gross accuracy bug
+         * in floating-point arithmetics, when float_T is set to float_X. */
+        ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar2*helpVar1) );
         
-        const complex_T helpVar5 = (
+        const complex_T helpVar4 = (
             cspeed*om0*(
                 cspeed*om0*tauG*tauG
                 - complex_T(0,8)*y*pmMath::tan( float_T(PI) / float_T(2.0) - phiT )
-                    / pmMath::sin(phiT) / pmMath::sin(phiT)*sinPhi2*sinPhi2*sinPhi2*sinPhi2
+                    / sinPhi / sinPhi * sinPhi2*sinPhi2*sinPhi2*sinPhi2
                 - complex_T(0,2)*z*tanPhi2*tanPhi2
             )
-        )/rho0;
+        ) / rho0;
         
         const complex_T result = float_T(-1.0)*(
-            cspeed*pmMath::exp(helpVar4)*k*tauG*x*pmMath::pow( helpVar3, float_T(-1.5) )
-            /pmMath::sqrt(helpVar5)
+            cspeed*pmMath::exp(helpVar3)*k*tauG*x*pmMath::pow( helpVar2, float_T(-1.5) )
+            / pmMath::sqrt(helpVar4)
         );
-
-
+        
         return result.get_real() / UNIT_SPEED;
     }
 

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -210,18 +210,18 @@ namespace twts
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = float_T(PI/2) - (phiReal - alphaTilt); */
-
-        const float_T cspeed = float_T(1.0);
+        
+        const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-        const float_T om0 = float_T(2.0*PI*cspeed / lambda0*UNIT_TIME);
+        const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
         /* factor 2  in tauG arises from definition convention in laser formula */
         const float_T tauG = float_T(pulselength_SI*2.0 / UNIT_TIME);
         /* w0 is wx here --> w0 could be replaced by wx */
         const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-        const float_T rho0 = float_T(PI*w0*w0 / lambda0 / UNIT_LENGTH);
+        const float_T rho0 = float_T(PI*w0*w0 / lambda0);
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-        const float_T k = float_T(2.0*PI / lambda0*UNIT_LENGTH);
+        const float_T k = float_T(2.0*PI / lambda0);
         const float_T x = float_T(pos.x() / UNIT_LENGTH);
         const float_T y = float_T(pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
@@ -314,7 +314,7 @@ namespace twts
             )*pmMath::pow(helpVar3,float_T(-1.5))
         ) / (float_T(2.0)*helpVar5*pmMath::sqrt(helpVar6));
 
-        return result.get_real();
+        return result.get_real() / UNIT_SPEED;
     }
 
     /** Calculate the Bz(r,t) field
@@ -351,18 +351,18 @@ namespace twts
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt); */
-
-        const float_T cspeed = float_T(1.0);
+        
+        const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-        const float_T om0 = float_T(2.0*PI*cspeed / lambda0*UNIT_TIME);
+        const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
         /* factor 2  in tauG arises from definition convention in laser formula */
         const float_T tauG = float_T(pulselength_SI*2.0 / UNIT_TIME);
         /* w0 is wx here --> w0 could be replaced by wx */
         const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-        const float_T rho0 = float_T(PI*w0*w0 / lambda0 / UNIT_LENGTH);
+        const float_T rho0 = float_T(PI*w0*w0 / lambda0);
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-        const float_T k = float_T(2.0*PI / lambda0*UNIT_LENGTH);
+        const float_T k = float_T(2.0*PI / lambda0);
         const float_T x = float_T(pos.x() / UNIT_LENGTH);
         const float_T y = float_T(pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
@@ -415,7 +415,7 @@ namespace twts
                                     *pmMath::sqrt( (om0*rho0) / helpVar3 )
                                   ) / pmMath::pow(helpVar7,float_T(1.5));
 
-        return result.get_real();
+        return result.get_real() / UNIT_SPEED;
     }
 
 } /* namespace twts */

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -81,6 +81,7 @@ namespace twts
         PosVecVec pos(PosVecVec::create(
                                            float3_64::create(0.0)
                                        ));
+        
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i)
                 pos[k][i] = bFieldPositions_SI[k][i];
@@ -113,18 +114,22 @@ namespace twts
             const PMacc::math::Vector<floatD_64,detail::numComponents>& bFieldPositions_SI,
             const float_64 time) const
     {
-        PMacc::math::Vector<float3_64,detail::numComponents> pos(0.0);
+        typedef PMacc::math::Vector<float3_64,detail::numComponents> PosVecVec;
+        PosVecVec pos(PosVecVec::create(
+                                           float3_64::create(0.0)
+                                       ));
+        
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i) pos[k][i] = bFieldPositions_SI[k][i];
         }
         
-        /* Calculate Bz-component with the Yee-Cell offset of a By-field */
+        /* Calculate Bz-component with the intra-cell offset of a By-field */
         const float_64 Bz_By = calcTWTSBz_Ey(pos[1], time);
-        /* Calculate Bz-component with the Yee-Cell offset of a Bz-field */
+        /* Calculate Bz-component with the intra-cell offset of a Bz-field */
         const float_64 Bz_Bz = calcTWTSBz_Ey(pos[2], time);
-        /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz_Ex,
+        /* Since we rotated all position vectors before calling calcTWTSBz_Ey,
          * we need to back-rotate the resulting B-field vector. */
-        /* RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the Field-Vektors. */
+        /* RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field-vectors. */
         const float_64 By_rot = +pmMath::cos(+phi)*Bz_By;
         const float_64 Bz_rot = -pmMath::sin(+phi)*Bz_Bz;
         
@@ -197,7 +202,11 @@ namespace twts
             const PMacc::math::Vector<floatD_64,detail::numComponents>& bFieldPositions_SI,
             const float_64 time) const
     {
-        PMacc::math::Vector<float3_64,detail::numComponents> pos(0.0);
+        typedef PMacc::math::Vector<float3_64,detail::numComponents> PosVecVec;
+        PosVecVec pos(PosVecVec::create(
+                                           float3_64::create(0.0)
+                                       ));
+        
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             /* The 2D output of getFieldPositions_SI only returns
              * the y- and z-component of a 3D vector. */
@@ -212,23 +221,23 @@ namespace twts
          *            3D TWTS-field-function and set x = -0)
          *  Ex --> Ez (Meaning: Calculate Ex-component of existing 3D TWTS-field to obtain
          *             corresponding Ez-component in 2D.
-         *             Note: the position offset due to the Yee-Cell for Ez.)
+         *             Note: the intra-cell position offset due to the staggered grid for Ez.)
          *  By --> By
          *  Bz --> -Bx (Yes, the sign is necessary.)
          */ 
         /* Analogous to 3D case, but replace By --> By and Bz --> -Bx. Hence the grid cell offset
          * for Bx has to be used instead of Bz. Mind the -sign. */
          
-        /* Calculate Bx-component with the Yee-Cell offset of a By-field */
+        /* Calculate Bx-component with the intra-cell offset of a By-field */
         const float_64 Bx_By = -calcTWTSBz_Ex(pos[1], time);
-        /* Calculate Bx-component with the Yee-Cell offset of a Bx-field */
+        /* Calculate Bx-component with the intra-cell offset of a Bx-field */
         const float_64 Bx_Bx = -calcTWTSBz_Ex(pos[0], time);
-        /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz_Ex, we
+        /* Since we rotated all position vectors before calling calcTWTSBz_Ex, we
          * need to back-rotate the resulting B-field vector. Now the rotation is done
          * analogously in the (y,x)-plane. (Reverse of the position vector transformation.) */
         /* RotationMatrix[-(PI / 2+phi)].(By,Bx) */
         const float_64 By_rot = +pmMath::cos(phi)*Bx_By;
-        /* for rotating back the Field-Vektors.*/
+        /* for rotating back the field-vectors.*/
         const float_64 Bx_rot = -pmMath::sin(phi)*Bx_Bx;
         
         /* Finally, the B-field normalized to the peak amplitude. */
@@ -255,7 +264,7 @@ namespace twts
             case WITHIN_TILTPLANE :
             return getTWTSBfield_Normalized_Ey<simDim>(bFieldPositions_SI, time_SI);
         }
-        return getTWTSBfield_Normalized<simDim>(bFieldPositions_SI, time_SI);
+        return getTWTSBfield_Normalized<simDim>(bFieldPositions_SI, time_SI); // defensive default
     }
 
     /** Calculate the By(r,t) field here

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -247,6 +247,14 @@ namespace twts
               detail::getFieldPositions_SI(cellIdx,halfSimSize,
                 fieldSolver::NumericalCellType::getBFieldPosition(),unit_length,focus_y_SI,phi);
         /* Single TWTS-Pulse */
+        switch (pol)
+        {
+            case NORMAL_TO_TILTPLANE :
+            return getTWTSBfield_Normalized<simDim>(bFieldPositions_SI, time_SI);
+            
+            case WITHIN_TILTPLANE :
+            return getTWTSBfield_Normalized_Ey<simDim>(bFieldPositions_SI, time_SI);
+        }
         return getTWTSBfield_Normalized<simDim>(bFieldPositions_SI, time_SI);
     }
 

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -258,10 +258,10 @@ namespace twts
         /* Single TWTS-Pulse */
         switch (pol)
         {
-            case NORMAL_TO_TILTPLANE :
+            case LINEAR_X :
             return getTWTSBfield_Normalized<simDim>(bFieldPositions_SI, time_SI);
 
-            case WITHIN_TILTPLANE :
+            case LINEAR_YZ :
             return getTWTSBfield_Normalized_Ey<simDim>(bFieldPositions_SI, time_SI);
         }
         return getTWTSBfield_Normalized<simDim>(bFieldPositions_SI, time_SI); // defensive default

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -54,7 +54,7 @@ namespace twts
                     const float_X phi,
                     const float_X beta_0,
                     const float_64 tdelay_user_SI,
-                    const bool auto_tdelay
+                    const bool auto_tdelay,
                     const PolarizationType pol ) :
         focus_y_SI(focus_y_SI), wavelength_SI(wavelength_SI),
         pulselength_SI(pulselength_SI), w_x_SI(w_x_SI),
@@ -540,17 +540,17 @@ namespace twts
          * documentation purposes. */
         /* const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt); */
         
-        const float_T cspeed = float_T(1.0);
+        const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-        const float_T om0 = float_T(2.0*PI*cspeed / lambda0*UNIT_TIME);
+        const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
         /* factor 2  in tauG arises from definition convention in laser formula */
         const float_T tauG = float_T(pulselength_SI*2.0 / UNIT_TIME);
         /* w0 is wx here --> w0 could be replaced by wx */
         const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-        const float_T rho0 = float_T(PI*w0*w0 / lambda0 / UNIT_LENGTH);
+        const float_T rho0 = float_T(PI*w0*w0 / lambda0);
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-        const float_T k = float_T(2.0*PI / lambda0*UNIT_LENGTH);
+        const float_T k = float_T(2.0*PI / lambda0);
         const float_T x = float_T(pos.x() / UNIT_LENGTH);
         const float_T y = float_T(pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
@@ -641,7 +641,7 @@ namespace twts
         );
 
 
-        return result.get_real();
+        return result.get_real() / UNIT_SPEED;
     }
 
 } /* namespace twts */

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -267,6 +267,7 @@ namespace twts
     BField::calcTWTSBy( const float3_64& pos, const float_64 time ) const
     {
         typedef PMacc::math::Complex<float_T> complex_T;
+        typedef PMacc::math::Complex<float_64> complex_64;
         /** Unit of Speed */
         const double UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /** Unit of time */
@@ -379,8 +380,10 @@ namespace twts
                     )*pmMath::tan(float_T(PI / 2)-phiT)
                 )*tanPhi2*tanPhi2
             )
-        )/(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2);
-
+        /* The "round-trip" conversion in the line below fixes a gross accuracy bug
+         * in floating-point arithmetics, when float_T is set to float_X. */
+        ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2) );
+        
         const complex_T helpVar5 = complex_T(0,-1)*cspeed*om0*tauG*tauG
                                 + (-z - y*pmMath::tan(float_T(PI / 2)-phiT))
                                     *tanPhi2*tanPhi2*float_T(2.0);

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -89,12 +89,12 @@ namespace twts
         /* Calculate By-component with the intra-cell offset of a By-field */
         const float_64 By_By = calcTWTSBy(pos[1], time);
         /* Calculate Bz-component the the intra-cell offset of a By-field */
-        const float_64 Bz_By = calcTWTSBz(pos[1], time);
+        const float_64 Bz_By = calcTWTSBz_Ex(pos[1], time);
         /* Calculate By-component the the intra-cell offset of a Bz-field */
         const float_64 By_Bz = calcTWTSBy(pos[2], time);
         /* Calculate Bz-component the the intra-cell offset of a Bz-field */
-        const float_64 Bz_Bz = calcTWTSBz(pos[2], time);
-        /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz,
+        const float_64 Bz_Bz = calcTWTSBz_Ex(pos[2], time);
+        /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz_Ex,
          * we need to back-rotate the resulting B-field vector. */
         /* RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field vectors. */
         const float_64 By_rot = -pmMath::sin(+phi)*By_By+pmMath::cos(+phi)*Bz_By;
@@ -144,12 +144,12 @@ namespace twts
         /* Calculate By-component with the intra-cell offset of a By-field */
         const float_64 By_By =  calcTWTSBy(pos[1], time);
         /* Calculate Bx-component with the intra-cell offset of a By-field */
-        const float_64 Bx_By = -calcTWTSBz(pos[1], time);
+        const float_64 Bx_By = -calcTWTSBz_Ex(pos[1], time);
         /* Calculate By-component with the intra-cell offset of a Bx-field */
         const float_64 By_Bx =  calcTWTSBy(pos[0], time);
         /* Calculate Bx-component with the intra-cell offset of a Bx-field */
-        const float_64 Bx_Bx = -calcTWTSBz(pos[0], time);
-        /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz, we
+        const float_64 Bx_Bx = -calcTWTSBz_Ex(pos[0], time);
+        /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz_Ex, we
          * need to back-rotate the resulting B-field vector. Now the rotation is done
          * analogously in the (y,x)-plane. (Reverse of the position vector transformation.) */
         /* RotationMatrix[-(PI / 2+phi)].(By,Bx) */
@@ -323,7 +323,7 @@ namespace twts
      * \param time Absolute time (SI, including all offsets and transformations)
      *             for calculating the field */
     HDINLINE BField::float_T
-    BField::calcTWTSBz( const float3_64& pos, const float_64 time ) const
+    BField::calcTWTSBz_Ex( const float3_64& pos, const float_64 time ) const
     {
         typedef PMacc::math::Complex<float_T> complex_T;
         /** Unit of Speed */
@@ -416,6 +416,158 @@ namespace twts
                                   ) / pmMath::pow(helpVar7,float_T(1.5));
 
         return result.get_real() / UNIT_SPEED;
+    }
+    
+    /** Calculate the Bx(r,t) field
+     *
+     * \param pos Spatial position of the target field.
+     * \param time Absolute time (SI, including all offsets and transformations)
+     *             for calculating the field */
+    HDINLINE BField::float_T
+    BField::calcTWTSBx( const float3_64& pos, const float_64 time ) const
+    {
+        /* The Bx-field for the Ey-field is the same as
+         * for the By-field for the Ex-field except for the sign. */
+        return -calcTWTSBy( pos, time );
+    }
+    
+    /** Calculate the Bz(r,t) field
+     *
+     * \param pos Spatial position of the target field.
+     * \param time Absolute time (SI, including all offsets and transformations)
+     *             for calculating the field */
+    HDINLINE BField::float_T
+    BField::calcTWTSBz_Ey( const float3_64& pos, const float_64 time ) const
+    {
+        typedef PMacc::math::Complex<float_T> complex_T;
+        /** Unit of Speed */
+        const double UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
+        /** Unit of time */
+        const double UNIT_TIME = SI::DELTA_T_SI;
+        /** Unit of length */
+        const double UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
+        
+        /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
+        const float_T beta0 = float_T(beta_0);
+        const float_T phiReal = float_T(phi);
+        const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
+                                                beta0*pmMath::sin(phiReal));
+        const float_T phiT = float_T(2.0)*alphaTilt;
+        /* Definition of the laser pulse front tilt angle for the laser field below.
+         * For beta0=1.0, this is equivalent to our standard definition. Question: Why is the
+         * local "phi_T" not equal in value to the object member "phiReal" or "phi"?
+         * Because the standard TWTS pulse is defined for beta0 = 1.0 and in the coordinate-system
+         * of the TWTS model phi is responsible for pulse front tilt and dispersion only. Hence
+         * the dispersion will (although physically correct) be slightly off the ideal TWTS
+         * pulse for beta0 != 1.0. This only shows that this TWTS pulse is primarily designed for
+         * scenarios close to beta0 = 1. */
+        
+        /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
+         * documentation purposes. */
+        /* const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt); */
+        
+        const float_T cspeed = float_T(1.0);
+        const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+        const float_T om0 = float_T(2.0*PI*cspeed / lambda0*UNIT_TIME);
+        /* factor 2  in tauG arises from definition convention in laser formula */
+        const float_T tauG = float_T(pulselength_SI*2.0 / UNIT_TIME);
+        /* w0 is wx here --> w0 could be replaced by wx */
+        const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
+        const float_T rho0 = float_T(PI*w0*w0 / lambda0 / UNIT_LENGTH);
+        /* wy is width of TWTS pulse */
+        const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
+        const float_T k = float_T(2.0*PI / lambda0*UNIT_LENGTH);
+        const float_T x = float_T(pos.x() / UNIT_LENGTH);
+        const float_T y = float_T(pos.y() / UNIT_LENGTH);
+        const float_T z = float_T(pos.z() / UNIT_LENGTH);
+        const float_T t = float_T(time / UNIT_TIME);
+                        
+        /* Shortcuts for speeding up the field calculation. */
+        const float_T sinPhi = pmMath::sin(phiT);
+        const float_T cosPhi = pmMath::cos(phiT);
+        const float_T sinPhi2 = pmMath::sin(phiT / float_T(2.0));
+        const float_T cosPhi2 = pmMath::cos(phiT / float_T(2.0));
+        const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
+        
+        /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
+         * thus help with formal code verification through manual code inspection. */
+        const complex_T helpVar1 = 
+            complex_T(0,-1)*cspeed*om0*tauG*tauG
+            - y*cosPhi / pmMath::cos(phiT / float_T(2.0)) / pmMath::cos(phiT / float_T(2.0))*tanPhi2
+            - 2*z*tanPhi2*tanPhi2;
+        const complex_T helpVar2 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
+        const complex_T helpVar3 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
+        
+        const complex_T helpVar4 = (
+            - cspeed*cspeed*k*om0*tauG*tauG*wy*wy*x*x
+            - float_T(2.0)*cspeed*cspeed*om0*t*t*wy*wy*rho0
+            + complex_T(0,2)*cspeed*cspeed*om0*om0*t*tauG*tauG*wy*wy*rho0
+            - float_T(2.0)*cspeed*cspeed*om0*tauG*tauG*y*y*rho0
+            + float_T(4.0)*cspeed*om0*t*wy*wy*z*rho0
+            - complex_T(0,2)*cspeed*om0*om0*tauG*tauG*wy*wy*z*rho0
+            - float_T(2.0)*om0*wy*wy*z*z*rho0
+            - complex_T(0,8)*om0*wy*wy*y*(cspeed*t - z)*z*sinPhi2*sinPhi2
+            + complex_T(0,8) / pmMath::sin(phiT)*(
+                float_T(2.0)*z*z*(cspeed*om0*t*wy*wy + complex_T(0,1)*cspeed*y*y - om0*wy*wy*z)
+                + y*(
+                    cspeed*k*wy*wy*x*x
+                    - complex_T(0,2)*cspeed*om0*t*wy*wy*rho0
+                    + float_T(2.0)*cspeed*y*y*rho0
+                    + complex_T(0,2)*om0*wy*wy*z*rho0
+                )*tan(float_T(PI) / float_T(2.0)-phiT) / pmMath::sin(phiT)
+            )*sinPhi2*sinPhi2*sinPhi2*sinPhi2
+            - complex_T(0,2)*cspeed*cspeed*om0*t*t*wy*wy*z*sinPhi
+            - float_T(2.0)*cspeed*cspeed*om0*om0*t*tauG*tauG*wy*wy*z*sinPhi
+            - complex_T(0,2)*cspeed*cspeed*om0*tauG*tauG*y*y*z*sinPhi
+            + complex_T(0,4)*cspeed*om0*t*wy*wy*z*z*sinPhi
+            + float_T(2.0)*cspeed*om0*om0*tauG*tauG*wy*wy*z*z*sinPhi
+            - complex_T(0,2)*om0*wy*wy*z*z*z*sinPhi
+            - float_T(4.0)*cspeed*om0*t*wy*wy*y*rho0*tanPhi2
+            + float_T(4.0)*om0*wy*wy*y*z*rho0*tanPhi2
+            + complex_T(0,2)*y*y*(
+                cspeed*om0*t*wy*wy
+                + complex_T(0,1)*cspeed*y*y
+                - om0*wy*wy*z
+            )*cosPhi2*cosPhi2 / pmMath::cos(phiT / float_T(2.0)) / pmMath::cos(phiT / float_T(2.0))
+                *tanPhi2
+            + complex_T(0,2)*cspeed*k*wy*wy*x*x*z*tanPhi2*tanPhi2
+            - float_T(2.0)*om0*wy*wy*y*y*rho0*tanPhi2*tanPhi2
+            + float_T(4.0)*cspeed*om0*t*wy*wy*z*rho0*tanPhi2*tanPhi2
+            + complex_T(0,4)*cspeed*y*y*z*rho0*tanPhi2*tanPhi2
+            - float_T(4.0)*om0*wy*wy*z*z*rho0*tanPhi2*tanPhi2
+            - complex_T(0,2)*om0*wy*wy*y*y*z*sinPhi*tanPhi2*tanPhi2
+            - float_T(2.0)*y*cos(phiT)*(
+                om0*(
+                    cspeed*cspeed*(complex_T(0,1)*t*t*wy*wy
+                    + om0*t*tauG*tauG*wy*wy
+                    + complex_T(0,1)*tauG*tauG*y*y)
+                    - cspeed*(complex_T(0,2)*t + om0*tauG*tauG)*wy*wy*z
+                    + complex_T(0,1)*wy*wy*z*z
+                )
+                + complex_T(0,2)*om0*wy*wy*y*(cspeed*t - z)*pmMath::tan( phiT / float_T(2.0) )
+                + complex_T(0,1)*(
+                    complex_T(0,-4)*cspeed*y*y*z 
+                    + om0*wy*wy*(y*y - float_T(4.0)*(cspeed*t - z)*z)
+                )*tanPhi2*tanPhi2
+            )
+        ) / (float_T(2.0)*cspeed*wy*wy*helpVar2*helpVar1);
+        
+        const complex_T helpVar5 = (
+            cspeed*om0*(
+                cspeed*om0*tauG*tauG
+                - complex_T(0,8)*y*pmMath::tan( float_T(PI) / float_T(2.0) - phiT )
+                    / pmMath::sin(phiT) / pmMath::sin(phiT)*sinPhi2*sinPhi2*sinPhi2*sinPhi2
+                - complex_T(0,2)*z*tanPhi2*tanPhi2
+            )
+        )/rho0;
+        
+        const complex_T result = float_T(-1.0)*(
+            cspeed*pmMath::exp(helpVar4)*k*tauG*x*pmMath::pow( helpVar3, float_T(-1.5) )
+            /pmMath::sqrt(helpVar5)
+        );
+
+
+        return result.get_real();
     }
 
 } /* namespace twts */

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -63,7 +63,8 @@ namespace twts
         unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay), pol(pol)
     {
         /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
-         * on host (see fieldBackground.param), this is no problem. */
+         * on host (see fieldBackground.param), this is no problem.
+         */
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         halfSimSize = subGrid.getGlobalDomain().size / 2;
         tdelay = detail::getInitialTimeDelay_SI(auto_tdelay, tdelay_user_SI,
@@ -87,8 +88,10 @@ namespace twts
                 pos[k][i] = bFieldPositions_SI[k][i];
         }
 
-        /* An example of intra-cell position offsets is the staggered Yee-grid. */
-        /* Calculate By-component with the intra-cell offset of a By-field */
+        /* An example of intra-cell position offsets is the staggered Yee-grid.
+         *
+         * Calculate By-component with the intra-cell offset of a By-field
+         */
         const float_64 By_By = calcTWTSBy(pos[1], time);
         /* Calculate Bz-component the the intra-cell offset of a By-field */
         const float_64 Bz_By = calcTWTSBz_Ex(pos[1], time);
@@ -97,8 +100,10 @@ namespace twts
         /* Calculate Bz-component the the intra-cell offset of a Bz-field */
         const float_64 Bz_Bz = calcTWTSBz_Ex(pos[2], time);
         /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz_Ex,
-         * we need to back-rotate the resulting B-field vector. */
-        /* RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field vectors. */
+         * we need to back-rotate the resulting B-field vector.
+         *
+         * RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field vectors.
+         */
         const float_64 By_rot = -pmMath::sin(+phi)*By_By+pmMath::cos(+phi)*Bz_By;
         const float_64 Bz_rot = -pmMath::cos(+phi)*By_Bz-pmMath::sin(+phi)*Bz_Bz;
 
@@ -128,8 +133,10 @@ namespace twts
         /* Calculate Bz-component with the intra-cell offset of a Bz-field */
         const float_64 Bz_Bz = calcTWTSBz_Ey(pos[2], time);
         /* Since we rotated all position vectors before calling calcTWTSBz_Ey,
-         * we need to back-rotate the resulting B-field vector. */
-        /* RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field-vectors. */
+         * we need to back-rotate the resulting B-field vector.
+         *
+         * RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field-vectors.
+         */
         const float_64 By_rot = +pmMath::cos(+phi)*Bz_By;
         const float_64 Bz_rot = -pmMath::sin(+phi)*Bz_Bz;
 
@@ -155,7 +162,10 @@ namespace twts
             for (uint32_t i = 0; i<simDim;++i)
                 pos[k][i+1] = bFieldPositions_SI[k][i];
         }
-        /*  Corresponding position vector for the Field-components in 2D simulations.
+
+        /* General background comment for the rest of this function:
+         *
+         * Corresponding position vector for the field components in 2D simulations.
          *  3D     3D vectors in 2D space (x, y)
          *  x -->  z (Meaning: In 2D-sim, insert cell-coordinate x
          *            into TWTS field function coordinate z.)
@@ -169,10 +179,12 @@ namespace twts
          *                   intra-cell position offset.)
          *  By --> By
          *  Bz --> -Bx (Yes, the sign is necessary.)
+         *
+         * An example of intra-cell position offsets is the staggered Yee-grid.
+         *
+         * This procedure is analogous to 3D case, but replace By --> By and Bz --> -Bx. Hence the
+         * grid cell offset for Bx has to be used instead of Bz. Mind the "-"-sign.
          */
-        /* An example of intra-cell position offsets is the staggered Yee-grid. */
-        /* Analogous to 3D case, but replace By --> By and Bz --> -Bx. Hence the grid cell offset
-         * for Bx has to be used instead of Bz. Mind the "-"-sign. */
 
         /* Calculate By-component with the intra-cell offset of a By-field */
         const float_64 By_By =  calcTWTSBy(pos[1], time);
@@ -184,10 +196,11 @@ namespace twts
         const float_64 Bx_Bx = -calcTWTSBz_Ex(pos[0], time);
         /* Since we rotated all position vectors before calling calcTWTSBy and calcTWTSBz_Ex, we
          * need to back-rotate the resulting B-field vector. Now the rotation is done
-         * analogously in the (y,x)-plane. (Reverse of the position vector transformation.) */
-        /* RotationMatrix[-(PI / 2+phi)].(By,Bx) */
+         * analogously in the (y,x)-plane. (Reverse of the position vector transformation.)
+         *
+         * RotationMatrix[-(PI / 2+phi)].(By,Bx) for rotating back the field vectors.
+         */
         const float_64 By_rot = -pmMath::sin(phi)*By_By+pmMath::cos(phi)*Bx_By;
-        /* for rotating back the field vectors.*/
         const float_64 Bx_rot = -pmMath::cos(phi)*By_Bx-pmMath::sin(phi)*Bx_Bx;
 
         /* Finally, the B-field normalized to the peak amplitude. */
@@ -209,10 +222,14 @@ namespace twts
 
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             /* The 2D output of getFieldPositions_SI only returns
-             * the y- and z-component of a 3D vector. */
+             * the y- and z-component of a 3D vector.
+             */
             for (uint32_t i = 0; i<simDim;++i) pos[k][i+1] = bFieldPositions_SI[k][i];
         }
-        /*  Corresponding position vector for the Field-components in 2D simulations.
+
+        /* General background comment for the rest of this function:
+         *
+         * Corresponding position vector for the field components in 2D simulations.
          *  3D     3D vectors in 2D space (x, y)
          *  x -->  z (Meaning: In 2D-sim, insert cell-coordinate x
          *            into TWTS field function coordinate z.)
@@ -224,20 +241,24 @@ namespace twts
          *             Note: the intra-cell position offset due to the staggered grid for Ez.)
          *  By --> By
          *  Bz --> -Bx (Yes, the sign is necessary.)
+         *
+         * This procedure is analogous to 3D case, but replace By --> By and Bz --> -Bx. Hence the
+         * grid cell offset for Bx has to be used instead of Bz. Mind the -sign.
          */
-        /* Analogous to 3D case, but replace By --> By and Bz --> -Bx. Hence the grid cell offset
-         * for Bx has to be used instead of Bz. Mind the -sign. */
 
         /* Calculate Bx-component with the intra-cell offset of a By-field */
         const float_64 Bx_By = -calcTWTSBz_Ex(pos[1], time);
         /* Calculate Bx-component with the intra-cell offset of a Bx-field */
         const float_64 Bx_Bx = -calcTWTSBz_Ex(pos[0], time);
+
         /* Since we rotated all position vectors before calling calcTWTSBz_Ex, we
          * need to back-rotate the resulting B-field vector. Now the rotation is done
-         * analogously in the (y,x)-plane. (Reverse of the position vector transformation.) */
-        /* RotationMatrix[-(PI / 2+phi)].(By,Bx) */
+         * analogously in the (y,x)-plane. (Reverse of the position vector transformation.)
+         *
+         * RotationMatrix[-(PI / 2+phi)].(By,Bx)
+         * for rotating back the field-vectors.
+         */
         const float_64 By_rot = +pmMath::cos(phi)*Bx_By;
-        /* for rotating back the field-vectors.*/
         const float_64 Bx_rot = -pmMath::sin(phi)*Bx_Bx;
 
         /* Finally, the B-field normalized to the peak amplitude. */
@@ -277,31 +298,34 @@ namespace twts
     {
         typedef PMacc::math::Complex<float_T> complex_T;
         typedef PMacc::math::Complex<float_64> complex_64;
-        /** Unit of Speed */
+        /* Unit of speed */
         const double UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
-        /** Unit of time */
+        /* Unit of time */
         const double UNIT_TIME = SI::DELTA_T_SI;
-        /** Unit of length */
+        /* Unit of length */
         const double UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
-        /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
+        /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
         const float_T phiReal = float_T(phi);
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
                                                 beta0*pmMath::sin(phiReal));
-        const float_T phiT = float_T(2.0)*alphaTilt;
         /* Definition of the laser pulse front tilt angle for the laser field below.
+         *
          * For beta0=1.0, this is equivalent to our standard definition. Question: Why is the
          * local "phi_T" not equal in value to the object member "phiReal" or "phi"?
          * Because the standard TWTS pulse is defined for beta0 = 1.0 and in the coordinate-system
          * of the TWTS model phi is responsible for pulse front tilt and dispersion only. Hence
          * the dispersion will (although physically correct) be slightly off the ideal TWTS
          * pulse for beta0 != 1.0. This only shows that this TWTS pulse is primarily designed for
-         * scenarios close to beta0 = 1. */
+         * scenarios close to beta0 = 1.
+         */
+        const float_T phiT = float_T(2.0)*alphaTilt;
 
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
-         * documentation purposes. */
-        /* const float_T eta = float_T(PI/2) - (phiReal - alphaTilt); */
+         * documentation purposes.
+         * const float_T eta = float_T(PI/2) - (phiReal - alphaTilt);
+         */
 
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
@@ -326,7 +350,8 @@ namespace twts
         const float_T tanPhi2 = pmMath::tan(phiT / 2.0);
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
-         * thus help with formal code verification through manual code inspection. */
+         * thus help with formal code verification through manual code inspection.
+         */
         const complex_T helpVar1 = rho0 + complex_T(0,1)*y*cosPhi + complex_T(0,1)*z*sinPhi;
         const complex_T helpVar2 = cspeed*om0*tauG*tauG + complex_T(0,2)
                                     *(-z - y*pmMath::tan(float_T(PI / 2)-phiT))*tanPhi2*tanPhi2;
@@ -390,7 +415,8 @@ namespace twts
                 )*tanPhi2*tanPhi2
             )
         /* The "round-trip" conversion in the line below fixes a gross accuracy bug
-         * in floating-point arithmetics, when float_T is set to float_X. */
+         * in floating-point arithmetics, when float_T is set to float_X.
+         */
         ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2) );
 
         const complex_T helpVar5 = complex_T(0,-1)*cspeed*om0*tauG*tauG
@@ -432,19 +458,23 @@ namespace twts
         const float_T phiReal = float_T(phi);
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
                                                 beta0*pmMath::sin(phiReal));
-        const float_T phiT = float_T(2.0)*alphaTilt;
+
         /* Definition of the laser pulse front tilt angle for the laser field below.
+         *
          * For beta0=1.0, this is equivalent to our standard definition. Question: Why is the
          * local "phi_T" not equal in value to the object member "phiReal" or "phi"?
          * Because the standard TWTS pulse is defined for beta0 = 1.0 and in the coordinate-system
          * of the TWTS model phi is responsible for pulse front tilt and dispersion only. Hence
          * the dispersion will (although physically correct) be slightly off the ideal TWTS
          * pulse for beta0 != 1.0. This only shows that this TWTS pulse is primarily designed for
-         * scenarios close to beta0 = 1. */
+         * scenarios close to beta0 = 1.
+         */
+        const float_T phiT = float_T(2.0)*alphaTilt;
 
-        /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
-         * documentation purposes. */
-        /* const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt); */
+        /* Angle between the laser pulse front and the y-axis.
+         * Not used, but remains in code for documentation purposes.
+         * const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt);
+         */
 
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
@@ -470,7 +500,8 @@ namespace twts
         const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
-         * thus help with formal code verification through manual code inspection. */
+         * thus help with formal code verification through manual code inspection.
+         */
         const complex_T helpVar1 = -(cspeed*z) - cspeed*y*pmMath::tan(float_T(PI / 2)-phiT)
                                     + complex_T(0,1)*cspeed*rho0 / sinPhi;
         const complex_T helpVar2 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
@@ -521,7 +552,8 @@ namespace twts
     BField::calcTWTSBx( const float3_64& pos, const float_64 time ) const
     {
         /* The Bx-field for the Ey-field is the same as
-         * for the By-field for the Ex-field except for the sign. */
+         * for the By-field for the Ex-field except for the sign.
+         */
         return -calcTWTSBy( pos, time );
     }
 
@@ -535,31 +567,34 @@ namespace twts
     {
         typedef PMacc::math::Complex<float_T> complex_T;
         typedef PMacc::math::Complex<float_64> complex_64;
-        /** Unit of Speed */
+        /** Unit of speed */
         const double UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /** Unit of time */
         const double UNIT_TIME = SI::DELTA_T_SI;
         /** Unit of length */
         const double UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
-        /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
+        /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
         const float_T phiReal = float_T(phi);
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
                                                 beta0*pmMath::sin(phiReal));
-        const float_T phiT = float_T(2.0)*alphaTilt;
         /* Definition of the laser pulse front tilt angle for the laser field below.
+         *
          * For beta0=1.0, this is equivalent to our standard definition. Question: Why is the
          * local "phi_T" not equal in value to the object member "phiReal" or "phi"?
          * Because the standard TWTS pulse is defined for beta0 = 1.0 and in the coordinate-system
          * of the TWTS model phi is responsible for pulse front tilt and dispersion only. Hence
          * the dispersion will (although physically correct) be slightly off the ideal TWTS
          * pulse for beta0 != 1.0. This only shows that this TWTS pulse is primarily designed for
-         * scenarios close to beta0 = 1. */
+         * scenarios close to beta0 = 1.
+         */
+        const float_T phiT = float_T(2.0)*alphaTilt;
 
-        /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
-         * documentation purposes. */
-        /* const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt); */
+        /* Angle between the laser pulse front and the y-axis.
+         * Not used, but remains in code for documentation purposes.
+         * const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt);
+         */
 
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
@@ -585,7 +620,8 @@ namespace twts
         const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
-         * thus help with formal code verification through manual code inspection. */
+         * thus help with formal code verification through manual code inspection.
+         */
         const complex_T helpVar1 =
             complex_T(0,-1)*cspeed*om0*tauG*tauG
             - y*cosPhi / cosPhi2 / cosPhi2 * tanPhi2
@@ -644,7 +680,8 @@ namespace twts
                 )*tanPhi2*tanPhi2
             )
         /* The "round-trip" conversion in the line below fixes a gross accuracy bug
-         * in floating-point arithmetics, when float_T is set to float_X. */
+         * in floating-point arithmetics, when float_T is set to float_X.
+         */
         ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar2*helpVar1) );
 
         const complex_T helpVar4 = (

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -54,12 +54,13 @@ namespace twts
                     const float_X phi,
                     const float_X beta_0,
                     const float_64 tdelay_user_SI,
-                    const bool auto_tdelay ) :
+                    const bool auto_tdelay
+                    const PolarizationType pol ) :
         focus_y_SI(focus_y_SI), wavelength_SI(wavelength_SI),
         pulselength_SI(pulselength_SI), w_x_SI(w_x_SI),
         w_y_SI(w_y_SI), phi(phi), beta_0(beta_0),
         tdelay_user_SI(tdelay_user_SI), dt(SI::DELTA_T_SI),
-        unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay)
+        unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay), pol(pol)
     {
         /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
          * on host (see fieldBackground.param), this is no problem. */

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -81,7 +81,7 @@ namespace twts
         PosVecVec pos(PosVecVec::create(
                                            float3_64::create(0.0)
                                        ));
-        
+
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i)
                 pos[k][i] = bFieldPositions_SI[k][i];
@@ -118,11 +118,11 @@ namespace twts
         PosVecVec pos(PosVecVec::create(
                                            float3_64::create(0.0)
                                        ));
-        
+
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i) pos[k][i] = bFieldPositions_SI[k][i];
         }
-        
+
         /* Calculate Bz-component with the intra-cell offset of a By-field */
         const float_64 Bz_By = calcTWTSBz_Ey(pos[1], time);
         /* Calculate Bz-component with the intra-cell offset of a Bz-field */
@@ -132,13 +132,13 @@ namespace twts
         /* RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field-vectors. */
         const float_64 By_rot = +pmMath::cos(+phi)*Bz_By;
         const float_64 Bz_rot = -pmMath::sin(+phi)*Bz_Bz;
-        
+
         /* Finally, the B-field normalized to the peak amplitude. */
         return float3_X( float_X( calcTWTSBx(pos[0], time) ),
                          float_X( By_rot ),
                          float_X( Bz_rot ) );
     }
-    
+
     template<>
     HDINLINE float3_X
     BField::getTWTSBfield_Normalized<DIM2>(
@@ -195,7 +195,7 @@ namespace twts
                          float_X(By_rot),
                          float_X(0.0) );
     }
-    
+
     template<>
     HDINLINE float3_X
     BField::getTWTSBfield_Normalized_Ey<DIM2>(
@@ -206,7 +206,7 @@ namespace twts
         PosVecVec pos(PosVecVec::create(
                                            float3_64::create(0.0)
                                        ));
-        
+
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             /* The 2D output of getFieldPositions_SI only returns
              * the y- and z-component of a 3D vector. */
@@ -224,10 +224,10 @@ namespace twts
          *             Note: the intra-cell position offset due to the staggered grid for Ez.)
          *  By --> By
          *  Bz --> -Bx (Yes, the sign is necessary.)
-         */ 
+         */
         /* Analogous to 3D case, but replace By --> By and Bz --> -Bx. Hence the grid cell offset
          * for Bx has to be used instead of Bz. Mind the -sign. */
-         
+
         /* Calculate Bx-component with the intra-cell offset of a By-field */
         const float_64 Bx_By = -calcTWTSBz_Ex(pos[1], time);
         /* Calculate Bx-component with the intra-cell offset of a Bx-field */
@@ -239,7 +239,7 @@ namespace twts
         const float_64 By_rot = +pmMath::cos(phi)*Bx_By;
         /* for rotating back the field-vectors.*/
         const float_64 Bx_rot = -pmMath::sin(phi)*Bx_Bx;
-        
+
         /* Finally, the B-field normalized to the peak amplitude. */
         return float3_X( float_X( Bx_rot ),
                          float_X( By_rot ),
@@ -260,7 +260,7 @@ namespace twts
         {
             case NORMAL_TO_TILTPLANE :
             return getTWTSBfield_Normalized<simDim>(bFieldPositions_SI, time_SI);
-            
+
             case WITHIN_TILTPLANE :
             return getTWTSBfield_Normalized_Ey<simDim>(bFieldPositions_SI, time_SI);
         }
@@ -302,7 +302,7 @@ namespace twts
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = float_T(PI/2) - (phiReal - alphaTilt); */
-        
+
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
         const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
@@ -392,7 +392,7 @@ namespace twts
         /* The "round-trip" conversion in the line below fixes a gross accuracy bug
          * in floating-point arithmetics, when float_T is set to float_X. */
         ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2) );
-        
+
         const complex_T helpVar5 = complex_T(0,-1)*cspeed*om0*tauG*tauG
                                 + (-z - y*pmMath::tan(float_T(PI / 2)-phiT))
                                     *tanPhi2*tanPhi2*float_T(2.0);
@@ -445,7 +445,7 @@ namespace twts
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt); */
-        
+
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
         const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
@@ -511,7 +511,7 @@ namespace twts
 
         return result.get_real() / UNIT_SPEED;
     }
-    
+
     /** Calculate the Bx(r,t) field
      *
      * \param pos Spatial position of the target field.
@@ -524,7 +524,7 @@ namespace twts
          * for the By-field for the Ex-field except for the sign. */
         return -calcTWTSBy( pos, time );
     }
-    
+
     /** Calculate the Bz(r,t) field
      *
      * \param pos Spatial position of the target field.
@@ -541,7 +541,7 @@ namespace twts
         const double UNIT_TIME = SI::DELTA_T_SI;
         /** Unit of length */
         const double UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
-        
+
         /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
         const float_T phiReal = float_T(phi);
@@ -556,11 +556,11 @@ namespace twts
          * the dispersion will (although physically correct) be slightly off the ideal TWTS
          * pulse for beta0 != 1.0. This only shows that this TWTS pulse is primarily designed for
          * scenarios close to beta0 = 1. */
-        
+
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt); */
-        
+
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
         const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
@@ -576,22 +576,22 @@ namespace twts
         const float_T y = float_T(pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
         const float_T t = float_T(time / UNIT_TIME);
-                        
+
         /* Shortcuts for speeding up the field calculation. */
         const float_T sinPhi = pmMath::sin(phiT);
         const float_T cosPhi = pmMath::cos(phiT);
         const float_T sinPhi2 = pmMath::sin(phiT / float_T(2.0));
         const float_T cosPhi2 = pmMath::cos(phiT / float_T(2.0));
         const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
-        
+
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
          * thus help with formal code verification through manual code inspection. */
-        const complex_T helpVar1 = 
+        const complex_T helpVar1 =
             complex_T(0,-1)*cspeed*om0*tauG*tauG
             - y*cosPhi / cosPhi2 / cosPhi2 * tanPhi2
             - float_T(2.0)*z*tanPhi2*tanPhi2;
         const complex_T helpVar2 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
-        
+
         const complex_T helpVar3 = (
             - cspeed*cspeed*k*om0*tauG*tauG*wy*wy*x*x
             - float_T(2.0)*cspeed*cspeed*om0*t*t*wy*wy*rho0
@@ -646,7 +646,7 @@ namespace twts
         /* The "round-trip" conversion in the line below fixes a gross accuracy bug
          * in floating-point arithmetics, when float_T is set to float_X. */
         ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar2*helpVar1) );
-        
+
         const complex_T helpVar4 = (
             cspeed*om0*(
                 cspeed*om0*tauG*tauG
@@ -655,12 +655,12 @@ namespace twts
                 - complex_T(0,2)*z*tanPhi2*tanPhi2
             )
         ) / rho0;
-        
+
         const complex_T result = float_T(-1.0)*(
             cspeed*pmMath::exp(helpVar3)*k*tauG*x*pmMath::pow( helpVar2, float_T(-1.5) )
             / pmMath::sqrt(helpVar4)
         );
-        
+
         return result.get_real() / UNIT_SPEED;
     }
 

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -29,10 +29,10 @@
 
 namespace picongpu
 {
-/** Load pre-defined background field */
+/* Load pre-defined background field */
 namespace templates
 {
-/** Traveling-wave Thomson scattering laser pulse */
+/* Traveling-wave Thomson scattering laser pulse */
 namespace twts
 {
 
@@ -44,8 +44,9 @@ public:
     enum PolarizationType
     {
         /* The linear polarization of the TWTS laser is defined
-         * relative to the plane of the pulse front tilt. */
-        /* Polarisation is normal to the reference plane.
+         * relative to the plane of the pulse front tilt.
+         *
+         * Polarisation is normal to the reference plane.
          * Use Ex-fields (and corresponding B-fields) in TWTS laser internal coordinate system.
          */
         LINEAR_X = 1u,
@@ -83,7 +84,8 @@ public:
     /* TWTS laser time delay */
     PMACC_ALIGN(tdelay,float_64);
     /* Should the TWTS laser delay be chosen automatically, such that
-       the laser gradually enters the simulation volume? [Default: TRUE] */
+     * the laser gradually enters the simulation volume? [Default: TRUE]
+     */
     const PMACC_ALIGN(auto_tdelay,bool);
     /* Polarization of TWTS laser */
     const PMACC_ALIGN(pol,PolarizationType);

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -110,7 +110,7 @@ public:
             const float_X phi               = 90.*(PI / 180.),
             const float_X beta_0            = 1.0,
             const float_64 tdelay_user_SI   = 0.0,
-            const bool auto_tdelay          = true
+            const bool auto_tdelay          = true,
             const PolarizationType pol      = NORMAL_TO_TILTPLANE );
 
     /** Specify your background field E(r,t) here
@@ -148,6 +148,16 @@ public:
     template <unsigned T_dim>
     HDINLINE float3_X
     getTWTSEfield_Normalized(
+            const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
+            const float_64 time) const;
+
+    /** Calculate the E-field vector of the "in-plane polarized" TWTS laser in SI units.
+     * \tparam T_dim Specializes for the simulation dimension
+     * \param cellIdx The total cell id counted from the start at timestep 0
+     * \return Efield vector of the rotated TWTS field in SI units */
+    template <unsigned T_dim>
+    HDINLINE float3_X
+    getTWTSEfield_Normalized_Ey(
             const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
             const float_64 time) const;
     

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -41,6 +41,14 @@ class EField
 public:
     typedef float_X float_T;
     
+    enum PolarizationType
+    {
+        /* The linear polarization of the TWTS laser is defined
+         * relative to the plane of the pulse front tilt. */
+        NORMAL_TO_TILTPLANE = 1u, /* use Ex-fields in TWTS laser internal coordinate system */
+        WITHIN_TILTPLANE = 2u,    /* use Ey-fields in TWTS laser internal coordinate system */
+    };
+    
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);
     /* y-position of TWTS coordinate origin inside the simulation coordinates [meter]
@@ -71,6 +79,8 @@ public:
     /* Should the TWTS laser delay be chosen automatically, such that
        the laser gradually enters the simulation volume? [Default: TRUE] */
     const PMACC_ALIGN(auto_tdelay,bool);
+    /* Polarization of TWTS laser */
+    const PMACC_ALIGN(pol,PolarizationType);
     
     /** Electric field of the TWTS laser
      *
@@ -88,6 +98,8 @@ public:
      * \param tdelay_user manual time delay if auto_tdelay is false
      * \param auto_tdelay calculate the time delay such that the TWTS pulse is not
      *  inside the simulation volume at simulation start timestep = 0 [default = true]
+     * \param pol dtermines the TWTS laser polarization, which is either normal or parallel
+     *  to the laser pulse front tilt plane [ default= NORMAL_TO_TILTPLANE , WITHIN_TILTPLANE ]
      */
     HINLINE
     EField( const float_64 focus_y_SI,
@@ -98,7 +110,8 @@ public:
             const float_X phi               = 90.*(PI / 180.),
             const float_X beta_0            = 1.0,
             const float_64 tdelay_user_SI   = 0.0,
-            const bool auto_tdelay          = true );
+            const bool auto_tdelay          = true
+            const PolarizationType pol      = NORMAL_TO_TILTPLANE );
 
     /** Specify your background field E(r,t) here
      *

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -40,15 +40,21 @@ class EField
 {
 public:
     typedef float_X float_T;
-    
+
     enum PolarizationType
     {
         /* The linear polarization of the TWTS laser is defined
          * relative to the plane of the pulse front tilt. */
-        NORMAL_TO_TILTPLANE = 1u, /* use Ex-fields in TWTS laser internal coordinate system */
-        WITHIN_TILTPLANE = 2u,    /* use Ey-fields in TWTS laser internal coordinate system */
+        /* Polarisation is normal to the reference plane.
+         * Use Ex-fields (and corresponding B-fields) in TWTS laser internal coordinate system.
+         */
+        LINEAR_X = 1u,
+        /* Polarization lies within the reference plane.
+         * Use Ey-fields (and corresponding B-fields) in TWTS laser internal coordinate system.
+         */
+        LINEAR_YZ = 2u,
     };
-    
+
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);
     /* y-position of TWTS coordinate origin inside the simulation coordinates [meter]
@@ -81,12 +87,12 @@ public:
     const PMACC_ALIGN(auto_tdelay,bool);
     /* Polarization of TWTS laser */
     const PMACC_ALIGN(pol,PolarizationType);
-    
+
     /** Electric field of the TWTS laser
      *
      * \param focus_y_SI the distance to the laser focus in y-direction [m]
      * \param wavelength_SI central wavelength [m]
-     * \param pulselength_SI sigma of std. gauss for intensity (E^2), 
+     * \param pulselength_SI sigma of std. gauss for intensity (E^2),
      *  pulselength_SI = FWHM_of_Intensity / 2.35482 [seconds (sigma)]
      * \param w_x beam waist: distance from the axis where the pulse electric field
      *  decreases to its 1/e^2-th part at the focus position of the laser [m]
@@ -99,7 +105,7 @@ public:
      * \param auto_tdelay calculate the time delay such that the TWTS pulse is not
      *  inside the simulation volume at simulation start timestep = 0 [default = true]
      * \param pol dtermines the TWTS laser polarization, which is either normal or parallel
-     *  to the laser pulse front tilt plane [ default= NORMAL_TO_TILTPLANE , WITHIN_TILTPLANE ]
+     *  to the laser pulse front tilt plane [ default= LINEAR_X , LINEAR_YZ ]
      */
     HINLINE
     EField( const float_64 focus_y_SI,
@@ -111,7 +117,7 @@ public:
             const float_X beta_0            = 1.0,
             const float_64 tdelay_user_SI   = 0.0,
             const bool auto_tdelay          = true,
-            const PolarizationType pol      = NORMAL_TO_TILTPLANE );
+            const PolarizationType pol      = LINEAR_X );
 
     /** Specify your background field E(r,t) here
      *
@@ -131,7 +137,7 @@ public:
      * \return Ex-field component of the non-rotated TWTS field in SI units */
     HDINLINE float_T
     calcTWTSEx( const float3_64& pos, const float_64 time ) const;
-    
+
     /** Calculate the Ey(r,t) field here (electric field vector in pulse-front-tilt plane)
      *
      * \param pos Spatial position of the target field
@@ -140,7 +146,7 @@ public:
      * \return Ex-field component of the non-rotated TWTS field in SI units */
     HDINLINE float_T
     calcTWTSEy( const float3_64& pos, const float_64 time ) const;
-    
+
     /** Calculate the E-field vector of the TWTS laser in SI units.
      * \tparam T_dim Specializes for the simulation dimension
      * \param cellIdx The total cell id counted from the start at timestep 0
@@ -160,7 +166,7 @@ public:
     getTWTSEfield_Normalized_Ey(
             const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
             const float_64 time) const;
-    
+
 };
 
 } /* namespace twts */

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -39,7 +39,7 @@ namespace twts
 class EField
 {
 public:
-    typedef float_X float_T;
+    typedef float_64 float_T;
     
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -110,7 +110,7 @@ public:
     operator()( const DataSpace<simDim>& cellIdx,
                 const uint32_t currentStep ) const;
 
-    /** Calculate the Ex(r,t) field here
+    /** Calculate the Ex(r,t) field here (electric field vector normal to pulse-front-tilt plane)
      *
      * \param pos Spatial position of the target field
      * \param time Absolute time (SI, including all offsets and transformations)
@@ -118,6 +118,15 @@ public:
      * \return Ex-field component of the non-rotated TWTS field in SI units */
     HDINLINE float_T
     calcTWTSEx( const float3_64& pos, const float_64 time ) const;
+    
+    /** Calculate the Ey(r,t) field here (electric field vector in pulse-front-tilt plane)
+     *
+     * \param pos Spatial position of the target field
+     * \param time Absolute time (SI, including all offsets and transformations)
+     *  for calculating the field
+     * \return Ex-field component of the non-rotated TWTS field in SI units */
+    HDINLINE float_T
+    calcTWTSEy( const float3_64& pos, const float_64 time ) const;
     
     /** Calculate the E-field vector of the TWTS laser in SI units.
      * \tparam T_dim Specializes for the simulation dimension

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -39,7 +39,7 @@ namespace twts
 class EField
 {
 public:
-    typedef float_64 float_T;
+    typedef float_X float_T;
     
     /* Center of simulation volume in number of cells */
     PMACC_ALIGN(halfSimSize,DataSpace<simDim>);

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -177,10 +177,10 @@ namespace twts
         /* Single TWTS-Pulse */
         switch (pol)
         {
-            case NORMAL_TO_TILTPLANE :
+            case LINEAR_X :
             return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI);
 
-            case WITHIN_TILTPLANE :
+            case LINEAR_YZ :
             return getTWTSEfield_Normalized_Ey<simDim>(eFieldPositions_SI, time_SI);
         }
         return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI); // defensive default

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -121,6 +121,7 @@ namespace twts
     EField::calcTWTSEx( const float3_64& pos, const float_64 time) const
     {
         typedef PMacc::math::Complex<float_T> complex_T;
+        typedef PMacc::math::Complex<float_64> complex_64;
         /** Unit of Speed */
         const double UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /** Unit of time */
@@ -230,7 +231,9 @@ namespace twts
                     + om0*wy*wy*(y*y - float_T(4.0)*(cspeed*t - z)*z)
                 )
             )
-        ) / (float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2);
+        /* The "round-trip" conversion in the line below fixes a gross accuracy bug
+         * in floating-point arithmetics, when float_T is set to float_X. */
+        ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2) );
 
         const complex_T helpVar5 = cspeed*om0*tauG*tauG
             - complex_T(0,8)*y*pmMath::tan( float_T(PI / 2)-phiT )

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -54,12 +54,13 @@ namespace twts
                     const float_X phi,
                     const float_X beta_0,
                     const float_64 tdelay_user_SI,
-                    const bool auto_tdelay ) :
+                    const bool auto_tdelay
+                    const PolarizationType pol ) :
         focus_y_SI(focus_y_SI), wavelength_SI(wavelength_SI),
         pulselength_SI(pulselength_SI), w_x_SI(w_x_SI),
         w_y_SI(w_y_SI), phi(phi), beta_0(beta_0),
         tdelay_user_SI(tdelay_user_SI), dt(SI::DELTA_T_SI),
-        unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay)
+        unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay), pol(pol)
     {
         /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
                  on host (see fieldBackground.param), this is no problem. */

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -93,11 +93,11 @@ namespace twts
         PosVecVec pos(PosVecVec::create(
                                            float3_64::create(0.0)
                                        ));
-        
+
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i) pos[k][i] = eFieldPositions_SI[k][i];
         }
-        
+
         /* Calculate Ey-component with the intra-cell offset of a Ey-field */
         const float_64 Ey_Ey = calcTWTSEy(pos[1], time);
         /* Calculate Ey-component with the intra-cell offset of a Ez-field */
@@ -108,13 +108,13 @@ namespace twts
         /* RotationMatrix[-(PI/2+phi)].(Ey,Ez) for rotating back the field-vectors. */
         const float_64 Ey_rot = -pmMath::sin(+phi)*Ey_Ey;
         const float_64 Ez_rot = -pmMath::cos(+phi)*Ey_Ez;
-        
+
         /* Finally, the E-field normalized to the peak amplitude. */
         return float3_X( float_X(0.0),
                          float_X(Ey_rot),
                          float_X(Ez_rot) );
     }
-    
+
     template<>
     HDINLINE float3_X
     EField::getTWTSEfield_Normalized<DIM2>(
@@ -128,7 +128,7 @@ namespace twts
         return float3_X( float_X(0.), float_X(0.),
                          float_X( calcTWTSEx(pos,time) ) );
     }
-    
+
     template<>
     HDINLINE float3_X
     EField::getTWTSEfield_Normalized_Ey<DIM2>(
@@ -139,13 +139,13 @@ namespace twts
         PosVecVec pos(PosVecVec::create(
                                            float3_64::create(0.0)
                                        ));
-        
+
         /* The 2D output of getFieldPositions_SI only returns
          * the y- and z-component of a 3D vector. */
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i) pos[k][i+1] = eFieldPositions_SI[k][i];
         }
-        
+
         /* Ey->Ey, but grid cell offsets for Ex and Ey have to be used. */
         /* Calculate Ey-component with the intra-cell offset of a Ey-field */
         const float_64 Ey_Ey = calcTWTSEy(pos[1], time);
@@ -157,13 +157,13 @@ namespace twts
         /* RotationMatrix[-(PI / 2+phi)].(Ey,Ex) for rotating back the field-vectors. */
         const float_64 Ey_rot = -pmMath::sin(+phi)*Ey_Ey;
         const float_64 Ex_rot = -pmMath::cos(+phi)*Ey_Ex;
-        
+
         /* Finally, the E-field normalized to the peak amplitude. */
         return float3_X( float_X(Ex_rot),
                          float_X(Ey_rot),
                          float_X(0.0) );
     }
-    
+
     HDINLINE float3_X
     EField::operator()( const DataSpace<simDim>& cellIdx,
                             const uint32_t currentStep ) const
@@ -179,7 +179,7 @@ namespace twts
         {
             case NORMAL_TO_TILTPLANE :
             return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI);
-            
+
             case WITHIN_TILTPLANE :
             return getTWTSEfield_Normalized_Ey<simDim>(eFieldPositions_SI, time_SI);
         }
@@ -221,7 +221,7 @@ namespace twts
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = (PI / 2) - (phiReal - alphaTilt); */
-        
+
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
         const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
@@ -330,7 +330,7 @@ namespace twts
          * is by definition identical to Ex (polarization normal to pulse-front-tilt plane) */
         return calcTWTSEx( pos, time );
     }
-    
+
 } /* namespace twts */
 } /* namespace templates */
 } /* namespace picongpu */

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -37,10 +37,10 @@
 
 namespace picongpu
 {
-/** Load pre-defined background field */
+/* Load pre-defined background field */
 namespace templates
 {
-/** Traveling-wave Thomson scattering laser pulse */
+/* Traveling-wave Thomson scattering laser pulse */
 namespace twts
 {
     namespace pmMath = PMacc::algorithms::math;
@@ -63,7 +63,8 @@ namespace twts
         unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay), pol(pol)
     {
         /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
-                 on host (see fieldBackground.param), this is no problem. */
+                 on host (see fieldBackground.param), this is no problem.
+         */
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         halfSimSize = subGrid.getGlobalDomain().size / 2;
         tdelay = detail::getInitialTimeDelay_SI(auto_tdelay, tdelay_user_SI,
@@ -104,8 +105,10 @@ namespace twts
         const float_64 Ey_Ez = calcTWTSEy(pos[2], time);
 
         /* Since we rotated all position vectors before calling calcTWTSEy,
-         * we need to back-rotate the resulting E-field vector. */
-        /* RotationMatrix[-(PI/2+phi)].(Ey,Ez) for rotating back the field-vectors. */
+         * we need to back-rotate the resulting E-field vector.
+         *
+         * RotationMatrix[-(PI/2+phi)].(Ey,Ez) for rotating back the field-vectors.
+         */
         const float_64 Ey_rot = -pmMath::sin(+phi)*Ey_Ey;
         const float_64 Ez_rot = -pmMath::cos(+phi)*Ey_Ez;
 
@@ -141,20 +144,25 @@ namespace twts
                                        ));
 
         /* The 2D output of getFieldPositions_SI only returns
-         * the y- and z-component of a 3D vector. */
+         * the y- and z-component of a 3D vector.
+         */
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i) pos[k][i+1] = eFieldPositions_SI[k][i];
         }
 
-        /* Ey->Ey, but grid cell offsets for Ex and Ey have to be used. */
-        /* Calculate Ey-component with the intra-cell offset of a Ey-field */
+        /* Ey->Ey, but grid cell offsets for Ex and Ey have to be used.
+         *
+         * Calculate Ey-component with the intra-cell offset of a Ey-field
+         */
         const float_64 Ey_Ey = calcTWTSEy(pos[1], time);
         /* Calculate Ey-component with the intra-cell offset of a Ex-field */
         const float_64 Ey_Ex = calcTWTSEy(pos[0], time);
 
         /* Since we rotated all position vectors before calling calcTWTSEy,
-         * we need to back-rotate the resulting E-field vector. */
-        /* RotationMatrix[-(PI / 2+phi)].(Ey,Ex) for rotating back the field-vectors. */
+         * we need to back-rotate the resulting E-field vector.
+         *
+         * RotationMatrix[-(PI / 2+phi)].(Ey,Ex) for rotating back the field-vectors.
+         */
         const float_64 Ey_rot = -pmMath::sin(+phi)*Ey_Ey;
         const float_64 Ex_rot = -pmMath::cos(+phi)*Ey_Ex;
 
@@ -196,31 +204,34 @@ namespace twts
     {
         typedef PMacc::math::Complex<float_T> complex_T;
         typedef PMacc::math::Complex<float_64> complex_64;
-        /** Unit of Speed */
+        /* Unit of speed */
         const double UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
-        /** Unit of time */
+        /* Unit of time */
         const double UNIT_TIME = SI::DELTA_T_SI;
-        /** Unit of length */
+        /* Unit of length */
         const double UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
-        /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
+        /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
         const float_T phiReal = float_T(phi);
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
                                                 beta0*pmMath::sin(phiReal));
-        const float_T phiT = float_T(2.0)*alphaTilt;
         /* Definition of the laser pulse front tilt angle for the laser field below.
+         *
          * For beta0 = 1.0, this is equivalent to our standard definition. Question: Why is the
          * local "phi_T" not equal in value to the object member "phiReal" or "phi"?
          * Because the standard TWTS pulse is defined for beta0 = 1.0 and in the coordinate-system
          * of the TWTS model phi is responsible for pulse front tilt and dispersion only. Hence
          * the dispersion will (although physically correct) be slightly off the ideal TWTS
          * pulse for beta0 != 1.0. This only shows that this TWTS pulse is primarily designed for
-         * scenarios close to beta0 = 1. */
+         * scenarios close to beta0 = 1.
+         */
+        const float_T phiT = float_T(2.0)*alphaTilt;
 
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
-         * documentation purposes. */
-        /* const float_T eta = (PI / 2) - (phiReal - alphaTilt); */
+         * documentation purposes.
+         * const float_T eta = (PI / 2) - (phiReal - alphaTilt);
+         */
 
         const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
@@ -246,7 +257,8 @@ namespace twts
         const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
-         * thus help with formal code verification through manual code inspection. */
+         * thus help with formal code verification through manual code inspection.
+         */
         const complex_T helpVar1 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
         const complex_T helpVar2 = complex_T(0,-1)*cspeed*om0*tauG*tauG
                                     - y*cosPhi / cosPhi2 / cosPhi2*tanPhi2
@@ -306,7 +318,8 @@ namespace twts
                 )
             )
         /* The "round-trip" conversion in the line below fixes a gross accuracy bug
-         * in floating-point arithmetics, when float_T is set to float_X. */
+         * in floating-point arithmetics, when float_T is set to float_X.
+         */
         ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2) );
 
         const complex_T helpVar5 = cspeed*om0*tauG*tauG
@@ -327,7 +340,8 @@ namespace twts
     EField::calcTWTSEy( const float3_64& pos, const float_64 time) const
     {
         /* The field function of Ey (polarization in pulse-front-tilt plane)
-         * is by definition identical to Ex (polarization normal to pulse-front-tilt plane) */
+         * is by definition identical to Ex (polarization normal to pulse-front-tilt plane)
+         */
         return calcTWTSEx( pos, time );
     }
 

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -244,6 +244,19 @@ namespace twts
         return result.get_real();
     }
 
+    /** Calculate the Ey(r,t) field here
+     *
+     * \param pos Spatial position of the target field.
+     * \param time Absolute time (SI, including all offsets and transformations) for calculating
+     *             the field */
+    HDINLINE EField::float_T
+    EField::calcTWTSEy( const float3_64& pos, const float_64 time) const
+    {
+        /* The field function of Ey (polarization in pulse-front-tilt plane)
+         * is by definition identical to Ex (polarization normal to pulse-front-tilt plane) */
+        return calcTWTSEx( pos, time );
+    }
+    
 } /* namespace twts */
 } /* namespace templates */
 } /* namespace picongpu */

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -54,7 +54,7 @@ namespace twts
                     const float_X phi,
                     const float_X beta_0,
                     const float_64 tdelay_user_SI,
-                    const bool auto_tdelay
+                    const bool auto_tdelay,
                     const PolarizationType pol ) :
         focus_y_SI(focus_y_SI), wavelength_SI(wavelength_SI),
         pulselength_SI(pulselength_SI), w_x_SI(w_x_SI),

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -80,6 +80,8 @@ namespace twts
         for (uint32_t i = 0; i<simDim;++i) pos[i] = eFieldPositions_SI[0][i];
         return float3_X( float_X( calcTWTSEx(pos,time) ),
                          float_X(0.), float_X(0.) );
+        //return float3_X( float_X( pos.x() ),
+        //                 float_X( pos.y() ), float_X( pos.z() ) );
     }
 
     template<>
@@ -144,18 +146,18 @@ namespace twts
         /* Angle between the laser pulse front and the y-axis. Not used, but remains in code for
          * documentation purposes. */
         /* const float_T eta = (PI / 2) - (phiReal - alphaTilt); */
-
-        const float_T cspeed = float_T(1.0);
+        
+        const float_T cspeed = float_T( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
         const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-        const float_T om0 = float_T(2.0*PI*cspeed / lambda0*UNIT_TIME);
+        const float_T om0 = float_T(2.0*PI*cspeed / lambda0);
         /* factor 2  in tauG arises from definition convention in laser formula */
         const float_T tauG = float_T(pulselength_SI*2.0 / UNIT_TIME);
         /* w0 is wx here --> w0 could be replaced by wx */
         const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-        const float_T rho0 = float_T(PI*w0*w0/lambda0/UNIT_LENGTH);
+        const float_T rho0 = float_T(PI*w0*w0/lambda0);
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-        const float_T k = float_T(2.0*PI / lambda0*UNIT_LENGTH);
+        const float_T k = float_T(2.0*PI / lambda0);
         const float_T x = float_T(pos.x() / UNIT_LENGTH);
         const float_T y = float_T(pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -169,7 +169,15 @@ namespace twts
                 fieldSolver::NumericalCellType::getEFieldPosition(),unit_length,focus_y_SI,phi);
 
         /* Single TWTS-Pulse */
-        return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI);
+        switch (pol)
+        {
+            case NORMAL_TO_TILTPLANE :
+            return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI);
+            
+            case WITHIN_TILTPLANE :
+            return getTWTSEfield_Normalized_Ey<simDim>(eFieldPositions_SI, time_SI);
+        }
+        return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI); // defensive default
     }
 
     /** Calculate the Ex(r,t) field here

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -81,8 +81,6 @@ namespace twts
         for (uint32_t i = 0; i<simDim;++i) pos[i] = eFieldPositions_SI[0][i];
         return float3_X( float_X( calcTWTSEx(pos,time) ),
                          float_X(0.), float_X(0.) );
-        //return float3_X( float_X( pos.x() ),
-        //                 float_X( pos.y() ), float_X( pos.z() ) );
     }
 
     template<>
@@ -91,14 +89,18 @@ namespace twts
                 const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
                 const float_64 time) const
     {
-        PMacc::math::Vector<float3_64,detail::numComponents> pos(0.0);
+        typedef PMacc::math::Vector<float3_64,detail::numComponents> PosVecVec;
+        PosVecVec pos(PosVecVec::create(
+                                           float3_64::create(0.0)
+                                       ));
+        
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             for (uint32_t i = 0; i<simDim;++i) pos[k][i] = eFieldPositions_SI[k][i];
         }
         
-        /* Calculate Ey-component with the Yee-Cell offset of a Ey-field */
+        /* Calculate Ey-component with the intra-cell offset of a Ey-field */
         const float_64 Ey_Ey = calcTWTSEy(pos[1], time);
-        /* Calculate Ey-component with the Yee-Cell offset of a Ez-field */
+        /* Calculate Ey-component with the intra-cell offset of a Ez-field */
         const float_64 Ey_Ez = calcTWTSEy(pos[2], time);
 
         /* Since we rotated all position vectors before calling calcTWTSEy,
@@ -133,7 +135,11 @@ namespace twts
         const PMacc::math::Vector<floatD_64,detail::numComponents>& eFieldPositions_SI,
         const float_64 time) const
     {
-        PMacc::math::Vector<float3_64,detail::numComponents> pos(0.0);
+        typedef PMacc::math::Vector<float3_64,detail::numComponents> PosVecVec;
+        PosVecVec pos(PosVecVec::create(
+                                           float3_64::create(0.0)
+                                       ));
+        
         /* The 2D output of getFieldPositions_SI only returns
          * the y- and z-component of a 3D vector. */
         for (uint32_t k = 0; k<detail::numComponents;++k) {
@@ -141,9 +147,9 @@ namespace twts
         }
         
         /* Ey->Ey, but grid cell offsets for Ex and Ey have to be used. */
-        /* Calculate Ey-component with the Yee-Cell offset of a Ey-field */
+        /* Calculate Ey-component with the intra-cell offset of a Ey-field */
         const float_64 Ey_Ey = calcTWTSEy(pos[1], time);
-        /* Calculate Ey-component with the Yee-Cell offset of a Ex-field */
+        /* Calculate Ey-component with the intra-cell offset of a Ex-field */
         const float_64 Ey_Ex = calcTWTSEy(pos[0], time);
 
         /* Since we rotated all position vectors before calling calcTWTSEy,


### PR DESCRIPTION
This update includes the new feature of a TWTS laser, which now can be also polarized within the plane of the pulse-front tilt (in-plane) instead of normal polarization. This option can be controlled with an (optional) flag in the interface. The laser pulse has been extensively tested, both analytically and numerically.

Furthermore, this update fixes some variable normalization bugs, as well as some obscure, crippling arithmetic issues between double and single precision calculations. This means now, single precision calculations also deliver correct results and have the benefit of a 4-5 times speed-up in time step performance within vacuum. Have fun! :smile: