### PR TITLE
add preprocessor macros to create structs

### DIFF
--- a/src/libPMacc/include/preprocessor/facilities.hpp
+++ b/src/libPMacc/include/preprocessor/facilities.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2015 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/** echo given input */
+#define PMACC_PP_ECHO(...) __VA_ARGS__
+
+/** echo given input with delay */
+#define PMACC_PP_DEFER_ECHO() PMACC_PP_ECHO
+
+/** get the first element of a preprocessor pair */
+#define PMACC_PP_FIRST(first,second) first
+
+/** get the first element of a preprocessor pair with delay */
+#define PMACC_PP_DEFER_FIRST() PMACC_PP_FIRST
+
+
+/** get the second element of a preprocessor pair */
+#define PMACC_PP_SECOND(first,second) second
+
+/** get the second element of a preprocessor pair with delay */
+#define PMACC_PP_DEFER_SECOND() PMACC_PP_SECOND
+
+/** remove parentheses
+ *
+ * transform (...) to ...
+ */
+#define PMACC_PP_REMOVE_PAREN(...) PMACC_PP_DEFER_ECHO() __VA_ARGS__
+
+/** remove parentheses with delay */
+#define PMACC_PP_DEFER_REMOVE_PAREN() PMACC_PP_REMOVE_PAREN

--- a/src/libPMacc/include/preprocessor/struct.hpp
+++ b/src/libPMacc/include/preprocessor/struct.hpp
@@ -1,0 +1,289 @@
+/**
+ * Copyright 2015 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "preprocessor/facilities.hpp"
+#include "math/ConstVector.hpp"
+#include "math/Vector.hpp"
+
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/punctuation.hpp>
+#include <boost/preprocessor/punctuation/comma.hpp>
+#include <boost/preprocessor/seq/to_tuple.hpp>
+#include <boost/preprocessor/array/to_list.hpp>
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/seq/to_array.hpp>
+#include <boost/preprocessor/comparison/equal.hpp>
+#include <boost/preprocessor/facilities/expand.hpp>
+
+
+/** collection of TypeMemberPair's
+ *
+ * *type id + member descriptions* are combined in a pair (called: TypeMemberPair)
+ * (typeId,(value_type,name,initValue,...))
+ *   - typeID and name are the only necessary values
+ *     e.g. (0,(_,myName,_))
+ */
+
+/** create static const member vector that needs no memory inside of the struct
+ *
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_C_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);
+ */
+#define PMACC_C_VECTOR(type,name,...) (0,(type,name,dim,__VA_ARGS__))
+
+
+/** create static const member vector that needs no memory inside of the struct
+ *
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be greater or equal than dim)
+ *   \example `PMACC_C_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);`
+ */
+#define PMACC_C_VECTOR_DIM(type,dim,name,...) (0,(type,name,dim,__VA_ARGS__))
+
+/** create static const member
+ *
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_C_VALUE(float_64, power_SI, 2.0)`
+ *            is the compile time equivalent of
+ *            `static const float_64 power_SI = float_64(2.0);`
+ */
+#define PMACC_C_VALUE(type,name,value) (1,(type,name,value))
+
+/** create changeable member
+ *
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_VALUE(float_64, power_SI, 2.0)`
+ *            is the equivalent of
+ *            `float_64 power_SI(2.0);
+ */
+#define PMACC_VALUE(type,name,initValue) (2,(type,name,initValue))
+
+
+/** create changeable member vector
+ *
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `float2_64 center_SI(1.134e-5, 1.134e-5);`
+ */
+#define PMACC_VECTOR(type,name,...) (5,(type,name, type(__VA_ARGS__) ))
+
+/** create changeable member vector
+ *
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be equal to dim)
+ *   \example `PMACC_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `Vector<float_64,3> center_SI(1.134e-5, 1.134e-5, 1.134e-5);
+ */
+#define PMACC_VECTOR_DIM(type,dim,name,...)                                    \
+        (5,                                                                    \
+         (                                                                     \
+          (PMacc::math::Vector<type,dim>),                                     \
+          name,                                                                \
+          PMacc::math::Vector<type,dim>(__VA_ARGS__)                           \
+         )                                                                     \
+        )
+
+/** create static const character string
+ *
+ *   @param name member variable name
+ *   @param char_string character string
+ *   \example `PMACC_C_STRING(filename, "fooFile.txt")`
+ *            is the compile time equivalent of
+ *            `static const char* filename = (char*)"fooFile.tyt";`
+ */
+#define PMACC_C_STRING(name,initValue,...) (3,(_,name,initValue))
+
+/** create any code extension
+ *
+ *   @param ... any code
+ *   \example `PMACC_EXTENT(typedef float FooFloat;))`
+ *            is the equivalent of
+ *            `typedef float FooFloat;`
+ */
+#define PMACC_EXTENT(...) (4,(_,_,__VA_ARGS__))
+
+
+
+/** select member description
+ *
+ * @param selectTypeID searched type id
+ * @param op preprocessor function that is called with `def`
+ * @param typeID type id of the current processed element
+ * @param def element that is used by `op`
+ * @return result of `(op def)` if `selectTypeID == typeID`
+ *                   `( )`      else
+ */
+#define PMACC_PP_X_SELECT_TYPEID(selectTypeID,op,typeID,def)                   \
+    BOOST_PP_IF( BOOST_PP_EQUAL(typeID,selectTypeID), (op def) , () )
+
+/** select member description of a TypeMemberPair for a specific type id
+ *
+ * @param typeID searched type id
+ * @param op preprocessor function that is called with the second element of the selected pair
+ * @param ... preprocessor TypeMemberPair
+ * @return result of `op(secound(...))` if type is selected
+ *                   `( )`              else
+ */
+#define PMACC_PP_SELECT_TYPEID(typeID,op,...)                                  \
+    PMACC_PP_X_SELECT_TYPEID( typeID,op,PMACC_PP_DEFER_FIRST() __VA_ARGS__ ,PMACC_PP_DEFER_SECOND() __VA_ARGS__ )
+
+
+/** run macro which calls accessor on the given element
+ *
+ * - the secound parameter (data) of a  BOOST_PP_SEQ_FOR_EACH macro is used as accessor
+ * - parentheses around the result of the accessor were removed
+ *
+ * @param r no user argument (used by boost)
+ * @param accessor preprocessor function which accepts an element of the sequence
+ * @param elem the current evaluated element of the sequence
+ */
+#define PMACC_PP_SEQ_MACRO_WITH_ACCESSOR(r,accessor,elem) PMACC_PP_REMOVE_PAREN( accessor(elem))
+
+#define PMACC_PP_X_CREATE_C_VECTOR_DEF(data,type,name,dim,...) PMACC_CONST_VECTOR_DEF(type,dim,name,__VA_ARGS__);
+#define PMACC_PP_CREATE_C_VECTOR_DEF(elem)                                     \
+    PMACC_PP_SELECT_TYPEID( 0,PMACC_PP_X_CREATE_C_VECTOR_DEF, elem )
+
+#define PMACC_PP_X_CREATE_C_VECTOR_VARIABLE(data,type,name,dim,...) const BOOST_PP_CAT(name,_t) name;
+#define PMACC_PP_CREATE_C_VECTOR_VARIABLE(elem)                                \
+    PMACC_PP_SELECT_TYPEID( 0,PMACC_PP_X_CREATE_C_VECTOR_VARIABLE, elem )
+
+#define PMACC_PP_X_CREATE_VALUE_VARIABLE(data,type,name,...) type name;
+#define PMACC_PP_CREATE_VALUE_VARIABLE(elem)                                   \
+    PMACC_PP_SELECT_TYPEID( 2,PMACC_PP_X_CREATE_VALUE_VARIABLE, elem )
+
+#define PMACC_PP_X_CREATE_VALUE_VARIABLE_WITH_PAREN(data,type,name,...) PMACC_PP_REMOVE_PAREN(type) name;
+#define PMACC_PP_CREATE_VALUE_VARIABLE_WITH_PAREN(elem)                        \
+    PMACC_PP_SELECT_TYPEID( 5,PMACC_PP_X_CREATE_VALUE_VARIABLE_WITH_PAREN, elem )
+
+#define PMACC_PP_X_CREATE_C_VALUE_VARIABLE(data,type,name,...) static const type name = __VA_ARGS__;
+#define PMACC_PP_CREATE_C_VALUE_VARIABLE(elem)                                 \
+    PMACC_PP_SELECT_TYPEID( 1,PMACC_PP_X_CREATE_C_VALUE_VARIABLE,elem )
+
+
+#define PMACC_PP_X1_INIT_VALUE_VARIABLE(data,type,name,...) (name(__VA_ARGS__))
+#define PMACC_PP_X_INIT_VALUE_VARIABLE(elem)                                   \
+    PMACC_PP_SELECT_TYPEID( 2,PMACC_PP_X1_INIT_VALUE_VARIABLE,elem )
+
+#define PMACC_PP_X_INIT_VALUE_VARIABLE_WITH_PAREN(elem)                        \
+    PMACC_PP_SELECT_TYPEID( 5,PMACC_PP_X1_INIT_VALUE_VARIABLE,elem )
+
+#define PMACC_PP_X_CREATE_C_STRING_VARIABLE(data,type,name,...) static const char* name;
+#define PMACC_PP_CREATE_C_STRING_VARIABLE(elem)                                \
+    PMACC_PP_SELECT_TYPEID( 3,PMACC_PP_X_CREATE_C_STRING_VARIABLE, elem )
+
+#define PMACC_PP_X_INIT_C_STRING_VARIABLE(data,type,name,...) const char* data::name = (char*)__VA_ARGS__;
+#define PMACC_PP_INIT_C_STRING_VARIABLE(elem)                                  \
+    PMACC_PP_SELECT_TYPEID( 3,PMACC_PP_X_INIT_C_STRING_VARIABLE,elem )
+
+#define PMACC_PP_X_CREATE_EXTENT(data,type,name,...) __VA_ARGS__
+#define PMACC_PP_CREATE_EXTENT(elem)                                         \
+    PMACC_PP_SELECT_TYPEID( 4,PMACC_PP_X_CREATE_EXTENT,elem )
+
+#define PMACC_PP_X1_ADD_DATA_TO_TYPEDESCRIPTION_MACRO(data,first,second) ((first,(data,PMACC_PP_REMOVE_PAREN(second))))
+#define PMACC_PP_X_ADD_DATA_TO_TYPEDESCRIPTION_MACRO(data,value) PMACC_PP_X1_ADD_DATA_TO_TYPEDESCRIPTION_MACRO(data,value)
+
+
+
+#define PMACC_PP_ADD_DATA_TO_TYPEDESCRIPTION_MACRO(r,data,elem)                \
+    PMACC_PP_X_ADD_DATA_TO_TYPEDESCRIPTION_MACRO(data,PMACC_PP_REMOVE_PAREN(elem))
+
+
+/** create constructor initialization of non static variables
+ *
+ * add an emty struct to the end of the sequences to avoid problems with empty sequences
+ *
+ * @param ... preprocessor sequence with TypeMemberPair's to inherit from
+ */
+#define PMACC_PP_INIT_VALUE_VARIABLES(op,...)                                  \
+    PMACC_PP_DEFER_REMOVE_PAREN() (                                            \
+        BOOST_PP_EXPAND(                                                       \
+          BOOST_PP_SEQ_TO_TUPLE (                                              \
+            BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,op,__VA_ARGS__((2,(a,b,EmptyStruct)))) \
+          )                                                                    \
+        )                                                                      \
+    )
+
+/** generate the definition of a struct
+ *
+ * @param namespace_name name of a unique namespace to avoid naming conflicts
+ * @param name name of the struct
+ * @param ... preprocessor sequence with TypeMemberPair's
+ */
+#define PMACC_PP_STRUCT_DEF(namespace_name,name,...)                           \
+namespace namespace_name{                                                      \
+    BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_CREATE_C_VECTOR_DEF,__VA_ARGS__) \
+    struct EmptyStruct{};                                                      \
+    struct EmptyStruct2{};                                                     \
+    struct name : private EmptyStruct, private EmptyStruct2 {                  \
+        name():                                                                \
+        PMACC_PP_INIT_VALUE_VARIABLES(PMACC_PP_X_INIT_VALUE_VARIABLE,__VA_ARGS__),                            \
+        PMACC_PP_INIT_VALUE_VARIABLES(PMACC_PP_X_INIT_VALUE_VARIABLE_WITH_PAREN,__VA_ARGS__){}                \
+                                                                                                              \
+        BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_CREATE_C_VALUE_VARIABLE,__VA_ARGS__)  \
+        BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_CREATE_VALUE_VARIABLE,__VA_ARGS__)    \
+        BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_CREATE_C_VECTOR_VARIABLE,__VA_ARGS__) \
+        BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_CREATE_C_STRING_VARIABLE,__VA_ARGS__) \
+	    BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_CREATE_EXTENT,__VA_ARGS__)          \
+        BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_CREATE_VALUE_VARIABLE_WITH_PAREN,__VA_ARGS__)    \
+        };                                                                     \
+    BOOST_PP_SEQ_FOR_EACH(PMACC_PP_SEQ_MACRO_WITH_ACCESSOR,PMACC_PP_INIT_C_STRING_VARIABLE,__VA_ARGS__);      \
+}  /*namespace*/                                                               \
+using namespace_name::name
+
+
+/** add data to TypeMemberPair's
+ *
+ * transform (typeId,(value_type,name,initValue,...) to (typeId,(data,value_type,name,initValue,...)
+ *
+ * @param data any data which should be added to the TypeMemberPair's
+ * @param ... preprocessor sequence with TypeMemberPair's
+ */
+#define PMACC_PP_ADD_DATA_TO_TYPEDESCRIPTION(data,...) BOOST_PP_SEQ_FOR_EACH(PMACC_PP_ADD_DATA_TO_TYPEDESCRIPTION_MACRO,data,__VA_ARGS__)
+
+/** generate a struct with static and dynamic members
+ *
+ * @param name name of the struct
+ * @param ... preprocessor sequence with TypeMemberPair's e.g. (PMACC_C_VALUE(int,a,2))
+ */
+#define PMACC_STRUCT(name,...)                                                 \
+    PMACC_PP_STRUCT_DEF(BOOST_PP_CAT(BOOST_PP_CAT(pmacc_,name),__COUNTER__),name,PMACC_PP_ADD_DATA_TO_TYPEDESCRIPTION(name,__VA_ARGS__))


### PR DESCRIPTION
- add facilities macros
- add struct macros

This pull request allows to create struct with macro magic. 
Static constant vectors, strings and variable members are handled by the macro.

**Example:**
```C++
PMACC_STRUCT(Gauss,
            (PMACC_C_VECTOR(float,center,2.0,2.0,2.0))
            (PMACC_VALUE(int,a,2))
            (PMACC_C_VALUE(int,b,4))
            (PMACC_VALUE(int,x,23))
            (PMACC_C_VECTOR_DIM(float,3,center2,1.0,2.0,2.0))
            (PMACC_C_STRING(filename,"test.dat"))
            (PMACC_C_STRING(filename2,"test2.dat"))
	        (PMACC_C_EXTENT(typedef float Float;))
);
``` 

**Result:**
```C++
namespace pmacc_Gauss0
{
  typedef float center_t;
  typedef float center2_t;
  struct EmptyStruct{};

  struct Gauss : private EmptyStruct 
  {
    Gauss(): a(2), x(23), EmptyStruct() 
    { }
    static const int b = 4;
    int a;
    int x;
    static const center_t center;
    static const center2_t center2;
    static const char* filename;
    static const char* filename2;
    typedef float Float;
  };
  const char* Gauss::filename = (char*)"test.dat";
  const char* Gauss::filename2 = (char*)"test2.dat";
}
using pmacc_Gauss0::Gauss;
```