### PR TITLE
Further refactor libPMacc

### DIFF
--- a/src/libPMacc/include/algorithms/ForEach.hpp
+++ b/src/libPMacc/include/algorithms/ForEach.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -24,14 +24,7 @@
 #pragma once
 
 #include "compileTime/accessors/Identity.hpp"
-
-#include <boost/mpl/begin_end.hpp>
-#include <boost/mpl/next_prior.hpp>
-#include <boost/mpl/deref.hpp>
-#include <boost/mpl/bind.hpp>
-#include <boost/type_traits.hpp>
-
-#include <boost/mpl/if.hpp>
+#include "forward.hpp"
 
 #include <boost/preprocessor/repetition/enum.hpp>
 #include <boost/preprocessor/repetition/enum_params.hpp>
@@ -46,7 +39,12 @@
 #include <boost/preprocessor/repetition/enum_trailing.hpp>
 #include <boost/mpl/apply.hpp>
 #include <boost/mpl/transform.hpp>
-#include "forward.hpp"
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/next_prior.hpp>
+#include <boost/mpl/deref.hpp>
+#include <boost/mpl/bind.hpp>
+#include <boost/type_traits.hpp>
 
 
 /* Help to read this file:

--- a/src/libPMacc/include/communication/ICommunicator.hpp
+++ b/src/libPMacc/include/communication/ICommunicator.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera, Wolfgang Hoenig
+ * Copyright 2013, 2015 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,13 +20,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _ICOMMUNICATOR_HPP
-#define	_ICOMMUNICATOR_HPP
-
-#include <mpi.h>
+#pragma once
 
 #include "types.h"
+
+#include <mpi.h>
 
 namespace PMacc
 {
@@ -82,7 +80,3 @@ public:
 };
 
 } //namespace PMacc
-
-
-#endif	/* _ICOMMUNICATOR_HPP */
-

--- a/src/libPMacc/include/compileTime/AllCombinations.hpp
+++ b/src/libPMacc/include/compileTime/AllCombinations.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,21 +22,18 @@
 
 #pragma once
 
-#include "types.h"
 #include "compileTime/conversion/SeqToMap.hpp"
 #include "compileTime/conversion/TypeToAliasPair.hpp"
 #include "compileTime/conversion/TypeToPair.hpp"
 #include "compileTime/conversion/MakeSeqFromNestedSeq.hpp"
 #include "compileTime/conversion/MakeSeq.hpp"
+#include "math/Vector.hpp"
+#include "types.h"
+
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/copy.hpp>
-
-#include <boost/mpl/assert.hpp>
 #include <boost/mpl/pop_back.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-
-#include "math/Vector.hpp"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/compileTime/GetKeyFromAlias.hpp
+++ b/src/libPMacc/include/compileTime/GetKeyFromAlias.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,21 +22,18 @@
 
 #pragma once
 
-#include "types.h"
 #include "compileTime/conversion/SeqToMap.hpp"
 #include "compileTime/conversion/TypeToAliasPair.hpp"
 #include "compileTime/conversion/TypeToPair.hpp"
+#include "static_assert.hpp"
+#include "types.h"
+
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/copy.hpp>
-
-#include <boost/mpl/assert.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace PMacc
 {
-
-
 
 template<typename T_MPLSeq,
          typename T_Key

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,11 +20,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALGORITHM_KERNEL_DETAIL_SPHERICMAPPER_HPP
-#define ALGORITHM_KERNEL_DETAIL_SPHERICMAPPER_HPP
+#pragma once
 
-#include "types.h"
 #include "math/vector/Size_t.hpp"
+#include "types.h"
+
 #include <boost/mpl/void.hpp>
 
 namespace PMacc
@@ -216,5 +216,3 @@ struct SphericMapper<3, mpl::void_>
 } // kernel
 } // algorithm
 } // PMacc
-
-#endif // ALGORITHM_KERNEL_DETAIL_SPHERICMAPPER_HPP

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013, 2015 Heiko Burau
+ * Copyright 2013, 2015 Heiko Burau, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,9 +21,10 @@
  */
 
 #include "mappings/simulation/GridController.hpp"
-#include <iostream>
 #include "cuSTL/container/copier/Memcopy.hpp"
 #include "communication/manager_common.h"
+
+#include <iostream>
 
 namespace PMacc
 {
@@ -31,13 +32,13 @@ namespace algorithm
 {
 namespace mpi
 {
-    
+
 namespace GatherHelper
 {
-    
+
 /** @tparam dim dimension of mpi cluster
  *  @tparam memDim dimension of memory to be gathered
- * 
+ *
  * if memDim == dim - 1 then ``dir`` indicates the direction (orientation)
  * of the (meta)plane.
  */

--- a/src/libPMacc/include/cuSTL/container/compile-time/SharedBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/SharedBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_CT_SHAREDBUFFER_HPP
-#define CONTAINER_CT_SHAREDBUFFER_HPP
+#pragma once
 
 #include "CartBuffer.hpp"
 #include "../allocator/compile-time/SharedMemAllocator.hpp"
@@ -46,5 +45,3 @@ struct SharedBuffer
 } // CT
 } // container
 } // PMacc
-
-#endif // CONTAINER_CT_SHAREDBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef COPIER_D2DCOPIER_HPP
-#define COPIER_D2DCOPIER_HPP
+#pragma once
 
 #include "Memcopy.hpp"
 #include <types.h>
@@ -47,5 +46,3 @@ struct D2DCopier
 
 } // copier
 } // PMacc
-
-#endif // COPIER_D2DCOPIER_HPP

--- a/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef COPIER_H2HCOPIER_HPP
-#define COPIER_H2HCOPIER_HPP
+#pragma once
 
 #include "Memcopy.hpp"
 #include <types.h>
@@ -47,5 +46,3 @@ struct H2HCopier
 
 } // copier
 } // PMacc
-
-#endif // COPIER_H2HCOPIER_HPP

--- a/src/libPMacc/include/cuSTL/container/copier/Memcopy.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/Memcopy.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CUDAWRAPPERMEMCOPY_HPP
-#define CUDAWRAPPERMEMCOPY_HPP
+#pragma once
 
 #include "math/vector/Size_t.hpp"
 #include <types.h>
@@ -105,5 +104,3 @@ struct Memcopy<3>
 
 } // cudaWrapper
 } // PMacc
-
-#endif //CUDAWRAPPERMEMCOPY_HPP

--- a/src/libPMacc/include/dataManagement/AbstractInitialiser.hpp
+++ b/src/libPMacc/include/dataManagement/AbstractInitialiser.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,12 +20,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ABSTRACTINITIALISER_HPP
-#define	ABSTRACTINITIALISER_HPP
+#pragma once
 
 #include "dataManagement/ISimulationData.hpp"
 #include "dataManagement/IDataSorter.hpp"
-
 
 namespace PMacc
 {
@@ -60,6 +58,3 @@ namespace PMacc
     };
 
 }
-
-#endif	/* ABSTRACTINITIALISER_HPP */
-

--- a/src/libPMacc/include/dataManagement/Dataset.hpp
+++ b/src/libPMacc/include/dataManagement/Dataset.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera, Felix Schmitt
+ * Copyright 2013, 2015 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,14 +20,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef DATASET_HPP
-#define	DATASET_HPP
-
-#include <cassert>
+#pragma once
 
 #include "dataManagement/ISimulationData.hpp"
 
+#include <cassert>
 
 namespace PMacc
 {
@@ -107,6 +104,3 @@ namespace PMacc
         DatasetStatus status;
     };
 }
-
-#endif	/* DATASET_HPP */
-

--- a/src/libPMacc/include/dataManagement/IDataSorter.hpp
+++ b/src/libPMacc/include/dataManagement/IDataSorter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera, Felix Schmitt
+ * Copyright 2013, 2015 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef IDATASORTER_HPP
-#define	IDATASORTER_HPP
+#pragma once
 
 namespace PMacc
 {
@@ -76,6 +74,3 @@ namespace PMacc
         virtual ID_TYPE getNext() = 0;
     };
 }
-
-#endif	/* IDATASORTER_HPP */
-

--- a/src/libPMacc/include/dataManagement/ISimulationData.hpp
+++ b/src/libPMacc/include/dataManagement/ISimulationData.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,15 +20,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ISIMULATIONDATA_HPP
-#define	ISIMULATIONDATA_HPP
+#pragma once
 
 #include <string>
 
 namespace PMacc
 {
     typedef std::string SimulationDataId;
-    
+
     /**
      * Interface for simulation data which should be registered at DataConnector
      * for file output, visualization, etc.
@@ -41,16 +40,13 @@ namespace PMacc
          * will return up-to-date values.
          */
         virtual void synchronize() = 0;
-        
+
         /**
          * Return the globally unique identifier for this simulation data.
          *
          * @return globally unique identifier
          */
         virtual SimulationDataId getUniqueId() = 0;
-       
+
     };
 }
-
-#endif	/* ISIMULATIONDATA_HPP */
-

--- a/src/libPMacc/include/dataManagement/ListSorter.hpp
+++ b/src/libPMacc/include/dataManagement/ListSorter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LISTSORTER_HPP
-#define	LISTSORTER_HPP
+#pragma once
 
 #include "dataManagement/IDataSorter.hpp"
 
@@ -81,6 +80,3 @@ namespace PMacc
         typename std::list<ID_TYPE>::iterator iter;
     };
 }
-
-#endif	/* LISTSORTER_HPP */
-

--- a/src/libPMacc/include/debug/DebugBuffers.hpp
+++ b/src/libPMacc/include/debug/DebugBuffers.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,15 +20,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef DEBUGBUFFERS_HPP
-#define	DEBUGBUFFERS_HPP
+#include "memory/buffers/IHostBuffer.hpp"
+#include "types.h"
 
 #include <string>
 #include <sstream>
-
-#include "types.h"
-#include "memory/buffers/HostBuffer.hpp"
 
 namespace PMacc
 {
@@ -107,6 +105,3 @@ namespace PMacc
         }
     };
 }
-
-#endif	/* DEBUGBUFFERS_HPP */
-

--- a/src/libPMacc/include/debug/DebugDataSpace.hpp
+++ b/src/libPMacc/include/debug/DebugDataSpace.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                      Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,14 +21,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef DEBUGDATASPACE_HPP
-#define	DEBUGDATASPACE_HPP
+#include "dimensions/DataSpace.hpp"
 
 #include <string>
 #include <sstream>
-
-#include "dimensions/DataSpace.hpp"
 
 namespace PMacc
 {
@@ -73,6 +72,3 @@ namespace PMacc
     };
 
 }
-
-#endif	/* DEBUGDATASPACE_HPP */
-

--- a/src/libPMacc/include/debug/DebugExchangeTypes.hpp
+++ b/src/libPMacc/include/debug/DebugExchangeTypes.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013, 2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,14 +20,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DEBUGEXCHANGETYPES_HPP
-#define	DEBUGEXCHANGETYPES_HPP
+#pragma once
+
+#include "memory/dataTypes/Mask.hpp"
+#include "types.h"
 
 #include <string>
 #include <sstream>
-
-#include "types.h"
-#include "memory/dataTypes/Mask.hpp"
 
 namespace PMacc
 {
@@ -78,6 +77,3 @@ namespace PMacc
     };
 
 }
-
-#endif	/* DEBUGEXCHANGETYPES_HPP */
-

--- a/src/libPMacc/include/debug/VerboseLogMakros.hpp
+++ b/src/libPMacc/include/debug/VerboseLogMakros.hpp
@@ -20,17 +20,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include <sstream>
 #include <boost/format.hpp>
 #include <iostream>
-
-#include "static_assert.hpp"
 #include <string>
-
-
 
 /** create a log lvl
  * @param code integer which represent a bit in a 64bit bitmask
@@ -70,6 +65,3 @@
         typedef structName thisClass;           \
     public:                                     \
     __DEFINE_VERBOSE_CLASS_LVLS
-
-
-

--- a/src/libPMacc/include/dimensions/DataSpace.tpp
+++ b/src/libPMacc/include/dimensions/DataSpace.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -23,13 +23,13 @@
 
 #pragma once
 
-#include "types.h"
 #include "dimensions/DataSpace.hpp"
+
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
-
 #include "algorithms/math.hpp"
 #include "algorithms/TypeCast.hpp"
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/dimensions/DataSpaceOperations.hpp
+++ b/src/libPMacc/include/dimensions/DataSpaceOperations.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                      Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef DATASPACEOPERATIONS_HPP
-#define	DATASPACEOPERATIONS_HPP
+#pragma once
 
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
@@ -294,5 +293,3 @@ namespace PMacc
         }
     };
 }
-
-#endif	/* DATASPACEOPERATIONS_HPP */

--- a/src/libPMacc/include/dimensions/GridLayout.hpp
+++ b/src/libPMacc/include/dimensions/GridLayout.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013, 2015 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
+ *                      Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _GRIDLAYOUT_HPP
-#define	_GRIDLAYOUT_HPP
+#pragma once
 
 #include "dimensions/DataSpace.hpp"
 
@@ -87,6 +87,3 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-#endif	/* _GRIDLAYOUT_HPP */
-

--- a/src/libPMacc/include/fields/SimulationFieldHelper.hpp
+++ b/src/libPMacc/include/fields/SimulationFieldHelper.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013, 2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SIMULATIONFIELDHELPER_HPP
-#define	SIMULATIONFIELDHELPER_HPP
+#pragma once
 
 #include "dimensions/GridLayout.hpp"
 #include "eventSystem/EventSystem.hpp"
@@ -63,6 +62,3 @@ protected:
 };
 
 } //namespace PMacc
-
-#endif	/* SIMULATIONFIELDHELPER_HPP */
-

--- a/src/libPMacc/include/identifier/identifier.hpp
+++ b/src/libPMacc/include/identifier/identifier.hpp
@@ -22,7 +22,6 @@
 
 #pragma once
 
-
 #include "types.h"
 
 /* No namespace is needed because we only have defines*/
@@ -33,7 +32,7 @@
 #define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(host_placeholder,id)
 #endif
 
-/*define special makros for creating classes which are ony used as identifer*/
+/*define special macros for creating classes which are only used as identifier*/
 #define PMACC_identifier(name,id,...)                                          \
     namespace PMACC_JOIN(placeholder_definition,id) {                          \
         struct name{                                                           \
@@ -51,7 +50,7 @@
 
 
 /** create an identifier (identifier with arbitrary code as second parameter
- * !! second parameter is optinal and can be any C++ code one can add inside a class
+ * !! second parameter is optional and can be any C++ code one can add inside a class
  *
  * example: identifier(varname); //create type varname
  * example: identifier(varname,typedef int type;); //create type varname,

--- a/src/libPMacc/include/mappings/kernel/ExchangeMappingMethods.hpp
+++ b/src/libPMacc/include/mappings/kernel/ExchangeMappingMethods.hpp
@@ -315,5 +315,5 @@ namespace PMacc
             return result;
         }
     };
-    
+
 }//namespace PMacc

--- a/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
+++ b/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera, Wolfgang Hoenig
+ * Copyright 2013, 2015 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _ENVIRONMENTCONTROLLER_HPP
-#define	_ENVIRONMENTCONTROLLER_HPP
+#pragma once
 
 #include "memory/dataTypes/Mask.hpp"
 
@@ -90,7 +88,3 @@ private:
 };
 
 } //namespace PMacc
-
-
-#endif	/* _ENVIRONMENTCONTROLLER_HPP */
-

--- a/src/libPMacc/include/mappings/simulation/GridController.hpp
+++ b/src/libPMacc/include/mappings/simulation/GridController.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013, 2015 Axel Huebl, Felix Schmitt, Rene Widera,
+ *                      Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,10 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _GRIDCONTROLLER_HPP
-#define	_GRIDCONTROLLER_HPP
-
+#pragma once
 
 #include "dimensions/DataSpace.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
@@ -291,8 +289,3 @@ namespace PMacc
         CommunicatorMPI<DIM> GridController<DIM>::comm;
 
 } //namespace PMacc
-
-
-
-#endif	/* _GRIDCONTROLLER_HPP */
-

--- a/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
+++ b/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -23,10 +23,10 @@
 
 #pragma once
 
-#include "types.h"
-#include "dimensions/DataSpace.hpp"
-#include "dimensions/DataSpaceOperations.hpp"
 #include "dimensions/SuperCellDescription.hpp"
+#include "dimensions/DataSpaceOperations.hpp"
+#include "dimensions/DataSpace.hpp"
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,9 +22,9 @@
 
 #pragma once
 
-#include "types.h"
-#include "math/vector/Vector.tpp"
+#include "math/vector/Vector.hpp"
 #include "ppFunctions.hpp"
+#include "types.h"
 
 /* select namespace depending on __CUDA_ARCH__ compiler flag*/
 #ifdef __CUDA_ARCH__ //we are on gpu

--- a/src/libPMacc/include/math/complex/Complex.tpp
+++ b/src/libPMacc/include/math/complex/Complex.tpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Alexander Debus, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,10 +23,11 @@
 
 #pragma once
 
-#include <cmath>
-#include "math/Complex.hpp"
 #include "algorithms/math.hpp"
 #include "algorithms/TypeCast.hpp"
+#include "math/Complex.hpp"
+
+#include <cmath>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,14 +22,16 @@
 
 #pragma once
 
-#include "types.h"
-#include "result_of_Functor.hpp"
-#include <boost/static_assert.hpp>
-#include <boost/mpl/size.hpp>
-#include <iostream>
-#include <lambda/Expression.hpp>
 #include <math/vector/accessor/StandartAccessor.hpp>
 #include <math/vector/navigator/StandartNavigator.hpp>
+#include <lambda/Expression.hpp>
+#include "result_of_Functor.hpp"
+#include "static_assert.hpp"
+#include "types.h"
+
+#include <boost/mpl/size.hpp>
+
+#include <iostream>
 
 namespace PMacc
 {
@@ -101,7 +103,7 @@ struct CopyElementWise<true>
 
 namespace tag
 {
-struct Vector;
+    struct Vector;
 }
 
 template<typename T_Type, int T_dim,
@@ -136,8 +138,7 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
     };
 
     HDINLINE Vector()
-    {
-    }
+    {}
 
     HDINLINE
     Vector(const type x)
@@ -187,9 +188,9 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
     }
 
     /**
-     * Give a Vector<...> were all dimensions were set to the same value
+     * Creates a Vector where all dimensions are set to the same value
      *
-     * @param value value which is set for all dimensions
+     * @param value Value which is set for all dimensions
      * @return new Vector<...>
      */
     HDINLINE

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -27,10 +27,10 @@
 #include "math/Vector.hpp"
 #include "algorithms/math.hpp"
 #include "algorithms/TypeCast.hpp"
+#include "algorithms/PromoteType.hpp"
 #include "mpi/GetMPI_StructAsArray.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
-#include "algorithms/PromoteType.hpp"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/math/vector/accessor/StandartAccessor.hpp
+++ b/src/libPMacc/include/math/vector/accessor/StandartAccessor.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,6 +21,8 @@
  */
 
 #pragma once
+
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/math/vector/compile-time/Vector.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Vector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include "types.h"
-#include <stdint.h>
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/vector.hpp>
@@ -37,6 +35,9 @@
 #include <boost/mpl/accumulate.hpp>
 #include <boost/mpl/less.hpp>
 #include "math/Vector.hpp"
+#include "types.h"
+
+#include <stdint.h>
 
 namespace PMacc
 {
@@ -152,8 +153,7 @@ struct Vector
 
     /** Create a runtime Vector
      *
-     *  Creates the corresponding runtime vector
-     *  object
+     *  Creates the corresponding runtime vector object.
      *
      *  \return RT_type runtime vector with same value type
      */

--- a/src/libPMacc/include/math/vector/navigator/PermutedNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/PermutedNavigator.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,6 +21,8 @@
  */
 
 #pragma once
+
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/math/vector/navigator/StackedNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/StackedNavigator.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Heiko Burau, Rene Widera
+ * Copyright 2014, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,6 +21,8 @@
  */
 
 #pragma once
+
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/math/vector/navigator/StandartNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/StandartNavigator.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,6 +21,8 @@
  */
 
 #pragma once
+
+#include "types.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/memory/boxes/DataBox.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBox.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
+ * Copyright 2013, 2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                      Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef _DATABOX_HPP
-#define	_DATABOX_HPP
+#pragma once
 
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
@@ -164,5 +163,3 @@ namespace PMacc
     };
 
 }
-
-#endif	/* _DATABOX_HPP */

--- a/src/libPMacc/include/memory/dataTypes/BitData.hpp
+++ b/src/libPMacc/include/memory/dataTypes/BitData.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,11 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef BITDATA_HPP
-#define	BITDATA_HPP
-
+#pragma once
 
 #include "types.h"
 
@@ -205,6 +201,3 @@ namespace PMacc
 
 
 }
-
-#endif	/* BITDATA_HPP */
-

--- a/src/libPMacc/include/mpi/GetMPI_Op.hpp
+++ b/src/libPMacc/include/mpi/GetMPI_Op.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef GETMPI_OP_HPP
-#define	GETMPI_OP_HPP
+#pragma once
 
 #include "types.h"
 #include <mpi.h>
@@ -35,6 +34,3 @@ namespace PMacc
         MPI_Op getMPI_Op();
     }
 }
-
-#endif	/* GETMPI_OP_HPP */
-

--- a/src/libPMacc/include/mpi/MPI_StructAsArray.hpp
+++ b/src/libPMacc/include/mpi/MPI_StructAsArray.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,10 +20,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MPI_STRUCTASARRAY_HPP
-#define	MPI_STRUCTASARRAY_HPP
+#pragma once
 
 #include "types.h"
+
 #include <mpi.h>
 
 namespace PMacc
@@ -41,6 +41,3 @@ namespace PMacc
         };
     }
 }
-
-#endif	/* MPI_STRUCTASARRAY_HPP */
-

--- a/src/libPMacc/include/nvidia/functors/Add.hpp
+++ b/src/libPMacc/include/nvidia/functors/Add.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,12 +20,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef ADD_HPP
-#define	ADD_HPP
-
-#include "types.h"
 #include "mpi/GetMPI_Op.hpp"
+#include "types.h"
 
 namespace PMacc
 {
@@ -59,6 +57,3 @@ namespace PMacc
         }
     }
 }
-
-#endif	/* ADD_HPP */
-

--- a/src/libPMacc/include/nvidia/functors/Assign.hpp
+++ b/src/libPMacc/include/nvidia/functors/Assign.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ASSIGN_HPP
-#define	ASSIGN_HPP
+#pragma once
 
 #include "types.h"
 
@@ -44,6 +43,3 @@ namespace PMacc
         }
     }
 }
-
-#endif	/* ASSIGN_HPP */
-

--- a/src/libPMacc/include/nvidia/functors/Max.hpp
+++ b/src/libPMacc/include/nvidia/functors/Max.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,14 +20,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef MAX_HPP
-#define	MAX_HPP
-
-#include "types.h"
+#pragma once
 
 #include "mpi/GetMPI_Op.hpp"
 #include "algorithms/math.hpp"
+
+#include "types.h"
 
 namespace PMacc
 {
@@ -61,6 +59,3 @@ namespace PMacc
         }
     }
 }
-
-#endif	/* MAX_HPP */
-

--- a/src/libPMacc/include/nvidia/functors/Min.hpp
+++ b/src/libPMacc/include/nvidia/functors/Min.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,13 +21,12 @@
  */
 
 
-#ifndef MIN_HPP
-#define	MIN_HPP
-
-#include "types.h"
+#pragma once
 
 #include "mpi/GetMPI_Op.hpp"
 #include "algorithms/math.hpp"
+
+#include "types.h"
 
 namespace PMacc
 {
@@ -61,6 +60,3 @@ namespace PMacc
         }
     }
 }
-
-#endif	/* MIN_HPP */
-

--- a/src/libPMacc/include/nvidia/reduce/Reduce.hpp
+++ b/src/libPMacc/include/nvidia/reduce/Reduce.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,14 +20,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef REDUCE_HPP
-#define	REDUCE_HPP
-
-#include "types.h"
 
 #include "nvidia/functors/Assign.hpp"
 #include "traits/GetValueType.hpp"
+#include "types.h"
+
 #include <boost/type_traits.hpp>
 
 namespace PMacc
@@ -222,7 +221,7 @@ namespace PMacc
                  */
                 HINLINE uint32_t optimalThreadsPerBlock(uint32_t n, uint32_t sizePerElement)
                 {
-                    uint32_t sharedBorder = sharedMemByte / sizePerElement;
+                    uint32_t const sharedBorder = sharedMemByte / sizePerElement;
                     return getThreadsPerBlock(std::min(sharedBorder, n));
                 }
 
@@ -237,6 +236,3 @@ namespace PMacc
         }
     }
 }
-
-#endif	/* REDUCE_HPP */
-

--- a/src/libPMacc/include/particles/boostExtension/InheritGenerators.hpp
+++ b/src/libPMacc/include/particles/boostExtension/InheritGenerators.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,7 +20,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "particles/memory/frames/NullFrame.hpp"
@@ -39,7 +38,6 @@
 namespace PMacc
 {
 
-
 template <class list_>
 struct LinearInherit;
 
@@ -51,7 +49,7 @@ class LinearInheritFork : public Base1, public Base2
 
 /** Rule if head is a class without Base template parameter
  *
- * Create a fork an inharid from head and combined classes from Vec
+ * Create a fork and inherit from head and combined classes from Vec
  */
 template <class Head, class Vec,bool isVectorEmpty=bmpl::empty<Vec>::value>
 struct TypelistLinearInherit;
@@ -64,7 +62,7 @@ struct TypelistLinearInherit<Head,Vec,false>
 
 
 
-/** Rule if head is a clase which can inharit from other class
+/** Rule if head is a class which can inherit from other class
  */
 template < template<class> class Head, class Vec>
 struct TypelistLinearInherit<Head<PMacc::NullFrame>, Vec ,false>
@@ -75,7 +73,7 @@ struct TypelistLinearInherit<Head<PMacc::NullFrame>, Vec ,false>
 
 /** Rule if Vec is empty but Head is valid
  *
- * This is the recursiv end rule
+ * This is the recursive end rule
  */
 template <class Head,class Vec>
 struct TypelistLinearInherit<Head, Vec ,true>
@@ -85,7 +83,7 @@ struct TypelistLinearInherit<Head, Vec ,true>
 
 
 
-/** Create a data strcture which inharid lineary
+/** Create a data structure which inherit linearly
  * \tparam vec_ boost mpl vector with classes
  *
  * class A<PMacc::NullFrame>;

--- a/src/libPMacc/include/particles/frame_types.hpp
+++ b/src/libPMacc/include/particles/frame_types.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef FRAME_TYPES_HPP
-#define	FRAME_TYPES_HPP
+#pragma once
 
 #include "types.h"
 
@@ -34,16 +32,11 @@
 
 namespace PMacc
 {
-
-
-
     /**
      * Is used for indirect pointer layer.
      * This type is limited by atomicSub on device (in CUDA 3.2 we can use 32 Bit int only).
      */
-    typedef  unsigned  int vint_t;
-
-
+    typedef unsigned int vint_t;
 
     /**
      * Defines the local cell id type in a supercell
@@ -55,7 +48,3 @@ namespace PMacc
      */
     enum FrameType { CORE_FRAME = 0u, BORDER_FRAME =1u , BIG_FRAME=2u};
 }
-
-
-#endif	/* FRAME_TYPES_HPP */
-

--- a/src/libPMacc/include/particles/memory/boxes/ExchangePopDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ExchangePopDataBox.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef EXCHANGEPOPDATABOX_HPP
-#define	EXCHANGEPOPDATABOX_HPP
+#pragma once
 
 #include "particles/memory/dataTypes/ExchangeMemoryIndex.hpp"
 #include "particles/memory/boxes/TileDataBox.hpp"
@@ -70,6 +68,3 @@ protected:
 };
 
 }
-
-#endif	/* EXCHANGEPOPDATABOX_HPP */
-

--- a/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EXCHANGEPUSHDATABOX_HPP
-#define	EXCHANGEPUSHDATABOX_HPP
+#pragma once
 
 #include "particles/memory/dataTypes/ExchangeMemoryIndex.hpp"
 #include "memory/boxes/DataBox.hpp"
@@ -91,6 +90,3 @@ protected:
 };
 
 }
-
-#endif	/* EXCHANGEPUSHDATABOX_HPP */
-

--- a/src/libPMacc/include/particles/memory/boxes/PopDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PopDataBox.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,9 +21,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#ifndef POPDATABOX_HPP
-#define	POPDATABOX_HPP
+#pragma once
 
 #include <cuda.h>
 
@@ -118,5 +117,3 @@ protected:
 };
 
 }
-
-#endif	/* POPDATABOX_HPP */

--- a/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -21,9 +22,8 @@
  */
 
 
-#ifndef PUSHDATABOX_HPP
-#define	PUSHDATABOX_HPP
 
+#pragma once
 #include <cuda.h>
 
 #include "particles/memory/boxes/TileDataBox.hpp"
@@ -99,5 +99,3 @@ namespace PMacc
         PMACC_ALIGN(currentSize,TYPE*);
     };
 }
-
-#endif	/* PUSHDATABOX_HPP */

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef PARTICLESBUFFER_HPP
-#define	PARTICLESBUFFER_HPP
+#pragma once
 
 #include "particles/frame_types.hpp"
 #include "memory/buffers/GridBuffer.hpp"
@@ -317,5 +316,3 @@ private:
 
 };
 }
-
-#endif	/* PARTICLESBUFFER_HPP */

--- a/src/libPMacc/include/particles/memory/buffers/StackExchangeBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/StackExchangeBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef STACKEXCHANGEBUFFER_HPP
-#define	STACKEXCHANGEBUFFER_HPP
+#pragma once
 
 #include "particles/memory/boxes/ExchangePopDataBox.hpp"
 #include "particles/memory/boxes/ExchangePushDataBox.hpp"
@@ -175,6 +174,3 @@ namespace PMacc
         Exchange<FRAMEINDEX, DIM1>& stackIndexer;
     };
 }
-
-#endif	/* STACKEXCHANGEBUFFER_HPP */
-

--- a/src/libPMacc/include/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,15 +20,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EXCHANGEMEMORYINDEX_HPP
-#define	EXCHANGEMEMORYINDEX_HPP
+#pragma once
 
-#include "types.h"
 #include "dimensions/DataSpace.hpp"
+#include "types.h"
 
 namespace PMacc
 {
-
 
 template<class TYPE, unsigned DIM>
 class ExchangeMemoryIndex
@@ -75,6 +73,3 @@ private:
     PMACC_ALIGN(count, TYPE);
 };
 }
-
-#endif	/* EXCHANGEMEMORYINDEX_HPP */
-

--- a/src/libPMacc/include/particles/memory/frames/NullFrame.hpp
+++ b/src/libPMacc/include/particles/memory/frames/NullFrame.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,14 +20,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef NULLFRAME_HPP
-#define	NULLFRAME_HPP
-
-
-#include "types.h"
 #include "particles/memory/frames/NullFrame.hpp"
-
+#include "types.h"
 
 namespace PMacc
 {
@@ -44,7 +40,3 @@ namespace PMacc
     };
 
 }//namespace
-
-
-#endif	/* NULLFRAME_HPP */
-

--- a/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,13 +20,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef DEFAULTFILTER_HPP
-#define	DEFAULTFILTER_HPP
-
-#include "types.h"
-#include "particles/frame_types.hpp"
 #include "particles/memory/frames/NullFrame.hpp"
+#include "particles/frame_types.hpp"
+#include "types.h"
 
 namespace PMacc
 {
@@ -98,6 +96,3 @@ class DefaultFilter<NullFrame>
 
 
 } //namespace Frame
-
-#endif	/* DEFAULTFILTER_HPP */
-

--- a/src/libPMacc/include/particles/particleFilter/system/FalseFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/FalseFilter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,17 +20,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef FALSEFILTER_HPP
-#define	FALSEFILTER_HPP
-
-#include "types.h"
-#include "particles/frame_types.hpp"
 #include "particles/memory/frames/NullFrame.hpp"
+#include "particles/frame_types.hpp"
+#include "types.h"
 
 namespace PMacc
 {
-
 
     class FalseFilter
     {
@@ -53,6 +50,3 @@ namespace PMacc
     };
 
 } //namespace Frame
-
-#endif	/* FALSEFILTER_HPP */
-

--- a/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,17 +20,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef TRUEFILTER_HPP
-#define	TRUEFILTER_HPP
-
-#include "types.h"
-#include "particles/frame_types.hpp"
 #include "particles/memory/frames/NullFrame.hpp"
+#include "particles/frame_types.hpp"
+#include "types.h"
 
 namespace PMacc
 {
-
 
     class TrueFilter
     {
@@ -53,6 +50,3 @@ namespace PMacc
     };
 
 } //namespace Frame
-
-#endif	/* TRUEFILTER_HPP */
-

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
+ *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -35,7 +36,6 @@
 #include "dataManagement/DataConnector.hpp"
 
 
-#include "eventSystem/EventSystem.hpp"
 #include "pluginSystem/IPlugin.hpp"
 
 

--- a/src/libPMacc/include/simulationControl/TimeInterval.hpp
+++ b/src/libPMacc/include/simulationControl/TimeInterval.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013, 2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -20,16 +20,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TIMEINTERVAL_HPP
-#define	TIMEINTERVAL_HPP
-
-#include <sys/time.h>
-#include <string>
+#pragma once
 
 #include "types.h"
+
+#include <sys/time.h>
+
+#include <string>
 #include <iostream>
 #include <sstream>
-
 
 namespace PMacc
 {
@@ -124,7 +123,3 @@ namespace PMacc
         double end;
     };
 } //namespace PMacc
-
-
-#endif	/* TIMEINTERVAL_HPP */
-


### PR DESCRIPTION
Another round of refatoring libPMacc includes:
* reorder includes
* correct spelling errors
* pragma once instead of header guard for affected files