### PR TITLE
Add pragma once where it was missing and change ifdef guards

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/PngCreator.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/PngCreator.hpp
@@ -19,8 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef PNGCREATOR_HPP
-#define	PNGCREATOR_HPP
+#pragma once
 
 #include "types.h"
 #include <pngwriter.h>
@@ -53,6 +52,4 @@ namespace gol
     };
 
 }
-
-#endif	/* PNGCREATOR_HPP */
 

--- a/src/libPMacc/examples/gameOfLife2D/include/types.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/types.hpp
@@ -19,8 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TYPES_HPP
-#define	TYPES_HPP
+#pragma once
 
 #include "types.hpp"
 #include "dimensions/DataSpace.hpp"
@@ -40,5 +39,4 @@ namespace gol
     };
 }
 
-#endif	/* TYPES_HPP */
 

--- a/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALGORITHM_HOST_FOREACH_HPP
-#define ALGORITHM_HOST_FOREACH_HPP
+#pragma once
 
 #include "math/vector/Size_t.hpp"
 #include "math/vector/Int.hpp"
@@ -132,4 +131,3 @@ struct Foreach
 } // algorithm
 } // PMacc
 
-#endif // ALGORITHM_HOST_FOREACH_HPP

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALGORITHM_KERNEL_FFT_HPP
-#define ALGORITHM_KERNEL_FFT_HPP
+#pragma once
 
 namespace PMacc
 {
@@ -43,4 +42,3 @@ struct FFT
 
 #include "FFT.tpp"
 
-#endif // ALGORITHM_KERNEL_FFT_HPP

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "math/vector/Size_t.hpp"
 #include "math/Vector.hpp"
 #include "cuSTL/zone/SphericZone.hpp"

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALGORITHM_KERNEL_FOREACH_HPP
-#define ALGORITHM_KERNEL_FOREACH_HPP
+#pragma once
 
 #include "types.h"
 #include "math/vector/Size_t.hpp"
@@ -103,4 +102,3 @@ struct Foreach
 } // algorithm
 } // PMacc
 
-#endif // ALGORITHM_KERNEL_FOREACH_HPP

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALGORITHM_KERNEL_FOREACHBLOCK_HPP
-#define ALGORITHM_KERNEL_FOREACHBLOCK_HPP
+#pragma once
 
 #include "types.h"
 #include "math/vector/Size_t.hpp"
@@ -128,4 +127,3 @@ struct ForeachBlock
 } // algorithm
 } // PMacc
 
-#endif // ALGORITHM_KERNEL_FOREACHBLOCK_HPP

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "mappings/simulation/GridController.hpp"
 #include "cuSTL/container/copier/Memcopy.hpp"
 #include "communication/manager_common.h"

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "mappings/simulation/GridController.hpp"
 #include <iostream>
 #include <utility>

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "cuSTL/container/allocator/tag.h"
 #include "eventSystem/EventSystem.hpp"
 

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_HOSTBUFFER_HPP
-#define CONTAINER_HOSTBUFFER_HPP
+#pragma once
 
 #include <boost/type_traits/is_same.hpp>
 #include <cuSTL/container/allocator/HostMemAllocator.hpp>
@@ -85,4 +84,3 @@ public:
 } // container
 } // PMacc
 
-#endif // CONTAINER_HOSTBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_INDEXBUFFER_HPP
-#define CONTAINER_INDEXBUFFER_HPP
+#pragma once
 
 #include <stdint.h>
 #include "../vector/UInt32.hpp"
@@ -94,4 +93,3 @@ public:
 } // container
 } // PMacc
 
-#endif // CONTAINER_INDEXBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/PNGBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/PNGBuffer.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_PNGBUFFER_HPP
-#define CONTAINER_PNGBUFFER_HPP
+#pragma once
 
 #include "cuSTL/cursor/Cursor.hpp"
 #include "cuSTL/cursor/navigator/MultiIndexNavigator.hpp"
@@ -101,4 +100,3 @@ public:
 } // container
 } // PMacc
 
-#endif // CONTAINER_PNGBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/PseudoBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/PseudoBuffer.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_PSEUDOBUFFER_HPP
-#define CONTAINER_PSEUDOBUFFER_HPP
+#pragma once
 
 #include "memory/buffers/DeviceBuffer.hpp"
 #include "memory/buffers/HostBuffer.hpp"
@@ -46,4 +45,3 @@ struct PseudoBuffer : public container::CartBuffer<Type, dim>
 
 #include "PseudoBuffer.tpp"
 
-#endif // CONTAINER_PSEUDOBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/PseudoBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/PseudoBuffer.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 namespace PMacc
 {
 namespace container

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALLOCATOR_DEVICEMEMALLOCATOR_HPP
-#define ALLOCATOR_DEVICEMEMALLOCATOR_HPP
+#pragma once
 
 #include "math/vector/Size_t.hpp"
 #include "cuSTL/cursor/BufferCursor.hpp"
@@ -67,4 +66,3 @@ struct DeviceMemAllocator<Type, 1>
 
 #include "DeviceMemAllocator.tpp"
 
-#endif // ALLOCATOR_DEVICEMEMALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 namespace PMacc
 {
 namespace allocator

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALLOCATOR_DEVICEMEMEVENPITCHALLOCATOR_HPP
-#define ALLOCATOR_DEVICEMEMEVENPITCHALLOCATOR_HPP
+#pragma once
 
 #include "math/vector/Size_t.hpp"
 #include "cuSTL/cursor/BufferCursor.hpp"
@@ -63,4 +62,3 @@ struct DeviceMemEvenPitch<Type, 1>
 
 #include "DeviceMemEvenPitchAllocator.tpp"
 
-#endif // ALLOCATOR_DEVICEMEMEVENPITCHALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 namespace PMacc
 {
 namespace allocator

--- a/src/libPMacc/include/cuSTL/container/allocator/EmptyAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/EmptyAllocator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALLOCATOR_EMPTYALLOCATOR_HPP
-#define ALLOCATOR_EMPTYALLOCATOR_HPP
+#pragma once
 
 #include "tag.h"
 #include "types.h"
@@ -43,4 +42,3 @@ struct EmptyAllocator
 } // allocator
 } // PMacc
 
-#endif // ALLOCATOR_EMPTYALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALLOCATOR_HOSTMEMALLOCATOR_HPP
-#define ALLOCATOR_HOSTMEMALLOCATOR_HPP
+#pragma once
 
 #include <stdint.h>
 #include "math/vector/Size_t.hpp"
@@ -68,4 +67,3 @@ struct HostMemAllocator<Type, 1>
 
 #include "HostMemAllocator.tpp"
 
-#endif // ALLOCATOR_HOSTMEMALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 namespace PMacc
 {
 namespace allocator

--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ALLOCATOR_SHAREDMEMALLOCATOR_HPP
-#define ALLOCATOR_SHAREDMEMALLOCATOR_HPP
+#pragma once
 
 #include "math/Vector.hpp"
 #include "cuSTL/cursor/compile-time/BufferCursor.hpp"
@@ -88,4 +87,3 @@ struct SharedMemAllocator<Type, Size, 3, uid>
 } // allocator
 } // PMacc
 
-#endif // ALLOCATOR_SHAREDMEMALLOCATOR_HPP

--- a/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ASSIGNER_HOSTMEMASSIGNER_HPP
-#define ASSIGNER_HOSTMEMASSIGNER_HPP
+#pragma once
 
 #include <stdint.h>
 
@@ -85,4 +84,3 @@ struct HostMemAssigner<3>
 } // assigner
 } // PMacc
 
-#endif // ASSIGNER_HOSTMEMASSIGNER_HPP

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINER_CT_CTCARTBUFFER_HPP
-#define CONTAINER_CT_CTCARTBUFFER_HPP
+#pragma once
 
 #include "types.h"
 #include "math/Vector.hpp"
@@ -79,4 +78,3 @@ public:
 
 #include "CartBuffer.tpp"
 
-#endif // CONTAINER_CT_CTCARTBUFFER_HPP

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 namespace PMacc
 {
 namespace container

--- a/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_BUFFERCURSOR_HPP
-#define CURSOR_BUFFERCURSOR_HPP
+#pragma once
 
 #include "Cursor.hpp"
 #include "accessor/PointerAccessor.hpp"
@@ -77,4 +76,3 @@ struct dim<BufferCursor<Type, T_dim> >
 } // cursor
 } // PMacc
 
-#endif // CURSOR_BUFFERCURSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CURSOR_HPP
-#define CURSOR_CURSOR_HPP
+#pragma once
 
 #include <boost/mpl/void.hpp>
 #include "math/vector/Int.hpp"
@@ -175,4 +174,4 @@ struct dim< PMacc::cursor::Cursor<_Accessor, _Navigator, _Marker> >
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CURSOR_HPP
+

--- a/src/libPMacc/include/cuSTL/cursor/FunctorCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/FunctorCursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_FUNCTORCURSOR_HPP
-#define CURSOR_FUNCTORCURSOR_HPP
+#pragma once
 
 #include "Cursor.hpp"
 #include "accessor/FunctorAccessor.hpp"
@@ -57,4 +56,3 @@ Cursor<FunctorAccessor<typename lambda::result_of::make_Functor<Functor>::type,
 } // cursor
 } // PMacc
 
-#endif // CURSOR_FUNCTORCURSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_MULTIINDEXCURSOR
-#define CURSOR_MULTIINDEXCURSOR
+#pragma once
 
 #include "Cursor.hpp"
 #include "accessor/MarkerAccessor.hpp"
@@ -53,4 +52,3 @@ cursor::Cursor<cursor::MarkerAccessor<math::Int<dim> >, MultiIndexNavigator<dim>
 } // cursor
 } // PMacc
 
-#endif // CURSOR_MULTIINDEXCURSOR

--- a/src/libPMacc/include/cuSTL/cursor/NestedCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/NestedCursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_NESTEDCURSOR_HPP
-#define CURSOR_NESTEDCURSOR_HPP
+#pragma once
 
 #include "accessor/MarkerAccessor.hpp"
 #include "navigator/CursorNavigator.hpp"
@@ -47,4 +46,3 @@ Cursor<MarkerAccessor<TCursor>, CursorNavigator, TCursor> make_NestedCursor(cons
 } // cursor
 } // PMacc
 
-#endif // CURSOR_NESTEDCURSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_SAVECURSOR_HPP
-#define CURSOR_SAVECURSOR_HPP
+#pragma once
 
 #include <cuSTL/cursor/traits.hpp>
 #include <math/vector/Int.hpp>
@@ -164,4 +163,3 @@ HDINLINE SafeCursor<Cursor> make_SafeCursor(
 } // cursor
 } // PMacc
 
-#endif // CURSOR_SAVECURSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/accessor/CursorAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/CursorAccessor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CURSORACCESSOR_HPP
-#define CURSOR_CURSORACCESSOR_HPP
+#pragma once
 
 #include "types.h"
 
@@ -46,4 +45,3 @@ struct CursorAccessor
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CURSORACCESSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/accessor/FunctorAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/FunctorAccessor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_FUNCTORACCESSOR_HPP
-#define CURSOR_FUNCTORACCESSOR_HPP
+#pragma once
 
 #include <boost/type_traits/add_const.hpp>
 #include <forward.hpp>
@@ -56,4 +55,3 @@ struct FunctorAccessor
 } // cursor
 } // PMacc
 
-#endif // CURSOR_FUNCTORACCESSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/accessor/MarkerAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/MarkerAccessor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_MARKERACCESSOR_HPP
-#define CURSOR_MARKERACCESSOR_HPP
+#pragma once
 
 namespace PMacc
 {
@@ -49,4 +48,3 @@ struct MarkerAccessor
 } // cursor
 } // PMacc
 
-#endif //CURSOR_MARKERACCESSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/accessor/PointerAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/PointerAccessor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_POINTERACCESSOR_HPP
-#define CURSOR_POINTERACCESSOR_HPP
+#pragma once
 
 namespace PMacc
 {
@@ -50,4 +49,3 @@ struct PointerAccessor
 } // cursor
 } // PMacc
 
-#endif // CURSOR_POINTERACCESSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/BufferCursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CTBUFFERCURSOR_HPP
-#define CURSOR_CTBUFFERCURSOR_HPP
+#pragma once
 
 #include <cuSTL/cursor/Cursor.hpp>
 #include <cuSTL/cursor/accessor/PointerAccessor.hpp>
@@ -66,4 +65,3 @@ struct dim<CT::BufferCursor<Type, Pitch> >
 } // cursor
 } // PMacc
 
-#endif //CTBUFFERITER_HPP

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CT_SAVECURSOR_HPP
-#define CURSOR_CT_SAVECURSOR_HPP
+#pragma once
 
 #include <cuSTL/cursor/traits.hpp>
 #include <math/vector/Int.hpp>
@@ -130,4 +129,3 @@ make_SafeCursor(const Cursor& cursor, LowerExtent, UpperExtent)
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CT_SAVECURSOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_BUFFERNAVIGATOR_HPP
-#define CURSOR_BUFFERNAVIGATOR_HPP
+#pragma once
 
 #include "math/Vector.hpp"
 #include "tag.h"
@@ -96,4 +95,3 @@ struct dim<BufferNavigator<T_dim> >
 } //cursor
 } // PMacc
 
-#endif // CURSOR_BUFFERNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CARTNAVIGATOR_HPP
-#define CURSOR_CARTNAVIGATOR_HPP
+#pragma once
 
 #include <math/vector/Int.hpp>
 #include "tag.h"
@@ -71,4 +70,3 @@ struct dim<CartNavigator<T_dim> >
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CARTNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CursorNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CursorNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CURSORNAVIGATOR_HPP
-#define CURSOR_CURSORNAVIGATOR_HPP
+#pragma once
 
 #include "math/vector/Int.hpp"
 
@@ -43,4 +42,3 @@ struct CursorNavigator
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CURSORNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/EmptyNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/EmptyNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_EMPTYNAVIGATOR_HPP
-#define CURSOR_EMPTYNAVIGATOR_HPP
+#pragma once
 
 namespace PMacc
 {
@@ -41,4 +40,3 @@ struct EmptyNavigator
 } // cursor
 } // PMacc
 
-#endif // CURSOR_EMPTYNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_MULTIINDEXNAVIGATOR_HPP
-#define CURSOR_MULTIINDEXNAVIGATOR_HPP
+#pragma once
 
 #include "math/vector/Int.hpp"
 #include "tag.h"
@@ -60,4 +59,3 @@ struct dim<MultiIndexNavigator<T_dim> >
 } // cursor
 } // PMacc
 
-#endif // CURSOR_MULTIINDEXNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CTBUFFERNAVIGATOR_HPP
-#define CURSOR_CTBUFFERNAVIGATOR_HPP
+#pragma once
 
 #include <boost/type_traits/remove_pointer.hpp>
 #include "math/vector/Int.hpp"
@@ -88,4 +87,3 @@ struct BufferNavigator<Pitch, 3>
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CTBUFFERNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
-#define CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
+#pragma once
 
 #include "math/Vector.hpp"
 
@@ -72,4 +71,3 @@ struct TwistAxesNavigator<Axes, 3>
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
-#define CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP
+#pragma once
 
 #include "math/Vector.hpp"
 
@@ -72,4 +71,3 @@ struct TwistedAxesNavigator<Axes, 3>
 } // cursor
 } // PMacc
 
-#endif // CURSOR_CT_TWISTEDAXESNAVIGATOR_HPP

--- a/src/libPMacc/include/cuSTL/cursor/tools/slice.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/slice.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_TOOLS_SLICE_HPP
-#define CURSOR_TOOLS_SLICE_HPP
+#pragma once
 
 #include "cuSTL/cursor/Cursor.hpp"
 #include "cuSTL/cursor/navigator/BufferNavigator.hpp"
@@ -106,4 +105,3 @@ slice(const TCursor& cur)
 } // cursor
 } // PMacc
 
-#endif // CURSOR_TOOLS_SLICE_HPP

--- a/src/libPMacc/include/cuSTL/cursor/tools/twistAxes.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/twistAxes.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_TOOLS_TWISTAXIS_HPP
-#define CURSOR_TOOLS_TWISTAXIS_HPP
+#pragma once
 
 #include <cuSTL/cursor/Cursor.hpp>
 #include <cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp>
@@ -56,4 +55,3 @@ twistAxes(const TCursor& cursor)
 } // cursor
 } // PMacc
 
-#endif // CURSOR_TOOLS_TWISTAXIS_HPP

--- a/src/libPMacc/include/cuSTL/cursor/traits.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/traits.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CURSOR_TRAITS_HPP
-#define CURSOR_TRAITS_HPP
+#pragma once
 
 namespace PMacc
 {
@@ -37,4 +36,3 @@ struct dim;
 } // cursor
 } // PMacc
 
-#endif // CURSOR_TRAITS_HPP

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ZONE_SPHERICZONE_HPP
-#define ZONE_SPHERICZONE_HPP
+#pragma once
 
 #include <stdint.h>
 #include "math/vector/Int.hpp"
@@ -70,4 +69,3 @@ struct SphericZone
 } // zone
 } // PMacc
 
-#endif // ZONE_SPHERICZONE_HPP

--- a/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ZONE_STAGGEREDZONE_HPP
-#define ZONE_STAGGEREDZONE_HPP
+#pragma once
 
 #include <stdint.h>
 #include "vector/Vector.hpp"
@@ -47,4 +46,3 @@ struct StaggeredZone : public SphericZone<T_dim>
 } // zone
 } // PMacc
 
-#endif // ZONE_STAGGEREDZONE_HPP

--- a/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ZONE_TORICZONE_HPP
-#define ZONE_TORICZONE_HPP
+#pragma once
 
 #include <stdint.h>
 #include "../vector/Size_t.hpp"
@@ -47,6 +46,4 @@ struct ToricZone
 
 } // zone
 } // PMacc
-
-#endif // ZONE_TORICCZONE_HPP
 

--- a/src/libPMacc/include/eventSystem/Manager.tpp
+++ b/src/libPMacc/include/eventSystem/Manager.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "eventSystem/events/EventPool.hpp"
 #include "eventSystem/streams/StreamController.hpp"
 #include "eventSystem/EventSystem.hpp"

--- a/src/libPMacc/include/eventSystem/events/EventNotify.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.tpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "eventSystem/events/EventNotify.hpp"
 #include "eventSystem/events/IEventData.hpp"
 #include "eventSystem/events/IEvent.hpp"

--- a/src/libPMacc/include/eventSystem/events/EventTask.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventTask.tpp
@@ -20,6 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/tasks/ITask.hpp"

--- a/src/libPMacc/include/eventSystem/tasks/Factory.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.tpp
@@ -20,6 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include "eventSystem/tasks/Factory.hpp"
 

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
@@ -20,6 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include "Environment.hpp"
 //#include "eventSystem/EventSystem.hpp"

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
@@ -19,7 +19,9 @@
  * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
+#pragma once
+
 #include "eventSystem/transactions/Transaction.hpp"
 
 #include "eventSystem/streams/StreamController.hpp"

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
@@ -19,7 +19,9 @@
  * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
+#pragma once
+
 #include "eventSystem/EventSystem.hpp"
 
 #include <cassert>

--- a/src/libPMacc/include/lambda/CT/Eval.hpp
+++ b/src/libPMacc/include/lambda/CT/Eval.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LAMBDA_CT_EVAL_HPP
-#define LAMBDA_CT_EVAL_HPP
+#pragma once
 
 #define BOOST_BIND_NO_PLACEHOLDERS
 
@@ -383,4 +382,3 @@ struct Eval<CT::Expression<lambda::Expression<exprTypes::subscript, mpl::vector<
 } // lambda
 } // PMacc
 
-#endif // LAMBDA_CT_EVAL_HPP

--- a/src/libPMacc/include/lambda/CT/FillTerminalList.hpp
+++ b/src/libPMacc/include/lambda/CT/FillTerminalList.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LAMBDA_CT_FILLTERMINALLIST_HPP
-#define LAMBDA_CT_FILLTERMINALLIST_HPP
+#pragma once
 
 #include "../Expression.hpp"
 #include "Expression.hpp"
@@ -225,4 +224,3 @@ struct FillTerminalList<lambda::Expression<exprTypes::subscript, mpl::vector<Chi
 } // lambda
 } // PMacc
 
-#endif // LAMBDA_CT_FILLTERMINALLIST_HPP

--- a/src/libPMacc/include/lambda/CT/TerminalTL.hpp
+++ b/src/libPMacc/include/lambda/CT/TerminalTL.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LAMBDA_CT_TERMINALTL_HPP
-#define LAMBDA_CT_TERMINALTL_HPP
+#pragma once
 
 #include "../ExprTypes.h"
 #include "../placeholder.h"
@@ -207,4 +206,3 @@ struct TerminalTL<Expression<exprTypes::subscript, mpl::vector<Child0, Child1> >
 } // lambda
 } // PMacc
 
-#endif // LAMBDA_CT_TERMINALTL_HPP

--- a/src/libPMacc/include/lambda/Expression.hpp
+++ b/src/libPMacc/include/lambda/Expression.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LAMBDA_EXPRESSION_HPP
-#define LAMBDA_EXPRESSION_HPP
+#pragma once
 
 #include "types.h"
 #include "ExprTypes.h"
@@ -199,4 +198,3 @@ DECLARE_PLACEHOLDERS()
 } // lambda
 } // PMacc
 
-#endif // LAMBDA_EXPRESSION_HPP

--- a/src/libPMacc/include/lambda/is_Expression.hpp
+++ b/src/libPMacc/include/lambda/is_Expression.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LAMBDA_KERNEL_IS_EXPRESSION_HPP
-#define LAMBDA_KERNEL_IS_EXPRESSION_HPP
+#pragma once
 
 #include <boost/mpl/bool.hpp>
 namespace mpl = boost::mpl;
@@ -40,4 +39,3 @@ struct is_Expression
 } // lambda
 } // PMacc
 
-#endif // LAMBDA_KERNEL_IS_EXPRESSION_HPP

--- a/src/libPMacc/include/lambda/make_Expr.hpp
+++ b/src/libPMacc/include/lambda/make_Expr.hpp
@@ -20,8 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LAMBDA_KERNEL_MAKE_EXPR_HPP
-#define LAMBDA_KERNEL_MAKE_EXPR_HPP
+#pragma once
 
 #include "is_Expression.hpp"
 #include "ExprTypes.h"
@@ -88,4 +87,3 @@ expr(const T& t)
 } // lambda
 } // PMacc
 
-#endif // LAMBDA_KERNEL_MAKE_EXPR_HPP

--- a/src/libPMacc/include/lambda/make_Functor.hpp
+++ b/src/libPMacc/include/lambda/make_Functor.hpp
@@ -20,9 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LAMBDA_MAKE_FUNCTOR_HPP
-#define LAMBDA_MAKE_FUNCTOR_HPP
-
+#pragma once
 
 #include "types.h"
 #include "is_Expression.hpp"
@@ -161,4 +159,3 @@ make_Functor(const Expression<ExprType, Childs>& expr)
 } // lambda
 } // PMacc
 
-#endif // LAMBDA_MAKE_FUNCTOR_HPP

--- a/src/libPMacc/include/math/complex/Complex.hpp
+++ b/src/libPMacc/include/math/complex/Complex.hpp
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 namespace PMacc
 {
 namespace math

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -20,6 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include "Environment.hpp"
 #include "eventSystem/EventSystem.hpp"


### PR DESCRIPTION
I used the commands

    find . -name "*.hpp" -print | xargs grep -iL "pragma once"
    find . -name "*.tpp" -print | xargs grep -iL "pragma once"
    find . -name "*.def" -print | xargs grep -iL "pragma once"

to find files where pragma once was missing. In some cases (e.g. ~21 tpp files) no header guard was present at all which can cause problems when including them multiple times. As pragma once is the new standard I also removed the old header guards and replaced them by pragma once so the above commands don't list relevant files