### PR TITLE
Set pointers to NULL before calling cudaMalloc

### DIFF
--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -31,10 +31,11 @@ template<typename Type, int T_dim>
 cursor::BufferCursor<Type, T_dim>
 DeviceMemEvenPitch<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
 {
-    Type* dataPointer;
+    Type* dataPointer = NULL;
     math::Size_t<T_dim-1> pitch;
 
-    CUDA_CHECK(cudaMalloc((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
+    if(size.productOfComponents())
+        CUDA_CHECK(cudaMalloc((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
 
     if (dim == 2u)
     {
@@ -53,9 +54,10 @@ template<typename Type>
 cursor::BufferCursor<Type, 1>
 DeviceMemEvenPitch<Type, 1>::allocate(const math::Size_t<1>& size)
 {
-    Type* dataPointer;
+    Type* dataPointer = NULL;
 
-    CUDA_CHECK(cudaMalloc((void**)&dataPointer, size[0] * sizeof(Type)));
+    if(size.productOfComponents())
+        CUDA_CHECK(cudaMalloc((void**)&dataPointer, size[0] * sizeof(Type)));
 
     return cursor::BufferCursor<Type, 1>(dataPointer, math::Size_t<0>());
 }

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -32,10 +32,11 @@ cursor::BufferCursor<Type, T_dim>
 HostMemAllocator<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
 {
 #ifndef __CUDA_ARCH__
-    Type* dataPointer;
+    Type* dataPointer = NULL;
     math::Size_t<T_dim-1> pitch;
 
-    CUDA_CHECK_NO_EXCEP(cudaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
+    if(size.productOfComponents())
+        CUDA_CHECK_NO_EXCEP(cudaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
     if(dim == 2u)
     {
         pitch[0] = size[0] * sizeof(Type);
@@ -61,10 +62,11 @@ cursor::BufferCursor<Type, 1>
 HostMemAllocator<Type, 1>::allocate(const math::Size_t<1>& size)
 {
 #ifndef __CUDA_ARCH__
-    Type* dataPointer;
+    Type* dataPointer = NULL;
     math::Size_t<0> pitch;
 
-    CUDA_CHECK_NO_EXCEP(cudaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
+    if(size.productOfComponents())
+        CUDA_CHECK_NO_EXCEP(cudaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
 
     return cursor::BufferCursor<Type, 1>(dataPointer, pitch);
 #endif

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -52,7 +52,7 @@ namespace PMacc
          * @param dataSpace description of spread of any dimension
          */
         Buffer(DataSpace<DIM> dataSpace) :
-        data_space(dataSpace),data1D(true)
+        data_space(dataSpace), data1D(true), current_size(NULL)
         {
             CUDA_CHECK(cudaMallocHost(&current_size, sizeof (size_t)));
             *current_size = dataSpace.productOfComponents();


### PR DESCRIPTION
This sets the pointers to NULL before calling cudaMalloc and also calls it only on non-zero sizes. See #1179 for details on the issue

Closes #1179

Note: Affects only cuSTL. PMacc seems to be fine. A single change for consistency in PMacc is included but it's not worth mentioning, so 1 PR should be ok.