### PR TITLE
close #997 - fix `vector_32` in radiation

### DIFF
--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -227,8 +227,8 @@ void kernelRadiationParticles(ParBox pb,
 
                 PMACC_AUTO(par,(*frame)[linearThreadIdx]);
                 // get old and new particle momenta
-                const vector_32 particle_momentumNow = vector_32(par[momentum_]);
-                const vector_32 particle_momentumOld = vector_32(par[momentumPrev1_]);
+                const vector_X particle_momentumNow = vector_X(par[momentum_]);
+                const vector_X particle_momentumOld = vector_X(par[momentumPrev1_]);
                 /* initializes "saveParticleAt" flag with -1
                  * because "counter_s" will never be -1
                  * therefore, if a particle is saved, a value of counter
@@ -275,7 +275,7 @@ void kernelRadiationParticles(ParBox pb,
                                                           (cellIdx));
 
                         // add global position of cell with local position of particle in cell
-                        vector_32 particle_locationNow;
+                        vector_X particle_locationNow;
                         // set z component to zero in case of simDim==DIM2
                         particle_locationNow[2] = 0.0;
                         // run over all components and compute gobal position

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -25,7 +25,8 @@
 #include "simulation_defines.hpp"
 
 
-typedef /*__align__(16)*/ cuda_vec<picongpu::float3_X, picongpu::float_X> vector_32;
+typedef cuda_vec<picongpu::float3_X, picongpu::float_X> vector_X;
+typedef /*__align__(16)*/ cuda_vec<picongpu::float3_32, picongpu::float_32> vector_32;
 typedef /*__align__(32)*/ cuda_vec<picongpu::float3_64, picongpu::float_64> vector_64;
 
 

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -54,16 +54,16 @@ public:
     {
         location_begin = When::now, momentum_begin = When::now, beta_begin = When::first
     };
-    const vector_32 momentum_now;
-    const vector_32 momentum_old;
-    const vector_32 location_now;
+    const vector_X momentum_now;
+    const vector_X momentum_old;
+    const vector_X location_now;
     const picongpu::float_X mass;
 
 public:
     //////////////////////////////////////////////////////////////////
     // constructors:
 
-  HDINLINE Particle(const vector_32& locationNow_set, const vector_32& momentumOld_set, const vector_32& momentumNow_set, const picongpu::float_X mass_set)
+  HDINLINE Particle(const vector_X& locationNow_set, const vector_X& momentumOld_set, const vector_X& momentumNow_set, const picongpu::float_X mass_set)
     : location_now(locationNow_set), momentum_old(momentumOld_set), momentum_now(momentumNow_set), mass(mass_set)
     {
 
@@ -113,26 +113,26 @@ private:
     //////////////////////////////////////////////////////////////////
     // private methods:
 
-    HDINLINE vector_64 calc_beta(const vector_32& momentum) const
+    HDINLINE vector_64 calc_beta(const vector_X& momentum) const
     {
         // returns beta=v/c
         const picongpu::float_32 gamma1 = calc_gamma(momentum);
         return momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT * gamma1));
     }
 
-    HDINLINE picongpu::float_64 calc_gamma(const vector_32& momentum) const
+    HDINLINE picongpu::float_64 calc_gamma(const vector_X& momentum) const
     {
         // return gamma = E/(mc^2)
-        const picongpu::float_32 x = util::square<vector_32, picongpu::float_32 > (momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT)));
+        const picongpu::float_32 x = util::square<vector_X, picongpu::float_32 > (momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT)));
         return picongpu::math::sqrt(1.0 + x);
 
     }
 
-    HDINLINE picongpu::float_64 calc_gamma_inv_square(const vector_32& momentum) const
+    HDINLINE picongpu::float_64 calc_gamma_inv_square(const vector_X& momentum) const
     {
         // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2)
         const picongpu::float_32 Emass = mass * picongpu::SPEED_OF_LIGHT;
-        return Emass / (Emass + (util::square<vector_32, picongpu::float_32 > (momentum)) / Emass);
+        return Emass / (Emass + (util::square<vector_X, picongpu::float_32 > (momentum)) / Emass);
     }
 
     HDINLINE picongpu::float_64 calc_cos_theta(const vector_64& n, const vector_64& beta) const

--- a/src/picongpu/include/plugins/radiation/radFormFactor.hpp
+++ b/src/picongpu/include/plugins/radiation/radFormFactor.hpp
@@ -32,7 +32,7 @@ namespace picongpu
       HDINLINE radFormFactor(void)
       { }
 
-      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_32 observer_unit_vec) const
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
       {
 
     /* Form Factor for CIC charge distribution of N discrete electrons:
@@ -67,7 +67,7 @@ namespace picongpu
       HDINLINE radFormFactor(void)
       { }
 
-      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_32 observer_unit_vec) const
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
       {
 
     /* Form Factor for 1D CIC charge distribution of N discrete electrons:
@@ -91,7 +91,7 @@ namespace picongpu
       HDINLINE radFormFactor(void)
       { }
 
-      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_32 observer_unit_vec) const
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
       {
 
     /* Form Factor for 1D CIC charge distribution of N discrete electrons:


### PR DESCRIPTION
This pull request renames `vector_32` to `vector_X` (which it actually is) and adds a `vector_32` class just in case someone needs an explicit `float32` type 3D vector.

This pull request closes issue #997. 

- [x] please do not merge before #996 