### PR TITLE
remove `CommunicationId` from species

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -106,8 +106,7 @@ typedef Particles<
         bmpl::string<'e'>,
         SuperCellSize,
         AttributeSeqElectrons,
-        ParticleFlagsElectrons,
-        CommunicationId<0>
+        ParticleFlagsElectrons
     >
 > PIC_Electrons;
 
@@ -166,8 +165,7 @@ typedef Particles<
         bmpl::string<'i'>,
         SuperCellSize,
         AttributeSeqIons,
-        ParticleFlagsIons,
-        CommunicationId<1>
+        ParticleFlagsIons
     >
 > PIC_Ions;
 

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -93,8 +93,7 @@ typedef Particles<
         bmpl::string<'e'>,
         SuperCellSize,
         DefaultAttributesSeq,
-        ParticleFlagsElectrons,
-        CommunicationId<0>
+        ParticleFlagsElectrons
     >
 > PIC_Electrons;
 
@@ -119,8 +118,7 @@ typedef Particles<
         bmpl::string<'i'>,
         SuperCellSize,
         DefaultAttributesSeq,
-        ParticleFlagsIons,
-        CommunicationId<1>
+        ParticleFlagsIons
     >
 > PIC_Ions;
 

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -49,6 +49,7 @@
 
 #include "fields/numericalCellTypes/YeeCell.hpp"
 
+#include "traits/GetUniqueTypeId.hpp"
 #include "traits/Resolve.hpp"
 
 namespace picongpu
@@ -72,7 +73,9 @@ datasetID( datasetID )
 
     log<picLog::MEMORY > ( "size for all exchange = %1% MiB" ) % ( (double) sizeOfExchanges / 1024. / 1024. );
 
-    const uint32_t commTag = FrameType::CommunicationTag + SPECIES_FIRSTTAG;
+    const uint32_t commTag = PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() + SPECIES_FIRSTTAG;
+    log<picLog::MEMORY > ( "communication tag for species %1%: %2%" ) % FrameType::getName( ) % commTag;
+
     this->particlesBuffer->addExchange( Mask( LEFT ) + Mask( RIGHT ),
                                         BYTES_EXCHANGE_X,
                                         commTag);

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -26,6 +26,7 @@
 #include "nvidia/rng/methods/Xor.hpp"
 #include "nvidia/rng/distributions/Uniform_float.hpp"
 #include "mpi/SeedPerRank.hpp"
+#include "traits/GetUniqueTypeId.hpp"
 
 namespace picongpu
 {
@@ -50,7 +51,7 @@ struct RandomPositionImpl
 
         GlobalSeed globalSeed;
         mpi::SeedPerRank<simDim> seedPerRank;
-        seed = seedPerRank(globalSeed(), FrameType::CommunicationTag);
+        seed = seedPerRank(globalSeed(), PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid());
         seed ^= POSITION_SEED ^ currentStep;
 
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -26,6 +26,7 @@
 #include "nvidia/rng/methods/Xor.hpp"
 #include "nvidia/rng/distributions/Normal_float.hpp"
 #include "mpi/SeedPerRank.hpp"
+#include "traits/GetUniqueTypeId.hpp"
 
 namespace picongpu
 {
@@ -53,7 +54,7 @@ struct TemperatureImpl : private T_ValueFunctor
 
         GlobalSeed globalSeed;
         mpi::SeedPerRank<simDim> seedPerRank;
-        seed = seedPerRank(globalSeed(), FrameType::CommunicationTag);
+        seed = seedPerRank(globalSeed(), PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid());
         seed ^= TEMPERATURE_SEED;
 
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();

--- a/src/picongpu/include/particles/startPosition/RandomImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/RandomImpl.hpp
@@ -27,6 +27,7 @@
 #include "nvidia/rng/methods/Xor.hpp"
 #include "nvidia/rng/distributions/Uniform_float.hpp"
 #include "mpi/SeedPerRank.hpp"
+#include "traits/GetUniqueTypeId.hpp"
 
 namespace picongpu
 {
@@ -51,7 +52,7 @@ struct RandomImpl
         typedef typename SpeciesType::FrameType FrameType;
 
         mpi::SeedPerRank<simDim> seedPerRank;
-        seed = seedPerRank(GlobalSeed()(), FrameType::CommunicationTag);
+        seed = seedPerRank(GlobalSeed()(), PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid());
         seed ^= POSITION_SEED;
 
         const uint32_t numSlides = MovingWindow::getInstance( ).getSlideCounter( currentStep );

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -112,10 +112,4 @@ alias(chargeRatio);
  */
 alias(densityRatio);
 
-template<uint32_t T_commTag>
-struct CommunicationId
-{
-    static const uint32_t CommunicationTag=T_commTag;
-};
-
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -93,8 +93,7 @@ typedef Particles<
         bmpl::string<'e'>,
         SuperCellSize,
         DefaultAttributesSeq,
-        ParticleFlagsElectrons,
-        CommunicationId<0>
+        ParticleFlagsElectrons
     >
 > PIC_Electrons;
 
@@ -119,8 +118,7 @@ typedef Particles<
         bmpl::string<'i'>,
         SuperCellSize,
         DefaultAttributesSeq,
-        ParticleFlagsIons,
-        CommunicationId<1>
+        ParticleFlagsIons
     >
 > PIC_Ions;
 


### PR DESCRIPTION
- use new `UniqueTypeId` to generate unique id for a species
- `speciesAttributes.param`: remove `CommunicationId`

- [x] please do not merge before #957
- [x] needs rebase against `dev` after #962 