### PR TITLE
Buffer: Fix Invalid Pitches

### DIFF
--- a/src/libPMacc/include/dimensions/DataSpaceOperations.hpp
+++ b/src/libPMacc/include/dimensions/DataSpaceOperations.hpp
@@ -100,6 +100,11 @@ namespace PMacc
             return pos.x();
         }
 
+        static HDINLINE DataSpace<DIM1> map(const DataSpace<DIM1>& size, uint32_t pos)
+        {
+            return DataSpace<DIM1 > (pos);
+        }
+
         static HDINLINE DataSpace<DIM2> extend(DataSpace<DIM1> ds, uint32_t ex,
                                               DataSpace<DIM2> target, DataSpace<DIM2> offset)
         {

--- a/src/libPMacc/include/memory/boxes/MultiBox.hpp
+++ b/src/libPMacc/include/memory/boxes/MultiBox.hpp
@@ -155,9 +155,9 @@ public:
         return DataBoxType(PitchedBox<Type, DIM2 > ((Type*) ((char*) fixedPointer + attributePitch * nameId), pitch));
     }
 
-    HDINLINE MultiBox(Type* pointer, const DataSpace<DIM2> &offset, const DataSpace<DIM2> &size, const size_t pitch) :
+    HDINLINE MultiBox(Type* pointer, const DataSpace<DIM2> &offset, const DataSpace<DIM2> &memSize, const size_t pitch) :
     pitch(pitch),
-    attributePitch(pitch*size.y()),
+    attributePitch(pitch*memSize.y()),
     fixedPointer((Type*) ((char*) pointer + offset[1] * pitch) + offset[0])
     {
     }
@@ -238,9 +238,16 @@ public:
         return ReducedType((Type*) ((char*) (this->fixedPointer) + idx * pitch2D), pitch, attributePitch);
     }
 
-    HDINLINE MultiBox(Type* pointer, const DataSpace<DIM3> &offset, const DataSpace<DIM3> &size, const size_t pitch) :
-    pitch(pitch), pitch2D(size.y() * pitch), attributePitch(pitch2D*size.z()),
-    fixedPointer((Type*) ((char*) pointer + offset[2] * pitch2D + offset[1] * pitch) + offset[0])
+    /** constructor
+     *
+     * @param pointer pointer to the origin of the physical memory
+     * @param offset offset (in elements)
+     * @param memSize size of the physical memory (in elements)
+     * @param pitch number of bytes in one line (first dimension)
+     */
+    HDINLINE MultiBox(Type* pointer, const DataSpace<DIM3> &offset, const DataSpace<DIM3> &memSize, const size_t pitch) :
+    pitch(pitch), pitch2D(memSize.y() * pitch), attributePitch((memSize.y() * pitch) * size.z()),
+    fixedPointer((Type*) ((char*) pointer + offset[2] * (memSize.y() * pitch) + offset[1] * pitch) + offset[0])
     {
     }
 

--- a/src/libPMacc/include/memory/boxes/PitchedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/PitchedBox.hpp
@@ -192,9 +192,16 @@ public:
         return ReducedType((TYPE*) ((char*) (this->fixedPointer) + idx * pitch2D), pitch);
     }
 
-    HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM3> &offset, const DataSpace<DIM3> &size, const size_t pitch) :
-    pitch(pitch), pitch2D(size[1] * pitch),
-    fixedPointer((TYPE*) ((char*) pointer + offset[2] * pitch2D + offset[1] * pitch) + offset[0])
+    /** constructor
+     *
+     * @param pointer pointer to the origin of the physical memory
+     * @param offset offset (in elements)
+     * @param memSize size of the physical memory (in elements)
+     * @param pitch number of bytes in one line (first dimension)
+     */
+    HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM3> &offset, const DataSpace<DIM3> &memSize, const size_t pitch) :
+    pitch(pitch), pitch2D(memSize[1] * pitch),
+    fixedPointer((TYPE*) ((char*) pointer + offset[2] * (memSize[1] * pitch) + offset[1] * pitch) + offset[0])
     {
     }
 

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -47,16 +47,18 @@ namespace PMacc
 
         typedef DataBox<PitchedBox<TYPE, DIM> > DataBoxType;
 
-        /*
-         * @param dataSpace description of spread of any dimension (in elements)
-         *                  can be lesser than `physicalMemorySize`
+        /** constructor
+         *
+         * @param size extent for each dimension (in elements)
+         *             if the buffer is a view to an existing buffer the size
+         *             can be less than `physicalMemorySize`
          * @param physicalMemorySize size of the physical memory (in elements)
          */
-        Buffer(DataSpace<DIM> dataSpace, DataSpace<DIM> physicalMemorySize) :
-        data_space(dataSpace), data1D(true), current_size(NULL), m_physicalMemorySize(physicalMemorySize)
+        Buffer(DataSpace<DIM> size, DataSpace<DIM> physicalMemorySize) :
+        data_space(size), data1D(true), current_size(NULL), m_physicalMemorySize(physicalMemorySize)
         {
             CUDA_CHECK(cudaMallocHost(&current_size, sizeof (size_t)));
-            *current_size = dataSpace.productOfComponents();
+            *current_size = size.productOfComponents();
         }
 
         /**

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -47,12 +47,13 @@ namespace PMacc
 
         typedef DataBox<PitchedBox<TYPE, DIM> > DataBoxType;
 
-        /**
-         * constructor
-         * @param dataSpace description of spread of any dimension
+        /*
+         * @param dataSpace description of spread of any dimension (in elements)
+         *                  can be lesser than `physicalMemorySize`
+         * @param physicalMemorySize size of the physical memory (in elements)
          */
-        Buffer(DataSpace<DIM> dataSpace) :
-        data_space(dataSpace), data1D(true), current_size(NULL)
+        Buffer(DataSpace<DIM> dataSpace, DataSpace<DIM> physicalMemorySize) :
+        data_space(dataSpace), data1D(true), current_size(NULL), m_physicalMemorySize(physicalMemorySize)
         {
             CUDA_CHECK(cudaMallocHost(&current_size, sizeof (size_t)));
             *current_size = dataSpace.productOfComponents();
@@ -83,6 +84,14 @@ namespace PMacc
         {
             return data_space;
         }
+
+        /** get size of the physical memory (in elements)
+         */
+        DataSpace<DIM> getPhysicalMemorySize() const
+        {
+            return m_physicalMemorySize;
+        }
+
 
         virtual DataSpace<DIM> getCurrentDataSpace()
         {
@@ -183,6 +192,7 @@ namespace PMacc
         }
 
         DataSpace<DIM> data_space;
+        DataSpace<DIM> m_physicalMemorySize;
 
         size_t *current_size;
 

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -46,14 +46,18 @@ namespace PMacc
      *
      * @tparam TYPE datatype of the buffer
      * @tparam DIM dimension of the buffer
+     *
+     * @param dataSpace dataSpace size of each dimension of the buffer (in elements)
+     *                   can be lesser than `physicalMemorySize`
+     * @param physicalMemorySize size of the physical memory (in elements)
      */
     template <class TYPE, unsigned DIM>
     class DeviceBuffer : public Buffer<TYPE, DIM>
     {
     protected:
 
-        DeviceBuffer(DataSpace<DIM> dataSpace) :
-        Buffer<TYPE, DIM>(dataSpace)
+        DeviceBuffer(DataSpace<DIM> dataSpace, DataSpace<DIM> physicalMemorySize) :
+        Buffer<TYPE, DIM>(dataSpace, physicalMemorySize)
         {
 
         }
@@ -86,7 +90,7 @@ namespace PMacc
             if(DIM == 3)
             {
                 result.pitch[0] = cudaData.pitch;
-                result.pitch[1] = cudaData.pitch * result._size.y();
+                result.pitch[1] = cudaData.pitch * this->getPhysicalMemorySize()[1];
             }
 #ifndef __CUDA_ARCH__
             result.refCount = new int;

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -46,18 +46,21 @@ namespace PMacc
      *
      * @tparam TYPE datatype of the buffer
      * @tparam DIM dimension of the buffer
-     *
-     * @param dataSpace dataSpace size of each dimension of the buffer (in elements)
-     *                   can be lesser than `physicalMemorySize`
-     * @param physicalMemorySize size of the physical memory (in elements)
      */
     template <class TYPE, unsigned DIM>
     class DeviceBuffer : public Buffer<TYPE, DIM>
     {
     protected:
 
-        DeviceBuffer(DataSpace<DIM> dataSpace, DataSpace<DIM> physicalMemorySize) :
-        Buffer<TYPE, DIM>(dataSpace, physicalMemorySize)
+        /** constructor
+         *
+         * @param size extent for each dimension (in elements)
+         *             if the buffer is a view to an existing buffer the size
+         *             can be less than `physicalMemorySize`
+         * @param physicalMemorySize size of the physical memory (in elements)
+         */
+        DeviceBuffer(DataSpace<DIM> size, DataSpace<DIM> physicalMemorySize) :
+        Buffer<TYPE, DIM>(size, physicalMemorySize)
         {
 
         }
@@ -76,7 +79,7 @@ namespace PMacc
 
 #define COMMA ,
 
-        __forceinline__
+        HINLINE
         container::CartBuffer<TYPE, DIM, allocator::DeviceMemAllocator<TYPE, DIM>,
                                 copier::D2DCopier<DIM>,
                                 assigner::DeviceMemAssigner<DIM> >

--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -44,13 +44,13 @@ public:
     typedef typename DeviceBuffer<TYPE, DIM>::DataBoxType DataBoxType;
 
     /*! create device buffer
-     * @param dataSpace size in any dimension of the grid on the device
+     * @param size extent for each dimension (in elements)
      * @param sizeOnDevice memory with the current size of the grid is stored on device
      * @param useVectorAsBase use a vector as base of the array (is not lined pitched)
      *                      if true size on device is atomaticly set to false
      */
-    DeviceBufferIntern(DataSpace<DIM> dataSpace, bool sizeOnDevice = false, bool useVectorAsBase = false) :
-    DeviceBuffer<TYPE, DIM>(dataSpace, dataSpace),
+    DeviceBufferIntern(DataSpace<DIM> size, bool sizeOnDevice = false, bool useVectorAsBase = false) :
+    DeviceBuffer<TYPE, DIM>(size, size),
     sizeOnDevice(sizeOnDevice),
     useOtherMemory(false),
     offset(DataSpace<DIM>())
@@ -72,8 +72,8 @@ public:
 
     }
 
-    DeviceBufferIntern(DeviceBuffer<TYPE, DIM>& source, DataSpace<DIM> dataSpace, DataSpace<DIM> offset, bool sizeOnDevice = false) :
-    DeviceBuffer<TYPE, DIM>(dataSpace, source.getPhysicalMemorySize()),
+    DeviceBufferIntern(DeviceBuffer<TYPE, DIM>& source, DataSpace<DIM> size, DataSpace<DIM> offset, bool sizeOnDevice = false) :
+    DeviceBuffer<TYPE, DIM>(size, source.getPhysicalMemorySize()),
     sizeOnDevice(sizeOnDevice),
     offset(offset + source.getOffset()),
     data(source.getCudaPitched()),
@@ -211,7 +211,7 @@ public:
 
     void copyFrom(HostBuffer<TYPE, DIM>& other)
     {
-        
+
         assert(this->isMyDataSpaceGreaterThan(other.getCurrentDataSpace()));
         Environment<>::get().Factory().createTaskCopyHostToDevice(other, *this);
 

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -61,7 +61,7 @@ namespace PMacc
             __startOperation(ITask::TASK_HOST);
             return this->current_size;
         }
-        
+
         /**
          * Destructor.
          */
@@ -90,10 +90,12 @@ namespace PMacc
         /**
          * Constructor.
          *
-         * @param dataSpace size of each dimension of the buffer
+         * @param dataSpace size of each dimension of the buffer (in elements)
+         *                   can be lesser than `physicalMemorySize`
+         * @param physicalMemorySize size of the physical memory (in elements)
          */
-        HostBuffer(DataSpace<DIM> dataSpace) :
-        Buffer<TYPE, DIM>(dataSpace)
+        HostBuffer(DataSpace<DIM> dataSpace, DataSpace<DIM> physicalMemorySize) :
+        Buffer<TYPE, DIM>(dataSpace, physicalMemorySize)
         {
 
         }

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -69,7 +69,7 @@ namespace PMacc
         {
         };
 
-        __forceinline__
+        HINLINE
         container::HostBuffer<TYPE, DIM>
         cartBuffer()
         {
@@ -87,15 +87,15 @@ namespace PMacc
 
     protected:
 
-        /**
-         * Constructor.
+        /** Constructor.
          *
-         * @param dataSpace size of each dimension of the buffer (in elements)
-         *                   can be lesser than `physicalMemorySize`
+         * @param size extent for each dimension (in elements)
+         *             if the buffer is a view to an existing buffer the size
+         *             can be less than `physicalMemorySize`
          * @param physicalMemorySize size of the physical memory (in elements)
          */
-        HostBuffer(DataSpace<DIM> dataSpace, DataSpace<DIM> physicalMemorySize) :
-        Buffer<TYPE, DIM>(dataSpace, physicalMemorySize)
+        HostBuffer(DataSpace<DIM> size, DataSpace<DIM> physicalMemorySize) :
+        Buffer<TYPE, DIM>(size, physicalMemorySize)
         {
 
         }

--- a/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
@@ -41,12 +41,16 @@ namespace PMacc
 template <class TYPE, unsigned DIM>
 class MappedBufferIntern : public DeviceBuffer<TYPE, DIM>
 {
+    /** IMPORTANT: if someone implements that a MappedBufferIntern can points to an other
+     * mapped buffer then `getDataSpace()` in `getHostDataBox()` and `getDeviceDataBox`
+     * must be changed to `getPhysicalMemorySize`
+     */
 public:
 
     typedef typename DeviceBuffer<TYPE, DIM>::DataBoxType DataBoxType;
 
     MappedBufferIntern(DataSpace<DIM> dataSpace):
-    DeviceBuffer<TYPE, DIM>(dataSpace),
+    DeviceBuffer<TYPE, DIM>(dataSpace, dataSpace),
     pointer(NULL), ownPointer(true)
     {
         CUDA_CHECK(cudaMallocHost(&pointer, dataSpace.productOfComponents() * sizeof (TYPE), cudaHostAllocMapped));

--- a/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
@@ -49,11 +49,15 @@ public:
 
     typedef typename DeviceBuffer<TYPE, DIM>::DataBoxType DataBoxType;
 
-    MappedBufferIntern(DataSpace<DIM> dataSpace):
-    DeviceBuffer<TYPE, DIM>(dataSpace, dataSpace),
+    /** constructor
+     *
+     * @param size extent for each dimension (in elements)
+     */
+    MappedBufferIntern(DataSpace<DIM> size):
+    DeviceBuffer<TYPE, DIM>(size, size),
     pointer(NULL), ownPointer(true)
     {
-        CUDA_CHECK(cudaMallocHost(&pointer, dataSpace.productOfComponents() * sizeof (TYPE), cudaHostAllocMapped));
+        CUDA_CHECK(cudaMallocHost(&pointer, size.productOfComponents() * sizeof (TYPE), cudaHostAllocMapped));
         reset(false);
     }
 

--- a/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
@@ -229,8 +229,8 @@ public:
         __startOperation(ITask::TASK_HOST);
         return DataBoxType(MultiBox<Type, DIM > (getGridBuffer(static_cast<NameType> (0)).getHostBuffer().getBasePointer(),
                                                  DataSpace<DIM > (),
-                                                 getGridBuffer(static_cast<NameType> (0)).getHostBuffer().getDataSpace(),
-                                                 getGridBuffer(static_cast<NameType> (0)).getHostBuffer().getDataSpace().x() * sizeof (Type)));
+                                                 getGridBuffer(static_cast<NameType> (0)).getHostBuffer().getPhysicalMemorySize(),
+                                                 getGridBuffer(static_cast<NameType> (0)).getHostBuffer().getPhysicalMemorySize().x() * sizeof (Type)));
     }
 
     DataBoxType getDeviceDataBox()
@@ -238,7 +238,7 @@ public:
         __startOperation(ITask::TASK_CUDA);
         return DataBoxType(MultiBox<Type, DIM > (getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getBasePointer(),
                                                  getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getOffset(),
-                                                 getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getDataSpace(),
+                                                 getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getPhysicalMemorySize(),
                                                  getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getCudaPitched().pitch));
     }
 


### PR DESCRIPTION
- fix that a buffer that points to an existing buffer calculates and uses the
  wrong pitch to move over x-y plane
- Buffer.hpp:
	- add member `m_physicalMemorySize`
        - add getter `getPhysicalMemorySize()`
- DataSpaceOperation.hpp: add missing map method for 1D
- Multibox and PitchedBox
  - rename parameter `size` in constructor to `memSize` to make it more
    clear which size is needed
  - add documentation
- *Buffer.hpp: use `getPhysicalMemorySize()` to create boxes

**This bug affects all previous (libPMacc) releases but PIConGPU simulations were not affected!**
~~The result in PIConGPU is wrong communicated current on the GPU borders, the effect can not be estimated.~~ The old KHI heating and the new one show no differences.

Tests:
- [x] KHI positrons/electrons