### PR TITLE
PMacc: Use BOOST_STATIC_CONSTEXPR where possible

### DIFF
--- a/src/libPMacc/include/compileTime/AllCombinations.hpp
+++ b/src/libPMacc/include/compileTime/AllCombinations.hpp
@@ -88,7 +88,7 @@ struct AllCombinations<T_MplSeq, T_TmpResult, false >
     typedef T_MplSeq MplSeq;
     typedef T_TmpResult TmpResult;
 
-    static const uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
+    BOOST_STATIC_CONSTEXPR uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
     typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1 > > ::type LastElement;
     typedef typename MakeSeq<LastElement>::type LastElementAsSequence;
     typedef typename bmpl::pop_back<MplSeq>::type ShrinkedRangeVector;
@@ -146,7 +146,7 @@ struct AllCombinations
      * a sequence because all next algorithms can only work with sequences */
     typedef typename MakeSeq<T_MplSeq>::type MplSeq;
 
-    static const uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
+    BOOST_STATIC_CONSTEXPR uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
     typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1 > > ::type LastElement;
     typedef typename MakeSeq<LastElement>::type LastElementAsSequence;
 

--- a/src/libPMacc/include/debug/VerboseLog.hpp
+++ b/src/libPMacc/include/debug/VerboseLog.hpp
@@ -55,13 +55,13 @@ namespace verboseLog_detail
 template<typename X, typename Y>
 struct IsSameClassType
 {
-    static const bool result = false;
+    BOOST_STATIC_CONSTEXPR bool result = false;
 };
 
 template<typename X>
 struct IsSameClassType<X, X>
 {
-    static const bool result = true;
+    BOOST_STATIC_CONSTEXPR bool result = true;
 };
 
 } //namespace verboseLog_detail
@@ -70,7 +70,7 @@ template<uint64_t lvl_, class membership_>
 struct LogLvl
 {
     typedef membership_ Parent;
-    static const uint64_t lvl = lvl_;
+    BOOST_STATIC_CONSTEXPR uint64_t lvl = lvl_;
 
     /* This operation is only allowed for LogLvl with the same Parent type.
      * Create a LogLvl that contains two levels. At least one lvl has to be true
@@ -91,7 +91,7 @@ class VerboseLog
 {
 private:
     typedef typename LogLevel::Parent LogParent;
-    static const uint64_t logLvl = LogLevel::lvl;
+    BOOST_STATIC_CONSTEXPR uint64_t logLvl = LogLevel::lvl;
 public:
 
     VerboseLog(const char* msg) : fmt(msg)

--- a/src/libPMacc/include/debug/VerboseLogMakros.hpp
+++ b/src/libPMacc/include/debug/VerboseLogMakros.hpp
@@ -40,7 +40,7 @@
  * @param default_lvl must be a integer which represent a defined log lvl
  */
 #define __DEFINE_VERBOSE_CLASS_DEFAULT_LVL(default_lvl) \
-    static const uint64_t log_level = default_lvl;      \
+    BOOST_STATIC_CONSTEXPR uint64_t log_level = default_lvl;      \
     }
 
 /** helper for define log lvl inside of DEFINE_VERBOSE_CLASS

--- a/src/libPMacc/include/dimensions/DataSpace.hpp
+++ b/src/libPMacc/include/dimensions/DataSpace.hpp
@@ -42,7 +42,7 @@ namespace PMacc
     {
     public:
 
-        static const int Dim=DIM;
+        BOOST_STATIC_CONSTEXPR int Dim=DIM;
         typedef math::Vector<int,DIM> BaseType;
 
         /**

--- a/src/libPMacc/include/dimensions/DataSpace.tpp
+++ b/src/libPMacc/include/dimensions/DataSpace.tpp
@@ -47,7 +47,7 @@ struct GetComponentsType<DataSpace<DIM>, false >
 template<unsigned DIM>
 struct GetNComponents<DataSpace<DIM>,false >
 {
-    static const uint32_t value=DIM;
+    BOOST_STATIC_CONSTEXPR uint32_t value=DIM;
 };
 
 }// namespace traits

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -114,7 +114,7 @@ class TaskSetValueBase : public StreamTask
 {
 public:
     typedef T_ValueType ValueType;
-    static const uint32_t dim = T_dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
 
     TaskSetValueBase(DeviceBuffer<ValueType, dim>& dst, const ValueType& value) :
     StreamTask(),
@@ -158,7 +158,7 @@ class TaskSetValue<T_ValueType, T_dim, true> : public TaskSetValueBase<T_ValueTy
 {
 public:
     typedef T_ValueType ValueType;
-    static const uint32_t dim = T_dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
 
     TaskSetValue(DeviceBuffer<ValueType, dim>& dst, const ValueType& value) :
     TaskSetValueBase<ValueType, dim>(dst, value)
@@ -196,7 +196,7 @@ class TaskSetValue<T_ValueType, T_dim, false> : public TaskSetValueBase<T_ValueT
 {
 public:
     typedef T_ValueType ValueType;
-    static const uint32_t dim = T_dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
 
     TaskSetValue(DeviceBuffer<ValueType, dim>& dst, const ValueType& value) :
     TaskSetValueBase<ValueType, dim>(dst, value), valuePointer_host(NULL)

--- a/src/libPMacc/include/lambda/CT/Expression.hpp
+++ b/src/libPMacc/include/lambda/CT/Expression.hpp
@@ -37,19 +37,19 @@ struct Expression;
 template<typename Child0, int _terminalTypeIdx>
 struct Expression<lambda::Expression<exprTypes::terminal, mpl::vector<Child0> >, _terminalTypeIdx>
 {
-    static const int nextTerminalTypeIdx = _terminalTypeIdx + 1;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = _terminalTypeIdx + 1;
 };
 
 template<int I, int _terminalTypeIdx>
 struct Expression<lambda::Expression<exprTypes::terminal, mpl::vector<placeholder<I> > >, _terminalTypeIdx>
 {
-    static const int nextTerminalTypeIdx = _terminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = _terminalTypeIdx;
 };
 
 template<int I, int _terminalTypeIdx>
 struct Expression<lambda::Expression<exprTypes::terminal, mpl::vector<mpl::int_<I> > >, _terminalTypeIdx>
 {
-    static const int nextTerminalTypeIdx = _terminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = _terminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -57,7 +57,7 @@ struct Expression<lambda::Expression<exprTypes::assign, mpl::vector<_Child0, _Ch
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -65,7 +65,7 @@ struct Expression<lambda::Expression<exprTypes::plus, mpl::vector<_Child0, _Chil
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -73,7 +73,7 @@ struct Expression<lambda::Expression<exprTypes::minus, mpl::vector<_Child0, _Chi
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -81,7 +81,7 @@ struct Expression<lambda::Expression<exprTypes::multiply, mpl::vector<_Child0, _
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -89,7 +89,7 @@ struct Expression<lambda::Expression<exprTypes::divide, mpl::vector<_Child0, _Ch
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -97,7 +97,7 @@ struct Expression<lambda::Expression<exprTypes::comma, mpl::vector<_Child0, _Chi
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -105,7 +105,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, int _terminalTypeIdx>
@@ -114,7 +114,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
     typedef CT::Expression<_Child2, Child1::nextTerminalTypeIdx> Child2;
-    static const int nextTerminalTypeIdx = Child2::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child2::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, typename _Child3, int _terminalTypeIdx>
@@ -124,7 +124,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
     typedef CT::Expression<_Child2, Child1::nextTerminalTypeIdx> Child2;
     typedef CT::Expression<_Child3, Child2::nextTerminalTypeIdx> Child3;
-    static const int nextTerminalTypeIdx = Child3::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child3::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, typename _Child3, typename _Child4, int _terminalTypeIdx>
@@ -135,7 +135,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child2, Child1::nextTerminalTypeIdx> Child2;
     typedef CT::Expression<_Child3, Child2::nextTerminalTypeIdx> Child3;
     typedef CT::Expression<_Child4, Child3::nextTerminalTypeIdx> Child4;
-    static const int nextTerminalTypeIdx = Child4::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child4::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, typename _Child3, typename _Child4, typename _Child5, int _terminalTypeIdx>
@@ -147,7 +147,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child3, Child2::nextTerminalTypeIdx> Child3;
     typedef CT::Expression<_Child4, Child3::nextTerminalTypeIdx> Child4;
     typedef CT::Expression<_Child5, Child4::nextTerminalTypeIdx> Child5;
-    static const int nextTerminalTypeIdx = Child5::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child5::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -155,7 +155,7 @@ struct Expression<lambda::Expression<exprTypes::subscript, mpl::vector<_Child0, 
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    static const int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 } // CT

--- a/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
+++ b/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
@@ -38,7 +38,7 @@ private:
     typedef typename BlockArea_::SuperCellSize SuperCellSize;
     typedef typename BlockArea_::FullSuperCellSize FullSuperCellSize;
     typedef typename BlockArea_::OffsetOrigin OffsetOrigin;
-    static const int maxThreads=MaxThreads_;
+    BOOST_STATIC_CONSTEXPR int maxThreads=MaxThreads_;
 
     enum
     {

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -65,9 +65,9 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
     template<typename T_Type, int T_Dim>                                       \
     struct ConstArrayStorage                                                   \
     {                                                                          \
-        static const bool isConst = true;                                      \
+        BOOST_STATIC_CONSTEXPR bool isConst = true;                                      \
         typedef T_Type type;                                                   \
-        static const int dim=T_Dim;                                            \
+        BOOST_STATIC_CONSTEXPR int dim=T_Dim;                                            \
                                                                                \
         HDINLINE const type& operator[](const int idx) const                   \
         {                                                                      \

--- a/src/libPMacc/include/math/MapTuple.hpp
+++ b/src/libPMacc/include/math/MapTuple.hpp
@@ -110,7 +110,7 @@ Map_, typename mpl::deref<typename mpl::begin<Map_>::type>::type::first>::type, 
 {
 public:
     typedef Map_ Map;
-    static const int dim = mpl::size<Map>::type::value;
+    BOOST_STATIC_CONSTEXPR int dim = mpl::size<Map>::type::value;
 private:
    
     typedef MapTuple<typename mpl::erase_key<

--- a/src/libPMacc/include/math/Tuple.hpp
+++ b/src/libPMacc/include/math/Tuple.hpp
@@ -71,7 +71,7 @@ class Tuple<TypeList, false>
     : public Tuple<typename mpl::pop_front<TypeList>::type>
 {
 public:
-    static const int dim = mpl::size<TypeList>::type::value;
+    BOOST_STATIC_CONSTEXPR int dim = mpl::size<TypeList>::type::value;
     typedef TypeList TypeList_;
 private:
     typedef Tuple<typename mpl::pop_front<TypeList>::type> base;

--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -43,8 +43,8 @@ namespace detail
 template<typename T_Type, int T_Dim>
 struct Vector_components
 {
-    static const bool isConst = false;
-    static const int dim = T_Dim;
+    BOOST_STATIC_CONSTEXPR bool isConst = false;
+    BOOST_STATIC_CONSTEXPR int dim = T_Dim;
     typedef T_Type type;
 
     /*align full vector*/
@@ -114,7 +114,7 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
 {
     typedef T_Storage<T_Type, T_dim> Storage;
     typedef typename Storage::type type;
-    static const int dim = Storage::dim;
+    BOOST_STATIC_CONSTEXPR int dim = Storage::dim;
     typedef tag::Vector tag;
     typedef T_Accessor Accessor;
     typedef T_Navigator Navigator;
@@ -492,7 +492,7 @@ template<typename Type>
 struct Vector<Type, 0 >
 {
     typedef Type type;
-    static const int dim = 0;
+    BOOST_STATIC_CONSTEXPR int dim = 0;
 
     template<typename OtherType >
     HDINLINE operator Vector<OtherType, 0 > () const

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -46,7 +46,7 @@ struct GetComponentsType<PMacc::math::Vector<T_DataType, T_Dim>, false >
 template<typename T_DataType, int T_Dim>
 struct GetNComponents<PMacc::math::Vector<T_DataType, T_Dim>,false >
 {
-    static const uint32_t value = (uint32_t) PMacc::math::Vector<T_DataType, T_Dim>::dim;
+    BOOST_STATIC_CONSTEXPR uint32_t value = (uint32_t) PMacc::math::Vector<T_DataType, T_Dim>::dim;
 };
 
 } //namespace traits

--- a/src/libPMacc/include/math/vector/compile-time/Float.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Float.hpp
@@ -44,7 +44,7 @@ struct Float
     typedef Y y;
     typedef Z z;
 
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
 };
 
 template<>
@@ -55,7 +55,7 @@ struct Float<X>
 {
     typedef X x;
 
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
 };
 
 template<typename X, typename Y>
@@ -64,7 +64,7 @@ struct Float<X, Y>
     typedef X x;
     typedef Y y;
 
-    static const int dim = 2u;
+    BOOST_STATIC_CONSTEXPR int dim = 2u;
 };
 
 } // CT

--- a/src/libPMacc/include/math/vector/compile-time/Vector.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Vector.hpp
@@ -135,7 +135,7 @@ struct Vector
         typedef typename mpl::at_c<mplVector, element>::type type;
     };
 
-    static const int dim = mpl::size<mplVector >::type::value;
+    BOOST_STATIC_CONSTEXPR int dim = mpl::size<mplVector >::type::value;
 
     typedef typename detail::TypeSelector<x>::type type;
     typedef Vector<x, y, z> This;

--- a/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
@@ -36,7 +36,7 @@ class DataBoxDim1Access : protected T_Base
 public:
 
     typedef T_Base Base;
-    static const uint32_t Dim= Base::Dim;
+    BOOST_STATIC_CONSTEXPR uint32_t Dim= Base::Dim;
 
 
     typedef typename Base::ValueType ValueType;

--- a/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
@@ -48,7 +48,7 @@ public:
 
     typedef typename UnaryFunctor::result ValueType;
     typedef ValueType RefValueType;
-    static const uint32_t Dim = Base::Dim;
+    BOOST_STATIC_CONSTEXPR uint32_t Dim = Base::Dim;
 
     HDINLINE DataBoxUnaryTransform(const Base& base) : Base(base)
     {

--- a/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
@@ -42,8 +42,8 @@ template<typename Type_, uint32_t communicationTag_ = 0, bool sizeOnDevice_ = fa
         struct TypeDescriptionElement
 {
     typedef Type_ Type;
-    static const uint32_t communicationTag = communicationTag_;
-    static const bool sizeOnDevice = sizeOnDevice_;
+    BOOST_STATIC_CONSTEXPR uint32_t communicationTag = communicationTag_;
+    BOOST_STATIC_CONSTEXPR bool sizeOnDevice = sizeOnDevice_;
 
 
 };
@@ -62,7 +62,7 @@ template<typename Type_, uint32_t communicationTag_ = 0, bool sizeOnDevice_ = fa
  *  struct Mem
  *  {
  *    enum Names{VALUE1,VALUE2};
- *    static const uint32_t Count=2;
+ *    BOOST_STATIC_CONSTEXPR uint32_t Count=2;
  *  };
  * @tparam BORDERTYPE optional type for border data in the buffers. TYPE is used by default.
  */

--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -52,7 +52,7 @@ public:
     typedef SuperCell<FrameType> SuperCellType;
     typedef DataBox<PitchedBox<SuperCell<FRAME>, DIM> > BaseType;
 
-    static const uint32_t Dim = DIM;
+    BOOST_STATIC_CONSTEXPR uint32_t Dim = DIM;
 
     /** default constructor
      *

--- a/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
@@ -152,7 +152,7 @@ private:
     typedef T_FrameType FrameType;
 public:
     typedef typename HasIdentifier<FrameType, T_Key>::type type;
-    static const bool value = type::value;
+    BOOST_STATIC_CONSTEXPR bool value = type::value;
 };
 } //namespace traits
 

--- a/src/libPMacc/include/particles/memory/dataTypes/StaticArray.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/StaticArray.hpp
@@ -35,7 +35,7 @@ template<typename T_Type, typename T_size>
 class StaticArray
 {
 public:
-    static const uint32_t size = T_size::value;
+    BOOST_STATIC_CONSTEXPR uint32_t size = T_size::value;
     typedef T_Type Type;
 private:
     Type data[size];

--- a/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
@@ -39,7 +39,7 @@ template<unsigned T_dim, class Base = NullFrame>
 class PositionFilter : public Base
 {
 public:
-    static const uint32_t dim = T_dim;
+    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
 protected:
     DataSpace<dim> offset;
     DataSpace<dim> max;

--- a/src/libPMacc/include/preprocessor/struct.hpp
+++ b/src/libPMacc/include/preprocessor/struct.hpp
@@ -46,7 +46,7 @@
  *     e.g. (0,(_,myName,_))
  */
 
-/** create static const member vector that needs no memory inside of the struct
+/** create BOOST_STATIC_CONSTEXPR member vector that needs no memory inside of the struct
  *
  *   @param type type of an element (types containing a comma are not allowed (e.g. `Vector<type,dim>`)
  *               use `typedef Vector<type,dim> NewType;` to avoid this behavior
@@ -54,7 +54,7 @@
  *   @param ... enumeration of init values
  *   \example `PMACC_C_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5)`
  *            is the compile time equivalent of
- *            `static const float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);
+ *            `BOOST_STATIC_CONSTEXPR float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);
  */
 #define PMACC_C_VECTOR(type,name,...) (0,(typename PMacc::traits::GetValueType<type>::type, \
                                           name,                                             \
@@ -62,7 +62,7 @@
                                           __VA_ARGS__))
 
 
-/** create static const member vector that needs no memory inside of the struct
+/** create BOOST_STATIC_CONSTEXPR member vector that needs no memory inside of the struct
  *
  *   @param type type of an element
  *   @param dim number of vector components
@@ -70,18 +70,18 @@
  *   @param ... enumeration of init values (number of components must be greater or equal than dim)
  *   \example `PMACC_C_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5)`
  *            is the compile time equivalent of
- *            `static const Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);`
+ *            `BOOST_STATIC_CONSTEXPR Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);`
  */
 #define PMACC_C_VECTOR_DIM(type,dim,name,...) (0,(type,name,dim,__VA_ARGS__))
 
-/** create static const member
+/** create BOOST_STATIC_CONSTEXPR member
  *
  *   @param type type of the member
  *   @param name member variable name
  *   @param value init value
  *   \example `PMACC_C_VALUE(float_64, power_SI, 2.0)`
  *            is the compile time equivalent of
- *            `static const float_64 power_SI = float_64(2.0);`
+ *            `BOOST_STATIC_CONSTEXPR float_64 power_SI = float_64(2.0);`
  */
 #define PMACC_C_VALUE(type,name,value) (1,(type,name,value))
 
@@ -127,13 +127,13 @@
          )                                                                     \
         )
 
-/** create static const character string
+/** create BOOST_STATIC_CONSTEXPR character string
  *
  *   @param name member variable name
  *   @param char_string character string
  *   \example `PMACC_C_STRING(filename, "fooFile.txt")`
  *            is the compile time equivalent of
- *            `static const char* filename = (char*)"fooFile.tyt";`
+ *            `BOOST_STATIC_CONSTEXPR char* filename = (char*)"fooFile.tyt";`
  */
 #define PMACC_C_STRING(name,initValue) (3,(_,name,initValue))
 

--- a/src/libPMacc/include/traits/GetNComponents.hpp
+++ b/src/libPMacc/include/traits/GetNComponents.hpp
@@ -42,7 +42,7 @@ struct GetNComponents;
 template<typename T_Type>
 struct GetNComponents<T_Type, true>
 {
-    static const uint32_t value=1;
+    BOOST_STATIC_CONSTEXPR uint32_t value=1;
 };
 
 } //namespace traits

--- a/src/libPMacc/include/traits/IsSameType.hpp
+++ b/src/libPMacc/include/traits/IsSameType.hpp
@@ -35,13 +35,13 @@ namespace PMacc
     template< typename T1, typename T2 >
     struct IsSameType
     {
-        static const bool result = false;
+        BOOST_STATIC_CONSTEXPR bool result = false;
     };
 
     template< typename T1 >
     struct IsSameType< T1, T1 >
     {
-        static const bool result = true;
+        BOOST_STATIC_CONSTEXPR bool result = true;
     };
 
 } // namespace PMacc

--- a/src/libPMacc/include/traits/Limits.tpp
+++ b/src/libPMacc/include/traits/Limits.tpp
@@ -37,19 +37,19 @@ namespace limits
 template<>
 struct Max<int>
 {
-    static const int value=INT_MAX;
+    BOOST_STATIC_CONSTEXPR int value=INT_MAX;
 };
 
 template<>
 struct Max<uint32_t>
 {
-    static const uint32_t value=static_cast<uint32_t>(-1);
+    BOOST_STATIC_CONSTEXPR uint32_t value=static_cast<uint32_t>(-1);
 };
 
 template<>
 struct Max<uint64_t>
 {
-    static const uint64_t value=static_cast<uint64_t>(-1);
+    BOOST_STATIC_CONSTEXPR uint64_t value=static_cast<uint64_t>(-1);
 };
 
 } //namespace limits

--- a/src/libPMacc/include/traits/NumberOfExchanges.hpp
+++ b/src/libPMacc/include/traits/NumberOfExchanges.hpp
@@ -41,19 +41,19 @@ struct NumberOfExchanges;
 template<>
 struct NumberOfExchanges<DIM1>
 {
-    static const uint32_t value = LEFT + RIGHT;
+    BOOST_STATIC_CONSTEXPR uint32_t value = LEFT + RIGHT;
 };
 
 template<>
 struct NumberOfExchanges<DIM2>
 {
-    static const uint32_t value = TOP + BOTTOM;
+    BOOST_STATIC_CONSTEXPR uint32_t value = TOP + BOTTOM;
 };
 
 template<>
 struct NumberOfExchanges<DIM3>
 {
-    static const uint32_t value = BACK + FRONT;
+    BOOST_STATIC_CONSTEXPR uint32_t value = BACK + FRONT;
 };
 
 } //namespace traits


### PR DESCRIPTION
This replaces all usages of `static const` by `BOOST_STATIC_CONSTEXPR` to make those values usable in C++11 `constexpr`

Follow up to #1155 