### PR TITLE
Current Interpolation: During add to EMF

### DIFF
--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -124,6 +124,7 @@ public:
 private:
 
     GridBuffer<ValueType, simDim> fieldJ;
+    GridBuffer<ValueType, simDim>* fieldJrecv;
 
     FieldE *fieldE;
     FieldB *fieldB;

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -70,7 +70,7 @@ public:
 
     virtual EventTask asyncCommunication(EventTask serialEvent);
 
-    void init(FieldE &fieldE);
+    void init(FieldE &fieldE, FieldB &fieldB);
 
     GridLayout<simDim> getGridLayout();
 
@@ -87,8 +87,8 @@ public:
     template<uint32_t AREA, class ParticlesClass>
     void computeCurrent(ParticlesClass &parClass, uint32_t currentStep) throw (std::invalid_argument);
 
-    template<uint32_t AREA>
-    void addCurrentToE();
+    template<uint32_t AREA, class T_CurrentInterpolation>
+    void addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation );
 
     SimulationDataId getUniqueId();
 
@@ -126,6 +126,7 @@ private:
     GridBuffer<ValueType, simDim> fieldJ;
 
     FieldE *fieldE;
+    FieldB *fieldB;
 };
 
 template<typename T_SpeciesName, typename T_Area>

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -160,24 +160,45 @@ private:
     const PMACC_ALIGN(deltaTime, float);
 };
 
-template<class Mapping>
-__global__ void kernelAddCurrentToE(typename FieldE::DataBoxType fieldE,
-                                    J_DataBox fieldJ,
-                                    Mapping mapper)
+template<class T_CurrentInterpolation, class T_Mapping>
+__global__ void kernelAddCurrentToEMF(typename FieldE::DataBoxType fieldE,
+                                      typename FieldB::DataBoxType fieldB,
+                                      J_DataBox fieldJ,
+                                      T_CurrentInterpolation currentInterpolation,
+                                      T_Mapping mapper)
 {
+    /* Caching of fieldJ */
+    typedef SuperCellDescription<
+                SuperCellSize,
+                typename T_CurrentInterpolation::LowerMargin,
+                typename T_CurrentInterpolation::UpperMargin
+                > BlockArea;
 
-    const DataSpace<simDim> blockCell(
-                                      mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx))
-                                      * Mapping::SuperCellSize::toRT()
-                                      );
-    const DataSpace<Mapping::Dim> cell(blockCell + DataSpace<simDim > (threadIdx));
+    PMACC_AUTO(cachedJ, CachedBox::create < 0, typename J_DataBox::ValueType > (BlockArea()));
+
+    nvidia::functors::Assign assign;
+    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+    const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
+
+    const DataSpace<simDim > threadIndex(threadIdx);
+    PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
+
+    ThreadCollective<BlockArea> collectiv(threadIndex);
+    collectiv(
+              assign,
+              cachedJ,
+              fieldJBlock
+              );
+
+    __syncthreads();
+
+    const DataSpace<T_Mapping::Dim> cell(blockCell + threadIndex);
 
     // Amperes Law:
     //   Change of the dE = - j / EPS0 * dt
     //                        j = current density (= current per area)
     //                          = fieldJ
-    const float_X deltaT = DELTA_T;
-    fieldE(cell) -= fieldJ(cell) * (float_X(1.0) / EPS0) * deltaT;
+    currentInterpolation( fieldE.shift(cell), fieldB.shift(cell), cachedJ.shift(threadIndex) );
 }
 
 template<class Mapping>

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -57,17 +57,31 @@ fieldJ( cellDescription.getGridLayout( ) ), fieldE( NULL ), fieldB( NULL )
 {
     const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout( ).getDataSpaceWithoutGuarding( );
 
-
+    /* cell margins the current might spread to due to particle shapes */
     typedef typename bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetLowerMargin< GetCurrentSolver<bmpl::_2> > >
-        >::type LowerMargin;
+        >::type LowerMarginShapes;
 
     typedef typename bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetUpperMargin< GetCurrentSolver<bmpl::_2> > >
+        >::type UpperMarginShapes;
+
+    /* margins are always positive, also for lower margins
+     * additional current interpolations and current filters on FieldJ might
+     * spread the dependencies on neighboring cells
+     *   -> use max(shape,filter) */
+    typedef typename PMacc::math::CT::max<
+        LowerMarginShapes,
+        GetMargin<fieldSolver::CurrentInterpolation>::LowerMargin
+        >::type LowerMargin;
+
+    typedef typename PMacc::math::CT::max<
+        UpperMarginShapes,
+        GetMargin<fieldSolver::CurrentInterpolation>::UpperMargin
         >::type UpperMargin;
 
     const DataSpace<simDim> originGuard( LowerMargin( ).toRT( ) );

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.def
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.def
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace currentInterpolation
+{
+
+/* 2nd order Binomial filter */
+template<uint32_t T_dim>
+struct Binomial;
+
+} /* namespace currentInterpolation */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.def
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.def
@@ -31,4 +31,24 @@ struct Binomial;
 
 } /* namespace currentInterpolation */
 
+namespace traits
+{
+
+/* Get margin of the current interpolation
+ *
+ * This class defines a LowerMargin and an UpperMargin.
+ */
+template<uint32_t T_dim>
+struct GetMargin<picongpu::currentInterpolation::Binomial<T_dim > >
+{
+private:
+    typedef picongpu::currentInterpolation::Binomial<T_dim> MyInterpolation;
+
+public:
+    typedef typename MyInterpolation::LowerMargin LowerMargin;
+    typedef typename MyInterpolation::UpperMargin UpperMargin;
+};
+
+} /* namespace traits */
+
 } /* namespace picongpu */

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "types.h"
+#include "basicOperations.hpp"
+
+#include "fields/currentInterpolation/None/None.def"
+
+namespace picongpu
+{
+namespace currentInterpolation
+{
+using namespace PMacc;
+
+template<uint32_t T_dim>
+struct Binomial
+{
+    static const uint32_t dim = T_dim;
+
+    typedef typename PMacc::math::CT::make_Int<dim, 1>::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int<dim, 1>::type UpperMargin;
+
+    template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
+    HDINLINE void operator()(DataBoxE fieldE,
+                             DataBoxB,
+                             DataBoxJ fieldJ )
+    {
+        const DataSpace<dim> self;
+        typedef typename DataBoxJ::ValueType TypeJ;
+
+        /* 1 2 1 weighting for "left"(1x) "center"(2x) "right"(1x),
+         * see Pascal's triangle level N=2 */
+        TypeJ dirSum( TypeJ::create(0.0) );
+        for( uint32_t d = 0; d < dim; ++d )
+        {
+            DataSpace<dim> dw;
+            dw[d] = -1;
+            DataSpace<dim> up;
+            up[d] =  1;
+            const TypeJ dirDw = fieldJ(dw) + fieldJ(self);
+            const TypeJ dirUp = fieldJ(up) + fieldJ(self);
+
+            /* each fieldJ component is added individually */
+            dirSum += dirDw + dirUp;
+        }
+
+        /* component-wise division by sum of all weightings,
+         * in the second order binomial filter these are 4 values per direction
+         * (1D: 4 values; 2D: 8 values; 3D: 12 values) */
+        const TypeJ filteredJ = dirSum / TypeJ::create(4.0 * dim);
+
+        const float_X deltaT = DELTA_T;
+        fieldE(self) -= filteredJ * (float_X(1.0) / EPS0) * deltaT;
+    }
+};
+
+} /* namespace currentInterpolation */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.def
+++ b/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.def
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "fields/currentInterpolation/None/None.def"
+#include "fields/currentInterpolation/Binomial/Binomial.def"

--- a/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.hpp
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "fields/currentInterpolation/None/None.hpp"
+#include "fields/currentInterpolation/Binomial/Binomial.hpp"

--- a/src/picongpu/include/fields/currentInterpolation/None/None.def
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.def
@@ -30,4 +30,24 @@ struct None;
 
 } /* namespace currentInterpolation */
 
+namespace traits
+{
+
+/* Get margin of the current interpolation
+ *
+ * This class defines a LowerMargin and an UpperMargin.
+ */
+template<uint32_t T_dim>
+struct GetMargin<picongpu::currentInterpolation::None<T_dim > >
+{
+private:
+    typedef picongpu::currentInterpolation::None<T_dim> MyInterpolation;
+
+public:
+    typedef typename MyInterpolation::LowerMargin LowerMargin;
+    typedef typename MyInterpolation::UpperMargin UpperMargin;
+};
+
+} /* namespace traits */
+
 } /* namespace picongpu */

--- a/src/picongpu/include/fields/currentInterpolation/None/None.def
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.def
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace currentInterpolation
+{
+
+template<uint32_t T_dim>
+struct None;
+
+} /* namespace currentInterpolation */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/fields/currentInterpolation/None/None.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "types.h"
+#include "basicOperations.hpp"
+
+#include "fields/currentInterpolation/None/None.def"
+
+namespace picongpu
+{
+namespace currentInterpolation
+{
+using namespace PMacc;
+
+template<uint32_t T_dim>
+struct None
+{
+    static const uint32_t dim = T_dim;
+
+    typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int<dim, 0>::type UpperMargin;
+
+    template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
+    HDINLINE void operator()(DataBoxE fieldE,
+                             DataBoxB,
+                             DataBoxJ fieldJ )
+    {
+        const DataSpace<dim> self;
+
+        const float_X deltaT = DELTA_T;
+        fieldE(self) -= fieldJ(self) * (float_X(1.0) / EPS0) * deltaT;
+    }
+
+};
+
+} /* namespace currentInterpolation */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/simulation_defines/param/fieldSolver.param
+++ b/src/picongpu/include/simulation_defines/param/fieldSolver.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -18,8 +18,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
+#include "fields/currentInterpolation/CurrentInterpolation.def"
 
 /**! Configure the selected field solver method
  *
@@ -30,24 +31,24 @@ namespace picongpu
 {
     namespace fieldSolverNone
     {
-        
+        typedef currentInterpolation::None<simDim> CurrentInterpolation;
     }
-    
+
     namespace fieldSolverYee
     {
-        
+        typedef currentInterpolation::None<simDim> CurrentInterpolation;
     }
-    
+
     namespace fieldSolverYeeNative
     {
-    
+        typedef currentInterpolation::None<simDim> CurrentInterpolation;
     }
 
     namespace fieldSolverDirSplitting
     {
-        
+        typedef currentInterpolation::None<simDim> CurrentInterpolation;
     }
-    
+
     /**! Lehe Solver
      * The solver proposed by R. Lehe et al
      * in Phys. Rev. ST Accel. Beams 16, 021301 (2013)
@@ -57,11 +58,13 @@ namespace picongpu
         class CherenkovFreeDirection_X {};
         class CherenkovFreeDirection_Y {};
         class CherenkovFreeDirection_Z {};
-        
+
         /*! Distinguish the direction where numerical Cherenkov Radiation
          *  by moving particles shall be suppressed.
          */
         typedef CherenkovFreeDirection_Y CherenkovFreeDir;
+
+        typedef currentInterpolation::None<simDim> CurrentInterpolation;
     }
 
 } // namespace picongpu

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -17,7 +17,6 @@
  * along with PIConGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-
 
 
 #pragma once
@@ -48,8 +47,8 @@ enum ParticleType
 
 enum CommunicationTag
 {
-    FIELD_B = 0u, FIELD_E = 1u, FIELD_J = 2u, FIELD_TMP = 3u,
-    PAR_IONS = 4u, PAR_ELECTRONS = 5u,
+    FIELD_B = 0u, FIELD_E = 1u, FIELD_J = 2u, FIELD_JRECV = 3u, FIELD_TMP = 4u,
+    PAR_IONS = 5u, PAR_ELECTRONS = 6u,
     NO_COMMUNICATION = 16u
 };
 


### PR DESCRIPTION
This commit adds the general infrastructure to call functors before adding `FieldJ` to the electro-magnetic fields (in `Yee`: before manipulating the `E` field).

The previous method `None` without interpolation is added as a default in `fieldSolver.param`. Additionally, a simple second order Binomial filter for 2D and 3D is added to test the new functionality.

Run time tests:
- [x] KHI 3D e+/e- `dev`vs. with/without Binomial filter (with ZigZag & TSC)