### PR TITLE
Topic update mallocMC thirdParty

### DIFF
--- a/thirdParty/mallocMC/INSTALL.md
+++ b/thirdParty/mallocMC/INSTALL.md
@@ -58,7 +58,7 @@ Because we are linking to Boost and CUDA, the following **external dependencies*
 
 If you are using CMake you can download our `FindmallocMC.cmake` module with
 ```bash
-wget https://raw.githubusercontent.com/ComputationalRadiationPhysics/picongpu/dev/src/cmake/FindmallocMC.cmake
+wget https://raw.githubusercontent.com/ComputationalRadiationPhysics/cmake-modules/dev/FindmallocMC.cmake
 # read the documentation
 cmake -DCMAKE_MODULE_PATH=. --help-module FindmallocMC | less
 ```
@@ -68,7 +68,7 @@ and use the following lines in your `CMakeLists.txt`:
 # this example will require at least CMake 2.8.5
 cmake_minimum_required(VERSION 2.8.5)
 
-# add path to FindmallocMC.cmake, e.g. in the directory in cmake/
+# add path to FindmallocMC.cmake, e.g., in the directory in cmake/
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
 
 # find the packages that are required by mallocMC. This has to be done BEFORE

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_overwrites.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_overwrites.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include "mallocMC_prefixes.hpp"
+#include <vector>
 
 /** Creates a global object of a many core memory allocator
  *
@@ -103,6 +104,20 @@ void  free(void* p) __THROW                                                    \
 } /* end namespace mallocMC */
 
 
+/** Create the function getHeapLocations inside a namespace
+ *
+ * This returns a vector of type mallocMC::HeapInfo. The HeapInfo should at least
+ * contain the pointer to the heap (on device) and its size.
+ */
+#define MALLOCMC_HEAPLOC()                                                     \
+namespace mallocMC{                                                            \
+MAMC_HOST                                                                      \
+std::vector<mallocMC::HeapInfo> getHeapLocations()                             \
+{                                                                              \
+  return mallocMC::mallocMCGlobalObject.getHeapLocations();                    \
+}                                                                              \
+} /* end namespace mallocMC */
+
 
 /* if the defines do not exist (wrong CUDA version etc),
  * create at least empty defines
@@ -121,4 +136,5 @@ void  free(void* p) __THROW                                                    \
 #define MALLOCMC_SET_ALLOCATOR_TYPE(MALLOCMC_USER_DEFINED_TYPE)                  \
 MALLOCMC_GLOBAL_FUNCTIONS(MALLOCMC_USER_DEFINED_TYPE)                            \
 MALLOCMC_MALLOC()                                                               \
+MALLOCMC_HEAPLOC()                                                              \
 MALLOCMC_AVAILABLESLOTS()


### PR DESCRIPTION
Update thirdParty/mallocMC with latest changes from it's upstream **dev** repo.

- new feature of the upcoming mallocMC 2.2.0crp release 
  - added host function to return heap pointer

Update performed via:

```
GIT_AUTHOR_NAME="Third Party" \
GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
git subtree pull --prefix=thirdParty/mallocMC  \
git@github.com:ComputationalRadiationPhysics/mallocMC.git dev --squash
```