### PR TITLE
remove deprecated throw declarations

### DIFF
--- a/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
@@ -46,7 +46,7 @@ namespace PMacc
             notify(this->myId, KERNEL, NULL);
         }
 
-        bool executeIntern() throw (std::runtime_error)
+        bool executeIntern()
         {
             if(canBeChecked)
             {

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -64,7 +64,7 @@ public:
         setSize();
     }
 
-    bool executeIntern() throw (std::runtime_error)
+    bool executeIntern()
     {
         return isFinished();
     }

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -131,7 +131,7 @@ public:
 
     virtual void init() = 0;
 
-    bool executeIntern() throw (std::runtime_error)
+    bool executeIntern()
     {
         return isFinished();
     }

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
@@ -45,7 +45,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~TransactionManager() throw(std::runtime_error);
+    virtual ~TransactionManager() /*noexcept(false)*/;
 
     /**
      * Adds a new transaction to the stack.

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
@@ -27,7 +27,7 @@
 namespace PMacc
 {
 
-inline TransactionManager::~TransactionManager() throw(std::runtime_error)
+inline TransactionManager::~TransactionManager() /*noexcept(false)*/
 {
     if(transactions.size() == 0)
         throw std::runtime_error("Missing transaction on the stack!");


### PR DESCRIPTION
Dynamic exception declarations with throw(...) are deprecated.

In C++11 destructors will implicitly be marked noexcept(true).
Therefore the destructor of TransactionManager will have to be declared noexcept(false) then.