### PR TITLE
Fix spelling in `ThreadCollective` instances

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Marco Garten
  *
  * This file is part of libPMacc.
  *
@@ -57,10 +57,10 @@ namespace gol
             const Space threadIndex(threadIdx);
             PMACC_AUTO(buffRead_shifted, buffRead.shift(blockCell));
 
-            ThreadCollective<BlockArea> collectiv(threadIndex);
+            ThreadCollective<BlockArea> collective(threadIndex);
 
             nvidia::functors::Assign assign;
-            collectiv(
+            collective(
                       assign,
                       cache,
                       buffRead_shifted

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -183,8 +183,8 @@ __global__ void kernelAddCurrentToEMF(typename FieldE::DataBoxType fieldE,
     const DataSpace<simDim > threadIndex(threadIdx);
     PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
 
-    ThreadCollective<BlockArea> collectiv(threadIndex);
-    collectiv(
+    ThreadCollective<BlockArea> collective(threadIndex);
+    collective(
               assign,
               cachedJ,
               fieldJBlock

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -88,8 +88,8 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
     __syncthreads();
 
     Set<typename JBox::ValueType > set(float3_X::create(0.0));
-    ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectivSet(linearThreadIdx);
-    collectivSet(set, cachedJ);
+    ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveSet(linearThreadIdx);
+    collectiveSet(set, cachedJ);
 
     __syncthreads();
 
@@ -117,9 +117,9 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
 
     nvidia::functors::Add add;
     const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
-    ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectivAdd(linearThreadIdx);
+    ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveAdd(linearThreadIdx);
     PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
-    collectivAdd(add, fieldJBlock, cachedJ);
+    collectiveAdd(add, fieldJBlock, cachedJ);
 }
 
 template<class ParticleAlgo, class Velocity, class TVec>

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -75,8 +75,8 @@ namespace picongpu
         PMACC_AUTO( cachedVal, CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) ) );
         Set<typename TmpBox::ValueType > set( float_X( 0.0 ) );
 
-        ThreadCollective<BlockDescription_> collectiv( linearThreadIdx );
-        collectiv( set, cachedVal );
+        ThreadCollective<BlockDescription_> collective( linearThreadIdx );
+        collective( set, cachedVal );
 
         __syncthreads( );
         while( isValid )
@@ -97,7 +97,7 @@ namespace picongpu
         nvidia::functors::Add add;
         const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT( );
         PMACC_AUTO( fieldTmpBlock, fieldTmp.shift( blockCell ) );
-        collectiv( add, fieldTmpBlock, cachedVal );
+        collective( add, fieldTmpBlock, cachedVal );
         __syncthreads( );
     }
 

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -38,8 +38,8 @@ __global__ void kernelUpdateE(EBox fieldE, BBox fieldB, Mapping mapper)
     const DataSpace<simDim > threadIndex(threadIdx);
     PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
 
-    ThreadCollective<BlockDescription_> collectiv(threadIndex);
-    collectiv(
+    ThreadCollective<BlockDescription_> collective(threadIndex);
+    collective(
               assign,
               cachedB,
               fieldBBlock
@@ -68,8 +68,8 @@ __global__ void kernelUpdateBHalf(BBox fieldB,
     const DataSpace<simDim > threadIndex(threadIdx);
     PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
 
-    ThreadCollective<BlockDescription_> collectiv(threadIndex);
-    collectiv(
+    ThreadCollective<BlockDescription_> collective(threadIndex);
+    collective(
               assign,
               cachedE,
               fieldEBlock

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu, 
+ *                     Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -198,15 +199,15 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
     PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
 
     nvidia::functors::Assign assign;
-    ThreadCollective<BlockDescription_> collectiv(linearThreadIdx);
-    collectiv(
+    ThreadCollective<BlockDescription_> collective(linearThreadIdx);
+    collective(
               assign,
               cachedB,
               fieldBBlock
               );
 
     PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
-    collectiv(
+    collective(
               assign,
               cachedE,
               fieldEBlock

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -187,15 +187,15 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
     nvidia::functors::Assign assign;
     
     PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
-    ThreadCollective<BlockDescription_> collectiv(linearThreadIdx);
-    collectiv(
+    ThreadCollective<BlockDescription_> collective(linearThreadIdx);
+    collective(
               assign,
               cachedB,
               fieldBBlock
               );
 
     PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
-    collectiv(
+    collective(
               assign,
               cachedE,
               fieldEBlock


### PR DESCRIPTION
`collectiv`-->`collective`