### PR TITLE
use forward declaration of EventPool in Manager.hpp

### DIFF
--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "eventSystem/tasks/ITask.hpp"
-#include "eventSystem/events/EventPool.hpp"
 
 #include <map>
 #include <set>
@@ -33,6 +32,7 @@ namespace PMacc
 {
     // forward declaration
     class EventTask;
+    class EventPool;
 
     /**
      * Manages the event system by executing and waiting for tasks.

--- a/src/libPMacc/include/eventSystem/Manager.tpp
+++ b/src/libPMacc/include/eventSystem/Manager.tpp
@@ -20,6 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "eventSystem/events/EventPool.hpp"
 #include "eventSystem/streams/StreamController.hpp"
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/Manager.hpp"


### PR DESCRIPTION
The full definition of EventPool is not required within Manager.hpp, therefore a forward declaration is enough.