### PR TITLE
Make error message better

### DIFF
--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -285,7 +285,11 @@ public:
         {
             PMacc::log< picLog::MEMORY > ("%1% MiB free memory < %2% MiB required reserved memory")
                 % (freeGpuMem / 1024 / 1024) % (reservedGpuMemorySize / 1024 / 1024) ;
-            throw std::runtime_error("Cannot reserve enough memory");
+            std::stringstream msg;
+            msg << "Cannot reserve "
+                << (reservedGpuMemorySize / 1024 / 1024) << " MiB as there is only "
+                << (freeGpuMem / 1024 / 1024) << " MiB free GPU memory left";
+            throw std::runtime_error(msg.str());
         }
 
         size_t heapSize = freeGpuMem - reservedGpuMemorySize;


### PR DESCRIPTION
As suggested by @psychocoderHPC in https://github.com/ComputationalRadiationPhysics/picongpu/pull/1190#discussion_r42345229 the error message should be improved when there is not enough free gpu memory.