### PR TITLE
remove openMPI module load

### DIFF
--- a/src/picongpu/submit/taurus/picongpu.profile.example
+++ b/src/picongpu/submit/taurus/picongpu.profile.example
@@ -7,7 +7,6 @@ module load cmake/3.3.1 git
 module load cuda/6.5.14  # gcc 4.8, intel 14.0 == 2013-sp1
 module load bullxmpi
 module load gnuplot/4.6.1
-module load openmpi/1.6
 module load zlib/1.2.8
 
 # Compilers ###################################################################


### PR DESCRIPTION
This pull request removes the `module load openmpi/1.6` I introduced with #1111.
Now `bullxmpi` is preferred again.  