### PR TITLE
[BP]  #1090: Gaussian Beam Envelope 2D

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -56,9 +56,12 @@ namespace picongpu
             //gaussian beam waist in the nearfield: w_y(y=0) == W0
             const double w_y = W0 * sqrt( 1.0 + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
 
-
-            const double envelope = double( AMPLITUDE ) * double( W0 ) / w_y;
-
+            float_64 envelope = float_64( AMPLITUDE );
+            if( simDim == DIM2 )
+                envelope *= math::sqrt( float_64( W0 ) / w_y );
+            else if( simDim == DIM3 )
+                envelope *= float_64( W0 ) / w_y;
+            /* no 1D representation/implementation */
 
             if( Polarisation == LINEAR_X )
             {

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -56,9 +56,12 @@ namespace picongpu
             //gaussian beam waist in the nearfield: w_y(y=0) == W0
             const double w_y = W0 * sqrt( 1.0 + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
 
-
-            const double envelope = double( AMPLITUDE ) * double( W0 ) / w_y;
-
+            float_64 envelope = float_64( AMPLITUDE );
+            if( simDim == DIM2 )
+                envelope *= math::sqrt( float_64( W0 ) / w_y );
+            else if( simDim == DIM3 )
+                envelope *= float_64( W0 ) / w_y;
+            /* no 1D representation/implementation */
 
             if( Polarisation == LINEAR_X )
             {


### PR DESCRIPTION
Backport of  #1090

--

This fixes the underestimation of the amplitude of the laser implementations for Gaussian Beam (and based on it for pulse front tilted Gaussian Beams) in 2D3V simulations.

Calculations of the pre-factor are performed on the host-side and therefore a simple `if` avoids code duplication.