### PR TITLE
cleanup OpenMP section in `CMakeLists.txt`

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -254,17 +254,15 @@ if( (Boost_VERSION EQUAL 105500) AND
       "${CUDA_NVCC_FLAGS} \"-DBOOST_NOINLINE=__attribute__((noinline))\" ")
 endif()
 
+
 ################################################################################
-# OPENMP
-##############################################################################
+# Find OpenMP
+################################################################################
 
-FIND_PACKAGE(OpenMP)
-IF(NOT OPENMP_FOUND)
-    MESSAGE(STATUS "Disable OpenMP: Can't find library")
-
-ELSE()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-ENDIF()
+find_package(OpenMP)
+if(OPENMP_FOUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
 
 
 ################################################################################


### PR DESCRIPTION
- remove message if OpenMP can't found
- change cmake internals to lowercase spelling

follow up to #904