### PR TITLE
Load plugins in registered order

### DIFF
--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -43,6 +43,7 @@ namespace PMacc
 
         /** Register a plugin for loading/unloading and notifications
          *
+         * Plugins are loaded in the order they are registered and unloaded in reverse order.
          * To trigger plugin notifications, call \see setNotificationPeriod after
          * registration.
          *
@@ -64,8 +65,8 @@ namespace PMacc
         void loadPlugins()
         {
             // load all plugins
-            for (std::list<IPlugin*>::reverse_iterator iter = plugins.rbegin();
-                 iter != plugins.rend(); ++iter)
+            for (std::list<IPlugin*>::iterator iter = plugins.begin();
+                 iter != plugins.end(); ++iter)
             {
                 if (!(*iter)->isLoaded())
                 {


### PR DESCRIPTION
The plugins were loaded in reverse order. This is at the very least unexpected.
The C++ convention for loading/unloading is, that everything is deleted in the reverse order than what it was created (stack like behaviour)
This ensures e.g. that plugins could rely on each other (an other plugin that was available on load will still be available on unload)

In my specific use case I need a plugin to be executed before others. I expected registering it first would do that, but it did not. Maybe a follow-up could add priorities to plugins?