### PR TITLE
add const value pointer getter for const boxes

### DIFF
--- a/src/libPMacc/include/memory/boxes/MultiBox.hpp
+++ b/src/libPMacc/include/memory/boxes/MultiBox.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -119,6 +119,10 @@ public:
         return RefValueType(fixedPointer, attributePitch);
     }
 
+    HDINLINE Type const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE Type* getPointer()
     {
         return fixedPointer;
@@ -188,6 +192,10 @@ public:
         return RefValueType(fixedPointer, attributePitch);
     }
 
+    HDINLINE Type const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE Type* getPointer()
     {
         return fixedPointer;
@@ -249,6 +257,10 @@ public:
         return RefValueType(fixedPointer, attributePitch);
     }
 
+    HDINLINE Type const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE Type* getPointer()
     {
         return fixedPointer;

--- a/src/libPMacc/include/memory/boxes/PitchedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/PitchedBox.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -84,6 +84,10 @@ public:
         return *(fixedPointer);
     }
 
+    HDINLINE TYPE const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE TYPE* getPointer()
     {
         return fixedPointer;
@@ -149,6 +153,10 @@ public:
         return *((TYPE*) fixedPointer);
     }
 
+    HDINLINE TYPE const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE TYPE* getPointer()
     {
         return fixedPointer;
@@ -209,6 +217,10 @@ public:
         return *(fixedPointer);
     }
 
+    HDINLINE TYPE const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE TYPE* getPointer()
     {
         return fixedPointer;

--- a/src/libPMacc/include/memory/boxes/SharedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/SharedBox.hpp
@@ -84,6 +84,10 @@ public:
         return *(fixedPointer);
     }
 
+    HDINLINE ValueType const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE ValueType* getPointer()
     {
         return fixedPointer;
@@ -140,6 +144,10 @@ public:
         return *((ValueType*) fixedPointer);
     }
 
+    HDINLINE ValueType const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE ValueType* getPointer()
     {
         return fixedPointer;
@@ -203,6 +211,10 @@ public:
         return *(fixedPointer);
     }
 
+    HDINLINE ValueType const * getPointer() const
+    {
+        return fixedPointer;
+    }
     HDINLINE ValueType* getPointer()
     {
         return fixedPointer;


### PR DESCRIPTION
When getting a box by const reference you should be able to get a pointer to the const values.