### PR TITLE
Taurus: CMake & LIBRARY_PATH

### DIFF
--- a/src/picongpu/submit/taurus/picongpu.profile.example
+++ b/src/picongpu/submit/taurus/picongpu.profile.example
@@ -7,7 +7,6 @@ module load cmake/3.3.1 git
 module load cuda/6.5.14  # gcc 4.8, intel 14.0 == 2013-sp1
 module load bullxmpi
 module load gnuplot/4.6.1
-module load zlib/1.2.8
 
 # Compilers ###################################################################
 ### GCC
@@ -22,15 +21,18 @@ module load gcc/4.8.0 boost/1.55.0-gnu4.8
 #   set NOSWITCHERROR=YES;
 #module load pgi/14.1 boost/1.55.0-pgi14.1
 
+# Other Software ##############################################################
+#
+module load hdf5/1.8.14
+module load zlib/1.2.8
+
 # Environment #################################################################
 #
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_LIB
 
 export PNGWRITER_ROOT=$HOME/lib/pngwriter
-export HDF5_ROOT=$HOME/lib/hdf5
 export SPLASH_ROOT=$HOME/lib/splash
 
-export LD_LIBRARY_PATH=$HOME/lib/hdf5/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/pngwriter/lib/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
 

--- a/src/picongpu/submit/taurus/picongpu.profile.example
+++ b/src/picongpu/submit/taurus/picongpu.profile.example
@@ -37,6 +37,11 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
 export PICSRC=$HOME/src/picongpu
 export PATH=$PATH:$PICSRC/src/tools/bin
 
+# cmake work-around: avoids wrong linkage if system-wide
+# libraries are available that shall not be used (hdf5, boost, ...)
+#   see https://www.mail-archive.com/cmake@cmake.org/msg50018.html
+unset LIBRARY_PATH
+
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)
 #   - "gpu" queue


### PR DESCRIPTION
Avoids wrong linkage if system-wide libraries are available that shall not be used (hdf5, boost, ...).

Fixes the issue reported in
  https://github.com/ComputationalRadiationPhysics/libSplash/issues/191

Detailed analysis above and in
  https://www.mail-archive.com/cmake@cmake.org/msg50018.html