### PR TITLE
Feature: cuSTL/MapTo1DNavigator

### DIFF
--- a/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015 Heiko Burau
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace PMacc
+{
+namespace cursor
+{
+
+/**
+ * @class MapTo1DNavigator
+ * @brief Use this navigator to wrap a ndim-cursor into a 1D cursor.
+ */
+template<int T_dim>
+class MapTo1DNavigator
+{
+public:
+    static const int dim = T_dim;
+private:
+    math::Size_t<dim> shape;
+    int pos;
+    
+    HDINLINE
+    math::Int<dim> toNdim(int idx) const
+    {
+        math::Int<dim> result;
+        int volume = 1;
+        for(int i = 0; i < dim; i++)
+        {
+            result[i] = (idx / volume) % this->shape[i];
+            volume *= this->shape[i];
+        }
+        return result;
+    }
+public:
+    HDINLINE
+    MapTo1DNavigator(math::Size_t<dim> shape) 
+     : shape(shape), pos(0) {}
+
+    template<typename Cursor>
+    HDINLINE
+    Cursor operator()(const Cursor& cursor, math::Int<1> jump)
+    {
+        math::Int<dim> ndstart = toNdim(this->pos);
+        this->pos += jump.x();
+        math::Int<dim> ndend = toNdim(this->pos);
+        
+        math::Int<dim> ndjump = ndend - ndstart;
+        
+        return cursor(ndjump);
+    }
+
+};
+
+} // namespace cursor
+} // namespace PMacc

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
@@ -28,8 +28,7 @@ namespace cursor
 {
 
 /**
- * @class MapTo1DNavigator
- * @brief Use this navigator to wrap a ndim-cursor into a 1D cursor.
+ * Use this navigator to wrap a ndim-cursor into a 1D cursor.
  */
 template<int T_dim>
 class MapTo1DNavigator
@@ -53,6 +52,9 @@ private:
         return result;
     }
 public:
+    /**
+     * @param shape area to map the 1D index to.
+     */
     HDINLINE
     MapTo1DNavigator(math::Size_t<dim> shape) 
      : shape(shape), pos(0) {}


### PR DESCRIPTION
Add cuSTL/MapTo1DNavigator which can be used to wrap a ndim-cursor into a 1D-cursor.