### PR TITLE
Range of validity: TWTS pulses with negative tilt angles

### DIFF
--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -73,6 +73,8 @@ public:
     const PMACC_ALIGN(w_y_SI,float_64);
     /* interaction angle between TWTS laser propagation vector and the y-axis [rad] */
     const PMACC_ALIGN(phi,float_X);
+    /* Takes value 1.0 for phi > 0 and -1.0 for phi < 0. */
+    PMACC_ALIGN(phiPositive,float_X);
     /* propagation speed of TWTS laser overlap
        normalized to the speed of light. [Default: beta0 = 1.0] */
     const PMACC_ALIGN(beta_0,float_X);

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -344,6 +344,10 @@ namespace twts
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
         const float_T k = float_T(2.0*PI / lambda0);
+        /* If phi < 0 the entire pulse is rotated by 180 deg around the
+         * z-axis of the coordinate system without also changing
+         * the orientation of the resulting field vectors.
+         */
         const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
         const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
@@ -464,10 +468,6 @@ namespace twts
         /* If phi < 0 the formulas below are not directly applicable.
          * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
          * z-axis of the coordinate system in this function.
-         * Note a: Another consequence is that the resulting field vectors also need to be rotated.
-         * Note b: Instead of modifying field_x --> -field_x and field_y --> -field_y according
-         *         to "Note a", we choose to introduce an additional 180deg shift due symmetry
-         *         and modify only field_z --> -field_z .
          */
         const float_T phiReal = float_T( pmMath::abs(phi) );
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
@@ -501,6 +501,10 @@ namespace twts
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
         const float_T k = float_T(2.0*PI / lambda0);
+        /* If phi < 0 the entire pulse is rotated by 180 deg around the
+         * z-axis of the coordinate system without also changing
+         * the orientation of the resulting field vectors.
+         */
         const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
         const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
@@ -593,10 +597,6 @@ namespace twts
         /* If phi < 0 the formulas below are not directly applicable.
          * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
          * z-axis of the coordinate system in this function.
-         * Note a: Another consequence is that the resulting field vectors also need to be rotated.
-         * Note b: Instead of modifying field_x --> -field_x and field_y --> -field_y according
-         *         to "Note a", we choose to introduce an additional 180deg shift due symmetry
-         *         and modify only field_z --> -field_z .
          */
         const float_T phiReal = float_T( pmMath::abs(phi) );
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
@@ -629,6 +629,10 @@ namespace twts
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
         const float_T k = float_T(2.0*PI / lambda0);
+        /* If phi < 0 the entire pulse is rotated by 180 deg around the
+         * z-axis of the coordinate system without also changing
+         * the orientation of the resulting field vectors.
+         */
         const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
         const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -60,7 +60,7 @@ namespace twts
         pulselength_SI(pulselength_SI), w_x_SI(w_x_SI),
         w_y_SI(w_y_SI), phi(phi), beta_0(beta_0),
         tdelay_user_SI(tdelay_user_SI), dt(SI::DELTA_T_SI),
-        unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay), pol(pol)
+        unit_length(UNIT_LENGTH), auto_tdelay(auto_tdelay), pol(pol), phiPositive( float_X(1.0) )
     {
         /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
          * on host (see fieldBackground.param), this is no problem.
@@ -70,6 +70,7 @@ namespace twts
         tdelay = detail::getInitialTimeDelay_SI(auto_tdelay, tdelay_user_SI,
                                                 halfSimSize, pulselength_SI,
                                                 focus_y_SI, phi, beta_0);
+        if ( phi < float_X(0.0) ) phiPositive = float_X(-1.0);
     }
 
     template<>
@@ -308,7 +309,11 @@ namespace twts
 
         /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
-        const float_T phiReal = float_T(phi);
+        /* If phi < 0 the formulas below are not directly applicable.
+         * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
+         * z-axis of the coordinate system in this function.
+         */
+        const float_T phiReal = float_T( pmMath::abs(phi) );
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
                                                 beta0*pmMath::sin(phiReal));
         /* Definition of the laser pulse front tilt angle for the laser field below.
@@ -339,8 +344,8 @@ namespace twts
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
         const float_T k = float_T(2.0*PI / lambda0);
-        const float_T x = float_T(pos.x() / UNIT_LENGTH);
-        const float_T y = float_T(pos.y() / UNIT_LENGTH);
+        const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+        const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
         const float_T t = float_T(time / UNIT_TIME);
 
@@ -456,7 +461,15 @@ namespace twts
 
         /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
-        const float_T phiReal = float_T(phi);
+        /* If phi < 0 the formulas below are not directly applicable.
+         * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
+         * z-axis of the coordinate system in this function.
+         * Note a: Another consequence is that the resulting field vectors also need to be rotated.
+         * Note b: Instead of modifying field_x --> -field_x and field_y --> -field_y according
+         *         to "Note a", we choose to introduce an additional 180deg shift due symmetry
+         *         and modify only field_z --> -field_z .
+         */
+        const float_T phiReal = float_T( pmMath::abs(phi) );
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
                                                 beta0*pmMath::sin(phiReal));
 
@@ -488,8 +501,8 @@ namespace twts
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
         const float_T k = float_T(2.0*PI / lambda0);
-        const float_T x = float_T(pos.x() / UNIT_LENGTH);
-        const float_T y = float_T(pos.y() / UNIT_LENGTH);
+        const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+        const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
         const float_T t = float_T(time / UNIT_TIME);
 
@@ -577,7 +590,15 @@ namespace twts
 
         /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
         const float_T beta0 = float_T(beta_0);
-        const float_T phiReal = float_T(phi);
+        /* If phi < 0 the formulas below are not directly applicable.
+         * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
+         * z-axis of the coordinate system in this function.
+         * Note a: Another consequence is that the resulting field vectors also need to be rotated.
+         * Note b: Instead of modifying field_x --> -field_x and field_y --> -field_y according
+         *         to "Note a", we choose to introduce an additional 180deg shift due symmetry
+         *         and modify only field_z --> -field_z .
+         */
+        const float_T phiReal = float_T( pmMath::abs(phi) );
         const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
                                                 beta0*pmMath::sin(phiReal));
         /* Definition of the laser pulse front tilt angle for the laser field below.
@@ -608,8 +629,8 @@ namespace twts
         /* wy is width of TWTS pulse */
         const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
         const float_T k = float_T(2.0*PI / lambda0);
-        const float_T x = float_T(pos.x() / UNIT_LENGTH);
-        const float_T y = float_T(pos.y() / UNIT_LENGTH);
+        const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+        const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
         const float_T z = float_T(pos.z() / UNIT_LENGTH);
         const float_T t = float_T(time / UNIT_TIME);
 

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -72,6 +72,8 @@ public:
     const PMACC_ALIGN(w_y_SI,float_64);
     /* interaction angle between TWTS laser propagation vector and the y-axis [rad] */
     const PMACC_ALIGN(phi,float_X);
+    /* Takes value 1.0 for phi > 0 and -1.0 for phi < 0. */
+    PMACC_ALIGN(phiPositive,float_X);
     /* propagation speed of TWTS laser overlap
     normalized to the speed of light. [Default: beta0=1.0] */
     const PMACC_ALIGN(beta_0,float_X);


### PR DESCRIPTION
This is a bugfix/feature upgrade, which enables to also use negative tilt angles `phi`. Until now the code was already running for `phi<0`. However, the results were subtly wrong, because the original TWTS field solution is only defined for `phi>0`, but nevertheless returns an *almost* correct result for `phi<0`.

In this specific implementation that issue is fixed by using symmetry properties of the TWTS pulse. In the laser specific coordinates of the TWTS pulse the entire pulse is rotated by 180° around the z-axis in order to achieve an inverted pulse front tilt. The rest of the code then already takes care of the correct field positions and field vector orientations.

Have fun! :boom: