### PR TITLE
Checkpoints: Check for CUDA Errors

### DIFF
--- a/src/picongpu/include/initialization/InitialiserController.hpp
+++ b/src/picongpu/include/initialization/InitialiserController.hpp
@@ -84,6 +84,14 @@ public:
         Environment<>::get().PluginConnector().restartPlugins(restartStep, restartDirectory);
         __getTransactionEvent().waitForFinished();
 
+        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaGetLastError());
+
+        GridController<simDim> &gc = Environment<simDim>::get().GridController();
+        /* can be spared for better scalings, but guarantees the user
+         * that the restart was successful */
+        MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
+
         log<picLog::SIMULATION_STATE > ("Loading from persistent data finished");
     }
 


### PR DESCRIPTION
Check for cuda errors to spare the time for writing a checkpoint and also synchronize again afterwards to ensure a checkpoint can really be considered "valid" (not corrupted).