### PR TITLE
[WIP] cuSTL Host/DeviceBuffers: Contructors (Pointers)

### DIFF
--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -75,11 +75,13 @@ public:
     BOOST_STATIC_CONSTEXPR int dim = T_dim;
     typedef cursor::BufferCursor<Type, T_dim> Cursor;
     typedef typename Allocator::tag memoryTag;
+    typedef math::Size_t<T_dim> SizeType;
+    typedef math::Size_t<T_dim-1> PitchType;
 public:
     Type* dataPointer;
     int* refCount;
-    math::Size_t<T_dim> _size;
-    math::Size_t<T_dim-1> pitch;
+    SizeType _size;
+    PitchType pitch;
     HDINLINE void init();
     HDINLINE void exit();
     HDINLINE CartBuffer() : refCount(NULL) {}

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -93,7 +93,7 @@ public:
     HDINLINE CartBuffer(size_t x, size_t y, size_t z);
     /* the copy constructor just increments the reference counter but does not copy memory */
     HDINLINE CartBuffer(const CartBuffer& other);
-    /* the move constructor has currently the same behavior as the copy constructor */
+    /* the move constructor */
     HDINLINE CartBuffer(BOOST_RV_REF(CartBuffer) other);
     HDINLINE ~CartBuffer();
 

--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -43,25 +43,26 @@ namespace container
 /** typedef version of a CartBuffer for a GPU.
  * Additional feature: Able to copy data from a HostBuffer
  * \tparam Type type of a single datum
- * \tparam dim Dimension of the container
+ * \tparam T_dim Dimension of the container
  */
-template<typename Type, int dim>
+template<typename Type, int T_dim>
 class DeviceBuffer
- : public CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>,
-                                copier::D2DCopier<dim>,
+ : public CartBuffer<Type, T_dim, allocator::DeviceMemAllocator<Type, T_dim>,
+                                copier::D2DCopier<T_dim>,
                                 assigner::DeviceMemAssigner<> >
 {
 private:
-    typedef CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>,
-                                  copier::D2DCopier<dim>,
+    typedef CartBuffer<Type, T_dim, allocator::DeviceMemAllocator<Type, T_dim>,
+                                  copier::D2DCopier<T_dim>,
                                   assigner::DeviceMemAssigner<> > Base;
-    typedef DeviceBuffer<Type, dim> This;
 
 protected:
     HDINLINE DeviceBuffer() {}
 
-    BOOST_COPYABLE_AND_MOVABLE(This)
+    BOOST_COPYABLE_AND_MOVABLE(DeviceBuffer)
 public:
+    typedef typename Base::PitchType PitchType;
+
     /* constructors
      *
      * \param _size size of the container
@@ -69,7 +70,7 @@ public:
      * \param x,y,z convenient wrapper
      *
      */
-    HDINLINE DeviceBuffer(const math::Size_t<dim>& size) : Base(size) {}
+    HDINLINE DeviceBuffer(const math::Size_t<T_dim>& size) : Base(size) {}
     HDINLINE DeviceBuffer(size_t x) : Base(x) {}
     HDINLINE DeviceBuffer(size_t x, size_t y) : Base(x, y) {}
     HDINLINE DeviceBuffer(size_t x, size_t y, size_t z) : Base(x, y, z) {}
@@ -81,25 +82,25 @@ public:
      * @param size Size of the buffer
      * @param ownMemory Set to false if the memory is only a reference and managed outside of this class
      *                  Ignored for device side creation!y
-     * @param pitch Pitch in bytes (number of bytes in the lowest dimension)
+     * @param pitch Pitch in bytes (number of bytes in the lower dimensions)
      */
-    HDINLINE DeviceBuffer(Type* ptr, const math::Size_t<dim>& size, bool ownMemory, size_t pitch = 0)
+    HDINLINE DeviceBuffer(Type* ptr, const math::Size_t<T_dim>& size, bool ownMemory, PitchType pitch = PitchType::create(0))
     {
         this->dataPointer = ptr;
         this->_size = size;
-        if(dim >= 2)
-            this->pitch[0] = (pitch) ? pitch : size.x() * sizeof(Type);
-        if(dim == 3)
-            this->pitch[1] = this->pitch[0] * size.y();
+        if(T_dim >= 2)
+            this->pitch[0] = (pitch[0]) ? pitch[0] : size.x() * sizeof(Type);
+        if(T_dim == 3)
+            this->pitch[1] = (pitch[1]) ? pitch[1] : this->pitch[0] * size.y();
 #ifndef __CUDA_ARCH__
         this->refCount = new int;
         *this->refCount = (ownMemory) ? 1 : 2;
 #endif
     }
-    HDINLINE DeviceBuffer(BOOST_RV_REF(This) obj): Base(boost::move(static_cast<Base&>(obj))) {}
+    HDINLINE DeviceBuffer(BOOST_RV_REF(DeviceBuffer) obj): Base(boost::move(static_cast<Base&>(obj))) {}
 
-    HDINLINE This&
-    operator=(BOOST_RV_REF(This) rhs)
+    HDINLINE DeviceBuffer&
+    operator=(BOOST_RV_REF(DeviceBuffer) rhs)
     {
         Base::operator=(boost::move(static_cast<Base&>(rhs)));
         return *this;
@@ -111,13 +112,13 @@ public:
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::memoryTag, allocator::tag::host>::value));
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::type, Type>::value));
-        BOOST_STATIC_ASSERT(dim == HBuffer::dim);
+        BOOST_STATIC_ASSERT(T_dim == HBuffer::dim);
         if(rhs.size() != this->size())
             throw std::invalid_argument(static_cast<std::stringstream&>(
                 std::stringstream() << "Assignment: Sizes of buffers do not match: "
                     << this->size() << " <-> " << rhs.size() << std::endl).str());
 
-        cudaWrapper::Memcopy<dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
+        cudaWrapper::Memcopy<T_dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
                                 this->_size, cudaWrapper::flags::Memcopy::hostToDevice);
 
         return *this;

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -53,8 +53,9 @@ private:
     typedef CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>,
                                   copier::H2HCopier<dim>,
                                   assigner::HostMemAssigner<> > Base;
-///\todo: make protected
-public:
+    /* makes this class able to emulate a r-value reference */
+    BOOST_COPYABLE_AND_MOVABLE(HostBuffer)
+protected:
     HostBuffer() {}
 public:
     /* constructors
@@ -64,11 +65,37 @@ public:
      * \param x,y,z convenient wrapper
      *
      */
-    HostBuffer(const math::Size_t<dim>& _size) : Base(_size) {}
-    HostBuffer(size_t x) : Base(x) {}
-    HostBuffer(size_t x, size_t y) : Base(x, y) {}
-    HostBuffer(size_t x, size_t y, size_t z) : Base(x, y, z) {}
-    HostBuffer(const Base& base) : Base(base) {}
+    HINLINE HostBuffer(const math::Size_t<dim>& size) : Base(size) {}
+    HINLINE HostBuffer(size_t x) : Base(x) {}
+    HINLINE HostBuffer(size_t x, size_t y) : Base(x, y) {}
+    HINLINE HostBuffer(size_t x, size_t y, size_t z) : Base(x, y, z) {}
+    /**
+     * Creates a host buffer from a pointer with a size. Assumes dense layout (no padding)
+     *
+     * @param ptr Pointer to the first element
+     * @param size Size of the buffer
+     * @param ownMemory Set to false if the memory is only a reference and managed outside of this class
+     */
+    HINLINE HostBuffer(Type* ptr, const math::Size_t<dim>& size, bool ownMemory)
+    {
+        this->dataPointer = ptr;
+        this->_size = size;
+        if(dim >= 2)
+            this->pitch[0] = size.x() * sizeof(Type);
+        if(dim >= 3)
+            this->pitch[1] = this->pitch[0] * size.y();
+        this->refCount = new int;
+        *this->refCount = (ownMemory) ? 1 : 2;
+    }
+    HINLINE HostBuffer(const Base& base) : Base(base) {}
+    HINLINE HostBuffer(BOOST_RV_REF(This) obj): Base(boost::move(static_cast<Base&>(obj))) {}
+
+    HINLINE This&
+    operator=(BOOST_RV_REF(This) rhs)
+    {
+        Base::operator=(boost::move(static_cast<Base&>(rhs)));
+        return *this;
+    }
 
     template<typename DBuffer>
     HostBuffer& operator=(const DBuffer& rhs)

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -41,23 +41,25 @@ namespace container
 /** typedef version of a CartBuffer for a CPU.
  * Additional feature: Able to copy data from a DeviceBuffer
  * \tparam Type type of a single datum
- * \tparam dim Dimension of the container
+ * \tparam T_dim Dimension of the container
  */
-template<typename Type, int dim>
+template<typename Type, int T_dim>
 class HostBuffer
- : public CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>,
-                                copier::H2HCopier<dim>,
+ : public CartBuffer<Type, T_dim, allocator::HostMemAllocator<Type, T_dim>,
+                                copier::H2HCopier<T_dim>,
                                 assigner::HostMemAssigner<> >
 {
 private:
-    typedef CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>,
-                                  copier::H2HCopier<dim>,
+    typedef CartBuffer<Type, T_dim, allocator::HostMemAllocator<Type, T_dim>,
+                                  copier::H2HCopier<T_dim>,
                                   assigner::HostMemAssigner<> > Base;
     /* makes this class able to emulate a r-value reference */
     BOOST_COPYABLE_AND_MOVABLE(HostBuffer)
 protected:
     HostBuffer() {}
 public:
+    typedef typename Base::PitchType PitchType;
+
     /* constructors
      *
      * \param _size size of the container
@@ -65,7 +67,7 @@ public:
      * \param x,y,z convenient wrapper
      *
      */
-    HINLINE HostBuffer(const math::Size_t<dim>& size) : Base(size) {}
+    HINLINE HostBuffer(const math::Size_t<T_dim>& size) : Base(size) {}
     HINLINE HostBuffer(size_t x) : Base(x) {}
     HINLINE HostBuffer(size_t x, size_t y) : Base(x, y) {}
     HINLINE HostBuffer(size_t x, size_t y, size_t z) : Base(x, y, z) {}
@@ -75,23 +77,24 @@ public:
      * @param ptr Pointer to the first element
      * @param size Size of the buffer
      * @param ownMemory Set to false if the memory is only a reference and managed outside of this class
+     * @param pitch Pitch in bytes (number of bytes in the lower dimensions)
      */
-    HINLINE HostBuffer(Type* ptr, const math::Size_t<dim>& size, bool ownMemory)
+    HINLINE HostBuffer(Type* ptr, const math::Size_t<T_dim>& size, bool ownMemory, PitchType pitch = PitchType::create(0))
     {
         this->dataPointer = ptr;
         this->_size = size;
-        if(dim >= 2)
-            this->pitch[0] = size.x() * sizeof(Type);
-        if(dim >= 3)
-            this->pitch[1] = this->pitch[0] * size.y();
+        if(T_dim >= 2)
+            this->pitch[0] = (pitch[0]) ? pitch[0] : size.x() * sizeof(Type);
+        if(T_dim == 3)
+            this->pitch[1] = (pitch[1]) ? pitch[1] : this->pitch[0] * size.y();
         this->refCount = new int;
         *this->refCount = (ownMemory) ? 1 : 2;
     }
     HINLINE HostBuffer(const Base& base) : Base(base) {}
-    HINLINE HostBuffer(BOOST_RV_REF(This) obj): Base(boost::move(static_cast<Base&>(obj))) {}
+    HINLINE HostBuffer(BOOST_RV_REF(HostBuffer) obj): Base(boost::move(static_cast<Base&>(obj))) {}
 
-    HINLINE This&
-    operator=(BOOST_RV_REF(This) rhs)
+    HINLINE HostBuffer&
+    operator=(BOOST_RV_REF(HostBuffer) rhs)
     {
         Base::operator=(boost::move(static_cast<Base&>(rhs)));
         return *this;
@@ -102,13 +105,13 @@ public:
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename DBuffer::memoryTag, allocator::tag::device>::value));
         BOOST_STATIC_ASSERT((boost::is_same<typename DBuffer::type, Type>::value));
-        BOOST_STATIC_ASSERT(DBuffer::dim == dim);
+        BOOST_STATIC_ASSERT(DBuffer::dim == T_dim);
         if(rhs.size() != this->size())
             throw std::invalid_argument(static_cast<std::stringstream&>(
                 std::stringstream() << "Assignment: Sizes of buffers do not match: "
                     << this->size() << " <-> " << rhs.size() << std::endl).str());
 
-        cudaWrapper::Memcopy<dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
+        cudaWrapper::Memcopy<T_dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
                                 this->_size, cudaWrapper::flags::Memcopy::deviceToHost);
 
         return *this;

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -85,7 +85,15 @@ namespace PMacc
         cartBuffer() const
         {
             cudaPitchedPtr cudaData = this->getCudaPitched();
-            container::DeviceBuffer<TYPE, DIM> result((TYPE*)cudaData.ptr, this->getDataSpace(), false, cudaData.pitch);
+            math::Size_t<DIM - 1> pitch;
+            if(DIM >= 2)
+            {
+                assert(this->getPhysicalMemorySize()[0] == cudaData.pitch);
+                pitch[0] = this->getPhysicalMemorySize()[0];
+            }
+            if(DIM == 3)
+                pitch[1] = pitch[0] * this->getPhysicalMemorySize()[1];
+            container::DeviceBuffer<TYPE, DIM> result((TYPE*)cudaData.ptr, this->getDataSpace(), false, pitch);
             return result;
         }
 

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -1,5 +1,6 @@
 /**
  * Copyright 2013-2016 Heiko Burau, Rene Widera, Benjamin Worpitz
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -77,31 +78,16 @@ namespace PMacc
         };
 
 
-#define COMMA ,
-
         HINLINE
         container::CartBuffer<TYPE, DIM, allocator::DeviceMemAllocator<TYPE, DIM>,
                                 copier::D2DCopier<DIM>,
                                 assigner::DeviceMemAssigner<> >
         cartBuffer() const
         {
-            container::DeviceBuffer<TYPE, DIM> result;
             cudaPitchedPtr cudaData = this->getCudaPitched();
-            result.dataPointer = (TYPE*)cudaData.ptr;
-            result._size = (math::Size_t<DIM>)this->getDataSpace();
-            if(DIM == 2) result.pitch[0] = cudaData.pitch;
-            if(DIM == 3)
-            {
-                result.pitch[0] = cudaData.pitch;
-                result.pitch[1] = cudaData.pitch * this->getPhysicalMemorySize()[1];
-            }
-#ifndef __CUDA_ARCH__
-            result.refCount = new int;
-#endif
-            *result.refCount = 2;
+            container::DeviceBuffer<TYPE, DIM> result((TYPE*)cudaData.ptr, this->getDataSpace(), false, cudaData.pitch);
             return result;
         }
-#undef COMMA
 
 
         /**

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -73,7 +73,12 @@ namespace PMacc
         container::HostBuffer<TYPE, DIM>
         cartBuffer()
         {
-            container::HostBuffer<TYPE, DIM> result(this->getBasePointer(), this->getDataSpace(), false);
+            math::Size_t<DIM - 1> pitch;
+            if(DIM >= 2)
+                pitch[0] = this->getPhysicalMemorySize()[0];
+            if(DIM == 3)
+                pitch[1] = pitch[0] * this->getPhysicalMemorySize()[1];
+            container::HostBuffer<TYPE, DIM> result(this->getBasePointer(), this->getDataSpace(), false, pitch);
             return result;
         }
 

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -73,15 +73,7 @@ namespace PMacc
         container::HostBuffer<TYPE, DIM>
         cartBuffer()
         {
-            container::HostBuffer<TYPE, DIM> result;
-            result.dataPointer = this->getBasePointer();
-            result._size = math::Size_t<DIM>(this->getDataSpace());
-            if(DIM >= 2)
-                result.pitch[0] = result._size.x() * sizeof(TYPE);
-            if(DIM >= 3)
-                result.pitch[1] = result.pitch[0] * result._size.y();
-            result.refCount = new int;
-            *result.refCount = 2;
+            container::HostBuffer<TYPE, DIM> result(this->getBasePointer(), this->getDataSpace(), false);
             return result;
         }
 


### PR DESCRIPTION
This implements the cartBuffer functions correctly by calling constructors that actually take parameters. Allowing the default ctor is dangerous.

This also adds the missing move operators required for effective returning.

This also supersedes #1093 

- [x] Do not merge until rebased and changed according to PR #1096 (see: https://github.com/ComputationalRadiationPhysics/picongpu/pull/1094#issuecomment-139565612)
- [x] Test plugins using this