### PR TITLE
ArgsParser: add `validate` command line option

### DIFF
--- a/src/picongpu/ArgsParser.cpp
+++ b/src/picongpu/ArgsParser.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera
+ * Copyright 2013, 2015 Axel Huebl, Felix Schmitt, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -61,7 +61,7 @@ namespace picongpu
         return instance;
     }
 
-    bool ArgsParser::parse( int argc, char** argv )
+    ArgsParser::ArgsErrorCode ArgsParser::parse( int argc, char** argv )
     throw (std::runtime_error )
     {
         try
@@ -76,7 +76,8 @@ namespace picongpu
 
             // add possible options
             desc.add_options()
-                    ( "help,h", "print help message" )
+                    ( "help,h", "print help message and exit" )
+                    ( "validate", "validate command line parameters and exit" )
                     ( "config,c", po::value<std::vector<std::string> > ( &config_files )->multitoken( ), "Config file(s)" )
                     ;
 
@@ -109,16 +110,23 @@ namespace picongpu
             if ( vm.count( "help" ) )
             {
                 std::cerr << desc << "\n";
-                return false;
+                return SUCCESS_EXIT;
+            }
+            if ( vm.count( "validate" ) )
+            {
+                /* if we reach this part of code the parameters are valid
+                 * and the option `validate` is set.
+                 */
+                return SUCCESS_EXIT;
             }
         }
         catch ( boost::program_options::error& e )
         {
             std::cerr << e.what() << std::endl;
-            return false;
+            return ERROR;
         }
 
-        return true;
+        return SUCCESS;
     }
 
 }

--- a/src/picongpu/include/ArgsParser.hpp
+++ b/src/picongpu/include/ArgsParser.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera
+ * Copyright 2013, 2015 Axel Huebl, Felix Schmitt, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -19,9 +19,7 @@
  */
 
 
-
-#ifndef ARGSPARSER_HPP
-#define	ARGSPARSER_HPP
+#pragma once
 
 #include <boost/program_options/options_description.hpp>
 
@@ -44,6 +42,7 @@ namespace picongpu
     {
     public:
 
+        enum ArgsErrorCode {SUCCESS=0,SUCCESS_EXIT=1,ERROR=42};
         /**
          * Returns an instance of ArgsParser
          *
@@ -63,7 +62,7 @@ namespace picongpu
          * @param argv command line arguments
          * @return true if the simulation should proceed, false otherwise
          */
-        bool parse(int argc, char **argv) throw (std::runtime_error);
+        ArgsErrorCode parse(int argc, char **argv) throw (std::runtime_error);
 
 
 
@@ -79,6 +78,3 @@ namespace picongpu
     };
 
 }
-
-#endif	/* ARGSPARSER_HPP */
-

--- a/src/picongpu/include/simulationControl/ISimulationStarter.hpp
+++ b/src/picongpu/include/simulationControl/ISimulationStarter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -19,15 +19,12 @@
  */
 
 
-
-#ifndef ISIMULATIONSTARTER_HPP
-#define	ISIMULATIONSTARTER_HPP
-
-#include "types.h"
-#include "simulation_defines.hpp"
-
+#pragma once
 
 #include "pluginSystem/IPlugin.hpp"
+#include "ArgsParser.hpp"
+#include "simulation_defines.hpp"
+#include "types.h"
 
 namespace picongpu
 {
@@ -48,7 +45,7 @@ namespace picongpu
          *
          * @return true if no error else false
          */
-        virtual bool parseConfigs(int argc, char **argv) = 0;
+        virtual ArgsParser::ArgsErrorCode parseConfigs(int argc, char **argv) = 0;
 
         /*start simulation
          * is called after parsConfig and pluginLoad
@@ -66,6 +63,3 @@ namespace picongpu
         }
     };
 }
-
-#endif	/* ISIMULATIONSTARTER_HPP */
-

--- a/src/picongpu/include/simulationControl/SimulationStarter.hpp
+++ b/src/picongpu/include/simulationControl/SimulationStarter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013, 2015 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -94,7 +94,7 @@ namespace picongpu
         {
         }
 
-        bool parseConfigs(int argc, char **argv)
+        ArgsParser::ArgsErrorCode parseConfigs(int argc, char **argv)
         {
             ArgsParser& ap = ArgsParser::getInstance();
             PluginConnector& pluginConnector = Environment<>::get().PluginConnector();


### PR DESCRIPTION
- add command line option `validate`
- `ArgsParser`:
  - add enum `ArgsErrorCode`
  - change return code of parse from `bool` to `ArgsErrorCode`
- `main.cu`: handle ArgsParser error codes

`validate` validates the command line options without starting the simulation