### PR TITLE
Refactor ionization: remove from `Particles` class member functions

### DIFF
--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Marco Garten
  *
  * This file is part of PIConGPU.
@@ -71,10 +71,6 @@ public:
     void synchronize();
 
     void syncToDevice();
-
-    //Ionization
-    template<typename T_Elec>
-    void ionize(T_Elec electrons, uint32_t currentStep);
 
 private:
     SimulationDataId datasetID;

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *
@@ -29,9 +29,6 @@
 
 
 #include "particles/Particles.kernel"
-
-// Ionization
-#include "particles/ionization/ionization.hpp"
 
 #include "dataManagement/DataConnector.hpp"
 #include "mappings/kernel/AreaMapping.hpp"

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -156,7 +156,11 @@ struct CallUpdate
 };
 
 /** \struct CallIonization
- * \brief Tests if species can be ionized and calls the kernel to do that */
+ * 
+ * \brief Tests if species can be ionized and calls the kernel to do that
+ *
+ * \tparam T_SpeciesName name of particle species that is checked for ionization
+ */
 template<typename T_SpeciesName>
 struct CallIonization
 {
@@ -166,10 +170,14 @@ struct CallIonization
     /* SelectIonizer will be either the specified one or fallback: None */
     typedef typename GetIonizer<SpeciesType>::type SelectIonizer;
 
-    /* Functor implementation
+    /** Functor implementation
+     *
      * \tparam T_StorageStuple contains info about the particle species
      * \tparam T_CellDescription contains the number of blocks and blocksize
      *                           that is later passed to the kernel
+     * \param tuple An n-tuple containing the type-info of multiple particle species
+     * \param cellDesc points to logical block information like dimension and cell sizes
+     * \param currentStep The current time step
      */
     template<typename T_StorageTuple, typename T_CellDescription>
     HINLINE void operator()(

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -184,7 +184,8 @@ struct CallIonization
         {
 
             /* define the type of the species to be created
-             * from inside the ionization model specialization */
+             * from inside the ionization model specialization
+             */
             typedef typename SelectIonizer::DestSpecies DestSpecies;
             /* alias for pointer on source species */
             PMACC_AUTO(srcSpeciesPtr, tuple[SpeciesName()]);
@@ -206,10 +207,11 @@ struct CallIonization
                 (block)
                 ( srcSpeciesPtr->getDeviceParticlesBox( ),
                   electronsPtr->getDeviceParticlesBox( ),
-                  SelectIonizer()
+                  SelectIonizer(currentStep)
                   );
             /* fill the gaps in the created species' particle frames to ensure that only
-             * the last frame is not completely filled but every other before is full */
+             * the last frame is not completely filled but every other before is full
+             */
             electronsPtr->fillAllGaps();
 
         }

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera, Marco Garten
+ * Copyright 2014-2015 Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -155,29 +155,64 @@ struct CallUpdate
     }
 };
 
-/* Tests if species can be ionized and calls the function to do that */
+/** \struct CallIonization
+ * \brief Tests if species can be ionized and calls the kernel to do that */
 template<typename T_SpeciesName>
 struct CallIonization
 {
     typedef T_SpeciesName SpeciesName;
     typedef typename SpeciesName::type SpeciesType;
-    
+    typedef typename SpeciesType::FrameType FrameType;
+    /* SelectIonizer will be either the specified one or fallback: None */
     typedef typename GetIonizer<SpeciesType>::type SelectIonizer;
 
-    /* describes the instance of CallIonization */
-    template<typename T_StorageTuple>
+    /* Functor implementation
+     * \tparam T_StorageStuple contains info about the particle species
+     * \tparam T_CellDescription contains the number of blocks and blocksize
+     *                           that is later passed to the kernel
+     */
+    template<typename T_StorageTuple, typename T_CellDescription>
     HINLINE void operator()(
                         T_StorageTuple& tuple,
+                        T_CellDescription* cellDesc,
                         const uint32_t currentStep
                         ) const
     {
-        
-        /* alias for pointer on source species */
-        PMACC_AUTO(speciesPtr, tuple[SpeciesName()]);
-        /* instance of particle ionizer that was flagged in speciesDefinition.param */
-        SelectIonizer myIonizer;
-        myIonizer(*speciesPtr, tuple, currentStep);
-        
+        /* only if an ionizer has been specified, this is executed */
+        typedef typename HasFlag<FrameType, ionizer<> >::type hasIonizer;
+        if (hasIonizer::value)
+        {
+
+            /* define the type of the species to be created
+             * from inside the ionization model specialization */
+            typedef typename SelectIonizer::DestSpecies DestSpecies;
+            /* alias for pointer on source species */
+            PMACC_AUTO(srcSpeciesPtr, tuple[SpeciesName()]);
+            /* alias for pointer on destination species */
+            PMACC_AUTO(electronsPtr,  tuple[typename MakeIdentifier<DestSpecies>::type()]);
+
+            /* 3-dim vector : number of threads to be started in every dimension */
+            dim3 block( MappingDesc::SuperCellSize::toRT().toDim3() );
+
+            /** kernelIonizeParticles
+             * \brief calls the ionization model and handles that electrons are created correctly
+             *        while cycling through the particle frames
+             *
+             * kernel call : instead of name<<<blocks, threads>>> (args, ...)
+             * "blocks" will be calculated from "this->cellDescription" and "CORE + BORDER"
+             * "threads" is calculated from the previously defined vector "block"
+             */
+            __picKernelArea( particles::ionization::kernelIonizeParticles, *cellDesc, CORE + BORDER )
+                (block)
+                ( srcSpeciesPtr->getDeviceParticlesBox( ),
+                  electronsPtr->getDeviceParticlesBox( ),
+                  SelectIonizer()
+                  );
+            /* fill the gaps in the created species' particle frames to ensure that only
+             * the last frame is not completely filled but every other before is full */
+            electronsPtr->fillAllGaps();
+
+        }
     }
 
 }; // struct CallIonization

--- a/src/picongpu/include/particles/ionization/None/AlgorithmNone.hpp
+++ b/src/picongpu/include/particles/ionization/None/AlgorithmNone.hpp
@@ -22,9 +22,13 @@
 
 #include "types.h"
 
-/** IONIZATION ALGORITHM
+/** \file AlgorithNone.hpp
+ *
+ * IONIZATION ALGORITHM for the model None
+ *
  * - implements the calculation of ionization probability and changes charge states
- * - is called with the IONIZATION MODEL, specifically by setting the flag in @see speciesDefinition.param */
+ * - is called with the IONIZATION MODEL, specifically by setting the flag in @see speciesDefinition.param
+ */
 
 namespace picongpu
 {
@@ -34,11 +38,14 @@ namespace ionization
 {
 
     /** \struct AlgorithmNone
-     * \brief ionization algorithm that does nothing  */
+     *
+     * \brief ionization algorithm that does nothing
+     */
     struct AlgorithmNone
     {
 
         /** Functor implementation
+         *
          * \tparam EType type of electric field
          * \tparam BType type of magnetic field
          * \tparam ParticleType type of particle to be ionized

--- a/src/picongpu/include/particles/ionization/None/None.def
+++ b/src/picongpu/include/particles/ionization/None/None.def
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "types.h"
+
 namespace picongpu
 {
 namespace particles
@@ -29,7 +31,14 @@ namespace ionization
 
     /** \struct None
      * \brief Fallback for all species that cannot/should not be ionized */
-    struct None;
+    template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
+    struct None_Impl;
+
+    template<typename T_DestSpecies>
+    struct None
+    {
+        typedef None_Impl<T_DestSpecies> type;
+    };
 
 } // namespace ionization
 } // namespace particles

--- a/src/picongpu/include/particles/ionization/None/None.def
+++ b/src/picongpu/include/particles/ionization/None/None.def
@@ -30,7 +30,8 @@ namespace ionization
 {
 
     /** \struct None_Impl
-     * \brief Empty ionization model
+     *
+     * \brief Empty ionization model [that is used for all species that are not ionized]
      *
      * \tparam T_DestSpecies electron species to be created
      * \tparam T_SrcSpecies particle species that is ionized
@@ -42,6 +43,7 @@ namespace ionization
     struct None_Impl;
 
     /** \struct None
+     *
      * \brief Fallback for all species that cannot/should not be ionized
      *
      * \tparam T_DestSpecies electron species to be created

--- a/src/picongpu/include/particles/ionization/None/None.def
+++ b/src/picongpu/include/particles/ionization/None/None.def
@@ -29,11 +29,12 @@ namespace particles
 namespace ionization
 {
 
-    /** \struct None
-     * \brief Fallback for all species that cannot/should not be ionized */
     template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
     struct None_Impl;
 
+    /** \struct None
+     * \brief Fallback for all species that cannot/should not be ionized
+     */
     template<typename T_DestSpecies>
     struct None
     {

--- a/src/picongpu/include/particles/ionization/None/None.def
+++ b/src/picongpu/include/particles/ionization/None/None.def
@@ -29,11 +29,27 @@ namespace particles
 namespace ionization
 {
 
+    /** \struct None_Impl
+     * \brief Empty ionization model
+     *
+     * \tparam T_DestSpecies electron species to be created
+     * \tparam T_SrcSpecies particle species that is ionized
+     *         default is boost::mpl placeholder because specialization
+     *         cannot be known in list of particle species' flags
+     *         \see speciesDefinition.param
+     */
     template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
     struct None_Impl;
 
     /** \struct None
      * \brief Fallback for all species that cannot/should not be ionized
+     *
+     * \tparam T_DestSpecies electron species to be created
+     *
+     * wrapper class,
+     * needed because the SrcSpecies cannot be known during the
+     * first specialization of the ionization model in the particle definition
+     * \see speciesDefinition.param
      */
     template<typename T_DestSpecies>
     struct None

--- a/src/picongpu/include/particles/ionization/None/None.hpp
+++ b/src/picongpu/include/particles/ionization/None/None.hpp
@@ -42,7 +42,7 @@ namespace ionization
             /* nothing here */
         public:
 
-            None_Impl()
+            None_Impl(const uint32_t currentStep)
             { /* ... */ }
 
             DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset)

--- a/src/picongpu/include/particles/ionization/None/None.hpp
+++ b/src/picongpu/include/particles/ionization/None/None.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "types.h"
 #include "particles/ionization/None/None.def"
 #include "particles/ionization/None/AlgorithmNone.hpp"
 
@@ -29,17 +30,33 @@ namespace particles
 {
 namespace ionization
 {
-            
+
     /* fallback for all species that cannot/should not be ionized */
-    struct None
+    template<typename T_DestSpecies, typename T_SrcSpecies>
+    struct None_Impl
     {
-        template<typename T_SrcSpecies, typename T_ParticleStorage>
-        void operator()(T_SrcSpecies& src, T_ParticleStorage& pst, const uint32_t currentStep)
-        {
-            // Do nothing
-        }
+        typedef T_DestSpecies DestSpecies;
+        typedef T_SrcSpecies  SrcSpecies;
+
+        private:
+            /* nothing here */
+        public:
+
+            None_Impl()
+            { /* ... */ }
+
+            DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset)
+            {
+                /* Do nothing */
+            }
+
+            template<typename FrameType>
+            DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
+            {
+                /* Do nothing */
+            }
     };
-            
+
 } // namespace ionization
 } // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/particles/ionization/None/None_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/None/None_Impl.hpp
@@ -39,21 +39,23 @@ namespace ionization
         typedef T_SrcSpecies  SrcSpecies;
 
         private:
-            /* nothing here */
+
         public:
 
             None_Impl(const uint32_t currentStep)
-            { /* ... */ }
-
-            DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset)
             {
-                /* Do nothing */
+
+            }
+
+            DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset) const
+            {
+
             }
 
             template<typename FrameType>
-            DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
+            DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons) const
             {
-                /* Do nothing */
+
             }
     };
 

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -26,10 +26,14 @@
 #include "traits/attribute/GetChargeState.hpp"
 #include "algorithms/math/floatMath/floatingPoint.tpp"
 
-/** IONIZATION ALGORITHM
+/** \file AlgorithmBSI.hpp
+ *
+ * IONIZATION ALGORITHM for the BSI model
+ *
  * - implements the calculation of ionization probability and changes charge states
  *   by decreasing the number of bound electrons
- * - is called with the IONIZATION MODEL, specifically by setting the flag in @see speciesDefinition.param */
+ * - is called with the IONIZATION MODEL, specifically by setting the flag in @see speciesDefinition.param
+ */
 
 namespace picongpu
 {
@@ -39,11 +43,14 @@ namespace ionization
 {
 
     /** \struct AlgorithmBSI
-     * \brief calculation for the Barrier Suppression Ionization model */
+     *
+     * \brief calculation for the Barrier Suppression Ionization model
+     */
     struct AlgorithmBSI
     {
-        
+
         /** Functor implementation
+         *
          * \tparam EType type of electric field
          * \tparam BType type of magnetic field
          * \tparam ParticleType type of particle to be ionized
@@ -59,9 +66,9 @@ namespace ionization
 
             const float_X protonNumber = GetAtomicNumbers<ParticleType>::type::numberOfProtons;
             float_X chargeState = attribute::getChargeState(parentIon);
-            
+
             uint32_t cs = math::float2int_rd(chargeState);
-            
+
             /* ionization condition */
             if (math::abs(eField)*UNIT_EFIELD >= SI::IONIZATION_EFIELD[cs] && chargeState < protonNumber)
             {

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -37,13 +37,15 @@ namespace ionization
      * - see for example: Delone, N. B.; Krainov, V. P. (1998). "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
      *
      * \tparam T_DestSpecies electron species to be created
-     * \tparam T_SrcSpecies particle species that is ionized */
+     * \tparam T_SrcSpecies particle species that is ionized
+     */
     template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
     struct BSI_Impl;
 
     /* wrapper class, needed because the SrcSpecies cannot be known during the
      * first specialization of the ionization model in the particle definition
-     * \see speciesDefinition.param */
+     * \see speciesDefinition.param
+     */
     template<typename T_DestSpecies>
     struct BSI
     {

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -29,6 +29,7 @@ namespace particles
 namespace ionization
 {
     /** \struct BSI_Impl
+     *
      * \brief Barrier Suppression Ionization - Implementation
      *
      * \tparam T_DestSpecies electron species to be created
@@ -41,6 +42,7 @@ namespace ionization
     struct BSI_Impl;
 
     /** \struct BSI
+     * 
      * \brief Barrier Suppression Ionization
      *
      * - takes the ionization energies of the various charge states of ions

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -33,6 +33,9 @@ namespace ionization
      *
      * \tparam T_DestSpecies electron species to be created
      * \tparam T_SrcSpecies particle species that is ionized
+     *         default is boost::mpl placeholder because specialization
+     *         cannot be known in list of particle species' flags
+     *         \see speciesDefinition.param
      */
     template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
     struct BSI_Impl;
@@ -47,7 +50,8 @@ namespace ionization
      *
      * \tparam T_DestSpecies electron species to be created
      *
-     * wrapper class, needed because the SrcSpecies cannot be known during the
+     * wrapper class,
+     * needed because the SrcSpecies cannot be known during the
      * first specialization of the ionization model in the particle definition
      * \see speciesDefinition.param
      */

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -20,24 +20,35 @@
 
 #pragma once
 
+#include "types.h"
+
 namespace picongpu
 {
 namespace particles
 {
 namespace ionization
 {
-
-    /** \struct BSI
-     * \brief Barrier Suppression Ionization
+    /** \struct BSI_Impl
+     * \brief Barrier Suppression Ionization - Implementation
      *
      * - takes the ionization energies of the various charge states of ions
      * - calculates the corresponding field strengths necessary to overcome the binding energy of the electron to the core
      * - if the field strength is locally exceeded: increase the charge state
      * - see for example: Delone, N. B.; Krainov, V. P. (1998). "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
      *
-     * \tparam T_DestSpecies electron species to be created */
+     * \tparam T_DestSpecies electron species to be created
+     * \tparam T_SrcSpecies particle species that is ionized */
+    template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
+    struct BSI_Impl;
+
+    /* wrapper class, needed because the SrcSpecies cannot be known during the
+     * first specialization of the ionization model in the particle definition
+     * \see speciesDefinition.param */
     template<typename T_DestSpecies>
-    struct BSI;
+    struct BSI
+    {
+        typedef BSI_Impl<T_DestSpecies> type;
+    };
 
 } // namespace ionization
 } // namespace particles

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -31,18 +31,23 @@ namespace ionization
     /** \struct BSI_Impl
      * \brief Barrier Suppression Ionization - Implementation
      *
-     * - takes the ionization energies of the various charge states of ions
-     * - calculates the corresponding field strengths necessary to overcome the binding energy of the electron to the core
-     * - if the field strength is locally exceeded: increase the charge state
-     * - see for example: Delone, N. B.; Krainov, V. P. (1998). "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
-     *
      * \tparam T_DestSpecies electron species to be created
      * \tparam T_SrcSpecies particle species that is ionized
      */
     template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
     struct BSI_Impl;
 
-    /* wrapper class, needed because the SrcSpecies cannot be known during the
+    /** \struct BSI
+     * \brief Barrier Suppression Ionization
+     *
+     * - takes the ionization energies of the various charge states of ions
+     * - calculates the corresponding field strengths necessary to overcome the binding energy of the electron to the core
+     * - if the field strength is locally exceeded: increase the charge state
+     * - see for example: Delone, N. B.; Krainov, V. P. (1998). "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
+     *
+     * \tparam T_DestSpecies electron species to be created
+     *
+     * wrapper class, needed because the SrcSpecies cannot be known during the
      * first specialization of the ionization model in the particle definition
      * \see speciesDefinition.param
      */

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.hpp
@@ -95,7 +95,7 @@ namespace ionization
 
         public:
             /* host constructor */
-            BSI_Impl()
+            BSI_Impl(const uint32_t currentStep)
             {
                 DataConnector &dc = Environment<>::get().DataConnector();
                 /* initialize pointers on host-side E-(B-)field databoxes */
@@ -111,7 +111,8 @@ namespace ionization
              *  \brief Cache EM-fields on device
              *         and initialize possible prerequisites for ionization, like e.g. random number generator.
              *
-             * This function will be called inline on the device which must happen BEFORE threads diverge */
+             * This function will be called inline on the device which must happen BEFORE threads diverge
+             */
             DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset)
             {
 

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.hpp
@@ -20,10 +20,23 @@
 
 #pragma once
 
+#include "types.h"
+#include "math/vector/Size_t.hpp"
+#include "simulation_defines.hpp"
+#include "traits/Resolve.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+
+#include "fields/FieldB.hpp"
+#include "fields/FieldE.hpp"
+
 #include "particles/ionization/byField/BSI/BSI.def"
 #include "particles/ionization/byField/BSI/AlgorithmBSI.hpp"
+#include "particles/ionization/ionization.hpp"
 
 #include "compileTime/conversion/TypeToPointerPair.hpp"
+#include "memory/boxes/DataBox.hpp"
+
+#include "particles/ParticlesFunctors.hpp"
 
 namespace picongpu
 {
@@ -32,30 +45,146 @@ namespace particles
 namespace ionization
 {
 
-    /** \struct BSI
-     * \brief Barrier Suppression Ionization
+    /** \struct BSI_Impl
+     * \brief Barrier Suppression Ionization - Implementation
+     *
+     * \tparam T_DestSpecies electron species to be created
+     * \tparam T_SrcSpecies particle species that is ionized
      */
-    template<typename T_DestSpecies>
-    struct BSI
+    template<typename T_DestSpecies, typename T_SrcSpecies>
+    struct BSI_Impl
     {
 
-        /* define ionization ALGORITHM for ionization MODEL */
-        typedef particles::ionization::AlgorithmBSI IonizationAlgorithm;
+        typedef T_DestSpecies DestSpecies;
+        typedef T_SrcSpecies  SrcSpecies;
 
-        /** Functor implementation
-         * \tparam T_SrcSpecies particle species to be ionized
-         * \tparam T_ParticleStorage \see picongpu/src/libPMacc/include/math/MapTuple.hpp
-         *
-         * \param currentStep current time step */
-        template<typename T_SrcSpecies,typename T_ParticleStorage>
-        void operator()(T_SrcSpecies& src, T_ParticleStorage& pst, const uint32_t currentStep)
-        {
+        typedef typename SrcSpecies::FrameType FrameType;
 
-            /* alias for electron species to be created */
-            PMACC_AUTO(electrons,pst[typename MakeIdentifier<T_DestSpecies>::type()]);
-            /* call the ionization function */
-            src.ionize(electrons, currentStep);
-        }
+        /* specify field to particle interpolation scheme */
+        typedef typename PMacc::traits::Resolve<
+            typename GetFlagType<FrameType,interpolation<> >::type
+        >::type InterpolationScheme;
+
+        /* margins around the supercell for the interpolation of the field on the cells */
+        typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
+        typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
+
+        /* relevant area of a block */
+        typedef SuperCellDescription<
+            typename MappingDesc::SuperCellSize,
+            LowerMargin,
+            UpperMargin
+            > BlockArea;
+
+        BlockArea BlockDescription;
+
+        private:
+
+            /* define ionization ALGORITHM (calculation) for ionization MODEL */
+            typedef particles::ionization::AlgorithmBSI IonizationAlgorithm;
+
+            typedef MappingDesc::SuperCellSize TVec;
+            typedef FieldE::ValueType ValueType;
+            typedef FieldE::DataBoxType DataBoxType;
+            /* global memory EM-field device databoxes */
+            DataBoxType eBox;
+            DataBoxType bBox;
+            /* shared memory EM-field device databoxes */
+            PMACC_ALIGN(cachedE,DataBox<SharedBox<ValueType, typename BlockArea::FullSuperCellSize,1> >);
+            PMACC_ALIGN(cachedB,DataBox<SharedBox<ValueType, typename BlockArea::FullSuperCellSize,0> >);
+
+        public:
+            /* host constructor */
+            BSI_Impl()
+            {
+                DataConnector &dc = Environment<>::get().DataConnector();
+                /* initialize pointers on host-side E-(B-)field databoxes */
+                FieldE* fieldE = &(dc.getData<FieldE > (FieldE::getName(), true));
+                FieldB* fieldB = &(dc.getData<FieldB > (FieldB::getName(), true));
+                /* initialize device-side E-(B-)field databoxes */
+                eBox = fieldE->getDeviceDataBox();
+                bBox = fieldB->getDeviceDataBox();
+
+            }
+
+            /** init
+             *  \brief Cache EM-fields on device
+             *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+             *
+             * This function will be called inline on the device which must happen BEFORE threads diverge */
+            DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset)
+            {
+
+                /* caching of E and B fields */
+                cachedB = CachedBox::create < 0, ValueType > (BlockArea());
+                cachedE = CachedBox::create < 1, ValueType > (BlockArea());
+                /* wait for shared memory to be initialized */
+                __syncthreads();
+                /* instance of nvidia assignment operator */
+                nvidia::functors::Assign assign;
+                /* copy fields from global to shared */
+                PMACC_AUTO(fieldBBlock, bBox.shift(blockCell));
+                ThreadCollective<BlockArea> collectiv(linearThreadIdx);
+                collectiv(
+                          assign,
+                          cachedB,
+                          fieldBBlock
+                          );
+                /* copy fields from global to shared */
+                PMACC_AUTO(fieldEBlock, eBox.shift(blockCell));
+                collectiv(
+                          assign,
+                          cachedE,
+                          fieldEBlock
+                          );
+            }
+
+            /** Functor implementation
+             *
+             * \param ionFrame (here address of: ) frame of the to-be-ionized particles
+             * \param localIdx local (linear) index in super cell / frame
+             * \param newMacroElectrons (here address of: ) variable for each thread that stores the number
+             *        of macro electrons to be created during the current time step
+             */
+            DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
+            {
+
+                /* type for field to particle interpolation */
+                typedef InterpolationScheme Field2ParticleInterpolation;
+
+                /* type of PIC-scheme cell */
+                typedef typename fieldSolver::NumericalCellType NumericalCellType;
+
+                typedef ValueType BType;
+                typedef ValueType EType;
+                /* alias for the single macro-particle */
+                PMACC_AUTO(particle,ionFrame[localIdx]);
+                /* particle position, used for field-to-particle interpolation */
+                floatD_X pos = particle[position_];
+                const int particleCellIdx = particle[localCellIdx_];
+                /* multi-dim coordinate of the local cell inside the super cell */
+                DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
+                /* interpolation of E- */
+                EType eField = Field2ParticleInterpolation()
+                    (cachedE.shift(localCell).toCursor(), pos, NumericalCellType::getEFieldPosition());
+                /*                     and B-field on the particle position */
+                BType bField = Field2ParticleInterpolation()
+                    (cachedB.shift(localCell).toCursor(), pos, NumericalCellType::getBFieldPosition());
+
+                /* define number of bound macro electrons before ionization */
+                float_X prevBoundElectrons = particle[boundElectrons_];
+
+                /* this is the point where actual ionization takes place */
+                IonizationAlgorithm ionizeAlgo;
+                ionizeAlgo(
+                     bField, eField,
+                     particle
+                     );
+
+                /* determine number of new macro electrons to be created */
+                newMacroElectrons = prevBoundElectrons - particle[boundElectrons_];
+
+            }
 
     };
 

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -108,11 +108,14 @@ namespace ionization
 
             }
 
-            /** init
-             *  \brief Cache EM-fields on device
+            /** Initialization function on device
+             *
+             * \brief Cache EM-fields on device
              *         and initialize possible prerequisites for ionization, like e.g. random number generator.
              *
              * This function will be called inline on the device which must happen BEFORE threads diverge
+             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+             * initializing the E-/B-field shared boxes in shared memory.
              */
             DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset)
             {

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -63,11 +63,11 @@ namespace ionization
         /* specify field to particle interpolation scheme */
         typedef typename PMacc::traits::Resolve<
             typename GetFlagType<FrameType,interpolation<> >::type
-        >::type InterpolationScheme;
+        >::type Field2ParticleInterpolation;
 
         /* margins around the supercell for the interpolation of the field on the cells */
-        typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
-        typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
+        typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
+        typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
 
         /* relevant area of a block */
         typedef SuperCellDescription<
@@ -143,22 +143,17 @@ namespace ionization
 
             /** Functor implementation
              *
-             * \param ionFrame (here address of: ) frame of the to-be-ionized particles
+             * \param ionFrame reference to frame of the to-be-ionized particles
              * \param localIdx local (linear) index in super cell / frame
-             * \param newMacroElectrons (here address of: ) variable for each thread that stores the number
+             * \param newMacroElectrons reference to variable for each thread that stores the number
              *        of macro electrons to be created during the current time step
              */
             DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
             {
 
-                /* type for field to particle interpolation */
-                typedef InterpolationScheme Field2ParticleInterpolation;
-
                 /* type of PIC-scheme cell */
                 typedef typename fieldSolver::NumericalCellType NumericalCellType;
 
-                typedef ValueType_B BType;
-                typedef ValueType_E EType;
                 /* alias for the single macro-particle */
                 PMACC_AUTO(particle,ionFrame[localIdx]);
                 /* particle position, used for field-to-particle interpolation */
@@ -167,10 +162,10 @@ namespace ionization
                 /* multi-dim coordinate of the local cell inside the super cell */
                 DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
                 /* interpolation of E- */
-                EType eField = Field2ParticleInterpolation()
+                ValueType_E eField = Field2ParticleInterpolation()
                     (cachedE.shift(localCell).toCursor(), pos, NumericalCellType::getEFieldPosition());
                 /*                     and B-field on the particle position */
-                BType bField = Field2ParticleInterpolation()
+                ValueType_B bField = Field2ParticleInterpolation()
                     (cachedB.shift(localCell).toCursor(), pos, NumericalCellType::getBFieldPosition());
 
                 /* define number of bound macro electrons before ionization */

--- a/src/picongpu/include/particles/ionization/byField/ionizers.def
+++ b/src/picongpu/include/particles/ionization/byField/ionizers.def
@@ -20,7 +20,10 @@
 
 #pragma once
 
-/* These includes contain forward declarations of < Ionization Models > */
+/* \file ionizers.def
+ *
+ * These includes contain forward declarations of < Ionization Models >
+ */
 
 #include "particles/ionization/byField/BSI/BSI.def"
 #include "particles/ionization/None/None.def"

--- a/src/picongpu/include/particles/ionization/byField/ionizers.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ionizers.hpp
@@ -24,5 +24,5 @@
  * which itself each include their own < Ionization Algorithm >
  * that implements what the model actually DOES */
 
-#include "particles/ionization/byField/BSI/BSI.hpp"
-#include "particles/ionization/None/None.hpp"
+#include "particles/ionization/byField/BSI/BSI_Impl.hpp"
+#include "particles/ionization/None/None_Impl.hpp"

--- a/src/picongpu/include/particles/ionization/byField/ionizers.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ionizers.hpp
@@ -20,9 +20,12 @@
 
 #pragma once
 
-/* Includes containing definition of < Ionization Models >
+/** \file ionizers.hpp
+ *
+ * Includes containing definition of < Ionization Models >
  * which itself each include their own < Ionization Algorithm >
- * that implements what the model actually DOES */
+ * that implements what the model actually DOES
+ */
 
 #include "particles/ionization/byField/BSI/BSI_Impl.hpp"
 #include "particles/ionization/None/None_Impl.hpp"

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -1,6 +1,6 @@
 /**
- * Copyright 2014 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
- *                  Richard Pausch, Felix Schmitt
+ * Copyright 2014-2015 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *
@@ -38,110 +38,57 @@
 
 namespace picongpu
 {
-    
-using namespace PMacc;
-
-/** \struct IonizeParticlesPerFrame
- * \brief gathers fields for particle interpolation and gives them to the ionization model
- *
- * \tparam IonizeAlgo ionization algorithm
- * \tparam TVec dimensions of the target:
- *         e.g. size of the super cell
- * \tparam T_Field2ParticleInterpolation type of field to particle interpolation
- * \tparam NumericalCellType type of cell with respect to field discretization:
-           e.g. Yee cell
- */
-template<class IonizeAlgo, class TVec, class T_Field2ParticleInterpolation, class NumericalCellType>
-struct IonizeParticlesPerFrame
+namespace particles
 {
-    /** Functor implementation
-     *
-     * \tparam FrameType frame type of particles that get ionized
-     * \tparam T_BBox type of B-field box
-     * \tparam T_EBox type of E-field box
-     *
-     * \param ionFrame (here address of: ) frame of the to-be-ionized particles
-     * \param localIdx local (linear) index in super cell / frame
-     * \param bBox B-field box instance
-     * \param ebox E-field box instance
-     * \param newMacroElectrons (here address of: ) variable for each thread that stores the number
-     *        of macro electrons to be created during the current time step
-     */
-    template<class FrameType, class T_BBox, class T_EBox >
-    DINLINE void operator()(FrameType& ionFrame, int localIdx, T_BBox& bBox, T_EBox& eBox, unsigned int& newMacroElectrons)
-    {
+namespace ionization
+{
 
-        typedef TVec Block;
-        /** type for field to particle interpolation */
-        typedef T_Field2ParticleInterpolation Field2ParticleInterpolation;
-
-        typedef typename T_BBox::ValueType BType;
-        typedef typename T_EBox::ValueType EType;
-
-        PMACC_AUTO(particle,ionFrame[localIdx]);
-        
-        floatD_X pos = particle[position_];
-        const int particleCellIdx = particle[localCellIdx_];
-
-        DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
-
-       
-        EType eField = Field2ParticleInterpolation()
-            (eBox.shift(localCell).toCursor(), pos, NumericalCellType::getEFieldPosition());
-        
-        BType bField =Field2ParticleInterpolation()
-            (bBox.shift(localCell).toCursor(), pos, NumericalCellType::getBFieldPosition());
-        
-        /* define number of bound macro electrons before ionization */
-        float_X prevBoundElectrons = particle[boundElectrons_];
- 
-        /* this is the point where actual ionization takes place */
-        IonizeAlgo ionizeAlgo;
-        ionizeAlgo(
-             bField, eField,
-             particle
-             );
-        
-        /* determine number of new macro electrons to be created */
-        newMacroElectrons = prevBoundElectrons - particle[boundElectrons_];
-        /*calculate one dimensional cell index*/
-
-    }
-}; // struct IonizeParticlesPerFrame
-
+using namespace PMacc;
 
 /** kernelIonizeParticles
  * \brief main kernel for ionization
  *
  * - maps the frame dimensions and gathers the particle boxes
- * - caches the E- and B-fields
  * - contains / calls the ionization algorithm
  * - calls the electron creation functors
  *
- * \tparam BlockDescription_ container for information about block / super cell dimensions
  * \tparam ParBoxIons container of the ions
  * \tparam ParBoxElectrons container of the electrons
- * \tparam BBox b-field box class
- * \tparam EBox e-field box class
  * \tparam Mapping class containing methods for acquiring info from the block
- * \tparam FrameIonizer \see IonizeParticlesPerFrame
+ * \tparam FrameIonizer \see e.g. BSI_Impl in BSI.hpp
+ *         instance of the ionization model functor
  */
-template<class BlockDescription_, class ParBoxIons, class ParBoxElectrons, class BBox, class EBox, class Mapping, class FrameIonizer>
+template<class ParBoxIons, class ParBoxElectrons, class Mapping, class FrameIonizer>
 __global__ void kernelIonizeParticles(ParBoxIons ionBox,
                                       ParBoxElectrons electronBox,
-                                      EBox fieldE,
-                                      BBox fieldB,
                                       FrameIonizer frameIonizer,
                                       Mapping mapper)
 {
-    
+
     /* "particle box" : container/iterator where the particles live in
      * and where one can get the frame in a super cell from */
     typedef typename ParBoxElectrons::FrameType ELECTRONFRAME;
     typedef typename ParBoxIons::FrameType IONFRAME;
-    /* for not mixing assign up with the nVidia functor assign */
+
+    /* specify field to particle interpolation scheme */
+    typedef typename PMacc::traits::Resolve<
+        typename GetFlagType<IONFRAME,interpolation<> >::type
+    >::type InterpolationScheme;
+
+    /* margins around the supercell for the interpolation of the field on the cells */
+    typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
+    typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
+
+    /* relevant area of a block */
+    typedef SuperCellDescription<
+        typename MappingDesc::SuperCellSize,
+        LowerMargin,
+        UpperMargin
+        > BlockDescription_;
+
+    /* for not mixing operations::assign up with the nVidia functor assign */
     namespace partOp = PMacc::particles::operations;
-    
+
     /* definitions for domain variables, like indices of blocks and threads */
     typedef typename BlockDescription_::SuperCellSize SuperCellSize;
     /* "offset" 3D distance to origin in units of super cells */
@@ -154,7 +101,13 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
 
     /* "offset" from origin of the grid in unit of cells */
     const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
-    
+
+    /* get local cell idx for random generator init */
+    const DataSpace<simDim> idx(block * SuperCellSize::toRT() + threadIndex);
+    /* subtract guarding cells to only have the simulation volume */
+    const DataSpace<simDim> localCellIndex = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+
+    /* typedef for the functor that writes new macro electrons into electron frames during runtime */
     typedef typename particles::ionization::WriteElectronIntoFrame WriteElectronIntoFrame;
 
     __syncthreads();
@@ -178,46 +131,26 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
     if (!isValid)
         return; //end kernel if we have no frames
 
-    /* caching of E and B fields */
-    PMACC_AUTO(cachedB, CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_()));
-    PMACC_AUTO(cachedE, CachedBox::create < 1, typename EBox::ValueType > (BlockDescription_()));
+    /* caching of E- and B- fields and initialization of random generator if needed */
+    frameIonizer.init(blockCell, linearThreadIdx, localCellIndex);
 
-    __syncthreads();
-    
-    nvidia::functors::Assign assign;
-    
-    PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
-    ThreadCollective<BlockDescription_> collective(linearThreadIdx);
-    collective(
-              assign,
-              cachedB,
-              fieldBBlock
-              );
-
-    PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
-    collective(
-              assign,
-              cachedE,
-              fieldEBlock
-              );
-    
     /* Declare counter in shared memory that will later tell the current fill level or
      * occupation of the newly created target electron frames. */
     __shared__ int newFrameFillLvl;
-    
+
     __syncthreads(); /*wait that all shared memory is initialized*/
-    
+
     /* Declare local variable oldFrameFillLvl for each thread */
     int oldFrameFillLvl;
-    
+
     /* Initialize local (register) counter for each thread
      * - describes how many new macro electrons should be created */
     unsigned int newMacroElectrons = 0;
-    
+
     /* Declare local electron ID
      * - describes at which position in the new frame the new electron is to be created */
     int electronId;
-    
+
     /* Master initializes the frame fill level with 0 */
     if (linearThreadIdx == 0)
     {
@@ -225,7 +158,7 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
         electronFrame = NULL;
     }
     __syncthreads();
-    
+
     /* move over source species frames and call frameIonizer
      * frames are worked on in backwards order to avoid asking if there is another frame
      * --> performance
@@ -242,8 +175,8 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
          * if they are non-particles their inner ionization counter remains at 0 */
         if (isParticle)
             /* ionization based on ionization model - this actually increases charge states*/
-            frameIonizer(*ionFrame, linearThreadIdx, cachedB, cachedE, newMacroElectrons);
-       
+            frameIonizer(*ionFrame, linearThreadIdx, newMacroElectrons);
+
         __syncthreads();
         /* always true while-loop over all particles inside source frame until each thread breaks out individually
          *
@@ -269,13 +202,13 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
              * - then sync */
             if (newMacroElectrons > 0)
                 electronId = atomicAdd(&newFrameFillLvl, 1);
-            
+
             __syncthreads();
             /* < EXIT? >
              * - if the counter hasn't changed all threads break out of the loop */
             if (oldFrameFillLvl == newFrameFillLvl)
                 break;
-            
+
             __syncthreads();
             /* < FIRST NEW FRAME >
              * - if there is no frame, yet, the master will create a new target electron frame
@@ -300,12 +233,12 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
                 PMACC_AUTO(parentIon,((*ionFrame)[linearThreadIdx]));
                 /* each thread initializes an electron if one should be created */
                 PMACC_AUTO(targetElectronFull,((*electronFrame)[electronId]));
-                
+
                 /* create an electron in the new electron frame:
                  * - see particles/ionization/ionizationMethods.hpp */
                 WriteElectronIntoFrame writeElectron;
                 writeElectron(parentIon,targetElectronFull);
-                
+
                 newMacroElectrons -= 1;
             }
             __syncthreads();
@@ -337,12 +270,12 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
                 PMACC_AUTO(parentIon,((*ionFrame)[linearThreadIdx]));
                 /* each thread initializes an electron if one should be produced */
                 PMACC_AUTO(targetElectronFull,((*electronFrame)[electronId]));
-                
+
                 /* create an electron in the new electron frame:
                  * - see particles/ionization/ionizationMethods.hpp */
                 WriteElectronIntoFrame writeElectron;
                 writeElectron(parentIon,targetElectronFull);
-         
+
                 newMacroElectrons -= 1;
             }
             __syncthreads();
@@ -358,60 +291,6 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
     }
 } // void kernelIonizeParticles
 
-/** ionize
- * \brief ionization function currently being a member function of the source species
- *
- * \tparam T_ParticleDescription container of particle source species information
- * \tparam T_Elec type of species to be created during ionization
- */
-template< typename T_ParticleDescription >
-template< typename T_Elec >
-void Particles<T_ParticleDescription>::ionize( T_Elec electrons, uint32_t )
-{
-    
-    /* get the alias for the used ionizer (ionization model) and specify the ionization algorithm */
-    typedef typename GetFlagType<FrameType,ionizer<> >::type IonizerAlias;
-    typedef typename PMacc::traits::Resolve<IonizerAlias>::type::IonizationAlgorithm IonizationAlgorithm;
-
-    typedef typename PMacc::traits::Resolve<
-        typename GetFlagType<FrameType,interpolation<> >::type
-    >::type InterpolationScheme;
-
-    /* margins around the supercell for the interpolation of the field on the cells */
-    typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
-    typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
-    
-    /* frame ionizer that moves over the frames with the particles and executes an operation on them */
-    typedef IonizeParticlesPerFrame<IonizationAlgorithm, MappingDesc::SuperCellSize,
-        InterpolationScheme,
-        fieldSolver::NumericalCellType > FrameIonizer;
-    
-    /* relevant area of a block */
-    typedef SuperCellDescription<
-        typename MappingDesc::SuperCellSize,
-        LowerMargin,
-        UpperMargin
-        > BlockArea;
-
-    /* 3-dim vector : number of threads to be started in every dimension */
-    dim3 block( MappingDesc::SuperCellSize::toRT().toDim3() );
-    
-    /* kernel call : instead of name<<<blocks, threads>>> (args, ...)
-       "blocks" will be calculated from "this->cellDescription" and "CORE + BORDER"
-       "threads" is calculated from the previously defined vector "block" */
-    __picKernelArea( kernelIonizeParticles<BlockArea>, this->cellDescription, CORE + BORDER )
-        (block)
-        ( this->getDeviceParticlesBox( ),
-          electrons->getDeviceParticlesBox(),
-          this->fieldE->getDeviceDataBox( ),
-          this->fieldB->getDeviceDataBox( ),
-          FrameIonizer( )
-          );
-
-    /* fill the gaps in the created species' particle frames to ensure that only
-     * the last frame is not completely filled but every other before is full */
-    electrons->fillAllGaps();
-    
-} // Particles::ionize
-
+} // namespace ionization
+} // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -55,7 +55,7 @@ using namespace PMacc;
  * \tparam ParBoxIons container of the ions
  * \tparam ParBoxElectrons container of the electrons
  * \tparam Mapping class containing methods for acquiring info from the block
- * \tparam FrameIonizer \see e.g. BSI_Impl in BSI.hpp
+ * \tparam FrameIonizer \see e.g. BSI_Impl in BSI_Impl.hpp
  *         instance of the ionization model functor
  */
 template<class ParBoxIons, class ParBoxElectrons, class Mapping, class FrameIonizer>

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -86,7 +86,7 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
         UpperMargin
         > BlockDescription_;
 
-    /* for not mixing operations::assign up with the nVidia functor assign */
+    /* for not mixing operations::assign up with the nvidia functor assign */
     namespace partOp = PMacc::particles::operations;
 
     /* definitions for domain variables, like indices of blocks and threads */
@@ -102,10 +102,8 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
     /* "offset" from origin of the grid in unit of cells */
     const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
 
-    /* get local cell idx for random generator init */
-    const DataSpace<simDim> idx(block * SuperCellSize::toRT() + threadIndex);
     /* subtract guarding cells to only have the simulation volume */
-    const DataSpace<simDim> localCellIndex = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+    const DataSpace<simDim> localCellIndex = (block * SuperCellSize::toRT() + threadIndex) - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
     /* typedef for the functor that writes new macro electrons into electron frames during runtime */
     typedef typename particles::ionization::WriteElectronIntoFrame WriteElectronIntoFrame;
@@ -138,7 +136,7 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
      * occupation of the newly created target electron frames. */
     __shared__ int newFrameFillLvl;
 
-    __syncthreads(); /*wait that all shared memory is initialized*/
+    __syncthreads(); /*wait until all shared memory is initialized*/
 
     /* Declare local variable oldFrameFillLvl for each thread */
     int oldFrameFillLvl;

--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -35,10 +35,10 @@ namespace ionization
 {
 
     using namespace PMacc;
-    
+
     /* operations on particles */
     namespace partOp = PMacc::particles::operations;
-    
+
     /** \struct WriteElectronIntoFrame
      *
      * \brief functor that fills an electron frame entry with details about the created particle
@@ -63,7 +63,8 @@ namespace ionization
              * - multiMask: reading from global memory takes longer than just setting it again explicitly
              * - momentum: because the electron would get a higher energy because of the ion mass
              * - boundElectrons: because species other than ions or atoms do not have them
-             * (gets AUTOMATICALLY deselected because electrons do not have this attribute) */
+             * (gets AUTOMATICALLY deselected because electrons do not have this attribute)
+             */
             PMACC_AUTO(targetElectronClone, partOp::deselect<bmpl::vector2<multiMask, momentum> >(childElectron));
 
             partOp::assign(targetElectronClone, parentIon);
@@ -74,16 +75,16 @@ namespace ionization
             float3_X electronMomentum (parentIon[momentum_]*(massElectron/massIon));
 
             childElectron[momentum_] = electronMomentum;
-            
+
             /* conservation of momentum
              * \todo add conservation of mass */
             parentIon[momentum_] -= electronMomentum;
         }
     };
-    
+
 } // namespace ionization
 
 } // namespace particles
-    
+
 } // namespace picongpu
 

--- a/src/picongpu/include/particles/traits/GetIonizer.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizer.hpp
@@ -56,6 +56,7 @@ struct GetIonizer
         particles::ionization::None<SpeciesType>
     >::type UserIonizer;
 
+    /* specializes the designated ionization model with the particle species it is called upon */
     typedef typename bmpl::apply1<typename UserIonizer::type, SpeciesType>::type type;
 
 }; // struct GetIonizer

--- a/src/picongpu/include/particles/traits/GetIonizer.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Marco Garten
+ * Copyright 2014-2015 Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -56,16 +56,6 @@ struct GetIonizer
         particles::ionization::None<SpeciesType>
     >::type UserIonizer;
 
-//    template< template< typename, typename > class T_Ionizer, typename T_Src, typename T_Dest, typename T_SrcSpeciesPlaceholder >
-//    struct myApply;
-//
-//    template< template< typename, typename > class T_Ionizer, typename T_Src, typename T_Dest, typename T_SrcSpeciesPlaceholder >
-//    struct myApply<T_Ionizer<T_Dest,T_SrcSpeciesPlaceholder>, T_Src >
-//    {
-//        typedef T_Ionizer< T_Dest, T_Src> type;
-//    };
-//
-//    typedef typename myApply<UserIonizer, SpeciesType>::type type;
     typedef typename bmpl::apply1<typename UserIonizer::type, SpeciesType>::type type;
 
 }; // struct GetIonizer

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -384,9 +384,11 @@ public:
     {
         namespace nvfct = PMacc::nvidia::functors;
 
-        /* Ionization */
+        /* Initialize ionization routine for each species
+         *      - valid species will be ionized
+         *      - invalid species (e.g. electrons): fallback */
         ForEach<VectorAllSpecies, particles::CallIonization<bmpl::_1>, MakeIdentifier<bmpl::_1> > particleIonization;
-        particleIonization(forward(particleStorage), currentStep);
+        particleIonization(forward(particleStorage), cellDescription, currentStep);
 
         EventTask initEvent = __getTransactionEvent();
         EventTask updateEvent;


### PR DESCRIPTION
Formerly ionization was started from a `Particles` class member function `void ionize()`. This seems unnatural, though, since ionization should start from an ionization model and be performed **on** the various particle species.

It was thus refactored and now allows for a more variable ionization routine. Different models can call kernels with or without loading random generators, for example.