### PR TITLE
Move MallocMCBuffer to PMacc

### DIFF
--- a/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.hpp
@@ -1,36 +1,35 @@
 /**
  * Copyright 2015 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-
 
 #pragma once
 
 
 #include "dataManagement/ISimulationData.hpp"
-#include "simulation_defines.hpp"
 
 #include "mallocMC/mallocMC.hpp"
 #include <string>
 
-namespace picongpu
+namespace PMacc
 {
-    using namespace PMacc;
 
     class MallocMCBuffer : public ISimulationData
     {
@@ -66,6 +65,6 @@ namespace picongpu
     };
 
 
-} // namespace picongpu
+} // namespace PMacc
 
-#include "particles/MallocMCBuffer.tpp"
+#include "particles/memory/buffers/MallocMCBuffer.tpp"

--- a/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.tpp
@@ -1,30 +1,34 @@
 /**
- * Copyright 2015 Rene Widera
+ * Copyright 2015 Rene Widera, Alexander Grund
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
 
-#include "particles/MallocMCBuffer.hpp"
+#include "particles/memory/buffers/MallocMCBuffer.hpp"
+#include "types.h"
+#include "Environment.hpp"
+#include "eventSystem/EventSystem.hpp"
 
-namespace picongpu
+namespace PMacc
 {
-using namespace PMacc;
 
 MallocMCBuffer::MallocMCBuffer( ) : hostPtr( NULL ),hostBufferOffset(0)
 {
@@ -55,16 +59,16 @@ void MallocMCBuffer::synchronize( )
          * but with the some result (create page-locked memory)
          */
         hostPtr = new char[deviceHeapInfo.size];
-        CUDA_CHECK(cudaHostRegister(hostPtr,deviceHeapInfo.size,cudaHostRegisterDefault));
+        CUDA_CHECK(cudaHostRegister(hostPtr, deviceHeapInfo.size, cudaHostRegisterDefault));
 
 
-        this->hostBufferOffset=int64_t(((char*)deviceHeapInfo.p) - hostPtr);
+        this->hostBufferOffset = static_cast<int64_t>(reinterpret_cast<char*>(deviceHeapInfo.p) - hostPtr);
     }
     /* add event system hints */
     __startOperation(ITask::TASK_CUDA);
     __startOperation(ITask::TASK_HOST);
-    CUDA_CHECK(cudaMemcpy(hostPtr,deviceHeapInfo.p,deviceHeapInfo.size,cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(hostPtr, deviceHeapInfo.p, deviceHeapInfo.size, cudaMemcpyDeviceToHost));
 
 }
 
-} //namespace picongpu
+} //namespace PMacc

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2014-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -50,7 +50,7 @@
 #include "pluginSystem/PluginConnector.hpp"
 #include "simulationControl/MovingWindow.hpp"
 #include "math/Vector.hpp"
-#include "particles/MallocMCBuffer.hpp"
+#include "particles/memory/buffers/MallocMCBuffer.hpp"
 #include "traits/Limits.hpp"
 
 #include "plugins/ILightweightPlugin.hpp"

--- a/src/picongpu/include/plugins/adios/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/WriteSpecies.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2014-2015 Rene Widera, Felix Schmitt, Axel Huebl
+ * Copyright 2014-2015 Rene Widera, Felix Schmitt, Axel Huebl,
+ *                     Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -46,6 +47,7 @@
 
 #include "particles/particleFilter/FilterFactory.hpp"
 #include "particles/particleFilter/PositionFilter.hpp"
+#include "particles/memory/buffers/MallocMCBuffer.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -1,7 +1,7 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -44,7 +44,6 @@
 #include "fields/FieldB.hpp"
 #include "fields/FieldJ.hpp"
 #include "fields/FieldTmp.hpp"
-#include "particles/MallocMCBuffer.hpp"
 #include "fields/MaxwellSolver/Solvers.hpp"
 #include "fields/currentInterpolation/CurrentInterpolation.hpp"
 #include "fields/background/cellwiseOperation.hpp"
@@ -62,6 +61,7 @@
 #include "algorithms/ForEach.hpp"
 #include "particles/ParticlesFunctors.hpp"
 #include "particles/InitFunctors.hpp"
+#include "particles/memory/buffers/MallocMCBuffer.hpp"
 #include <boost/mpl/int.hpp>
 
 namespace picongpu


### PR DESCRIPTION
This class might also be useful outside of PIConGPU as it's pretty generic

- Requires mallocMC when used
- Also some minor changes to formatting, C-Style casts and includes

Requires permission by @psychocoderHPC 