### PR TITLE
refactor host/device identifier defines

### DIFF
--- a/src/libPMacc/include/identifier/alias.hpp
+++ b/src/libPMacc/include/identifier/alias.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -35,6 +35,15 @@ identifier(pmacc_void);
 identifier(pmacc_isAlias);
 } //namespace PMacc
 
+#ifdef __CUDACC__
+    #define PMACC_alias_CUDA(name,id)                                          \
+        namespace PMACC_JOIN(device_placeholder,id){                           \
+            __constant__ PMACC_JOIN(placeholder_definition,id)::name<> PMACC_JOIN(name,_); \
+        }
+#else
+    #define PMACC_alias_CUDA(name,id)
+#endif
+
 /*define special makros for creating classes which are only used as identifer*/
 #define PMACC_alias(name,id)                                                   \
     namespace PMACC_JOIN(placeholder_definition,id) {                          \
@@ -51,9 +60,7 @@ identifier(pmacc_isAlias);
     namespace PMACC_JOIN(host_placeholder,id){                                 \
         PMACC_JOIN(placeholder_definition,id)::name<> PMACC_JOIN(name,_);      \
     }                                                                          \
-    namespace PMACC_JOIN(device_placeholder,id){                               \
-        __constant__ PMACC_JOIN(placeholder_definition,id)::name<> PMACC_JOIN(name,_); \
-    }                                                                          \
+    PMACC_alias_CUDA(name,id);                                                 \
     PMACC_PLACEHOLDER(id);
 
 

--- a/src/libPMacc/include/identifier/identifier.hpp
+++ b/src/libPMacc/include/identifier/identifier.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -32,6 +32,15 @@
 #define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(host_placeholder,id)
 #endif
 
+#ifdef __CUDACC__
+    #define PMACC_identifier_CUDA(name,id)                                         \
+        namespace PMACC_JOIN(device_placeholder,id){                               \
+            __constant__ PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
+        }
+#else
+    #define PMACC_identifier_CUDA(name,id)
+#endif
+
 /*define special macros for creating classes which are only used as identifier*/
 #define PMACC_identifier(name,id,...)                                          \
     namespace PMACC_JOIN(placeholder_definition,id) {                          \
@@ -43,9 +52,7 @@
     namespace PMACC_JOIN(host_placeholder,id){                                 \
         PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_);        \
     }                                                                          \
-    namespace PMACC_JOIN(device_placeholder,id){                               \
-        __constant__ PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
-    }                                                                          \
+    PMACC_identifier_CUDA(name,id);                                            \
     PMACC_PLACEHOLDER(id);
 
 

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -33,6 +33,17 @@
 #define PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id) using namespace PMACC_JOIN(pmacc_static_const_vector_host,id)
 #endif
 
+#ifdef __CUDACC__
+    #define PMACC_STATIC_CONST_VECTOR_DIM_DEF_CUDA(id,Name,Type,...)               \
+        namespace PMACC_JOIN(pmacc_static_const_vector_device,id)                  \
+        {                                                                          \
+           /* store all values in a const C array on device*/                      \
+            __constant__ const Type PMACC_JOIN(Name, _data)[]={__VA_ARGS__};       \
+        } /*namespace pmacc_static_const_vector_device + id */
+#else
+    #define PMACC_STATIC_CONST_VECTOR_DIM_DEF_CUDA(id,Name,Type,...)
+#endif
+
 /** define a const vector
  *
  * create type definition `Name_t`
@@ -43,14 +54,10 @@
 #define PMACC_STATIC_CONST_VECTOR_DIM_DEF(id,Name,Type,Dim,count,...)          \
 namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
 {                                                                              \
-    namespace PMACC_JOIN(pmacc_static_const_vector_device,id)                  \
+    PMACC_STATIC_CONST_VECTOR_DIM_DEF_CUDA(id,Name,Type,__VA_ARGS__);          \
+    namespace PMACC_JOIN(pmacc_static_const_vector_host,id)                    \
     {                                                                          \
-       /* store all values in a const C array on device*/                      \
-        __constant__ const Type PMACC_JOIN(Name,_data)[]={__VA_ARGS__};        \
-    } /*namespace pmacc_static_const_vector_device + id */                     \
-    namespace PMACC_JOIN( pmacc_static_const_vector_host,id)                   \
-    {                                                                          \
-        /* store all values in a const C array on device*/                     \
+        /* store all values in a const C array on host*/                       \
         const Type PMACC_JOIN(Name,_data)[]={__VA_ARGS__};                     \
     } /* namespace pmacc_static_const_vector_host + id  */                     \
     /* select host or device namespace depending on __CUDA_ARCH__ compiler flag*/ \
@@ -82,17 +89,25 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
 } /* namespace pmacc_static_const_storage + id */                              \
 using namespace PMACC_JOIN(pmacc_static_const_storage,id)
 
+#ifdef __CUDACC__
+    #define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE_CUDA(Name,id)               \
+        namespace PMACC_JOIN(pmacc_static_const_vector_device,id)              \
+        {                                                                      \
+            /* create const instance on device */                              \
+            __constant__ const PMACC_JOIN(Name,_t) Name;                       \
+        } /* namespace pmacc_static_const_vector_device + id */
+#else
+    #define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE_CUDA(Name,id)
+#endif
+
 /** create a instance of type `Name_t` with the name `Name`
  */
 #define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE(id,Name,Type,Dim,count,...)     \
 namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
 {                                                                              \
-    namespace PMACC_JOIN(pmacc_static_const_vector_device,id)                  \
-    {                                                                          \
-        /* create const instance on device */                                  \
-        __constant__ const PMACC_JOIN(Name,_t) Name;                           \
-    } /* namespace pmacc_static_const_vector_device + id */                    \
-    namespace PMACC_JOIN( pmacc_static_const_vector_host,id)                   \
+    /* Conditionally define the instance on CUDA devices */                    \
+    PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE_CUDA(Name,id)                       \
+    namespace PMACC_JOIN(pmacc_static_const_vector_host,id)                    \
     {                                                                          \
         /* create const instance on host*/                                     \
         const PMACC_JOIN(Name,_t) Name;                                        \


### PR DESCRIPTION
Only define the CUDA \__constant\__ variables if CUDA is available.
This refactoring allows to use these defines without the CUDA compiler.