### PR TITLE
fix radiation if ions are used in LWFA example

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera, Marco Garten
+ * Copyright 2013-2015 Rene Widera, Marco Garten, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -74,6 +74,8 @@ AttributRadiationFlag
 typedef
 typename MakeSeq<
 DefaultParticleAttributes,
+AttributMomentum_mt1,
+AttributRadiationFlag,
 boundElectrons
 >::type AttributeSeqIons;
 


### PR DESCRIPTION
If **ions and radiation** are both used in a setup derived from the `examples/LaserWakefield`, a massiv template error occures which, due to its lengthy error message, is hard to fix. 

This "bug" exists since the creation of `speciesDefinition.param` in this directory on **Jan. 27 2015**.

Thus this pull request adds radiation attributes to the ions to avoid a compile time error.

In a future pull request we should :
 - set the automated compile suite up to check if radiation still works for the *Laser Wakefield example* 
 - allow radiation plugins only for suited species