### PR TITLE
Radiation: remove native `float` in `*.pram/unitless`

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -69,7 +69,7 @@ namespace radiation_frequencies = rad_linear_frequencies;
 
 namespace radiationNyquist
 {
-  const float NyquistFactor = 0.5;
+  const float_32 NyquistFactor = 0.5;
 }
 
 ///////////////////////////////////////////////////
@@ -116,7 +116,7 @@ namespace parameters
 //diable (0) / enable (1)
 #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-const float RadiationGamma = 5.;
+const float_32 RadiationGamma = 5.;
 
 const unsigned int N_observer = 128; // number of looking directions
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -73,7 +73,7 @@ namespace radiation_frequencies = rad_log_frequencies;
 
 namespace radiationNyquist
 {
-  const float NyquistFactor = 0.5;
+  const float_32 NyquistFactor = 0.5;
 }
 
 ///////////////////////////////////////////////////
@@ -122,7 +122,7 @@ namespace parameters
 //diable (0) / enable (1)
 #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-const float RadiationGamma = 5.;
+const float_32 RadiationGamma = 5.;
 
 const unsigned int N_observer = 256; // number of looking directions
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
@@ -69,7 +69,7 @@ namespace radiation_frequencies = rad_linear_frequencies;
 
 namespace radiationNyquist
 {
-  const float NyquistFactor = 0.5;
+  const float_32 NyquistFactor = 0.5;
 }
 
 
@@ -117,7 +117,7 @@ namespace parameters
 //diable (0) / enable (1)
 #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-const float RadiationGamma = 5.;
+const float_32 RadiationGamma = 5.;
 
 const unsigned int N_observer = 128; // number of looking directions
 

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -69,7 +69,7 @@ namespace radiation_frequencies = rad_linear_frequencies;
 
 namespace radiationNyquist
 {
-  const float NyquistFactor = 0.5;
+  const float_32 NyquistFactor = 0.5;
 }
 
 
@@ -117,7 +117,7 @@ namespace parameters
 //diable (0) / enable (1)
 #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-const float RadiationGamma = 5.;
+const float_32 RadiationGamma = 5.;
 
 const unsigned int N_observer = 256; // number of looking directions
 

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -58,7 +58,7 @@ value_identifier(bool, radiationFlag, false);
 /** number of electrons bound to the atom / ion
  *
  * value type is float_X to avoid casts during the runtime
- * - float is also reasonable because effective charge numbers are possible
+ * - float_X is also reasonable because effective charge numbers are possible
  * - only reasonable for ion species if ionization is enabled
  *
  * \todo connect default to proton number

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -58,8 +58,9 @@ value_identifier(bool, radiationFlag, false);
 /** number of electrons bound to the atom / ion
  *
  * value type is float_X to avoid casts during the runtime
- * - float_X is also reasonable because effective charge numbers are possible
- * - only reasonable for ion species if ionization is enabled
+ * - float_X instead of integer types are reasonable because effective charge
+ *   numbers are possible
+ * - required for ion species if ionization is enabled
  *
  * \todo connect default to proton number
  */


### PR DESCRIPTION
radiationConfig.param: remove in `*.param/unitless` the usage of the native type `float` with `float_32`

- [x] rebase against #993