### PR TITLE
fix struct/class declaration mix

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
@@ -55,7 +55,7 @@ private:
     };
 
     template<typename Type, int memDim>
-    friend class CopyToDest;
+    friend struct CopyToDest;
 public:
     Gather(const zone::SphericZone<dim>& p_zone);
     ~Gather();


### PR DESCRIPTION
This removes a warning because the type was declared with struct but declared as friend with class.
