### PR TITLE
Close #1001 LWFA Example: Increase dt to CFL

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -29,7 +29,7 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        const float_64 DELTA_T_SI = 0.8e-16;
+        const float_64 DELTA_T_SI = 1.39e-16;
         /** equals X
          *  unit: meter */
         const float_64 CELL_WIDTH_SI = 0.1772e-6;


### PR DESCRIPTION
This commit closes #1001 by increaseint the time step of the LWFA example so it's closer to the CFL.
This lowers numerical dispersion and also has positive impact on time-to-solution.