### PR TITLE
Remove deprecated throw declarations

### DIFF
--- a/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -54,7 +55,7 @@ public:
         notify(this->myId,GETVALUE, NULL);
     }
 
-    bool executeIntern() throw(std::runtime_error)
+    bool executeIntern()
     {
         return isFinished();
     }

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -80,7 +81,7 @@ public:
 
 private:
 
-    void setSize() throw (std::runtime_error)
+    void setSize()
     {
         kernelSetValueOnDeviceMemory
             << < 1, 1, 0, this->getCudaStream() >> >

--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -160,7 +161,7 @@ public:
         return sizeOnDevice;
     }
 
-    size_t* getCurrentSizeOnDevicePointer() throw (std::runtime_error)
+    size_t* getCurrentSizeOnDevicePointer()
     {
         __startOperation(ITask::TASK_CUDA);
         if (!sizeOnDevice)

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -45,7 +46,7 @@ public:
      * constructor
      * @param dataSpace DataSpace describing the size of the HostBufferIntern to be created
      */
-    HostBufferIntern(DataSpace<DIM> dataSpace) throw (std::bad_alloc) :
+    HostBufferIntern(DataSpace<DIM> dataSpace) :
     HostBuffer<TYPE, DIM>(dataSpace),
     pointer(NULL),ownPointer(true)
     {
@@ -53,7 +54,7 @@ public:
         reset(false);
     }
 
-    HostBufferIntern(HostBufferIntern& source, DataSpace<DIM> dataSpace, DataSpace<DIM> offset=DataSpace<DIM>())  :
+    HostBufferIntern(HostBufferIntern& source, DataSpace<DIM> dataSpace, DataSpace<DIM> offset=DataSpace<DIM>()) :
     HostBuffer<TYPE, DIM>(dataSpace),
     pointer(NULL),ownPointer(false)
     {
@@ -64,7 +65,7 @@ public:
     /**
      * destructor
      */
-    virtual ~HostBufferIntern() throw (std::runtime_error)
+    virtual ~HostBufferIntern()
     {
         __startOperation(ITask::TASK_HOST);
 

--- a/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2014-2015 Rene Widera, Axel Huebl, Benjamin Worpitz
+ * Copyright 2014-2015 Rene Widera, Axel Huebl, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -44,7 +45,7 @@ public:
 
     typedef typename DeviceBuffer<TYPE, DIM>::DataBoxType DataBoxType;
 
-    MappedBufferIntern(DataSpace<DIM> dataSpace) throw (std::bad_alloc) :
+    MappedBufferIntern(DataSpace<DIM> dataSpace):
     DeviceBuffer<TYPE, DIM>(dataSpace),
     pointer(NULL), ownPointer(true)
     {
@@ -55,7 +56,7 @@ public:
     /**
      * destructor
      */
-    virtual ~MappedBufferIntern() throw (std::runtime_error)
+    virtual ~MappedBufferIntern()
     {
         __startOperation(ITask::TASK_CUDA);
         __startOperation(ITask::TASK_HOST);
@@ -132,7 +133,7 @@ public:
         return this->current_size;
     }
 
-    size_t* getCurrentSizeOnDevicePointer() throw (std::runtime_error)
+    size_t* getCurrentSizeOnDevicePointer()
     {
         return NULL;
     }


### PR DESCRIPTION
Fixed those in libPMacc
This is a showstopper for e.g. CUDA 7!
@psychocoderHPC @n01r 

**Environment**
CUDA 7.0.27
gcc (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4