### PR TITLE
Output Radiation detector's directions & frequencies

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -39,7 +39,7 @@ namespace picongpu
      *           type: vector_64
      *
      */
-    DINLINE vector_64 observation_direction(const int observation_id_extern)
+    HDINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** Computes observation angles along the x-y plane.
        *  Assuming electron(s) fly in -x direction and the laser

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
@@ -39,7 +39,7 @@ namespace picongpu
      *           type: vector_64
      *
      */
-    DINLINE vector_64 observation_direction(const int observation_id_extern)
+    HDINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** This computes observation directions for one octant
        *  of a sphere around the simulation area.

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
@@ -39,7 +39,7 @@ namespace picongpu
      *           type: vector_64
      *
      */
-    DINLINE vector_64 observation_direction(const int observation_id_extern)
+    HDINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** Computes observation angles along the x-y plane.
        *  Assuming electron(s) fly in -x direction and the laser

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -127,6 +127,8 @@ private:
     uint32_t lastStep;
 
     std::string pathRestart;
+    std::string meshesPathName;
+    std::string particlesPathName;
 
     mpi::MPIReduce reduce;
     bool compressionOn;
@@ -152,6 +154,8 @@ public:
     currentStep(0),
     radPerGPU(false),
     lastStep(0),
+    meshesPathName("DetectorMesh/"),
+    particlesPathName("DetectorParticle/"),
     compressionOn(false)
     {
         Environment<>::get().PluginConnector().registerPlugin(this);
@@ -615,13 +619,13 @@ private:
                              radSplashType,
                              3,
                              dataSelection,
-                             dataLabels(ampIndex).c_str(),
+                             (meshesPathName + dataLabels(ampIndex)).c_str(),
                              values);
 
           /* save SI unit as attribute together with data set */
           HDF5dataFile.writeAttribute(currentStep,
                                       radSplashType,
-                                      dataLabels(ampIndex).c_str(),
+                                      (meshesPathName + dataLabels(ampIndex)).c_str(),
                                       "unitSI",
                                       &factor);
       }
@@ -629,7 +633,7 @@ private:
       /* save SI unit as attribute in the Amplitude group (for convenience) */
       HDF5dataFile.writeAttribute(currentStep,
                                   radSplashType,
-                                  "Amplitude",
+                                  (meshesPathName + std::string("Amplitude")).c_str(),
                                   "unitSI",
                                   &factor);
 
@@ -656,7 +660,7 @@ private:
                              radSplashType,
                              3,
                              dataSelection,
-                             dataLabelsDetector(detectorDim).c_str(),
+                             (meshesPathName + dataLabelsDetector(detectorDim)).c_str(),
                              detectorPositions);
       }
 
@@ -679,14 +683,14 @@ private:
                          radSplashType,
                          3,
                          dataSelection,
-                         dataLabelsDetector(3).c_str(),
+                         (meshesPathName + dataLabelsDetector(3)).c_str(),
                          detectorFrequencies);
 
       /* save SI unit as attribute together with data set */
       const picongpu::float_64 factorOmega = 1.0 / UNIT_TIME ;
       HDF5dataFile.writeAttribute(currentStep,
                                   radSplashType,
-                                  dataLabelsDetector(3).c_str(),
+                                  (meshesPathName + dataLabelsDetector(3)).c_str(),
                                   "unitSI",
                                   &factorOmega);
 
@@ -710,17 +714,16 @@ private:
                                         "basePath",
                                         basePath.c_str() );
 
-      std::string meshesPath("fields/");
-      splash::ColTypeString ctMeshesPath(meshesPath.length());
+      splash::ColTypeString ctMeshesPath(meshesPathName.length());
       HDF5dataFile.writeGlobalAttribute(ctMeshesPath,
                                         "meshesPath",
-                                        meshesPath.c_str() );
+                                        meshesPathName.c_str() );
 
-      std::string particlesPath("particles/");
-      splash::ColTypeString ctParticlesPath(particlesPath.length());
+
+      splash::ColTypeString ctParticlesPath(particlesPathName.length());
       HDF5dataFile.writeGlobalAttribute( ctParticlesPath,
                                          "particlesPath",
-                                         particlesPath.c_str() );
+                                         particlesPathName.c_str() );
 
       std::string iterationEncoding("fileBased");
       splash::ColTypeString ctIterationEncoding(iterationEncoding.length());
@@ -828,7 +831,7 @@ private:
           for(uint32_t ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
           {
               HDF5dataFile.read(timeStep,
-                                dataLabels(ampIndex).c_str(),
+                                (meshesPathName + dataLabels(ampIndex)).c_str(),
                                 componentSize,
                                 tmpBuffer);
 

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -530,6 +530,7 @@ private:
    *
    *  Arguments:
    *  int index - index of Amplitude
+   *              "-1" return record name
    *
    *  Return:
    *  std::string - name
@@ -538,34 +539,71 @@ private:
    */
   static const std::string dataLabels(int index)
   {
-      const std::string dataLabelsList[] = {"Amplitude/x/Re",
-                                            "Amplitude/x/Im",
-                                            "Amplitude/y/Re",
-                                            "Amplitude/y/Im",
-                                            "Amplitude/z/Re",
-                                            "Amplitude/z/Im"};
+      const std::string path("Amplitude/");
 
-      return dataLabelsList[index];
+      /* return record name if handed -1 */
+      if(index == -1)
+          return path;
+
+      const std::string dataLabelsList[] = {"x/Re",
+                                            "x/Im",
+                                            "y/Re",
+                                            "y/Im",
+                                            "z/Re",
+                                            "z/Im"};
+
+      return path + dataLabelsList[index];
   }
 
-  /** This method returns hdf5 data structure names for detector positions
+  /** This method returns hdf5 data structure names for detector directions
    *
    *  Arguments:
    *  int index - index of detector
+   *              "-1" return record name
    *
    *  Return:
    *  std::string - name
    *
    * This method avoids initializing static const string arrays.
    */
-  static const std::string dataLabelsDetector(int index)
+  static const std::string dataLabelsDetectorDirection(int index)
   {
-      const std::string dataLabelsList[] = {"Detector/x",
-                                            "Detector/y",
-                                            "Detector/z",
-                                            "Detector/omega"};
+      const std::string path("DetectorDirection/");
 
-      return dataLabelsList[index];
+      /* return record name if handed -1 */
+      if(index == -1)
+          return path;
+
+      const std::string dataLabelsList[] = {"x",
+                                            "y",
+                                            "z"};
+
+      return path + dataLabelsList[index];
+  }
+
+
+  /** This method returns hdf5 data structure names for detector frequencies
+   *
+   *  Arguments:
+   *  int index - index of detector
+   *              "-1" return record name
+   *
+   *  Return:
+   *  std::string - name
+   *
+   * This method avoids initializing static const string arrays.
+   */
+  static const std::string dataLabelsDetectorFrequency(int index)
+  {
+      const std::string path("DetectorFrequency/");
+
+      /* return record name if handed -1 */
+      if(index == -1)
+          return path;
+
+      const std::string dataLabelsList[] = {"omega"};
+
+      return path + dataLabelsList[index];
   }
 
 
@@ -660,7 +698,7 @@ private:
                              radSplashType,
                              3,
                              dataSelection,
-                             (meshesPathName + dataLabelsDetector(detectorDim)).c_str(),
+                             (meshesPathName + dataLabelsDetectorDirection(detectorDim)).c_str(),
                              detectorPositions);
       }
 
@@ -683,14 +721,14 @@ private:
                          radSplashType,
                          3,
                          dataSelection,
-                         (meshesPathName + dataLabelsDetector(3)).c_str(),
+                         (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
                          detectorFrequencies);
 
       /* save SI unit as attribute together with data set */
       const picongpu::float_64 factorOmega = 1.0 / UNIT_TIME ;
       HDF5dataFile.writeAttribute(currentStep,
                                   radSplashType,
-                                  (meshesPathName + dataLabelsDetector(3)).c_str(),
+                                  (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
                                   "unitSI",
                                   &factorOmega);
 

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -654,7 +654,7 @@ private:
    */
   void writeHDF5file(Amplitude* values, std::string name)
   {
-      splash::SerialDataCollector HDF5dataFile(1);
+      splash::SerialDataCollector hdf5DataFile(1);
       splash::DataCollector::FileCreationAttr fAttr;
 
       splash::DataCollector::initFileCreationAttr(fAttr);
@@ -663,7 +663,7 @@ private:
       std::ostringstream filename;
       filename << name << currentStep;
 
-      HDF5dataFile.open(filename.str().c_str(), fAttr);
+      hdf5DataFile.open(filename.str().c_str(), fAttr);
 
       typename PICToSplash<float_64>::type radSplashType;
 
@@ -694,7 +694,7 @@ private:
                                           stride);
 
           /* save data for each x/y/z * Re/Im amplitude */
-          HDF5dataFile.write(currentStep,
+          hdf5DataFile.write(currentStep,
                              radSplashType,
                              3,
                              dataSelection,
@@ -702,7 +702,7 @@ private:
                              values);
 
           /* save SI unit as attribute together with data set */
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       radSplashType,
                                       (meshesPathName + dataLabels(ampIndex)).c_str(),
                                       "unitSI",
@@ -710,7 +710,7 @@ private:
 
           /* position */
           std::vector<float_X> positionMesh(simDim, 0.0); /* there is no offset - zero */
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       splashFloatXType,
                                       (meshesPathName + dataLabels(ampIndex)).c_str(),
                                       "position",
@@ -720,7 +720,7 @@ private:
       }
 
       /* save SI unit as attribute in the Amplitude group (for convenience) */
-      HDF5dataFile.writeAttribute(currentStep,
+      hdf5DataFile.writeAttribute(currentStep,
                                   radSplashType,
                                   (meshesPathName + std::string("Amplitude")).c_str(),
                                   "unitSI",
@@ -745,7 +745,7 @@ private:
                                       offset,
                                       strideDetector);
 
-          HDF5dataFile.write(currentStep,
+          hdf5DataFile.write(currentStep,
                              radSplashType,
                              3,
                              dataSelection,
@@ -754,7 +754,7 @@ private:
 
           /* save SI unit as attribute together with data set */
           const picongpu::float_64 factorDirection = 1.0  ;
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       radSplashType,
                                       (meshesPathName + dataLabelsDetectorDirection(detectorDim)).c_str(),
                                       "unitSI",
@@ -762,7 +762,7 @@ private:
 
           /* position */
           std::vector<float_X> positionMesh(simDim, 0.0); /* there is no offset - zero */
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       splashFloatXType,
                                       (meshesPathName + dataLabelsDetectorDirection(detectorDim)).c_str(),
                                       "position",
@@ -787,7 +787,7 @@ private:
                                       offset,
                                       strideOmega);
 
-      HDF5dataFile.write(currentStep,
+      hdf5DataFile.write(currentStep,
                          radSplashType,
                          3,
                          dataSelection,
@@ -796,7 +796,7 @@ private:
 
       /* save SI unit as attribute together with data set */
       const picongpu::float_64 factorOmega = 1.0 / UNIT_TIME ;
-      HDF5dataFile.writeAttribute(currentStep,
+      hdf5DataFile.writeAttribute(currentStep,
                                   radSplashType,
                                   (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
                                   "unitSI",
@@ -804,7 +804,7 @@ private:
 
       /* position */
       std::vector<float_X> positionMesh(simDim, 0.0); /* there is no offset - zero */
-      HDF5dataFile.writeAttribute(currentStep,
+      hdf5DataFile.writeAttribute(currentStep,
                                   splashFloatXType,
                                   (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
                                   "position",
@@ -817,36 +817,36 @@ private:
       /* begin required openPMD global attributes */
       std::string openPMDversion("1.0.0");
       splash::ColTypeString ctOpenPMDversion(openPMDversion.length());
-      HDF5dataFile.writeGlobalAttribute( ctOpenPMDversion,
+      hdf5DataFile.writeGlobalAttribute( ctOpenPMDversion,
                                          "openPMD",
                                          openPMDversion.c_str() );
 
       const uint32_t openPMDextension = 0; // no extension
       splash::ColTypeUInt32 ctUInt32;
-      HDF5dataFile.writeGlobalAttribute( ctUInt32,
+      hdf5DataFile.writeGlobalAttribute( ctUInt32,
                                          "openPMDextension",
                                          &openPMDextension );
 
       std::string basePath("/data/%T/");
       splash::ColTypeString ctBasePath(basePath.length());
-      HDF5dataFile.writeGlobalAttribute(ctBasePath,
+      hdf5DataFile.writeGlobalAttribute(ctBasePath,
                                         "basePath",
                                         basePath.c_str() );
 
       splash::ColTypeString ctMeshesPath(meshesPathName.length());
-      HDF5dataFile.writeGlobalAttribute(ctMeshesPath,
+      hdf5DataFile.writeGlobalAttribute(ctMeshesPath,
                                         "meshesPath",
                                         meshesPathName.c_str() );
 
 
       splash::ColTypeString ctParticlesPath(particlesPathName.length());
-      HDF5dataFile.writeGlobalAttribute( ctParticlesPath,
+      hdf5DataFile.writeGlobalAttribute( ctParticlesPath,
                                          "particlesPath",
                                          particlesPathName.c_str() );
 
       std::string iterationEncoding("fileBased");
       splash::ColTypeString ctIterationEncoding(iterationEncoding.length());
-      HDF5dataFile.writeGlobalAttribute( ctIterationEncoding,
+      hdf5DataFile.writeGlobalAttribute( ctIterationEncoding,
                                          "iterationEncoding",
                                          iterationEncoding.c_str() );
 
@@ -855,15 +855,15 @@ private:
       const int indexCutDirectory = name.rfind('/');
       std::string iterationFormat(name.substr(indexCutDirectory + 1) +  std::string("%T_0_0_0.h5"));
       splash::ColTypeString ctIterationFormat(iterationFormat.length());
-      HDF5dataFile.writeGlobalAttribute( ctIterationFormat,
+      hdf5DataFile.writeGlobalAttribute( ctIterationFormat,
                                          "iterationFormat",
                                          iterationFormat.c_str() );
 
-      HDF5dataFile.writeAttribute(currentStep, splashFloatXType, NULL, "dt", &DELTA_T);
+      hdf5DataFile.writeAttribute(currentStep, splashFloatXType, NULL, "dt", &DELTA_T);
       const float_X time = float_X(currentStep) * DELTA_T;
-      HDF5dataFile.writeAttribute(currentStep, splashFloatXType, NULL, "time", &time);
+      hdf5DataFile.writeAttribute(currentStep, splashFloatXType, NULL, "time", &time);
       splash::ColTypeDouble ctDouble;
-      HDF5dataFile.writeAttribute(currentStep, ctDouble, NULL, "timeUnitSI", &UNIT_TIME);
+      hdf5DataFile.writeAttribute(currentStep, ctDouble, NULL, "timeUnitSI", &UNIT_TIME);
 
       /* end required openPMD global attributes */
 
@@ -873,14 +873,14 @@ private:
       if( author.length() > 0 )
         {
           splash::ColTypeString ctAuthor(author.length());
-          HDF5dataFile.writeGlobalAttribute( ctAuthor,
+          hdf5DataFile.writeGlobalAttribute( ctAuthor,
                                              "author",
                                              author.c_str() );
         }
 
       std::string software("PIConGPU");
       splash::ColTypeString ctSoftware(software.length());
-      HDF5dataFile.writeGlobalAttribute( ctSoftware,
+      hdf5DataFile.writeGlobalAttribute( ctSoftware,
                                          "software",
                                          software.c_str() );
 
@@ -889,13 +889,13 @@ private:
                       << PICONGPU_VERSION_MINOR << "."
                       << PICONGPU_VERSION_PATCH;
       splash::ColTypeString ctSoftwareVersion(softwareVersion.str().length());
-      HDF5dataFile.writeGlobalAttribute( ctSoftwareVersion,
+      hdf5DataFile.writeGlobalAttribute( ctSoftwareVersion,
                                          "softwareVersion",
                                          softwareVersion.str().c_str() );
 
       std::string date  = helper::getDateString("%F %T %z");
       splash::ColTypeString ctDate(date.length());
-      HDF5dataFile.writeGlobalAttribute( ctDate,
+      hdf5DataFile.writeGlobalAttribute( ctDate,
                                          "date",
                                          date.c_str() );
 
@@ -907,13 +907,13 @@ private:
       {
           /* timeOffset */
           const float_X timeOffset = 0.0;
-          HDF5dataFile.writeAttribute(currentStep, splashFloatXType,
+          hdf5DataFile.writeAttribute(currentStep, splashFloatXType,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "timeOffset", &timeOffset);
 
           /* gridGlobalOffset */
           std::vector<float_64> gridGlobalOffset(simDim, 0.0); /* there is no offset - zero */
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       ctDouble,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "gridGlobalOffset",
@@ -924,7 +924,7 @@ private:
           /* gridUnit */
           /* ALL grids have indices as axises - thus no unit conversion */
           const double unitNone = 1.0;
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       ctDouble,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "gridUnitSI",
@@ -933,7 +933,7 @@ private:
           /* geometry */
           const std::string geometry("cartesian");
           splash::ColTypeString ctGeometry(geometry.length());
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       ctGeometry,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "geometry",
@@ -942,7 +942,7 @@ private:
           /* dataOrder */
           const std::string dataOrder("C");
           splash::ColTypeString ctDataOrder(dataOrder.length());
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       ctDataOrder,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "dataOrder",
@@ -951,7 +951,7 @@ private:
           std::vector<float_X> gridSpacing(simDim, 0.0);
           for( uint32_t d = 0; d < simDim; ++d )
               gridSpacing.at(d) = float_X(1.0);
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       splashFloatXType,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "gridSpacing",
@@ -984,7 +984,7 @@ private:
           myArrOfStr = getSplashArrayOfString( myListOfStr );
           splash::ColTypeString ctSomeListOfStr( myArrOfStr.maxLen );
 
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       ctSomeListOfStr,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "axisLabels",
@@ -1011,7 +1011,7 @@ private:
               /* units 1./second -> Time^-1  */
               unitDimension[traits::SIBaseUnits::time] = -1.0;
           }
-          HDF5dataFile.writeAttribute(currentStep,
+          hdf5DataFile.writeAttribute(currentStep,
                                       ctDouble,
                                       (meshesPathName + meshRecordLabels(i)).c_str(),
                                       "unitDimension",
@@ -1024,7 +1024,7 @@ private:
       /* end required openPMD attributes for meshes */
       /* end openPMD attributes */
 
-      HDF5dataFile.close();
+      hdf5DataFile.close();
     }
 
 
@@ -1038,7 +1038,7 @@ private:
    */
   void readHDF5file(Amplitude* values, std::string name, const int timeStep)
   {
-      splash::SerialDataCollector HDF5dataFile(1);
+      splash::SerialDataCollector hdf5DataFile(1);
       splash::DataCollector::FileCreationAttr fAttr;
 
       splash::DataCollector::initFileCreationAttr(fAttr);
@@ -1056,7 +1056,7 @@ private:
       }
       else
       {
-          HDF5dataFile.open(filename.str().c_str(), fAttr);
+          hdf5DataFile.open(filename.str().c_str(), fAttr);
 
           typename PICToSplash<float_64>::type radSplashType;
 
@@ -1069,7 +1069,7 @@ private:
 
           for(uint32_t ampIndex=0; ampIndex < Amplitude::numComponents; ++ampIndex)
           {
-              HDF5dataFile.read(timeStep,
+              hdf5DataFile.read(timeStep,
                                 (meshesPathName + dataLabels(ampIndex)).c_str(),
                                 componentSize,
                                 tmpBuffer);
@@ -1083,7 +1083,7 @@ private:
           }
 
           delete[] tmpBuffer;
-          HDF5dataFile.close();
+          hdf5DataFile.close();
 
           log<picLog::INPUT_OUTPUT > ("Radiation: read radiation data from HDF5");
       }

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -43,9 +43,9 @@ namespace picongpu
       FreqFunctor(void)
       { }
 
-      DINLINE float_X operator()(const int ID)
+      HDINLINE float_X operator()(const int ID)
       {
-    return omega_min + float_X(ID) * delta_omega;
+          return omega_min + float_X(ID) * delta_omega;
       }
     };
 

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -47,12 +47,12 @@ namespace picongpu
       { }
 
       FreqFunctor(DBoxType frequencies_handed)
-    : frequencies(frequencies_handed)
+      : frequencies(frequencies_handed)
       { }
 
-      DINLINE float_X operator()(const unsigned int ID)
+      HDINLINE float_X operator()(const unsigned int ID)
       {
-    return (ID < radiation_frequencies::N_omega) ?  frequencies[ID] : 0.0  ;
+          return (ID < radiation_frequencies::N_omega) ?  frequencies[ID] : 0.0  ;
       }
 
     private:
@@ -78,42 +78,42 @@ namespace picongpu
       HINLINE void Init(const std::string path )
       {
 
-    frequencyBuffer = new GridBuffer<float_X, DIM1>(DataSpace<DIM1> (N_omega));
+          frequencyBuffer = new GridBuffer<float_X, DIM1>(DataSpace<DIM1> (N_omega));
 
 
-    DBoxType frequencyDB = frequencyBuffer->getHostBuffer().getDataBox();
+          DBoxType frequencyDB = frequencyBuffer->getHostBuffer().getDataBox();
 
-    std::ifstream freqListFile(path.c_str());
-    unsigned int i;
+          std::ifstream freqListFile(path.c_str());
+          unsigned int i;
 
-    printf("freq: %s\n", path.c_str());
+          printf("freq: %s\n", path.c_str());
 
-    if(!freqListFile)
-      {
-        throw std::runtime_error(std::string("The radiation-frequency-file ") + path + std::string(" could not be found.\n"));
-      }
+          if(!freqListFile)
+          {
+              throw std::runtime_error(std::string("The radiation-frequency-file ") + path + std::string(" could not be found.\n"));
+          }
 
 
-    for(i=0; i<N_omega && !freqListFile.eof(); ++i)
-      {
-        freqListFile >> frequencyDB[i];
-        // verbose output of loaded frequencies if verbose level PHYSICS is set:
-        log<PIConGPUVerboseRadiation::PHYSICS >("freq: %1% \t %2%") % i % frequencyDB[i];
-        frequencyDB[i] *= UNIT_TIME;
-      }
+          for(i=0; i<N_omega && !freqListFile.eof(); ++i)
+          {
+              freqListFile >> frequencyDB[i];
+              // verbose output of loaded frequencies if verbose level PHYSICS is set:
+              log<PIConGPUVerboseRadiation::PHYSICS >("freq: %1% \t %2%") % i % frequencyDB[i];
+              frequencyDB[i] *= UNIT_TIME;
+          }
 
-    if(i != N_omega)
-      {
-        throw std::runtime_error(std::string("The number of frequencies in the list and the number of frequencies in the parameters differ.\n"));
-      }
+          if(i != N_omega)
+          {
+              throw std::runtime_error(std::string("The number of frequencies in the list and the number of frequencies in the parameters differ.\n"));
+          }
 
-    frequencyBuffer->hostToDevice();
+          frequencyBuffer->hostToDevice();
 
       }
 
       FreqFunctor getFunctor(void)
       {
-    return FreqFunctor(frequencyBuffer->getDeviceBuffer().getDataBox());
+          return FreqFunctor(frequencyBuffer->getDeviceBuffer().getDataBox());
       }
 
     private:

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -43,13 +43,13 @@ namespace picongpu
     public:
       FreqFunctor(void)
       {
-    omega_log_min = math::log(omega_min);
-    delta_omega_log = (math::log(omega_max) - omega_log_min) / float_X(N_omega - 1);
+          omega_log_min = math::log(omega_min);
+          delta_omega_log = (math::log(omega_max) - omega_log_min) / float_X(N_omega - 1);
        }
 
-      DINLINE float_X operator()(const int ID)
+      HDINLINE float_X operator()(const int ID)
       {
-    return  math::exp(omega_log_min + (float_X(ID)) * delta_omega_log) ;
+          return  math::exp(omega_log_min + (float_X(ID)) * delta_omega_log) ;
       }
 
     private:
@@ -70,7 +70,7 @@ namespace picongpu
 
       HINLINE FreqFunctor getFunctor(void)
       {
-    return FreqFunctor();
+          return FreqFunctor();
       }
     };
 

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -39,7 +39,7 @@ namespace picongpu
      *           type: vector_64
      *
      */
-    DINLINE vector_64 observation_direction(const int observation_id_extern)
+    HDINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** compute observation directions for 2D virtual detector field
        *  pointing toward the +x direction


### PR DESCRIPTION
This pull request follows the idea behind openPMD and adds information on frequencies and propagation directions computed with the radiation plugin to the hdf5 output.

This pull request adjusts also some examples since the `radiationObserver.param` needed some updates.

@RemiLehe and @ax3l Is this in agreement with todays offline discussion?

**needs:**
 - [x] #1323 to be merged
