### PR TITLE
Close #1035 usage of boost::result_of

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -51,9 +51,9 @@ Requirements
   - *Debian/Ubuntu:* `sudo apt-get install zlib1g-dev`
   - *Arch Linux:* `sudo pacman --sync zlib`
 
-- **boost** 1.49.0+ ("program options", "regex" , "filesystem", "system" and nearly all header-only libs)
-  - download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.49.0/boost_1_49_0.tar.gz/download),
-      e.g. version 1.49.0
+- **boost** 1.52.0+ ("program options", "regex" , "filesystem", "system" and nearly all header-only libs)
+  - download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.52.0/boost_1_52_0.tar.gz/download),
+      e.g. version 1.52.0
   - *Debian/Ubuntu:* `sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev`
   - *Arch Linux:* `sudo pacman --sync boost`
   - *From source:*

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -254,6 +254,9 @@ if( (Boost_VERSION EQUAL 105500) AND
       "${CUDA_NVCC_FLAGS} \"-DBOOST_NOINLINE=__attribute__((noinline))\" ")
 endif()
 
+# PMacc (ab)uses boost::result_of for non-functors. This forces boost to use the
+# result<> member template of the target type if available
+add_definitions(-DBOOST_RESULT_OF_USE_TR1)
 
 ################################################################################
 # Find OpenMP

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -88,6 +88,18 @@ if(CUDA_KEEP_FILES)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --keep --keep-dir "${PROJECT_BINARY_DIR}/nvcc_tmp")
 endif(CUDA_KEEP_FILES)
 
+################################################################################
+# C++11 Enabler
+################################################################################
+
+# By using this if-else one can assume that CMAKE_CXX_STANDARD==11 <=> CUDA_NVCC_FLAGS contain "-std=c++11"
+if("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11")
+    set(CMAKE_CXX_STANDARD 11)
+elseif("${CMAKE_CXX_STANDARD}" STREQUAL "11")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -std=c++11)
+else()
+    set(CMAKE_CXX_STANDARD 98)
+endif()
 
 ################################################################################
 # VampirTrace
@@ -262,11 +274,10 @@ else()
     # Boost 1.55 adds support for another define that makes result_of look for the result<> template
     # and falls back to decltype if none is found. This is great for the transition from the "wrong"
     # usage to the "correct" one as both can be used. But:
-    # 1) Cannot be used before 7.5 due to nvcc bug:
+    # 1) Cannot be used in 7.0 due to nvcc bug:
     #    http://stackoverflow.com/questions/31940457/make-nvcc-output-traces-on-compile-error
     # 2) Requires c++11 enabled as there is no further check in boost besides the version check
-    if( (NOT CUDA_VERSION VERSION_LESS 7.5) AND
-        ("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11") )
+    if( (NOT CUDA_VERSION VERSION_EQUAL 7.0) AND (CMAKE_CXX_STANDARD EQUAL 11) )
         add_definitions(-DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
     else()
         # Fallback

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright 2013-2015 Axel Huebl, Benjamin Schneider, Felix Schmitt, Heiko Burau, Rene Widera
+# Copyright 2013-2015 Axel Huebl, Benjamin Schneider, Felix Schmitt, Heiko Burau,
+#                     Rene Widera, Alexander Grund
 #
 # This file is part of PIConGPU.
 #
@@ -92,12 +93,14 @@ endif(CUDA_KEEP_FILES)
 # C++11 Enabler
 ################################################################################
 
-# By using this if-else one can assume that CMAKE_CXX_STANDARD==11 <=> CUDA_NVCC_FLAGS contain "-std=c++11"
+# By using this if-else one can assume that:
+# CMAKE_CXX_STANDARD==11 <=> CUDA_NVCC_FLAGS contain "-std=c++11"
 if("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11")
     set(CMAKE_CXX_STANDARD 11)
 elseif("${CMAKE_CXX_STANDARD}" STREQUAL "11")
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -std=c++11)
 else()
+    # Note: Add support for C++14 once CUDA supports it (maybe 8.0?)
     set(CMAKE_CXX_STANDARD 98)
 endif()
 
@@ -266,17 +269,19 @@ if( (Boost_VERSION EQUAL 105500) AND
       "${CUDA_NVCC_FLAGS} \"-DBOOST_NOINLINE=__attribute__((noinline))\" ")
 endif()
 
-# PMacc (ab)uses boost::result_of for non-functors. This define forces boost to use the
-# result<> member template of the target type
+# PMacc (ab)uses boost::result_of for non-functors (e.g. []-operators). This
+# define forces boost to use the result<> member template of the target type
 if(Boost_VERSION LESS 105500)
     add_definitions(-DBOOST_RESULT_OF_USE_TR1)
 else()
-    # Boost 1.55 adds support for another define that makes result_of look for the result<> template
-    # and falls back to decltype if none is found. This is great for the transition from the "wrong"
-    # usage to the "correct" one as both can be used. But:
+    # Boost 1.55 adds support for another define that makes result_of look for
+    # the result<> template and falls back to decltype if none is found. This is
+    # great for the transition from the "wrong" usage to the "correct" one as
+    # both can be used. But:
     # 1) Cannot be used in 7.0 due to nvcc bug:
-    #    http://stackoverflow.com/questions/31940457/make-nvcc-output-traces-on-compile-error
-    # 2) Requires c++11 enabled as there is no further check in boost besides the version check
+    #    http://stackoverflow.com/questions/31940457/
+    # 2) Requires C++11 enabled as there is no further check in boost besides
+    #    the version check of nvcc
     if( (NOT CUDA_VERSION VERSION_EQUAL 7.0) AND (CMAKE_CXX_STANDARD EQUAL 11) )
         add_definitions(-DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
     else()

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -256,6 +256,8 @@ endif()
 
 # PMacc (ab)uses boost::result_of for non-functors. This forces boost to use the
 # result<> member template of the target type if available
+# Note: For CUDA > 7.5 and Boost >= 1.55 one can also use BOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK
+# as CUDA versions up till 7.5 have a serious compiler bug when using boost::result_of with decltype
 add_definitions(-DBOOST_RESULT_OF_USE_TR1)
 
 ################################################################################

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -240,7 +240,7 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.49.0 REQUIRED COMPONENTS program_options regex filesystem system)
+find_package(Boost 1.52.0 REQUIRED COMPONENTS program_options regex filesystem system)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 
@@ -254,11 +254,25 @@ if( (Boost_VERSION EQUAL 105500) AND
       "${CUDA_NVCC_FLAGS} \"-DBOOST_NOINLINE=__attribute__((noinline))\" ")
 endif()
 
-# PMacc (ab)uses boost::result_of for non-functors. This forces boost to use the
-# result<> member template of the target type if available
-# Note: For CUDA > 7.5 and Boost >= 1.55 one can also use BOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK
-# as CUDA versions up till 7.5 have a serious compiler bug when using boost::result_of with decltype
-add_definitions(-DBOOST_RESULT_OF_USE_TR1)
+# PMacc (ab)uses boost::result_of for non-functors. This define forces boost to use the
+# result<> member template of the target type
+if(Boost_VERSION LESS 105500)
+    add_definitions(-DBOOST_RESULT_OF_USE_TR1)
+else()
+    # Boost 1.55 adds support for another define that makes result_of look for the result<> template
+    # and falls back to decltype if none is found. This is great for the transition from the "wrong"
+    # usage to the "correct" one as both can be used. But:
+    # 1) Cannot be used before 7.5 due to nvcc bug:
+    #    http://stackoverflow.com/questions/31940457/make-nvcc-output-traces-on-compile-error
+    # 2) Requires c++11 enabled as there is no further check in boost besides the version check
+    if( (NOT CUDA_VERSION VERSION_LESS 7.5) AND
+        ("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11") )
+        add_definitions(-DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
+    else()
+        # Fallback
+        add_definitions(-DBOOST_RESULT_OF_USE_TR1)
+    endif()
+endif()
 
 ################################################################################
 # Find OpenMP


### PR DESCRIPTION
PMacc uses `boost::result_of` to get the return type of arbitrary functions from a couple of structs. For example it is used, to get the result of the []-operator.
This violates the standard protocol which specifies that the result<> template member type should return the return type of the ()-operator and therefore breaks once decltype() (C++11) can be used (which is then automatically chosen by boost) This makes compiling with C++11 impossible --> #1147

This PR adds a define that forces boost to keep that behaviour. Note that the related ` BOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK` define cannot be used in **CUDA 7.0** due to a nvcc compiler bug ~~that should be fixed in the next CUDA release after 7.5 (according to NVIDIA)~~ (not in CUDA 6.5; fixed in CUDA 7.5).

Source for boost::result_of: http://www.boost.org/doc/libs/1_59_0/libs/utility/utility.htm

This **requires** at least **boost 1.52**: http://www.boost.org/doc/libs/1_52_0/libs/utility/utility.htm

Closes #1035 (for now)