### PR TITLE
submitAction.sh: copy cmakeFlags

### DIFF
--- a/src/picongpu/submit/submitAction.sh
+++ b/src/picongpu/submit/submitAction.sh
@@ -24,6 +24,10 @@ mkdir picongpu
 cp -r $TBG_projectPath/bin picongpu
 cp -r $TBG_projectPath/include picongpu
 cp -r $TBG_projectPath/submit picongpu
+if [ -f $TBG_projectPath/cmakeFlags ]
+then
+  cp $TBG_projectPath/cmakeFlags picongpu
+fi
 cp -a $TBG_cfgPath/openib.conf tbg
 cp $TBG_cfgPath/cuda.filter tbg
 cp $TBG_cfgPath/scorep.filter tbg


### PR DESCRIPTION
This issue is related to #1100 : `cmakeFlags` in examples are copied if they exist so later
`createParameterSet` calls and/or following `configure` calls can use the `-t` options again to select a specific example

this is still discouraged for users since it is actually a CI feature, but it at least documents the available options (still not the one that was choosen for the binaries in the run)