### PR TITLE
Fix `ConstVector` const ref operator[]

### DIFF
--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -68,11 +68,7 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
         static const bool isConst = true;                                      \
         typedef T_Type type;                                                   \
         static const int dim=T_Dim;                                            \
-        HDINLINE type& operator[](const int idx)                               \
-        {                                                                      \
-            /*access const C array with the name of array*/                    \
-            return PMACC_JOIN(Name,_data)[idx];                                \
-        }                                                                      \
+                                                                               \
         HDINLINE const type& operator[](const int idx) const                   \
         {                                                                      \
             /*access const C array with the name of array*/                    \
@@ -80,7 +76,7 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
         }                                                                      \
     };                                                                         \
     /*define a const vector type, ConstArrayStorage is used as Storage policy*/\
-    typedef PMacc::math::Vector<                                               \
+    typedef const PMacc::math::Vector<                                         \
         Type,                                                                  \
         Dim,                                                                   \
         PMacc::math::StandardAccessor,                                         \


### PR DESCRIPTION
ConstVector is not defined as const, therefore it is
possible to access data member with the `operator[]` which
results is in a not const reference.

Solution:
  - define `ConstVector` as const class
  - remove non const `operator[]`

**This pull request effects master but there is no code known where this bug was triggered**