### PR TITLE
Add boost bool_switch to radiation plugin

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -96,17 +96,18 @@ TBG_movingWindow="-m"
 # For a full description, see the plugins section in the online wiki.
 #--<species>_radiation.period 	Radiation is calculated every .period steps. Currently 0 or 1
 #--<species>_radiation.dump 	Period, after which the calculated radiation data should be dumped to the file system
-#--<species>_radiation.lastRadiation 	If set to 1, the spectra summed between the last and the current dump-time-step are stored
+#--<species>_radiation.lastRadiation 	If flag is set, the spectra summed between the last and the current dump-time-step are stored
 #--<species>_radiation.folderLastRad 	Folder in which the summed spectra are stored
-#--<species>_radiation.totalRadiation 	Set to 1 to store spectra summed from simulation start till current time step
+#--<species>_radiation.totalRadiation 	If flag is set, store spectra summed from simulation start till current time step
 #--<species>_radiation.folderTotalRad 	Folder in which total radiation spectra are stored
 #--<species>_radiation.start 	Time step to start calculating the radition
 #--<species>_radiation.end 	Time step to stop calculating the radiation
 #--<species>_radiation.omegaList 	If spectrum frequencies are taken from a file, this gives the path to this list
-#--<species>_radiation.radPerGPU 	If set to 1, each GPU stores its own spectra without summing the entire simulation area
+#--<species>_radiation.radPerGPU 	If flag is set, each GPU stores its own spectra without summing the entire simulation area
 #--<species>_radiation.folderRadPerGPU 	Folder where the GPU specific spectras are stored
-TBG_radiation="--<species>_radiation.period 1 --<species>_radiation.dump 2 --<species>_radiation.totalRadiation 1 \
-               --<species>_radiation.lastRadiation 0 --<species>_radiation.start 2800 --<species>_radiation.end 3000"
+#--e_<species>_radiation.compression    If flag is set, the hdf5 output will be compressed.
+TBG_radiation="--<species>_radiation.period 1 --<species>_radiation.dump 2 --<species>_radiation.totalRadiation \
+               --<species>_radiation.lastRadiation --<species>_radiation.start 2800 --<species>_radiation.end 3000"
 
 
 # Create 2D images in PNG format every .period steps.

--- a/examples/Bunch/submit/bunch_0032.cfg
+++ b/examples/Bunch/submit/bunch_0032.cfg
@@ -47,8 +47,8 @@ TBG_periodic="--periodic 1 0 1"
 ## Section: Optional Variables ##
 #################################s
 
-TBG_radiation="--e_radiation.period 1 --e_radiation.dump 2 --e_radiation.totalRadiation 1 \
-               --e_radiation.lastRadiation 0 --e_radiation.start 2800 --e_radiation.end 3000"
+TBG_radiation="--e_radiation.period 1 --e_radiation.dump 2 --e_radiation.totalRadiation \
+               --e_radiation.start 2800 --e_radiation.end 3000"
 
 TBG_pngYX="--e_png.period 100 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 

--- a/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
+++ b/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
@@ -49,7 +49,7 @@ TBG_periodic="--periodic 1 0 1"
 TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
 TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
-TBG_radiation="--e_radiation.period 1 --e_radiation.dump 40 --e_radiation.totalRadiation 1 --e_radiation.lastRadiation 0"
+TBG_radiation="--e_radiation.period 1 --e_radiation.dump 40 --e_radiation.totalRadiation"
 
 TBG_plugins="!TBG_pngYX                    \
               !TBG_pngYZ                    \

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -195,16 +195,16 @@ public:
         desc.add_options()
             ((analyzerPrefix + ".period").c_str(), po::value<uint32_t > (&notifyFrequency), "enable analyser [for each n-th step]")
             ((analyzerPrefix + ".dump").c_str(), po::value<uint32_t > (&dumpPeriod)->default_value(0), "dump integrated radiation from last dumped step [for each n-th step] (0 = only print data at end of simulation)")
-            ((analyzerPrefix + ".lastRadiation").c_str(), po::value<bool > (&lastRad)->default_value(false), "enable(1)/disable(0) calculation integrated radiation from last dumped step")
+            ((analyzerPrefix + ".lastRadiation").c_str(), po::bool_switch(&lastRad), "enable(1)/disable(0) calculation integrated radiation from last dumped step")
             ((analyzerPrefix + ".folderLastRad").c_str(), po::value<std::string > (&folderLastRad)->default_value("lastRad"), "folder in which the integrated radiation from last dumped step is written")
-            ((analyzerPrefix + ".totalRadiation").c_str(), po::value<bool > (&totalRad)->default_value(false), "enable(1)/disable(0) calculation integrated radiation from start of simulation")
+            ((analyzerPrefix + ".totalRadiation").c_str(), po::bool_switch(&totalRad), "enable(1)/disable(0) calculation integrated radiation from start of simulation")
             ((analyzerPrefix + ".folderTotalRad").c_str(), po::value<std::string > (&folderTotalRad)->default_value("totalRad"), "folder in which the integrated radiation from start of simulation is written")
             ((analyzerPrefix + ".start").c_str(), po::value<uint32_t > (&radStart)->default_value(2), "time index when radiation should start with calculation")
             ((analyzerPrefix + ".end").c_str(), po::value<uint32_t > (&radEnd)->default_value(0), "time index when radiation should end with calculation")
             ((analyzerPrefix + ".omegaList").c_str(), po::value<std::string > (&pathOmegaList)->default_value("_noPath_"), "path to file containing all frequencies to calculate")
-            ((analyzerPrefix + ".radPerGPU").c_str(), po::value<bool > (&radPerGPU)->default_value(false), "enable(1)/disable(0) radiation output from each GPU individually")
+            ((analyzerPrefix + ".radPerGPU").c_str(), po::bool_switch(&radPerGPU), "enable(1)/disable(0) radiation output from each GPU individually")
             ((analyzerPrefix + ".folderRadPerGPU").c_str(), po::value<std::string > (&folderRadPerGPU)->default_value("radPerGPU"), "folder in which the radiation of each GPU is written")
-            ((analyzerPrefix + ".compression").c_str(), po::value<bool > (&compressionOn)->default_value(false), "enable(1)/disable(0) compression of hdf5 output");
+            ((analyzerPrefix + ".compression").c_str(), po::bool_switch(&compressionOn), "enable(1)/disable(0) compression of hdf5 output");
     }
 
 

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -195,16 +195,16 @@ public:
         desc.add_options()
             ((analyzerPrefix + ".period").c_str(), po::value<uint32_t > (&notifyFrequency), "enable analyser [for each n-th step]")
             ((analyzerPrefix + ".dump").c_str(), po::value<uint32_t > (&dumpPeriod)->default_value(0), "dump integrated radiation from last dumped step [for each n-th step] (0 = only print data at end of simulation)")
-            ((analyzerPrefix + ".lastRadiation").c_str(), po::bool_switch(&lastRad), "enable(1)/disable(0) calculation integrated radiation from last dumped step")
+            ((analyzerPrefix + ".lastRadiation").c_str(), po::bool_switch(&lastRad), "enable calculation of integrated radiation from last dumped step")
             ((analyzerPrefix + ".folderLastRad").c_str(), po::value<std::string > (&folderLastRad)->default_value("lastRad"), "folder in which the integrated radiation from last dumped step is written")
-            ((analyzerPrefix + ".totalRadiation").c_str(), po::bool_switch(&totalRad), "enable(1)/disable(0) calculation integrated radiation from start of simulation")
+            ((analyzerPrefix + ".totalRadiation").c_str(), po::bool_switch(&totalRad), "enable calculation of integrated radiation from start of simulation")
             ((analyzerPrefix + ".folderTotalRad").c_str(), po::value<std::string > (&folderTotalRad)->default_value("totalRad"), "folder in which the integrated radiation from start of simulation is written")
             ((analyzerPrefix + ".start").c_str(), po::value<uint32_t > (&radStart)->default_value(2), "time index when radiation should start with calculation")
             ((analyzerPrefix + ".end").c_str(), po::value<uint32_t > (&radEnd)->default_value(0), "time index when radiation should end with calculation")
             ((analyzerPrefix + ".omegaList").c_str(), po::value<std::string > (&pathOmegaList)->default_value("_noPath_"), "path to file containing all frequencies to calculate")
-            ((analyzerPrefix + ".radPerGPU").c_str(), po::bool_switch(&radPerGPU), "enable(1)/disable(0) radiation output from each GPU individually")
+            ((analyzerPrefix + ".radPerGPU").c_str(), po::bool_switch(&radPerGPU), "enable radiation output from each GPU individually")
             ((analyzerPrefix + ".folderRadPerGPU").c_str(), po::value<std::string > (&folderRadPerGPU)->default_value("radPerGPU"), "folder in which the radiation of each GPU is written")
-            ((analyzerPrefix + ".compression").c_str(), po::bool_switch(&compressionOn), "enable(1)/disable(0) compression of hdf5 output");
+            ((analyzerPrefix + ".compression").c_str(), po::bool_switch(&compressionOn), "enable compression of hdf5 output");
     }
 
 


### PR DESCRIPTION
This pull request replaces the `po::value<bool >` workaround with [`po::bool_switch`](http://www.boost.org/doc/libs/1_57_0/doc/html/boost/program_options/bool_switch.html).

This simplifies the command line flags of the radiation plugin.

**ToDo:**
 - [x] perform run time test with new flag structe
 - [x] update wiki description of command line flags

**Update:**
Old submit scripts will **not result in a crash of `picongpu`**. 
However,  `--e_radiation.lastRad 0` will be **switch its meaning** and activate `lastRad` while `--e_radiation.lastRad 1` **keeps its meaning** and activate `lastRad` (integer values will be ignored). 