### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/src/cuda_memtest/misc.cpp
+++ b/src/cuda_memtest/misc.cpp
@@ -49,8 +49,10 @@ get_driver_info(char* info, unsigned int len)
     if ( fgets(info, len, file) == NULL){
 	PRINTF("Warning: reading file failed\n");
 	info[0] = 0;
+        fclose(file);
 	return;
     }
+    fclose(file);
 
     PRINTF("%s", info);
 

--- a/src/cuda_memtest/ocl_memtest.cpp
+++ b/src/cuda_memtest/ocl_memtest.cpp
@@ -149,9 +149,10 @@ read_kernel_source(void)
   size_t rc = fread(kernel_source, 1, MAX_KERNEL_FILE_SIZE, fd);
   if (rc < 0 || rc >= MAX_KERNEL_FILE_SIZE){
     printf("ERROR: return value out of range for reading kernel file(rc=%lx)\n", rc);
+    fclose(fd);
     exit(1);
   }
-
+  fclose(fd);
   return;
 }
 

--- a/src/libPMacc/include/eventSystem/events/EventNotify.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.tpp
@@ -33,7 +33,7 @@ namespace PMacc
         inline void EventNotify::notify( id_t eventId, EventType type, IEventData *data )
         {
             std::set<IEvent*>::iterator iter = observers.begin( );
-            for (; iter != observers.end( ); iter++ )
+            for (; iter != observers.end( ); ++iter )
             {
                 if ( *iter != NULL )
                     ( *iter )->event( eventId, type, data );

--- a/src/tools/livevis/server/src/VisualizationServer.cpp
+++ b/src/tools/livevis/server/src/VisualizationServer.cpp
@@ -121,7 +121,7 @@ void VisualizationServer::startListening()
             std::cout << "=========================" << std::endl;
             std::cout << "Name              Status  URI" << std::endl;
             std::cout << "----------------  ------  ---------------------------" << std::endl;
-            for (std::vector<Visualization*>::const_iterator it = m_visualizations.begin(); it != m_visualizations.end(); it++)
+            for (std::vector<Visualization*>::const_iterator it = m_visualizations.begin(); it != m_visualizations.end(); ++it)
             {
                 /// get vis name
                 std::string name = (*it)->getName();
@@ -214,7 +214,7 @@ void * VisualizationServer::runInfoChannel(void * server)
             ::sendto(srv->m_info_socket, (void*)&count, sizeof(uint32_t), 0, (struct sockaddr*)&remote_addr, sizeof(remote_addr));
 
             /// send a list of the available visualizations
-            for (std::vector<Visualization*>::iterator it = srv->m_visualizations.begin(); it != srv->m_visualizations.end(); it++)
+            for (std::vector<Visualization*>::iterator it = srv->m_visualizations.begin(); it != srv->m_visualizations.end(); ++it)
             {
                 /// get vis name and send it
                 char name[128];
@@ -440,7 +440,7 @@ void VisualizationServer::stopListening()
     ::close(m_info_socket);
 
     /// kill all visualization threads
-    for (std::vector<Visualization*>::iterator it = m_visualizations.begin(); it != m_visualizations.end(); it++)
+    for (std::vector<Visualization*>::iterator it = m_visualizations.begin(); it != m_visualizations.end(); ++it)
     {
         delete *it;
     }

--- a/src/tools/png2gas/png2gas.cpp
+++ b/src/tools/png2gas/png2gas.cpp
@@ -144,6 +144,7 @@ int main(int argc, char **argv)
         std::cerr << "Invalid image size (" << image.getwidth() << "," <<
                 image.getheight() << ") for data size" << std::endl;
         MPI_Finalize();
+        delete[] data;
         return -1;
     }
 


### PR DESCRIPTION
[src/libPMacc/include/eventSystem/events/EventNotify.tpp:36]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/tools/livevis/server/src/VisualizationServer.cpp:124]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/tools/livevis/server/src/VisualizationServer.cpp:217]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/tools/livevis/server/src/VisualizationServer.cpp:443]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/cuda_memtest/misc.cpp:57]: (error) Resource leak: file
[src/cuda_memtest/ocl_memtest.cpp:155]: (error) Resource leak: fd
[src/tools/png2gas/png2gas.cpp:147]: (error) Memory leak: data