### PR TITLE
performance improvement `Vector<>::operator==()`

### DIFF
--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -423,10 +423,10 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
      */
     HDINLINE bool operator==(const This& rhs) const
     {
+        bool result = true;
         for (int i = 0; i < dim; i++)
-
-            if ((*this)[i] != rhs[i]) return false;
-        return true;
+            result = result && ((*this)[i] == rhs[i]);
+        return result;
     }
 
     /**


### PR DESCRIPTION
- `math::Vector<>::operator==()`: remove early return in comparison operator

The early return results in `stack frame` (slows down the simulation) usage in some cases.

@PrometheusPi : This pull request should solve the performance decrease from #996.