### PR TITLE
remove invalid typename keyword

### DIFF
--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -51,7 +52,7 @@ namespace picongpu
     {
     public:
         typedef float3_X ValueType;
-        typedef typename promoteType<float_64, ValueType>::type UnitValueType;
+        typedef promoteType<float_64, ValueType>::type UnitValueType;
         static const int numComponents = ValueType::dim;
 
         typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -50,7 +51,7 @@ namespace picongpu
     {
     public:
         typedef float3_X ValueType;
-        typedef typename promoteType<float_64, ValueType>::type UnitValueType;
+        typedef promoteType<float_64, ValueType>::type UnitValueType;
         static const int numComponents = ValueType::dim;
 
         typedef MappingDesc::SuperCellSize SuperCellSize;

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -59,7 +60,7 @@ class FieldJ : public SimulationFieldHelper<MappingDesc>, public ISimulationData
 public:
 
     typedef float3_X ValueType;
-    typedef typename promoteType<float_64, ValueType>::type UnitValueType;
+    typedef promoteType<float_64, ValueType>::type UnitValueType;
     static const int numComponents = ValueType::dim;
 
     typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;

--- a/src/picongpu/include/fields/FieldTmp.hpp
+++ b/src/picongpu/include/fields/FieldTmp.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -52,7 +53,7 @@ namespace picongpu
     {
     public:
         typedef float1_X ValueType;
-        typedef typename promoteType<float_64, ValueType>::type UnitValueType;
+        typedef promoteType<float_64, ValueType>::type UnitValueType;
 
         typedef MappingDesc::SuperCellSize SuperCellSize;
         typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -1,6 +1,7 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Benjamin Schneider, Felix Schmitt,
- *                     Heiko Burau, Rene Widera, Richard Pausch
+ *                     Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -146,11 +147,11 @@ private:
 
     typedef bmpl::vector< FieldB, FieldE, FieldJ> AllFields;
 
-    typedef typename AllCombinations<
+    typedef AllCombinations<
       bmpl::vector<AllFields, UnspecializedFieldPlugins>
     >::type CombinedUnspecializedFieldPlugins;
 
-    typedef typename bmpl::transform<
+    typedef bmpl::transform<
     CombinedUnspecializedFieldPlugins,
       ApplyDataToPlugin<bmpl::_1>
     >::type FieldPlugins;
@@ -175,18 +176,18 @@ private:
 #endif
     > UnspecializedSpeciesPlugins;
 
-    typedef typename AllCombinations<
+    typedef AllCombinations<
         bmpl::vector<VectorAllSpecies, UnspecializedSpeciesPlugins>
     >::type CombinedUnspecializedSpeciesPlugins;
 
-    typedef typename bmpl::transform<
+    typedef bmpl::transform<
         CombinedUnspecializedSpeciesPlugins,
         ApplyDataToPlugin<bmpl::_1>
     >::type SpeciesPlugins;
 
 
     /* create sequence with all plugins*/
-    typedef typename MakeSeq<
+    typedef MakeSeq<
         StandAllownPlugins,
         FieldPlugins,
         SpeciesPlugins

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -1,6 +1,7 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Richard Pausch, Alexander Debus, Marco Garten
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -583,7 +584,7 @@ protected:
     cellwiseOperation::CellwiseOperation< CORE + BORDER + GUARD >* pushBGField;
     cellwiseOperation::CellwiseOperation< CORE + BORDER + GUARD >* currentBGField;
 
-    typedef typename SeqToMap<VectorAllSpecies, TypeToPointerPair<bmpl::_1> >::type ParticleStorageMap;
+    typedef SeqToMap<VectorAllSpecies, TypeToPointerPair<bmpl::_1> >::type ParticleStorageMap;
     typedef PMacc::math::MapTuple<ParticleStorageMap> ParticleStorage;
 
     ParticleStorage particleStorage;


### PR DESCRIPTION
`typename` cannot be used outside a template declaration.
Only gcc allows this code in c++98. Clang correctly rejects this as it is only allowed in c++11.