### PR TITLE
Close #518 No `__syncthreads()` shared memory alloc

### DIFF
--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -85,8 +85,6 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
     /* This memory is used by all virtual blocks*/
     PMACC_AUTO(cachedJ, CachedBox::create < 0, typename JBox::ValueType > (BlockDescription_()));
 
-    __syncthreads();
-
     Set<typename JBox::ValueType > set(float3_X::create(0.0));
     ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveSet(linearThreadIdx);
     collectiveSet(set, cachedJ);

--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -49,7 +49,6 @@ DINLINE void absorb(BoxedMemory field, uint32_t thickness, float_X absorber_stre
 
     __shared__ int finish;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     float_X factor = float_X(0.0);
 

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -59,8 +59,6 @@ namespace picongpu
         __shared__ bool isValid;
         __shared__ lcellId_t particlesInSuperCell;
 
-        /* wait until all shared memory is initialised */
-        __syncthreads( );
 
         if( linearThreadIdx == 0 )
         {

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -68,7 +68,6 @@ __global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, Partic
     __shared__ bool isValid;
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
 
@@ -122,7 +121,6 @@ __global__ void kernelManipulateAllParticles(T_ParBox pb,
     __shared__ bool isValid;
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     const DataSpace<simDim > threadIndex(threadIdx);
     const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
@@ -190,7 +188,6 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
     __shared__ int mustShift;
     lcellId_t particlesInSuperCell;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     if (linearThreadIdx == 0)
     {

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -73,8 +73,7 @@ __global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
 
     __shared__ FRAME *frame;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
-
+    
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
     const DataSpace<simDim > threadIndex(threadIdx);

--- a/src/picongpu/include/particles/access/Cell2Particle.tpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.tpp
@@ -49,7 +49,6 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
     __shared__ Frame* frame; \
     __shared__ bool isValid; \
     __shared__ uint16_t particlesInSuperCell; \
-    __syncthreads(); /*wait that all shared memory is initialised*/ \
     \
     if(linearThreadIdx == 0) \
     { \

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -128,8 +128,7 @@ namespace ionization
                 /* caching of E and B fields */
                 cachedB = CachedBox::create < 0, ValueType_B > (BlockArea());
                 cachedE = CachedBox::create < 1, ValueType_E > (BlockArea());
-                /* wait for shared memory to be initialized */
-                __syncthreads();
+
                 /* instance of nvidia assignment operator */
                 nvidia::functors::Assign assign;
                 /* copy fields from global to shared */

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -131,8 +131,7 @@ namespace ionization
                 /* caching of E and B fields */
                 cachedB = CachedBox::create < 0, ValueType_B > (BlockArea());
                 cachedE = CachedBox::create < 1, ValueType_E > (BlockArea());
-                /* wait for shared memory to be initialized */
-                __syncthreads();
+
                 /* instance of nvidia assignment operator */
                 nvidia::functors::Assign assign;
                 /* copy fields from global to shared */
@@ -150,8 +149,6 @@ namespace ionization
                           cachedE,
                           fieldEBlock
                           );
-                /* wait for shared memory to be initialized */
-                __syncthreads();
             }
 
             /** Functor implementation

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -112,14 +112,12 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
     /* typedef for the functor that writes new macro electrons into electron frames during runtime */
     typedef typename particles::ionization::WriteElectronIntoFrame WriteElectronIntoFrame;
 
-    __syncthreads();
 
     __shared__ IONFRAME *ionFrame;
     __shared__ ELECTRONFRAME *electronFrame;
     __shared__ bool isValid;
     __shared__ lcellId_t maxParticlesInFrame;
 
-    __syncthreads(); /*wait that all shared memory is initialized*/
 
     /* find last frame in super cell
      * define maxParticlesInFrame as the maximum frame size
@@ -141,8 +139,6 @@ __global__ void kernelIonizeParticles(ParBoxIons ionBox,
      * occupation of the newly created target electron frames.
      */
     __shared__ int newFrameFillLvl;
-
-    __syncthreads(); /*wait until all shared memory is initialized*/
 
     /* Declare local variable oldFrameFillLvl for each thread */
     int oldFrameFillLvl;

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -85,7 +85,6 @@ struct CreateParticlesFromParticleImpl : private T_Functor
         __shared__ DestFrameType* destFrame;
         __shared__ int particlesInDestSuperCell;
 
-        __syncthreads();
 
         uint32_t ltid = DataSpaceOperations<simDim>::template map<SuperCellSize>(DataSpace<simDim>(threadIdx));
         const DataSpace<simDim> superCell((guardCells + localCellIdx) / SuperCellSize::toRT());

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -78,8 +78,6 @@ __global__ void kernelBinEnergyParticles(ParticlesBox<FRAME, simDim> pb,
      */
     extern __shared__ float_X shBin[]; /* size must be numBins+2 because we have <min and >max */
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
-
     int realNumBins = numBins + 2;
 
 

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -62,7 +62,6 @@ __global__ void kernelEnergyParticles(ParticlesBox<FRAME, simDim> pb,
     __shared__ bool isValid; /* is data frame valid? */
     __shared__ float_X shEnergyKin; /* shared kinetic energy */
     __shared__ float_X shEnergy; /* shared total energy */
-    __syncthreads(); /* wait that all shared memory is initialised */
 
     float_X _local_energyKin = float_X(0.0); /* sum kinetic energy for this thread */
     float_X _local_energy = float_X(0.0); /* sum total energy for this thread */

--- a/src/picongpu/include/plugins/IntensityPlugin.hpp
+++ b/src/picongpu/include/plugins/IntensityPlugin.hpp
@@ -59,7 +59,6 @@ __global__ void kernelIntensity(FieldBox field, DataSpace<simDim> cellsCount, Bo
     __shared__ float_X s_integrated[SuperCellSize::y::value];
     __shared__ float_X s_max[SuperCellSize::y::value];
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     /*descripe size of a worker block for cached memory*/
     typedef SuperCellDescription<

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -104,7 +104,6 @@ __global__ void kernelPositionsParticles(ParticlesBox<FRAME, simDim> pb,
 
     __shared__ FRAME *frame;
     __shared__ bool isValid;
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     typedef typename Mapping::SuperCellSize SuperCellSize;
 

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -48,7 +48,6 @@ __global__ void kernelSumCurrents(J_DataBox fieldJ, float3_X* gCurrent, Mapping 
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
     __shared__ float3_X sh_sumJ;
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     const DataSpace<simDim > threadIndex(threadIdx);
     const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -169,7 +169,6 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
 
     __shared__ bool isValid;
 
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
     const DataSpace<Mapping::Dim> superCellPosition((block - mapper.getGuardingSuperCells()) * mapper.getSuperCellSize());

--- a/src/picongpu/include/plugins/kernel/CopySpeciesGlobal2Local.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpeciesGlobal2Local.kernel
@@ -62,7 +62,6 @@ __global__ void copySpeciesGlobal2Local(T_CounterBox counter, T_DestBox destBox,
 
     const int linearThreadIdx = threadIdx.x;
 
-    __syncthreads(); /*wait that all shared memory is initialized*/
 
     const DataSpace<simDim> superCellsCount(cellDesc.getGridSuperCells() - cellDesc.getGuardingSuperCells()*2);
     if (linearThreadIdx == 0)

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -276,7 +276,7 @@ kernelPaintParticles3D(ParBox pb,
     typedef typename MappingDesc::SuperCellSize Block;
     __shared__ FRAME *frame;
     __shared__ bool isValid;
-    __syncthreads(); /*wait that all shared memory is initialised*/
+
     bool isImageThread = false;
 
     const DataSpace<simDim> threadId(threadIdx);
@@ -318,7 +318,6 @@ kernelPaintParticles3D(ParBox pb,
     // counter is always DIM2
     typedef DataBox < PitchedBox< float_X, DIM2 > > SharedMem;
     extern __shared__ float_X shBlock[];
-    __syncthreads(); /*wait that all shared memory is initialised*/
 
     const DataSpace<simDim> blockSize(blockDim);
     SharedMem counter(PitchedBox<float_X, DIM2 > ((float_X*) shBlock,

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -152,10 +152,6 @@ void kernelRadiationParticles(ParBox pb,
 
     const int theta_idx = blockIdx.x; //blockIdx.x is used to determine theta
     const uint32_t linearThreadIdx = threadIdx.x; // used for determine omega and particle id
-    // old:  DataSpaceOperations<DIM3>::map<Block > (DataSpace<DIM3 > (threadIdx));
-
-
-    __syncthreads(); /*wait that all shared memory is initialized*/
 
 
     // simulation time (needed for retarded time)


### PR DESCRIPTION
- remove all `__syncthreads()` after shared memory allocations
- related to #518

Tests: (together with #1082)
- [x] heating KHI 3D Esirkepov
- [x] speedup KHI 3D Esirkepov (speed decrease by <1%)
- [x] speedup KHI 3D ZigZag (no speedup)
