### PR TITLE
remove variable length arrays

### DIFF
--- a/src/libPMacc/include/mpi/MPIReduce.hpp
+++ b/src/libPMacc/include/mpi/MPIReduce.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -22,17 +22,17 @@
 
 #pragma once
 
-#include "types.h"
-
-
-#include <mpi.h>
 #include "communication/manager_common.h"
 
+#include "mpi/reduceMethods/AllReduce.hpp"
 #include "mpi/GetMPI_StructAsArray.hpp"
 #include "mpi/GetMPI_Op.hpp"
 
+#include "types.h"
+
 #include <cassert>
-#include "mpi/reduceMethods/AllReduce.hpp"
+
+#include <mpi.h>
 
 namespace PMacc
 {
@@ -90,14 +90,14 @@ struct MPIReduce
 
         int countRanks;
         MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &countRanks));
-        int reduceRank[countRanks];
-        int groupRanks[countRanks];
+        std::vector<int> reduceRank(countRanks);
+        std::vector<int> groupRanks(countRanks);
         MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank));
 
         if (!isActive)
             mpiRank = -1;
 
-        MPI_CHECK(MPI_Allgather(&mpiRank, 1, MPI_INT, reduceRank, 1, MPI_INT, MPI_COMM_WORLD));
+        MPI_CHECK(MPI_Allgather(&mpiRank, 1, MPI_INT, &reduceRank[0], 1, MPI_INT, MPI_COMM_WORLD));
 
         for (int i = 0; i < countRanks; ++i)
         {
@@ -111,7 +111,7 @@ struct MPIReduce
         MPI_Group group = MPI_GROUP_NULL;
         MPI_Group newgroup = MPI_GROUP_NULL;
         MPI_CHECK(MPI_Comm_group(MPI_COMM_WORLD, &group));
-        MPI_CHECK(MPI_Group_incl(group, numRanks, groupRanks, &newgroup));
+        MPI_CHECK(MPI_Group_incl(group, numRanks, &groupRanks[0], &newgroup));
 
         MPI_CHECK(MPI_Comm_create(MPI_COMM_WORLD, newgroup, &comm));
 


### PR DESCRIPTION
The usage of variable length arrays is a GCC extension not supported by standard C++.
Their usage is replaced by `std::vector`.