### PR TITLE
Ionization: update barrier suppression and energies

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -155,6 +155,7 @@ typedef bmpl::vector<
     chargeRatio<ChargeRatioIons>,
     #if(PARAM_IONIZATION == 1)
     ionizer<particles::ionization::BSI<PIC_Electrons> >,
+    ionizationEnergies<AU::IONIZATION_ENERGY_HYDROGEN_t>,
     #endif
     atomicNumbers<Hydrogen>
 > ParticleFlagsIons;

--- a/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -92,5 +92,11 @@ namespace picongpu
 
     // = 1/c^2
     const float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+
+    /* Atomic unit of electric field in PIC Efield units */
+    const float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+
+    /* Atomic unit of time in PIC units */
+    const float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -92,5 +92,11 @@ namespace picongpu
 
     // = 1/c^2
     const float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+
+    /* Atomic unit of electric field in PIC Efield units */
+    const float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+
+    /* Atomic unit of time in PIC units */
+    const float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu

--- a/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -92,5 +92,11 @@ namespace picongpu
 
     // = 1/c^2
     const float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+
+    /* Atomic unit of electric field in PIC Efield units */
+    const float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+
+    /* Atomic unit of time in PIC units */
+    const float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Marco Garten
+ * Copyright 2014-2015 Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -70,7 +70,7 @@ namespace ionization
             uint32_t cs = math::float2int_rd(chargeState);
 
             /* ionization condition */
-            if (math::abs(eField)*UNIT_EFIELD >= SI::IONIZATION_EFIELD[cs] && chargeState < protonNumber)
+            if (math::abs(eField) / ATOMIC_UNIT_EFIELD >= AU::IONIZATION_EFIELD_HYDROGEN[cs] && chargeState < protonNumber)
             {
                 /* set new particle charge state */
                 parentIon[boundElectrons_] -= float_X(1.0);

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -42,13 +42,16 @@ namespace ionization
     struct BSI_Impl;
 
     /** \struct BSI
-     * 
+     *
      * \brief Barrier Suppression Ionization
      *
      * - takes the ionization energies of the various charge states of ions
-     * - calculates the corresponding field strengths necessary to overcome the binding energy of the electron to the core
+     * - calculates the corresponding field strengths necessary to overcome
+     *   the binding energy of the electron to the core
      * - if the field strength is locally exceeded: increase the charge state
-     * - see for example: Delone, N. B.; Krainov, V. P. (1998). "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
+     * - see for example: Delone, N. B.; Krainov, V. P. (1998).
+     *   "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
+     *   doi:10.1070/PU1998v041n05ABEH000393
      *
      * \tparam T_DestSpecies electron species to be created
      *

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -46,6 +46,7 @@ namespace ionization
 {
 
     /** \struct BSI_Impl
+     * 
      * \brief Barrier Suppression Ionization - Implementation
      *
      * \tparam T_DestSpecies electron species to be created

--- a/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
+++ b/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2015 Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/** forward declarations for ionization algorithms
+ *
+ * ionization model has a < Name >
+ * so the algorithm is called "Algorithm< Name >"
+ */
+
+namespace picongpu
+{
+
+namespace particles
+{
+
+namespace ionization
+{
+
+    struct AlgorithmNone;
+
+    struct AlgorithmBSI;
+
+} // namespace ionization
+
+} // namespace particles
+
+} // namespace picongpu

--- a/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.hpp
+++ b/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.hpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015 Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/ionization/byField/BSI/AlgorithmBSI.hpp"
+#include "particles/ionization/None/AlgorithmNone.hpp"

--- a/src/picongpu/include/particles/traits/GetIonizationEnergies.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizationEnergies.hpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015 Marco Garten, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "static_assert.hpp"
+#include "traits/GetFlagType.hpp"
+#include "traits/Resolve.hpp"
+#include "particles/memory/frames/Frame.hpp"
+
+namespace picongpu
+{
+namespace traits
+{
+template<typename T_Species>
+struct GetIonizationEnergies
+{
+    typedef typename T_Species::FrameType FrameType;
+
+    typedef typename HasFlag<FrameType, ionizationEnergies<> >::type hasIonizationEnergies;
+    /* throw static assert if species has no protons or neutrons */
+    PMACC_CASSERT_MSG(No_ionization_energies_are_defined_for_this_species,hasIonizationEnergies::value==true);
+
+    typedef typename GetFlagType<FrameType,ionizationEnergies<> >::type FoundIonizationEnergiesAlias;
+    /* Extract ionization energy vector from AU namespace */
+    typedef typename PMacc::traits::Resolve<FoundIonizationEnergiesAlias >::type type;
+};
+} //namespace traits
+
+}// namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
+++ b/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Marco Garten
+ * Copyright 2014-2015 Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -20,38 +20,65 @@
 
 /** \file
  * This file contains the ionization energies and conversion to corresponding
- * electric field strengths for different species. */
+ * electric field strengths for different species.
+ */
 
 #pragma once
 
 /** \todo Make compatible for multiple atom species
  * - Probably do some calculation from energy to required field strength (or do that model dependent)
  * - Introduce some clever way of storage, like matrices for different charge states of the same species
- * - future: even different states of excitation should be possible */
+ * - future: even different states of excitation should be possible
+ */
 
 namespace picongpu
 {
-namespace SI
+namespace AU
 {
 
-    /* ionization energy for ground state hydrogen: 13.6 eV --> converted to Joule */
-    /* Joule = kg * m^2 / s^2 */
-    PMACC_CONST_VECTOR(float_X,1,IONIZATION_ENERGY,
-        2.179e-18
+    /** Ionization potentials
+     *
+     * Please follow these rules for defining ionization energies of atomic species,
+     * unless your chosen ionization model requires a different unit system than AU:
+     *     - input of values in either atomic units or converting eV or Joule to them
+     *     -> use either UNITCONV_eV_to_AU or SI::ATOMIC_UNIT_ENERGY for that purpose
+     *     - use float_X as the preferred data type
+     *
+     * example:
+     *     ionization energy for ground state hydrogen: 13.6 eV
+     *     1 Joule       = 1 kg * m^2 / s^2
+     *     1 eV          = 1.602e-19 J
+     *
+     *     1 AU (energy) = 27.2 eV
+     *                   = 1 Hartree
+     *                   = 4.36e-18 J
+     *                   = 2 Rydberg
+     *                   = 2 x Hydrogen ground state binding energy
+     *
+     * Atomic units are useful for ionization models because they simplify the
+     * formulae greatly and provide intuitively understandable relations to a
+     * well-known system, i.e. the Hydrogen atom.
+     *
+     * for PMACC_CONST_VECTOR usage,
+     * @see libPMacc/include/math/ConstVector.hpp
+     * for finding ionization energies,
+     * @see http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html
+     */
+
+    /* ionization energy for ground state hydrogen in atomic units */
+    PMACC_CONST_VECTOR(float_X,1,IONIZATION_ENERGY_HYDROGEN,
+        13.60569 * UNITCONV_eV_to_AU
     );
-    /* ionization field strength (E-field) for hydrogen: in Volt / meter
+    /** Ionization field strengths
      *
-     * usage:
-     * PMACC_CONST_VECTOR(float_X,<NUMBER_OF_PROTONS>,IONIZATION_EFIELD,
-     *     <value_1>,
-     *     ...
-     *     <value_Z>
-     * );
-     *
-     * Do not forget to change the weight of the ion and the atomic numbers in
-     * their respective `.param` file */
-    PMACC_CONST_VECTOR(float_X,1,IONIZATION_EFIELD,
-        5.14e11
+     * Define field strengths for the barrier suppression ionization (BSI) model
+     * in SI units, normalized by the atomic unit (AU) for electric field strength.
+     */
+
+    /* ionization field strength (E-field) for hydrogen in atomic units
+     *     - conversion from V/m to AU (E-field) */
+    PMACC_CONST_VECTOR(float_X,1,IONIZATION_EFIELD_HYDROGEN,
+        5.14e11 / SI::ATOMIC_UNIT_EFIELD
     );
 
 } // namespace SI

--- a/src/picongpu/include/simulation_defines/param/ionizerConfig.param
+++ b/src/picongpu/include/simulation_defines/param/ionizerConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Marco Garten
+ * Copyright 2014-2015 Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -20,27 +20,4 @@
 
 #pragma once
 
-/** forward declarations for ionization algorithms
- *
- * ionization model has a < Name >
- * so the algorithm is called "Algorithm< Name >"
- */
-
-namespace picongpu
-{
-
-namespace particles
-{
-
-namespace ionization
-{
-
-    struct AlgorithmNone;
-
-    struct AlgorithmBSI;
-
-} // namespace ionization
-
-} // namespace particles
-
-} // namespace picongpu
+#include "particles/ionization/byField/fieldIonizationCalc.def"

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013, 2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013, 2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                      Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -42,6 +43,21 @@ namespace picongpu
         const float_64 ELECTRON_MASS_SI = 9.109382e-31;
         /** unit: C */
         const float_64 ELECTRON_CHARGE_SI = -1.602176e-19;
+
+        /* atomic unit for energy:
+         * 1 Rydberg = 27.21 eV --> converted to Joule
+         */
+        const float_64 ATOMIC_UNIT_ENERGY = 4.36e-18;
+
+        /* atomic unit for electric field in V/m:
+         * field strength between electron and core in ground state hydrogen
+         */
+        const float_64 ATOMIC_UNIT_EFIELD = 5.14e11;
+
+        /* atomic unit for time in s:
+         * 150 attoseconds (classical electron orbit time in hydrogen)  / 2 PI
+         */
+        const float_64 ATOMIC_UNIT_TIME = 2.4189e-17;
     }
 
     // converts
@@ -70,5 +86,10 @@ namespace picongpu
     //
     const float_64 UNITCONV_keV_to_Joule = 1.60217646e-16;
     const float_64 UNITCONV_Joule_to_keV = (1.0 / UNITCONV_keV_to_Joule);
+
+    /* 1 atomic unit of energy is equal to 1 Hartree or 2 Rydberg
+     * which is twice the ground state binding energy of atomic hydrogen */
+    const float_64 UNITCONV_AU_to_eV = 27.21139;
+    const float_64 UNITCONV_eV_to_AU = (1.0 / UNITCONV_AU_to_eV);
 
 }

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera, Marco Garten
+ * Copyright 2014-2015 Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -79,6 +79,9 @@ alias(particlePusher);
 
 /*! alias for particle ionizer @see speciesDefinition.param */
 alias(ionizer);
+
+/*! alias for ionization energy container @see ionizationEnergies.param */
+alias(ionizationEnergies);
 
 /*! alias for particle to field interpolation @see species.param */
 alias(interpolation);

--- a/src/picongpu/include/simulation_defines/unitless/ionizerConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/ionizerConfig.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Marco Garten
+ * Copyright 2014-2015 Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -20,5 +20,4 @@
 
 #pragma once
 
-#include "particles/ionization/byField/BSI/AlgorithmBSI.hpp"
-#include "particles/ionization/None/AlgorithmNone.hpp"
+#include "particles/ionization/byField/fieldIonizationCalc.hpp"

--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -93,5 +93,11 @@ namespace picongpu
 
     // = 1/c^2
     const float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+
+    /* Atomic unit of electric field in PIC Efield units */
+    const float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+
+    /* Atomic unit of time in PIC units */
+    const float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu


### PR DESCRIPTION
In preparation for the upcoming ADK model, some of the non-model related changes have been removed from #922 to be implemented before. 

This pull request features:   
- some renaming of the ionization framework and relocation of includes
- ionization energies that are pinned to the particle species itself
- the atomic unit system for ionization energy input

Should be merged **before** #922!

- [x] wait till ~~#1021~~ is merged and rebase