### PR TITLE
correct spelling in comments

### DIFF
--- a/src/libPMacc/include/eventSystem/Manager.tpp
+++ b/src/libPMacc/include/eventSystem/Manager.tpp
@@ -55,7 +55,7 @@ inline bool Manager::execute( id_t taskToWait )
     if ( deep > old_max )
     {
         old_max = deep;
-     }
+    }
 #endif
 
     static TaskMap::iterator iter = tasks.begin( );
@@ -63,7 +63,7 @@ inline bool Manager::execute( id_t taskToWait )
     if ( iter == tasks.end( ) )
         iter = tasks.begin( );
 
-    // this is the slow but very save variant to delete taks in a map
+    // this is the slow but very save variant to delete tasks in a map
     while ( iter != tasks.end( ) )
     {
         id_t id = iter->first;

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -186,7 +186,7 @@ public:
     }
 };
 
-/** implementation for small values (>256 byte)
+/** implementation for big values (>256 byte)
  *
  * This class uses CUDA memcopy to copy an instance of T_ValueType to the GPU
  * and runs a kernel which assigns this value to all cells.

--- a/src/libPMacc/include/math/vector/math_functor/abs.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/abs.hpp
@@ -4,7 +4,7 @@
  * This file is part of libPMacc.
  *
  * libPMacc is free software: you can redistribute it and/or modify
- * it under the terms of of either the GNU General Public License or
+ * it under the terms of either the GNU General Public License or
  * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -35,9 +35,9 @@ namespace PMacc
 {
 
     /**
-     * Minimal function descriptiin of a buffer,
+     * Minimal function description of a buffer,
      *
-     * @tparam TYPE datatype stored in the buffer
+     * @tparam TYPE data type stored in the buffer
      * @tparam DIM dimension of the buffer (1-3)
      */
     template <class TYPE, unsigned DIM>

--- a/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
@@ -156,9 +156,9 @@ public:
     }
 
     /**
-     * Starts sync data from own device buffer to neigbhor device buffer.
+     * Starts sync data from own device buffer to neighboring device buffer.
      *
-     * Asynchronously starts syncronization data from internal DeviceBuffer using added
+     * Asynchronously starts synchronization of data from internal DeviceBuffer using added
      * Exchange buffers.
      *
      */
@@ -174,11 +174,11 @@ public:
     }
 
     /**
-     * Starts sync data from own device buffer to neigbhor device buffer.
+     * Starts sync data from own device buffer to neighboring device buffer.
      *
-     * Asynchronously starts syncronization data from internal DeviceBuffer using added
+     * Asynchronously starts synchronization of data from internal DeviceBuffer using added
      * Exchange buffers.
-     * This operation runs sequential to other code but intern asyncron
+     * This operation runs sequentially to other code but uses asynchronous operations internally.
      *
      */
     EventTask communication()

--- a/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
@@ -50,7 +50,7 @@ namespace PMacc
          * Constructor.
          *
          * @param data pointer to buffer holding data of type VALUE
-         * @param offset realtiv offset to pointer start adress
+         * @param offset relative offset to pointer start address
          * @param currentSize size of the buffer data points to
          */
         HDINLINE PushDataBox(VALUE *data, TYPE *currentSize, DataSpace<DIM1> offset=DataSpace<DIM1>(0)) :


### PR DESCRIPTION
EDIT (by @PrometheusPi):
ADD: This pull request fixes logical errors, typos and white space issues in the comments.