### PR TITLE
Fix #1052 Gaussian Beam Envelope 2D

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -53,9 +53,12 @@ namespace picongpu
             //gaussian beam waist in the nearfield: w_y(y=0) == W0
             const float_64 w_y = W0 * sqrt( 1.0 + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
 
-
-            const float_64 envelope = float_64( AMPLITUDE ) * float_64( W0 ) / w_y;
-
+            float_64 envelope = float_64( AMPLITUDE );
+            if( simDim == DIM2 )
+                envelope *= math::sqrt( float_64( W0 ) / w_y );
+            else if( simDim == DIM3 )
+                envelope *= float_64( W0 ) / w_y;
+            /* no 1D representation/implementation */
 
             if( Polarisation == LINEAR_X )
             {

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -53,9 +53,12 @@ namespace picongpu
             //gaussian beam waist in the nearfield: w_y(y=0) == W0
             const float_64 w_y = W0 * sqrt( 1.0 + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
 
-
-            const float_64 envelope = float_64( AMPLITUDE ) * float_64( W0 ) / w_y;
-
+            float_64 envelope = float_64( AMPLITUDE );
+            if( simDim == DIM2 )
+                envelope *= math::sqrt( float_64( W0 ) / w_y );
+            else if( simDim == DIM3 )
+                envelope *= float_64( W0 ) / w_y;
+            /* no 1D representation/implementation */
 
             if( Polarisation == LINEAR_X )
             {


### PR DESCRIPTION
This fixes the underestimation of the amplitude of the laser implementations for Gaussian Beam (and based on it for pulse front tilted Gaussian Beams) in 2D3V simulations.

Calculations of the pre-factor are performed on the host-side and therefore a simple `if` avoids code duplication.

- [ ] needs backport to master (after review & merge)

Fixed image:
![gaussian_beam_2d_3d_fixed](https://cloud.githubusercontent.com/assets/1353258/9768999/8bf70e7c-5727-11e5-84de-e784ecfb7bf8.png)
