### PR TITLE
ADIOS: speedup particle preparation before dump

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -666,19 +666,22 @@ private:
         }
 
 
+        /*copy species only one time per timestep to the host*/
         if( lastSpeciesSyncStep != currentStep )
         {
-            /*copy species only one time per timestep to the host*/
-
             DataConnector &dc = Environment<>::get().DataConnector();
+            
+            /* synchronizes the MallocMCBuffer to the host side */
             dc.getData<MallocMCBuffer> (MallocMCBuffer::getName());
 
-            /* we copy all species to the host because we can not check if
-             * a normal adios dump and a checkpoint are in the same time step
+            /* here we are copying all species to the host side since we
+             * can not say at this point if this time step will need all of them
+             * for sure (checkpoint) or just some user-defined species (dump)
              */
             ForEach<FileCheckpointParticles, CopySpeciesToHost<bmpl::_1> > copySpeciesToHost;
             copySpeciesToHost();
             lastSpeciesSyncStep = currentStep;
+            dc.releaseData(MallocMCBuffer::getName());
         }
 
         beginAdios(fname);

--- a/src/picongpu/include/plugins/adios/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/WriteSpecies.hpp
@@ -54,8 +54,6 @@ namespace adios
 {
 using namespace PMacc;
 
-
-
 /** Write copy particle to host memory and dump to ADIOS file
  *
  * @tparam T_Species type of species
@@ -77,8 +75,8 @@ public:
 
     /* add globalCellIdx for adios particle*/
     typedef typename MakeSeq<
-            ParticleCleanedAttributeList,
-            globalCellIdx<globalCellIdx_pic>
+    ParticleCleanedAttributeList,
+    globalCellIdx<globalCellIdx_pic>
     >::type ParticleNewAttributeList;
 
     typedef
@@ -107,23 +105,16 @@ public:
         log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) count particles: %1% = %2%") % AdiosFrameType::getName() % totalNumParticles;
 
         AdiosFrameType hostFrame;
-        log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) malloc mapped memory: %1%") % AdiosFrameType::getName();
 
-        /* malloc mapped memory */
-        ForEach<typename AdiosFrameType::ValueTypeSeq, MallocMemory<bmpl::_1> > mallocMem;
+        /* malloc host memory */
+        log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) malloc host memory: %1%") % AdiosFrameType::getName();
+        ForEach<typename AdiosFrameType::ValueTypeSeq, MallocHostMemory<bmpl::_1> > mallocMem;
         mallocMem(forward(hostFrame), totalNumParticles);
-        log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) malloc mapped memory: %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) malloc host memory: %1%") % AdiosFrameType::getName();
 
         if (totalNumParticles > 0)
         {
-            log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) get mapped memory device pointer: %1%") % AdiosFrameType::getName();
-            /* load device pointer of mapped memory */
-            AdiosFrameType deviceFrame;
-            ForEach<typename AdiosFrameType::ValueTypeSeq, GetDevicePtr<bmpl::_1> > getDevicePtr;
-            getDevicePtr(forward(deviceFrame), forward(hostFrame));
-            log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) get mapped memory device pointer: %1%") % AdiosFrameType::getName();
-
-            log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) copy particle to host: %1%") % AdiosFrameType::getName();
+            log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) copy particle host (with hierarchy) to host (without hierarchy): %1%") % AdiosFrameType::getName();
             typedef bmpl::vector< typename GetPositionFilter<simDim>::type > usedFilters;
             typedef typename FilterFactory<usedFilters>::FilterType MyParticleFilter;
             MyParticleFilter filter;
@@ -132,32 +123,36 @@ public:
             filter.setWindowPosition(params->localWindowToDomainOffset,
                                      params->window.localDimensions.size);
 
-            dim3 block(PMacc::math::CT::volume<SuperCellSize>::type::value);
+            __getTransactionEvent().waitForFinished();
 
-            GridBuffer<int, DIM1> counterBuffer(DataSpace<DIM1>(1));
+            int threads = PMacc::math::CT::volume<SuperCellSize>::type::value;
+
+            DataConnector &dc = Environment<>::get().DataConnector();
+            MallocMCBuffer& mallocMCBuffer = dc.getData<MallocMCBuffer> (MallocMCBuffer::getName());
+
+            int globalParticleOffset = 0;
             AreaMapping < CORE + BORDER, MappingDesc > mapper(*(params->cellDescription));
 
-            __cudaKernel(copySpecies)
-                (mapper.getGridDim(), block)
-                (counterBuffer.getDeviceBuffer().getPointer(),
-                 deviceFrame, speciesTmp->getDeviceParticlesBox(),
-                 filter,
-                 particleOffset, /*relative to data domain (not to physical domain)*/
-                 mapper
-                 );
-            counterBuffer.deviceToHost();
-            log<picLog::INPUT_OUTPUT > ("ADIOS:   ( end ) copy particle to host: %1%") % AdiosFrameType::getName();
-            __getTransactionEvent().waitForFinished();
-            log<picLog::INPUT_OUTPUT > ("ADIOS:   all events are finished: %1%") % AdiosFrameType::getName();
+            CopySpeciesToGlobal copySpeciesToGlobal(mapper.getGridDim(), threads);
+
+            copySpeciesToGlobal(
+                                globalParticleOffset,
+                                hostFrame,
+                                speciesTmp->getHostParticlesBox(mallocMCBuffer.getOffset()),
+                                filter,
+                                particleOffset, /*relative to data domain (not to physical domain)*/
+                                mapper
+                                );
+
             /* this costs a little bit of time but adios writing is slower */
-            assert((uint64_cu) counterBuffer.getHostBuffer().getDataBox()[0] == totalNumParticles);
+            assert((uint64_cu) globalParticleOffset == totalNumParticles);
         }
         /* dump to adios file */
         ForEach<typename AdiosFrameType::ValueTypeSeq, adios::ParticleAttribute<bmpl::_1> > writeToAdios;
         writeToAdios(params, forward(hostFrame), totalNumParticles);
 
         /* free host memory */
-        ForEach<typename AdiosFrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;
+        ForEach<typename AdiosFrameType::ValueTypeSeq, FreeHostMemory<bmpl::_1> > freeMem;
         freeMem(forward(hostFrame));
         log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) writing species: %1%") % AdiosFrameType::getName();
 

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -33,8 +33,104 @@ namespace picongpu
 
 using namespace PMacc;
 
+/** copy particle to single frame
+ *
+ * copy particle data which are stored in linked list and superCell hierarchy
+ * to a single frame.
+ */
+struct CopySpeciesToGlobal
+{
+    DataSpace<simDim> gridDim;
+    int threads;
 
+    CopySpeciesToGlobal(const DataSpace<simDim>& gridDim, const int threads) :
+    gridDim(gridDim), threads(threads)
+    {
 
+    }
+
+    /** copy particles
+     *
+     * @param counter scalar offset in `destFrame`
+     * @param destFrame single frame were all particles are copied in
+     * @param srcBox particle box were particles are read from
+     * @param filter filter to select particles
+     * @param gpuOffset gpu localOffset or to sliding window begin
+     * @param mapper mapper which describe the area were particles are copied from
+     */
+    template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Mapping>
+    void operator()(int& counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter, T_Space gpuOffset, T_Mapping mapper)
+    {
+        #pragma omp parallel for
+        for (int linearBlockIdx = 0;
+             linearBlockIdx < gridDim.productOfComponents();
+             ++linearBlockIdx
+             )
+        {
+            DataSpace<simDim> blockIdx(DataSpaceOperations<simDim>::map(gridDim, linearBlockIdx));
+
+            using namespace PMacc::particles::operations;
+
+            typedef T_DestFrame DestFrameType;
+            typedef typename T_SrcBox::FrameType SrcFrameType;
+            typedef T_Mapping Mapping;
+            typedef typename Mapping::SuperCellSize Block;
+
+            SrcFrameType *srcFramePtr;
+            int localCounter;
+            int globalOffset;
+            const int particlePerFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+            int storageOffset[particlePerFrame];
+
+            bool isValid;
+
+            const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(blockIdx);
+            const DataSpace<Mapping::Dim> superCellPosition((block - mapper.getGuardingSuperCells()) * mapper.getSuperCellSize());
+            filter.setSuperCellPosition(superCellPosition);
+
+            srcFramePtr = &(srcBox.getFirstFrame(block, isValid));
+
+            while (isValid) //move over all Frames
+            {
+                localCounter = 0;
+                /* clear storageOffset array*/
+                for (int threadIdx = 0; threadIdx < particlePerFrame; ++threadIdx)
+                {
+                    storageOffset[threadIdx] = -1;
+                    PMACC_AUTO(parSrc, ((*srcFramePtr)[threadIdx]));
+                    /*count particle in frame*/
+                    if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx))
+                        storageOffset[threadIdx] = localCounter++;
+                }
+
+                /* atomic update with openmp*/
+                #pragma omp critical
+                {
+                    globalOffset = counter;
+                    counter += localCounter;
+                }
+
+                for (int threadIdx = 0; threadIdx < particlePerFrame; ++threadIdx)
+                {
+                    if (storageOffset[threadIdx] != -1)
+                    {
+                        PMACC_AUTO(parSrc, ((*srcFramePtr)[threadIdx]));
+                        PMACC_AUTO(parDest, destFrame[globalOffset + storageOffset[threadIdx]]);
+                        PMACC_AUTO(parDestNoGlobalIdx, deselect<globalCellIdx<> >(parDest));
+                        assign(parDestNoGlobalIdx, parSrc);
+                        /*calculate global cell index*/
+                        DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));
+                        parDest[globalCellIdx_] = gpuOffset + superCellPosition + localCell;
+                    }
+                }
+                /*get next frame in supercell*/
+                srcFramePtr = &(srcBox.getNextFrame(*srcFramePtr, isValid));
+
+            }
+        }
+    }
+
+};
 
 /** copy particle of a species to a host frame
  *
@@ -51,8 +147,8 @@ using namespace PMacc;
  * @param gpuOffset global offset from sliding window zero (origin) to origin of local gpu domain
  * @param mapper apper to map cuda idx to supercells
  */
-template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space ,class T_Mapping>
-__global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter,T_Space gpuOffset, T_Mapping mapper)
+template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Mapping>
+__global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter, T_Space gpuOffset, T_Mapping mapper)
 {
     using namespace PMacc::particles::operations;
 
@@ -85,7 +181,7 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
         PMACC_AUTO(parSrc, ((*srcFramePtr)[threadIdx.x]));
         storageOffset = -1;
         /*count particle in frame*/
-        if (parSrc[multiMask_]==1 &&  filter(*srcFramePtr, threadIdx.x))
+        if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx.x))
             storageOffset = atomicAdd(&localCounter, 1);
         __syncthreads();
         if (threadIdx.x == 0)
@@ -101,7 +197,7 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
             assign(parDestNoGlobalIdx, parSrc);
             /*calculate global cell index*/
             DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));
-            parDest[globalCellIdx_]=gpuOffset+superCellPosition+localCell;
+            parDest[globalCellIdx_] = gpuOffset + superCellPosition + localCell;
         }
         __syncthreads();
         if (threadIdx.x == 0)

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -33,33 +33,36 @@ namespace picongpu
 
 using namespace PMacc;
 
-/** copy particle to single frame
+/** Copy Particles to a Single Frame
  *
- * copy particle data which are stored in linked list and superCell hierarchy
- * to a single frame.
+ * - copy particle data that was stored in a linked list of frames for each
+ *   super-cell on the GPU to a single frame on the CPU RAM
+ * - the deep on-GPU hierarchy must be copied to the CPU beforehand
+ * - remove species attributes `multiMask` and `localCellIdx`
+ * - add new attribute `globalCellIdx` (particle offset to begin of global
+ *   moving window)
  */
-struct CopySpeciesToGlobal
+struct ConcatListOfFrames
 {
     DataSpace<simDim> gridDim;
-    int threads;
 
-    CopySpeciesToGlobal(const DataSpace<simDim>& gridDim, const int threads) :
-    gridDim(gridDim), threads(threads)
+    ConcatListOfFrames(const DataSpace<simDim>& gridDim) :
+    gridDim(gridDim)
     {
 
     }
 
-    /** copy particles
+    /** concatenate list of frames to single frame
      *
      * @param counter scalar offset in `destFrame`
      * @param destFrame single frame were all particles are copied in
      * @param srcBox particle box were particles are read from
      * @param filter filter to select particles
-     * @param gpuOffset gpu localOffset or to sliding window begin
+     * @param particleOffset can be negative for the first GPU: localDomain.offset - globalWindow.offset
      * @param mapper mapper which describe the area were particles are copied from
      */
     template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Mapping>
-    void operator()(int& counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter, T_Space gpuOffset, T_Mapping mapper)
+    void operator()(int& counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter, T_Space particleOffset, T_Mapping mapper)
     {
         #pragma omp parallel for
         for (int linearBlockIdx = 0;
@@ -120,7 +123,7 @@ struct CopySpeciesToGlobal
                         assign(parDestNoGlobalIdx, parSrc);
                         /*calculate global cell index*/
                         DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));
-                        parDest[globalCellIdx_] = gpuOffset + superCellPosition + localCell;
+                        parDest[globalCellIdx_] = particleOffset + superCellPosition + localCell;
                     }
                 }
                 /*get next frame in supercell*/
@@ -144,11 +147,11 @@ struct CopySpeciesToGlobal
  * @param destFrame frame were we store particles in host memory (no Databox<...>)
  * @param srcBox ParticlesBox with frames
  * @param filer filer with rules to select particles
- * @param gpuOffset global offset from sliding window zero (origin) to origin of local gpu domain
+ * @param particleOffset can be negative for the first GPU: localDomain.offset - globalWindow.offset
  * @param mapper apper to map cuda idx to supercells
  */
 template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Mapping>
-__global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter, T_Space gpuOffset, T_Mapping mapper)
+__global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter, T_Space particleOffset, T_Mapping mapper)
 {
     using namespace PMacc::particles::operations;
 
@@ -197,7 +200,7 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
             assign(parDestNoGlobalIdx, parSrc);
             /*calculate global cell index*/
             DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));
-            parDest[globalCellIdx_] = gpuOffset + superCellPosition + localCell;
+            parDest[globalCellIdx_] = particleOffset + superCellPosition + localCell;
         }
         __syncthreads();
         if (threadIdx.x == 0)

--- a/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
+++ b/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
@@ -65,6 +65,47 @@ struct MallocMemory
     }
 };
 
+/** allocate memory on host
+ *
+ * This functor use `new[]` to allocate memory
+ */
+template<typename T_Attribute>
+struct MallocHostMemory
+{
+    template<typename ValueType >
+    HINLINE void operator()(ValueType& v1, const size_t size) const
+    {
+        typedef T_Attribute Attribute;
+        typedef typename PMacc::traits::Resolve<Attribute>::type::type type;
+
+        type* ptr = NULL;
+        if (size != 0)
+        {
+            ptr = new type[size];
+        }
+        v1.getIdentifier(Attribute()) = VectorDataBox<type>(ptr);
+
+    }
+};
+
+
+/** copy species to host memory
+ *
+ * use `DataConnector::getData<...>()` to copy data
+ */
+template<typename T_SpeciesType>
+struct CopySpeciesToHost
+{
+    typedef T_SpeciesType SpeciesType;
+
+    HINLINE void operator()() const
+    {
+        /* DataConnector copies data to host */
+        DataConnector &dc = Environment<>::get().DataConnector();
+        dc.getData<SpeciesType> (SpeciesType::FrameType::getName());
+    }
+};
+
 template<typename T_Type>
 struct GetDevicePtr
 {
@@ -85,7 +126,7 @@ struct GetDevicePtr
 
 template<typename T_Type>
 struct FreeMemory
-    {
+{
     template<typename ValueType >
     HINLINE void operator()(ValueType& value) const
     {
@@ -95,6 +136,29 @@ struct FreeMemory
         if (ptr != NULL)
         {
             CUDA_CHECK(cudaFreeHost(ptr));
+            ptr=NULL;
+        }
+    }
+};
+
+/** free memory
+ *
+ * use `__deleteArray()` to free memory
+ */
+template<typename T_Attribute>
+struct FreeHostMemory
+{
+
+    template<typename ValueType >
+    HINLINE void operator()(ValueType& value) const
+    {
+        typedef T_Attribute Attribute;
+        typedef typename PMacc::traits::Resolve<Attribute>::type::type type;
+
+        type* ptr = value.getIdentifier(Attribute()).getPointer();
+        if (ptr != NULL)
+        {
+            __deleteArray(ptr);
             ptr=NULL;
         }
     }

--- a/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
+++ b/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
@@ -103,6 +103,7 @@ struct CopySpeciesToHost
         /* DataConnector copies data to host */
         DataConnector &dc = Environment<>::get().DataConnector();
         dc.getData<SpeciesType> (SpeciesType::FrameType::getName());
+        dc.releaseData(SpeciesType::FrameType::getName());
     }
 };
 


### PR DESCRIPTION
- prepare particles on host instead of device
- add host functor `CopySpeciesToGlobal` to transform particles before
  write operation
- `WriteSpeciesCommon.hpp`
  - add functor `MallocHostMemory`
  - add `CopySpeciesToHost`
  - add `FreeHostMemory`

**Todo:**

- [x] rebased against `dev` with ~~#905~~
- [x] restart KHI 
- [x] restart LWFA with moving window
- [x] some doc lines and renaming

~~**Do not merge before #905 and #902**~~

This pull request is related/closes #858 