### PR TITLE
Calculate better seeds

### DIFF
--- a/src/libPMacc/include/algorithms/reverseBits.hpp
+++ b/src/libPMacc/include/algorithms/reverseBits.hpp
@@ -25,7 +25,7 @@
 
 #include "static_assert.hpp"
 #include <boost/type_traits.hpp>
-#include <climits>
+#include <limits>
 
 namespace PMacc {
 
@@ -48,7 +48,7 @@ reverseBits(T value)
     /* init with value (to get LSB) */
     T result = value;
     /* extra shift needed at end */
-    int s = sizeof(T) * CHAR_BIT - 1;
+    int s = std::numeric_limits<T>::digits - 1;
     for (value >>= 1; value; value >>= 1)
     {
         result <<= 1;

--- a/src/libPMacc/include/algorithms/reverseBits.hpp
+++ b/src/libPMacc/include/algorithms/reverseBits.hpp
@@ -25,7 +25,7 @@
 
 #include "static_assert.hpp"
 #include <boost/type_traits.hpp>
-#include <limits>
+#include <climits>
 
 namespace PMacc {
 
@@ -48,7 +48,7 @@ reverseBits(T value)
     /* init with value (to get LSB) */
     T result = value;
     /* extra shift needed at end */
-    int s = std::numeric_limits<T>::digits - 1;
+    int s = sizeof(T) * CHAR_BIT - 1;
     for (value >>= 1; value; value >>= 1)
     {
         result <<= 1;

--- a/src/libPMacc/include/mpi/SeedPerRank.hpp
+++ b/src/libPMacc/include/mpi/SeedPerRank.hpp
@@ -68,7 +68,7 @@ namespace mpi
             /* localSeed often contains a counted number, so we rotate it by some bits to not "destroy"
              * the counted rank that is already there. Also it is not reversed to get a different pattern
              */
-            localSeed = (localSeed << 16) | (localSeed >> (std::numeric_limits<uint32_t>::digits - 16));
+            localSeed = (localSeed << 16) | (localSeed >> (sizeof(uint32_t) * CHAR_BIT - 16));
             globalUniqueSeed ^= localSeed;
             /* For any globally constant localSeed globalUniqueSeed is now guaranteed
              * to be globally unique

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Rene Widera
+ * Copyright 2015 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -51,8 +51,11 @@ struct RandomPositionImpl
 
         GlobalSeed globalSeed;
         mpi::SeedPerRank<simDim> seedPerRank;
-        seed = seedPerRank(globalSeed(), PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid());
-        seed ^= POSITION_SEED ^ currentStep;
+        seed = globalSeed() ^
+               PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() ^
+               POSITION_SEED;
+        seed = seedPerRank(seed);
+        seed ^= currentStep;
 
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         localCells = subGrid.getLocalDomain().size;

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -54,8 +54,7 @@ struct RandomPositionImpl
         seed = globalSeed() ^
                PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() ^
                POSITION_SEED;
-        seed = seedPerRank(seed);
-        seed ^= currentStep;
+        seed = seedPerRank(seed) ^ currentStep;
 
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         localCells = subGrid.getLocalDomain().size;

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera,
+ *                     Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -54,8 +55,10 @@ struct TemperatureImpl : private T_ValueFunctor
 
         GlobalSeed globalSeed;
         mpi::SeedPerRank<simDim> seedPerRank;
-        seed = seedPerRank(globalSeed(), PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid());
-        seed ^= TEMPERATURE_SEED;
+        seed = globalSeed() ^
+               PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() ^
+               TEMPERATURE_SEED;
+        seed = seedPerRank(seed);
 
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         localCells = subGrid.getLocalDomain().size;

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -58,7 +58,7 @@ struct TemperatureImpl : private T_ValueFunctor
         seed = globalSeed() ^
                PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() ^
                TEMPERATURE_SEED;
-        seed = seedPerRank(seed);
+        seed = seedPerRank(seed) ^ currentStep;
 
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         localCells = subGrid.getLocalDomain().size;

--- a/src/picongpu/include/particles/startPosition/RandomImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/RandomImpl.hpp
@@ -57,7 +57,7 @@ struct RandomImpl
         seed = globalSeed() ^
                PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() ^
                POSITION_SEED;
-        seed = seedPerRank(seed);
+        seed = seedPerRank(seed) ^ currentStep;
 
         const uint32_t numSlides = MovingWindow::getInstance( ).getSlideCounter( currentStep );
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();

--- a/src/picongpu/include/particles/startPosition/RandomImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/RandomImpl.hpp
@@ -53,8 +53,11 @@ struct RandomImpl
         typedef typename SpeciesType::FrameType FrameType;
 
         mpi::SeedPerRank<simDim> seedPerRank;
-        seed = seedPerRank(GlobalSeed()(), PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid());
-        seed ^= POSITION_SEED;
+        GlobalSeed globalSeed;
+        seed = globalSeed() ^
+               PMacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() ^
+               POSITION_SEED;
+        seed = seedPerRank(seed);
 
         const uint32_t numSlides = MovingWindow::getInstance( ).getSlideCounter( currentStep );
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();


### PR DESCRIPTION
This improves the global  uniqueness of the seeds by using local seeds that vary in the upper bits.

When XORing those with e.g. cellIdxs that are counted (from 0-N) the resulting seeds are still globally unique. Previously the counted rank and the counted cellIdx could cancel each other out resulting in "seed collisions" over different ranks.

Helps e.g. @n01r :)