### PR TITLE
Third Party: cuda_memtest update

### DIFF
--- a/thirdParty/cuda_memtest/.travis.yml
+++ b/thirdParty/cuda_memtest/.travis.yml
@@ -1,0 +1,40 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+env:
+  global:
+    - INSTALL_DIR=~/mylibs
+    - NVML_FILE=cuda_346.46_gdk_linux.run
+    - NVML_LINK=http://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers/
+  matrix:
+    - USE_NVML=1
+    - USE_NVML=0
+
+script:
+  - mkdir build_tmp && cd build_tmp
+# CUDA 4.0 on travis... work-around missing atomicAdd
+  - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCUDA_ARCH=sm_10 -DSAME_NVCC_FLAGS_IN_SUBPROJECTS=ON $TRAVIS_BUILD_DIR
+  - make
+  - make install
+
+before_script:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq build-essential
+  - sudo apt-get install -qq gcc-4.4 g++-4.4
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.4 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.4
+  - gcc --version && g++ --version
+  - sudo apt-get install -qq nvidia-common
+  - sudo apt-get install -qq nvidia-current
+  - sudo apt-get install -qq nvidia-cuda-toolkit nvidia-cuda-dev
+  - if [ $USE_NVML -eq 1 ]; then wget $NVML_LINK$NVML_FILE && chmod u+x $NVML_FILE && sudo ./$NVML_FILE --silent --installdir=/ ; fi
+  - if [ $USE_NVML -eq 1 ]; then export CMAKE_PREFIX_PATH=/usr/src/gdk/nvml/lib/ ; fi
+  - sudo find /usr/ -name libcuda*.so
+  - sudo find /usr/ -name nvml.h
+  - sudo find /usr/ -name libnvidia*.so
+  - sudo find /usr/ -name libnvml*.so
+
+after_script:
+  - ls -halR $INSTALL_DIR

--- a/thirdParty/cuda_memtest/CMakeLists.txt
+++ b/thirdParty/cuda_memtest/CMakeLists.txt
@@ -31,6 +31,9 @@ find_package(CUDA REQUIRED)
 if(SAME_NVCC_FLAGS_IN_SUBPROJECTS)
   set(CUDA_ARCH sm_13 CACHE STRING "set GPU architecture" )
   set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} ${nvcc_flags} -arch=${CUDA_ARCH})
+  if(CUDA_ARCH STREQUAL "sm_10")
+    add_definitions(-DSM_10=1)
+  endif()
 
   if(CUDA_SHOW_CODELINES)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --source-in-ptx -Xcompiler -rdynamic -lineinfo)
@@ -69,6 +72,12 @@ endif()
 ################################################################################
 
 find_package(Threads REQUIRED)
+list(APPEND LIBS ${CMAKE_THREAD_LIBS_INIT})
+
+# work around for Hypnos (Ubuntu 14.04) with gcc 4.8.2
+if(NOT CMAKE_THREAD_LIBS_INIT)
+    list(APPEND LIBS "-pthread")
+endif()
 
 
 ################################################################################
@@ -76,27 +85,21 @@ find_package(Threads REQUIRED)
 ################################################################################
 
 option(CUDA_MEMTEST_RELEASE "disable all runtime asserts" ON)
-if(PIC_RELEASE)
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=-pthread")
+if(CUDA_MEMTEST_RELEASE)
     add_definitions(-DNDEBUG)
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" "-Xcompiler=-pthread")
-else(PIC_RELEASE)
+else(CUDA_MEMTEST_RELEASE)
     set(CMAKE_BUILD_TYPE Debug)
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -g "-Xcompiler=-g,-pthread")
-endif(PIC_RELEASE)
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=-g")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -g")
+endif(CUDA_MEMTEST_RELEASE)
 
 
 ################################################################################
 # Warnings
 ################################################################################
 
-set(CMAKE_CXX_FLAGS_DEFAULT "-Wall")
-
-
-################################################################################
-# Configure include directories
-################################################################################
-
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} ${INCLUDE_DIRECTORIES})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 
 ################################################################################
@@ -109,7 +112,7 @@ cuda_add_executable(cuda_memtest
     cuda_memtest.cu
 )
 
-target_link_libraries(cuda_memtest ${LIBS} ${CUDA_CUDART_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(cuda_memtest ${LIBS} ${CUDA_CUDART_LIBRARY})
 
 
 ################################################################################
@@ -117,4 +120,4 @@ target_link_libraries(cuda_memtest ${LIBS} ${CUDA_CUDART_LIBRARY} ${CMAKE_THREAD
 ################################################################################
 
 install(TARGETS cuda_memtest
-         RUNTIME DESTINATION bin)
+        RUNTIME DESTINATION bin)

--- a/thirdParty/cuda_memtest/cuda_memtest.h
+++ b/thirdParty/cuda_memtest/cuda_memtest.h
@@ -39,7 +39,7 @@
  */
 
 #ifndef __MEMTEST_H__
-#define __MEMTEST_H_
+#define __MEMTEST_H__
 
 #include <stdio.h>
 #include <stdint.h>
@@ -80,12 +80,12 @@ extern void get_driver_info(char* info, unsigned int len);
 #define PRINTF(fmt,...) do{						\
 	if (monitor_temp){						\
 	    pthread_mutex_lock(&mutex);					\
-	    printf("[%s][%s][%d][%d C]:"fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
+	    printf("[%s][%s][%d][%d C]:" fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
 	    pthread_mutex_unlock(&mutex);				\
 	}								\
 	else{								\
 	    pthread_mutex_lock(&mutex);					\
-	    printf("[%s][%s][%d]:"fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
+	    printf("[%s][%s][%d]:" fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
 	    pthread_mutex_unlock(&mutex);					\
 	}								\
 	fflush(stdout);							\
@@ -94,10 +94,10 @@ extern void get_driver_info(char* info, unsigned int len);
 
 #define FPRINTF(fmt,...) do{						\
 	if (monitor_temp){					\
-	    fprintf(stderr, "[%s][%s][%d][%d C]:"fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
+	    fprintf(stderr, "[%s][%s][%d][%d C]:" fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
 	}								\
 	else{								\
-	    fprintf(stderr, "[%s][%s][%d]:"fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
+	    fprintf(stderr, "[%s][%s][%d]:" fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
 	}								\
 	fflush(stderr);							\
     } while(0)

--- a/thirdParty/cuda_memtest/tests.cu
+++ b/thirdParty/cuda_memtest/tests.cu
@@ -588,7 +588,7 @@ test0(char* ptr, unsigned int tot_num_blocks)
     kernel_test0_global_read<<<1, 1>>>(ptr, end_ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
     error_checking("test0 on global address",  0);
 
-    for(int ite = 0;ite < num_iterations; ite++){
+    for(unsigned int ite = 0;ite < num_iterations; ite++){
 	for (i=0;i < tot_num_blocks; i+= GRIDSIZE){
 	    dim3 grid;
 	    grid.x= GRIDSIZE;


### PR DESCRIPTION
This PR updates `cuda_memtest` with the latest updates from our [upstream repository](https://github.com/ComputationalRadiationPhysics/cuda_memtest):
  https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/2
  https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/3
  https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/4
  https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/6 (follow up of #1156)

Updated via:
```bash
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git subtree pull --prefix thirdParty/cuda_memtest/ \
  git@github.com:ComputationalRadiationPhysics/cuda_memtest.git dev --squash
```