### PR TITLE
use `atomicAll*()` to speedup atomic operation

### DIFF
--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -26,6 +26,7 @@
 #include "types.h"
 #include "simulation_defines.hpp"
 #include "simulation_classTypes.hpp"
+#include "nvidia/atomic.hpp"
 
 namespace picongpu
 {
@@ -75,7 +76,7 @@ DINLINE void absorb(BoxedMemory field, uint32_t thickness, float_X absorber_stre
         if (factor <= float_X(0.0))
         {
             factor = float_X(0.0);
-            atomicExch(&finish, 1);
+            nvidia::atomicAllExch(&finish,1);
         }
         else
         {

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu, 
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu,
  *                     Marco Garten
  *
  * This file is part of PIConGPU.
@@ -50,6 +50,7 @@
 
 #include "particles/operations/Assign.hpp"
 #include "particles/operations/Deselect.hpp"
+#include "nvidia/atomic.hpp"
 
 namespace picongpu
 {
@@ -387,7 +388,8 @@ struct PushParticlePerFrame
          */
         if (direction >= 2)
         {
-            atomicExch(&mustShift, 1); /*if we not use atomic we get a WAW error*/
+            /* if we did not use atomic we would get a WAW error */
+            nvidia::atomicAllExch(&mustShift, 1);
         }
     }
 };

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *
@@ -32,6 +32,7 @@
 #include "compileTime/conversion/ResolveAndRemoveFromSeq.hpp"
 #include "particles/startPosition/MacroParticleCfg.hpp"
 #include "particles/traits/GetDensityRatio.hpp"
+#include "nvidia/atomic.hpp"
 
 namespace picongpu
 {
@@ -111,7 +112,7 @@ __global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
     const uint32_t totalNumParsPerCell = numParsPerCell;
 
     if (numParsPerCell > 0)
-        atomicExch(&finished, 0); //one or more cell has particles to create
+        nvidia::atomicAllExch(&finished, 0); //one or more cells have particles to create
 
     __syncthreads();
     if (finished == 1)

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -31,6 +31,7 @@
 #include "mappings/simulation/GridController.hpp"
 #include "simulationControl/MovingWindow.hpp"
 #include "traits/Resolve.hpp"
+#include "nvidia/atomic.hpp"
 
 #include "types.h"
 
@@ -209,7 +210,7 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
              * - then sync
              */
             if (newMacroElectrons > 0)
-                electronId = atomicAdd(&newFrameFillLvl, 1);
+                electronId = nvidia::atomicAllInc(&newFrameFillLvl);
 
             __syncthreads();
             /* < EXIT? >

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "simulation_defines.hpp"
+#include "nvidia/atomic.hpp"
 
 namespace picongpu
 {
@@ -123,7 +124,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
             __syncthreads();
             if (isParticle && numParToCreate > 0)
             {
-                freeSlot = atomicAdd(&particlesInDestSuperCell, 1);
+                freeSlot = nvidia::atomicAllInc(&particlesInDestSuperCell);
             }
             --numParToCreate;
             if (freeSlot>-1 && freeSlot < cellsInSuperCell)

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -26,6 +26,7 @@
 #include "types.h"
 #include "simulation_types.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
+#include "nvidia/atomic.hpp"
 
 
 namespace picongpu
@@ -185,7 +186,7 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
         storageOffset = -1;
         /*count particle in frame*/
         if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx.x))
-            storageOffset = atomicAdd(&localCounter, 1);
+            storageOffset = nvidia::atomicAllInc(&localCounter);
         __syncthreads();
         if (threadIdx.x == 0)
         {

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *
@@ -70,6 +70,7 @@
 #include "algorithms/GlobalReduce.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
 #include "nvidia/functors/Max.hpp"
+#include "nvidia/atomic.hpp"
 
 namespace picongpu
 {
@@ -300,7 +301,7 @@ kernelPaintParticles3D(ParBox pb,
     if (globalCell == slice)
 #endif
     {
-        atomicExch((int*) &isValid, 1); /*WAW Error in cuda-memcheck racecheck*/
+        nvidia::atomicAllExch((int*) &isValid,1); /*WAW Error in cuda-memcheck racecheck*/
         isImageThread = true;
     }
     __syncthreads();

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -46,6 +46,7 @@
 #include "mpi/reduceMethods/Reduce.hpp"
 #include "mpi/MPIReduce.hpp"
 #include "nvidia/functors/Add.hpp"
+#include "nvidia/atomic.hpp"
 
 
 #if (__NYQUISTCHECK__==1)
@@ -251,7 +252,7 @@ void kernelRadiationParticles(ParBox pb,
 #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
                     if (par[radiationFlag_])
 #endif
-                    saveParticleAt = atomicAdd(&counter_s, 1);
+                    saveParticleAt = nvidia::atomicAllInc(&counter_s);
                     /* for information:
                     *   atomicAdd returns an int with the previous
                     *   value of "counter_s" != -1


### PR DESCRIPTION
use warp aggregated `atomicAll*()` to speedup atomic operations in PIConGPU

- [x] rebase against #1013
