### PR TITLE
replace usage of CUDA uint by uint32_t

### DIFF
--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -32,7 +32,7 @@ class Amplitude
 {
 public:
   // number of scalars of type picongpu::float_64 in Amplitude = 3 (3D) * 2 (complex) = 6
-  static const uint numComponents = 3 * sizeof(complex_64) / sizeof(picongpu::float_64);
+  static const uint32_t numComponents = 3 * sizeof(complex_64) / sizeof(picongpu::float_64);
 
   /** constructor
    *

--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -31,8 +31,8 @@ typedef PMacc::math::Complex<picongpu::float_64> complex_64;
 class Amplitude
 {
 public:
-  // number of scalars of type picongpu::float_64 in Amplitude = 3 (3D) * 2 (complex) = 6
-  static const uint32_t numComponents = 3 * sizeof(complex_64) / sizeof(picongpu::float_64);
+  /* number of scalar components in Amplitude = 3 (3D) * 2 (complex) = 6 */
+  static const uint32_t numComponents = uint32_t(3) * uint32_t(sizeof(complex_64) / sizeof(typename complex_64::type));
 
   /** constructor
    *


### PR DESCRIPTION
To ease the porting to non-CUDA back-ends the CUDA types should not be directly used in non kernel related code.