### PR TITLE
Particle Manipulators: Init Multi Ion Species

### DIFF
--- a/src/picongpu/include/particles/manipulators/AssignImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/AssignImpl.hpp
@@ -40,7 +40,7 @@ struct AssignImpl
         typedef AssignImpl type;
     };
 
-    HINLINE AssignImpl(uint32_t currentStep)
+    HINLINE AssignImpl(uint32_t)
     {
     }
 

--- a/src/picongpu/include/particles/manipulators/DriftImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/DriftImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -40,9 +40,8 @@ struct DriftImpl : private T_ValueFunctor
 
     typedef T_ValueFunctor ValueFunctor;
 
-    HINLINE DriftImpl(uint32_t currentStep)
+    HINLINE DriftImpl(uint32_t)
     {
-
     }
 
     template<typename T_Particle1, typename T_Particle2>

--- a/src/picongpu/include/particles/manipulators/FreeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/FreeImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -43,9 +43,8 @@ struct FreeImpl
         typedef FreeImpl<T_Functor> type;
     };
 
-    HINLINE FreeImpl(uint32_t currentStep)
+    HINLINE FreeImpl(uint32_t)
     {
-
     }
 
     template<typename T_Particle1, typename T_Particle2>

--- a/src/picongpu/include/particles/manipulators/NoneImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/NoneImpl.hpp
@@ -38,7 +38,7 @@ struct NoneImpl
         typedef NoneImpl type;
     };
 
-    HINLINE NoneImpl(uint32_t currentStep)
+    HINLINE NoneImpl(uint32_t)
     {
     }
 

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.def
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.def
@@ -37,6 +37,11 @@ namespace manipulators
  * of the new species' macro particles to be a multiplied by
  * the number of protons on the initial species.
  *
+ * As an example, this comes useful when initializing a quasi-neutral,
+ * pre-ionized plasma of ions and electrons. Electrons can be created
+ * from ions via cloning and increasing their weight to avoid simulating
+ * multiple macro electrons per macro ion (with Z>1).
+ *
  * note: needs the atomicNumbers flag on the initial species,
  *       used by the GetAtomicNumbers trait.
  */

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.def
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.def
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+/* Re-scale the weighting of a cloned species by numberOfProtons
+ *
+ * When cloning species from each other, the new
+ * species "inherits" the macro-particle weighting
+ * of the first one.
+ * This functor can be used to manipulate the weighting
+ * of the new species' macro particles to be a multiplied by
+ * the number of protons on the initial species.
+ *
+ * note: needs the atomicNumbers flag on the initial species,
+ *       used by the GetAtomicNumbers trait.
+ */
+struct ProtonTimesWeightingImpl;
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.hpp
@@ -42,20 +42,33 @@ struct ProtonTimesWeightingImpl
         typedef ProtonTimesWeightingImpl type;
     };
 
-    HINLINE ProtonTimesWeightingImpl(uint32_t currentStep)
+    HINLINE ProtonTimesWeightingImpl(uint32_t)
     {
-
     }
 
-    template<typename T_Particle1, typename T_Particle2>
+    /* Increase weighting of particleDest by proton number of SrcParticle
+     *
+     * The frame's `atomicNumber` `numberOfProtons`of `T_SrcParticle`
+     * is used to increase the weighting of particleDest.
+     * Useful to increase the weighting of macro electrons when cloned from an
+     * ion with Z>1. Otherwise one would need Z macro electrons (each with the
+     * same weighting as the initial ion) to keep the charge of a pre-ionized
+     * atom neutral.
+     *
+     * \tparam T_DestParticle type of the particle species with weighting to manipulate
+     * \tparam T_SrcParticle type of the particle species with proton number Z
+     *
+     * \see picongpu::particles::ManipulateCloneSpecies , picongpu::kernelCloneParticles
+     */
+    template<typename T_DestParticle, typename T_SrcParticle>
     DINLINE void operator()(const DataSpace<simDim>&,
-                            T_Particle1& particleSpecies1, T_Particle2&,
-                            const bool isParticle1, const bool isParticle2)
+                            T_DestParticle& particleDest, T_SrcParticle&,
+                            const bool isDestParticle, const bool isSrcParticle)
     {
-        if (isParticle1 && isParticle2)
+        if (isDestParticle && isSrcParticle)
         {
-            const float_X protonNumber = traits::GetAtomicNumbers<T_Particle2>::type::numberOfProtons;
-            particleSpecies1[weighting_] *= protonNumber;
+            const float_X protonNumber = traits::GetAtomicNumbers<T_SrcParticle>::type::numberOfProtons;
+            particleDest[weighting_] *= protonNumber;
         }
     }
 };

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeightingImpl.hpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "particles/manipulators/ProtonTimesWeightingImpl.def"
+#include "particles/traits/GetAtomicNumbers.hpp"
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+struct ProtonTimesWeightingImpl
+{
+
+    template<typename T_SpeciesType>
+    struct apply
+    {
+        typedef ProtonTimesWeightingImpl type;
+    };
+
+    HINLINE ProtonTimesWeightingImpl(uint32_t currentStep)
+    {
+
+    }
+
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>&,
+                            T_Particle1& particleSpecies1, T_Particle2&,
+                            const bool isParticle1, const bool isParticle2)
+    {
+        if (isParticle1 && isParticle2)
+        {
+            const float_X protonNumber = traits::GetAtomicNumbers<T_Particle2>::type::numberOfProtons;
+            particleSpecies1[weighting_] *= protonNumber;
+        }
+    }
+};
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/RatioWeightingImpl.def
+++ b/src/picongpu/include/particles/manipulators/RatioWeightingImpl.def
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+/* Re-scale the weighting of a cloned species by densityRatio
+ *
+ * When cloning species from each other, the new
+ * species "inherits" the macro-particle weighting
+ * of the first one.
+ * This functor can be used to manipulate the weighting
+ * of the new species' macro particles to satisfy the
+ * input densityRatio of it.
+ *
+ * note: needs the densityRatio flag on both species,
+ *       used by the GetDensityRatio trait.
+ */
+struct RatioWeighting;
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/RatioWeightingImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RatioWeightingImpl.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "particles/manipulators/RatioWeightingImpl.def"
+#include "particles/traits/GetDensityRatio.hpp"
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+struct RatioWeightingImpl
+{
+
+    template<typename T_SpeciesType>
+    struct apply
+    {
+        typedef RatioWeightingImpl type;
+    };
+
+    HINLINE RatioWeightingImpl(uint32_t currentStep)
+    {
+
+    }
+
+    template<typename T_Particle1, typename T_Particle2>
+    DINLINE void operator()(const DataSpace<simDim>&,
+                            T_Particle1& particleSpecies1, T_Particle2&,
+                            const bool isParticle1, const bool isParticle2)
+    {
+        if (isParticle1 && isParticle2)
+        {
+            const float_X densityRatioDes =
+                traits::GetDensityRatio<T_Particle1>::type::getDefaultValue();
+            const float_X densityRatioSrc =
+                traits::GetDensityRatio<T_Particle2>::type::getDefaultValue();
+
+            particleSpecies1[weighting_] *= densityRatioDes / densityRatioSrc;
+        }
+    }
+};
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Marco Garten
+ * Copyright 2015 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -39,9 +39,8 @@ struct SetAttributeImpl : private T_ValueFunctor
 
     typedef T_ValueFunctor ValueFunctor;
 
-    HINLINE SetAttributeImpl(uint32_t currentStep)
+    HINLINE SetAttributeImpl(uint32_t)
     {
-
     }
 
     template<typename T_Particle1, typename T_Particle2>

--- a/src/picongpu/include/particles/manipulators/manipulators.def
+++ b/src/picongpu/include/particles/manipulators/manipulators.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -32,3 +32,5 @@
 #include "particles/manipulators/FreeImpl.def"
 #include "particles/manipulators/SetAttributeImpl.def"
 #include "particles/manipulators/RandomPositionImpl.def"
+#include "particles/manipulators/RatioWeightingImpl.def"
+#include "particles/manipulators/ProtonTimesWeightingImpl.def"

--- a/src/picongpu/include/particles/manipulators/manipulators.hpp
+++ b/src/picongpu/include/particles/manipulators/manipulators.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -31,3 +31,5 @@
 #include "particles/manipulators/FreeImpl.hpp"
 #include "particles/manipulators/SetAttributeImpl.hpp"
 #include "particles/manipulators/RandomPositionImpl.hpp"
+#include "particles/manipulators/RatioWeightingImpl.hpp"
+#include "particles/manipulators/ProtonTimesWeightingImpl.hpp"


### PR DESCRIPTION
This commit adds new manipulators that can be used during the species init-pipeline.

- `RatioWeightingImpl`: Useful to clone one ion species from an other ion species by still satisfying the `densityRatio` of the new created species.

- `ProtonTimesWeightingImpl`: Useful to clone electron species from an ion species for pre-ionized plasmas. The weighting of the electrons is simply multiplied by the proton number of the initial ion species.

### Example Usage

in `particleConfig.param`:
```c++
namespace picongpu
{
namespace particles
{
// [...]
namespace manipulators
{
    // [...]
    typedef ProtonTimesWeightingImpl ProtonTimesWeighting;
    typedef RatioWeightingImpl RatioWeighting;
} /* namespace manipulators */
// [...]
} /* namespace particles */
} /* namespace picongpu */
```

in `speciesInitialization.param`:
```c++
namespace picongpu
{
namespace particles
{
    // [...]
    // Init-Pipeline for PMMA with Carbon, Oxygen, Proton and a general Electron species
    // (4 species in total, need to be defined in `speciesDefinition.param`)
    typedef mpl::vector<
        /* at this point, the reference density * densityRatio is taken to
         * calculate weightings */
        CreateGas<gasProfiles::SphereFlanks, startPosition::Random, PIC_Proton>,
        /* clone and weight additional ions according to their `densityRatio` */
        ManipulateCloneSpecies<manipulators::RatioWeighting, PIC_Proton, PIC_Carbon>,
        ManipulateCloneSpecies<manipulators::RatioWeighting, PIC_Proton, PIC_Oxygen>,
        /* re-distribute new ion species in their cell */
        Manipulate<manipulators::RandomPosition, PIC_Carbon>,
        Manipulate<manipulators::RandomPosition, PIC_Oxygen>,
        /* create electrons with numberOfProtons-higher weighting to emulate pre-ionization,
         * additionally, the initial plasma distribution is now field-neutral */
        ManipulateCloneSpecies<manipulators::ProtonTimesWeighting, PIC_Carbon, PIC_Electrons>,
        ManipulateCloneSpecies<manipulators::ProtonTimesWeighting, PIC_Oxygen, PIC_Electrons>,
        /* cloning from Hydrogen (Protons) is always easy: numberOfProtons == 1 */
        CloneSpecies<PIC_Proton, PIC_Electrons>
    > InitPipeline;
} /* namespace particles */
} /* namespace picongpu */
```

*Alternatively*, if `CreateGas` is using a quick/unexpensive functor and one does not care that `MIN_WEIGHTING` might create cells in low-density areas with only some of the three ion species:
```c++
namespace picongpu
{
namespace particles
{
    // [...]
    // Init-Pipeline for PMMA with Carbon, Oxygen, Proton and a general Electron species
    // (4 species in total, need to be defined in `speciesDefinition.param`)
    typedef mpl::vector<
        /* at this point, the reference density * densityRatio is taken to
         * calculate weightings */
        CreateGas<gasProfiles::SphereFlanks, startPosition::Random, PIC_Proton>,
        CreateGas<gasProfiles::SphereFlanks, startPosition::Random, PIC_Carbon>,
        CreateGas<gasProfiles::SphereFlanks, startPosition::Random, PIC_Oxygen>,
        /* create electrons with numberOfProtons-higher weighting to emulate pre-ionization,
         * additionally, the initial plasma distribution is now field-neutral */
        ManipulateCloneSpecies<manipulators::ProtonTimesWeighting, PIC_Carbon, PIC_Electrons>,
        ManipulateCloneSpecies<manipulators::ProtonTimesWeighting, PIC_Oxygen, PIC_Electrons>,
        /* cloning from Hydrogen (Protons) is always easy: numberOfProtons == 1 */
        CloneSpecies<PIC_Proton, PIC_Electrons>
    > InitPipeline;
} /* namespace particles */
} /* namespace picongpu */
```

### Note

I did only add the second part of the documentation for the new work-flow in `speciesInitialization.param` ([docs init pipeline](https://github.com/ComputationalRadiationPhysics/picongpu/blob/df8e8de789d564b707c6f6936bacb435f8428c11/src/picongpu/include/simulation_defines/param/speciesInitialization.param#L30-L79)) yet.
Missing part: the `particleConfig.param` (will probably be renamed) does include and select (via `typedef`) the `particles/manipulators/` that are used in `speciesInitialization.param` and is not yet documented (will contain a list + short description of all manipulators before the next release, see #1020).

### To do

- [x] compile test: I changed the namings a bit for the functors from my local branch (which was runtime tested)
- add example in follow-up PR? (which one?)
- add according `.def` file to each manipulator's `.hpp` file -> follow-up PR?