### PR TITLE
Add more rounding functions

### DIFF
--- a/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -34,19 +34,66 @@ template<typename Type>
 struct Floor;
 
 template<typename Type>
+struct Ceil;
+
+template<typename Type>
+struct Float2int_ru;
+
+template<typename Type>
 struct Float2int_rd;
 
+template<typename Type>
+struct Float2int_rn;
 
+/**
+ * Rounds down (towards -inf)
+ */
 template<typename T1>
 HDINLINE typename Floor< T1>::result floor(T1 value)
 {
     return Floor< T1 > ()(value);
 }
 
+/**
+ * Rounds up (towards +inf)
+ */
+template<typename T1>
+HDINLINE typename Ceil< T1>::result ceil(T1 value)
+{
+    return Ceil< T1 > ()(value);
+}
+
+/**
+ * Returns the smallest int value that is at least as big as value
+ * Note: Using values outside the range of an int is undefined
+ * @return integer value
+ */
+template<typename T1>
+HDINLINE typename Float2int_ru< T1>::result float2int_ru(T1 value)
+{
+    return Float2int_ru< T1 > ()(value);
+}
+
+/**
+ * Returns the largest int value that is not greater than value
+ * Note: Using values outside the range of an int is undefined
+ * @return integer value
+ */
 template<typename T1>
 HDINLINE typename Float2int_rd< T1>::result float2int_rd(T1 value)
 {
     return Float2int_rd< T1 > ()(value);
+}
+
+/**
+ * Rounds towards nearest (even) value returning an int
+ * Note: Using values outside the range of an int is undefined
+ * @return integer value
+ */
+template<typename T1>
+HDINLINE typename Float2int_rn< T1>::result float2int_rn(T1 value)
+{
+    return Float2int_rn< T1 > ()(value);
 }
 
 } //namespace math

--- a/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
@@ -86,7 +86,8 @@ HDINLINE typename Float2int_rd< T1>::result float2int_rd(T1 value)
 }
 
 /**
- * Rounds towards nearest (even) value returning an int
+ * Rounds towards the nearest value returning an int
+ * For the case of x.5 the even value is chosen from the 2 possible values
  * Note: Using values outside the range of an int is undefined
  * @return integer value
  */

--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -25,7 +26,7 @@
 
 #include "types.h"
 #include "math.h"
-
+#include <limits>
 
 namespace PMacc
 {
@@ -46,6 +47,32 @@ struct Floor<double>
 };
 
 template<>
+struct Ceil<double>
+{
+    typedef double result;
+
+    HDINLINE result operator( )(result value)
+    {
+        return ::ceil( value );
+    }
+};
+
+template<>
+struct Float2int_ru<double>
+{
+    typedef int result;
+
+    HDINLINE result operator( )(double value)
+    {
+#if __CUDA_ARCH__
+        return ::__double2int_ru( value );
+#else
+        return static_cast<int>(ceil(value));
+#endif
+    }
+};
+
+template<>
 struct Float2int_rd<double>
 {
     typedef int result;
@@ -56,6 +83,29 @@ struct Float2int_rd<double>
         return ::__double2int_rd( value );
 #else
         return static_cast<int>(floor(value));
+#endif
+    }
+};
+
+template<>
+struct Float2int_rn<double>
+{
+    typedef int result;
+
+    HDINLINE result operator( )(double value)
+    {
+#if __CUDA_ARCH__
+        return ::__double2int_rn( value );
+#else
+        if(value < 0.0)
+            return -(*this)(-value);
+        /* Round towards nearest with x.5 rounded to +inf */
+        result res = float2int_rd(value + 0.5);
+        /* If we were close to x.5 then make sure res is even */
+        if( ::abs(0.5 - (res - value)) < std::numeric_limits<double>::epsilon() )
+            return res & ~1; /* Cancel out last bit of integer which makes it even */
+        else
+            return res;
 #endif
     }
 };

--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -102,7 +102,7 @@ struct Float2int_rn<double>
         /* Round towards nearest with x.5 rounded to +inf */
         result res = float2int_rd(value + 0.5);
         /* If we were close to x.5 then make sure res is even */
-        if( ::abs(0.5 - (res - value)) < std::numeric_limits<double>::epsilon() )
+        if( abs(0.5 - (res - value)) < std::numeric_limits<double>::epsilon() )
             return res & ~1; /* Cancel out last bit of integer which makes it even */
         else
             return res;

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -105,7 +105,7 @@ struct Float2int_rn<float>
         float fracPart = std::modf(value, &intPart);
         result res = float2int_rd(fracPart + 0.5f) + static_cast<int>(intPart);
         /* If we were close to x.5 then make sure res is even */
-        if( ::abs(0.5f - (res - value)) < std::numeric_limits<float>::epsilon() )
+        if( abs(0.5f - (res - value)) < std::numeric_limits<float>::epsilon() )
             return res & ~1; /* Cancel out last bit of integer which makes it even */
         else
             return res;


### PR DESCRIPTION
This adds a function for rounding to nearest even value (result converted to int) and ceil function

This can be used in cases, where a rounded value is required and one does not want it to be always rounded down. For CUDA the intrinsic function is used (similar to *_rd) and for the host, this functions is emulated with a +-0.5 as there is no intrinsic function for that.