### PR TITLE
add namespace qualifier to min and max calls

### DIFF
--- a/src/libPMacc/include/algorithms/math.hpp
+++ b/src/libPMacc/include/algorithms/math.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *
@@ -40,6 +40,7 @@
 #include "algorithms/math/floatMath/exp.tpp"
 #include "algorithms/math/floatMath/erf.tpp"
 #include "algorithms/math/floatMath/trigo.tpp"
+#include "algorithms/math/floatMath/comparison.tpp"
 #include "algorithms/math/floatMath/floatingPoint.tpp"
 #include "algorithms/math/floatMath/pow.tpp"
 
@@ -48,6 +49,7 @@
 #include "algorithms/math/doubleMath/exp.tpp"
 #include "algorithms/math/doubleMath/erf.tpp"
 #include "algorithms/math/doubleMath/trigo.tpp"
+#include "algorithms/math/doubleMath/comparison.tpp"
 #include "algorithms/math/doubleMath/floatingPoint.tpp"
 #include "algorithms/math/doubleMath/pow.tpp"
 

--- a/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<>
+struct Min<double, double>
+{
+    typedef double result;
+
+    HDINLINE double operator()(double value1, double value2)
+    {
+        return ::fmin(value1, value2);
+    }
+};
+
+template<>
+struct Max<double, double>
+{
+    typedef double result;
+
+    HDINLINE double operator()(double value1, double value2)
+    {
+        return ::fmax(value1, value2);
+    }
+};
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<>
+struct Min<float, float>
+{
+    typedef float result;
+
+    HDINLINE float operator()(float value1, float value2)
+    {
+        return ::fminf(value1, value2);
+    }
+};
+
+template<>
+struct Max<float, float>
+{
+    typedef float result;
+
+    HDINLINE float operator()(float value1, float value2)
+    {
+        return ::fmaxf(value1, value2);
+    }
+};
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -72,7 +72,7 @@ struct Max< ::PMacc::math::Vector<Type, dim>, ::PMacc::math::Vector<Type, dim> >
     {
         result tmp;
         for ( int i = 0; i < dim; ++i )
-            tmp[i] = ::max( vector1[i], vector2[i] );
+            tmp[i] = PMacc::algorithms::math::max( vector1[i], vector2[i] );
         return tmp;
     }
 };
@@ -87,7 +87,7 @@ struct Min< ::PMacc::math::Vector<Type, dim>, ::PMacc::math::Vector<Type, dim> >
     {
         result tmp;
         for ( int i = 0; i < dim; ++i )
-            tmp[i] = ::min( vector1[i], vector2[i] );
+            tmp[i] = PMacc::algorithms::math::min( vector1[i], vector2[i] );
         return tmp;
     }
 };


### PR DESCRIPTION
When not using CUDA, the calls to global namespace ```::min``` and ```::max``` would fail.
Using the wrappers inteded for this usage solves this and makes the calls equal to those in other functions in this file.