### PR TITLE
math::Vector<...> fix const storage handling

### DIFF
--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -58,6 +58,7 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
     template<typename T_Type, int T_Dim>                                       \
     struct ConstArrayStorage                                                   \
     {                                                                          \
+        static const bool isConst = true;                                      \
         typedef T_Type type;                                                   \
         static const int dim=T_Dim;                                            \
         HDINLINE type& operator[](const int idx)                               \


### PR DESCRIPTION
The current implementation of `math::Vector<>` takes no care whether the used internal data storage is const (not copyable). This produce compile time errors if a `ConstVector`  from `math/ConstVector.hpp` is used as member in a class and the class is copied.

- add functor CopyElementWise<bool>
- use CopyElementWise in implicit math::Vector copy constructor

**This pull request affects the `master` and the `release-0.1.0` but there is no usage of `ConstVector` as class member.** 

example what kind of code not compiles:
```C++
CONST_VECTOR(float_64, simDim, GaussianCloudParam_center, 1.134e-5, 1.134e-5, 1.134e-5);

struct GaussianCloudParam
{
    const GaussianCloudParam_center_t center_si;
};
```