### PR TITLE
remove usage of cuda types in host only code

### DIFF
--- a/src/libPMacc/include/math/vector/Float.hpp
+++ b/src/libPMacc/include/math/vector/Float.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -64,24 +64,6 @@ struct Float : public Vector<float, dim>
     HDINLINE Float(const BaseType& vec) :
     BaseType(vec)
     {
-    }
-
-    HDINLINE Float(float1 vec) : BaseType(vec.x)
-    {
-    }
-
-    HDINLINE Float(float2 vec) : BaseType(vec.x, vec.y)
-    {
-    }
-
-    HDINLINE Float(float3 vec) : BaseType(vec.x, vec.y, vec.z)
-    {
-    }
-
-    HDINLINE operator float3() const
-    {
-        BOOST_STATIC_ASSERT(dim == 3);
-        return make_float3(this->x(), this->y(), this->z());
     }
 };
 

--- a/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
+++ b/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -30,16 +30,6 @@ namespace mpi
 {
 namespace def
 {
-
-template<>
-struct GetMPI_StructAsArray<float3 >
-{
-
-    MPI_StructAsArray operator()() const
-    {
-        return MPI_StructAsArray(MPI_FLOAT, 3);
-    }
-};
 
 template<>
 struct GetMPI_StructAsArray<int >

--- a/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +49,7 @@ namespace picongpu
                 z = 2
             };
 
-            HDINLINE float_X levichivita( const uint i, const uint j, const uint k )
+            HDINLINE float_X levichivita( const unsigned int i, const unsigned int j, const unsigned int k )
             {
                 if( i == j || j == k || i == k ) return float_X(0.0);
 

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2014-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2014-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -142,7 +143,7 @@ private:
     static std::vector<double> createUnit(UnitType unit, uint32_t numComponents)
     {
         std::vector<double> tmp(numComponents);
-        for (uint i = 0; i < numComponents; ++i)
+        for (uint32_t i = 0; i < numComponents; ++i)
             tmp[i] = unit[i];
         return tmp;
     }

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2014-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -44,7 +45,7 @@ public:
     static std::vector<double> createUnit(UnitType unit, uint32_t numComponents)
     {
         std::vector<double> tmp(numComponents);
-        for (uint i = 0; i < numComponents; ++i)
+        for (uint32_t i = 0; i < numComponents; ++i)
             tmp[i] = unit[i];
         return tmp;
     }

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -380,7 +380,7 @@ private:
             last_time_step_str << lastStep;
             current_time_step_str << currentStep;
 
-            for(uint dimIndex=0; dimIndex<simDim; ++dimIndex)
+            for(uint32_t dimIndex=0; dimIndex<simDim; ++dimIndex)
                 GPUpos_str << "_" <<currentGPUpos[dimIndex];
 
             writeFile(radiation->getHostBuffer().getBasePointer(), folderRadPerGPU + "/" + filename_prefix
@@ -559,7 +559,7 @@ private:
       Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
       const picongpu::float_64 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
 
-      for(uint ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
+      for(uint32_t ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
       {
           splash::Dimensions offset(ampIndex,0,0);
           splash::Selection dataSelection(bufferSize,
@@ -633,7 +633,7 @@ private:
           const int N_tmpBuffer = radiation_frequencies::N_omega * parameters::N_observer;
           picongpu::float_64* tmpBuffer = new picongpu::float_64[N_tmpBuffer];
 
-          for(uint ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
+          for(uint32_t ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
           {
               HDF5dataFile.read(timeStep,
                                 dataLabels(ampIndex).c_str(),


### PR DESCRIPTION
To decouple the code from CUDA headers, this commit removes some usages of cuda types in host code where standard C++ types can be used.