### PR TITLE
ADIOS: Log, Striping & No Meta File

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -164,7 +164,7 @@ TBG_adios="--adios.period 100 --adios.file simData"
 # for parallel large-scale parallel file-systems:
 #   --adios.aggregators <N * 3> --adios.ost <N>
 # avoid writing meta file on massively parallel runs
-#   --adios.create-meta 0
+#   --adios.disable-meta
 # specify further options for the transports, see ADIOS manual
 # chapter 6.1.5, e.g., 'random_offset=1;stripe_count=4'
 #                      (FS chooses OST;user chooses striping factor)

--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -163,6 +163,12 @@ TBG_adios="--adios.period 100 --adios.file simData"
 #   --adios.compression zlib
 # for parallel large-scale parallel file-systems:
 #   --adios.aggregators <N * 3> --adios.ost <N>
+# avoid writing meta file on massively parallel runs
+#   --adios.create-meta 0
+# specify further options for the transports, see ADIOS manual
+# chapter 6.1.5, e.g., 'random_offset=1;stripe_count=4'
+#                      (FS chooses OST;user chooses striping factor)
+#   --adios.transport-params "semicolon_separated_list"
 
 # Create a checkpoint that is restartable every --checkpoints steps
 #   http://git.io/PToFYg

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -105,6 +105,8 @@ struct ThreadParams
     uint64_t adiosGroupSize;                /* size of ADIOS group in bytes */
     uint32_t adiosAggregators;              /* number of ADIOS aggregators for MPI_AGGREGATE */
     uint32_t adiosOST;                      /* number of ADIOS OST for MPI_AGGREGATE */
+    uint32_t adiosCreateMeta;               /* gather and write a meta file online */
+    std::string adiosTransportParams;       /* additional transport params */
     std::string adiosBasePath;              /* base path for the current step */
     std::string adiosCompression;           /* ADIOS data transform compression method */
 

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -105,7 +105,7 @@ struct ThreadParams
     uint64_t adiosGroupSize;                /* size of ADIOS group in bytes */
     uint32_t adiosAggregators;              /* number of ADIOS aggregators for MPI_AGGREGATE */
     uint32_t adiosOST;                      /* number of ADIOS OST for MPI_AGGREGATE */
-    uint32_t adiosCreateMeta;               /* gather and write a meta file online */
+    bool adiosDisableMeta;                  /* disable online gather and write of a meta file */
     std::string adiosTransportParams;       /* additional transport params */
     std::string adiosBasePath;              /* base path for the current step */
     std::string adiosCompression;           /* ADIOS data transform compression method */

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -27,7 +27,8 @@
 #include <limits>
 #include <sstream>
 #include <string>
-#include <iostream> // std::cerr
+#include <iostream>  // std::cerr
+#include <stdexcept> // throw std::runtime_error
 
 #include "types.h"
 #include "math/Vector.hpp"
@@ -58,22 +59,34 @@ namespace po = boost::program_options;
 #define ADIOS_SIZE_GLOBAL    "totalSize_"
 #define ADIOS_OFFSET_GLOBAL  "offset_"
 
-#define ADIOS_CMD(_cmd)                                                        \
-{                                                                              \
-    int _err_code = _cmd;                                                      \
-    if (_err_code != ADIOS_SUCCESS)                                            \
-        std::cerr << "ADIOS: error at cmd '" << #_cmd                          \
-                  << "' (" << _err_code << ") in "                             \
-                  << __FILE__ << ":" << __LINE__ << adios_errmsg();            \
+#define ADIOS_CMD(_cmd)                                                       \
+{                                                                             \
+    int _err_code = _cmd;                                                     \
+    if (_err_code != ADIOS_SUCCESS)                                           \
+    {                                                                         \
+        std::string errMsg( adios_errmsg() );                                 \
+        if( errMsg.empty() ) errMsg = '\n';                                   \
+        std::stringstream s;                                                  \
+        s << "ADIOS: error at cmd '" << #_cmd                                 \
+          << "' (" << _err_code << ", " << adios_errno << ") in "             \
+          << __FILE__ << ":" << __LINE__ << " " << errMsg;                    \
+        throw std::runtime_error(s.str());                                    \
+    }                                                                         \
 }
 
-#define ADIOS_CMD_EXPECT_NONZERO(_cmd)                                         \
-{                                                                              \
-    int _err_code = _cmd;                                                      \
-    if (_err_code == 0)                                                        \
-        std::cerr << "ADIOS: error at cmd '" << #_cmd                          \
-                  << "' (" << _err_code << ") in "                             \
-                  << __FILE__ << ":" << __LINE__ << adios_errmsg();            \
+#define ADIOS_CMD_EXPECT_NONZERO(_cmd)                                        \
+{                                                                             \
+    int _err_code = _cmd;                                                     \
+    if (_err_code == 0)                                                       \
+    {                                                                         \
+        std::string errMsg( adios_errmsg() );                                 \
+        if( errMsg.empty() ) errMsg = '\n';                                   \
+        std::stringstream s;                                                  \
+        s << "ADIOS: error at cmd '" << #_cmd                                 \
+          << "' (" << _err_code << ", " << adios_errno << ") in "             \
+          << __FILE__ << ":" << __LINE__ << " " << errMsg;                    \
+        throw std::runtime_error(s.str());                                    \
+    }                                                                         \
 }
 
 struct ThreadParams

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -719,7 +719,11 @@ private:
         /* select MPI method, #OSTs and #aggregators */
         std::stringstream strMPITransportParams;
         strMPITransportParams << "num_aggregators=" << mThreadParams.adiosAggregators
-                              << ";num_ost=" << mThreadParams.adiosOST;
+                              << ";num_ost=" << mThreadParams.adiosOST
+                              /* use system-defaults for striping per aggregated file */
+                              << ";striping=0"
+                              /* create meta file offline with bpmeta */
+                              << ";have_metadata_file=0";
         mpiTransportParams = strMPITransportParams.str();
 
         if (restartFilename == "")

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -479,7 +479,7 @@ public:
          */
         ADIOS_CMD(adios_read_init_method(ADIOS_READ_METHOD_BP,
                                          mThreadParams.adiosComm,
-                                         "verbose=3;")); //mpiTransportParams.c_str())); // rly ?
+                                         "verbose=3;abort_on_error;"));
 
         /* if restartFilename is relative, prepend with restartDirectory */
         if (!boost::filesystem::path(restartFilename).has_root_path())

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -442,7 +442,7 @@ public:
              * The only reason why we use 1M particles per chunk is that we can get a
              * frame overflow in our memory manager if we process all particles in one kernel.
              **/
-            ("adios.restart-chunkSize", po::value<uint32_t > (&restartChunkSize)->default_value(1000000),
+            ("adios.restart-chunkSize", po::value<uint32_t > (&restartChunkSize)->default_value(50000),
              "Number of particles processed in one kernel call during restart to prevent frame count blowup");
     }
 

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -114,7 +114,7 @@ public:
             float_X* field_container = new float_X[local_domain_size.productOfComponents()];
             /* magic parameters (0, 1): `from_step` (not used in streams), `nsteps` to read (must be 1 for stream) */
             log<picLog::INPUT_OUTPUT > ("ADIOS: Schedule read from field (%1%, %2%, %3%, %4%)") %
-                                        params->fp % fSel % datasetName.str().c_str() % (void*)field_container;
+                                        params->fp % fSel % datasetName.str() % (void*)field_container;
             ADIOS_CMD(adios_schedule_read( params->fp, fSel, datasetName.str().c_str(), 0, 1, (void*)field_container ));
 
             /* start a blocking read of all scheduled variables */

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -21,13 +21,6 @@
 
 #pragma once
 
-#include <adios.h>
-#include <adios_read.h>
-#include <adios_error.h>
-
-#include <string>
-#include <sstream>
-
 #include "types.h"
 #include "simulation_defines.hpp"
 #include "plugins/adios/ADIOSWriter.def"
@@ -37,6 +30,14 @@
 #include "dimensions/DataSpace.hpp"
 #include "dimensions/GridLayout.hpp"
 #include "simulationControl/MovingWindow.hpp"
+
+#include <adios.h>
+#include <adios_read.h>
+#include <adios_error.h>
+
+#include <string>
+#include <sstream>
+#include <stdexcept> // throw std::runtime_error
 
 namespace picongpu
 {
@@ -83,6 +84,16 @@ public:
                 datasetName.str();
 
             ADIOS_VARINFO* varInfo = adios_inq_var( params->fp, datasetName.str().c_str() );
+            if( varInfo == NULL )
+            {
+                std::string errMsg( adios_errmsg() );
+                if( errMsg.empty() ) errMsg = '\n';
+                std::stringstream s;
+                s << "ADIOS: error at adios_inq_var '"
+                  << "' (" << adios_errno << ") in "
+                  << __FILE__ << ":" << __LINE__ << " " << errMsg;
+                throw std::runtime_error(s.str());
+            }
             uint64_t start[varInfo->ndim];
             uint64_t count[varInfo->ndim];
             for(int d = 0; d < varInfo->ndim; ++d)
@@ -102,6 +113,8 @@ public:
             /// \todo float_X should be some kind of gridBuffer's GetComponentsType<ValueType>::type
             float_X* field_container = new float_X[local_domain_size.productOfComponents()];
             /* magic parameters (0, 1): `from_step` (not used in streams), `nsteps` to read (must be 1 for stream) */
+            log<picLog::INPUT_OUTPUT > ("ADIOS: Schedule read from field (%1%, %2%, %3%, %4%)") %
+                                        params->fp % fSel % datasetName.str().c_str() % (void*)field_container;
             ADIOS_CMD(adios_schedule_read( params->fp, fSel, datasetName.str().c_str(), 0, 1, (void*)field_container ));
 
             /* start a blocking read of all scheduled variables */


### PR DESCRIPTION
This pull request updates the ADIOS file output plugin, used for output and checkpoints.

**Change in behaviour:**
- adios errors are now causing the application to abort (only affects errors that we are unable to handle anyway, such as failing `schedule_read` calls)

**New Options Exposed to the User:**
- online meta file creation (a light-weight file describing the individual outputs of aggregators) can be disabled (poor performance for highly parallel runs), use `bpmeta <fileName>_<step>.bp` offline to create it for a directory `<fileName>_<step>.bp.dir/`
- further options such as `striping=0` can be set. example means: *system default*, each file of an aggregator will now ask the file system *where* (OST-name(s)) and *how* (striping over *N* OSTs) to create it's file (avoids adios-based selection of OSTs that might be non-ideal for output, e.g., because they are already pretty much filled by other users)

**Misc:**
- more log output was added