### PR TITLE
PIConGPU: Use BOOST_STATIC_CONSTEXPR where possible

### DIFF
--- a/src/picongpu/include/algorithms/DifferenceToLower.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToLower.hpp
@@ -39,7 +39,7 @@ using namespace PMacc;
 template<uint32_t T_Dim>
 struct DifferenceToLower
 {
-    static const uint32_t dim = T_Dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_Dim;
 
 
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type OffsetOrigin;
@@ -53,7 +53,7 @@ struct DifferenceToLower
     template<uint32_t T_direction, bool T_isLesserThanDim = (T_direction < dim)>
     struct GetDifference
     {
-        static const uint32_t direction = T_direction;
+        BOOST_STATIC_CONSTEXPR uint32_t direction = T_direction;
 
         /** get difference to lower value
          * @return difference divided by cell size of the given direction

--- a/src/picongpu/include/algorithms/DifferenceToUpper.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToUpper.hpp
@@ -38,7 +38,7 @@ namespace picongpu
 template<uint32_t T_Dim>
 struct DifferenceToUpper
 {
-    static const uint32_t dim = T_Dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_Dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type OffsetOrigin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type OffsetEnd;
@@ -51,7 +51,7 @@ struct DifferenceToUpper
     template<uint32_t T_direction, bool T_isLesserThanDim = (T_direction < dim)>
     struct GetDifference
     {
-        static const uint32_t direction = T_direction;
+        BOOST_STATIC_CONSTEXPR uint32_t direction = T_direction;
 
         /** get difference to lower value
          * @return difference divided by cell size of the given direction

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
@@ -44,16 +44,16 @@ template<class T_Shape, class InterpolationMethod>
 struct FieldToParticleInterpolation
 {
     typedef typename T_Shape::ChargeAssignmentOnSupport AssignmentFunction;
-    static const int supp = AssignmentFunction::support;
+    BOOST_STATIC_CONSTEXPR int supp = AssignmentFunction::support;
 
-    static const int lowerMargin = supp / 2 ;
-    static const int upperMargin = (supp + 1) / 2;
+    BOOST_STATIC_CONSTEXPR int lowerMargin = supp / 2 ;
+    BOOST_STATIC_CONSTEXPR int upperMargin = (supp + 1) / 2;
     typedef typename PMacc::math::CT::make_Int<simDim,lowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim,upperMargin>::type UpperMargin;
 
     /*(supp + 1) % 2 is 1 for even supports else 0*/
-    static const int begin = -supp / 2 + (supp + 1) % 2;
-    static const int end = begin+supp-1;
+    BOOST_STATIC_CONSTEXPR int begin = -supp / 2 + (supp + 1) % 2;
+    BOOST_STATIC_CONSTEXPR int end = begin+supp-1;
 
     template<class Cursor, class VecVector_ >
     HDINLINE float3_X operator()(Cursor field, const floatD_X & particlePos,

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
@@ -44,10 +44,10 @@ template<class T_Shape, class InterpolationMethod>
 struct FieldToParticleInterpolationNative
 {
     typedef typename T_Shape::ChargeAssignment AssignmentFunction;
-    static const int supp = AssignmentFunction::support;
+    BOOST_STATIC_CONSTEXPR int supp = AssignmentFunction::support;
 
-    static const int lowerMargin = supp / 2;
-    static const int upperMargin = (supp + 1) / 2;
+    BOOST_STATIC_CONSTEXPR int lowerMargin = supp / 2;
+    BOOST_STATIC_CONSTEXPR int upperMargin = (supp + 1) / 2;
     typedef typename PMacc::math::CT::make_Int<simDim,lowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim,upperMargin>::type UpperMargin;
 

--- a/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
+++ b/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
@@ -38,7 +38,7 @@ namespace picongpu
 template<uint32_t T_Dim>
 struct LinearInterpolateWithUpper
 {
-    static const uint32_t dim = T_Dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_Dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type OffsetOrigin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type OffsetEnd;
@@ -51,7 +51,7 @@ struct LinearInterpolateWithUpper
     template<uint32_t T_direction, bool T_isLesserThanDim = (T_direction < dim)>
     struct GetInterpolatedValue
     {
-        static const uint32_t direction = T_direction;
+        BOOST_STATIC_CONSTEXPR uint32_t direction = T_direction;
 
         /** get interpolated value
          * @return interpolated value

--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -53,7 +53,7 @@ namespace picongpu
     public:
         typedef float3_X ValueType;
         typedef promoteType<float_64, ValueType>::type UnitValueType;
-        static const int numComponents = ValueType::dim;
+        BOOST_STATIC_CONSTEXPR int numComponents = ValueType::dim;
 
         typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
 

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -52,7 +52,7 @@ namespace picongpu
     public:
         typedef float3_X ValueType;
         typedef promoteType<float_64, ValueType>::type UnitValueType;
-        static const int numComponents = ValueType::dim;
+        BOOST_STATIC_CONSTEXPR int numComponents = ValueType::dim;
 
         typedef MappingDesc::SuperCellSize SuperCellSize;
 

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -61,7 +61,7 @@ public:
 
     typedef float3_X ValueType;
     typedef promoteType<float_64, ValueType>::type UnitValueType;
-    static const int numComponents = ValueType::dim;
+    BOOST_STATIC_CONSTEXPR int numComponents = ValueType::dim;
 
     typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
 

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -39,10 +39,10 @@ template<typename T_ParticleShape>
 struct Esirkepov<T_ParticleShape, DIM3>
 {
     typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
-    static const int supp = ParticleAssign::support;
+    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
 
-    static const int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
-    static const int currentUpperMargin = (supp + 1) / 2 + 1;
+    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef PMacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
     typedef PMacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
 
@@ -54,8 +54,8 @@ struct Esirkepov<T_ParticleShape, DIM3>
      * For the case were previous position is greater than current position we correct
      * begin and end on runtime and add +1 to begin and end.
      */
-    static const int begin = -currentLowerMargin;
-    static const int end = begin + supp + 1;
+    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin;
+    BOOST_STATIC_CONSTEXPR int end = begin + supp + 1;
 
     float_X charge;
 

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -47,10 +47,10 @@ template<typename T_ParticleShape>
 struct Esirkepov<T_ParticleShape, DIM2>
 {
     typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
-    static const int supp = ParticleAssign::support;
+    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
 
-    static const int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
-    static const int currentUpperMargin = (supp + 1) / 2 + 1;
+    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef typename PMacc::math::CT::make_Int<DIM2, currentLowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<DIM2, currentUpperMargin>::type UpperMargin;
 
@@ -62,8 +62,8 @@ struct Esirkepov<T_ParticleShape, DIM2>
      * For the case were previous position is greater than current position we correct
      * begin and end on runtime and add +1 to begin and end.
      */
-    static const int begin = -currentLowerMargin;
-    static const int end = begin + supp + 1;
+    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin;
+    BOOST_STATIC_CONSTEXPR int end = begin + supp + 1;
 
     float_X charge;
 

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -48,17 +48,17 @@ template<typename T_ParticleShape>
 struct EsirkepovNative
 {
     typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
-    static const int supp = ParticleAssign::support;
+    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
 
-    static const int currentLowerMargin = supp / 2 + 1;
-    static const int currentUpperMargin = (supp + 1) / 2 + 1;
+    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1;
+    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef PMacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
     typedef PMacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
 
 
     /* iterate over all grid points */
-    static const int begin = -currentLowerMargin;
-    static const int end = currentUpperMargin + 1;
+    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin;
+    BOOST_STATIC_CONSTEXPR int end = currentUpperMargin + 1;
 
     float_X charge;
 

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -142,10 +142,10 @@ struct ZigZag
      */
     typedef T_ParticleShape ParticleShape;
     typedef typename ParticleShape::ChargeAssignmentOnSupport ParticleAssign;
-    static const int supp = ParticleAssign::support;
+    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
 
-    static const int currentLowerMargin = supp / 2 + 1;
-    static const int currentUpperMargin = (supp + 1) / 2 + 1;
+    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1;
+    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef typename PMacc::math::CT::make_Int<simDim, currentLowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim, currentUpperMargin>::type UpperMargin;
 
@@ -154,15 +154,15 @@ struct ZigZag
      * @see ShiftCoordinateSystem
      * grid points were we calculate the current [begin;end)
      */
-    static const int begin = -supp / 2 + (supp + 1) % 2;
-    static const int end = begin + supp;
+    BOOST_STATIC_CONSTEXPR int begin = -supp / 2 + (supp + 1) % 2;
+    BOOST_STATIC_CONSTEXPR int end = begin + supp;
 
     /* same as begin and end but for the direction where we calculate j
      * supp_dir = support of the cloud shape
      */
-    static const int supp_dir = supp - 1;
-    static const int dir_begin = -supp_dir / 2 + (supp_dir + 1) % 2;
-    static const int dir_end = dir_begin + supp_dir;
+    BOOST_STATIC_CONSTEXPR int supp_dir = supp - 1;
+    BOOST_STATIC_CONSTEXPR int dir_begin = -supp_dir / 2 + (supp_dir + 1) % 2;
+    BOOST_STATIC_CONSTEXPR int dir_end = dir_begin + supp_dir;
 
     /** functor to calculate current for one direction
      *

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -34,7 +34,7 @@ using namespace PMacc;
 template<uint32_t T_dim>
 struct Binomial
 {
-    static const uint32_t dim = T_dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type UpperMargin;

--- a/src/picongpu/include/fields/currentInterpolation/None/None.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.hpp
@@ -34,7 +34,7 @@ using namespace PMacc;
 template<uint32_t T_dim>
 struct None
 {
-    static const uint32_t dim = T_dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type UpperMargin;

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -42,7 +42,7 @@ namespace detail
     template<uint32_t T_simDim, uint32_t T_plane>
     struct LinearInterpolateComponentPlaneUpper
     {
-        static const uint32_t dim = T_simDim;
+        BOOST_STATIC_CONSTEXPR uint32_t dim = T_simDim;
 
         /* UpperMargin is actually 0 in direction of T_plane */
         typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
@@ -81,8 +81,8 @@ namespace detail
     template<uint32_t T_simDim, uint32_t T_direction, bool isShiftAble=(T_direction<T_simDim) >
     struct ShiftMeIfYouCan
     {
-        static const uint32_t dim = T_simDim;
-        static const uint32_t dir = T_direction;
+        BOOST_STATIC_CONSTEXPR uint32_t dim = T_simDim;
+        BOOST_STATIC_CONSTEXPR uint32_t dir = T_direction;
 
         template<class T_DataBox >
         HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
@@ -131,7 +131,7 @@ namespace detail
 template<uint32_t T_simDim>
 struct NoneDS
 {
-    static const uint32_t dim = T_simDim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_simDim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type UpperMargin;

--- a/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
@@ -39,7 +39,7 @@ class TaskFieldReceiveAndInsert : public MPITask
 public:
 
 
-    static const uint32_t Dim = picongpu::simDim;
+    BOOST_STATIC_CONSTEXPR uint32_t Dim = picongpu::simDim;
 
     TaskFieldReceiveAndInsert(Field &buffer) :
     m_buffer(buffer),

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -56,8 +56,8 @@ struct CreateParticlesFromParticleImpl : private T_Functor
 
 
     typedef T_Functor Functor;
-    static const uint32_t particlePerParticle = T_Count::value;
-    static const int cellsInSuperCell = (int)PMacc::math::CT::volume<SuperCellSize>::type::value;
+    BOOST_STATIC_CONSTEXPR uint32_t particlePerParticle = T_Count::value;
+    BOOST_STATIC_CONSTEXPR int cellsInSuperCell = (int)PMacc::math::CT::volume<SuperCellSize>::type::value;
 
     HINLINE CreateParticlesFromParticleImpl(uint32_t currentStep) : Functor(currentStep)
     {

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -33,12 +33,12 @@ namespace particleToGrid
 
 struct ComputeGridValueOptions
 {
-    static const uint32_t calcDensity = 0u;
-    static const uint32_t calcEnergy = 1u;
-    static const uint32_t calcEnergyDensity = 2u;
-    static const uint32_t calcCounter = 3u;
+    BOOST_STATIC_CONSTEXPR uint32_t calcDensity = 0u;
+    BOOST_STATIC_CONSTEXPR uint32_t calcEnergy = 1u;
+    BOOST_STATIC_CONSTEXPR uint32_t calcEnergyDensity = 2u;
+    BOOST_STATIC_CONSTEXPR uint32_t calcCounter = 3u;
 #if(ENABLE_RADIATION == 1)
-    static const uint32_t calcLarmorEnergy = 4u;
+    BOOST_STATIC_CONSTEXPR uint32_t calcLarmorEnergy = 4u;
 #endif
 };
 
@@ -48,10 +48,10 @@ class ComputeGridValuePerFrame
 public:
 
     typedef typename T_ParticleShape::ChargeAssignment AssignmentFunction;
-    static const int supp = AssignmentFunction::support;
+    BOOST_STATIC_CONSTEXPR int supp = AssignmentFunction::support;
 
-    static const int lowerMargin = supp / 2;
-    static const int upperMargin = (supp + 1) / 2;
+    BOOST_STATIC_CONSTEXPR int lowerMargin = supp / 2;
+    BOOST_STATIC_CONSTEXPR int upperMargin = (supp + 1) / 2;
     typedef typename PMacc::math::CT::make_Int<simDim, lowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim, upperMargin>::type UpperMargin;
 

--- a/src/picongpu/include/particles/shapes/CIC.hpp
+++ b/src/picongpu/include/particles/shapes/CIC.hpp
@@ -37,7 +37,7 @@ struct CIC
      * width of the support of this form_factor. This is the area where the function
      * is non-zero.
      */
-    static const int support = 2;
+    BOOST_STATIC_CONSTEXPR int support = 2;
 };
 
 }//namespace shared_CIC

--- a/src/picongpu/include/particles/shapes/Counter.hpp
+++ b/src/picongpu/include/particles/shapes/Counter.hpp
@@ -39,7 +39,7 @@ namespace shapes
              * width of the support of this form_factor. This is the area where the function
              * is non-zero.
              */
-            static const int support = 0;
+            BOOST_STATIC_CONSTEXPR int support = 0;
         };
 
     } // namespace shared_Counter

--- a/src/picongpu/include/particles/shapes/NGP.hpp
+++ b/src/picongpu/include/particles/shapes/NGP.hpp
@@ -39,7 +39,7 @@ namespace shapes
              * width of the support of this form_factor. This is the area where the function
              * is non-zero.
              */
-            static const int support = 1;
+            BOOST_STATIC_CONSTEXPR int support = 1;
         };
 
     } // namespace shared_NGP

--- a/src/picongpu/include/particles/shapes/P4S.hpp
+++ b/src/picongpu/include/particles/shapes/P4S.hpp
@@ -34,7 +34,7 @@ namespace shared_P4S
 
 struct P4S
 {
-    static const int support = 5;
+    BOOST_STATIC_CONSTEXPR int support = 5;
 
     HDINLINE static float_X ff_1st_radius(const float_X x)
     {

--- a/src/picongpu/include/particles/shapes/PCS.hpp
+++ b/src/picongpu/include/particles/shapes/PCS.hpp
@@ -33,7 +33,7 @@ namespace shared_PCS
 {
 struct PCS
 {
-    static const int support = 4;
+    BOOST_STATIC_CONSTEXPR int support = 4;
 
 
 

--- a/src/picongpu/include/particles/shapes/TSC.hpp
+++ b/src/picongpu/include/particles/shapes/TSC.hpp
@@ -39,7 +39,7 @@ struct TSC
      * width of the support of this form_factor. This is the area where the function
      * is non-zero.
      */
-    static const int support = 3;
+    BOOST_STATIC_CONSTEXPR int support = 3;
 
 
     HDINLINE static float_X ff_1st_radius(const float_X x)

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
@@ -74,8 +74,8 @@ namespace picongpu
             bmpl::int_<0>,
             bmpl::max<bmpl::_1, bmpl::_2>
             >::type SuperCellsLongestEdge;
-        static const uint32_t maxShared = 32*1024; /* 32 KB */
-        static const uint32_t num_pbins = maxShared/(sizeof(float_PS)*SuperCellsLongestEdge::value);
+        BOOST_STATIC_CONSTEXPR uint32_t maxShared = 32*1024; /* 32 KB */
+        BOOST_STATIC_CONSTEXPR uint32_t num_pbins = maxShared/(sizeof(float_PS)*SuperCellsLongestEdge::value);
 
         container::DeviceBuffer<float_PS, 2>* dBuffer;
 

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -508,7 +508,7 @@ private:
    *  Return:
    *  std::string - name
    *
-   * This method avoids initializing static const string arrays.
+   * This method avoids initializing BOOST_STATIC_CONSTEXPR string arrays.
    */
   static const std::string dataLabels(int index)
   {

--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -32,7 +32,7 @@ class Amplitude
 {
 public:
   /* number of scalar components in Amplitude = 3 (3D) * 2 (complex) = 6 */
-  static const uint32_t numComponents = uint32_t(3) * uint32_t(sizeof(complex_64) / sizeof(typename complex_64::type));
+  BOOST_STATIC_CONSTEXPR uint32_t numComponents = uint32_t(3) * uint32_t(sizeof(complex_64) / sizeof(typename complex_64::type));
 
   /** constructor
    *


### PR DESCRIPTION
This replaces all usages of `static const` by `BOOST_STATIC_CONSTEXPR` to make those values usable in C++11 `constexpr`

Follow up to #1155 