### PR TITLE
add support to read particles on host side

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -155,6 +155,11 @@ public:
         return particlesBuffer->getDeviceParticleBox();
     }
 
+    ParticlesBoxType getHostParticlesBox(const int64_t memoryOffset)
+    {
+        return particlesBuffer->getHostParticleBox(memoryOffset);
+    }
+
     /* Get the particles buffer which is used for the particles.
      */
     BufferType& getParticlesBuffer()

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -199,6 +199,20 @@ public:
     }
 
     /**
+     * Returns a ParticlesBox for host frame data.
+     *
+     * @return host frames ParticlesBox
+     */
+    ParticlesBox<ParticleType, DIM> getHostParticleBox(int64_t memoryOffset)
+    {
+
+        return ParticlesBox<ParticleType, DIM > (
+                                                 superCells->getHostBuffer().getDataBox(),
+                                                 memoryOffset
+                                                );
+    }
+
+    /**
      * Returns if the buffer has a send exchange in ex direction.
      *
      * @param ex direction to query
@@ -302,6 +316,10 @@ public:
         return superCellSize;
     }
 
+    void deviceToHost()
+    {
+        superCells->deviceToHost();
+    }
 
 
 private:

--- a/src/picongpu/include/particles/MallocMCBuffer.hpp
+++ b/src/picongpu/include/particles/MallocMCBuffer.hpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+
+#include "dataManagement/ISimulationData.hpp"
+#include "simulation_defines.hpp"
+
+#include "mallocMC/mallocMC.hpp"
+#include <string>
+
+namespace picongpu
+{
+    using namespace PMacc;
+
+    class MallocMCBuffer : public ISimulationData
+    {
+    public:
+
+        MallocMCBuffer();
+
+        virtual ~MallocMCBuffer();
+
+        SimulationDataId getUniqueId()
+        {
+            return getName();
+        }
+
+        static std::string getName()
+        {
+            return std::string("MallocMCBuffer");
+        }
+
+        int64_t getOffset()
+        {
+            return hostBufferOffset;
+        }
+
+        void synchronize();
+
+    private:
+
+        char* hostPtr;
+        int64_t hostBufferOffset;
+        mallocMC::HeapInfo deviceHeapInfo;
+
+    };
+
+
+} // namespace picongpu
+
+#include "particles/MallocMCBuffer.tpp"

--- a/src/picongpu/include/particles/MallocMCBuffer.tpp
+++ b/src/picongpu/include/particles/MallocMCBuffer.tpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/MallocMCBuffer.hpp"
+
+namespace picongpu
+{
+using namespace PMacc;
+
+MallocMCBuffer::MallocMCBuffer( ) : hostPtr( NULL ),hostBufferOffset(0)
+{
+    /* currently mallocMC has only one heap */
+    this->deviceHeapInfo=mallocMC::getHeapLocations()[0];
+    Environment<>::get().DataConnector().registerData( *this);
+}
+
+MallocMCBuffer::~MallocMCBuffer( )
+{
+    if ( hostPtr != NULL )
+        cudaHostUnregister(hostPtr);
+
+    __deleteArray(hostPtr);
+
+}
+
+void MallocMCBuffer::synchronize( )
+{
+    /** \todo: we had no abstraction to create a host buffer and a pseudo
+     *         device buffer (out of the mallocMC ptr) and copy both with our event
+     *         system.
+     *         WORKAROUND: use native cuda calls :-(
+     */
+    if ( hostPtr == NULL )
+    {
+        /* use `new` and than `cudaHostRegister` is faster than `cudaMallocHost`
+         * but with the some result (create page-locked memory)
+         */
+        hostPtr = new char[deviceHeapInfo.size];
+        CUDA_CHECK(cudaHostRegister(hostPtr,deviceHeapInfo.size,cudaHostRegisterDefault));
+
+
+        this->hostBufferOffset=int64_t(((char*)deviceHeapInfo.p) - hostPtr);
+    }
+    /* add event system hints */
+    __startOperation(ITask::TASK_CUDA);
+    __startOperation(ITask::TASK_HOST);
+    CUDA_CHECK(cudaMemcpy(hostPtr,deviceHeapInfo.p,deviceHeapInfo.size,cudaMemcpyDeviceToHost));
+
+}
+
+} //namespace picongpu

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -68,6 +68,12 @@ public:
 
     SimulationDataId getUniqueId();
 
+    /* sync device data to host
+     *
+     * ATTENTION: - in the current implementation only supercell meta data are copied!
+     *            - the shared (between all species) mallocMC buffer must be copied once
+     *              by the user
+     */
     void synchronize();
 
     void syncToDevice();

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -116,7 +116,7 @@ SimulationDataId Particles<T_ParticleDescription>::getUniqueId( )
 template< typename T_ParticleDescription>
 void Particles<T_ParticleDescription>::synchronize( )
 {
-
+    this->particlesBuffer->deviceToHost();
 }
 
 template< typename T_ParticleDescription>

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -44,6 +44,7 @@
 #include "fields/FieldB.hpp"
 #include "fields/FieldJ.hpp"
 #include "fields/FieldTmp.hpp"
+#include "particles/MallocMCBuffer.hpp"
 #include "fields/MaxwellSolver/Solvers.hpp"
 #include "fields/currentInterpolation/CurrentInterpolation.hpp"
 #include "fields/background/cellwiseOperation.hpp"
@@ -88,6 +89,7 @@ public:
     fieldE(NULL),
     fieldJ(NULL),
     fieldTmp(NULL),
+    mallocMCBuffer(NULL),
     myFieldSolver(NULL),
     myCurrentInterpolation(NULL),
     pushBGField(NULL),
@@ -242,6 +244,8 @@ public:
 
         __delete(fieldTmp);
 
+        __delete(mallocMCBuffer);
+
         __delete(myFieldSolver);
 
         __delete(myCurrentInterpolation);
@@ -290,6 +294,7 @@ public:
 
         // initializing the heap for particles
         mallocMC::initHeap(freeGpuMem);
+        this->mallocMCBuffer = new MallocMCBuffer();
 
         ForEach<VectorAllSpecies, particles::CallCreateParticleBuffer<bmpl::_1>, MakeIdentifier<bmpl::_1> > createParticleBuffer;
         createParticleBuffer(forward(particleStorage));
@@ -578,6 +583,7 @@ protected:
     FieldE *fieldE;
     FieldJ *fieldJ;
     FieldTmp *fieldTmp;
+    MallocMCBuffer *mallocMCBuffer;
 
     // field solver
     fieldSolver::FieldSolver* myFieldSolver;


### PR DESCRIPTION
- add `MallocMCBuffer` to syncronize *mallocMC* heap
- add interface `getHostParticleBox()` to `ParticleBuffer.hpp`
- `ParticlesBox.hpp`
  - add new constructor
  - add method `mapPtr()`

~~Please do not merge before https://github.com/ComputationalRadiationPhysics/mallocMC/pull/86 is merged to our `thirdParty` libraries~~

~~Please do not merge before #906 is merged to our `thirdParty` libraries.~~

- [x] needs rebase against `dev`