### PR TITLE
Add more specializations to GetMPI_StructAsArray

### DIFF
--- a/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
+++ b/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -42,22 +42,62 @@ struct GetMPI_StructAsArray<int >
 };
 
 template<>
+struct GetMPI_StructAsArray<unsigned >
+{
+
+    MPI_StructAsArray operator()() const
+    {
+        return MPI_StructAsArray(MPI_UNSIGNED, 1);
+    }
+};
+
+template<>
+struct GetMPI_StructAsArray<long >
+{
+
+    MPI_StructAsArray operator()() const
+    {
+        return MPI_StructAsArray(MPI_LONG, 1);
+    }
+};
+
+template<>
+struct GetMPI_StructAsArray<unsigned long >
+{
+
+    MPI_StructAsArray operator()() const
+    {
+        return MPI_StructAsArray(MPI_UNSIGNED_LONG, 1);
+    }
+};
+
+template<>
+struct GetMPI_StructAsArray<long long >
+{
+
+    MPI_StructAsArray operator()() const
+    {
+        return MPI_StructAsArray(MPI_LONG_LONG, 1);
+    }
+};
+
+template<>
+struct GetMPI_StructAsArray<unsigned long long >
+{
+
+    MPI_StructAsArray operator()() const
+    {
+        return MPI_StructAsArray(MPI_UNSIGNED_LONG_LONG, 1);
+    }
+};
+
+template<>
 struct GetMPI_StructAsArray<float >
 {
 
     MPI_StructAsArray operator()() const
     {
         return MPI_StructAsArray(MPI_FLOAT, 1);
-    }
-};
-
-template<>
-struct GetMPI_StructAsArray<uint64_cu >
-{
-
-    MPI_StructAsArray operator()() const
-    {
-        return MPI_StructAsArray(MPI_UNSIGNED_LONG_LONG, 1);
     }
 };
 


### PR DESCRIPTION
This allows e.g. MPI reduces of unsigned, unsigned long etc. It also removes the specialization of uint64_cu as this is not defined in the MPI interface. This does not break existing implementations as uint64_cu is an alias for unsigned long long for which this is specialized.

As a minor improvement it also removes a (long forgotten) tpl file lingering in that folder.

There will be no impact on runtime/correctness of existing implementations.

Side note: The use of e.g. `unsigned` or `long long` instead of `unsigned int` and `long long int` is C++ standard compliant as the name is only the *specifier* for the *type* (see e.g. http://stackoverflow.com/questions/11779704/c-type-unsigned-long-int) As most MPI implementations define e.g. `MPI_UNSIGNED_LONG_LONG` but not `MPI_UNSIGNED_LONG_LONG_INT` I used the short *specifiers* instead of the long ones for consistency.