### PR TITLE
add trait  GetDefaultConstructibleType

### DIFF
--- a/src/libPMacc/include/traits/GetEmptyDefaultConstructibleType.hpp
+++ b/src/libPMacc/include/traits/GetEmptyDefaultConstructibleType.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2015 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace PMacc
+{
+namespace traits
+{
+
+/** Get type with empty default constructor
+ *
+ * the returned type must fulfill the points:
+ *   1. empty constructor
+ *   2. no default initialized member inside the empty constructor
+ *   3. all member must fulfill point 1. and 2.
+ *   4. all base classes must fulfill 1. and 2.
+ *
+ * The result is typical used to define structs/classes in the cuda shared memory
+ *
+ * @tparam T_Type any object (class or typename)
+ *
+ * @treturn ::type
+ */
+template<typename T_Type>
+struct GetEmptyDefaultConstructibleType;
+
+
+}//namespace traits
+
+}//namespace PMacc


### PR DESCRIPTION
- define new trait to get shared memory compatible types

It is not allowed that a object in cuda shared memory initialize any member in it's default constructor.
This trait returned a shared memory compatible type.

This pull request shipped only the definition of the trait, at the moment there is no specialized type that can used with the new trait.