### PR TITLE
Fix Gas Profile: Free Formula Types

### DIFF
--- a/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Rene Widera, Richard Pausch
+ * Copyright 2015 Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -51,17 +51,10 @@ struct FreeFormulaImpl : public T_ParamClass
      */
     HDINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset)
     {
-        DataSpace<simDim> position_SI = totalCellOffset;
-        cellSize_t cellSize_SI = cellSize;
-        for(unsigned int i = 0; i<simDim ; i++)
-        {
-            cellSize_SI *= UNIT_LENGTH;
-            position_SI[i] *= cellSize_SI[i];
-        }
+        const floatD_64 cellSize_SI( precisionCast<float_64>(cellSize) * UNIT_LENGTH );
+        const floatD_64 position_SI( precisionCast<float_64>(totalCellOffset) * cellSize_SI );
 
-        float_X density = ParamClass::operator()(position_SI, cellSize_SI);
-
-        return density;
+        return ParamClass::operator()(position_SI, cellSize_SI);
     }
 
 };

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -251,10 +251,10 @@ struct FreeFormulaFunctor
      * @return float_X density [normalized to 1.0]
      */
     template<class cellSizeType>
-    HDINLINE float_X operator()(const DataSpace<simDim>& position_SI, const cellSizeType& cellSize_SI)
+    HDINLINE float_X operator()(const floatD_64& position_SI, const floatD_64& cellSize_SI)
     {
-        const float_64 y = float_64(position_SI.y()) * 1000.0; // m -> mm
-        //const unsigned int y_cell_id = position_SI.y() / cellSize_SI[1];
+        const float_64 y( position_SI.y() * 1000.0 ); // m -> mm
+        //const uint64_t y_cell_id( uint64_t(position_SI.y() / cellSize_SI[1]) );
 
         /* triangle function example
          * for a density profile from 0 to 400 microns */


### PR DESCRIPTION
I overlooked a few types in #899 (`dev` only) which should cause the `position_SI` argument always to
be zero and the `cellSize_SI` argument to potentially overflow (or at least to loose precision).

This pull request fixes that.