### PR TITLE
refactor particle update

### DIFF
--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -400,8 +400,9 @@ public:
         EventTask updateEvent;
         EventTask commEvent;
 
-        ForEach<VectorAllSpecies, particles::CallUpdate<bmpl::_1>, MakeIdentifier<bmpl::_1> > particleUpdate;
-        particleUpdate(forward(particleStorage), currentStep, initEvent, forward(updateEvent), forward(commEvent));
+        /* push all species */
+        particles::PushAllSpecies pushAllSpecies;
+        pushAllSpecies(particleStorage, currentStep, initEvent, updateEvent, commEvent);
 
         __setTransactionEvent(updateEvent);
         /** remove background field for particle pusher */


### PR DESCRIPTION
- add functor `PushAllSpecies`
- add functor `CommunicateSpecies`
- add functor `PushSpecies`
- remove functor `CallUpdate`

This pull request optimize the overlapping of the species push calculation and the communication.
The optimization results in a constant time step reduction of `2ms/species`

Tests:
- [x] KHI electrons/positrons
