### PR TITLE
Move header to PMacc

### DIFF
--- a/src/libPMacc/include/compileTime/conversion/TypeToPointerPair.hpp
+++ b/src/libPMacc/include/compileTime/conversion/TypeToPointerPair.hpp
@@ -1,20 +1,22 @@
 /**
- * Copyright 2013-2014 Rene Widera
+ * Copyright 2013-2015 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
@@ -25,7 +27,7 @@
 #include <boost/mpl/pair.hpp>
 
 
-namespace picongpu
+namespace PMacc
 {
 
 /** Wrapper to use any type as identifier
@@ -62,7 +64,7 @@ struct MakeIdentifier<TypeAsIdentifier<T_Type> >
 /** create boost mpl pair <TypeAsIdentifier<Type>,PointerOfType>
  *
  * @tparam T_Type any type
- * @return ::type boos::mpl::pair<TypeAsIdentifier<Type>,PointerOfType>
+ * @return ::type boost::mpl::pair<TypeAsIdentifier<Type>,PointerOfType>
  */
 template<typename T_Type>
 struct TypeToPointerPair
@@ -71,4 +73,4 @@ struct TypeToPointerPair
     typedef bmpl::pair< typename MakeIdentifier<T_Type>::type , TypePtr > type;
 };
 
-}//namespace picongpu
+}//namespace PMacc


### PR DESCRIPTION
Moves the generic header to PMacc
Requires confirmation by @psychocoderHPC 