### PR TITLE
only use rsqrt when in CUDA code

### DIFF
--- a/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -50,7 +50,7 @@ struct RSqrt<double>
 
     HDINLINE double operator( )(const double& value )
     {
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
+#if !defined(__CUDACC__)
         return 1.0/::sqrt(value);
 #else
         return ::rsqrt(value);

--- a/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -50,7 +50,7 @@ struct RSqrt<float>
 
     HDINLINE float operator( )(const float& value )
     {
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
+#if !defined(__CUDACC__)
         return 1.0f/::sqrtf(value);
 #else
         return ::rsqrtf(value);


### PR DESCRIPTION
```rsqrt``` is not available without CUDA and therefore can not be used.