### PR TITLE
[BP] #1115: Correct Device ID

### DIFF
--- a/src/libPMacc/include/Environment.hpp
+++ b/src/libPMacc/include/Environment.hpp
@@ -188,7 +188,7 @@ private:
             if (rc == cudaSuccess)
             {
                 cudaDeviceProp dprop;
-                cudaGetDeviceProperties(&dprop, deviceNumber);
+                cudaGetDeviceProperties(&dprop, tryDeviceId);
                 log<ggLog::CUDA_RT > ("Set device to %1%: %2%") % tryDeviceId % dprop.name;
                 CUDA_CHECK(cudaSetDeviceFlags(cudaDeviceScheduleSpin));
                 break;


### PR DESCRIPTION
Backport of #1115: Corrects the mapping of device when querying their properties.