### PR TITLE
Close #1109 Remove Shebang from *.gnuplot

### DIFF
--- a/src/tools/share/gnuplot/BinEnergyPlot.gnuplot
+++ b/src/tools/share/gnuplot/BinEnergyPlot.gnuplot
@@ -1,6 +1,4 @@
-#!/usr/bin/gnuplot -persist
-# 
-# Copyright 2013-2014 Axel Huebl, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Richard Pausch
 #
 # This file is part of PIConGPU.
 #


### PR DESCRIPTION
Close #1109 the file is just a template for an other script, only used in memory via `echo "$script" | gnuplot -persist` and has a clear suffix.