### PR TITLE
Add conversion operator from uint3

### DIFF
--- a/src/libPMacc/include/dimensions/DataSpace.hpp
+++ b/src/libPMacc/include/dimensions/DataSpace.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2015 Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Wolfgang Hoenig, Benjamin Worpitz
+ *                     Wolfgang Hoenig, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -62,6 +62,18 @@ namespace PMacc
          * Sets size of all dimensions from cuda dim3.
          */
         HDINLINE DataSpace(dim3 value)
+        {
+            for (uint32_t i = 0; i < DIM; ++i)
+            {
+                (*this)[i] = *(&(value.x) + i);
+            }
+        }
+
+        /**
+         * constructor.
+         * Sets size of all dimensions from cuda uint3 (e.g. threadIdx/blockIdx)
+         */
+        HDINLINE DataSpace(uint3 value)
         {
             for (uint32_t i = 0; i < DIM; ++i)
             {


### PR DESCRIPTION
This simplifies quite some kernels as no explicit conversion is required anymore from threadIdx and blockIdx. Example:

    // Old
    const PMacc::DataSpace<3> superCellIdx(mapper.getSuperCellIndex(PMacc::DataSpace<3>(blockIdx)));
    
    //New
    const PMacc::DataSpace<3> superCellIdx(mapper.getSuperCellIndex(blockIdx));

There is a chance for an overflow if a value from the source is greater than INT_MAX. However this cannot happen for threadIdx and blockIdx as those are limited to 2^31 - 1 which is INT_MAX. (https://en.wikipedia.org/wiki/CUDA#Version_features_and_specifications)