### PR TITLE
Fix spacing for C++11 compatibility

### DIFF
--- a/thirdParty/cuda_memtest/cuda_memtest.h
+++ b/thirdParty/cuda_memtest/cuda_memtest.h
@@ -80,12 +80,12 @@ extern void get_driver_info(char* info, unsigned int len);
 #define PRINTF(fmt,...) do{						\
 	if (monitor_temp){						\
 	    pthread_mutex_lock(&mutex);					\
-	    printf("[%s][%s][%d][%d C]:"fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
+	    printf("[%s][%s][%d][%d C]:" fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
 	    pthread_mutex_unlock(&mutex);				\
 	}								\
 	else{								\
 	    pthread_mutex_lock(&mutex);					\
-	    printf("[%s][%s][%d]:"fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
+	    printf("[%s][%s][%d]:" fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
 	    pthread_mutex_unlock(&mutex);					\
 	}								\
 	fflush(stdout);							\
@@ -94,10 +94,10 @@ extern void get_driver_info(char* info, unsigned int len);
 
 #define FPRINTF(fmt,...) do{						\
 	if (monitor_temp){					\
-	    fprintf(stderr, "[%s][%s][%d][%d C]:"fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
+	    fprintf(stderr, "[%s][%s][%d][%d C]:" fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
 	}								\
 	else{								\
-	    fprintf(stderr, "[%s][%s][%d]:"fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
+	    fprintf(stderr, "[%s][%s][%d]:" fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
 	}								\
 	fflush(stderr);							\
     } while(0)


### PR DESCRIPTION
C++11 compilation throws a warning for those lines: `invalid suffix on literal; C++11 requires a space between literal and identifier`

This commit fixes this. No runtime influence.