### PR TITLE
fix MSVC compiler error

### DIFF
--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -53,11 +53,11 @@ struct HostMemAllocator<Type, 1>
 {
     typedef Type type;
     static const int dim = 1;
-    typedef cursor::BufferCursor<type, dim> Cursor;
+    typedef cursor::BufferCursor<type, 1> Cursor;
     typedef allocator::tag::host tag;
 
     HDINLINE
-    static cursor::BufferCursor<type, dim> allocate(const math::Size_t<dim>& size);
+    static cursor::BufferCursor<type, 1> allocate(const math::Size_t<1>& size);
     template<typename TCursor>
     HDINLINE
     static void deallocate(const TCursor& cursor);


### PR DESCRIPTION
VC 2015 RC does not allow the usage of `dim` defined as `static const int dim = 1` to be used in further  type definitions within the template specialization. Only the direct usage of the value `1` seems to work.
This change makes the code equivalent to the DeviceMemAllocator template specialization with the same purpose.