### PR TITLE
move CommunicationTag's to param file

### DIFF
--- a/src/picongpu/include/simulation_defines/_defaultParam.loader
+++ b/src/picongpu/include/simulation_defines/_defaultParam.loader
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include "simulation_defines/param/communication.param"
 #include "simulation_defines/param/dimension.param"
 #include "simulation_defines/param/memory.param"
 #include "simulation_defines/param/precision.param"

--- a/src/picongpu/include/simulation_defines/param/communication.param
+++ b/src/picongpu/include/simulation_defines/param/communication.param
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+
+namespace picongpu
+{
+
+/* define unique communication id's
+ *
+ * define unique id's for all elements those can be send and received
+ */
+enum CommunicationTag
+{
+    NO_COMMUNICATION = 0u,
+    FIELD_B = 1u,
+    FIELD_E = 2u,
+    FIELD_J = 3u,
+    FIELD_JRECV = 4u,
+    FIELD_TMP = 5u,
+    PAR_ELECTRONS = 16u,
+    PAR_IONS = 17u
+
+};
+
+}//namespace picongpu

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -43,16 +43,6 @@ enum ParticleType
     ION = 0, ELECTRON = 1
 };
 
-//! define all elements which can send and resive
-
-enum CommunicationTag
-{
-    FIELD_B = 0u, FIELD_E = 1u, FIELD_J = 2u, FIELD_JRECV = 3u, FIELD_TMP = 4u,
-    PAR_IONS = 5u, PAR_ELECTRONS = 6u,
-    NO_COMMUNICATION = 16u
-};
-
-
 //! define the place where data is stored
 
 enum DataPlace


### PR DESCRIPTION
- add new param file `communication.param`
- move `CommunicationTag`'s to `communication.param`
- change tags enumeration

The change of the tag enumeration not influence the code stability, therefor it is not critical.