### PR TITLE
GoL: Fix offset for example

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -182,9 +182,10 @@ struct GatherSlice
             for (int i = 0; i < numRanks; ++i)
             {
                 MessageHeader* head = (MessageHeader*) (recvHeader + sizeof(MessageHeader)* i);
+                size_t offset = header.nodeSize.productOfComponents() * static_cast<size_t>(i);
                 Box srcBox = Box(PitchedBox<ValueType, DIM2 > (
-                                                               (ValueType*) fullData,
-                                                               Space(0, head->nodeSize.y() * i),
+                                                               reinterpret_cast<ValueType*>(fullData) + offset,
+                                                               Space(),
                                                                head->nodeSize,
                                                                head->nodeSize.x() * sizeof (ValueType)
                                                                ));


### PR DESCRIPTION
The offset for the example fullData is wrong. This breaks, when there is a layout that has "columns" of GPUs. E.g. 2x2 instead of 1x4