### PR TITLE
ADIOS Restart: Avoid NxN access pattern with Aggregators

### DIFF
--- a/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
@@ -102,17 +102,15 @@ public:
         ThisSpecies* speciesTmp = &(dc.getData<ThisSpecies >(ThisSpecies::FrameType::getName(), true));
 
         /* count total number of particles on the device */
-        uint64_cu totalNumParticles = 0;
+        uint64_t totalNumParticles = 0;
 
-        /* load particles info table entry for this process
+        /* load particles info table entry for ONE process
+           (note: this is NOT necessarily THIS process!)
            particlesInfo is (part-count, scalar pos, x, y, z) */
-        typedef uint64_t uint64Quint[5];
-        uint64Quint particlesInfo[gc.getGlobalSize()];
+        uint64_t particlesInfo[5];
 
-        /* read full data set: putting NULL (== full data set) for `piSel` crashed ADIOS 1.8.0
-         * with transforms enabled -> reported and confirmed as a bug in ADIOS 1.8.0 */
-        uint64_t start = 0;
-        uint64_t count = 5 * gc.getGlobalSize(); // ADIOSCountParticles: uint64_t
+        uint64_t start = 5 * gc.getGlobalRank();
+        uint64_t count = 5; // ADIOSCountParticles: uint64_t
         ADIOS_SELECTION* piSel = adios_selection_boundingbox( 1, &start, &count );
 
         ADIOS_CMD(adios_schedule_read( params->fp,
@@ -126,19 +124,26 @@ public:
         ADIOS_CMD(adios_perform_reads( params->fp, 1 ));
         adios_selection_delete(piSel);
 
-        /* search my entry (using my scalar position) in particlesInfo */
+        /* Run a prefix sum over the numParticles[0] element in particlesInfo
+         * to retreive the offset of particles before gc.getGlobalRank() */
         uint64_t particleOffset = 0;
-        uint64_t myScalarPos = gc.getScalarPosition();
+
+        uint64_t fullParticlesInfo[gc.getGlobalSize()];
+
+        MPI_CHECK(MPI_Allgather( particlesInfo, 1, MPI_UINT64_T,
+                                 fullParticlesInfo, 1, MPI_UINT64_T,
+                                 gc.getCommunicator().getMPIComm() ));
 
         for (size_t i = 0; i < gc.getGlobalSize(); ++i)
         {
-            if (particlesInfo[i][1] == myScalarPos)
-            {
-                totalNumParticles = particlesInfo[i][0];
-                break;
-            }
-
-            particleOffset += particlesInfo[i][0];
+            /* this comparison is potentially harmful, since the order of ranks
+               is not necessarily the same in subsequent MPI jobs.
+               But due to the wrong sorting by rank in `ADIOSCountParticles.hpp`
+               while calculating the `myParticleOffset` we have to immitate that. */
+            if( i < gc.getGlobalRank() )
+                particleOffset += fullParticlesInfo[i];
+            if( i == gc.getGlobalRank() )
+                totalNumParticles = fullParticlesInfo[i];
         }
 
         log<picLog::INPUT_OUTPUT > ("ADIOS: Loading %1% particles from offset %2%") %
@@ -204,12 +209,12 @@ public:
 
             log<picLog::INPUT_OUTPUT > ("ADIOS: used frames to load particles: %1%") % counterBuffer.getHostBuffer().getDataBox()[2];
 
-            if ((uint64_cu) counterBuffer.getHostBuffer().getDataBox()[1] != totalNumParticles)
+            if ((uint64_t) counterBuffer.getHostBuffer().getDataBox()[1] != totalNumParticles)
             {
                 log<picLog::INPUT_OUTPUT >("ADIOS: error load species | counter is %1% but should %2%") % counterBuffer.getHostBuffer().getDataBox()[1] % totalNumParticles;
                 throw std::runtime_error("ADIOS: Failed to load expected number of particles to GPU.");
             }
-            assert((uint64_cu) counterBuffer.getHostBuffer().getDataBox()[1] == totalNumParticles);
+            assert((uint64_t) counterBuffer.getHostBuffer().getDataBox()[1] == totalNumParticles);
 
             /*free host memory*/
             ForEach<typename AdiosFrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;

--- a/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
@@ -214,8 +214,8 @@ public:
             /*free host memory*/
             ForEach<typename AdiosFrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;
             freeMem(forward(hostFrame));
-            log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) load species: %1%") % AdiosFrameType::getName();
         }
+        log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) load species: %1%") % AdiosFrameType::getName();
     }
 };
 


### PR DESCRIPTION
During restart, the written N files by N aggregators (N <= |MPI_Size|)
are read again by each rank which causes NxN open files and fails for
large numbers of aggregators on parallel file systems.

~~We read our individual chunk now instead and perform a rather light
weight |MPI_Scan| on it to retreive the offsets.~~

Note 1: This bug is basically the same problem we had once with the
|libSplash| |SerialDataCollector| when we assumed that in general, a
re-sorting of GPUs /could/ have happened. (A pre-|alpha| bug during
GB2013.) On the ADIOS side, this can actually be achieved very
efficiently with an |ADIOS_READ_METHOD_BP_AGGREGATE| but is still very
experimental (did not work with zero-reads and/or zlib transport enabled).

Note 2: The HDF5 implementation
<https://github.com/ComputationalRadiationPhysics/picongpu/blob/f0ba5151411ac09eac317f97b5d93e05e20ce29f/src/picongpu/include/plugins/hdf5/restart/LoadSpecies.hpp#L114-L137>
can be optimized the same way, nevertheless due to our MPI-I/O read
there it is not as severe as with aggregations right now.

- tested with large scale runs and lwfa moving window