### PR TITLE
[WIP] documentation for gasConfig.param

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/gasConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gasConfig.param
@@ -43,6 +43,82 @@ const double GAS_DENSITY_SI = 1.e25;
 //##########################################################################
 namespace gasProfiles
 {
+
+/* possible struct elements
+ *
+ * - PMACC_C_VECTOR_DIM(type,dim,name,...)
+ *   create static const member vector that needs no memory inside of the struct
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be greater or equal than dim)
+ *   \example `PMACC_C_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_VECTOR_DIM(type,dim,name,...)  //runtime
+ *   create changeable member vector
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be equal to dim)
+ *   \example `PMACC_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `Vector<float_64,3> center_SI(1.134e-5, 1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_C_VECTOR(type,name,...)
+ *   create static const member vector that needs no memory inside of the struct
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_C_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_VECTOR(type,name,...)          //runtime
+ *   create changeable member vector
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `float2_64 center_SI(1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_C_VALUE(type,name,value)
+ *   create static const member
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_C_VALUE(float_64, power_SI, 2.0)`
+ *            is the compile time equivalent of
+ *            `static const float_64 power_SI = float_64(2.0);`
+ *
+ * PMACC_VALUE(type,name,value)         //runtime
+ *   create changeable member
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_VALUE(float_64, power_SI, 2.0)`
+ *            is the equivalent of
+ *            `float_64 power_SI(2.0);`
+ *
+ * PMACC_C_STRING(name,char_string)
+ *   create static const character string
+ *   @param name member variable name
+ *   @param char_string character string
+ *   \example `PMACC_C_STRING(filename, "fooFile.txt")`
+ *            is the compile time equivalent of
+ *            `static const char* filename = (char*)"fooFile.tyt";`
+ *
+ * PMACC_EXTENT(...)
+ *   create any code extension
+ *   @param ... any code
+ *   \example `PMACC_EXTENT(typedef float FooFloat;))`
+ *            is the equivalent of
+ *            `typedef float FooFloat;`
+ */
+
+
 CONST_VECTOR(float_64, simDim, GaussianCloudParam_center, 1.024e-5, 9.072e-5, 1.024e-5);
 CONST_VECTOR(float_64, simDim, GaussianCloudParam_sigma, 6.0e-6, 6.0e-6, 6.0e-6);
 

--- a/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
@@ -45,6 +45,81 @@ namespace gasProfiles
 {
 struct GaussianParameter
 {
+
+/* possible struct elements
+ *
+ * - PMACC_C_VECTOR_DIM(type,dim,name,...)
+ *   create static const member vector that needs no memory inside of the struct
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be greater or equal than dim)
+ *   \example `PMACC_C_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_VECTOR_DIM(type,dim,name,...)  //runtime
+ *   create changeable member vector
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be equal to dim)
+ *   \example `PMACC_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `Vector<float_64,3> center_SI(1.134e-5, 1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_C_VECTOR(type,name,...)
+ *   create static const member vector that needs no memory inside of the struct
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_C_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_VECTOR(type,name,...)          //runtime
+ *   create changeable member vector
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `float2_64 center_SI(1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_C_VALUE(type,name,value)
+ *   create static const member
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_C_VALUE(float_64, power_SI, 2.0)`
+ *            is the compile time equivalent of
+ *            `static const float_64 power_SI = float_64(2.0);`
+ *
+ * PMACC_VALUE(type,name,value)         //runtime
+ *   create changeable member
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_VALUE(float_64, power_SI, 2.0)`
+ *            is the equivalent of
+ *            `float_64 power_SI(2.0);`
+ *
+ * PMACC_C_STRING(name,char_string)
+ *   create static const character string
+ *   @param name member variable name
+ *   @param char_string character string
+ *   \example `PMACC_C_STRING(filename, "fooFile.txt")`
+ *            is the compile time equivalent of
+ *            `static const char* filename = (char*)"fooFile.tyt";`
+ *
+ * PMACC_EXTENT(...)
+ *   create any code extension
+ *   @param ... any code
+ *   \example `PMACC_EXTENT(typedef float FooFloat;))`
+ *            is the equivalent of
+ *            `typedef float FooFloat;`
+ */
+
     /** Gas Formular:
                 const float_X exponent = fabs((y - GAS_CENTER) / GAS_SIGMA);
                 const float_X density = __expf(GAS_FACTOR*__powf(exponent, GAS_POWER));

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -44,6 +44,80 @@ const double GAS_DENSITY_SI = 1.e25;
 namespace gasProfiles
 {
 
+/* possible struct elements
+ *
+ * - PMACC_C_VECTOR_DIM(type,dim,name,...)
+ *   create static const member vector that needs no memory inside of the struct
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be greater or equal than dim)
+ *   \example `PMACC_C_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_VECTOR_DIM(type,dim,name,...)  //runtime
+ *   create changeable member vector
+ *   @param type type of on element
+ *   @param dim number of vector components
+ *   @param name member variable name
+ *   @param ... enumeration of init values (number of components must be equal to dim)
+ *   \example `PMACC_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `Vector<float_64,3> center_SI(1.134e-5, 1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_C_VECTOR(type,name,...)
+ *   create static const member vector that needs no memory inside of the struct
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_C_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the compile time equivalent of
+ *            `static const float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_VECTOR(type,name,...)          //runtime
+ *   create changeable member vector
+ *   @param type type of on element
+ *   @param name member variable name
+ *   @param ... enumeration of init values
+ *   \example `PMACC_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
+ *            is the equivalent of
+ *            `float2_64 center_SI(1.134e-5, 1.134e-5);`
+ *
+ * - PMACC_C_VALUE(type,name,value)
+ *   create static const member
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_C_VALUE(float_64, power_SI, 2.0)`
+ *            is the compile time equivalent of
+ *            `static const float_64 power_SI = float_64(2.0);`
+ *
+ * PMACC_VALUE(type,name,value)         //runtime
+ *   create changeable member
+ *   @param type type of the member
+ *   @param name member variable name
+ *   @param value init value
+ *   \example `PMACC_VALUE(float_64, power_SI, 2.0)`
+ *            is the equivalent of
+ *            `float_64 power_SI(2.0);`
+ *
+ * PMACC_C_STRING(name,char_string)
+ *   create static const character string
+ *   @param name member variable name
+ *   @param char_string character string
+ *   \example `PMACC_C_STRING(filename, "fooFile.txt")`
+ *            is the compile time equivalent of
+ *            `static const char* filename = (char*)"fooFile.tyt";`
+ *
+ * PMACC_EXTENT(...)
+ *   create any code extension
+ *   @param ... any code
+ *   \example `PMACC_EXTENT(typedef float FooFloat;))`
+ *            is the equivalent of
+ *            `typedef float FooFloat;`
+ */
+
 struct GaussianParam
 {
     /** Gas Formula:


### PR DESCRIPTION
add documentation for the upcoming `PMACC_STRUCT` generator

This pull request documents macros of #972 which are used in a upcoming pull request to describe parameters of gas profiles.