### PR TITLE
remove invalid typename keywords

### DIFF
--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -1,6 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -64,24 +64,24 @@ fieldE( NULL )
     /*#####create FieldB###############*/
     fieldB = new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) );
 
-    typedef typename bmpl::accumulate<
+    typedef bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetLowerMargin< GetInterpolation<bmpl::_2> > >
         >::type LowerMarginInterpolation;
 
-    typedef typename bmpl::accumulate<
+    typedef bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetUpperMargin< GetInterpolation<bmpl::_2> > >
         >::type UpperMarginInterpolation;
 
     /* Calculate the maximum Neighbors we need from MAX(ParticleShape, FieldSolver) */
-    typedef typename PMacc::math::CT::max<
+    typedef PMacc::math::CT::max<
         LowerMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_B>::LowerMargin
         >::type LowerMargin;
-    typedef typename PMacc::math::CT::max<
+    typedef PMacc::math::CT::max<
         UpperMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_B>::UpperMargin
         >::type UpperMargin;
@@ -173,7 +173,7 @@ void FieldB::reset( uint32_t )
 }
 
 HDINLINE
-typename FieldB::UnitValueType
+FieldB::UnitValueType
 FieldB::getUnit( )
 {
     return UnitValueType( UNIT_BFIELD, UNIT_BFIELD, UNIT_BFIELD );

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -1,6 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -59,24 +59,24 @@ fieldB( NULL )
 {
     fieldE = new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) );
 
-    typedef typename bmpl::accumulate<
+    typedef bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetLowerMargin< GetInterpolation<bmpl::_2> > >
         >::type LowerMarginInterpolation;
 
-    typedef typename bmpl::accumulate<
+    typedef bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetUpperMargin< GetInterpolation<bmpl::_2> > >
         >::type UpperMarginInterpolation;
-    
+
     /* Calculate the maximum Neighbors we need from MAX(ParticleShape, FieldSolver) */
-    typedef typename PMacc::math::CT::max<
+    typedef PMacc::math::CT::max<
         LowerMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_E>::LowerMargin
         >::type LowerMargin;
-    typedef typename PMacc::math::CT::max<
+    typedef PMacc::math::CT::max<
         UpperMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_E>::UpperMargin
         >::type UpperMargin;
@@ -186,7 +186,7 @@ void FieldE::reset( uint32_t )
 
 
 HDINLINE
-typename FieldE::UnitValueType
+FieldE::UnitValueType
 FieldE::getUnit( )
 {
     return UnitValueType( UNIT_EFIELD, UNIT_EFIELD, UNIT_EFIELD );

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -45,7 +46,7 @@ namespace picongpu
 
 using namespace PMacc;
 
-typedef typename FieldJ::DataBoxType J_DataBox;
+typedef FieldJ::DataBoxType J_DataBox;
 
 template<int workerMultiplier, class BlockDescription_, uint32_t AREA, class JBox, class ParBox, class Mapping, class FrameSolver>
 __global__ void kernelComputeCurrent(JBox fieldJ,

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Richard Pausch
+ *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -58,13 +58,13 @@ fieldJ( cellDescription.getGridLayout( ) ), fieldE( NULL ), fieldB( NULL ), fiel
     const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout( ).getDataSpaceWithoutGuarding( );
 
     /* cell margins the current might spread to due to particle shapes */
-    typedef typename bmpl::accumulate<
+    typedef bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetLowerMargin< GetCurrentSolver<bmpl::_2> > >
         >::type LowerMarginShapes;
 
-    typedef typename bmpl::accumulate<
+    typedef bmpl::accumulate<
         VectorAllSpecies,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetUpperMargin< GetCurrentSolver<bmpl::_2> > >
@@ -74,12 +74,12 @@ fieldJ( cellDescription.getGridLayout( ) ), fieldE( NULL ), fieldB( NULL ), fiel
      * additional current interpolations and current filters on FieldJ might
      * spread the dependencies on neighboring cells
      *   -> use max(shape,filter) */
-    typedef typename PMacc::math::CT::max<
+    typedef PMacc::math::CT::max<
         LowerMarginShapes,
         GetMargin<fieldSolver::CurrentInterpolation>::LowerMargin
         >::type LowerMargin;
 
-    typedef typename PMacc::math::CT::max<
+    typedef PMacc::math::CT::max<
         UpperMarginShapes,
         GetMargin<fieldSolver::CurrentInterpolation>::UpperMargin
         >::type UpperMargin;
@@ -236,7 +236,7 @@ void FieldJ::clear( )
 }
 
 HDINLINE
-typename FieldJ::UnitValueType
+FieldJ::UnitValueType
 FieldJ::getUnit( )
 {
     const double UNIT_CURRENT = UNIT_CHARGE / UNIT_TIME / ( UNIT_LENGTH * UNIT_LENGTH );

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -1,6 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -65,56 +65,56 @@ namespace picongpu
         const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout( ).getDataSpaceWithoutGuarding( );
 
         /* ------------------ lower margin  ----------------------------------*/
-        typedef typename bmpl::accumulate<
+        typedef bmpl::accumulate<
             VectorAllSpecies,
             typename PMacc::math::CT::make_Int<simDim, 0>::type,
             PMacc::math::CT::max<bmpl::_1, GetLowerMargin< GetInterpolation<bmpl::_2> > >
         >::type SpeciesLowerMargin;
 
-        typedef typename bmpl::accumulate<
+        typedef bmpl::accumulate<
             FieldTmpSolvers,
             typename PMacc::math::CT::make_Int<simDim, 0>::type,
             PMacc::math::CT::max<bmpl::_1, GetLowerMargin< bmpl::_2 > >
         >::type FieldTmpLowerMargin;
 
-        typedef typename PMacc::math::CT::max<
+        typedef PMacc::math::CT::max<
             SpeciesLowerMargin,
             FieldTmpLowerMargin>::type SpeciesFieldTmpLowerMargin;
 
-        typedef typename PMacc::math::CT::max<
+        typedef PMacc::math::CT::max<
             GetMargin<fieldSolver::FieldSolver, FIELD_B>::LowerMargin,
             GetMargin<fieldSolver::FieldSolver, FIELD_E>::LowerMargin>::type
             FieldSolverLowerMargin;
 
-        typedef typename PMacc::math::CT::max<
+        typedef PMacc::math::CT::max<
             SpeciesFieldTmpLowerMargin,
             FieldSolverLowerMargin>::type LowerMargin;
 
 
         /* ------------------ upper margin  -----------------------------------*/
 
-        typedef typename bmpl::accumulate<
+        typedef bmpl::accumulate<
             VectorAllSpecies,
             typename PMacc::math::CT::make_Int<simDim, 0>::type,
             PMacc::math::CT::max<bmpl::_1, GetUpperMargin< GetInterpolation<bmpl::_2> > >
         >::type SpeciesUpperMargin;
 
-        typedef typename bmpl::accumulate<
+        typedef bmpl::accumulate<
             FieldTmpSolvers,
             typename PMacc::math::CT::make_Int<simDim, 0>::type,
             PMacc::math::CT::max<bmpl::_1, GetUpperMargin< bmpl::_2 > >
         >::type FieldTmpUpperMargin;
 
-        typedef typename PMacc::math::CT::max<
+        typedef PMacc::math::CT::max<
             SpeciesUpperMargin,
             FieldTmpUpperMargin>::type SpeciesFieldTmpUpperMargin;
 
-        typedef typename PMacc::math::CT::max<
+        typedef PMacc::math::CT::max<
             GetMargin<fieldSolver::FieldSolver, FIELD_B>::UpperMargin,
             GetMargin<fieldSolver::FieldSolver, FIELD_E>::UpperMargin>::type
             FieldSolverUpperMargin;
 
-        typedef typename PMacc::math::CT::max<
+        typedef PMacc::math::CT::max<
             SpeciesFieldTmpUpperMargin,
             FieldSolverUpperMargin>::type UpperMargin;
 
@@ -272,7 +272,7 @@ namespace picongpu
     }
 
     template<class FrameSolver >
-    HDINLINE typename FieldTmp::UnitValueType
+    HDINLINE FieldTmp::UnitValueType
     FieldTmp::getUnit( )
     {
         return FrameSolver().getUnit();

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -72,7 +72,7 @@ struct EvalAssignmentFunction
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, 0> >
 {
-    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+    typedef picongpu::particles::shapes::P4S ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -85,7 +85,7 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, 1> >
 {
-    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+    typedef picongpu::particles::shapes::P4S ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -95,9 +95,9 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c
 };
 
 template<>
-struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, -1 > >
+struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, -1> >
 {
-    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+    typedef picongpu::particles::shapes::P4S ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -109,7 +109,7 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, 2> >
 {
-    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+    typedef picongpu::particles::shapes::P4S ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -119,9 +119,9 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c
 };
 
 template<>
-struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, -2 > >
+struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c<int, -2> >
 {
-    typedef typename picongpu::particles::shapes::P4S ParticleAssign;
+    typedef picongpu::particles::shapes::P4S ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -133,7 +133,7 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::P4S, bmpl::integral_c
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c<int, 0> >
 {
-    typedef typename picongpu::particles::shapes::TSC ParticleAssign;
+    typedef picongpu::particles::shapes::TSC ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -147,7 +147,7 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c<int, 1> >
 {
-    typedef typename picongpu::particles::shapes::TSC ParticleAssign;
+    typedef picongpu::particles::shapes::TSC ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -159,9 +159,9 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c
 };
 
 template<>
-struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c<int, -1 > >
+struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c<int, -1> >
 {
-    typedef typename picongpu::particles::shapes::TSC ParticleAssign;
+    typedef picongpu::particles::shapes::TSC ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -174,7 +174,7 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::TSC, bmpl::integral_c
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c<int, 0> >
 {
-    typedef typename picongpu::particles::shapes::PCS ParticleAssign;
+    typedef picongpu::particles::shapes::PCS ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -188,7 +188,7 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c<int, 1> >
 {
-    typedef typename picongpu::particles::shapes::PCS ParticleAssign;
+    typedef picongpu::particles::shapes::PCS ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -202,7 +202,7 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c
 template<>
 struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c<int, 2> >
 {
-    typedef typename picongpu::particles::shapes::PCS ParticleAssign;
+    typedef picongpu::particles::shapes::PCS ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)
@@ -214,9 +214,9 @@ struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c
 };
 
 template<>
-struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c<int, -1 > >
+struct EvalAssignmentFunction<picongpu::particles::shapes::PCS, bmpl::integral_c<int, -1> >
 {
-    typedef typename picongpu::particles::shapes::PCS ParticleAssign;
+    typedef picongpu::particles::shapes::PCS ParticleAssign;
 
     HDINLINE float_X
     operator()(const float_X parPos)

--- a/src/picongpu/include/initialization/ParserGridDistribution.hpp
+++ b/src/picongpu/include/initialization/ParserGridDistribution.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ public:
     uint32_t
     getOffset( const int gpuPos, const uint32_t maxCells ) const
     {
-        typename value_type::const_iterator iter = parsedInput.begin();
+        value_type::const_iterator iter = parsedInput.begin();
         // go to last gpu of this block b{n}
         int i = iter->second - 1;
         int sum = 0;
@@ -84,7 +84,7 @@ public:
     uint32_t
     getLocalSize( const int gpuPos ) const
     {
-        typename value_type::const_iterator iter = parsedInput.begin();
+        value_type::const_iterator iter = parsedInput.begin();
         // go to last gpu of this block b{n}
         int i = iter->second - 1;
 

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -99,7 +100,7 @@ private:
 
     nvidia::reduce::Reduce* localReduce;
 
-    typedef typename promoteType<float_64, FieldB::ValueType>::type EneVectorType;
+    typedef promoteType<float_64, FieldB::ValueType>::type EneVectorType;
 
 public:
 

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -43,7 +44,7 @@ using namespace PMacc;
 
 namespace po = boost::program_options;
 
-typedef typename FieldJ::DataBoxType J_DataBox;
+typedef FieldJ::DataBoxType J_DataBox;
 
 template<class Mapping>
 __global__ void kernelSumCurrents(J_DataBox fieldJ, float3_X* gCurrent, Mapping mapper)


### PR DESCRIPTION
typename cannot be used outside a template declaration.
Only gcc allows this code in c++98. Clang correctly rejects this as it is only allowed in c++11

This is the same as #926 and #917.