### PR TITLE
remove method to calculate info: particles on GPU

### DIFF
--- a/src/picongpu/include/initialization/InitialiserController.hpp
+++ b/src/picongpu/include/initialization/InitialiserController.hpp
@@ -133,7 +133,7 @@ public:
                                      (laserProfile::WAVE_LENGTH / CELL_HEIGHT);
             const int localNrOfCells = cellDescription->getGridLayout().getDataSpaceWithoutGuarding().productOfComponents();
             log<picLog::PHYSICS >("macro particles per gpu: %1%") %
-                                 (localNrOfCells * particles::TYPICAL_PARTICLES_PER_CELL * (1 + 1 * ENABLE_IONS));
+                                 (localNrOfCells * particles::TYPICAL_PARTICLES_PER_CELL * (bmpl::size<VectorAllSpecies>::type::value));
             log<picLog::PHYSICS >("typical macro particle weighting: %1%") % (particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
 
 


### PR DESCRIPTION
remove usage of `ENABLE_IONS` to calculate the number of species