### PR TITLE
Fix Gas Profile: Sphere Flanks Unit Exponent

### DIFF
--- a/src/picongpu/include/particles/gasProfiles/SphereFlanksImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/SphereFlanksImpl.hpp
@@ -56,7 +56,7 @@ struct SphereFlanksImpl : public T_ParamClass
         const floatD_X center = precisionCast<float>(ParamClass::SI().center / unit_length);
         const float_X r = ParamClass::SI::r / unit_length;
         const float_X ri = ParamClass::SI::ri / unit_length;
-        const float_X exponent = ParamClass::SI::exponent / unit_length;
+        const float_X exponent = ParamClass::SI::exponent * unit_length;
 
 
         const floatD_X globalCellPos(


### PR DESCRIPTION
The exponent of the density profile SphereFlanks is in units of 1/m which requires a multiplication with `UNIT_LENGTH` to make it unitless.

Bug is only in the current `dev` version due to a full refactoring of the density profiles.