### PR TITLE
split `ConstVector` definition and instantiation

### DIFF
--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -33,11 +33,14 @@
 #define PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id) using namespace PMACC_JOIN(pmacc_static_const_vector_host,id)
 #endif
 
-/** @see PMACC_CONST_VECTOR documentation, only unique "id" is added
+/** define a const vector
+ *
+ * create type definition `Name_t`
+ * @see PMACC_CONST_VECTOR documentation, only unique "id" is added
  *
  * @param id unique precompiler id to create unique namespaces
  */
-#define PMACC_STATIC_CONST_VECTOR_DIM(id,Name,Type,Dim,count,...)               \
+#define PMACC_STATIC_CONST_VECTOR_DIM_DEF(id,Name,Type,Dim,count,...)          \
 namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
 {                                                                              \
     namespace PMACC_JOIN(pmacc_static_const_vector_device,id)                  \
@@ -64,7 +67,7 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
         }                                                                      \
         HDINLINE const type& operator[](const int idx) const                   \
         {                                                                      \
-        /*access const C array with the name of array*/                    \
+            /*access const C array with the name of array*/                    \
             return PMACC_JOIN(Name,_data)[idx];                                \
         }                                                                      \
     };                                                                         \
@@ -75,6 +78,14 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
         PMacc::math::StandartAccessor,                                         \
         PMacc::math::StandartNavigator,                                        \
         ConstArrayStorage > PMACC_JOIN(Name,_t);                               \
+} /* namespace pmacc_static_const_storage + id */                              \
+using namespace PMACC_JOIN(pmacc_static_const_storage,id)
+
+/** create a instance of type `Name_t` with the name `Name`
+ */
+#define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE(id,Name,Type,Dim,count,...)     \
+namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
+{                                                                              \
     namespace PMACC_JOIN(pmacc_static_const_vector_device,id)                  \
     {                                                                          \
         /* create const instance on device */                                  \
@@ -85,9 +96,25 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
         /* create const instance on host*/                                     \
         const PMACC_JOIN(Name,_t) Name;                                        \
     } /* namespace pmacc_static_const_vector_host + id  */                     \
-} /* namespace pmacc_static_const_storage + id */                              \
-using namespace PMACC_JOIN(pmacc_static_const_storage,id)
+} /* namespace pmacc_static_const_storage + id */
 
+/** @see PMACC_CONST_VECTOR documentation, only unique "id" is added
+ *
+ * @param id unique precompiler id to create unique namespaces
+ */
+#define PMACC_STATIC_CONST_VECTOR_DIM(id,Name,Type,Dim,count,...)              \
+    PMACC_STATIC_CONST_VECTOR_DIM_DEF(id,Name,Type,Dim,count,__VA_ARGS__);     \
+    PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE(id,Name,Type,Dim,count,__VA_ARGS__)
+
+
+/** define a const vector
+ *
+ * for description @see PMACC_CONST_VECTOR
+ *
+ * create type definition `name_t`
+ */
+#define PMACC_CONST_VECTOR_DEF(type,dim,name,...)                              \
+    PMACC_STATIC_CONST_VECTOR_DIM_DEF(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(__VA_ARGS__),__VA_ARGS__)
 
 /** Create global constant math::Vector with compile time values which can be
  *  used on device and host
@@ -107,4 +134,3 @@ using namespace PMACC_JOIN(pmacc_static_const_storage,id)
  */
 #define PMACC_CONST_VECTOR(type,dim,name,...)                                   \
     PMACC_STATIC_CONST_VECTOR_DIM(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(__VA_ARGS__),__VA_ARGS__)
-


### PR DESCRIPTION
split the creation of `ConstVector` definition and instantiation

- add macro `PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE`
- add macro `PMACC_STATIC_CONST_VECTOR_DIM_DEF`
- add macro `PMACC_CONST_VECTOR_DEF`

**This pull request is fully backward compatible to the old version**