### PR TITLE
close #882 - fix gas free formular

### DIFF
--- a/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
@@ -52,10 +52,14 @@ struct FreeFormulaImpl : public T_ParamClass
     HDINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset)
     {
         DataSpace<simDim> position_SI = totalCellOffset;
+        cellSize_t cellSize_SI = cellSize;
         for(unsigned int i = 0; i<simDim ; i++)
-            position_SI[i] *= cellSize[i] * UNIT_LENGTH;
+        {
+            cellSize_SI *= UNIT_LENGTH;
+            position_SI[i] *= cellSize_SI[i];
+        }
 
-        float_X density = ParamClass::operator()( position_SI , cellSize );
+        float_X density = ParamClass::operator()( position_SI , cellSize_SI );
 
         return density;
     }

--- a/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
@@ -55,7 +55,7 @@ struct FreeFormulaImpl : public T_ParamClass
         for(unsigned int i = 0; i<simDim ; i++)
             position_SI[i] *= cellSize[i] * UNIT_LENGTH;
 
-        float_X density = ParamClass::operator()( position_SI );
+        float_X density = ParamClass::operator()( position_SI , cellSize );
 
         return density;
     }

--- a/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
@@ -59,7 +59,7 @@ struct FreeFormulaImpl : public T_ParamClass
             position_SI[i] *= cellSize_SI[i];
         }
 
-        float_X density = ParamClass::operator()( position_SI , cellSize_SI );
+        float_X density = ParamClass::operator()(position_SI, cellSize_SI);
 
         return density;
     }

--- a/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Rene Widera
+ * Copyright 2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -51,9 +51,11 @@ struct FreeFormulaImpl : public T_ParamClass
      */
     HDINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset)
     {
-        const float_64 unit_length = UNIT_LENGTH;
+        DataSpace<simDim> position_SI = totalCellOffset;
+        for(unsigned int i = 0; i<simDim ; i++)
+            position_SI[i] *= cellSize[i] * UNIT_LENGTH;
 
-        float_X density = ParamClass::operator()( totalCellOffset, unit_length );
+        float_X density = ParamClass::operator()( position_SI );
 
         return density;
     }

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -242,19 +242,19 @@ struct FreeFormulaFunctor
 {
 
     /**
-     * This formula should use SI quantities only!
+     * This formula uses SI quantities only
      * The profile will be multiplied by GAS_DENSITY.
      *
-     * @param totalCellOffset total offset including all slides [in cells]
-     * @param unitLength PIConGPU unit length
+     * @param position_SI total offset including all slides [in meter]
+     * @param cellSize_SI cell sizes [in meter]
      *
-     * @return float_X density
+     * @return float_X density [normalized to 1.0]
      */
     template<class cellSizeType>
-    HDINLINE float_X operator()(const DataSpace<simDim>& position_SI, const cellSizeType& cellSize)
+    HDINLINE float_X operator()(const DataSpace<simDim>& position_SI, const cellSizeType& cellSize_SI)
     {
         const float_64 y = float_64(position_SI.y()) * 1000.0; // m -> mm
-        //const unsigned int y_cell_id = position_SI.y() / cellSize[1];
+        //const unsigned int y_cell_id = position_SI.y() / cellSize_SI[1];
 
         /* triangle function example
          * for a density profile from 0 to 400 microns */
@@ -269,7 +269,7 @@ struct FreeFormulaFunctor
     }
 };
 
-/* definition of gas sphere with flanks*/
+/* definition of gas free formula */
 typedef FreeFormulaImpl<FreeFormulaFunctor> FreeFormula;
 
 }//namespace gasProfiles

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -260,7 +260,7 @@ struct FreeFormulaFunctor
          * for a density profile from 0 to 400 microns */
         float_64 s = 1.0 - 5.0 * math::abs(y - 0.2);
 
-        /* give it an on/off shape for everey second cell */
+        /* give it an empty/filled shape for every second cell */
         //s *= float_64( (y_cell_id % 2) == 0 );
 
         /* all parts of the function MUST be > 0 */

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.
@@ -250,9 +250,9 @@ struct FreeFormulaFunctor
      *
      * @return float_X density
      */
-    HDINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset, const float_64 unitLength)
+    HDINLINE float_X operator()(const DataSpace<simDim>& position_SI)
     {
-        const float_64 y = float_64(totalCellOffset.y()) * unitLength * 1000.0; // m -> mm
+        const float_64 y = float_64(position_SI.y()) * 1000.0; // m -> mm
 
         /* triangle function example
          * for a density profile from 0 to 400 microns */

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -250,13 +250,18 @@ struct FreeFormulaFunctor
      *
      * @return float_X density
      */
-    HDINLINE float_X operator()(const DataSpace<simDim>& position_SI)
+    template<class cellSizeType>
+    HDINLINE float_X operator()(const DataSpace<simDim>& position_SI, const cellSizeType& cellSize)
     {
         const float_64 y = float_64(position_SI.y()) * 1000.0; // m -> mm
+        //const unsigned int y_cell_id = position_SI.y() / cellSize[1];
 
         /* triangle function example
          * for a density profile from 0 to 400 microns */
         float_64 s = 1.0 - 5.0 * math::abs(y - 0.2);
+
+        /* give it an on/off shape for everey second cell */
+        //s *= float_64( (y_cell_id % 2) == 0 );
 
         /* all parts of the function MUST be > 0 */
         s *= float_64(s >= 0.0);


### PR DESCRIPTION
This pull request solves issue #882:
It changes to interface from gasFreeFormular from *cell offset* back to *position in SI units*.

**No examples** are affected by this pull request.

`gasConfig.param` was changed for the reference file.