### PR TITLE
Fix: missing `__syncthreads()` after shared mem usage

### DIFF
--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -117,6 +117,13 @@ namespace ionization
              * This function will be called inline on the device which must happen BEFORE threads diverge
              * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
              * initializing the E-/B-field shared boxes in shared memory.
+             *
+             * @param blockCell Offset of the cell from the origin of the local domain
+             *                  <b>including guarding supercells</b> in units of cells
+             * @param linearThreadIdx Linearized thread ID inside the block
+             * @param localCellOffset Offset of the cell from the origin of the local
+             *                        domain, i.e. from the @see BORDER
+             *                        <b>without guarding supercells</b>
              */
             DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& localCellOffset)
             {

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -46,7 +46,7 @@ namespace ionization
 {
 
     /** \struct BSI_Impl
-     * 
+     *
      * \brief Barrier Suppression Ionization - Implementation
      *
      * \tparam T_DestSpecies electron species to be created
@@ -118,7 +118,7 @@ namespace ionization
              * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
              * initializing the E-/B-field shared boxes in shared memory.
              */
-            DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& totalCellOffset)
+            DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& localCellOffset)
             {
 
                 /* caching of E and B fields */
@@ -143,6 +143,8 @@ namespace ionization
                           cachedE,
                           fieldEBlock
                           );
+                /* wait for shared memory to be initialized */
+                __syncthreads();
             }
 
             /** Functor implementation


### PR DESCRIPTION
* `BSI_Impl.hpp`:    
    * added `__syncthreads()` after fields are copied   
      from global to shared memory   
    * renamed `totalCellOffset` to `localCellOffset`   
      because that's what it is

@n01r Rebase #922 on `dev` after this is merged