### PR TITLE
Photon & Free Pusher: 2D3V Support

### DIFF
--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -43,7 +43,7 @@ namespace picongpu
             {
 
                 Velocity velocity;
-                const float3_X vel = velocity(mom, mass);
+                const MomType vel = velocity(mom, mass);
 
 
                 for(uint32_t d=0;d<simDim;++d)

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera,
+ *                     Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -42,7 +43,7 @@ namespace picongpu
             {
 
                 Velocity velocity;
-                const PosType vel = velocity(mom, mass);
+                const float3_X vel = velocity(mom, mass);
 
 
                 for(uint32_t d=0;d<simDim;++d)

--- a/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera,
- *                     Alexander Grund
+ *                     Alexander Grund, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -43,7 +43,7 @@ namespace picongpu
             {
 
                 const float_X mom_abs = math::abs( mom );
-                const PosType vel = mom * ( SPEED_OF_LIGHT / mom_abs );
+                const MomType vel = mom * ( SPEED_OF_LIGHT / mom_abs );
 
                 for(uint32_t d=0;d<simDim;++d)
                 {


### PR DESCRIPTION
Currently, the **Free Pusher** and the **Photon Pusher** do not support 2D simulation setups. 
The compiler throws an error when using these pushers in 2D.

This pull request fixes this, by keeping the type of speed ~~`float3_X`~~ **Update:** `MomType`.
