### PR TITLE
Workaround for device call to pow

### DIFF
--- a/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -52,7 +52,15 @@ struct Pow<double, int>
 
     HDINLINE result operator()(const double& base, const int& exponent)
     {
+#ifdef __CUDA_ARCH__ /*device version*/
+        /* @todo: There is an incompatibility with C++11 + CUDA + GCC where no device function
+         *        pow(double, int) is defined: http://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-tools-title-known
+         *        Use the pow(double, double) instead which reduces performance or implement an own (faster) version
+         */
+        return ::pow(base, static_cast<double>(exponent));
+#else
         return ::pow(base, exponent);
+#endif
     }
 };
 

--- a/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -43,6 +43,7 @@ struct Pow<float, float>
     HDINLINE result operator()(const float& base, const float& exponent)
     {
 #ifdef __CUDA_ARCH__ /*device version*/
+        /* CUDA seems to have an optimized version for powf which is faster and (maybe) less accurate. */
         return ::powf(base, exponent);
 #else
         return ::pow(base, exponent);
@@ -56,9 +57,13 @@ struct Pow<float, int>
 {
     typedef float result;
 
-    HDINLINE result operator()(const float& base,const int& exponent)
+    HDINLINE result operator()(const float& base, const int& exponent)
     {
 #ifdef __CUDA_ARCH__ /*device version*/
+        /* @todo: There is an incompatibility with C++11 + CUDA + GCC where no device function
+         *        pow(float, int) is defined: http://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-tools-title-known
+         *        Use the powf(float, float) instead which reduces performance or implement an own (faster) version
+         */
         return ::powf(base, exponent);
 #else
         return ::pow(base, exponent);


### PR DESCRIPTION
Workaround is required for CUDA + C++11 + GCC:


Compiling with C++11 shows a problem with C++98 compatible CUDA compilers:
http://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-tools-title-known 

C++98 defines a pow(double, int) function, but CUDA (in the above config) has only pow(double, double)
Therefore the host function would be called (see comment)

Note that this lack results in reduced performance for int exponents but you got to wait for NVIDIA to fix that.

This DOES change the behavior compared to previous implementation for the case if there was actually a pow(double, int) function which does not just forward to pow(double, double)