### PR TITLE
Direction Splitting: Self-Consistent J & EMF

### DIFF
--- a/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
+++ b/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015 Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#pragma once
+
+#include "types.h"
+#include "math/Vector.hpp"
+
+namespace picongpu
+{
+
+/** Calculate linear interpolation to upper cell value
+ *
+ * @tparam T_Dim for how many dimensions does this operator interpolate
+ *
+ * If `GetDifference` is called for a direction greater or equal T_Dim,
+ * a zeroed value is returned (assumes symmetry in those directions).
+ */
+template<uint32_t T_Dim>
+struct LinearInterpolateWithUpper
+{
+    static const uint32_t dim = T_Dim;
+
+    typedef typename PMacc::math::CT::make_Int<dim, 0>::type OffsetOrigin;
+    typedef typename PMacc::math::CT::make_Int<dim, 1>::type OffsetEnd;
+
+    /** calculate the linear interpolation for a given direction
+     *
+     * @tparam T_direction direction for the interpolation operation
+     * @tparam T_isLesserThanDim not needed/ this is calculated by the compiler
+     */
+    template<uint32_t T_direction, bool T_isLesserThanDim = (T_direction < dim)>
+    struct GetInterpolatedValue
+    {
+        static const uint32_t direction = T_direction;
+
+        /** get interpolated value
+         * @return interpolated value
+         */
+        template<class Memory >
+        HDINLINE typename Memory::ValueType operator()(const Memory& mem) const
+        {
+            const DataSpace<dim> indexIdentity; /* defaults to (0, 0, 0) in 3D */
+            DataSpace<dim> indexUpper; /* e.g., (0, 1, 0) for direction y in 3D */
+            indexUpper[direction] = 1;
+
+            return ( mem(indexUpper) + mem(indexIdentity)) * Memory::ValueType::create(0.5);
+        }
+    };
+
+    /** special case for `direction >= simulation dimensions`*/
+    template<uint32_t T_direction>
+    struct GetInterpolatedValue<T_direction, false>
+    {
+
+        /** @return always identity
+         */
+        template<class Memory >
+        HDINLINE typename Memory::ValueType operator()(const Memory& mem) const
+        {
+            return *mem;
+        }
+    };
+
+};
+
+} //namespace picongpu

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -150,7 +150,20 @@ public:
     }
 
     void update_afterCurrent(uint32_t) const
-    {    }
+    {
+        DataConnector &dc = Environment<>::get().DataConnector();
+
+        FieldE& fieldE = dc.getData<FieldE > (FieldE::getName(), true);
+        FieldB& fieldB = dc.getData<FieldB > (FieldB::getName(), true);
+
+        EventTask eRfieldE = fieldE.asyncCommunication(__getTransactionEvent());
+        EventTask eRfieldB = fieldB.asyncCommunication(__getTransactionEvent());
+        __setTransactionEvent(eRfieldE);
+        __setTransactionEvent(eRfieldB);
+
+        dc.releaseData(FieldE::getName());
+        dc.releaseData(FieldB::getName());
+    }
 };
 
 } // dirSplitting

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -195,7 +195,7 @@ struct ZigZag
              *   - run calculations in a shape optimized coordinate system
              *     with fixed interpolation points
              */
-            ShiftCoordinateSystem<Supports_direction>()(cursor, pos, fieldSolver::NumericalCellType::getEFieldPosition()[dir]);
+            ShiftCoordinateSystem<Supports_direction>()(cursor, pos, fieldSolver::NumericalCellType::getJFieldPosition()[dir]);
 
             /* define grid points where we evaluate the shape function*/
             typedef typename PMacc::math::CT::make_Vector<

--- a/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.def
+++ b/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.def
@@ -21,3 +21,4 @@
 
 #include "fields/currentInterpolation/None/None.def"
 #include "fields/currentInterpolation/Binomial/Binomial.def"
+#include "fields/currentInterpolation/NoneDS/NoneDS.def"

--- a/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.hpp
@@ -21,3 +21,4 @@
 
 #include "fields/currentInterpolation/None/None.hpp"
 #include "fields/currentInterpolation/Binomial/Binomial.hpp"
+#include "fields/currentInterpolation/NoneDS/NoneDS.hpp"

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.def
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.def
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace currentInterpolation
+{
+
+/* The standard interpolation for Directional Splitting
+ *
+ * In the Directional Splitting scheme (see MaxwellSolver and
+ * numericalCellTypes
+ */
+template<uint32_t T_simDim>
+struct NoneDS;
+
+} /* namespace currentInterpolation */
+
+namespace traits
+{
+
+/* Get margin of the current interpolation
+ *
+ * This class defines a LowerMargin and an UpperMargin.
+ */
+template<uint32_t T_dim>
+struct GetMargin<picongpu::currentInterpolation::NoneDS<T_dim > >
+{
+private:
+    typedef picongpu::currentInterpolation::NoneDS<T_dim> MyInterpolation;
+
+public:
+    typedef typename MyInterpolation::LowerMargin LowerMargin;
+    typedef typename MyInterpolation::UpperMargin UpperMargin;
+};
+
+} /* namespace traits */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "types.h"
+#include "basicOperations.hpp"
+
+#include "fields/currentInterpolation/None/None.def"
+#include "algorithms/DifferenceToUpper.hpp"
+#include "algorithms/LinearInterpolateWithUpper.hpp"
+#include "traits/GetComponentsType.hpp"
+
+#include "fields/MaxwellSolver/Yee/Curl.hpp"
+
+
+namespace picongpu
+{
+namespace currentInterpolation
+{
+using namespace PMacc;
+
+namespace detail
+{
+    template<uint32_t T_simDim, uint32_t T_plane>
+    struct LinearInterpolateComponentPlaneUpper
+    {
+        static const uint32_t dim = T_simDim;
+
+        /* UpperMargin is actually 0 in direction of T_plane */
+        typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
+        typedef typename PMacc::math::CT::make_Int<dim, 1>::type UpperMargin;
+
+        template<typename DataBox>
+        HDINLINE float_X operator()(DataBox field) const
+        {
+            const DataSpace<dim> self;
+            DataSpace<dim> up;
+            up[(T_plane + 1) % dim] = 1;
+
+            typedef LinearInterpolateWithUpper<dim> Avg;
+
+            const typename Avg::template GetInterpolatedValue<(T_plane + 2) % dim> avg;
+
+            return float_X(0.5) * ( avg(field)[T_plane] + avg(field.shift(up))[T_plane] );
+        }
+    };
+
+    /* shift a databox along a specific direction
+     *
+     * returns the identity (assume periodic symmetry) if direction is not
+     * available, such as in a 2D simulation
+     *
+     * \todo accept a full CT::Vector and shift if possible
+     * \todo call with CT::Vector of correct dimensionality that was created
+     *       with AssignIfInRange...
+     *
+     * \tparam T_simDim maximum dimensionality of the mesh
+     * \tparam T_direction (0)X (1)Y or (2)Z for the direction one wants to
+     *                     shift to
+     * \tparam isShiftAble auto-filled value that decides if this direction
+     *                     is actually non-existent == periodic
+     */
+    template<uint32_t T_simDim, uint32_t T_direction, bool isShiftAble=(T_direction<T_simDim) >
+    struct ShiftMeIfYouCan
+    {
+        static const uint32_t dim = T_simDim;
+        static const uint32_t dir = T_direction;
+
+        template<class T_DataBox >
+        HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
+        {
+            DataSpace<dim> shift;
+            shift[dir] = 1;
+            return dataBox.shift(shift);
+        }
+    };
+
+    template<uint32_t T_simDim, uint32_t T_direction>
+    struct ShiftMeIfYouCan<T_simDim, T_direction, false>
+    {
+        template<class T_DataBox >
+        HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
+        {
+            return dataBox;
+        }
+    };
+
+    /* that is not a "real" yee curl, but it looks a bit like it */
+    template<class Difference>
+    struct ShiftCurl
+    {
+        typedef typename Difference::OffsetOrigin LowerMargin;
+        typedef typename Difference::OffsetEnd UpperMargin;
+
+        template<class DataBox >
+        HDINLINE typename DataBox::ValueType operator()(const DataBox& mem) const
+        {
+            const typename Difference::template GetDifference<0> Dx;
+            const typename Difference::template GetDifference<1> Dy;
+            const typename Difference::template GetDifference<2> Dz;
+
+            const ShiftMeIfYouCan<simDim, 0> sx;
+            const ShiftMeIfYouCan<simDim, 1> sy;
+            const ShiftMeIfYouCan<simDim, 2> sz;
+
+            return float3_X(Dy(sx(mem)).z() - Dz(sx(mem)).y(),
+                            Dz(sy(mem)).x() - Dx(sy(mem)).z(),
+                            Dx(sz(mem)).y() - Dy(sz(mem)).x());
+        }
+    };
+} /* namespace detail */
+
+template<uint32_t T_simDim>
+struct NoneDS
+{
+    static const uint32_t dim = T_simDim;
+
+    typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int<dim, 1>::type UpperMargin;
+
+    template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
+    HDINLINE void operator()(DataBoxE fieldE,
+                             DataBoxB fieldB,
+                             DataBoxJ fieldJ )
+    {
+        typedef typename DataBoxJ::ValueType TypeJ;
+        typedef typename GetComponentsType<TypeJ>::type ComponentJ;
+
+        const DataSpace<dim> self;
+
+        const ComponentJ deltaT = DELTA_T;
+        const ComponentJ constE = (float_X(1.0)  / EPS0) * deltaT;
+        const ComponentJ constB = (float_X(0.25) / EPS0) * deltaT * deltaT;
+
+        const detail::LinearInterpolateComponentPlaneUpper<dim, 0> avgX;
+        const ComponentJ jXavg = avgX(fieldJ);
+        const detail::LinearInterpolateComponentPlaneUpper<dim, 1> avgY;
+        const ComponentJ jYavg = avgY(fieldJ);
+        const detail::LinearInterpolateComponentPlaneUpper<dim, 2> avgZ;
+        const ComponentJ jZavg = avgZ(fieldJ);
+
+        const TypeJ jAvgE = TypeJ(jXavg, jYavg, jZavg);
+        fieldE(self) -= jAvgE * constE;
+
+        typedef yeeSolver::Curl<DifferenceToUpper<dim> > CurlRight;
+        typedef detail::ShiftCurl<DifferenceToUpper<dim> > ShiftCurlRight;
+        CurlRight curl;
+        ShiftCurlRight shiftCurl;
+
+        const TypeJ jAvgB = curl(fieldJ) + shiftCurl(fieldJ);
+        fieldB(self) += jAvgB * constB;
+    }
+
+};
+
+} /* namespace currentInterpolation */
+
+} /* namespace picongpu */

--- a/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -28,7 +28,7 @@
 namespace picongpu
 {
 using namespace PMacc;
-namespace allCenteredCell
+namespace emfCenteredCell
 {
 
 // ___________posE____________
@@ -57,7 +57,34 @@ const float_X posB_z_x = 0.5;
 const float_X posB_z_y = 0.5;
 const float_X posB_z_z = 0.5;
 
-struct AllCenteredCell
+// ___________posJ____________
+const float_X posJ_x_x = 0.5;
+const float_X posJ_x_y = 0.0;
+const float_X posJ_x_z = 0.0;
+
+const float_X posJ_y_x = 0.0;
+const float_X posJ_y_y = 0.5;
+const float_X posJ_y_z = 0.0;
+
+const float_X posJ_z_x = 0.0;
+const float_X posJ_z_y = 0.0;
+const float_X posJ_z_z = 0.5;
+
+/** \todo posRho for FieldTmp depositions
+const float_X posRho_x_x = 0.0; ? or at center pos ?
+const float_X posRho_x_y = 0.0; ?
+const float_X posRho_x_z = 0.0; ?
+
+const float_X posRho_y_x = 0.0; ?
+const float_X posRho_y_y = 0.0; ?
+const float_X posRho_y_z = 0.0; ?
+
+const float_X posRho_z_x = 0.0; ?
+const float_X posRho_z_y = 0.0; ?
+const float_X posRho_z_z = 0.0; ?
+*/
+
+struct EMFCenteredCell
 {
     /** \tparam floatD_X position of the component in the cell
      *  \tparam DIM3     Fields (E/B) have 3 components, even in 1 or 2D ! */
@@ -95,7 +122,23 @@ struct AllCenteredCell
         return VectorVector(posB_x, posB_y, posB_z);
     }
 
+    static HDINLINE VectorVector getJFieldPosition()
+    {
+#if( SIMDIM == DIM3 )
+        const float3_X posJ_x(posJ_x_x, posJ_x_y, posJ_x_z);
+        const float3_X posJ_y(posJ_y_x, posJ_y_y, posJ_y_z);
+        const float3_X posJ_z(posJ_z_x, posJ_z_y, posJ_z_z);
+#elif( SIMDIM == DIM2 )
+        const float2_X posJ_x(posJ_x_x, posJ_x_y);
+        const float2_X posJ_y(posJ_y_x, posJ_y_y);
+        const float2_X posJ_z(posJ_z_x, posJ_z_y);
+#endif
+
+        /** position (floatD_x) in cell for J_x, J_y, J_z */
+        return VectorVector(posJ_x, posJ_y, posJ_z);
+    }
+
 };
 
-} // allCenteredCell
+} // emfCenteredCell
 } // picongpu

--- a/src/picongpu/include/fields/numericalCellTypes/NumericalCellTypes.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/NumericalCellTypes.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -23,4 +23,4 @@
 #pragma once
 
 #include "YeeCell.hpp"
-#include "AllCenteredCell.hpp"
+#include "EMFCenteredCell.hpp"

--- a/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
@@ -56,10 +56,37 @@ const float_X posB_z_x = 0.5;
 const float_X posB_z_y = 0.5;
 const float_X posB_z_z = 0.0;
 
+// ___________posJ____________
+const float_X posJ_x_x = 0.5;
+const float_X posJ_x_y = 0.0;
+const float_X posJ_x_z = 0.0;
+
+const float_X posJ_y_x = 0.0;
+const float_X posJ_y_y = 0.5;
+const float_X posJ_y_z = 0.0;
+
+const float_X posJ_z_x = 0.0;
+const float_X posJ_z_y = 0.0;
+const float_X posJ_z_z = 0.5;
+
+/** \todo posRho for FieldTmp depositions
+const float_X posRho_x_x = 0.0;
+const float_X posRho_x_y = 0.0;
+const float_X posRho_x_z = 0.0;
+
+const float_X posRho_y_x = 0.0;
+const float_X posRho_y_y = 0.0;
+const float_X posRho_y_z = 0.0;
+
+const float_X posRho_z_x = 0.0;
+const float_X posRho_z_y = 0.0;
+const float_X posRho_z_z = 0.0;
+*/
+
 struct YeeCell
 {
     /** \tparam floatD_X position of the component in the cell
-     *  \tparam DIM3     Fields (E/B) have 3 components, even in 1 or 2D ! */
+     *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D ! */
     typedef ::PMacc::math::Vector<floatD_X,DIM3> VectorVector;
 
     static HDINLINE VectorVector getEFieldPosition()
@@ -92,6 +119,22 @@ struct YeeCell
 
         /** position (floatD_x) in cell for B_x, B_y, B_z */
         return VectorVector(posB_x, posB_y, posB_z);
+    }
+
+    static HDINLINE VectorVector getJFieldPosition()
+    {
+#if( SIMDIM == DIM3 )
+        const float3_X posJ_x(posJ_x_x, posJ_x_y, posJ_x_z);
+        const float3_X posJ_y(posJ_y_x, posJ_y_y, posJ_y_z);
+        const float3_X posJ_z(posJ_z_x, posJ_z_y, posJ_z_z);
+#elif( SIMDIM == DIM2 )
+        const float2_X posJ_x(posJ_x_x, posJ_x_y);
+        const float2_X posJ_y(posJ_y_x, posJ_y_y);
+        const float2_X posJ_z(posJ_z_x, posJ_z_y);
+#endif
+
+        /** position (floatD_x) in cell for J_x, J_y, J_z */
+        return VectorVector(posJ_x, posJ_y, posJ_z);
     }
 
 };

--- a/src/picongpu/include/simulation_defines/param/fieldSolver.param
+++ b/src/picongpu/include/simulation_defines/param/fieldSolver.param
@@ -46,7 +46,7 @@ namespace picongpu
 
     namespace fieldSolverDirSplitting
     {
-        typedef currentInterpolation::None<simDim> CurrentInterpolation;
+        typedef currentInterpolation::NoneDS<simDim> CurrentInterpolation;
     }
 
     /**! Lehe Solver

--- a/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
@@ -57,7 +57,7 @@ namespace fieldSolverYee
 namespace fieldSolverDirSplitting
 {
     typedef picongpu::dirSplitting::DirSplitting FieldSolver;
-    typedef allCenteredCell::AllCenteredCell NumericalCellType;
+    typedef emfCenteredCell::EMFCenteredCell NumericalCellType;
 }
 
 namespace fieldSolverLehe


### PR DESCRIPTION
This pull request introduces the correct handling for the binding of electro-magnetic fields to currents in the directional splitting (DS) scheme.

### Rationale

In the directional splitting cell *only* the electro-magnetic fields are centered<sup>1</sup>. Both `B` and `E` are furthermore defined at the same time `t`.<sup>2</sup>

The particles are still moved between the updates of `B` and `E` making their current density `J` be defined at `t-1/2`.

Let's have a look at the cell for our **DS** implementation<sup>3</sup>, `E`<sup>t</sup> and `B`<sup>t</sup>:
![dscell](https://cloud.githubusercontent.com/assets/1353258/7836646/f94d20c2-0481-11e5-9ffa-709f75feee78.png)

Compared to the **Yee cell**<sup>3</sup>, `E`<sup>t</sup> and `B`<sup>t-1/2</sup>:
  ![yeecell](https://cloud.githubusercontent.com/assets/1353258/7836472/b6248872-0480-11e5-9edd-6fe3b23e08e5.png)

Nevertheless the source terms<sup>3</sup> (only `J` printed) are still at:
  ![yeecellsource](https://cloud.githubusercontent.com/assets/1353258/7836468/acf504f2-0480-11e5-8d78-64212ff03425.png)

the last image can be derived from either analytically checking the DS scheme for a plane wave equation<sup>4</sup> or by performing the substitution in the DS operators F<sup>+-</sup>, G<sup>+-</sup> in 2 or 3D and solving for `J` self-consistently, example for 1D in<sup>5</sup> (too long for Markdown, I need LaTeX for that).

Fun fact: we can now still use our current current solvers since the position of `J` stays the same<sup>1</sup>.

Nevertheless, the result is that `J` can not simply be subtracted from `E`. But simply put, we can just interpolate the `4 closed J values` along the plane that is perpendicular to the `J` component (e.g.: x-y plane for E<sub>z</sub>: `J`<sub>z</sub><sup>ijk</sup>, `J`<sub>z</sub><sup>i+1jk</sup>, `J`<sub>z</sub><sup>ij+1k</sup>, `J`<sub>z</sub><sup>i+1j+1k</sup>) and use the averaged results of each component for `E` (long reason: see derivation; `E`<sub>x</sub>(`J`<sub>x</sub>), `E`<sub>y</sub>(`J`<sub>y</sub>), `E`<sub>z</sub>(`J`<sub>z</sub>)).

Since the `E` and `B` field are calculated at the same point in time (and space) (and are not staggered in those as in `Yee`'s scheme), the influence of `J` should propagate to *both* immediately. We now take [Faraday's Law](https://en.wikipedia.org/wiki/Faraday%27s_law_of_induction) and split `E`<sup>t</sup> due to superposition to `E`<sup>t,free</sup>(`E`<sup>t-1</sup>,`B`<sup>t-1</sup>) and the `delta E`<sup>t</sup> that is introduced from `J`<sup>t-1/2</sup>. Now place the correct spatial averaged `J`'s in again (I need LaTeX or will scan my notebook an other day for that) and one comes to the result that the change `delta B` is basically a specifically spatially averaged `curl` of `J` (dependencies: `B`<sub>x</sub>(`J`<sub>y</sub>,`J`<sub>z</sub>), `B`<sub>y</sub>(`J`<sub>x</sub>,`J`<sub>z</sub>), `B`<sub>z</sub>(`J`<sub>x</sub>,`J`<sub>y</sub>) ).

### Implementation

Based on the (for that reason) introduced current interpolation/filters from #888 (*merged*).

See `src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp` for the main implementation.

I renamed `AllCenteredCell` to `EMFCenteredCell` to reflect the actual distribution of quantities. The inherent assumption that the position of `J` depends on the position of `E` of a `NumericalCellType` was removed.

The missing event dependency in `DS`'s `after_current` implementation was added.

### Current Status

I just published this rather untested branch (1,5 days from scratch to result) since other developers were interested in the result. The KHI test is not yet correct.

~~Needs double checking: is the trilinear interpolation correct for the `EMFCenteredCell`? (needs -1 and +1 now for NGP!)~~<sup>6</sup>

~~Compile check: just a CFL assert due to my `[WIP]` commit that changes a file temporarily.~~

~~I did not cross-check my derivations (yet) completely and also need some more minutes to cross-check my constants.~~ Furthermore, there are still several issues in the propagation of the fields ~~#889~~ ~~#890~~ ~~#891~~ #893 ...

Thx a lot to @psychocoderHPC for event system and implementation support and for debugging the implementation of the vacuum field solver with @Heikman . Thx to @stetie for great general discussions and literature - *why are all derivations 1D only*? ;)

### Footnotes

<sup>1</sup> One can place them also at some other point in the cell, e.g., the corners but we will see that this definition helps us in our implementation.
<sup>2</sup> Which btw. reduces some pusher artifacts that can lead to spurious emittance growth.
<sup>3</sup> Examples taken and modified under [CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/) from [my diploma thesis](http://dx.doi.org/10.5281/zenodo.15924)
<sup>4</sup> Talk by *Yasuhiko Sentoku*, University of Nevada - Reno: *Numerical Dispersion Free Maxwell Solver for multi-dimensional PIC*
<sup>5</sup> *R. Lichters, R.E.W. Pfund, J. Meyer-ter-Vehn*, MPI für Quantenoptik - Garching, *LPIC++ A Parallel One-dimensional Relativistic Electromagnetic Particle-In-Cell Code for Simulating
Laser-Plasma-Interaction*, chapter 5, https://books.google.de/books?id=FvkMHAAACAAJ (update: there is a [download link](http://lichters.net/download.html) including doc/book; code under GPLv2+; last update 07/2014 with v1.3.2)
<sup>6</sup> General but independent side note: we could implement two additional interpolation methods... Galerkin/"energy conserving" and "momentum conserving" via interpolation to grid nodes first; the latter might be the same as trilinear for DS (probably not, since rho is not at `E` and `B` positions).

CC'ing @psychocoderHPC @Heikman @DrThomasKluge @bussmann @PrometheusPi @stetie 