### PR TITLE
fix gas free formular remaining errors 

### DIFF
--- a/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FreeFormulaImpl.hpp
@@ -51,7 +51,8 @@ struct FreeFormulaImpl : public T_ParamClass
      */
     HDINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset)
     {
-        const floatD_64 cellSize_SI( precisionCast<float_64>(cellSize) * UNIT_LENGTH );
+        const float_64 unitLength(UNIT_LENGTH); // workaround to use UNIT_LENGTH on device 
+        const floatD_64 cellSize_SI( precisionCast<float_64>(cellSize) * unitLength );
         const floatD_64 position_SI( precisionCast<float_64>(totalCellOffset) * cellSize_SI );
 
         return ParamClass::operator()(position_SI, cellSize_SI);

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -250,7 +250,6 @@ struct FreeFormulaFunctor
      *
      * @return float_X density [normalized to 1.0]
      */
-    template<class cellSizeType>
     HDINLINE float_X operator()(const floatD_64& position_SI, const floatD_64& cellSize_SI)
     {
         const float_64 y( position_SI.y() * 1000.0 ); // m -> mm


### PR DESCRIPTION
This fixes a remnant template I oversaw in #976 :flushed: and an additional error caused by a nvcc bug while using const variables on the device.

@ComputationalRadiationPhysics/picongpu-maintainers 
As discussed offline with @ax3l, we need to add a test for free formular in the examples to verify the GasFreeFormular with the compile test.