### PR TITLE
Particle Manipulators: Make Quasi-Binary

### DIFF
--- a/src/picongpu/include/particles/InitFunctors.hpp
+++ b/src/picongpu/include/particles/InitFunctors.hpp
@@ -110,29 +110,49 @@ struct CreateGas
  * after the species is cloned `fillAllGaps()` on T_DestSpeciesType is called
  *
  *
+ * @tparam T_CloneFunctor a pseudo-binary functor accepting two particle species:
+                          destination and source, \see src/picongpu/include/particles/manipulators
  * @tparam T_SrcSpeciesType source species
  * @tparam T_DestSpeciesType destination species
  */
-template<typename T_SrcSpeciesType, typename T_DestSpeciesType = bmpl::_1>
-struct CloneSpecies
+template<typename T_CloneFunctor, typename T_SrcSpeciesType, typename T_DestSpeciesType = bmpl::_1>
+struct ManipulateCloneSpecies
 {
     typedef T_DestSpeciesType DestSpeciesType;
     typedef typename MakeIdentifier<DestSpeciesType>::type DestSpeciesName;
     typedef T_SrcSpeciesType SrcSpeciesType;
     typedef typename MakeIdentifier<SrcSpeciesType>::type SrcSpeciesName;
+    typedef T_CloneFunctor CloneFunctor;
 
     template<typename T_StorageTuple>
     HINLINE void operator()(
                             T_StorageTuple& tuple,
-                            const uint32_t
+                            const uint32_t currentStep
                             )
     {
         PMACC_AUTO(speciesPtr, tuple[DestSpeciesName()]);
         PMACC_AUTO(srcSpeciesPtr, tuple[SrcSpeciesName()]);
 
-        speciesPtr->deviceCloneFrom(*srcSpeciesPtr);
+        CloneFunctor cloneFunctor(currentStep);
+
+        speciesPtr->deviceCloneFrom(*srcSpeciesPtr, cloneFunctor);
     }
 };
+
+
+/** clone species out of a another species
+ *
+ * after the species is cloned `fillAllGaps()` on T_DestSpeciesType is called
+ *
+ *
+ * @tparam T_SrcSpeciesType source species
+ * @tparam T_DestSpeciesType destination species
+ */
+template<typename T_SrcSpeciesType, typename T_DestSpeciesType = bmpl::_1>
+struct CloneSpecies : ManipulateCloneSpecies<manipulators::AssignImpl, T_SrcSpeciesType, T_DestSpeciesType>
+{
+};
+
 
 /** run a user defined functor for every particle
  *
@@ -162,6 +182,7 @@ struct Manipulate
         speciesPtr->manipulateAllParticles(currentStep, functor);
     }
 };
+
 
 /** call method fill all gaps of a species
  *

--- a/src/picongpu/include/particles/InitFunctors.hpp
+++ b/src/picongpu/include/particles/InitFunctors.hpp
@@ -110,19 +110,19 @@ struct CreateGas
  * after the species is cloned `fillAllGaps()` on T_DestSpeciesType is called
  *
  *
- * @tparam T_CloneFunctor a pseudo-binary functor accepting two particle species:
-                          destination and source, \see src/picongpu/include/particles/manipulators
+ * @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle species:
+                               destination and source, \see src/picongpu/include/particles/manipulators
  * @tparam T_SrcSpeciesType source species
  * @tparam T_DestSpeciesType destination species
  */
-template<typename T_CloneFunctor, typename T_SrcSpeciesType, typename T_DestSpeciesType = bmpl::_1>
+template<typename T_ManipulateFunctor, typename T_SrcSpeciesType, typename T_DestSpeciesType = bmpl::_1>
 struct ManipulateCloneSpecies
 {
     typedef T_DestSpeciesType DestSpeciesType;
     typedef typename MakeIdentifier<DestSpeciesType>::type DestSpeciesName;
     typedef T_SrcSpeciesType SrcSpeciesType;
     typedef typename MakeIdentifier<SrcSpeciesType>::type SrcSpeciesName;
-    typedef T_CloneFunctor CloneFunctor;
+    typedef T_ManipulateFunctor ManipulateFunctor;
 
     template<typename T_StorageTuple>
     HINLINE void operator()(
@@ -133,9 +133,9 @@ struct ManipulateCloneSpecies
         PMACC_AUTO(speciesPtr, tuple[DestSpeciesName()]);
         PMACC_AUTO(srcSpeciesPtr, tuple[SrcSpeciesName()]);
 
-        CloneFunctor cloneFunctor(currentStep);
+        ManipulateFunctor manipulateFunctor(currentStep);
 
-        speciesPtr->deviceCloneFrom(*srcSpeciesPtr, cloneFunctor);
+        speciesPtr->deviceCloneFrom(*srcSpeciesPtr, manipulateFunctor);
     }
 };
 
@@ -149,7 +149,7 @@ struct ManipulateCloneSpecies
  * @tparam T_DestSpeciesType destination species
  */
 template<typename T_SrcSpeciesType, typename T_DestSpeciesType = bmpl::_1>
-struct CloneSpecies : ManipulateCloneSpecies<manipulators::AssignImpl, T_SrcSpeciesType, T_DestSpeciesType>
+struct CloneSpecies : ManipulateCloneSpecies<manipulators::NoneImpl, T_SrcSpeciesType, T_DestSpeciesType>
 {
 };
 

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -28,6 +28,7 @@
 #include "fields/Fields.hpp"
 #include "particles/ParticlesBase.hpp"
 #include "particles/memory/buffers/ParticlesBuffer.hpp"
+#include "particles/manipulators/manipulators.def"
 
 #include "dataManagement/ISimulationData.hpp"
 
@@ -60,8 +61,9 @@ public:
     template<typename T_GasFunctor, typename T_PositionFunctor>
     void initGas(T_GasFunctor& gasFunctor, T_PositionFunctor& positionFunctor, const uint32_t currentStep);
 
-    template< typename t_ParticleDescription>
-    void deviceCloneFrom(Particles<t_ParticleDescription> &src);
+    template< typename T_SrcParticleDescription,
+              typename T_CloneFunctor>
+    void deviceCloneFrom(Particles<T_SrcParticleDescription> &src, T_CloneFunctor& cloneFunctor);
 
     template<typename T_Functor>
     void manipulateAllParticles(uint32_t currentStep, T_Functor& functor);

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -62,8 +62,8 @@ public:
     void initGas(T_GasFunctor& gasFunctor, T_PositionFunctor& positionFunctor, const uint32_t currentStep);
 
     template< typename T_SrcParticleDescription,
-              typename T_CloneFunctor>
-    void deviceCloneFrom(Particles<T_SrcParticleDescription> &src, T_CloneFunctor& cloneFunctor);
+              typename T_ManipulateFunctor>
+    void deviceCloneFrom(Particles<T_SrcParticleDescription> &src, T_ManipulateFunctor& manipulateFunctor);
 
     template<typename T_Functor>
     void manipulateAllParticles(uint32_t currentStep, T_Functor& functor);

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -56,8 +56,8 @@ namespace picongpu
 
 using namespace PMacc;
 
-template<class MYFRAME, class OTHERFRAME, class Mapping>
-__global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, ParticlesBox<OTHERFRAME, simDim> otherBox, Mapping mapper)
+template<class MYFRAME, class OTHERFRAME, class T_CloneFunctor, class Mapping>
+__global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, ParticlesBox<OTHERFRAME, simDim> otherBox, T_CloneFunctor cloneFunctor, Mapping mapper)
 {
     using namespace PMacc::particles::operations;
 
@@ -65,6 +65,7 @@ __global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, Partic
 
     __shared__ MYFRAME *myFrame;
     __shared__ bool isValid;
+    typedef typename Mapping::SuperCellSize SuperCellSize;
 
     __syncthreads(); /*wait that all shared memory is initialised*/
 
@@ -85,8 +86,13 @@ __global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, Partic
     {
         PMACC_AUTO(parDest, ((*myFrame)[threadIdx.x]));
         PMACC_AUTO(parSrc, ((*frame)[threadIdx.x]));
-        assign(parDest, parSrc);
+
+        cloneFunctor(block + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x),
+                     parDest, parSrc,
+                     true, parSrc[multiMask_] == 1);
+
         __syncthreads();
+
         if (threadIdx.x == 0)
         {
             myBox.setAsLastFrame(*myFrame, block);
@@ -140,7 +146,7 @@ __global__ void kernelManipulateAllParticles(T_ParBox pb,
     while (isValid)
     {
         PMACC_AUTO(particle, ((*frame)[linearThreadIdx]));
-        particleFunctor(localCellIdx, particle, isParticle);
+        particleFunctor(localCellIdx, particle, particle, isParticle, isParticle);
 
         __syncthreads();
         if (linearThreadIdx == 0)

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -56,8 +56,8 @@ namespace picongpu
 
 using namespace PMacc;
 
-template<class MYFRAME, class OTHERFRAME, class T_CloneFunctor, class Mapping>
-__global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, ParticlesBox<OTHERFRAME, simDim> otherBox, T_CloneFunctor cloneFunctor, Mapping mapper)
+template<class MYFRAME, class OTHERFRAME, class T_ManipulateFunctor, class Mapping>
+__global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, ParticlesBox<OTHERFRAME, simDim> otherBox, T_ManipulateFunctor manipulateFunctor, Mapping mapper)
 {
     using namespace PMacc::particles::operations;
 
@@ -86,10 +86,14 @@ __global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, Partic
     {
         PMACC_AUTO(parDest, ((*myFrame)[threadIdx.x]));
         PMACC_AUTO(parSrc, ((*frame)[threadIdx.x]));
+        assign(parDest, parSrc);
 
-        cloneFunctor(block + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x),
-                     parDest, parSrc,
-                     true, parSrc[multiMask_] == 1);
+        const DataSpace<simDim> localCellIdx = block
+            + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x)
+            - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+        manipulateFunctor(localCellIdx,
+                          parDest, parSrc,
+                          true, parSrc[multiMask_] == 1);
 
         __syncthreads();
 

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -214,14 +214,15 @@ void Particles<T_ParticleDescription>::initGas( T_GasFunctor& gasFunctor,
 }
 
 template< typename T_ParticleDescription>
-template< typename t_ParticleDescription>
-void Particles<T_ParticleDescription>::deviceCloneFrom( Particles< t_ParticleDescription> &src )
+template< typename T_SrcParticleDescription,
+          typename T_CloneFunctor>
+void Particles<T_ParticleDescription>::deviceCloneFrom( Particles< T_SrcParticleDescription> &src, T_CloneFunctor& functor )
 {
     dim3 block( PMacc::math::CT::volume<SuperCellSize>::type::value );
 
     log<picLog::SIMULATION_STATE > ( "clone species %1%" ) % FrameType::getName( );
     __picKernelArea( kernelCloneParticles, this->cellDescription, CORE + BORDER )
-        (block) ( this->getDeviceParticlesBox( ), src.getDeviceParticlesBox( ) );
+        (block) ( this->getDeviceParticlesBox( ), src.getDeviceParticlesBox( ), functor );
     this->fillAllGaps( );
 }
 

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -215,8 +215,8 @@ void Particles<T_ParticleDescription>::initGas( T_GasFunctor& gasFunctor,
 
 template< typename T_ParticleDescription>
 template< typename T_SrcParticleDescription,
-          typename T_CloneFunctor>
-void Particles<T_ParticleDescription>::deviceCloneFrom( Particles< T_SrcParticleDescription> &src, T_CloneFunctor& functor )
+          typename T_ManipulateFunctor>
+void Particles<T_ParticleDescription>::deviceCloneFrom( Particles< T_SrcParticleDescription> &src, T_ManipulateFunctor& functor )
 {
     dim3 block( PMacc::math::CT::volume<SuperCellSize>::type::value );
 

--- a/src/picongpu/include/particles/manipulators/AssignImpl.def
+++ b/src/picongpu/include/particles/manipulators/AssignImpl.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2015 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -21,12 +21,15 @@
 
 #pragma once
 
-#include "particles/manipulators/IManipulator.hpp"
-#include "particles/manipulators/AssignImpl.hpp"
-#include "particles/manipulators/TemperatureImpl.hpp"
-#include "particles/manipulators/DriftImpl.hpp"
-#include "particles/manipulators/IfRelativeGlobalPositionImpl.hpp"
-#include "particles/manipulators/CreateParticlesFromParticleImpl.hpp"
-#include "particles/manipulators/FreeImpl.hpp"
-#include "particles/manipulators/SetAttributeImpl.hpp"
-#include "particles/manipulators/RandomPositionImpl.hpp"
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+struct AssignImpl;
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/AssignImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/AssignImpl.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2015 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+#include "particles/operations/Assign.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+struct AssignImpl
+{
+    template<typename T_SpeciesType>
+    struct apply
+    {
+        typedef AssignImpl type;
+    };
+
+    HINLINE AssignImpl(uint32_t currentStep)
+    {
+    }
+
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>&,
+                            T_Particle1& particleDest, T_Particle2& particleSrc,
+                            const bool, const bool)
+    {
+        PMacc::particles::operations::assign(particleDest, particleSrc);
+    }
+
+};
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -69,8 +69,10 @@ struct CreateParticlesFromParticleImpl : private T_Functor
         firstCall = true;
     }
 
-    template<typename T_Particle>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx, T_Particle& particle, const bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+                            T_Particle1& particle, T_Particle2&,
+                            const bool isParticle, const bool)
     {
         typedef typename DestSpeciesType::FrameType DestFrameType;
         typedef typename DestSpeciesType::ParticlesBoxType DestParticlesBoxType;

--- a/src/picongpu/include/particles/manipulators/DriftImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/DriftImpl.hpp
@@ -45,8 +45,10 @@ struct DriftImpl : private T_ValueFunctor
 
     }
 
-    template<typename T_Particle>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx, T_Particle& particle, const  bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+                            T_Particle1& particle, T_Particle2&,
+                            const bool isParticle, const bool)
     {
         typedef typename SpeciesType::FrameType FrameType;
 

--- a/src/picongpu/include/particles/manipulators/FreeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/FreeImpl.hpp
@@ -48,13 +48,15 @@ struct FreeImpl
 
     }
 
-    template<typename T_Particle>
-    DINLINE void operator()(const DataSpace<simDim>& , T_Particle& particle, const  bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>&,
+                            T_Particle1& particleSpecies1, T_Particle2& particleSpecies2,
+                            const bool isParticle1, const bool isParticle2)
     {
-        if (isParticle)
+        if (isParticle1 && isParticle2)
         {
             Functor userFunctor;
-            userFunctor(particle);
+            userFunctor(particleSpecies1, particleSpecies2);
         }
     }
 

--- a/src/picongpu/include/particles/manipulators/IManipulator.hpp
+++ b/src/picongpu/include/particles/manipulators/IManipulator.hpp
@@ -41,10 +41,12 @@ struct IManipulator : private T_Base
     {
     }
 
-    template<typename T_Particle>
-    HDINLINE void operator()(const DataSpace<simDim>& localCellIdx, T_Particle& particle, const bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+                            T_Particle1& particleSpecies1, T_Particle2& particleSpecies2,
+                            const bool isParticle1, const bool isParticle2)
     {
-        return Base::operator()(localCellIdx, particle, isParticle);
+        return Base::operator()(localCellIdx, particleSpecies1, particleSpecies2, isParticle1, isParticle2);
     }
 };
 

--- a/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
@@ -45,8 +45,10 @@ struct IfRelativeGlobalPositionImpl : private T_Functor
         localDomainOffset = subGrid.getLocalDomain().offset;
     }
 
-    template<typename T_Particle>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx, T_Particle& particle, const bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+                            T_Particle1& particle1, T_Particle2& particle2,
+                            const bool isParticle1, const bool isParticle2)
     {
         typedef typename SpeciesType::FrameType FrameType;
 
@@ -58,9 +60,12 @@ struct IfRelativeGlobalPositionImpl : private T_Functor
 
         const bool inRange=(ParamClass::lowerBound <= relativePosition &&
             relativePosition < ParamClass::upperBound);
-        const bool particleInRange = isParticle&& inRange;
+        const bool particleInRange1 = isParticle1 && inRange;
+        const bool particleInRange2 = isParticle2 && inRange;
 
-        Functor::operator()(localCellIdx, particle, particleInRange);
+        Functor::operator()(localCellIdx,
+                            particle1, particle2,
+                            particleInRange1, particleInRange2);
 
     }
 

--- a/src/picongpu/include/particles/manipulators/NoneImpl.def
+++ b/src/picongpu/include/particles/manipulators/NoneImpl.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2015 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -21,14 +21,15 @@
 
 #pragma once
 
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
 
-#include "particles/manipulators/IManipulator.def"
-#include "particles/manipulators/NoneImpl.def"
-#include "particles/manipulators/AssignImpl.def"
-#include "particles/manipulators/TemperatureImpl.def"
-#include "particles/manipulators/DriftImpl.def"
-#include "particles/manipulators/IfRelativeGlobalPositionImpl.def"
-#include "particles/manipulators/CreateParticlesFromParticleImpl.def"
-#include "particles/manipulators/FreeImpl.def"
-#include "particles/manipulators/SetAttributeImpl.def"
-#include "particles/manipulators/RandomPositionImpl.def"
+struct NoneImpl;
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/NoneImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/NoneImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2015 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -21,14 +21,36 @@
 
 #pragma once
 
+#include "simulation_defines.hpp"
 
-#include "particles/manipulators/IManipulator.def"
-#include "particles/manipulators/NoneImpl.def"
-#include "particles/manipulators/AssignImpl.def"
-#include "particles/manipulators/TemperatureImpl.def"
-#include "particles/manipulators/DriftImpl.def"
-#include "particles/manipulators/IfRelativeGlobalPositionImpl.def"
-#include "particles/manipulators/CreateParticlesFromParticleImpl.def"
-#include "particles/manipulators/FreeImpl.def"
-#include "particles/manipulators/SetAttributeImpl.def"
-#include "particles/manipulators/RandomPositionImpl.def"
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+struct NoneImpl
+{
+    template<typename T_SpeciesType>
+    struct apply
+    {
+        typedef NoneImpl type;
+    };
+
+    HINLINE NoneImpl(uint32_t currentStep)
+    {
+    }
+
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>&,
+                            T_Particle1&, T_Particle2&,
+                            const bool, const bool)
+    {
+    }
+
+};
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -57,10 +57,12 @@ struct RandomPositionImpl
         localCells = subGrid.getLocalDomain().size;
     }
 
-    template<typename T_Particle>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx, T_Particle& particle, const bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+                            T_Particle1& particle, T_Particle2&,
+                            const bool isParticle, const bool)
     {
-        typedef typename T_Particle::FrameType FrameType;
+        typedef typename T_Particle1::FrameType FrameType;
 
         if (!isInitialized)
         {

--- a/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
@@ -44,15 +44,18 @@ struct SetAttributeImpl : private T_ValueFunctor
 
     }
 
-    template<typename T_Particle>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx, T_Particle& particle, const  bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+                            T_Particle1& particle, T_Particle2&,
+                            const bool isParticle, const bool)
     {
+        typedef T_Particle1 Particle;
         typedef typename SpeciesType::FrameType FrameType;
 
         if (isParticle)
         {
             /** Number of bound electrons at initial state of the neutral atom */
-            const float_X protonNumber = GetAtomicNumbers<T_Particle>::type::numberOfProtons;
+            const float_X protonNumber = GetAtomicNumbers<Particle>::type::numberOfProtons;
 
             /* in this case: 'assign' the number of protons to the number of bound electrons
              * \see particleConfig.param for the ValueFunctor */

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -42,7 +42,7 @@ template<typename T_ParamClass, typename T_ValueFunctor, typename T_SpeciesType>
 struct TemperatureImpl : private T_ValueFunctor
 {
     typedef T_ParamClass ParamClass;
-     typedef T_SpeciesType SpeciesType;
+    typedef T_SpeciesType SpeciesType;
     typedef typename MakeIdentifier<SpeciesType>::type SpeciesName;
 
     typedef T_ValueFunctor ValueFunctor;
@@ -60,10 +60,12 @@ struct TemperatureImpl : private T_ValueFunctor
         localCells = subGrid.getLocalDomain().size;
     }
 
-    template<typename T_Particle>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx, T_Particle& particle, const bool isParticle)
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+                            T_Particle1& particle, T_Particle2&,
+                            const bool isParticle, const bool)
     {
-        typedef typename T_Particle::FrameType FrameType;
+        typedef typename T_Particle1::FrameType FrameType;
 
         if (!isInitialized)
         {

--- a/src/picongpu/include/particles/manipulators/manipulators.def
+++ b/src/picongpu/include/particles/manipulators/manipulators.def
@@ -23,6 +23,7 @@
 
 
 #include "particles/manipulators/IManipulator.def"
+#include "particles/manipulators/AssignImpl.def"
 #include "particles/manipulators/TemperatureImpl.def"
 #include "particles/manipulators/DriftImpl.def"
 #include "particles/manipulators/IfRelativeGlobalPositionImpl.def"

--- a/src/picongpu/include/particles/manipulators/manipulators.hpp
+++ b/src/picongpu/include/particles/manipulators/manipulators.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "particles/manipulators/IManipulator.hpp"
+#include "particles/manipulators/NoneImpl.hpp"
 #include "particles/manipulators/AssignImpl.hpp"
 #include "particles/manipulators/TemperatureImpl.hpp"
 #include "particles/manipulators/DriftImpl.hpp"


### PR DESCRIPTION
Particle manipulators are now quasi-binary, that means they always take *two* particle species as an attribute (+ additional parameters such as localCellIdx and 2x isParticle).

This allows to use the manipulators both during `Manipulate` of a single species and during `CloneSpecies`. A new `ManipulateCloneSpecies` functor was introduced that
allows for easier cloning-and-adjusting of, e.g., gas profiles that contain of multiple ion species and need to adjust the weighting of the created electrons directly during clone (when cloned in a common electron species).

- [x] needs run time testing