### PR TITLE
replace __forceinline__ by HINLINE

### DIFF
--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -61,7 +61,7 @@ namespace PMacc
             __startOperation(ITask::TASK_HOST);
             return this->current_size;
         }
-        
+
         /**
          * Destructor.
          */
@@ -69,7 +69,7 @@ namespace PMacc
         {
         };
 
-        __forceinline__
+        HINLINE
         container::HostBuffer<TYPE, DIM>
         cartBuffer()
         {


### PR DESCRIPTION
follow-up to #1093
replace __forceinline__ statement by HINLINE in src/libPMacc/include/memory/buffers/HostBuffer.hpp
