### PR TITLE
close #1106: remove shebang from *.cfg files

### DIFF
--- a/examples/Bunch/submit/bunch_0032.cfg
+++ b/examples/Bunch/submit/bunch_0032.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Richard Pausch, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/KelvinHelmholtz/submit/0004gpus.cfg
+++ b/examples/KelvinHelmholtz/submit/0004gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/KelvinHelmholtz/submit/0016gpus.cfg
+++ b/examples/KelvinHelmholtz/submit/0016gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/submit/0001gpus.cfg
+++ b/examples/LaserWakefield/submit/0001gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/submit/0008gpus.cfg
+++ b/examples/LaserWakefield/submit/0008gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/submit/0016gpus.cfg
+++ b/examples/LaserWakefield/submit/0016gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/LaserWakefield/submit/0032gpus.cfg
+++ b/examples/LaserWakefield/submit/0032gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/SingleParticleCurrent/submit/0001gpus.cfg
+++ b/examples/SingleParticleCurrent/submit/0001gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Heiko Burau, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
+++ b/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/SingleParticleTest/submit/0008gpus.cfg
+++ b/examples/SingleParticleTest/submit/0008gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0001gpu.cfg
+++ b/examples/ThermalTest/submit/0001gpu.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0004gpus.cfg
+++ b/examples/ThermalTest/submit/0004gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0008gpus.cfg
+++ b/examples/ThermalTest/submit/0008gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0032gpus.cfg
+++ b/examples/ThermalTest/submit/0032gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Heiko Burau, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/ThermalTest/submit/0064gpus.cfg
+++ b/examples/ThermalTest/submit/0064gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 

--- a/examples/WeibelTransverse/submit/0004gpus.cfg
+++ b/examples/WeibelTransverse/submit/0004gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright 2013 Rene Widera
 # 
 # This file is part of PIConGPU. 

--- a/src/libPMacc/examples/gameOfLife2D/submit/1gpu.cfg
+++ b/src/libPMacc/examples/gameOfLife2D/submit/1gpu.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/libPMacc/examples/gameOfLife2D/submit/2gpus.cfg
+++ b/src/libPMacc/examples/gameOfLife2D/submit/2gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #

--- a/src/libPMacc/examples/gameOfLife2D/submit/4gpus.cfg
+++ b/src/libPMacc/examples/gameOfLife2D/submit/4gpus.cfg
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2013 Rene Widera
 #


### PR DESCRIPTION
This pull request closes issue #1106 by removing the unneeded shebang in all `*.cfg` files.

The tool used was:
```python
import os
import stat
import re

executable = stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH


def remove_shebang(filename):
    f = open(filename, "r")
    text = f.readlines()
    f.close()
    f = open(filename, "w")
    for line in text:
        if not re.search("#!", line):
            f.write(line)
    f.close()

for dire in os.walk("../PIConGPU/picongpu/"):
    directory = dire[0]
    if not re.search("\.git", directory):
        for file in dire[2]:
            if re.search(".cfg\Z", file):
                filepath = directory + "/" + file
                st = os.stat(filepath)
                mode = st.st_mode
                if not (mode & executable):
                    f = open(filepath, "r")
                    try:
                        first_line = f.readline()
                        f.close()
                        if first_line[:2] == "#!":
                            print(filepath)
                            remove_shebang(filepath)
                    except UnicodeDecodeError:
                        1+1
                        #print(filepath + "-->not readable")
```