### PR TITLE
Use optimized atomicAllInc

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Felix Schmitt, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -135,7 +136,7 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
         int direction = (*frame)[linearThreadIdx][multiMask_] - 2;
         if ( direction >= 0 )
         {
-            destParticleIdx = atomicAdd( &(destFramesCounter[direction]), 1 );
+            destParticleIdx = nvidia::atomicAllInc( &(destFramesCounter[direction]) );
         }
         __syncthreads( );
 

--- a/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -30,6 +30,7 @@
 
 #include "memory/boxes/DataBox.hpp"
 #include "memory/boxes/PitchedBox.hpp"
+#include "nvidia/atomic.hpp"
 
 namespace PMacc
 {
@@ -89,7 +90,7 @@ namespace PMacc
 #if !defined(__CUDA_ARCH__) // Host code path
             TYPE old_addr = (*currentSize)++;
 #else
-            TYPE old_addr = atomicAdd(currentSize, 1);
+            TYPE old_addr = nvidia::atomicAllInc(currentSize);
 #endif
             (*this)[old_addr] = val;
         }


### PR DESCRIPTION
This uses atomicAllInc instead of atomicAdd(..., 1) which is optimized for less collisions