### PR TITLE
Add a policy for async communication

### DIFF
--- a/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
@@ -47,6 +47,7 @@
 
 #include "plugins/PluginController.hpp"
 #include "particles/ParticlesInitOneParticle.hpp"
+#include "communication/AsyncCommunication.hpp"
 
 
 namespace picongpu
@@ -139,7 +140,7 @@ public:
         //std::cout << "Begin update Electrons" << std::endl;
         particleStorage[TypeAsIdentifier<PIC_Electrons>()]->update(currentStep);
         //std::cout << "End update Electrons" << std::endl;
-        EventTask eRecvElectrons = particleStorage[TypeAsIdentifier<PIC_Electrons>()]->asyncCommunication(__getTransactionEvent());
+        EventTask eRecvElectrons = communication::asyncCommunication(*particleStorage[TypeAsIdentifier<PIC_Electrons>()], __getTransactionEvent());
         EventTask eElectrons = __endTransaction();
 #endif
 

--- a/examples/SingleParticleTest/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleTest/include/OneParticleSimulation.hpp
@@ -134,7 +134,7 @@ public:
 
         particleStorage[TypeAsIdentifier<PIC_Electrons>()]->update(currentStep);
 
-        EventTask eRecvElectrons = asyncCommunication(*particleStorage[TypeAsIdentifier<PIC_Electrons>()], __getTransactionEvent());
+        EventTask eRecvElectrons = communication::asyncCommunication(*particleStorage[TypeAsIdentifier<PIC_Electrons>()], __getTransactionEvent());
         EventTask eElectrons = __endTransaction();
 
         __setTransactionEvent(eRecvElectrons + eElectrons);

--- a/examples/SingleParticleTest/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleTest/include/OneParticleSimulation.hpp
@@ -46,6 +46,7 @@
 
 #include "plugins/PluginController.hpp"
 #include "particles/ParticlesInitOneParticle.hpp"
+#include "communication/AsyncCommunication.hpp"
 
 
 namespace picongpu
@@ -133,7 +134,7 @@ public:
 
         particleStorage[TypeAsIdentifier<PIC_Electrons>()]->update(currentStep);
 
-        EventTask eRecvElectrons = particleStorage[TypeAsIdentifier<PIC_Electrons>()]->asyncCommunication(__getTransactionEvent());
+        EventTask eRecvElectrons = asyncCommunication(*particleStorage[TypeAsIdentifier<PIC_Electrons>()], __getTransactionEvent());
         EventTask eElectrons = __endTransaction();
 
         __setTransactionEvent(eRecvElectrons + eElectrons);

--- a/src/libPMacc/include/communication/AsyncCommunication.hpp
+++ b/src/libPMacc/include/communication/AsyncCommunication.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace PMacc {
+namespace communication {
+
+    /**
+     * Wrapper to convert a bool into a type
+     */
+    template<bool T_value>
+    struct Bool2Type;
+
+    /**
+     * Implementations of \see AsyncCommunication should specialize this,
+     * but it is not intended to be called directly. Use \see AsyncCommunication
+     *
+     * The 2nd template parameter can be used to check for conditions on
+     * templated implementations. E.g.:
+     *
+     *     template<typename T_Data>
+     *     struct AsyncCommunicationImpl<
+     *         T_Data,
+     *         Bool2Type< boost::is_integral<T_Data>::value >
+     *     >{...}
+     */
+    template<typename T_Data, typename T_IsSpecialized = Bool2Type<true> >
+    struct AsyncCommunicationImpl;
+
+    /**
+     * This policy starts an asynchronous communication of the given data
+     * (e.g. a particle species)
+     *
+     * It must be a functor with signature EventTask(T_Data&, EventTask parentEvent)
+     * but can be templated (again) over T_Data to get the actual type. This
+     * is helpful for generic implementations that apply to T_Data and all
+     * derived classes but want to use the possibly more derived type
+     *
+     * For different T_Data types you can either specialize this or the more
+     * generic \see AsyncCommunicationImpl
+     */
+    template<typename T_Data>
+    struct AsyncCommunication: public AsyncCommunicationImpl<T_Data>
+    {};
+
+    template<typename T_Data>
+    EventTask
+    asyncCommunication(T_Data& data, EventTask parent)
+    {
+        return AsyncCommunication<T_Data>()(data, parent);
+    }
+
+}  // namespace communication
+}  // namespace PMacc

--- a/src/libPMacc/include/fields/SimulationFieldHelper.hpp
+++ b/src/libPMacc/include/fields/SimulationFieldHelper.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013, 2015 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -38,8 +39,10 @@ public:
 
     SimulationFieldHelper(CellDescription description) :
     cellDescription(description)
-    {
-    }
+    {}
+
+    virtual ~SimulationFieldHelper(){}
+
     /**
      * Reset is as well used for init.
      */
@@ -50,13 +53,6 @@ public:
      */
     virtual void syncToDevice() = 0;
 
-    /**
-     * Start an asynchronous communication.
-     *
-     * @param serialEvent an EventTask the method has to wait on
-     * @return an EventTask which can be used to wait on completion
-     */
-    virtual EventTask asyncCommunication(EventTask serialEvent)=0;
 protected:
     CellDescription cellDescription;
 };

--- a/src/libPMacc/include/particles/AsyncCommunicationImpl.hpp
+++ b/src/libPMacc/include/particles/AsyncCommunicationImpl.hpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "communication/AsyncCommunication.hpp"
+#include "Environment.hpp"
+#include "ParticlesBase.hpp"
+#include <boost/type_traits.hpp>
+
+namespace PMacc {
+
+    /**
+     * Trait that should return true if T is a particle species
+     */
+    template<typename T>
+    struct IsParticleSpecies
+    {
+        enum{ value = boost::is_same<typename T::SimulationDataTag, ParticlesTag>::value };
+    };
+
+    namespace communication {
+
+        template<typename T_Data>
+        struct AsyncCommunicationImpl<T_Data, Bool2Type<IsParticleSpecies<T_Data>::value> >
+        {
+            template<class T_Particles>
+            EventTask
+            operator()(T_Particles& par, EventTask event) const
+            {
+                EventTask ret;
+                __startTransaction(event);
+                Environment<>::get().ParticleFactory().createTaskParticlesReceive(par);
+                ret = __endTransaction();
+
+                __startTransaction(event);
+                Environment<>::get().ParticleFactory().createTaskParticlesSend(par);
+                ret += __endTransaction();
+                return ret;
+            }
+        };
+
+    }  // namespace communication
+}  // namespace PMacc

--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -37,6 +37,9 @@
 namespace PMacc
 {
 
+/* Tag used for marking particle types */
+struct ParticlesTag;
+
 template<typename T_ParticleDescription, class T_MappingDesc>
 class ParticlesBase : public SimulationFieldHelper<T_MappingDesc>
 {
@@ -69,6 +72,9 @@ public:
         Exchanges = traits::NumberOfExchanges<Dim>::value,
         TileSize = math::CT::volume<typename MappingDesc::SuperCellSize>::type::value
     };
+
+    /* Mark this simulation data as a particle type */
+    typedef ParticlesTag SimulationDataTag;
 
 protected:
 
@@ -176,12 +182,6 @@ public:
         assert(particlesBuffer != NULL);
         return *particlesBuffer;
     }
-
-    /* Communicate particles to neighbor devices.
-     * This method include bashing and insert of particles full
-     * asynchron.
-     */
-    EventTask asyncCommunication(EventTask event);
 
     /* set all internal objects to initial state*/
     virtual void reset(uint32_t currentStep);

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -103,18 +103,6 @@ namespace PMacc
         }
     }
 
-    template<typename T_ParticleDescription, class MappingDesc>
-    EventTask ParticlesBase<T_ParticleDescription, MappingDesc>::asyncCommunication(EventTask event)
-    {
-        EventTask ret;
-        __startTransaction(event);
-        Environment<>::get().ParticleFactory().createTaskParticlesReceive(*this);
-        ret = __endTransaction();
-
-        __startTransaction(event);
-        Environment<>::get().ParticleFactory().createTaskParticlesSend(*this);
-        ret += __endTransaction();
-        return ret;
-    }
-
 } //namespace PMacc
+
+#include "particles/AsyncCommunicationImpl.hpp"

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -29,6 +29,7 @@
 #include <boost/mpl/plus.hpp>
 #include <boost/mpl/accumulate.hpp>
 
+#include "communication/AsyncCommunication.hpp"
 #include "particles/traits/GetIonizer.hpp"
 
 namespace picongpu
@@ -184,10 +185,9 @@ struct CommunicateSpecies
         if (hasPusher::value)
         {
             EventTask updateEvent(*(updateEventList.begin()));
-            PMACC_AUTO(speciesPtr, tuple[SpeciesName()]);
 
             updateEventList.pop_front();
-            commEventList.push_back(speciesPtr->asyncCommunication(updateEvent));
+            commEventList.push_back( communication::asyncCommunication(*tuple[SpeciesName()], updateEvent) );
         }
     }
 };

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera, Marco Garten
+ * Copyright 2014-2015 Rene Widera, Marco Garten, Alexander Grund
  *
  * This file is part of PIConGPU.
  *


### PR DESCRIPTION
This makes the asyncCommunication a functor instead of a virtual method.
This has the advantage (besides beeing more TMP like) that a call preserves the actual type compared to "concreteParticleInstance->asyncCommunication(event)" where functors down the chain only have access to ParticleBase.

As requested by @psychocoderHPC the functor can be specialized for any type. Particles are the only one used right now, but a specialization can be defined for buffers too without much effort.

For inheritance detection a tag is used ->"SimulationDataTag" type member. This is similar to e.g. iterator_tag from STL and solves the problem, that one cannot detect, whether a type is derived from a templated type.