### PR TITLE
CMake: PNGwriter Version Support

### DIFF
--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -3,14 +3,15 @@ export TBG_mailAdress="mail@example.com"
 
 # basic environment #################################################
 source /opt/modules/3.2.6.7/init/bash
+module load craype-accel-nvidia35
 module swap PrgEnv-pgi PrgEnv-gnu
 # module swap gcc gcc/4.8.2 # default
 
 # Compile for CLE nodes
 #   (CMake likes to unwrap the Cray wrappers)
-export CC="`which cc` -target=compute_node"
-export CXX="`which CC` -target=compute_node"
-export FC="`which ftn` -target=compute_node"
+export CC=`which cc`
+export CXX=`which CC`
+export FC=`which ftn`
 #export LD="/sw/xk6/altd/bin/ld"
 
 # symbol bug work around (should not be required)


### PR DESCRIPTION
Pull in third-party update: Adds version support to the PNGwriter's CMake module.

Follow-up to #1076, see https://github.com/ComputationalRadiationPhysics/cmake-modules/pull/11

--

Third party update for `FindmallocMC.cmake` in `thirdParty/cmake-modules` performed via

```bash
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
    git subtree pull --prefix thirdParty/cmake-modules/ \
    git@github.com:ComputationalRadiationPhysics/cmake-modules.git dev --squash
```