### PR TITLE
update hypnos `picongpu.profile.example`

### DIFF
--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -10,17 +10,16 @@ then
         # Core Dependencies
         module load gcc/4.6.2
         module load cmake/3.0.1
-        module load openmpi/1.6.3
         module load boost/1.54.0
         module load cuda/6.5
-        module load mallocmc/2.0.1
+        module load openmpi/1.8.4.kepler
 
         # Plugins (optional)
         module load pngwriter/0.5.4
-        module load hdf5-parallel/1.8.14 libsplash/1.2.3
+        module load hdf5-parallel/1.8.14 libsplash/1.2.4
 
         # either use libSplash or ADIOS for file I/O
-        #module load libmxml/2.8 filelib/adios/1.7.0
+        #module load libmxml/2.8 adios/1.8.0
 
         # Debug Tools
         #module load valgrind/3.8.1


### PR DESCRIPTION
- update openmpi to `1.8.4.kepler` (k20/k80 compatible)
- update adios to `1.8.0` and correct module name
- update libsplash to `1.8.0`