### PR TITLE
Fix move operators of cart buffer

### DIFF
--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -131,9 +132,12 @@ template<typename Type, int T_dim, typename Allocator, typename Copier, typename
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer
 (BOOST_RV_REF(CartBuffer<Type COMMA T_dim COMMA Allocator COMMA Copier COMMA Assigner>) other) : refCount(NULL)
 {
-    this->dataPointer = 0;
-    this->refCount = 0;
-    *this = other;
+    this->dataPointer = other.dataPointer;
+    this->refCount = other.refCount;
+    this->_size = other._size;
+    this->pitch = other.pitch;
+    other.dataPointer = NULL;
+    other.refCount = NULL;
 }
 
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
@@ -189,9 +193,10 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::operator=
     exit();
     this->dataPointer = rhs.dataPointer;
     this->refCount = rhs.refCount;
-    (*this->refCount)++;
     this->_size = rhs._size;
     this->pitch = rhs.pitch;
+    rhs.dataPointer = NULL;
+    rhs.refCount = NULL;
     return *this;
 }
 


### PR DESCRIPTION
This fixes the wrong implementation of the move operators. The current implementation called the copy assignment operator which calls e.g. actual cuda memCopies which is neither required nor wanted.

This also fixes some warnings about calling host function from host-device functions somewhere down the call chain