### PR TITLE
Rename totalFreeGpuMemory to reservedGpuMemorySize

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/memory.param
+++ b/examples/Bunch/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t totalFreeGpuMemory = 350 *1024*1024;
+BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t totalFreeGpuMemory = 400 *1024*1024;
+BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 400 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;

--- a/examples/LaserWakefield/include/simulation_defines/param/memory.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t totalFreeGpuMemory = 350 *1024*1024;
+BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;

--- a/examples/ThermalTest/include/simulation_defines/param/memory.param
+++ b/examples/ThermalTest/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t totalFreeGpuMemory = 350 *1024*1024;
+BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;

--- a/examples/WeibelTransverse/include/simulation_defines/param/memory.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t totalFreeGpuMemory = 400 *1024*1024;
+BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 400 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -281,14 +281,14 @@ public:
 
         size_t freeGpuMem(0);
         Environment<>::get().EnvMemoryInfo().getMemoryInfo(&freeGpuMem);
-        if(freeGpuMem < totalFreeGpuMemory)
+        if(freeGpuMem < reservedGpuMemorySize)
         {
             PMacc::log< picLog::MEMORY > ("%1% MiB free memory < %2% MiB required reserved memory")
-                % (freeGpuMem / 1024 / 1024) % (totalFreeGpuMemory / 1024 / 1024) ;
+                % (freeGpuMem / 1024 / 1024) % (reservedGpuMemorySize / 1024 / 1024) ;
             throw std::runtime_error("Cannot reserve enough memory");
         }
 
-        size_t heapSize = freeGpuMem - totalFreeGpuMemory;
+        size_t heapSize = freeGpuMem - reservedGpuMemorySize;
 
         if( Environment<>::get().EnvMemoryInfo().isSharedMemoryPool() )
         {

--- a/src/picongpu/include/simulation_defines/param/memory.param
+++ b/src/picongpu/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
      *   - reduces
      *   - ...
      */
-    BOOST_CONSTEXPR_OR_CONST size_t totalFreeGpuMemory = 350 *1024*1024;
+    BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
 
     /* short namespace*/
     namespace mCT=PMacc::math::CT;


### PR DESCRIPTION
Split from #1188 and needs to be merged AFTER #1188:

Changes the bad/misleading name to a better one as it is not the free gpu memory that is meant but amount the amount of memory that should be reserved for random stuff.