### PR TITLE
remove wrong intensity to a_0 conversion

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/fieldBackground.param
+++ b/examples/Bunch/include/simulation_defines/param/fieldBackground.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Axel Huebl, Alexander Debus
+ * Copyright 2014-2015 Axel Huebl, Alexander Debus, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -88,20 +88,12 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            /* const float_64 UNITCONV_Intens_to_A0 = SI::ELECTRON_CHARGE_SI
-                * SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI
-                * SI::ELECTRON_MASS_SI * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
-                * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI
-                * SI::SPEED_OF_LIGHT_SI * SI::EPS0_SI); */
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
                 * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
                 * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
 
-            /* unit: W / m^2
-             * const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-             * unit: none
-             * const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
-             */
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /* unit: none */
             const float_64 _A0  = 1.0;
@@ -180,20 +172,12 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            /* const float_64 UNITCONV_Intens_to_A0 = SI::ELECTRON_CHARGE_SI
-                * SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI
-                * SI::ELECTRON_MASS_SI * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
-                * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI
-                * SI::SPEED_OF_LIGHT_SI * SI::EPS0_SI); */
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
                 * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
                 * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
 
-            /* unit: W / m^2
-             * const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-             * unit: none
-             * const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
-             */
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             const float_64 _A0  = 1.0;

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -34,13 +34,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 const float_64 _A0  = 1.5;
@@ -93,7 +90,6 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / ( 4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI );
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: Volt /meter */
@@ -147,13 +143,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 const float_64 _A0 = 1.0;
@@ -204,13 +197,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 //const float_64 _A0  = 3.9;
@@ -270,13 +260,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 //const float_64 _A0  = 3.9;

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -34,13 +34,10 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / ( 4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI );
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
-            //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-            /** unit: none */
-            //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             const float_64 _A0  = 8.0;
@@ -93,7 +90,6 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / ( 4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI );
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: Volt /meter */
@@ -147,13 +143,10 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / ( 4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI );
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
-            //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-            /** unit: none */
-            //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             const float_64 _A0 = 1.5;
@@ -204,13 +197,10 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / ( 4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI );
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
-            //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-            /** unit: none */
-            //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             //const float_64 _A0  = 3.9;
@@ -271,13 +261,10 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / ( 4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI );
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
-            //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-            /** unit: none */
-            //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             //const float_64 _A0  = 3.9;

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -34,13 +34,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 //const float_64 _A0  = 1.5;
@@ -93,13 +90,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 //const float_64 _A0  = 1.5;
@@ -158,13 +152,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 const float_64 _A0 = 1.0;
@@ -215,13 +206,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 //const float_64 _A0  = 3.9;
@@ -281,13 +269,10 @@ namespace SI
 const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
 const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
-//const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-/** unit: none */
-//const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
 //const float_64 _A0  = 3.9;

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -34,13 +34,10 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
-            //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-            /** unit: none */
-            //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             //const float_64 _A0  = 1.5;
@@ -93,7 +90,6 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / ( 4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI );
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: Volt /meter */
@@ -147,13 +143,10 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
-            //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-            /** unit: none */
-            //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             const float_64 _A0 = 1.5;
@@ -204,13 +197,10 @@ namespace picongpu
         const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
         /** UNITCONV */
-        const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
         const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
         /** unit: W / m^2 */
-        //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-        /** unit: none */
-        //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
         /** unit: none */
         //const float_64 _A0  = 3.9;
@@ -271,13 +261,10 @@ namespace picongpu
             const float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            const float_64 UNITCONV_Intens_to_A0 = ::picongpu::SI::ELECTRON_CHARGE_SI * ::picongpu::SI::ELECTRON_CHARGE_SI * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::EPS0_SI);
             const float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
-            //const float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4;
-            /** unit: none */
-            //const float_64 _A0  = _PEAK_INTENSITY_SI * UNITCONV_Intens_to_A0;
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
             //const float_64 _A0  = 3.9;


### PR DESCRIPTION
This pull request adjusts the wrong conversion from laser intensity to a_0 in `laserConfig.param` and one `fieldBackground.param` as discussed last week in person with @ax3l and @psychocoderHPC.
Since it was only a commented code part, it is **not a bug** but a **fix of documentation**.

@BeyondEspresso please have a look at this pull request as well since I adjusted your `fieldBackground.param`.

