### PR TITLE
remove unneeded headers

### DIFF
--- a/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
@@ -31,8 +31,6 @@
 #include "mappings/simulation/EnvironmentController.hpp"
 #include "memory/buffers/Exchange.hpp"
 
-#include <cuda_runtime_api.h>
-
 namespace PMacc
 {
 

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -23,7 +23,6 @@
 
 #include "types.h"
 #include "particles/frame_types.hpp"
-#include "basicOperations.hpp"
 
 #include "simulation_defines.hpp"
 

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -26,7 +26,6 @@
 
 #include "types.h"
 #include "simulation_defines.hpp"
-#include "basicOperations.hpp"
 
 #include "fields/SimulationFieldHelper.hpp"
 #include "dataManagement/ISimulationData.hpp"

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
@@ -23,7 +23,6 @@
 #include "simulation_defines.hpp"
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
-#include "basicOperations.hpp"
 #include <cuSTL/cursor/tools/twistVectorFieldAxes.hpp>
 #include "algorithms/FieldToParticleInterpolation.hpp"
 #include "algorithms/ShiftCoordinateSystem.hpp"

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Axel Huebl
+ * Copyright 2015 Axel Huebl, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -22,7 +22,6 @@
 
 #include "simulation_defines.hpp"
 #include "types.h"
-#include "basicOperations.hpp"
 
 #include "fields/currentInterpolation/None/None.def"
 

--- a/src/picongpu/include/fields/currentInterpolation/None/None.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Axel Huebl
+ * Copyright 2015 Axel Huebl, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -22,7 +22,6 @@
 
 #include "simulation_defines.hpp"
 #include "types.h"
-#include "basicOperations.hpp"
 
 #include "fields/currentInterpolation/None/None.def"
 

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Axel Huebl
+ * Copyright 2015 Axel Huebl, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -22,7 +22,6 @@
 
 #include "simulation_defines.hpp"
 #include "types.h"
-#include "basicOperations.hpp"
 
 #include "fields/currentInterpolation/None/None.def"
 #include "algorithms/DifferenceToUpper.hpp"

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -34,7 +34,6 @@
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
 
-#include "basicOperations.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
 #include "plugins/ISimulationPlugin.hpp"
 

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -1,6 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau,
- *                     Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau,
+ *                     Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -30,7 +30,6 @@
 #include "types.h"
 #include "simulation_defines.hpp"
 #include "simulation_types.hpp"
-#include "basicOperations.hpp"
 
 #include "simulation_classTypes.hpp"
 #include "mappings/kernel/AreaMapping.hpp"

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -26,7 +27,6 @@
 #include "types.h"
 #include "simulation_defines.hpp"
 #include "simulation_types.hpp"
-#include "basicOperations.hpp"
 
 #include "simulation_classTypes.hpp"
 #include "mappings/kernel/AreaMapping.hpp"

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -34,7 +34,6 @@
 
 #include "fields/FieldJ.hpp"
 
-#include "basicOperations.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
 #include "plugins/ILightweightPlugin.hpp"
 

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -1,6 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Klaus Steiniger,
- * Felix Schmitt
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -31,7 +31,6 @@
 #include "traits/SplashToPIC.hpp"
 #include "traits/PICToSplash.hpp"
 
-#include "basicOperations.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
 
 #include "simulation_classTypes.hpp"

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -1,6 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Klaus Steiniger,
- * Felix Schmitt
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -30,7 +30,6 @@
 #include "types.h"
 #include "simulation_defines.hpp"
 #include "simulation_types.hpp"
-#include "basicOperations.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
 
 #include "simulation_classTypes.hpp"
@@ -227,8 +226,8 @@ void kernelRadiationParticles(ParBox pb,
               {
 
                 /* initializes "saveParticleAt" flag with -1
-                 * because "counter_s" wil never be -1
-                 * therfore, if a particle is saved, a value of counter
+                 * because "counter_s" will never be -1
+                 * therefore, if a particle is saved, a value of counter
                  * is stored in "saveParticleAt" != -1
                  * THIS IS ACTUALLY ONLY NEEDED IF: the radiation flag was set
                  * LATER: can this be optimized?

--- a/src/picongpu/include/simulation_defines/param/visColorScales.param
+++ b/src/picongpu/include/simulation_defines/param/visColorScales.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -21,8 +21,6 @@
 
 
 #pragma once
-
-#include "basicOperations.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/simulation_defines/param/visualization.param
+++ b/src/picongpu/include/simulation_defines/param/visualization.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -22,7 +23,6 @@
 #pragma once
 
 #include <cmath>
-#include "basicOperations.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -22,7 +23,6 @@
 
 #pragma once
 
-#include "static_assert.hpp"
 #include "math/Vector.hpp"
 
 namespace picongpu


### PR DESCRIPTION
Nothing from the headers that are removed is used in the respective files.
It has been checked that this does not introduce any missing (transitive) includes in those or other files because those headers have completely been removed in my develop branch.