### PR TITLE
refactor cuSTL/cursor

### DIFF
--- a/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
@@ -51,7 +51,7 @@ class Cursor : private _Accessor, _Navigator
 {
 public:
     typedef typename _Accessor::type type;
-    typedef typename boost::remove_reference<type>::type pureType;
+    typedef typename boost::remove_reference<type>::type ValueType;
     typedef _Accessor Accessor;
     typedef _Navigator Navigator;
     typedef _Marker Marker;
@@ -95,8 +95,9 @@ public:
     template<typename Jump>
     HDINLINE This operator()(const Jump& jump) const
     {
-        return This(getAccessor(), getNavigator(),
-                    Navigator::operator()(this->marker, jump));
+        Navigator newNavigator(getNavigator());
+        Marker newMarker = newNavigator(this->marker, jump);
+        return This(getAccessor(), newNavigator, newMarker);
     }
 
     /* convenient method which is available if the navigator accepts a Int<1> */

--- a/src/libPMacc/include/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
@@ -34,7 +34,7 @@ template<typename TCursor, typename Axes>
 struct TwistAxesAccessor
 {
     typedef typename math::tools::result_of::TwistVectorAxes<
-        Axes, typename TCursor::pureType>::type type;
+        Axes, typename TCursor::ValueType>::type type;
 
     /** Returns a reference to the result of '*cursor' (with twisted axes).
      *


### PR DESCRIPTION
navigators may modify their members

 - rename: pureType -> ValueType (cuSTL/cursor)