### PR TITLE
mallocMC: update to pre-2.2.1 version (dev)

### DIFF
--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_hostclass.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_hostclass.hpp
@@ -52,10 +52,9 @@ namespace mallocMC{
    * bool providesAvailableSlots: declares if the allocator implements a useful
    * version of getAvailableSlots().
    */
-  template <class T>
-  class  Traits : public T{
-    public:
-    static const bool providesAvailableSlots = T::CreationPolicy::providesAvailableSlots::value;
+  template <class T_Allocator>
+  struct  Traits{
+    static const bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots::value;
   };
 
   class HeapInfo{
@@ -71,30 +70,37 @@ namespace mallocMC{
      *
      * Returns 0 else.
      *
-     * @tparam T_CreationPolicy The desired type of a CreationPolicy
-     * @tparam T_ProvidesAvailableSlotsHost If the CreationPolicy provides getAvailableSlotsHost
+     * @tparam T_Allocator The type of the Allocator to be used
+     * @tparam T_isHost True for the host call, false for the accelerator call
+     * @tparam T_providesAvailableSlots If the CreationPolicy provides getAvailableSlots[Host|Accelerator] (auto filled, do not set)
      */
-    template<typename T_ProvidesAvailableSlotsHost>
+    template<class T_Allocator, bool T_isHost, bool T_providesAvailableSlots = Traits<T_Allocator>::providesAvailableSlots >
     struct GetAvailableSlotsIfAvail
     {
-      template<typename T_Allocator>
       MAMC_HOST MAMC_ACCELERATOR
-      static unsigned getAvailableSlots(size_t slotSize, T_Allocator &){
+      static unsigned
+      getAvailableSlots(size_t slotSize, T_Allocator &){
         return 0;
       }
     };
-    template<>
-    struct GetAvailableSlotsIfAvail<
-      boost::mpl::bool_<true> >
+
+    template<class T_Allocator>
+    struct GetAvailableSlotsIfAvail<T_Allocator, true, true>
     {
-      template<typename T_Allocator>
-      MAMC_HOST MAMC_ACCELERATOR
-      static unsigned getAvailableSlots(size_t slotSize, T_Allocator & alloc){
-#ifdef __CUDA_ARCH__
-        return alloc.getAvailableSlotsAccelerator(slotSize);
-#else
-        return alloc.getAvailableSlotsHost(slotSize, alloc);
-#endif
+      MAMC_HOST
+      static unsigned
+      getAvailableSlots(size_t slotSize, T_Allocator& alloc){
+          return alloc.getAvailableSlotsHost(slotSize, alloc);
+      }
+    };
+
+    template<class T_Allocator>
+    struct GetAvailableSlotsIfAvail<T_Allocator, false, true>
+    {
+      MAMC_ACCELERATOR
+      static unsigned
+      getAvailableSlots(size_t slotSize, T_Allocator& alloc){
+          return alloc.getAvailableSlotsAccelerator(slotSize);
       }
     };
 
@@ -177,19 +183,6 @@ namespace mallocMC{
         heapInfos.p=pool;
         heapInfos.size=size;
 
-        /*
-        * This is a workaround for a bug with getAvailSlotsPoly:
-        * Due to some problems with conditional compilation (possibly a CUDA bug),
-        * getAvailableSlotsHost must explicitly be used from inside a host
-        * function at least once. Doing it here guarantees that it is executed
-        * and that this execution happens on the host. Usually, simply defining
-        * this inside a host function (without actually executing it) would be
-        * sufficient. However, due to the template nature of policy based
-        * design, functions are only compiled if they are actually used.
-        */
-        detail::GetAvailableSlotsIfAvail<boost::mpl::bool_<CreationPolicy::providesAvailableSlots::value> >
-          ::getAvailableSlots(1024, *this); //actual slot size does not matter
-
         return h;
       }
 
@@ -211,13 +204,20 @@ namespace mallocMC{
       }
 
 
-      // polymorphism over the availability of getAvailableSlots
-      MAMC_HOST MAMC_ACCELERATOR
+      // polymorphism over the availability of getAvailableSlots for calling from the host
+      MAMC_HOST
       unsigned getAvailableSlots(size_t slotSize){
         slotSize = AlignmentPolicy::applyPadding(slotSize);
 
-        return detail::GetAvailableSlotsIfAvail<boost::mpl::bool_<CreationPolicy::providesAvailableSlots::value> >
-          ::getAvailableSlots(slotSize, *this);
+        return detail::GetAvailableSlotsIfAvail<Allocator, true>::getAvailableSlots(slotSize, *this);
+      }
+
+      // polymorphism over the availability of getAvailableSlots for calling from the accelerator
+      MAMC_ACCELERATOR
+      unsigned getAvailableSlotsAccelerator(size_t slotSize){
+        slotSize = AlignmentPolicy::applyPadding(slotSize);
+
+        return detail::GetAvailableSlotsIfAvail<Allocator, false>::getAvailableSlots(slotSize, *this);
       }
 
       MAMC_HOST
@@ -230,3 +230,4 @@ namespace mallocMC{
   };
 
 } //namespace mallocMC
+

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_overwrites.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_overwrites.hpp
@@ -70,16 +70,22 @@ MAMC_HOST void finalizeHeap(                                                    
  */
 #define MALLOCMC_AVAILABLESLOTS()                                               \
 namespace mallocMC{                                                             \
-MAMC_HOST MAMC_ACCELERATOR                                                       \
-unsigned getAvailableSlots(                                                    \
-    size_t slotSize,                                                           \
-    mallocMCType &p = mallocMCGlobalObject){                                     \
-    return p.getAvailableSlots(slotSize);                                      \
-}                                                                              \
-MAMC_HOST MAMC_ACCELERATOR                                                       \
-bool providesAvailableSlots(){                                                 \
+MAMC_HOST                                                                       \
+unsigned getAvailableSlots(                                                     \
+    size_t slotSize,                                                            \
+    mallocMCType &p = mallocMCGlobalObject){                                    \
+    return p.getAvailableSlots(slotSize);                                       \
+}                                                                               \
+MAMC_ACCELERATOR                                                                \
+unsigned getAvailableSlotsAccelerator(                                          \
+    size_t slotSize,                                                            \
+    mallocMCType &p = mallocMCGlobalObject){                                    \
+    return p.getAvailableSlotsAccelerator(slotSize);                            \
+}                                                                               \
+MAMC_HOST MAMC_ACCELERATOR                                                      \
+bool providesAvailableSlots(){                                                  \
     return Traits<mallocMCType>::providesAvailableSlots;                        \
-}                                                                              \
+}                                                                               \
 } /* end namespace mallocMC */
 
 

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
@@ -130,70 +130,70 @@ namespace mallocMC
   typedef mallocMC::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
 
 
-  MAMC_ACCELERATOR inline uint32_t laneid()
+  MAMC_ACCELERATOR inline boost::uint32_t laneid()
   {
-    uint32_t mylaneid;
+    boost::uint32_t mylaneid;
     asm("mov.u32 %0, %laneid;" : "=r" (mylaneid));
     return mylaneid;
   }
 
-  MAMC_ACCELERATOR inline uint32_t warpid()
+  MAMC_ACCELERATOR inline boost::uint32_t warpid()
   {
-    uint32_t mywarpid;
+    boost::uint32_t mywarpid;
     asm("mov.u32 %0, %warpid;" : "=r" (mywarpid));
     return mywarpid;
   }
-  MAMC_ACCELERATOR inline uint32_t nwarpid()
+  MAMC_ACCELERATOR inline boost::uint32_t nwarpid()
   {
-    uint32_t mynwarpid;
+    boost::uint32_t mynwarpid;
     asm("mov.u32 %0, %nwarpid;" : "=r" (mynwarpid));
     return mynwarpid;
   }
 
-  MAMC_ACCELERATOR inline uint32_t smid()
+  MAMC_ACCELERATOR inline boost::uint32_t smid()
   {
-    uint32_t mysmid;
+    boost::uint32_t mysmid;
     asm("mov.u32 %0, %smid;" : "=r" (mysmid));
     return mysmid;
   }
 
-  MAMC_ACCELERATOR inline uint32_t nsmid()
+  MAMC_ACCELERATOR inline boost::uint32_t nsmid()
   {
-    uint32_t mynsmid;
+    boost::uint32_t mynsmid;
     asm("mov.u32 %0, %nsmid;" : "=r" (mynsmid));
     return mynsmid;
   }
-  MAMC_ACCELERATOR inline uint32_t lanemask()
+  MAMC_ACCELERATOR inline boost::uint32_t lanemask()
   {
-    uint32_t lanemask;
+    boost::uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_eq;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_t lanemask_le()
+  MAMC_ACCELERATOR inline boost::uint32_t lanemask_le()
   {
-    uint32_t lanemask;
+    boost::uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_le;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_t lanemask_lt()
+  MAMC_ACCELERATOR inline boost::uint32_t lanemask_lt()
   {
-    uint32_t lanemask;
+    boost::uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_lt;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_t lanemask_ge()
+  MAMC_ACCELERATOR inline boost::uint32_t lanemask_ge()
   {
-    uint32_t lanemask;
+    boost::uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_ge;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_t lanemask_gt()
+  MAMC_ACCELERATOR inline boost::uint32_t lanemask_gt()
   {
-    uint32_t lanemask;
+    boost::uint32_t lanemask;
     asm("mov.u32 %0, %lanemask_gt;" : "=r" (lanemask));
     return lanemask;
   }


### PR DESCRIPTION
Fixes the *two* bugs after the `2.2.0crp` release of mallocMC:
  https://github.com/ComputationalRadiationPhysics/mallocMC/pull/107
  https://github.com/ComputationalRadiationPhysics/mallocMC/pull/105

Since this is a pre-release (dev) version of mallocMC, there needs to follow an other PR as soon as `2.2.1crp` of mallocMC is released that will also update PIConGPU's `CMakeLists.txt` [version requirement](https://github.com/ComputationalRadiationPhysics/picongpu/blob/bfe45e86f5494e6bf128ece6652231ab610b8070/src/picongpu/CMakeLists.txt#L307).

Updated via:
```bash
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
   git subtree pull --prefix thirdParty/mallocMC/ \
   git@github.com:ComputationalRadiationPhysics/mallocMC.git dev --squash
```