### PR TITLE
remove splash traits from global scope

### DIFF
--- a/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -27,6 +27,8 @@
 #include "simulationControl/MovingWindow.hpp"
 #include "fields/Fields.hpp"
 #include "dataManagement/DataConnector.hpp"
+
+#include <splash/splash.h>
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/PhaseSpace/DumpHBufferSplashP.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/DumpHBufferSplashP.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -20,10 +20,11 @@
 
 #pragma once
 
-#include <mpi.h>
-#include <splash/splash.h>
-
 #include "simulation_defines.hpp"
+
+#include "traits/SplashToPIC.hpp"
+#include "traits/PICToSplash.hpp"
+
 #include "plugins/PhaseSpace/AxisDescription.hpp"
 #include "communication/manager_common.h"
 #include "mappings/simulation/GridController.hpp"
@@ -37,6 +38,8 @@
 #include <sstream>
 #include <utility>
 #include <cassert>
+#include <mpi.h>
+#include <splash/splash.h>
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -27,14 +27,13 @@
 #include <list>
 #include <vector>
 
-#include "types.h"
-#include "simulation_types.hpp"
 #include "simulation_defines.hpp"
+
 #include "plugins/hdf5/HDF5Writer.def"
+#include "traits/SplashToPIC.hpp"
+#include "traits/PICToSplash.hpp"
 
 #include "particles/frame_types.hpp"
-
-#include <splash/splash.h>
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
@@ -68,6 +67,8 @@
 #include "plugins/hdf5/restart/LoadSpecies.hpp"
 #include "plugins/hdf5/restart/RestartFieldLoader.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
+
+#include <splash/splash.h>
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -26,14 +26,11 @@
 #error The activated radiation plugin (radiationConfig.param) requires HDF5
 #endif
 
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <stdlib.h>
-
-#include "types.h"
 #include "simulation_defines.hpp"
-#include "simulation_types.hpp"
+
+#include "traits/SplashToPIC.hpp"
+#include "traits/PICToSplash.hpp"
+
 #include "basicOperations.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
 
@@ -53,6 +50,10 @@
 /* libSpash data output */
 #include <splash/splash.h>
 #include <boost/filesystem.hpp>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <stdlib.h>
 
 namespace picongpu
 {

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -27,8 +27,6 @@
 #include "algorithms/ForEach.hpp"
 #include "algorithms/math.hpp"
 #include "traits/GetMargin.hpp"
-#include "traits/SplashToPIC.hpp"
-#include "traits/PICToSplash.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/NumberOfExchanges.hpp"
 #include "traits/GetDataBoxType.hpp"


### PR DESCRIPTION
- remove splash traits from `simulation_types.hpp`
- add missing include in `FromHDF5Impl.hpp`

Splash traits can depend on PIConGPU types like `float_64` but `simulation_types.hpp` is loaded before all PIConGPU types are known. Therefore splash traits must be removed from global scope.