### PR TITLE
cuSTL: Use BOOST_STATIC_CONSTEXPR where possible

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -53,7 +53,7 @@ struct SphericMapper;
 template<typename BlockSize>
 struct SphericMapper<1, BlockSize>
 {
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
 
     dim3 cudaGridDim(const math::Size_t<1>& size) const
     {
@@ -78,7 +78,7 @@ struct SphericMapper<1, BlockSize>
 template<typename BlockSize>
 struct SphericMapper<2, BlockSize>
 {
-    static const int dim = 2;
+    BOOST_STATIC_CONSTEXPR int dim = 2;
 
     dim3 cudaGridDim(const math::Size_t<2>& size) const
     {
@@ -105,7 +105,7 @@ struct SphericMapper<2, BlockSize>
 template<typename BlockSize>
 struct SphericMapper<3, BlockSize>
 {
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
 
     dim3 cudaGridDim(const math::Size_t<3>& size) const
     {
@@ -134,7 +134,7 @@ struct SphericMapper<3, BlockSize>
 template<>
 struct SphericMapper<1, mpl::void_>
 {
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
 
     dim3 cudaGridDim(const math::Size_t<1>& size, const math::Size_t<3>& blockDim) const
     {
@@ -159,7 +159,7 @@ struct SphericMapper<1, mpl::void_>
 template<>
 struct SphericMapper<2, mpl::void_>
 {
-    static const int dim = 2;
+    BOOST_STATIC_CONSTEXPR int dim = 2;
 
     dim3 cudaGridDim(const math::Size_t<2>& size, const math::Size_t<3>& blockDim) const
     {
@@ -186,7 +186,7 @@ struct SphericMapper<2, mpl::void_>
 template<>
 struct SphericMapper<3, mpl::void_>
 {
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
 
     dim3 cudaGridDim(const math::Size_t<3>& size, const math::Size_t<3>& blockDim) const
     {

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -62,7 +62,7 @@ class CartBuffer
 public:
     typedef Type type;
     typedef CartBuffer<Type, T_dim, Allocator, Copier, Assigner> This;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     typedef cursor::BufferCursor<Type, T_dim> Cursor;
     typedef typename Allocator::tag memoryTag;
 public:

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -35,7 +35,7 @@ template<typename Type, int T_dim>
 struct DeviceMemAllocator
 {
     typedef Type type;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     typedef cursor::BufferCursor<type, dim> Cursor;
     typedef allocator::tag::device tag;
 
@@ -50,7 +50,7 @@ template<typename Type>
 struct DeviceMemAllocator<Type, 1>
 {
     typedef Type type;
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
     typedef cursor::BufferCursor<type, 1> Cursor;
     typedef allocator::tag::device tag;
 

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
@@ -35,7 +35,7 @@ template<typename Type, int T_dim>
 struct DeviceMemEvenPitch
 {
     typedef Type type;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     typedef cursor::BufferCursor<type, dim> Cursor;
     typedef allocator::tag::device tag;
 
@@ -48,7 +48,7 @@ template<typename Type>
 struct DeviceMemEvenPitch<Type, 1>
 {
     typedef Type type;
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
     typedef cursor::BufferCursor<type, 1> Cursor;
     typedef allocator::tag::device tag;
 

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -36,7 +36,7 @@ template<typename Type, int T_dim>
 struct HostMemAllocator
 {
     typedef Type type;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     typedef cursor::BufferCursor<type, T_dim> Cursor;
     typedef allocator::tag::host tag;
 
@@ -51,7 +51,7 @@ template<typename Type>
 struct HostMemAllocator<Type, 1>
 {
     typedef Type type;
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
     typedef cursor::BufferCursor<type, 1> Cursor;
     typedef allocator::tag::host tag;
 

--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -39,7 +39,7 @@ struct SharedMemAllocator<Type, Size, 1, uid>
 {
     typedef Type type;
     typedef math::CT::UInt32<> Pitch;
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
     typedef cursor::CT::BufferCursor<type, math::CT::UInt32<> > Cursor;
 
     __device__ static Cursor allocate()
@@ -54,7 +54,7 @@ struct SharedMemAllocator<Type, Size, 2, uid>
 {
     typedef Type type;
     typedef math::CT::UInt32<sizeof(Type) * Size::x::value> Pitch;
-    static const int dim = 2;
+    BOOST_STATIC_CONSTEXPR int dim = 2;
     typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
     __device__ static Cursor allocate()
@@ -70,7 +70,7 @@ struct SharedMemAllocator<Type, Size, 3, uid>
     typedef Type type;
     typedef math::CT::UInt32<sizeof(Type) * Size::x::value,
                              sizeof(Type) * Size::x::value * Size::y::value> Pitch;
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
     typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
     __device__ static Cursor allocate()

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -42,7 +42,7 @@ namespace assigner
 template<int T_dim>
 struct DeviceMemAssigner
 {
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
 
     template<typename Type>
     static void assign(

--- a/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -35,7 +35,7 @@ struct HostMemAssigner;
 template<>
 struct HostMemAssigner<1>
 {
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
     template<typename Type>
     static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
                        const math::Size_t<dim>& size)
@@ -47,7 +47,7 @@ struct HostMemAssigner<1>
 template<>
 struct HostMemAssigner<2u>
 {
-    static const int dim = 2u;
+    BOOST_STATIC_CONSTEXPR int dim = 2u;
     template<typename Type>
     static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
                        const math::Size_t<dim>& size)
@@ -64,7 +64,7 @@ struct HostMemAssigner<2u>
 template<>
 struct HostMemAssigner<3>
 {
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
     template<typename Type>
     static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
                        const math::Size_t<dim>& size)

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -47,7 +47,7 @@ public:
     typedef _Size Size;
     typedef typename Allocator::Pitch Pitch;
     typedef cursor::CT::BufferCursor<Type, Pitch> Cursor;
-    static const int dim = Size::dim;
+    BOOST_STATIC_CONSTEXPR int dim = Size::dim;
     typedef zone::CT::SphericZone<_Size, typename math::CT::make_Int<dim, 0>::type> Zone;
 private:
     Type* dataPointer;

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -33,7 +33,7 @@ namespace copier
 template<int T_dim>
 struct D2DCopier
 {
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     template<typename Type>
     static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
          Type* source, const math::Size_t<dim-1>& pitchSource,

--- a/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
@@ -33,7 +33,7 @@ namespace copier
 template<int T_dim>
 struct H2HCopier
 {
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     template<typename Type>
     static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
          Type* source, const math::Size_t<dim-1>& pitchSource,

--- a/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
@@ -67,7 +67,7 @@ namespace traits
 template<typename Type, int T_dim>
 struct dim<BufferCursor<Type, T_dim> >
 {
-    static const int value = PMacc::cursor::traits::dim<
+    BOOST_STATIC_CONSTEXPR int value = PMacc::cursor::traits::dim<
         Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*> >::value;
 };
 

--- a/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
@@ -166,7 +166,7 @@ namespace traits
 template<typename _Accessor, typename _Navigator, typename _Marker>
 struct dim< PMacc::cursor::Cursor<_Accessor, _Navigator, _Marker> >
 {
-    static const int value = PMacc::cursor::traits::dim<typename Cursor<_Accessor, _Navigator, _Marker>::Navigator >::value;
+    BOOST_STATIC_CONSTEXPR int value = PMacc::cursor::traits::dim<typename Cursor<_Accessor, _Navigator, _Marker>::Navigator >::value;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
@@ -37,7 +37,7 @@ template<typename Cursor>
 class SafeCursor : public Cursor
 {
 public:
-    static const int dim = PMacc::cursor::traits::dim<Cursor>::value;
+    BOOST_STATIC_CONSTEXPR int dim = PMacc::cursor::traits::dim<Cursor>::value;
 private:
     /* \todo: Use a zone instead of lowerExtent and UpperExtent */
     const math::Int<dim> lowerExtent;
@@ -145,7 +145,7 @@ namespace traits
 template<typename Cursor>
 struct dim<SafeCursor<Cursor> >
 {
-    static const int value = SafeCursor<Cursor>::dim;
+    BOOST_STATIC_CONSTEXPR int value = SafeCursor<Cursor>::dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -40,7 +40,7 @@ class SafeCursor : public Cursor
 {
 private:
     typedef SafeCursor<Cursor, LowerExtent, UpperExtent> This;
-    static const int dim = PMacc::cursor::traits::dim<Cursor>::value;
+    BOOST_STATIC_CONSTEXPR int dim = PMacc::cursor::traits::dim<Cursor>::value;
     math::Int<dim> offset;
 public:
     HDINLINE SafeCursor(const Cursor& cursor)

--- a/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -38,7 +38,7 @@ class BufferNavigator
 {
 public:
     typedef tag::BufferNavigator tag;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
 private:
     math::Size_t<dim-1> pitch;
 public:
@@ -65,7 +65,7 @@ class BufferNavigator<1>
 {
 public:
     typedef tag::BufferNavigator tag;
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
 
 public:
     HDINLINE
@@ -87,7 +87,7 @@ namespace traits
 template<int T_dim>
 struct dim<BufferNavigator<T_dim> >
 {
-    static const int value = T_dim;
+    BOOST_STATIC_CONSTEXPR int value = T_dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -36,7 +36,7 @@ class CartNavigator
 {
 public:
     typedef tag::CartNavigator tag;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
 private:
     math::Int<dim> factor;
 public:
@@ -62,7 +62,7 @@ namespace traits
 template<int T_dim>
 struct dim<CartNavigator<T_dim> >
 {
-    static const int value = T_dim;
+    BOOST_STATIC_CONSTEXPR int value = T_dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
@@ -34,7 +34,7 @@ template<int T_dim>
 class MapTo1DNavigator
 {
 public:
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
 private:
     math::Size_t<dim> shape;
     int pos;

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -35,7 +35,7 @@ template<int T_dim>
 struct MultiIndexNavigator
 {
     typedef tag::MultiIndexNavigator tag;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
 
     template<typename MultiIndex>
     HDINLINE
@@ -51,7 +51,7 @@ namespace traits
 template<int T_dim>
 struct dim<MultiIndexNavigator<T_dim> >
 {
-    static const int value = T_dim;
+    BOOST_STATIC_CONSTEXPR int value = T_dim;
 };
 
 }

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
@@ -38,7 +38,7 @@ struct BufferNavigator;
 template<typename Pitch>
 struct BufferNavigator<Pitch, 1>
 {
-    static const int dim = 1;
+    BOOST_STATIC_CONSTEXPR int dim = 1;
 
     template<typename Data>
     HDINLINE
@@ -53,7 +53,7 @@ struct BufferNavigator<Pitch, 1>
 template<typename Pitch>
 struct BufferNavigator<Pitch, 2>
 {
-    static const int dim = 2;
+    BOOST_STATIC_CONSTEXPR int dim = 2;
 
     template<typename Data>
     HDINLINE
@@ -69,7 +69,7 @@ struct BufferNavigator<Pitch, 2>
 template<typename Pitch>
 struct BufferNavigator<Pitch, 3>
 {
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
 
     template<typename Data>
     HDINLINE

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
@@ -37,7 +37,7 @@ struct TwistAxesNavigator;
 template<typename Axes>
 struct TwistAxesNavigator<Axes, 2>
 {
-    static const int dim = 2;
+    BOOST_STATIC_CONSTEXPR int dim = 2;
 
     template<typename TCursor>
     HDINLINE
@@ -53,7 +53,7 @@ struct TwistAxesNavigator<Axes, 2>
 template<typename Axes>
 struct TwistAxesNavigator<Axes, 3>
 {
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
 
     template<typename TCursor>
     HDINLINE

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
@@ -37,7 +37,7 @@ struct TwistedAxesNavigator;
 template<typename Axes>
 struct TwistedAxesNavigator<Axes, 2>
 {
-    static const int dim = 2;
+    BOOST_STATIC_CONSTEXPR int dim = 2;
 
     template<typename TCursor>
     HDINLINE
@@ -53,7 +53,7 @@ struct TwistedAxesNavigator<Axes, 2>
 template<typename Axes>
 struct TwistedAxesNavigator<Axes, 3>
 {
-    static const int dim = 3;
+    BOOST_STATIC_CONSTEXPR int dim = 3;
 
     template<typename TCursor>
     HDINLINE

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -47,7 +47,7 @@ template<int T_dim>
 struct SphericZone
 {
     typedef tag::SphericZone tag;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     math::Size_t<dim> size;
     math::Int<dim> offset;
 

--- a/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
@@ -38,7 +38,7 @@ template<int T_dim>
 struct ToricZone
 {
     typedef tag::ToricZone tag;
-    static const int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_dim;
     math::Size_t<dim> offset;
     math::Size_t<dim> size;
     uint32_t thickness;

--- a/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
@@ -46,7 +46,7 @@ struct SphericZone
 {
     typedef _Size Size;
     typedef _Offset Offset;
-    static const int dim = Size::dim;
+    BOOST_STATIC_CONSTEXPR int dim = Size::dim;
 };
 
 } // CT


### PR DESCRIPTION
This replaces all usages of `static const` by `BOOST_STATIC_CONSTEXPR` to make those values usable in C++11 `constexpr`

Follow up to #1155 