### PR TITLE
change namespaces of radiation `param/unitless`

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -17,7 +17,7 @@
  * along with PIConGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 
 
 #pragma once
@@ -72,19 +72,8 @@ namespace radiationNyquist
   const float NyquistFactor = 0.5;
 }
 
-
-}//namespace picongpu
-
-
-
-
-
 ///////////////////////////////////////////////////
 
-
-
-namespace picongpu
-{
 
   // corect treatment of coherent and incoherent  radiation from macroparticles
   // 1 = on  (slower and more memory, but correct quantitativ treatment)
@@ -104,13 +93,7 @@ namespace picongpu
   namespace radFormFactor = radFormFactor_CIC_3D;
 
 
-}//namespace picongpu
-
-
-
 ///////////////////////////////////////////////////////////
-
-
 
 
 namespace parameters
@@ -143,10 +126,6 @@ const unsigned int N_observer = 128; // number of looking directions
 
 //////////////////////////////////////////////////
 
-
-
-namespace picongpu
-{
 
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -17,7 +17,7 @@
  * along with PIConGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 
 
 #pragma once
@@ -76,19 +76,8 @@ namespace radiationNyquist
   const float NyquistFactor = 0.5;
 }
 
-
-}//namespace picongpu
-
-
-
-
-
 ///////////////////////////////////////////////////
 
-
-
-namespace picongpu
-{
 
   // corect treatment of coherent and incoherent  radiation from macroparticles
   // 1 = on  (slower and more memory, but correct quantitativ treatment)
@@ -108,13 +97,7 @@ namespace picongpu
   namespace radFormFactor = radFormFactor_CIC_3D;
 
 
-}//namespace picongpu
-
-
-
 ///////////////////////////////////////////////////////////
-
-
 
 
 namespace parameters
@@ -150,10 +133,6 @@ const unsigned int N_observer = 256; // number of looking directions
 //////////////////////////////////////////////////
 
 
-
-namespace picongpu
-{
-
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
 // default: no window function via `radWindowFunctionNone`
@@ -175,6 +154,3 @@ namespace radWindowFunction = radWindowFunctionTriangle;
 
 
 }//namespace picongpu
-
-
-

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
@@ -17,7 +17,7 @@
  * along with PIConGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 
 
 #pragma once
@@ -73,18 +73,8 @@ namespace radiationNyquist
 }
 
 
-}//namespace picongpu
-
-
-
-
-
 ///////////////////////////////////////////////////
 
-
-
-namespace picongpu
-{
 
   // corect treatment of coherent and incoherent  radiation from macroparticles
   // 1 = on  (slower and more memory, but correct quantitativ treatment)
@@ -104,13 +94,7 @@ namespace picongpu
   namespace radFormFactor = radFormFactor_CIC_3D;
 
 
-}//namespace picongpu
-
-
-
 ///////////////////////////////////////////////////////////
-
-
 
 
 namespace parameters
@@ -144,10 +128,6 @@ const unsigned int N_observer = 128; // number of looking directions
 //////////////////////////////////////////////////
 
 
-
-namespace picongpu
-{
-
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
 // default: no window function via `radWindowFunctionNone`
@@ -169,6 +149,3 @@ namespace radWindowFunction = radWindowFunctionNone;
 
 
 }//namespace picongpu
-
-
-

--- a/src/picongpu/include/plugins/radiation/check_consistency.hpp
+++ b/src/picongpu/include/plugins/radiation/check_consistency.hpp
@@ -25,11 +25,12 @@
 #include <cassert>
 #include "parameters.hpp"
 
+namespace picongpu
+{
 
 void check_consistency(void)
 {
   using namespace parameters;
-  using namespace picongpu;
   std::cout << " checking efficiency of radiation code: " ;
   if(radiation_frequencies::N_omega%radiation_frequencies::blocksize_omega == 0)
     std::cout << "OK" << std::endl;
@@ -37,3 +38,5 @@ void check_consistency(void)
     std::cout << "better use power of two for N_omega" << std::endl;
   // is there a way to do this with  compile time asserts???
 }
+
+} //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -73,18 +73,8 @@ namespace radiationNyquist
 }
 
 
-}//namespace picongpu
-
-
-
-
-
 ///////////////////////////////////////////////////
 
-
-
-namespace picongpu
-{
 
 // corect treatment of coherent and incoherent  radiation from macroparticles
 // 1 = on  (slower and more memory, but correct quantitativ treatment)
@@ -104,13 +94,7 @@ namespace radFormFactor_incoherent { }
 namespace radFormFactor = radFormFactor_CIC_3D;
 
 
-}//namespace picongpu
-
-
-
 ///////////////////////////////////////////////////////////
-
-
 
 
 namespace parameters
@@ -144,10 +128,6 @@ const unsigned int N_observer = 256; // number of looking directions
 //////////////////////////////////////////////////
 
 
-
-namespace picongpu
-{
-
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
 // default: no window function via `radWindowFunctionNone`
@@ -169,6 +149,3 @@ namespace radWindowFunction = radWindowFunctionNone;
 
 
 }//namespace picongpu
-
-
-

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -27,7 +27,6 @@
 
 #if (ENABLE_RADIATION == 1 )
 
-//PMACC_CASSERT_MSG(We_not_support_radiation_if_ENABLE_IONS_is_set_to_1__change_ENABLE_IONS_in_file_componentsConfig_param,ENABLE_IONS==0);
 PMACC_CASSERT_MSG(ENABLE_ELECTRONS_must_set_to_1__change_ENABLE_ELECTRONS_in_file_componentsConfig_param,ENABLE_ELECTRONS==1);
 
 
@@ -42,11 +41,7 @@ namespace picongpu
     const unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     const unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
   }
-}
 
-
-namespace picongpu
-{
   namespace rad_log_frequencies
   {
     const float_X omega_min = (SI::omega_min*UNIT_TIME);
@@ -55,18 +50,12 @@ namespace picongpu
     const unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     const unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
   }
-}
 
-namespace picongpu
-{
   namespace rad_frequencies_from_list
   {
     const unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     const unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
   }
-}
-
-
 
 namespace parameters
 {
@@ -74,6 +63,8 @@ namespace parameters
     const unsigned int gridsize_theta = N_observer; // size of grid /dim: y); radiation
 
 }
+
+} //namespace picongpu
 
 #endif
 


### PR DESCRIPTION
- move `check_consistency()` from global namespace to `picongpu` namespace
- move all configurations in `param/unitless` for radiation to `picongpu` namespace