### PR TITLE
Split EventSystem.hpp into hpp and tpp

### DIFF
--- a/src/libPMacc/include/Environment.def
+++ b/src/libPMacc/include/Environment.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
+ * Copyright 2015 Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -22,10 +22,9 @@
 
 #pragma once
 
-#include "eventSystem/Manager.hpp"
-#include "eventSystem/tasks/StreamTask.hpp"
-#include "eventSystem/transactions/Transaction.hpp"
-#include "eventSystem/transactions/TransactionManager.hpp"
-#include "eventSystem/events/EventTask.hpp"
-#include "eventSystem/events/EventNotify.hpp"
-#include "eventSystem/tasks/Factory.hpp"
+namespace PMacc {
+
+    template <unsigned DIM = DIM1>
+    class Environment;
+
+}  // namespace PMacc

--- a/src/libPMacc/include/Environment.hpp
+++ b/src/libPMacc/include/Environment.hpp
@@ -35,6 +35,8 @@
 #include "nvidia/memory/MemoryInfo.hpp"
 #include "mappings/simulation/Filesystem.hpp"
 
+#include "Environment.def"
+
 #include <cuda_runtime.h>
 
 namespace PMacc
@@ -44,7 +46,7 @@ namespace PMacc
  * Global Environment singleton for Picongpu
  */
 
-template <unsigned DIM = DIM1>
+template <unsigned DIM>
 class Environment
 {
 public:
@@ -246,4 +248,5 @@ private:
 #define __getTransactionEvent() (PMacc::Environment<>::get().TransactionManager().getTransactionEvent())
 #define __setTransactionEvent(event) (PMacc::Environment<>::get().TransactionManager().setTransactionEvent((event)))
 
+#include "eventSystem/EventSystem.tpp"
 #include "particles/tasks/ParticleFactory.tpp"

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -40,6 +40,7 @@
 
 #include "eventSystem/tasks/TaskKernel.hpp"
 #include "eventSystem/events/kernelEvents.hpp"
+#include "Environment.hpp"
 #include <cassert>
 
 namespace PMacc

--- a/src/libPMacc/include/eventSystem/EventSystem.tpp
+++ b/src/libPMacc/include/eventSystem/EventSystem.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
+ * Copyright 2015 Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -22,10 +22,10 @@
 
 #pragma once
 
-#include "eventSystem/Manager.hpp"
-#include "eventSystem/tasks/StreamTask.hpp"
-#include "eventSystem/transactions/Transaction.hpp"
-#include "eventSystem/transactions/TransactionManager.hpp"
-#include "eventSystem/events/EventTask.hpp"
-#include "eventSystem/events/EventNotify.hpp"
-#include "eventSystem/tasks/Factory.hpp"
+#include "eventSystem/Manager.tpp"
+#include "eventSystem/tasks/StreamTask.tpp"
+#include "eventSystem/transactions/Transaction.tpp"
+#include "eventSystem/transactions/TransactionManager.tpp"
+#include "eventSystem/events/EventTask.tpp"
+#include "eventSystem/events/EventNotify.tpp"
+#include "eventSystem/tasks/Factory.tpp"

--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "eventSystem/tasks/ITask.hpp"
+#include "Environment.def"
 
 #include <map>
 #include <set>

--- a/src/libPMacc/include/eventSystem/streams/StreamController.hpp
+++ b/src/libPMacc/include/eventSystem/streams/StreamController.hpp
@@ -26,6 +26,7 @@
 
 #include "eventSystem/streams/EventStream.hpp"
 #include "types.h"
+#include "Environment.def"
 
 #include <cuda_runtime.h>
 

--- a/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -25,7 +26,6 @@
 
 #include "eventSystem/tasks/StreamTask.hpp"
 #include "eventSystem/streams/EventStream.hpp"
-#include "eventSystem/EventSystem.hpp"
 
 namespace PMacc
 {
@@ -59,14 +59,7 @@ namespace PMacc
         {
         }
 
-        void activateChecks()
-        {
-            canBeChecked = true;
-            this->activate();
-            
-            Environment<>::get().Manager().addTask(this);
-            __setTransactionEvent(EventTask(this->getId()));
-        }
+        void activateChecks();
 
         virtual std::string toString()
         {

--- a/src/libPMacc/include/eventSystem/tasks/TaskKernel.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskKernel.tpp
@@ -20,13 +20,20 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #pragma once
 
-#include "eventSystem/Manager.tpp"
-#include "eventSystem/tasks/StreamTask.tpp"
-#include "eventSystem/tasks/TaskKernel.tpp"
-#include "eventSystem/transactions/Transaction.tpp"
-#include "eventSystem/transactions/TransactionManager.tpp"
-#include "eventSystem/events/EventTask.tpp"
-#include "eventSystem/events/EventNotify.tpp"
-#include "eventSystem/tasks/Factory.tpp"
+#include "eventSystem/tasks/TaskKernel.hpp"
+#include "Environment.hpp"
+
+namespace PMacc{
+
+    void TaskKernel::activateChecks()
+    {
+        canBeChecked = true;
+        this->activate();
+
+        Environment<>::get().Manager().addTask(this);
+        __setTransactionEvent(EventTask(this->getId()));
+    }
+} //namespace PMacc

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -22,7 +23,7 @@
 
 #pragma once
 
-#include "eventSystem/EventSystem.hpp"
+#include "eventSystem/events/EventTask.hpp"
 
 namespace PMacc
 {
@@ -61,11 +62,11 @@ public:
     /**
      * Performs an operation on the transaction which leads to synchronization.
      *
-     * @param operation type of operation to perform, defines resulting sychronization.
+     * @param operation type of operation to perform, defines resulting synchronization.
      */
     void operation(ITask::TaskType operation);
 
-    /* Get a EventStream which inlcude all dependencies
+    /* Get a EventStream which include all dependencies
      * @param operation type of operation to perform
      * @return EventStream with solved dependencies
      */


### PR DESCRIPTION
This solves a compilation failure when EventSystem.hpp is included AFTER Environment.hpp due to circular inclusion of those. Example:

    Environment.hpp ->   
        EventSystem.hpp ->
            StreamTask.tpp ->
                Environment.hpp (Ignored due to pragma once)
                [Use Environment]
    [Define Environment]

As you see, Environment will be used before it is defined in this case. This PR solves that, by splitting the hpp and tpp inclusions of the eventsystem into 2 files. The hpps are included as usual, but the tpps are included on the bottom of Environment.hpp (As already done for another tpp)

Issue already discussed with @psychocoderHPC 