### PR TITLE
Titan/ORNL: Update Modules

### DIFF
--- a/src/picongpu/submit/titan-ornl/batch_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_profile.tpl
@@ -55,9 +55,9 @@ echo -n "present working directory:"
 pwd
 
 
-source $MEMBERWORK/!TBG_nameProject/picongpu.profile 2>/dev/null
+source $PROJWORK/!TBG_nameProject/picongpu.profile 2>/dev/null
 if [ $? -ne 0 ] ; then
-  echo "Error: picongpu.profile not found in MEMBERWORK"
+  echo "Error: picongpu.profile not found in PROJWORK"
   exit 1
 fi
 

--- a/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
@@ -55,9 +55,9 @@ echo -n "present working directory:"
 pwd
 
 
-source $MEMBERWORK/!TBG_nameProject/picongpu.profile 2>/dev/null
+source $PROJWORK/!TBG_nameProject/picongpu.profile 2>/dev/null
 if [ $? -ne 0 ] ; then
-  echo "Error: picongpu.profile not found in MEMBERWORK"
+  echo "Error: picongpu.profile not found in PROJWORK"
   exit 1
 fi
 

--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -43,21 +43,21 @@ export HDF5_ROOT=$HDF5_DIR
 
 # download libSplash and compile it yourself from
 #   https://github.com/ComputationalRadiationPhysics/libSplash/
-export SPLASH_ROOT=$MEMBERWORK/$proj/lib/splash
+export SPLASH_ROOT=$PROJWORK/$proj/lib/splash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SPLASH_ROOT/lib
 
-#export T3PIO_ROOT=$MEMBERWORK/$proj/lib/t3pio
+#export T3PIO_ROOT=$PROJWORK/$proj/lib/t3pio
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$T3PIO_ROOT/lib
 
 # download libpng.h and compile yourself with
 #   http://www.libpng.org/pub/png/libpng.html
 #   tar -xvf libpng-1.6.9.tar.gz
-#   ./configure --host=x86 --prefix=$MEMBERWORK/$proj/lib/libpng
+#   ./configure --host=x86 --prefix=$PROJWORK/$proj/lib/libpng
 # afterwards install pngwriter yourself:
 #   https://github.com/ax3l/pngwriter#install
-export LIBPNG_ROOT=$MEMBERWORK/$proj/lib/libpng
+export LIBPNG_ROOT=$PROJWORK/$proj/lib/libpng
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBPNG_ROOT/lib
-export PNGWRITER_ROOT=$MEMBERWORK/$proj/lib/pngwriter
+export PNGWRITER_ROOT=$PROJWORK/$proj/lib/pngwriter
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGWRITER_ROOT/lib
 
 # helper variables and tools ########################################

--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -1,4 +1,5 @@
 export proj=<yourProject>
+export TBG_mailAdress="mail@example.com"
 
 # basic environment #################################################
 source /opt/modules/3.2.6.7/init/bash
@@ -9,6 +10,8 @@ module swap PrgEnv-pgi PrgEnv-gnu
 #   (CMake likes to unwrap the Cray wrappers)
 export CC="`which cc` -target=compute_node"
 export CXX="`which CC` -target=compute_node"
+export FC="`which ftn` -target=compute_node"
+#export LD="/sw/xk6/altd/bin/ld"
 
 # symbol bug work around (should not be required)
 #MY_CRAY_LIBS=/opt/gcc/4.8.2/snos/lib64
@@ -19,7 +22,7 @@ export CXX="`which CC` -target=compute_node"
 # required tools and libs
 module load git cmake
 module load cudatoolkit
-module load boost/1.54.0
+module load boost/1.57.0
 export BOOST_ROOT=$BOOST_DIR
 export MPI_ROOT=$MPICH_DIR
 
@@ -31,7 +34,7 @@ module load vampirtrace/5.14.4
 export VT_ROOT=$VAMPIRTRACE_DIR
 
 # plugins (optional) ################################################
-module load cray-hdf5-parallel/1.8.12
+module load cray-hdf5-parallel/1.8.14
 #module load adios/1.8.0 mxml/2.9 dataspaces/1.4.0
 export HDF5_ROOT=$HDF5_DIR
 #export ADIOS_ROOT=$ADIOS_DIR

--- a/src/picongpu/submit/titan-ornl/pythonOnComp.profile.example
+++ b/src/picongpu/submit/titan-ornl/pythonOnComp.profile.example
@@ -1,0 +1,19 @@
+# Long documentation, see:
+#   https://gist.github.com/ax3l/7d1fa52bb7f39a657920
+#
+. ~/picongpu.profile
+
+module load python
+
+# --user writes there
+export PYTHONUSERBASE=$MEMBERWORK/$proj
+
+# a weird cache that usually sits in $HOME
+export PYTHON_EGG_CACHE=$PYTHONUSERBASE/.python-eggs
+# were the actual binaries (and some messy pre-installed libs) sit
+#export PYTHONHOME=$(dirname $(which python))/..
+export PYTHONHOME=/lustre/atlas/sw/xk6/python/2.7.9/sles11.3_gnu4.3.4/
+# were our packages reside
+export PYTHONPATH=$PYTHONUSERBASE/lib/python2.7/site-packages:$PYTHONPATH
+
+export PATH=$PYTHONUSERBASE/bin:$PATH

--- a/src/picongpu/submit/titan-ornl/pythonOnComp.profile.example
+++ b/src/picongpu/submit/titan-ornl/pythonOnComp.profile.example
@@ -6,7 +6,7 @@
 module load python
 
 # --user writes there
-export PYTHONUSERBASE=$MEMBERWORK/$proj
+export PYTHONUSERBASE=$PROJWORK/$proj
 
 # a weird cache that usually sits in $HOME
 export PYTHON_EGG_CACHE=$PYTHONUSERBASE/.python-eggs

--- a/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
+++ b/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
@@ -16,7 +16,7 @@ module load python_scipy
 export IPYTHONDIR=$PROJWORK/$proj/ipython
 
 # ADIOS
-export ADIOS_ROOT=$MEMBERWORK/$proj/lib/adios-pre1.9.0-rhea
+export ADIOS_ROOT=$PROJWORK/$proj/lib/adios-pre1.9.0-rhea
 export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
 export PATH=$ADIOS_ROOT/bin:$PATH
 module load mxml
@@ -28,7 +28,7 @@ source $PROJWORK/$proj/python-venv/rhea/bin/activate
 #
 # first install adios
 #   LDFLAGS="-fPIC -pthread" CFLAGS="-fPIC -g -O2" CXXFLAGS="-fPIC -g -O2" \
-#     ./configure --prefix=$MEMBERWORK/$proj/lib/adios-pre1.9.0-rhea \
+#     ./configure --prefix=$PROJWORK/$proj/lib/adios-pre1.9.0-rhea \
 #     --with-zlib --with-mpi --enable-static --enable-shared \
 #     --with-mxml=$MXML_DIR --without-dataspaces
 #   make -j

--- a/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
+++ b/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
@@ -1,0 +1,56 @@
+export proj=<yourProject>
+
+module unload intel
+module swap PE-intel PE-gnu
+
+module load python
+module load python_setuptools
+module load python_pip
+module load python_virtualenv
+
+module load python_numpy
+module load python_h5py
+module load python_scipy
+
+# the place where ipython profiles are placed (default is ~/.ipython)
+export IPYTHONDIR=$PROJWORK/$proj/ipython
+
+# ADIOS
+export ADIOS_ROOT=$MEMBERWORK/$proj/lib/adios-pre1.9.0-rhea
+export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
+export PATH=$ADIOS_ROOT/bin:$PATH
+module load mxml
+
+# load python virtual env
+source $PROJWORK/$proj/python-venv/rhea/bin/activate
+
+# for an initial setup ########################################################
+#
+# first install adios
+#   LDFLAGS="-fPIC -pthread" CFLAGS="-fPIC -g -O2" CXXFLAGS="-fPIC -g -O2" \
+#     ./configure --prefix=$MEMBERWORK/$proj/lib/adios-pre1.9.0-rhea \
+#     --with-zlib --with-mpi --enable-static --enable-shared \
+#     --with-mxml=$MXML_DIR --without-dataspaces
+#   make -j
+#   make install
+#
+# now run for setting up the python virtual environment
+#   mkdir -p $PROJWORK/$proj/python-venv
+#   cd $PROJWORK/$proj
+#   virtualenv rhea
+#   source $PROJWORK/$proj/python-venv/rhea/bin/activate
+#   which pip
+#
+#   pip install adios
+#   pip install six
+#   pip install matplotlib
+#   pip install "ipython[all]"
+#   pip install mpi4py
+#   pip install h5py
+#   pip install psutil
+#   pip install pyDive
+#
+# create IPython profile for cluster:
+#   ipython profile create --parallel --profile=rhea
+# edit files: $IPYTHONDIR/profile_rhea/ip*_config.py
+#   as in http://ipython.org/ipython-doc/2/parallel/parallel_process.htm


### PR DESCRIPTION
This pull requests updates the `picongpu.profile` example that we provide for Titan/ORNL.

I also added an example profile that can be used for python on compute nodes, similar to my gist at https://gist.github.com/ax3l/7d1fa52bb7f39a657920 .