### PR TITLE
fix intensity normalization of tau

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -51,7 +51,7 @@ namespace picongpu
      *      not zero, the integral over the volume will only vanish if the plateau length is
      *      a multiple of the wavelength.
      *   2) Since we define our envelope by a sigma of the laser intensity, 
-     *      tau = PULSE_LENGTH / sqrt(2)
+     *      tau = PULSE_LENGTH * sqrt(2)
      */
     namespace laserPlaneWave
     {
@@ -72,7 +72,7 @@ namespace picongpu
             const double mue = 0.5 * RAMP_INIT * PULSE_LENGTH;
 
             const double w = 2.0 * PI * f;
-            const double tau = PULSE_LENGTH / sqrt( 2.0 );
+            const double tau = PULSE_LENGTH * sqrt( 2.0 );
 
             const double endUpramp = mue;
             const double startDownramp = mue + LASER_NOFOCUS_CONSTANT;


### PR DESCRIPTION
This pull request fixes a bug introduced with #851 introduced two weeks ago.
@stetie and me found it during code comparison between PIConGPU and the Jena code.

Since we define our temporal laser envelope over intensity not over electric field, the correction factor should be
```
tau = PULSE_LENGTH * sqrt(2)
```
**not**
```
tau = PULSE_LENGTH / sqrt(2)
```