### PR TITLE
Add namespace qualifier to cuda_kernel macro

### DIFF
--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -80,7 +80,7 @@ namespace PMacc
  */
 #define __cudaKernel(kernelname) {                                                      \
     CUDA_CHECK_KERNEL_MSG(cudaDeviceSynchronize(),"Crash before kernel call");          \
-    TaskKernel *taskKernel =  Environment<>::get().Factory().createTaskKernel(#kernelname);     \
+    PMacc::TaskKernel *taskKernel = PMacc::Environment<>::get().Factory().createTaskKernel(#kernelname);     \
     kernelname PMACC_CUDAKERNELCONFIG
 
 }


### PR DESCRIPTION
The current macro version needs to be used from inside PMacc namespace or with a "using namespace PMacc" declaration which is bad practice.

This commit adds namespace qualifiers to the macro