### PR TITLE
Bash Scripts: Update Shebang

### DIFF
--- a/buildsystem/CompileSuite/autoTests/config.sh
+++ b/buildsystem/CompileSuite/autoTests/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/autoTests/get_work.sh
+++ b/buildsystem/CompileSuite/autoTests/get_work.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/autoTests/report.sh
+++ b/buildsystem/CompileSuite/autoTests/report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/color.sh
+++ b/buildsystem/CompileSuite/color.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/buildsystem/CompileSuite/compileSet.sh
+++ b/buildsystem/CompileSuite/compileSet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/exec_helper.sh
+++ b/buildsystem/CompileSuite/exec_helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/help.sh
+++ b/buildsystem/CompileSuite/help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/options.sh
+++ b/buildsystem/CompileSuite/options.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/buildsystem/CompileSuite/path.sh
+++ b/buildsystem/CompileSuite/path.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/compile
+++ b/compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/createParameterSet
+++ b/createParameterSet
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/examples/Bunch/cmakeFlags
+++ b/examples/Bunch/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/examples/Bunch/submit/bunch_0032.cfg
+++ b/examples/Bunch/submit/bunch_0032.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Richard Pausch, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/Empty/cmakeFlags
+++ b/examples/Empty/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013-2015 Axel Huebl, Rene Widera
 #

--- a/examples/KelvinHelmholtz/cmakeFlags
+++ b/examples/KelvinHelmholtz/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013-2014 Axel Huebl, Rene Widera
 #

--- a/examples/KelvinHelmholtz/submit/0004gpus.cfg
+++ b/examples/KelvinHelmholtz/submit/0004gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/KelvinHelmholtz/submit/0016gpus.cfg
+++ b/examples/KelvinHelmholtz/submit/0016gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/cmakeFlags
+++ b/examples/LaserWakefield/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013-2014 Axel Huebl, Rene Widera
 #

--- a/examples/LaserWakefield/submit/0001gpus.cfg
+++ b/examples/LaserWakefield/submit/0001gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/submit/0008gpus.cfg
+++ b/examples/LaserWakefield/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/submit/0016gpus.cfg
+++ b/examples/LaserWakefield/submit/0016gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/submit/0032gpus.cfg
+++ b/examples/LaserWakefield/submit/0032gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/SingleParticleCurrent/cmakeFlags
+++ b/examples/SingleParticleCurrent/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/examples/SingleParticleCurrent/submit/0001gpus.cfg
+++ b/examples/SingleParticleCurrent/submit/0001gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Heiko Burau, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/SingleParticleRadiationWithLaser/cmakeFlags
+++ b/examples/SingleParticleRadiationWithLaser/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
 #

--- a/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
+++ b/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/SingleParticleTest/cmakeFlags
+++ b/examples/SingleParticleTest/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/examples/SingleParticleTest/submit/0008gpus.cfg
+++ b/examples/SingleParticleTest/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/cmakeFlags
+++ b/examples/ThermalTest/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera, Heiko Burau
 #

--- a/examples/ThermalTest/executeOnClone
+++ b/examples/ThermalTest/executeOnClone
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera, Heiko Burau
 #

--- a/examples/ThermalTest/submit/0001gpu.cfg
+++ b/examples/ThermalTest/submit/0001gpu.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0004gpus.cfg
+++ b/examples/ThermalTest/submit/0004gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0008gpus.cfg
+++ b/examples/ThermalTest/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0032gpus.cfg
+++ b/examples/ThermalTest/submit/0032gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Heiko Burau, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0064gpus.cfg
+++ b/examples/ThermalTest/submit/0064gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/WeibelTransverse/cmakeFlags
+++ b/examples/WeibelTransverse/cmakeFlags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/examples/WeibelTransverse/submit/0004gpus.cfg
+++ b/examples/WeibelTransverse/submit/0004gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Rene Widera
 # 
 # This file is part of PIConGPU. 

--- a/src/libPMacc/examples/gameOfLife2D/submit/1gpu.cfg
+++ b/src/libPMacc/examples/gameOfLife2D/submit/1gpu.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/libPMacc/examples/gameOfLife2D/submit/2gpus.cfg
+++ b/src/libPMacc/examples/gameOfLife2D/submit/2gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/libPMacc/examples/gameOfLife2D/submit/4gpus.cfg
+++ b/src/libPMacc/examples/gameOfLife2D/submit/4gpus.cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/picongpu/scripts/cuda_memtest.sh
+++ b/src/picongpu/scripts/cuda_memtest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013  Rene Widera
 #

--- a/src/picongpu/submit/bash/bash_mpiexec.tpl
+++ b/src/picongpu/submit/bash/bash_mpiexec.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/bash/bash_mpirun.tpl
+++ b/src/picongpu/submit/bash/bash_mpirun.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/davinci/picongpu.tpl
+++ b/src/picongpu/submit/davinci/picongpu.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/hypnos/fermi_profile.tpl
+++ b/src/picongpu/submit/hypnos/fermi_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_autoWait_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/hypnos/k20_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/hypnos/k20_vampir_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_vampir_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/hypnos/k20_wait_profile.tpl
+++ b/src/picongpu/submit/hypnos/k20_wait_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/hypnos/k80_profile.tpl
+++ b/src/picongpu/submit/hypnos/k80_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/joker/fermi.tpl
+++ b/src/picongpu/submit/joker/fermi.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/joker/fermi_vampir.tpl
+++ b/src/picongpu/submit/joker/fermi_vampir.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/joker/tesla.tpl
+++ b/src/picongpu/submit/joker/tesla.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/joker/tesla_vampir.tpl
+++ b/src/picongpu/submit/joker/tesla_vampir.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/judge/m2050.tpl
+++ b/src/picongpu/submit/judge/m2050.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/judge/m2050_profile.tpl
+++ b/src/picongpu/submit/judge/m2050_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Richard Pausch
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/judge/m2070.tpl
+++ b/src/picongpu/submit/judge/m2070.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/judge/m2070_profile.tpl
+++ b/src/picongpu/submit/judge/m2070_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Richard Pausch
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/keeneland/parallel.tpl
+++ b/src/picongpu/submit/keeneland/parallel.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl, Rene Widera, Robert Dietric
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/lawrencium/fermi_profile.tpl
+++ b/src/picongpu/submit/lawrencium/fermi_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/lawrencium/k20_profile.tpl
+++ b/src/picongpu/submit/lawrencium/k20_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/submitAction.sh
+++ b/src/picongpu/submit/submitAction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.

--- a/src/picongpu/submit/taurus/k20x_profile.tpl
+++ b/src/picongpu/submit/taurus/k20x_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013 Axel Huebl
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/titan-ornl/batch_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera
 # 
 # This file is part of PIConGPU. 

--- a/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.

--- a/src/tools/bin/BinEnergyPlot.sh
+++ b/src/tools/bin/BinEnergyPlot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
 #

--- a/src/tools/bin/create.sh
+++ b/src/tools/bin/create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/src/tools/bin/deleteHeadComment
+++ b/src/tools/bin/deleteHeadComment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Thanks to potong@stackoverflow
 # snipped licensed as CC BY-SA 3.0

--- a/src/tools/bin/egetopt
+++ b/src/tools/bin/egetopt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2014 Rene Widera
 #

--- a/src/tools/bin/findAndDo
+++ b/src/tools/bin/findAndDo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/src/tools/bin/plotIntensity
+++ b/src/tools/bin/plotIntensity
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # Copyright 2013 Axel Huebl, Rene Widera
 #

--- a/src/tools/bin/plotSumEnergyRange
+++ b/src/tools/bin/plotSumEnergyRange
@@ -1,5 +1,5 @@
-#!/bin/sh
-# 
+#!/usr/bin/env bash
+#
 # Copyright 2013 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/tools/bin/png2video.sh
+++ b/src/tools/bin/png2video.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/tools/bin/position2Trace.sh
+++ b/src/tools/bin/position2Trace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera, Richard Pausch
 #

--- a/src/tools/bin/splash2vtk.sh
+++ b/src/tools/bin/splash2vtk.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright 2013 Axel Huebl
 #

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
 #
@@ -187,7 +187,7 @@ help()
     echo " TBG_dstPath                   - absolute path to destination directory"
 }
 
-#!/bin/bash
+#!/usr/bin/env bash
 initCall="$0 $*"
 projectPath="."
 

--- a/src/tools/bin/transpose
+++ b/src/tools/bin/transpose
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # Copyright 2013 Rene Widera
 #

--- a/src/tools/bin/uncrustifyMyCode
+++ b/src/tools/bin/uncrustifyMyCode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2015 Rene Widera
 #
 # This file is part of PIConGPU.

--- a/src/tools/livevis/client/tunnel2cluster.sh
+++ b/src/tools/livevis/client/tunnel2cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 
 # set in /etc/hosts for the n_head

--- a/thirdParty/cuda_memtest/sanity_check.sh
+++ b/thirdParty/cuda_memtest/sanity_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script do a quick check if one GPU or all GPUs are in good health.
 # usage: ./sanity_check.sh 0   //check GPU 0
 #        ./sanity_check.sh 1   //check GPU 1


### PR DESCRIPTION
`/usr/bin/env bash` is more portable across various platforms than the absolute path

more information:
  https://github.com/azet/community_bash_style_guide

updated via
```bash
grep -iR "/bin/bash" .      \
  | awk -F: '{print $1}'    \
  | xargs -n1 -P1 -I{} sed -i 's|/bin/bash|/usr/bin/env bash|g' {}
```