### PR TITLE
add exclusive node reservation for hypnos

### DIFF
--- a/src/picongpu/submit/hypnos/fermi_profile.tpl
+++ b/src/picongpu/submit/hypnos/fermi_profile.tpl
@@ -45,6 +45,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # send me a mail on (b)egin, (e)nd, (a)bortion
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
+#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr

--- a/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
@@ -1,22 +1,22 @@
 #!/bin/bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
 
 ## calculation are done by tbg ##
@@ -47,6 +47,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # send me a mail on (b)egin, (e)nd, (a)bortion
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
+#PBS -n
 
 #PBS -W depend=afterany:!TBG_waitJob
 

--- a/src/picongpu/submit/hypnos/k20_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_profile.tpl
@@ -1,22 +1,22 @@
 #!/bin/bash
 # Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
 
 ## calculation are done by tbg ##
@@ -44,6 +44,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # send me a mail on (b)egin, (e)nd, (a)bortion
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
+#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr

--- a/src/picongpu/submit/hypnos/k20_vampir_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_vampir_profile.tpl
@@ -1,22 +1,22 @@
 #!/bin/bash
 # Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
 
 ## calculation are done by tbg ##
@@ -44,6 +44,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # send me a mail on (b)egin, (e)nd, (a)bortion
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
+#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr

--- a/src/picongpu/submit/hypnos/k20_wait_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_wait_profile.tpl
@@ -1,22 +1,22 @@
 #!/bin/bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
 
 ## calculation are done by tbg ##
@@ -44,6 +44,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # send me a mail on (b)egin, (e)nd, (a)bortion
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
+#PBS -n
 
 #PBS -W depend=afterany:!TBG_waitJob
 


### PR DESCRIPTION
If a fewer amount of gpu's were used as in a node exists `cuda_memcheck` crashed if another process already used the gpu with `ID=0`. To avoid this we always reserve nodes exclusive.

- add option `-n` (exclusive node reservation) to hypnos submit templates