### PR TITLE
update modules on taurus

### DIFF
--- a/src/picongpu/submit/taurus/picongpu.profile.example
+++ b/src/picongpu/submit/taurus/picongpu.profile.example
@@ -3,10 +3,12 @@ module purge
 # General modules #############################################################
 #
 module load oscar-modules llview
-module load cmake/2.8.11 git
+module load cmake/3.3.1 git
 module load cuda/6.5.14  # gcc 4.8, intel 14.0 == 2013-sp1
 module load bullxmpi
 module load gnuplot/4.6.1
+module load openmpi/1.6
+module load zlib/1.2.8
 
 # Compilers ###################################################################
 ### GCC


### PR DESCRIPTION
~~With the update of taurus, there are only two cmake version available with the module system:~~
 - `cmake/2.8.1`1(default) 
 - `cmake/2.8.2`

~~But if no cmake from the module system is selected, `cmake version 2.8.12.2` is used instead (which is our minimal requirement on `dev`). 
Thus I removed getting cmake via module.~~

**Update:** I contacted the support and they added version 2.8.12.2 and version 3.3.2.
Additionally I added the so far missing openmpi and zlib modules to `picongpu.profile.example`.
