### PR TITLE
Topic make ptr in frame optional

### DIFF
--- a/src/libPMacc/include/compileTime/conversion/OperateOnSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/OperateOnSeq.hpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "compileTime/accessors/Identity.hpp"
+#include "types.h"
+
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/copy.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/transform.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/back_inserter.hpp>
+#include <boost/type_traits.hpp>
+
+namespace PMacc
+{
+
+/** run a unary operator on every sequence element
+ *
+ * @tparam T_MPLSeq any boost mpl sequence
+ * @tparam T_UnaryOperator unary operator to translate type from the sequence
+ * to a mpl pair
+ * @tparam T_Accessor An unary lambda operator which is used before the type
+ * from the sequence is passed to T_UnaryOperator
+ * @return ::type bmpl::vector
+ */
+template<typename T_MPLSeq,
+typename T_UnaryOperator,
+typename T_Accessor = compileTime::accessors::Identity<>
+>
+struct OperateOnSeq
+{
+
+    template<typename X>
+    struct Op :bmpl::apply1<T_UnaryOperator, typename bmpl::apply1<T_Accessor,X>::type >
+    {
+    };
+
+    typedef T_MPLSeq MPLSeq;
+    //typedef bmpl::inserter< bmpl::vector0<>, bmpl::insert<bmpl::_1, bmpl::_2> > SeqInserter;
+    typedef bmpl::back_inserter< bmpl::vector<> > Inserter;
+    typedef typename bmpl::transform<
+            MPLSeq,
+            Op<bmpl::_1>,
+            Inserter
+            >::type type;
+};
+
+}//namespace PMacc

--- a/src/libPMacc/include/compileTime/conversion/OperateOnSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/OperateOnSeq.hpp
@@ -36,12 +36,12 @@
 namespace PMacc
 {
 
-/** run a unary operator on every sequence element
+/** run an unary operator on each element of a sequence
  *
  * @tparam T_MPLSeq any boost mpl sequence
  * @tparam T_UnaryOperator unary operator to translate type from the sequence
  * to a mpl pair
- * @tparam T_Accessor An unary lambda operator which is used before the type
+ * @tparam T_Accessor an unary lambda operator that is used before the type
  * from the sequence is passed to T_UnaryOperator
  * @return ::type bmpl::vector
  */
@@ -58,7 +58,6 @@ struct OperateOnSeq
     };
 
     typedef T_MPLSeq MPLSeq;
-    //typedef bmpl::inserter< bmpl::vector0<>, bmpl::insert<bmpl::_1, bmpl::_2> > SeqInserter;
     typedef bmpl::back_inserter< bmpl::vector<> > Inserter;
     typedef typename bmpl::transform<
             MPLSeq,

--- a/src/libPMacc/include/particles/ParticleDescription.hpp
+++ b/src/libPMacc/include/particles/ParticleDescription.hpp
@@ -43,10 +43,10 @@ namespace PMacc
  *                       (e.g. calculate mass, gamma, ...)
  *                       (e.g. useSolverXY, calcRadiation, ...)
  * @tparam T_FrameExtensionList sequence or single class with frame extentions
- *                    - extension must be a unary template class that supports bmpl::apply1<>
- *                    - type of the finale frame is applied to every extension class
- *                      ( this allows pointer and references in a frame to it self)
- *                    - the finale frame which use ParticleDescription inherits from all
+ *                    - extension must be an unary template class that supports bmpl::apply1<>
+ *                    - type of the finale frame is applied to each extension class
+ *                      (this allows pointers and references to a frame itself)
+ *                    - the finale frame that uses ParticleDescription inherits from all
  *                      extension classes
  */
 template<

--- a/src/libPMacc/include/particles/ParticleDescription.hpp
+++ b/src/libPMacc/include/particles/ParticleDescription.hpp
@@ -42,13 +42,20 @@ namespace PMacc
  * @tparam T_MethodsList sequence or single class with particle methods
  *                       (e.g. calculate mass, gamma, ...)
  *                       (e.g. useSolverXY, calcRadiation, ...)
+ * @tparam T_FrameExtensionList sequence or single class with frame extentions
+ *                    - extension must be a unary template class that supports bmpl::apply1<>
+ *                    - type of the finale frame is applied to every extension class
+ *                      ( this allows pointer and references in a frame to it self)
+ *                    - the finale frame which use ParticleDescription inherits from all
+ *                      extension classes
  */
 template<
 typename T_Name,
 typename T_SuperCellSize,
 typename T_ValueTypeSeq,
 typename T_Flags = bmpl::vector0<>,
-typename T_MethodsList = bmpl::vector0<>
+typename T_MethodsList = bmpl::vector0<>,
+typename T_FrameExtensionList = bmpl::vector0<>
 >
 struct ParticleDescription
 {
@@ -57,7 +64,15 @@ struct ParticleDescription
     typedef typename ToSeq<T_ValueTypeSeq>::type ValueTypeSeq;
     typedef typename ToSeq<T_MethodsList>::type MethodsList;
     typedef typename ToSeq<T_Flags>::type FlagsList;
-    typedef ParticleDescription<Name, SuperCellSize, ValueTypeSeq, FlagsList, MethodsList> ThisType;
+    typedef typename ToSeq<T_FrameExtensionList>::type FrameExtensionList;
+    typedef ParticleDescription<
+        Name,
+        SuperCellSize,
+        ValueTypeSeq,
+        FlagsList,
+        MethodsList,
+        FrameExtensionList
+    > ThisType;
 
 };
 
@@ -68,18 +83,38 @@ struct ParticleDescription
  * @tparam T_NewValueTypeSeq new boost mpl sequence with value types
  * @treturn ::type new ParticleDescription
  */
-template<typename T_OldParticleDescription,typename T_NewValueTypeSeq>
+template<typename T_OldParticleDescription, typename T_NewValueTypeSeq>
 struct ReplaceValueTypeSeq
 {
     typedef T_OldParticleDescription OldParticleDescription;
     typedef ParticleDescription<
-        typename OldParticleDescription::Name,
-        typename OldParticleDescription::SuperCellSize,
-        typename ToSeq<T_NewValueTypeSeq>::type,
-        typename OldParticleDescription::FlagsList,
-        typename OldParticleDescription::MethodsList
+    typename OldParticleDescription::Name,
+    typename OldParticleDescription::SuperCellSize,
+    typename ToSeq<T_NewValueTypeSeq>::type,
+    typename OldParticleDescription::FlagsList,
+    typename OldParticleDescription::MethodsList,
+    typename OldParticleDescription::FrameExtensionList
     > type;
 };
 
+/** Get ParticleDescription with a new FrameExtensionSeq
+ *
+ * @tparam T_OldParticleDescription base description
+ * @tparam T_FrameExtensionSeq new boost mpl sequence with value types
+ * @treturn ::type new ParticleDescription
+ */
+template<typename T_OldParticleDescription, typename T_FrameExtensionSeq>
+struct ReplaceFrameExtensionSeq
+{
+    typedef T_OldParticleDescription OldParticleDescription;
+    typedef ParticleDescription<
+    typename OldParticleDescription::Name,
+    typename OldParticleDescription::SuperCellSize,
+    typename OldParticleDescription::ValueTypeSeq,
+    typename OldParticleDescription::FlagsList,
+    typename OldParticleDescription::MethodsList,
+    typename ToSeq<T_FrameExtensionSeq>::type
+    > type;
+};
 
 } //namespace PMacc

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -47,6 +47,7 @@
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/pair.hpp>
 #include "particles/ParticleDescription.hpp"
+#include "particles/memory/dataTypes/ListPointer.hpp"
 
 
 namespace PMacc
@@ -99,6 +100,17 @@ public:
 
     typedef
     typename ReplaceValueTypeSeq<T_ParticleDescription, full_particleList>::type
+    ParticleDescriptionWithExtendedAttributes;
+
+    typedef
+    typename MakeSeq<
+        PreviousFramePtr<>,
+        NextFramePtr<>
+    >::type PtrExtension;
+
+    /* extent particle description with pointer to a frame*/
+    typedef
+    typename ReplaceFrameExtensionSeq<ParticleDescriptionWithExtendedAttributes, PtrExtension>::type
     ParticleDescriptionDefault;
 
     typedef Frame<

--- a/src/libPMacc/include/particles/memory/dataTypes/ListPointer.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/ListPointer.hpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015  Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/memory/dataTypes/Pointer.hpp"
+#include "types.h"
+
+
+namespace PMacc
+{
+
+template<typename T_Type = bmpl::_1>
+struct PreviousFramePtr
+{
+    PMACC_ALIGN(previousFrame, Pointer<T_Type>);
+};
+
+template<typename T_Type = bmpl::_1>
+struct NextFramePtr
+{
+    PMACC_ALIGN(nextFrame, Pointer<T_Type>);
+};
+
+} //namespace PMacc

--- a/src/libPMacc/include/particles/memory/frames/Frame.hpp
+++ b/src/libPMacc/include/particles/memory/frames/Frame.hpp
@@ -89,7 +89,7 @@ public InheritLinearly<
     typedef typename ParticleDescription::ValueTypeSeq ValueTypeSeq;
     typedef typename ParticleDescription::MethodsList MethodsList;
     typedef typename ParticleDescription::FlagsList FlagList;
-    typedef typename ParticleDescription::FrameExtensionList FrameExtentionList;
+    typedef typename ParticleDescription::FrameExtensionList FrameExtensionList;
     typedef Frame<T_CreatePairOperator, ParticleDescription> ThisType;
     /* definition of the MapTupel where we inherit from*/
     typedef pmath::MapTuple<typename SeqToMap<ValueTypeSeq, T_CreatePairOperator>::type, pmath::AlignedData> BaseType;

--- a/src/libPMacc/include/particles/memory/frames/Frame.hpp
+++ b/src/libPMacc/include/particles/memory/frames/Frame.hpp
@@ -35,6 +35,7 @@
 #include "particles/memory/dataTypes/Particle.hpp"
 #include "particles/frame_types.hpp"
 #include "compileTime/conversion/SeqToMap.hpp"
+#include "compileTime/conversion/OperateOnSeq.hpp"
 #include <boost/utility/result_of.hpp>
 #include <boost/mpl/find.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -45,7 +46,6 @@
 #include "traits/HasFlag.hpp"
 #include "traits/GetFlagType.hpp"
 #include <boost/mpl/contains.hpp>
-#include "particles/memory/dataTypes/Pointer.hpp"
 
 #include "particles/ParticleDescription.hpp"
 #include <boost/mpl/string.hpp>
@@ -75,7 +75,13 @@ template<typename T_CreatePairOperator,
 typename T_ParticleDescription >
 struct Frame :
 public InheritLinearly<typename T_ParticleDescription::MethodsList>,
-protected pmath::MapTuple<typename SeqToMap<typename T_ParticleDescription::ValueTypeSeq, T_CreatePairOperator>::type, pmath::AlignedData>
+protected pmath::MapTuple<typename SeqToMap<typename T_ParticleDescription::ValueTypeSeq, T_CreatePairOperator>::type, pmath::AlignedData>,
+public InheritLinearly<
+    typename OperateOnSeq<
+        typename T_ParticleDescription::FrameExtensionList,
+        bmpl::apply1<bmpl::_1, Frame<T_CreatePairOperator,T_ParticleDescription> >
+    >::type
+>
 {
     typedef T_ParticleDescription ParticleDescription;
     typedef typename ParticleDescription::Name Name;
@@ -83,6 +89,7 @@ protected pmath::MapTuple<typename SeqToMap<typename T_ParticleDescription::Valu
     typedef typename ParticleDescription::ValueTypeSeq ValueTypeSeq;
     typedef typename ParticleDescription::MethodsList MethodsList;
     typedef typename ParticleDescription::FlagsList FlagList;
+    typedef typename ParticleDescription::FrameExtensionList FrameExtentionList;
     typedef Frame<T_CreatePairOperator, ParticleDescription> ThisType;
     /* definition of the MapTupel where we inherit from*/
     typedef pmath::MapTuple<typename SeqToMap<ValueTypeSeq, T_CreatePairOperator>::type, pmath::AlignedData> BaseType;
@@ -153,12 +160,6 @@ protected pmath::MapTuple<typename SeqToMap<typename T_ParticleDescription::Valu
     {
         return std::string(boost::mpl::c_str<Name>::value);
     }
-
-    /* \todo find a generic solution to add `previousFrame` and `nextFrame`
-     * only if we use this frame in a double linked list
-     */
-    PMACC_ALIGN(previousFrame, Pointer<ThisType>);
-    PMACC_ALIGN(nextFrame, Pointer<ThisType>);
 
 };
 


### PR DESCRIPTION
- `OperateOnSeq`: add compile time method that runs an operator on each element of a sequence 
- remove fixed `nextFrame` and `previousFrame` pointer in a frame
- refactor `ParticleDescription` -> add FrameExtensionList
- extent `Frame<>`: now inherits from all extensions
to allow optional double linked list support on frames
 - add new type `PreviousFramePtr<>` with member previousFrame
 - add new type `NextFramePtr<>` with member nextFrame

This pull request removes the problem that every frame includes two pointers (to create a double linked list) on itself. The pointers result in 16 Bytes extra memory per frame. Since `BorderFrame`s consists of only one particle, the typical particle size growths by 50%.
The refactoring allows to send more particles to neighboring GPUs within the same amount of communication memory as before.