### PR TITLE
remove invalid typenames from example param files

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/memory.param
+++ b/examples/Bunch/include/simulation_defines/param/memory.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Richard Pausch, Rene Widera
+ * Copyright 2013-2015 Richard Pausch, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -40,7 +40,7 @@ namespace mCT=PMacc::math::CT;
  *
  * volume of a superCell must be <= 1024
  */
-typedef typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -20,6 +20,7 @@
 
 
 #pragma once
+
 #include "math/Vector.hpp"
 #include "mappings/kernel/MappingDescription.hpp"
 
@@ -39,7 +40,7 @@ namespace mCT=PMacc::math::CT;
  *
  * volume of a superCell must be <= 1024
  */
-typedef typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -40,7 +40,7 @@ namespace particles
         {
             /** Count of particles per cell per direction at initial state
              *  unit: none */
-           typedef typename mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type numParticlesPerDimension;
+           typedef mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type numParticlesPerDimension;
         };
 
         /* definition of random particle start*/
@@ -54,7 +54,7 @@ namespace particles
     const float_X MIN_WEIGHTING = 10.0;
 
     const uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
-        typename startPosition::QuietParam::numParticlesPerDimension
+        startPosition::QuietParam::numParticlesPerDimension
     >::type::value;
 
 namespace manipulators

--- a/examples/LaserWakefield/include/simulation_defines/param/memory.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/memory.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -40,7 +40,7 @@ namespace mCT=PMacc::math::CT;
  *
  * volume of a superCell must be <= 1024
  */
-typedef typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
@@ -53,4 +53,4 @@ const uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
 const uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
 const uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
 const uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
-} //namespace picongpu
+}//namespace picongpu

--- a/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Rene Widera, Marco Garten
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -59,7 +59,7 @@ struct QuietParameter
 {
     /** Count of particles per cell per direction at initial state
      *  unit: none */
-    typedef typename mCT::shrinkTo<mCT::Int<1, TYPICAL_PARTICLES_PER_CELL, 1>, simDim>::type numParticlesPerDimension;
+    typedef mCT::shrinkTo<mCT::Int<1, TYPICAL_PARTICLES_PER_CELL, 1>, simDim>::type numParticlesPerDimension;
 };
 
 /* definition of random particle start*/

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Rene Widera, Marco Garten, Richard Pausch
+ * Copyright 2013-2015 Rene Widera, Marco Garten, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -42,21 +43,21 @@ namespace picongpu
 /*########################### define particle attributes #####################*/
 
 /** describe attributes of a particle*/
-typedef typename MakeSeq<position<position_pic>, momentum, weighting>::type DefaultParticleAttributes;
+typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultParticleAttributes;
 
 /** \todo: not nice, we change this later with nice interfaces
  * Plugins should add required attributes
  */
 
 /*add old momentum for radiation plugin*/
-typedef typename MakeSeq<
+typedef MakeSeq<
 #if(ENABLE_RADIATION == 1)
 momentumPrev1
 #endif
 >::type AttributMomentum_mt1;
 
 /*add old radiation flag for radiation plugin*/
-typedef typename MakeSeq<
+typedef MakeSeq<
 #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
 radiationFlag
 #endif
@@ -64,7 +65,7 @@ radiationFlag
 
 /* attribute sequence for species: electrons */
 typedef
-typename MakeSeq<
+MakeSeq<
 DefaultParticleAttributes,
 AttributMomentum_mt1,
 AttributRadiationFlag
@@ -72,7 +73,7 @@ AttributRadiationFlag
 
 /* attribute sequence for species: ions */
 typedef
-typename MakeSeq<
+MakeSeq<
 DefaultParticleAttributes,
 AttributMomentum_mt1,
 AttributRadiationFlag,
@@ -99,7 +100,7 @@ typedef Particles<ParticleDescription<
     SuperCellSize,
     AttributeSeqElectrons,
     ParticleFlagsElectrons,
-    typename MakeSeq<CommunicationId<PAR_ELECTRONS> >::type  >
+    MakeSeq<CommunicationId<PAR_ELECTRONS> >::type  >
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -152,7 +153,7 @@ typedef Particles<ParticleDescription<
     SuperCellSize,
     AttributeSeqIons,
     ParticleFlagsIons,
-    typename MakeSeq<CommunicationId<PAR_IONS> >::type >
+    MakeSeq<CommunicationId<PAR_IONS> >::type >
 > PIC_Ions;
 
 /*########################### end species ####################################*/
@@ -161,19 +162,19 @@ typedef Particles<ParticleDescription<
 /*! we delete this ugly definition of VectorAllSpecies after all picongpu components
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
-typedef typename MakeSeq<
+typedef MakeSeq<
 #if (ENABLE_ELECTRONS == 1)
 PIC_Electrons
 #endif
 >::type Species1;
 
-typedef typename MakeSeq<
+typedef MakeSeq<
 #if (ENABLE_IONS == 1)
 PIC_Ions
 #endif
 >::type Species2;
 
-typedef typename MakeSeq<
+typedef MakeSeq<
 Species1,
 Species2
 >::type VectorAllSpecies;

--- a/examples/ThermalTest/include/simulation_defines/param/memory.param
+++ b/examples/ThermalTest/include/simulation_defines/param/memory.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -40,7 +40,7 @@ namespace mCT=PMacc::math::CT;
  *
  * volume of a superCell must be <= 1024
  */
-typedef typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;

--- a/examples/WeibelTransverse/include/simulation_defines/param/memory.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/memory.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -40,7 +40,7 @@ namespace mCT=PMacc::math::CT;
  *
  * volume of a superCell must be <= 1024
  */
-typedef typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;

--- a/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -89,7 +89,7 @@ namespace startPosition
     {
         /** Count of particles per cell per direction at initial state
          *  unit: none */
-       typedef typename mCT::shrinkTo<mCT::Int<TYPICAL_PARTICLES_PER_CELL/2, TYPICAL_PARTICLES_PER_CELL/2, 1>, simDim>::type numParticlesPerDimension;
+       typedef mCT::shrinkTo<mCT::Int<TYPICAL_PARTICLES_PER_CELL/2, TYPICAL_PARTICLES_PER_CELL/2, 1>, simDim>::type numParticlesPerDimension;
     };
 
     /* definition of random particle start*/


### PR DESCRIPTION
This is a follow up fixing missed files from #926.