### PR TITLE
mallocMC 2.2.0crp dependency

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -269,12 +269,12 @@ endif()
 # Find mallocMC
 ################################################################################
 
-find_package(mallocMC 2.1.0 QUIET)
+find_package(mallocMC 2.2.0 QUIET)
 
 if(NOT mallocMC_FOUND)
   message(STATUS "Using mallocMC from thirdParty/ directory")
   set(MALLOCMC_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdParty/mallocMC")
-  find_package(mallocMC 2.1.0 REQUIRED)
+  find_package(mallocMC 2.2.0 REQUIRED)
 endif(NOT mallocMC_FOUND)
 
 include_directories(SYSTEM ${mallocMC_INCLUDE_DIRS})

--- a/thirdParty/mallocMC/.travis.yml
+++ b/thirdParty/mallocMC/.travis.yml
@@ -9,13 +9,15 @@ env:
 
 script:
   - mkdir build_tmp && cd build_tmp
-  - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $TRAVIS_BUILD_DIR
+  - CXXFLAGS="-Werror" cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $TRAVIS_BUILD_DIR
   - make
   - make install
   - make examples
 
 before_script:
+  - sudo add-apt-repository --yes ppa:smspillaz/cmake-2.8.12
   - sudo apt-get update -qq
+  - sudo apt-get install -q -y cmake-data cmake
   - sudo apt-get install -qq build-essential
   - sudo apt-get install -qq gcc-4.4 g++-4.4
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.4 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.4

--- a/thirdParty/mallocMC/CHANGELOG.md
+++ b/thirdParty/mallocMC/CHANGELOG.md
@@ -1,6 +1,29 @@
 Change Log / Release Log for mallocMC
 ================================================================
 
+2.2.0crp
+-------------
+**Date:** 2015-09-25
+
+This release fixes some minor bugs that occured after the release of 2.1.0crp, adds some documentation and improves the interoperability with other projects and build systems.
+We closed all issues documented in
+[Milestone *2.2.0crp: Stabilizing the release*](https://github.com/ComputationalRadiationPhysics/mallocMC/issues?milestone=5&state=closed)
+
+### Changes to mallocMC 2.1.0crp
+
+**Features**
+ - the interface now provides the host function `HeapInfoVector getHeapLocations()` to obtain information about the location and size of existing mallocMC-heaps #86
+
+**Bug fixes**
+ - the function `getAvailableSlots` was always required in the policy classes, although the implementations might not provide it #89
+
+**Misc:**
+ - the code relied on `__TROW` being defined, which is not available in all compilers #91
+ - the CMake dependency increased to CMake >= 2.8.12.2 #92
+ - a new FindmallocMC.cmake module file is provided at https://github.com/ComputationalRadiationPhysics/cmake-modules #85
+ - See the full changes at https://github.com/ComputationalRadiationPhysics/mallocMC/compare/2.1.0crp...2.2.0crp
+
+
 2.1.0crp
 -------------
 **Date:** 2015-02-11

--- a/thirdParty/mallocMC/CMakeLists.txt
+++ b/thirdParty/mallocMC/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(mallocMC)
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 2.8.12.2)
 
 # helper for libs and packages
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/"
@@ -46,18 +46,20 @@ endif(Boost_VERSION EQUAL 105500)
 # GNU
 if(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
   # new warning in gcc 4.8 (flag ignored in previous version)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
-  # ICC
+# ICC
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_VARIADIC_TEMPLATES")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_VARIADIC_TEMPLATES")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_FENV_H")
-  # PGI
+# PGI
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
 endif()

--- a/thirdParty/mallocMC/INSTALL.md
+++ b/thirdParty/mallocMC/INSTALL.md
@@ -15,7 +15,7 @@ Install
    - *Debian/Ubuntu:* `sudo apt-get install libboost-dev libboost-program-options-dev`
    - *Arch Linux:* `sudo pacman -S boost`
    - or download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz/download)
- - `CMake` >= 2.8.5
+ - `CMake` >= 2.8.12.2
   - *Debian/Ubuntu:* `sudo apt-get install cmake file cmake-curses-gui`
   - *Arch Linux:* `sudo pacman -S cmake`
  - `git` >= 1.7.9.5
@@ -65,8 +65,8 @@ cmake -DCMAKE_MODULE_PATH=. --help-module FindmallocMC | less
 
 and use the following lines in your `CMakeLists.txt`:
 ```cmake
-# this example will require at least CMake 2.8.5
-cmake_minimum_required(VERSION 2.8.5)
+# this example will require at least CMake 2.8.12.2
+cmake_minimum_required(VERSION 2.8.12.2)
 
 # add path to FindmallocMC.cmake, e.g., in the directory in cmake/
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)

--- a/thirdParty/mallocMC/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -74,6 +74,8 @@ namespace Shrink2NS{
 #endif
     static const uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
+    // \TODO: The static_cast can be removed once the minimal dependencies of
+    //        this project is are at least CUDA 7.0 and gcc 4.8.2
     BOOST_STATIC_ASSERT(static_cast<uint32>(dataAlignment) > 0);
     //dataAlignment must also be a power of 2!
     BOOST_STATIC_ASSERT(dataAlignment && !(dataAlignment & (dataAlignment-1)) ); 

--- a/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -77,6 +77,9 @@ namespace DistributionPolicies{
 
       //all the properties must be unsigned integers > 0
       BOOST_STATIC_ASSERT(!std::numeric_limits<typename Properties::pagesize::type>::is_signed);
+
+      // \TODO: The static_cast can be removed once the minimal dependencies of
+      //        this project is are at least CUDA 7.0 and gcc 4.8.2
       BOOST_STATIC_ASSERT(static_cast<uint32>(pagesize) > 0);
 
     public:

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_overwrites.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_overwrites.hpp
@@ -83,6 +83,12 @@ bool providesAvailableSlots(){                                                 \
 } /* end namespace mallocMC */
 
 
+/** __THROW is defined in Glibc so it is not available on all platforms.
+ */
+#ifndef __THROW
+  #define __THROW
+#endif 
+
 /** Create the functions malloc() and free() inside a namespace
  *
  * This allows for a peaceful coexistence between different functions called

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
@@ -40,6 +40,7 @@
 #include <string>
 #include <sstream>
 #include <stdexcept>
+#include <boost/cstdint.hpp>
 
 #include "mallocMC_prefixes.hpp"
 
@@ -49,20 +50,20 @@ namespace CUDA
   class error : public std::runtime_error
   {
   private:
-    static std::string genErrorString(cudaError error, const char* file, int line)
+    static std::string genErrorString(cudaError errorValue, const char* file, int line)
     {
       std::ostringstream msg;
-      msg << file << '(' << line << "): error: " << cudaGetErrorString(error);
+      msg << file << '(' << line << "): error: " << cudaGetErrorString(errorValue);
       return msg.str();
     }
   public:
-    error(cudaError error, const char* file, int line)
-      : runtime_error(genErrorString(error, file, line))
+    error(cudaError errorValue, const char* file, int line)
+      : runtime_error(genErrorString(errorValue, file, line))
     {
     }
 
-    error(cudaError error)
-      : runtime_error(cudaGetErrorString(error))
+    error(cudaError errorValue)
+      : runtime_error(cudaGetErrorString(errorValue))
     {
     }
 
@@ -72,11 +73,11 @@ namespace CUDA
     }
   };
 
-  inline void checkError(cudaError error, const char* file, int line)
+  inline void checkError(cudaError errorValue, const char* file, int line)
   {
 #ifdef _DEBUG
-    if (error != cudaSuccess)
-      throw CUDA::error(error, file, line);
+    if (errorValue != cudaSuccess)
+      throw CUDA::error(errorValue, file, line);
 #endif
   }
 
@@ -88,9 +89,9 @@ namespace CUDA
   inline void checkError()
   {
 #ifdef _DEBUG
-    cudaError error = cudaGetLastError();
-    if (error != cudaSuccess)
-      throw CUDA::error(error);
+    cudaError errorValue = cudaGetLastError();
+    if (errorValue != cudaSuccess)
+      throw CUDA::error(errorValue);
 #endif
   }
 
@@ -100,7 +101,7 @@ namespace CUDA
 
 
 #define warp_serial                                    \
-  for (uint32_richtig_huebsch __mask = __ballot(1),                    \
+  for (unsigned int __mask = __ballot(1),              \
             __num = __popc(__mask),                    \
             __lanemask = mallocMC::lanemask_lt(),      \
             __local_id = __popc(__lanemask & __mask),  \
@@ -112,7 +113,6 @@ namespace CUDA
 
 namespace mallocMC 
 {
-  typedef unsigned int uint32_richtig_huebsch;
 
   template<int PSIZE>
   class __PointerEquivalent
@@ -130,70 +130,70 @@ namespace mallocMC
   typedef mallocMC::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
 
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch laneid()
+  MAMC_ACCELERATOR inline uint32_t laneid()
   {
-    uint32_richtig_huebsch mylaneid;
+    uint32_t mylaneid;
     asm("mov.u32 %0, %laneid;" : "=r" (mylaneid));
     return mylaneid;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch warpid()
+  MAMC_ACCELERATOR inline uint32_t warpid()
   {
-    uint32_richtig_huebsch mywarpid;
+    uint32_t mywarpid;
     asm("mov.u32 %0, %warpid;" : "=r" (mywarpid));
     return mywarpid;
   }
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch nwarpid()
+  MAMC_ACCELERATOR inline uint32_t nwarpid()
   {
-    uint32_richtig_huebsch mynwarpid;
+    uint32_t mynwarpid;
     asm("mov.u32 %0, %nwarpid;" : "=r" (mynwarpid));
     return mynwarpid;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch smid()
+  MAMC_ACCELERATOR inline uint32_t smid()
   {
-    uint32_richtig_huebsch mysmid;
+    uint32_t mysmid;
     asm("mov.u32 %0, %smid;" : "=r" (mysmid));
     return mysmid;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch nsmid()
+  MAMC_ACCELERATOR inline uint32_t nsmid()
   {
-    uint32_richtig_huebsch mynsmid;
+    uint32_t mynsmid;
     asm("mov.u32 %0, %nsmid;" : "=r" (mynsmid));
     return mynsmid;
   }
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask()
+  MAMC_ACCELERATOR inline uint32_t lanemask()
   {
-    uint32_richtig_huebsch lanemask;
+    uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_eq;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_le()
+  MAMC_ACCELERATOR inline uint32_t lanemask_le()
   {
-    uint32_richtig_huebsch lanemask;
+    uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_le;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_lt()
+  MAMC_ACCELERATOR inline uint32_t lanemask_lt()
   {
-    uint32_richtig_huebsch lanemask;
+    uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_lt;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_ge()
+  MAMC_ACCELERATOR inline uint32_t lanemask_ge()
   {
-    uint32_richtig_huebsch lanemask;
+    uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_ge;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_gt()
+  MAMC_ACCELERATOR inline uint32_t lanemask_gt()
   {
-    uint32_richtig_huebsch lanemask;
+    uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_gt;" : "=r" (lanemask));
     return lanemask;
   }

--- a/thirdParty/mallocMC/src/include/mallocMC/oOMPolicies/BadAllocException.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/oOMPolicies/BadAllocException.hpp
@@ -39,7 +39,7 @@ namespace OOMPolicies{
    * accelerators. Using this policy on other types of accelerators that do not
    * support exceptions results in undefined behaviour.
    */
-  class BadAllocException;
-    
+  struct BadAllocException;
+
 } //namespace OOMPolicies
 } //namespace mallocMC

--- a/thirdParty/mallocMC/src/include/mallocMC/version.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/version.hpp
@@ -38,10 +38,10 @@
 
 /** the mallocMC version: major API changes should be reflected here */
 #define MALLOCMC_VERSION_MAJOR 2
-#define MALLOCMC_VERSION_MINOR 1
+#define MALLOCMC_VERSION_MINOR 2
 #define MALLOCMC_VERSION_PATCH 0
 
-/** the mallocMC flavor is used to differenciate the releases of the
+/** the mallocMC flavor is used to differentiate the releases of the
  *  Computational Radiation Physics group (crp) from other releases
  *  This should be useful to avoid versioning conflicts */
 #define MALLOCMC_FLAVOR "crp"


### PR DESCRIPTION
 - mallocMC dependency in `CMakeLists.txt` increased
 - Squashed the new mallocMC master branch (which is at 2.2.0crp) into the `thirdParty` folder