### PR TITLE
fix spelling errors in gridConfig.param files

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
     
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -68,7 +69,7 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/

--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
     
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau
+ * Copyright 2013-2015 Heiko Burau, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
     
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
     
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/

--- a/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ namespace picongpu
         {0, 0}   /*z direction [negative,positive]*/
     }; //unit: number of cells
     
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/

--- a/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ namespace picongpu
         {0, 0}   /*z direction [negative,positive]*/
     }; //unit: number of cells
     
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -48,7 +48,7 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strange of the absober for any direction
+    //! Define the strength of the absorber for any direction
     const float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/


### PR DESCRIPTION
`gridConfig.param`: "strange of the absober" -> "strength of the absorber"