### PR TITLE
Fix NoSolver in 2D

### DIFF
--- a/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -37,15 +37,15 @@ using namespace PMacc;
 template<>
 struct GetMargin<picongpu::noSolver::NoSolver, FIELD_B>
 {
-    typedef PMacc::math::CT::Int< 0, 0, 0 > LowerMargin;
-    typedef PMacc::math::CT::Int< 0, 0, 0 > UpperMargin;
+    typedef typename PMacc::math::CT::make_Int< simDim, 0 >::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int< simDim, 0 >::type UpperMargin;
 };
 
 template<>
 struct GetMargin<picongpu::noSolver::NoSolver, FIELD_E>
 {
-    typedef PMacc::math::CT::Int< 0, 0, 0 > LowerMargin;
-    typedef PMacc::math::CT::Int< 0, 0, 0 > UpperMargin;
+    typedef typename PMacc::math::CT::make_Int< simDim, 0 >::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int< simDim, 0 >::type UpperMargin;
 };
 
 } //namespace traits


### PR DESCRIPTION
With simDim equal to 2 (2D3V simulation), the MaxwellSolver `NoSolver` did cause a compile error due to a missing trait specialization.

This commit fixes that, in 2D3V simulations we still have 3 components of each vector field (E and B) but only 2 directions for neighbors (the third direction is assumed to be "periodic" or "infinitely identical").

Thanks to @n01r for reporting the issue!