### PR TITLE
add include math.h to libPMacc algorithms

### DIFF
--- a/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Benjamin Worpitz
+ * Copyright 2015 Benjamin Worpitz, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -23,6 +23,8 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/doubleMath/erf.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/erf.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Axel Huebl
+ * Copyright 2014-2015 Axel Huebl, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz, 
+ *                     Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +25,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -24,6 +24,8 @@
 
 #include "types.h"
 #include <float.h>
+#include "math.h"
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Benjamin Worpitz
+ * Copyright 2015 Benjamin Worpitz, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -23,6 +23,8 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/floatMath/erf.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/erf.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Axel Huebl
+ * Copyright 2014-2015 Axel Huebl, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +25,8 @@
 #pragma once
 
 #include "types.h"
+#include "math.h"
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -25,6 +25,8 @@
 
 #include "types.h"
 #include <float.h>
+#include "math.h"
+
 
 namespace PMacc
 {


### PR DESCRIPTION
This fixes the missing `#include "math.h"` in *libPMacc* as dicovered in #969.