### PR TITLE
change default current solver to `ZigZag`

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/species.param
+++ b/examples/Bunch/include/simulation_defines/param/species.param
@@ -63,7 +63,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+typedef currentSolver::ZigZag<UsedParticleShape> UsedParticleCurrentSolver;
 
 /*! particle pusher configuration ----------------------------------------------
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
@@ -66,7 +66,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  *   without optimization (~4x slower and needs more shared memory)
  */
 #ifndef PARAM_CURRENTSOLVER
-#define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>
+#define PARAM_CURRENTSOLVER ZigZag<UsedParticleShape>
 #endif
 typedef currentSolver::PARAM_CURRENTSOLVER UsedParticleCurrentSolver;
 

--- a/examples/LaserWakefield/include/simulation_defines/param/species.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/species.param
@@ -76,7 +76,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  *   without optimization (~4x slower and needs more shared memory)
  */
 #ifndef PARAM_CURRENTSOLVER
-#define PARAM_CURRENTSOLVER Esirkepov
+#define PARAM_CURRENTSOLVER ZigZag
 #endif
 typedef currentSolver::PARAM_CURRENTSOLVER<UsedParticleShape> UsedParticleCurrentSolver;
 

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
@@ -63,7 +63,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+typedef currentSolver::ZigZag<UsedParticleShape> UsedParticleCurrentSolver;
 
 /*! particle pusher configuration ----------------------------------------------
  *

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
@@ -63,7 +63,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+typedef currentSolver::ZigZag<UsedParticleShape> UsedParticleCurrentSolver;
 
 /*! particle pusher configuration ----------------------------------------------
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/species.param
@@ -63,7 +63,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+typedef currentSolver::ZigZag<UsedParticleShape> UsedParticleCurrentSolver;
 
 /*! particle pusher configuration ----------------------------------------------
  *

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -65,7 +65,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  * - currentSolver::currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+typedef currentSolver::ZigZag<UsedParticleShape> UsedParticleCurrentSolver;
 
 /*! particle pusher configuration ----------------------------------------------
  *


### PR DESCRIPTION
- change current solver in all `species.param` files from `Esirkepov` to `ZigZag`

I changed the solver because that speedup a typical simulation by a factor of two. We should not waste our time :-)