### PR TITLE
close #889 field solver DS out of memory access

### DIFF
--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -36,7 +36,7 @@ struct DirSplittingKernel
 {
     typedef void result_type;
 
-    int totalLength;
+    PMACC_ALIGN(totalLength,int);
     DirSplittingKernel(int totalLength) : totalLength(totalLength) {}
 
     template<typename CursorE, typename CursorB >


### PR DESCRIPTION
twist `blockDim` before kernel call

close #889 *DirectionalSplitting not twitstet blockDim*

**Tests:** 
- [x] plane wave in vacuum 3D
- [x] cuda-memcheck with `-g 24 24 12`

**The bug affects master thus `Directional Splitting` is not well tested I think there is no back port needed** 