### PR TITLE
Add missing includes and virtual destructors

### DIFF
--- a/src/libPMacc/include/dataManagement/ISimulationData.hpp
+++ b/src/libPMacc/include/dataManagement/ISimulationData.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Rene Widera, Felix Schmitt, Benjamin Worpitz
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -35,6 +36,7 @@ namespace PMacc
     class ISimulationData
     {
     public:
+        virtual ~ISimulationData(){}
         /**
          * Synchronizes simulation data, meaning accessing (host side) data
          * will return up-to-date values.

--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -24,7 +25,7 @@
 
 #include "particles/ParticlesBase.kernel"
 #include "fields/SimulationFieldHelper.hpp"
-#include "mappings/kernel/ExchangeMapping.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
 
 #include "particles/memory/boxes/ParticlesBox.hpp"
 #include "particles/memory/buffers/ParticlesBuffer.hpp"
@@ -70,6 +71,8 @@ protected:
     ParticlesBase(MappingDesc description) : SimulationFieldHelper<MappingDesc>(description), particlesBuffer(NULL)
     {
     }
+
+    virtual ~ParticlesBase(){}
 
     /* Shift all particle in a AREA
      * @tparam AREA area which is used (CORE,BORDER,GUARD or a combination)

--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -27,6 +28,7 @@
 #include "dimensions/DataSpace.hpp"
 #include "particles/memory/dataTypes/SuperCell.hpp"
 #include "memory/boxes/PitchedBox.hpp"
+#include "memory/boxes/DataBox.hpp"
 #include "particles/memory/dataTypes/Pointer.hpp"
 
 namespace PMacc

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -24,9 +24,6 @@
 
 #pragma once
 
-#include <iostream>
-#include <iomanip>
-
 #include "types.h"
 
 #include "mappings/simulation/GridController.hpp"
@@ -38,6 +35,9 @@
 
 #include "pluginSystem/IPlugin.hpp"
 
+#include <iostream>
+#include <iomanip>
+#include <fstream>
 
 namespace PMacc
 {


### PR DESCRIPTION
This adds some more includes that were missing. Detected by using another include order than in PIConGPU.

Also adds virtual destructors to 2 virtual classes. One of them is in the same file as the include fix and this is only a minor change. Tell me, if a separate PR is still required.
Reasoning: Virtual classes should have virtual destructors in case anyone deletes it through a base pointer.