### PR TITLE
refactore usage of `communicationId`

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -101,12 +101,14 @@ typedef bmpl::vector<
 > ParticleFlagsElectrons;
 
 /* define species: electrons */
-typedef Particles<ParticleDescription<
-    bmpl::string<'e'>,
-    SuperCellSize,
-    AttributeSeqElectrons,
-    ParticleFlagsElectrons,
-    MakeSeq<CommunicationId<PAR_ELECTRONS> >::type  >
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'e'>,
+        SuperCellSize,
+        AttributeSeqElectrons,
+        ParticleFlagsElectrons,
+        CommunicationId<0>
+    >
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -159,12 +161,14 @@ typedef bmpl::vector<
 > ParticleFlagsIons;
 
 /* define species: ions */
-typedef Particles<ParticleDescription<
-    bmpl::string<'i'>,
-    SuperCellSize,
-    AttributeSeqIons,
-    ParticleFlagsIons,
-    MakeSeq<CommunicationId<PAR_IONS> >::type >
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'i'>,
+        SuperCellSize,
+        AttributeSeqIons,
+        ParticleFlagsIons,
+        CommunicationId<1>
+    >
 > PIC_Ions;
 
 /*########################### end species ####################################*/

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -88,12 +88,14 @@ typedef bmpl::vector<
 > ParticleFlagsElectrons;
 
 /*define specie electrons*/
-typedef Particles<ParticleDescription<
-    bmpl::string<'e'>,
-    SuperCellSize,
-    DefaultAttributesSeq,
-    ParticleFlagsElectrons,
-    MakeSeq<CommunicationId<PAR_ELECTRONS> >::type  >
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'e'>,
+        SuperCellSize,
+        DefaultAttributesSeq,
+        ParticleFlagsElectrons,
+        CommunicationId<0>
+    >
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -112,12 +114,14 @@ typedef bmpl::vector<
 > ParticleFlagsIons;
 
 /*define specie ions*/
-typedef Particles<ParticleDescription<
-    bmpl::string<'i'>,
-    SuperCellSize,
-    DefaultAttributesSeq,
-    ParticleFlagsIons,
-    MakeSeq<CommunicationId<PAR_IONS> >::type >
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'i'>,
+        SuperCellSize,
+        DefaultAttributesSeq,
+        ParticleFlagsIons,
+        CommunicationId<1>
+    >
 > PIC_Ions;
 
 /*########################### end species ####################################*/

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -72,26 +72,39 @@ datasetID( datasetID )
 
     log<picLog::MEMORY > ( "size for all exchange = %1% MiB" ) % ( (double) sizeOfExchanges / 1024. / 1024. );
 
-    this->particlesBuffer->addExchange( Mask( LEFT ) + Mask( RIGHT ), BYTES_EXCHANGE_X, FrameType::CommunicationTag );
-    this->particlesBuffer->addExchange( Mask( TOP ) + Mask( BOTTOM ), BYTES_EXCHANGE_Y, FrameType::CommunicationTag );
+    const uint32_t commTag = FrameType::CommunicationTag + SPECIES_FIRSTTAG;
+    this->particlesBuffer->addExchange( Mask( LEFT ) + Mask( RIGHT ),
+                                        BYTES_EXCHANGE_X,
+                                        commTag);
+    this->particlesBuffer->addExchange( Mask( TOP ) + Mask( BOTTOM ),
+                                        BYTES_EXCHANGE_Y,
+                                        commTag);
     //edges of the simulation area
     this->particlesBuffer->addExchange( Mask( RIGHT + TOP ) + Mask( LEFT + TOP ) +
-                                        Mask( LEFT + BOTTOM ) + Mask( RIGHT + BOTTOM ), BYTES_EDGES, FrameType::CommunicationTag );
+                                        Mask( LEFT + BOTTOM ) + Mask( RIGHT + BOTTOM ), BYTES_EDGES,
+                                        commTag);
 
 #if(SIMDIM==DIM3)
-    this->particlesBuffer->addExchange( Mask( FRONT ) + Mask( BACK ), BYTES_EXCHANGE_Z, FrameType::CommunicationTag );
+    this->particlesBuffer->addExchange( Mask( FRONT ) + Mask( BACK ), BYTES_EXCHANGE_Z,
+                                        commTag);
     //edges of the simulation area
     this->particlesBuffer->addExchange( Mask( FRONT + TOP ) + Mask( BACK + TOP ) +
                                         Mask( FRONT + BOTTOM ) + Mask( BACK + BOTTOM ),
-                                        BYTES_EDGES, FrameType::CommunicationTag );
+                                        BYTES_EDGES,
+                                        commTag);
     this->particlesBuffer->addExchange( Mask( FRONT + RIGHT ) + Mask( BACK + RIGHT ) +
                                         Mask( FRONT + LEFT ) + Mask( BACK + LEFT ),
-                                        BYTES_EDGES, FrameType::CommunicationTag );
+                                        BYTES_EDGES,
+                                        commTag);
     //corner of the simulation area
-    this->particlesBuffer->addExchange( Mask( TOP + FRONT + RIGHT ) + Mask( TOP + BACK + RIGHT ) + Mask( BOTTOM + FRONT + RIGHT ) + Mask( BOTTOM + BACK + RIGHT ),
-                                        BYTES_CORNER, FrameType::CommunicationTag );
-    this->particlesBuffer->addExchange( Mask( TOP + FRONT + LEFT ) + Mask( TOP + BACK + LEFT ) + Mask( BOTTOM + FRONT + LEFT ) + Mask( BOTTOM + BACK + LEFT ),
-                                        BYTES_CORNER, FrameType::CommunicationTag );
+    this->particlesBuffer->addExchange( Mask( TOP + FRONT + RIGHT ) + Mask( TOP + BACK + RIGHT ) +
+                                        Mask( BOTTOM + FRONT + RIGHT ) + Mask( BOTTOM + BACK + RIGHT ),
+                                        BYTES_CORNER,
+                                        commTag);
+    this->particlesBuffer->addExchange( Mask( TOP + FRONT + LEFT ) + Mask( TOP + BACK + LEFT ) +
+                                        Mask( BOTTOM + FRONT + LEFT ) + Mask( BOTTOM + BACK + LEFT ),
+                                        BYTES_CORNER,
+                                        commTag);
 #endif
 }
 

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -88,12 +88,14 @@ typedef bmpl::vector<
 > ParticleFlagsElectrons;
 
 /*define specie electrons*/
-typedef Particles<ParticleDescription<
-    bmpl::string<'e'>,
-    SuperCellSize,
-    DefaultAttributesSeq,
-    ParticleFlagsElectrons,
-    MakeSeq<CommunicationId<PAR_ELECTRONS> >::type  >
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'e'>,
+        SuperCellSize,
+        DefaultAttributesSeq,
+        ParticleFlagsElectrons,
+        CommunicationId<0>
+    >
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -112,12 +114,14 @@ typedef bmpl::vector<
 > ParticleFlagsIons;
 
 /*define specie ions*/
-typedef Particles<ParticleDescription<
-    bmpl::string<'i'>,
-    SuperCellSize,
-    DefaultAttributesSeq,
-    ParticleFlagsIons,
-    MakeSeq<CommunicationId<PAR_IONS> >::type >
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'i'>,
+        SuperCellSize,
+        DefaultAttributesSeq,
+        ParticleFlagsIons,
+        CommunicationId<1>
+    >
 > PIC_Ions;
 
 /*########################### end species ####################################*/

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -47,9 +47,13 @@ enum ParticleType
 
 enum CommunicationTag
 {
-    FIELD_B = 0u, FIELD_E = 1u, FIELD_J = 2u, FIELD_JRECV = 3u, FIELD_TMP = 4u,
-    PAR_IONS = 5u, PAR_ELECTRONS = 6u,
-    NO_COMMUNICATION = 16u
+    NO_COMMUNICATION = 0u,
+    FIELD_B = 1u,
+    FIELD_E = 2u,
+    FIELD_J = 3u,
+    FIELD_JRECV = 4u,
+    FIELD_TMP = 5u,
+    SPECIES_FIRSTTAG = 42u
 };
 
 


### PR DESCRIPTION
- add communication tag `SPECIES_FIRSTTAG`
  - `simulation_types.hpp`: remove explicit communication tag for ions and electrons
  - `Particles.tpp`: use `SPECIES_FIRSTTAG` as comminucation id offset
- changes in `speciesDefinition.param`
  - add unique integer to define `CommunicationId<>`
  - change code formatting of the species definition
 - remove usage of `MakeSeq<>` to define species methods 