### PR TITLE
Add pragma once where it was missing and change ifdef guards

### DIFF
--- a/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef ONEPARTICLESIMULATION_HPP
-#define    ONEPARTICLESIMULATION_HPP
+#pragma once
 
 #include "simulation_defines.hpp"
 #include "Environment.hpp"
@@ -166,6 +163,4 @@ public:
 };
 
 } // namespace picongpu
-
-#endif    /* ONEPARTICLESIMULATION_HPP */
 

--- a/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef PARTICLESINITONEPARTICLE_HPP
-#define    PARTICLESINITONEPARTICLE_HPP
+#pragma once
 
 #include "dimensions/DataSpace.hpp"
 #include "types.h"
@@ -143,6 +140,4 @@ public:
     }
 };
 }
-
-#endif    /* PARTICLESINITONEPARTICLE_HPP */
 

--- a/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef ONEPARTICLESIMULATION_HPP
-#define    ONEPARTICLESIMULATION_HPP
+#pragma once
 
 #include "simulation_defines.hpp"
 #include "Environment.hpp"
@@ -192,6 +189,4 @@ public:
 };
 
 } // namespace picongpu
-
-#endif    /* ONEPARTICLESIMULATION_HPP */
 

--- a/examples/SingleParticleTest/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleTest/include/OneParticleSimulation.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef ONEPARTICLESIMULATION_HPP
-#define    ONEPARTICLESIMULATION_HPP
+#pragma once
 
 #include "simulation_defines.hpp"
 #include "Environment.hpp"
@@ -182,4 +179,3 @@ public:
 
 } // namespace picongpu
 
-#endif    /* ONEPARTICLESIMULATION_HPP */

--- a/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef PARTICLESINITONEPARTICLE_HPP
-#define    PARTICLESINITONEPARTICLE_HPP
+#pragma once
 
 #include "dimensions/DataSpace.hpp"
 #include "types.h"
@@ -141,4 +138,3 @@ public:
 };
 }
 
-#endif    /* PARTICLESINITONEPARTICLE_HPP */

--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -18,8 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TERMALTESTSIMULATION_HPP
-#define    TERMALTESTSIMULATION_HPP
+#pragma once
 
 #include "simulation_defines.hpp"
 #include "Environment.hpp"
@@ -209,4 +208,3 @@ private:
 
 } // namespace picongpu
 
-#endif    /* TERMALTESTSIMULATION_HPP */

--- a/src/picongpu/include/algorithms/Gamma.hpp
+++ b/src/picongpu/include/algorithms/Gamma.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef GAMMA_HPP
-#define    GAMMA_HPP
+#pragma once
 
 namespace picongpu
 {
@@ -48,6 +45,4 @@ struct Gamma
 };
 
 }
-
-#endif    /* GAMMA_HPP */
 

--- a/src/picongpu/include/algorithms/Set.hpp
+++ b/src/picongpu/include/algorithms/Set.hpp
@@ -18,11 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef SET_HPP
-#define    SET_HPP
-
+#pragma once
 
 #include "types.h"
 
@@ -49,6 +45,4 @@ private:
     const PMACC_ALIGN(value, Type_);
 };
 }
-
-#endif    /* SET_HPP */
 

--- a/src/picongpu/include/algorithms/Velocity.hpp
+++ b/src/picongpu/include/algorithms/Velocity.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef VELOCITY_HPP
-#define    VELOCITY_HPP
+#pragma once
 
 namespace picongpu
 {
@@ -42,6 +39,4 @@ namespace picongpu
         }
     };
 }
-
-#endif    /* VELOCITY_HPP */
 

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef FIELDMANIPULATOR_HPP
-#define    FIELDMANIPULATOR_HPP
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -89,7 +86,4 @@ public:
 
 
 } //namespace
-
-
-#endif    /* FIELDMANIPULATOR_HPP */
 

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef LASERGAUSSIANBEAM_HPP
-#define    LASERGAUSSIANBEAM_HPP
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -159,8 +156,4 @@ namespace picongpu
 
     }
 }
-
-#endif    /* LASERGAUSSIANBEAM_HPP */
-
-
 

--- a/src/picongpu/include/fields/laserProfiles/laserNone.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserNone.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef LASERNONE_HPP
-#define    LASERNONE_HPP
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -61,8 +58,4 @@ namespace picongpu
 
     }
 }
-
-#endif    /* LASERNONE_HPP */
-
-
 

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef LASERPULSEFRONTTILT
-#define LASERPULSEFRONTTILT
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -167,4 +164,3 @@ namespace picongpu
     }
 }
 
-#endif    /* LASERPULSEFRONTTILT_HPP */

--- a/src/picongpu/include/fields/tasks/FieldFactory.hpp
+++ b/src/picongpu/include/fields/tasks/FieldFactory.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef _FIELDFACTORY_HPP
-#define    _FIELDFACTORY_HPP
+#pragma once
 
 #include "memory/buffers/Exchange.hpp"
 
@@ -89,6 +86,4 @@ namespace PMacc
 } //namespace PMacc
 
 #include "fields/tasks/FieldFactory.tpp"
-
-#endif    /* _PARTICLEFACTORY_HPP */
 

--- a/src/picongpu/include/fields/tasks/FieldFactory.tpp
+++ b/src/picongpu/include/fields/tasks/FieldFactory.tpp
@@ -18,6 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include "fields/tasks/FieldFactory.hpp"
 #include "fields/tasks/TaskFieldReceiveAndInsert.hpp"

--- a/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -18,11 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef _TASKFIELDRECEIVEANDINSERTEXCHANGE_HPP
-#define    _TASKFIELDRECEIVEANDINSERTEXCHANGE_HPP
-
+#pragma once
 
 #include "eventSystem/EventSystem.hpp"
 #include "fields/tasks/FieldFactory.hpp"
@@ -116,6 +112,4 @@ private:
 
 } //namespace PMacc
 
-
-#endif    /* _TASKFIELDRECEIVEANDINSERTEXCHANGE_HPP */
 

--- a/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
@@ -18,11 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef  _TASKFIELDSENDEXCHANGE_HPP
-#define    _TASKFIELDSENDEXCHANGE_HPP
-
+#pragma once
 
 #include "eventSystem/EventSystem.hpp"
 #include "fields/tasks/FieldFactory.hpp"
@@ -127,7 +123,4 @@ namespace PMacc
     };
 
 } //namespace PMacc
-
-
-#endif    /* _TASKFIELDSENDEXCHANGE_HPP */
 

--- a/src/picongpu/include/initialization/SimStartInitialiser.hpp
+++ b/src/picongpu/include/initialization/SimStartInitialiser.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef SIMSTARTINITIALISER_HPP
-#define    SIMSTARTINITIALISER_HPP
+#pragma once
 
 #include "simulation_types.hpp"
 #include "dataManagement/AbstractInitialiser.hpp"
@@ -54,6 +51,4 @@ public:
     }
 };
 }
-
-#endif    /* SIMSTARTINITIALISER_HPP */
 

--- a/src/picongpu/include/particles/access/Cell2Particle.hpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.hpp
@@ -18,8 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef particleAccess_PARTICLE2CELL_HPP
-#define particleAccess_PARTICLE2CELL_HPP
+#pragma once
 
 #include "types.h"
 
@@ -55,4 +54,3 @@ struct Cell2Particle
 
 #include "Cell2Particle.tpp"
 
-#endif // particleAccess_PARTICLE2CELL_HPP

--- a/src/picongpu/include/particles/access/Cell2Particle.tpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.tpp
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <stdint.h>
 #include "math/Vector.hpp"
 #include "math/MapTuple.hpp"

--- a/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
@@ -19,10 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef PARTICLEPUSHERAXL_HPP
-#define    PARTICLEPUSHERAXL_HPP
+#pragma once
 
 #include "simulation_defines.hpp"
 
@@ -185,5 +182,4 @@ namespace picongpu
     } //namespace
 }
 
-#endif    /* PARTICLEPUSHERAXL_HPP */
 

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -19,6 +19,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"
 #include "math/vector/Size_t.hpp"

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
@@ -19,7 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#pragma once
 
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -19,10 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef SUMCURRENTS_HPP
-#define    SUMCURRENTS_HPP
+#pragma once
 
 #include <iostream>
 
@@ -200,6 +197,4 @@ private:
 
 }
 
-
-#endif    /* SUMCURRENTS_HPP */
 

--- a/src/picongpu/include/plugins/output/header/ColorHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/ColorHeader.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef COLORHEADER_HPP
-#define    COLORHEADER_HPP
+#pragma once
 
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
@@ -77,7 +74,4 @@ struct ColorHeader
     }
 
 };
-
-
-#endif    /* COLORHEADER_HPP */
 

--- a/src/picongpu/include/plugins/output/header/MessageHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/MessageHeader.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef MESSAGEHEADER_HPP
-#define    MESSAGEHEADER_HPP
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -173,6 +170,4 @@ private:
     MessageHeader();
 
 };
-
-#endif    /* MESSAGEHEADER_HPP */
 

--- a/src/picongpu/include/plugins/output/header/NodeHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/NodeHeader.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef NODEHEADER_HPP
-#define    NODEHEADER_HPP
+#pragma once
 
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
@@ -58,6 +55,4 @@ struct NodeHeader
     }
 
 };
-
-#endif    /* NODEHEADER_HPP */
 

--- a/src/picongpu/include/plugins/output/header/WindowHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/WindowHeader.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef WINDOWHEADER_HPP
-#define    WINDOWHEADER_HPP
+#pragma once
 
 #include "types.h"
 #include "dimensions/DataSpace.hpp"
@@ -42,6 +39,4 @@ struct WindowHeader
     }
 
 };
-
-#endif    /* WINDOWHEADER_HPP */
 

--- a/src/picongpu/include/plugins/output/images/LiveViewClient.hpp
+++ b/src/picongpu/include/plugins/output/images/LiveViewClient.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef LIVEVIEWCLIENT_HPP
-#define    LIVEVIEWCLIENT_HPP
+#pragma once
 
 #include "plugins/output/sockets/SocketConnector.hpp"
 
@@ -113,6 +110,4 @@ namespace picongpu
         delete[] array;
     }
 }
-
-#endif    /* LIVEVIEWCLIENT_HPP */
 

--- a/src/picongpu/include/plugins/output/images/PngCreator.hpp
+++ b/src/picongpu/include/plugins/output/images/PngCreator.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef PNGCREATOR_HPP
-#define    PNGCREATOR_HPP
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -149,6 +146,4 @@ namespace picongpu
     }
 
 }//namespace
-
-#endif    /* PNGCREATOR_HPP */
 

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -18,14 +18,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include <stdint.h>
-
-
-#ifndef PARTICLE_RPAUSCH
-#define PARTICLE_RPAUSCH
-
-
 
 #include "math/Vector.hpp"
 #include "utilities.hpp"
@@ -173,5 +168,3 @@ HDINLINE vector_64 Particle::get_momentum<When::old>(void) const
     return momentum_old;
 } // get momentum at time when
 
-
-#endif

--- a/src/picongpu/include/simulationControl/SimulationStarter.hpp
+++ b/src/picongpu/include/simulationControl/SimulationStarter.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef SIMULATIONSTARTER_HPP
-#define    SIMULATIONSTARTER_HPP
+#pragma once
 
 #include "types.h"
 #include "simulation_defines.hpp"
@@ -154,6 +151,4 @@ namespace picongpu
         }
     };
 }
-
-#endif    /* SIMULATIONSTARTER_HPP */
 


### PR DESCRIPTION
I used the commands

    find . -name "*.hpp" -print | xargs grep -iL "pragma once"
    find . -name "*.tpp" -print | xargs grep -iL "pragma once"
    find . -name "*.def" -print | xargs grep -iL "pragma once"

to find files where pragma once was missing. In some cases (e.g. ~21 tpp files) no header guard was present at all which can cause problems when including them multiple times. As pragma once is the new standard I also removed the old header guards and replaced them by pragma once so the above commands don't list relevant files