### PR TITLE
Improve atomicAddInc

### DIFF
--- a/src/libPMacc/include/nvidia/atomic.hpp
+++ b/src/libPMacc/include/nvidia/atomic.hpp
@@ -76,9 +76,9 @@ namespace nvidia
         /**
          * Optimized version
          *
-         * This warp aggregated atomic increment implementation based on
-         * nvidia parallel forall example
+         * This warp aggregated atomic increment implementation based on nvidia parallel forall example
          * http://devblogs.nvidia.com/parallelforall/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/
+         * (author: Andrew Adinetz, date: October 1th, 2014)
          *
          */
         template<typename T_Type>

--- a/src/libPMacc/include/nvidia/atomic.hpp
+++ b/src/libPMacc/include/nvidia/atomic.hpp
@@ -57,10 +57,10 @@ namespace nvidia
         struct AtomicAllIncIsOptimized
         {
             enum{
-                value = boost::is_same<T,  int32_t>::value ||
-                        boost::is_same<T, uint32_t>::value ||
-                        boost::is_same<T,  int64_cu>::value ||
-                        boost::is_same<T, uint64_cu>::value ||
+                value = boost::is_same<T,          int>::value ||
+                        boost::is_same<T, unsigned int>::value ||
+                        boost::is_same<T,          long long int>::value ||
+                        boost::is_same<T, unsigned long long int>::value ||
                         boost::is_same<T, float>::value
             };
         };
@@ -103,19 +103,19 @@ namespace nvidia
         };
 
         /**
-         * Optimized version for int64_cu.
-         * As CUDA atomicAdd does not support int64_cu directly we just cast it
-         * and call the uint64_cu implementation
+         * Optimized version for int64.
+         * As CUDA atomicAdd does not support int64 directly we just cast it
+         * and call the uint64 implementation
          */
         template<>
-        struct AtomicAllIncKepler<int64_cu, true>
+        struct AtomicAllIncKepler<long long int, true>
         {
-            DINLINE int64_cu
-            operator()(int64_cu* ptr)
+            DINLINE long long int
+            operator()(long long int* ptr)
             {
-                return static_cast<int64_cu>(
-                        AtomicAllIncKepler<uint64_cu>()(
-                                reinterpret_cast<uint64_cu*>(ptr)
+                return static_cast<long long int>(
+                        AtomicAllIncKepler<unsigned long long int>()(
+                                reinterpret_cast<unsigned long long int*>(ptr)
                         )
                 );
             }

--- a/src/libPMacc/include/nvidia/atomic.hpp
+++ b/src/libPMacc/include/nvidia/atomic.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Rene Widera
+ * Copyright 2015 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -25,8 +25,10 @@
 
 #include "types.h"
 #include "nvidia/warp.hpp"
+#include <boost/type_traits.hpp>
 #include <math_functions.h>
 #include <device_functions.h>
+#include <climits>
 
 
 namespace PMacc
@@ -34,40 +36,113 @@ namespace PMacc
 namespace nvidia
 {
 
+    namespace detail {
+
+        template<typename T_Type, bool T_isKepler>
+        struct AtomicAllInc
+        {
+            DINLINE T_Type
+            operator()(T_Type* ptr)
+            {
+                return atomicAdd(ptr, 1);
+            }
+        };
+
+#if PMACC_CUDA_ARCH >= 300
+       /**
+         * Trait that returns whether an optimized version of AtomicAllInc
+         * exists for Kepler architectures (and up)
+         */
+        template<typename T>
+        struct AtomicAllIncIsOptimized
+        {
+            enum{
+                value = boost::is_same<T,  int32_t>::value ||
+                        boost::is_same<T, uint32_t>::value ||
+                        boost::is_same<T,  int64_cu>::value ||
+                        boost::is_same<T, uint64_cu>::value ||
+                        boost::is_same<T, float>::value
+            };
+        };
+
+        /**
+         * AtomicAllInc for Kepler and up
+         * Defaults to unoptimized version for unsupported types
+         */
+        template<typename T_Type, bool T_UseOptimized = AtomicAllIncIsOptimized<T_Type>::value>
+        struct AtomicAllIncKepler: public AtomicAllInc<T_Type, false>
+        {};
+
+        /**
+         * Optimized version
+         *
+         * This warp aggregated atomic increment implementation based on
+         * nvidia parallel forall example
+         * http://devblogs.nvidia.com/parallelforall/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/
+         *
+         */
+        template<typename T_Type>
+        struct AtomicAllIncKepler<T_Type, true>
+        {
+            DINLINE T_Type
+            operator()(T_Type* ptr)
+            {
+                /* Get a bitmask with 1 for each thread in the warp, that executes this */
+                const int mask = __ballot(1);
+                /* select the leader */
+                const int leader = __ffs(mask) - 1;
+                T_Type result;
+                const int laneId = getLaneId();
+                /* Get the start value for this warp */
+                if (laneId == leader)
+                    result = atomicAdd(ptr, static_cast<T_Type>(__popc(mask)));
+                result = warpBroadcast(result, leader);
+                /* Add offset per thread */
+                return result + static_cast<T_Type>(__popc(mask & ((1 << laneId) - 1)));
+            }
+        };
+
+        /**
+         * Optimized version for int64_cu.
+         * As CUDA atomicAdd does not support int64_cu directly we just cast it
+         * and call the uint64_cu implementation
+         */
+        template<>
+        struct AtomicAllIncKepler<int64_cu, true>
+        {
+            DINLINE int64_cu
+            operator()(int64_cu* ptr)
+            {
+                return static_cast<int64_cu>(
+                        AtomicAllIncKepler<uint64_cu>()(
+                                reinterpret_cast<uint64_cu*>(ptr)
+                        )
+                );
+            }
+        };
+
+        template<typename T_Type>
+        struct AtomicAllInc<T_Type, true>: public AtomicAllIncKepler<T_Type>
+        {};
+#endif /* PMACC_CUDA_ARCH >= 300 */
+
+    }  // namespace detail
+
 /** optimized atomic increment
  *
  * - only optimized if PTX ISA >=3.0
- * - this atomic uses warp aggregation to speedup the operation compared to
- *   cuda `atomicInc()`
- * - cuda `atomicAdd()` is used if the compute architecture not supports
- *   warp aggregation
- *   is used
- * - all participate threads must change the same
- *   pointer (ptr) else the result is unspecified
+ * - this atomic uses warp aggregation to speedup the operation compared to cuda `atomicInc()`
+ * - cuda `atomicAdd()` is used if the compute architecture does not support warp aggregation
+ * - all participate threads must change the same pointer (ptr) else the result is unspecified
  *
  * @param ptr pointer to memory (must be the same address for all threads in a block)
  *
- * This warp aggregated atomic increment implementation based on
- * nvidia parallel forall example
- * http://devblogs.nvidia.com/parallelforall/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/
  */
+template<typename T>
 DINLINE
-int atomicAllInc(int *ptr)
+T atomicAllInc(T *ptr)
 {
-#if (__CUDA_ARCH__ >= 300)
-    const int mask = __ballot(1);
-    /* select the leader */
-    const int leader = __ffs(mask) - 1;
-    int restult;
-    const int lanId = getLaneId();
-    if (lanId == leader)
-        restult = atomicAdd(ptr, __popc(mask));
-    restult = warpBroadcast(restult, leader);
-    /* each thread computes its own value */
-    return restult + __popc(mask & ((1 << lanId) - 1));
-#else
-    return atomicAdd(ptr,1);
-#endif
+    return detail::AtomicAllInc<T, (PMACC_CUDA_ARCH >= 300) >()(ptr);
 }
 
 /** optimized atomic value exchange

--- a/src/libPMacc/include/nvidia/warp.hpp
+++ b/src/libPMacc/include/nvidia/warp.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Rene Widera
+ * Copyright 2015 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -51,9 +51,65 @@ DINLINE uint32_t getLaneId()
  * required PTX ISA >=3.0
  */
 #if (__CUDA_ARCH__ >= 300)
-DINLINE int warpBroadcast(const int data, const int srcLaneId)
+DINLINE int32_t warpBroadcast(const int32_t data, const int32_t srcLaneId)
 {
     return  __shfl(data, srcLaneId);
+}
+/**
+ * Broadcast a 64bit integer by using 2 32bit broadcasts
+ */
+DINLINE int64_cu warpBroadcast(const int64_cu data, const int32_t srcLaneId)
+{
+    union{
+        int32_t dataHi, dataLo;
+        int64_cu data64;
+    } dataUnion;
+    dataUnion.data64 = data;
+    warpBroadcast(dataUnion.dataHi, srcLaneId);
+    warpBroadcast(dataUnion.dataLo, srcLaneId);
+    return dataUnion.data64;
+}
+/**
+ * Broadcast a 32bit unsigned int
+ * Maps to signed int function with no additional overhead
+ */
+DINLINE uint32_t warpBroadcast(const uint32_t data, const int32_t srcLaneId)
+{
+    return static_cast<uint32_t>(
+            warpBroadcast(static_cast<int32_t>(data), srcLaneId)
+            );
+}
+/**
+ * Broadcast a 32bit unsigned int
+ * Maps to signed int function with no additional overhead
+ */
+DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId)
+{
+    return static_cast<uint64_cu>(
+            warpBroadcast(static_cast<uint64_cu>(data), srcLaneId)
+            );
+}
+
+/**
+ * Broadcast a 32bit float
+ */
+DINLINE float warpBroadcast(const float data, const int32_t srcLaneId)
+{
+    return  __shfl(data, srcLaneId);
+}
+/**
+ * Broadcast a 64bit float by using 2 32bit broadcasts
+ */
+DINLINE double warpBroadcast(const double data, const int32_t srcLaneId)
+{
+    union{
+        float dataHi, dataLo;
+        double data64;
+    } dataUnion;
+    dataUnion.data64 = data;
+    warpBroadcast(dataUnion.dataHi, srcLaneId);
+    warpBroadcast(dataUnion.dataLo, srcLaneId);
+    return dataUnion.data64;
 }
 #endif
 

--- a/src/libPMacc/include/nvidia/warp.hpp
+++ b/src/libPMacc/include/nvidia/warp.hpp
@@ -80,7 +80,7 @@ DINLINE uint32_t warpBroadcast(const uint32_t data, const int32_t srcLaneId)
             );
 }
 /**
- * Broadcast a 32bit unsigned int
+ * Broadcast a 64bit unsigned int
  * Maps to signed int function with no additional overhead
  */
 DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId)

--- a/src/libPMacc/include/types.h
+++ b/src/libPMacc/include/types.h
@@ -1,6 +1,7 @@
 /**
  * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Wolfgang Hoenig, Benjamin Worpitz
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -59,6 +60,16 @@ typedef long long int int64_cu;
 #define HDINLINE __device__ __host__ __forceinline__
 #define DINLINE __device__ __forceinline__
 #define HINLINE __host__ inline
+
+/**
+ * CUDA architecture version (aka PTX ISA level)
+ * 0 for host compilation
+ */
+#ifndef __CUDA_ARCH__
+#   define PMACC_CUDA_ARCH 0
+#else
+#   define PMACC_CUDA_ARCH __CUDA_ARCH__
+#endif
 
 /*
  * Disable nvcc warning:


### PR DESCRIPTION
This adds overloads for (I think) all possible types that can be used with atomicAddInc and warpBroadcast. (atomicAddInc depends on the latter so this change is very related)

This also adds a macro PMACC_CUDA_ARCH which is equivalent to __CUDA_ARCH__ but defined to be 0 when __CUDA_ARCH__ is not defined. The reason for this is, that even while atomicAddInc is marked DINLINE it seems to be passed to the host compiler which throws as __CUDA_ARCH__ is an undefined symbol.

Code is based on code by @psychocoderHPC so I'd suggest him to review this.