### PR TITLE
Do not allocate memory if not root

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013, 2015 Heiko Burau, Benjamin Worpitz
+ * Copyright 2013-2015 Heiko Burau, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -174,10 +174,10 @@ void Gather<dim>::operator()(container::HostBuffer<Type, memDim>& dest,
     if(!this->m_participate) return;
 
     int numRanks; MPI_Comm_size(this->comm, &numRanks);
-    std::vector<Type> tmpDest(numRanks * source.size().productOfComponents());
+    std::vector<Type> tmpDest(root() ? numRanks * source.size().productOfComponents() : 0);
 
     MPI_CHECK(MPI_Gather((void*)source.getDataPointer(), source.size().productOfComponents() * sizeof(Type), MPI_CHAR,
-               (void*)tmpDest.data(), source.size().productOfComponents() * sizeof(Type), MPI_CHAR,
+               root() ? (void*)tmpDest.data() : NULL, source.size().productOfComponents() * sizeof(Type), MPI_CHAR,
                0, this->comm));
     if(!root()) return;
 


### PR DESCRIPTION
The recv buffer pointer is not meaningful and not used for non-root processes of a MPI gather operation. Therefore we do not need to allocate the memory for that.
This is important in low-memory environments where e.g. one distributed the root process for each gather operation in a round-robin fashion to counter load imbalances and expect, that the non-roots actually do less and need less memory.