### PR TITLE
Close #518 No `__syncthreads()` shared memory alloc

### DIFF
--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -45,7 +45,6 @@ struct SharedMemAllocator<Type, Size, 1, uid>
     __device__ static Cursor allocate()
     {
         __shared__ Type shMem[Size::x::value];
-        __syncthreads(); /*wait that all shared memory is initialised*/
         return Cursor((Type*)shMem);
     }
 };
@@ -61,7 +60,6 @@ struct SharedMemAllocator<Type, Size, 2, uid>
     __device__ static Cursor allocate()
     {
         __shared__ Type shMem[Size::x::value][Size::y::value];
-        __syncthreads(); /*wait that all shared memory is initialised*/
         return Cursor((Type*)shMem);
     }
 };
@@ -78,7 +76,6 @@ struct SharedMemAllocator<Type, Size, 3, uid>
     __device__ static Cursor allocate()
     {
         __shared__ Type shMem[Size::x::value][Size::y::value][Size::z::value];
-        __syncthreads(); /*wait that all shared memory is initialised*/
         return Cursor((Type*)shMem);
     }
 };

--- a/src/libPMacc/include/memory/boxes/SharedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/SharedBox.hpp
@@ -97,7 +97,6 @@ public:
     static DINLINE This init()
     {
         __shared__ ValueType mem_sh[Size::x::value];
-        __syncthreads(); /*wait that all shared memory is initialised*/
         return This((ValueType*) mem_sh);
     }
 
@@ -157,7 +156,6 @@ public:
     static DINLINE This init()
     {
         __shared__ ValueType mem_sh[Size::y::value][Size::x::value];
-        __syncthreads(); /*wait that all shared memory is initialised*/
         return This((ValueType*) mem_sh);
     }
 
@@ -233,7 +231,6 @@ public:
     static DINLINE This init()
     {
         __shared__ ValueType mem_sh[Size::z::value][Size::y::value][Size::x::value];
-        __syncthreads(); /*wait that all shared memory is initialised*/
         return This((ValueType*) mem_sh);
     }
 

--- a/src/libPMacc/include/nvidia/reduce/Reduce.hpp
+++ b/src/libPMacc/include/nvidia/reduce/Reduce.hpp
@@ -59,8 +59,6 @@ namespace PMacc
 
                     if (tid >= src_count) return; /*end not needed threads*/
 
-                    __syncthreads(); /*wait that all shared memory is initialized*/
-
                     /*fill shared mem*/
                     Type r_value = src[tid];
                     /*reduce not readed global memory to shared*/

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -75,7 +75,6 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
     __shared__ bool isFrameValid;
     __shared__ bool mustShift;
 
-    __syncthreads(); /*wait that all shared memory is initialized */
     DataSpace<dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<dim> (blockIdx) );
     const uint32_t linearThreadIdx = threadIdx.x;
 
@@ -247,7 +246,6 @@ __global__ void kernelFillGapsLastFrame(ParticlesBox<FRAME, Mapping::Dim> pb, Ma
 
     __shared__ int srcGap;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     if (threadIdx.x == 0)
     {
@@ -318,7 +316,6 @@ __global__ void kernelFillGaps(ParticlesBox<FRAME, Mapping::Dim> pb, Mapping map
     __shared__ int counterGaps;
     __shared__ int counterParticles;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     if (threadIdx.x == 0)
     {
@@ -429,7 +426,6 @@ __global__ void kernelDeleteParticles(T_ParticleBox pb,
     __shared__ FrameType *frame;
     __shared__ bool isValid;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     if (linearThreadIdx == 0)
     {
@@ -479,8 +475,6 @@ __global__ void kernelBashParticles(ParticlesBox<FRAME, Mapping::Dim> pb,
     __shared__ bool isValid;
     __shared__ bool hasMemory;
     __shared__ TileDataBox<BORDER> tmpBorder;
-
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     if (threadIdx.x == 0)
     {
@@ -565,7 +559,6 @@ __global__ void kernelInsertParticles(ParticlesBox<FRAME, Mapping::Dim> pb,
     __shared__ int elementCount;
     __shared__ TileDataBox<BORDER> tmpBorder;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     DataSpace < Mapping::Dim - 1 > superCell;
 

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -52,8 +52,6 @@ __global__ void kernelCountParticles(PBox pb,
     __shared__ lcellId_t particlesInSuperCell;
 
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
-
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
     const DataSpace<Dim > threadIndex(threadIdx);


### PR DESCRIPTION
- remove all `__syncthreads()` after shared memory allocation
- related to #518

Tests:

- I tested #1083 and this one together