### PR TITLE
Gas Profiles: Correct Definiton List is HDF5 is disabled

### DIFF
--- a/src/picongpu/include/particles/gasProfiles/profiles.def
+++ b/src/picongpu/include/particles/gasProfiles/profiles.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -28,7 +28,4 @@
 #include "particles/gasProfiles/LinearExponentialImpl.def"
 #include "particles/gasProfiles/GaussianCloudImpl.def"
 #include "particles/gasProfiles/SphereFlanksImpl.def"
-
-#if (ENABLE_HDF5 == 1)
 #include "particles/gasProfiles/FromHDF5Impl.def"
-#endif


### PR DESCRIPTION
The include for HDF5 support is not included when ENABLE_HDF5 !== 1 but gasConfig.param used it anyway.
Make this consistent and completely remove it when ENABLE_HDF5 is not set to 1