### PR TITLE
ADIOS: 1.9.0 Updates

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -91,7 +91,7 @@ Some of our examples will also need **libSplash**.
       [PNGWRITER\_ROOT](#additional-required-environment-variables-for-optional-libraries)
       to `$HOME/lib/pngwriter`
 
-- **libSplash** >= 1.2.4 (requires *hdf5*, *boost program-options*)
+- **libSplash** >= 1.2.4 (requires *HDF5*, *boost program-options*)
     - *Debian/Ubuntu dependencies:* `sudo apt-get install libhdf5-openmpi-dev libboost-program-options-dev`
     - *Arch Linux dependencies:* `sudo pacman --sync hdf5-openmpi boost`
     - example:
@@ -104,7 +104,7 @@ Some of our examples will also need **libSplash**.
       [SPLASH\_ROOT](#additional-required-environment-variables-for-optional-libraries)
       to `$HOME/lib/splash`
 
-- **hdf5** >= 1.8.6, standard shared version (no c++, enable parallel), e.g. `hdf5/1.8.5-threadsafe`
+- **HDF5** >= 1.8.6, standard shared version (no c++, enable parallel), e.g. `hdf5/1.8.5-threadsafe`
     - *Debian/Ubuntu:* `sudo apt-get install libhdf5-openmpi-dev`
     - *Arch Linux:* `sudo pacman --sync hdf5-openmpi`
     - example:
@@ -140,6 +140,25 @@ Some of our examples will also need **libSplash**.
     - converts png files to hdf5 files that can be used as an input for a
       species initial density profiles
     - compile and install exactly as *splash2txt* above
+
+- **ADIOS** >= 1.9.0 (requires *MPI*, *zlib* and *mxml* http://www.msweet.org/projects.php?Z3)
+    - *Debian/Ubuntu:* `sudo apt-get install libadios-dev libadios-bin`
+    - example:
+      - `mkdir -p ~/src ~/build ~/lib`
+      - `cd ~/src`
+      - `wget http://users.nccs.gov/~pnorbert/adios-1.9.0.tar.gz`
+      - `tar -xvzf adios-1.9.0.tar.gz`
+      - `cd adios-1.9.0`
+      - `CFLAGS="-fPIC" ./configure --enable-static --enable-shared --prefix=$HOME/lib/adios-1.9.0 --with-mxml=$MXML_ROOT --with-mpi=$MPI_ROOT --with-zlib=/usr`
+      - `make`
+      - `make install`
+    - set the environment variable
+      [ADIOS\_ROOT](#additional-required-environment-variables-for-optional-libraries)
+      to `export ADIOS_ROOT=$HOME/lib/adios-1.9.0`, the
+      [PATH](#additional-required-environment-variables-for-optional-libraries)
+      to `export PATH=$PATH:$ADIOS_ROOT/bin` and the
+      [LD\_LIBRARY\_PATH](#additional-required-environment-variables-for-optional-libraries)
+      to `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ADIOS_ROOT/lib`
 
 - for **VampirTrace** support
     - download 5.14.4 or higher, e.g. from 

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -361,15 +361,10 @@ endif(PIC_ENABLE_INSITU_VOLVIS)
 
 # find adios installation
 #   set(ADIOS_USE_STATIC_LIBS ON) # force static linking
-find_package(ADIOS 1.6.0)
+find_package(ADIOS 1.9.0)
 
 if(ADIOS_FOUND)
     add_definitions(-DENABLE_ADIOS=1)
-    if(NOT (ADIOS_VERSION VERSION_LESS 1.7.0))
-        message(STATUS "Enable ADIOS data transforms")
-        add_definitions(-DADIOS_TRANSFORMS=1)
-    endif(NOT (ADIOS_VERSION VERSION_LESS 1.7.0))
-
     include_directories(SYSTEM ${ADIOS_INCLUDE_DIRS})
     set(LIBS ${LIBS} ${ADIOS_LIBRARIES})
 endif(ADIOS_FOUND)

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -140,26 +140,6 @@ typedef PICToAdios<uint32_t> AdiosUInt32Type;
 typedef PICToAdios<float_X> AdiosFloatXType;
 typedef PICToAdios<double> AdiosDoubleType;
 
-/** Attribute conversation: values to c-strings in ADIOS C-API <= 1.8.0 */
-template<typename T>
-static std::string flt2str( T val )
-{
-    typedef std::numeric_limits< T > fltLimit;
-
-    std::stringstream s;
-    s.precision(fltLimit::digits10);
-    s << std::scientific << val;
-    return s.str();
-}
-
-template<typename T>
-static std::string int2str( T val )
-{
-    std::stringstream s;
-    s << val;
-    return s.str();
-}
-
 /**
  * Wrapper for adios_define_var that sets data transform method
  *
@@ -189,4 +169,3 @@ int64_t defineAdiosVar(int64_t group_id,
 
 } //namespace adios
 } //namespace picongpu
-

--- a/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -96,9 +96,8 @@ struct LoadParticleAttributesFromADIOS
 
             ADIOS_SELECTION* sel = adios_selection_boundingbox( 1, &particlesOffset, &elements );
 
-            /** work-around for ADIOS 1.8.0 bug: zero-reads fail for compressed (zlib) data sets,
-             *  so we skip the schedule read for this rank.
-             *  Note: adios_schedule_read is not a collective call */
+            /** Note: adios_schedule_read is not a collective call in any
+             *        ADIOS method and can therefore be skipped for empty reads */
             if( elements > 0 )
             {
                 ADIOS_CMD(adios_schedule_read( params->fp,
@@ -109,7 +108,8 @@ struct LoadParticleAttributesFromADIOS
                                                (void*)tmpArray ));
             }
 
-            /* start a blocking read of all scheduled variables */
+            /** start a blocking read of all scheduled variables
+             *  (this is collective call in many ADIOS methods) */
             ADIOS_CMD(adios_perform_reads( params->fp, 1 ));
 
             log<picLog::INPUT_OUTPUT > ("ADIOS:  Did read %1% local of %2% global elements for %3%") %

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -100,9 +100,9 @@ struct ParticleAttributeSize
 
             /* check if this attribute actually has a unit (unit.size() == 0 is no unit) */
             if (unit.size() >= (d + 1))
-                ADIOS_CMD(adios_define_attribute(params->adiosGroupHandle,
-                          "sim_unit", datasetName.str().c_str(), adiosDoubleType.type,
-                          flt2str(unit.at(d)).c_str(), ""));
+                ADIOS_CMD(adios_define_attribute_byvalue(params->adiosGroupHandle,
+                          "sim_unit", datasetName.str().c_str(),
+                          adiosDoubleType.type, 1, (void*)&unit.at(d) ));
         }
 
 

--- a/src/picongpu/submit/hypnos/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos/picongpu.profile.example
@@ -19,7 +19,7 @@ then
         module load hdf5-parallel/1.8.14 libsplash/1.2.4
 
         # either use libSplash or ADIOS for file I/O
-        #module load libmxml/2.8 adios/1.8.0
+        #module load libmxml/2.8 adios/1.9.0
 
         # Debug Tools
         #module load valgrind/3.8.1

--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -35,7 +35,7 @@ export VT_ROOT=$VAMPIRTRACE_DIR
 
 # plugins (optional) ################################################
 module load cray-hdf5-parallel/1.8.14
-#module load adios/1.8.0 mxml/2.9 dataspaces/1.4.0
+#module load adios/1.9.0 mxml/2.9 dataspaces/1.4.0
 export HDF5_ROOT=$HDF5_DIR
 #export ADIOS_ROOT=$ADIOS_DIR
 #export MXML_ROOT=$MXML_DIR


### PR DESCRIPTION
Changes the commit to require ADIOS 1.9.0 due to various bugs in the previous versions (main problem: aggregated files > 2GB).

By that, a good amount of legacy code can be removed:
 - transformations (at least "none") are always available (>= 1.7.0) (zlib support for compression is one of those but depends on compile, see `adios_config -m` output)
 - manual c-stringization of C attributes can be removed (1.9.0 feature)
 - zero-read work-around for zlib transformed data is not necessary any more (fixed in 1.9.0), but still avoids API overhead so we keep it with a note

Runtime tests look correct! :)