### PR TITLE
Close #1060 CMake3 on Titan: Cross Compile

### DIFF
--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -3,14 +3,15 @@ export TBG_mailAdress="mail@example.com"
 
 # basic environment #################################################
 source /opt/modules/3.2.6.7/init/bash
+module load craype-accel-nvidia35
 module swap PrgEnv-pgi PrgEnv-gnu
 # module swap gcc gcc/4.8.2 # default
 
 # Compile for CLE nodes
 #   (CMake likes to unwrap the Cray wrappers)
-export CC="`which cc` -target=compute_node"
-export CXX="`which CC` -target=compute_node"
-export FC="`which ftn` -target=compute_node"
+export CC=`which cc`
+export CXX=`which CC`
+export FC=`which ftn`
 #export LD="/sw/xk6/altd/bin/ld"
 
 # symbol bug work around (should not be required)


### PR DESCRIPTION
Close #1060 Compiling with cmake 3+ caused a wrong detection of the `-ccbin` host-side compiler by cmake.

The compile wrappers on titan seem to have changed so that our work-around is not needed any more (`target` is also now deprecated). We remove it to address the issue. Compiles with the last cmake2 version we support still work.