### PR TITLE
Make cuSTL gather accept CartBuffers and handle pitches

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
@@ -45,24 +45,22 @@ private:
     std::vector<math::Int<dim> > positions;
     bool m_participate;
 
-    template<typename Type, int memDim>
     struct CopyToDest
     {
+        template<typename Type, int memDim, class T_Alloc, class T_Copy, class T_Assign, class T_Alloc2, class T_Copy2, class T_Assign2>
         void operator()(const Gather<dim>& gather,
-                        container::HostBuffer<Type, memDim>& dest,
+                        container::CartBuffer<Type, memDim, T_Alloc, T_Copy, T_Assign>& dest,
                         std::vector<Type>& tmpDest,
-                        container::HostBuffer<Type, memDim>& source, int dir) const;
+                        container::CartBuffer<Type, memDim, T_Alloc2, T_Copy2, T_Assign2>& source, int dir) const;
     };
 
-    template<typename Type, int memDim>
-    friend struct CopyToDest;
 public:
     Gather(const zone::SphericZone<dim>& p_zone);
     ~Gather();
 
-    template<typename Type, int memDim>
-    void operator()(container::HostBuffer<Type, memDim>& dest,
-                    container::HostBuffer<Type, memDim>& source,
+    template<typename Type, int memDim, class T_Alloc, class T_Copy, class T_Assign, class T_Alloc2, class T_Copy2, class T_Assign2>
+    void operator()(container::CartBuffer<Type, memDim, T_Alloc, T_Copy, T_Assign>& dest,
+                    container::CartBuffer<Type, memDim, T_Alloc2, T_Copy2, T_Assign2>& source,
                     int dir = -1) const;
 
     inline bool participate() const {return m_participate;}

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -123,6 +123,10 @@ public:
     HDINLINE Type* getDataPointer() const {return dataPointer;}
     HDINLINE math::Size_t<T_dim> size() const {return this->_size;}
     HDINLINE math::Size_t<T_dim-1> getPitch() const {return this->pitch;}
+    /** Returns whether the buffer has no additional pitches
+     * The expected pitches are: 2D: size.x, 3D: size.x/size.x*size.y
+     */
+    HDINLINE bool isContigousMemory() const;
 };
 
 } // container

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -44,6 +44,8 @@ namespace detail
     {
         template<typename TCursor>
         HDINLINE math::Size_t<0u> operator()(const TCursor&) {return math::Size_t<0u>();}
+
+        HDINLINE math::Size_t<0u> operator()(const math::Size_t<1u>&) {return math::Size_t<0u>();}
     };
     template<>
     struct PitchHelper<2>
@@ -52,6 +54,11 @@ namespace detail
         HDINLINE math::Size_t<1> operator()(const TCursor& cursor)
         {
             return math::Size_t<1>(size_t((char*)cursor(0, 1).getMarker() - (char*)cursor.getMarker()));
+        }
+
+        HDINLINE math::Size_t<1> operator()(const math::Size_t<2>& size)
+        {
+            return math::Size_t<1>(size.x());
         }
     };
     template<>
@@ -62,6 +69,11 @@ namespace detail
         {
             return math::Size_t<2>((size_t)((char*)cursor(0, 1, 0).getMarker() - (char*)cursor.getMarker()),
                                    (size_t)((char*)cursor(0, 0, 1).getMarker() - (char*)cursor.getMarker()));
+        }
+
+        HDINLINE math::Size_t<2> operator()(const math::Size_t<3>& size)
+        {
+            return math::Size_t<2>(size.x(), size.x() * size.y());
         }
     };
 
@@ -251,7 +263,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::originCustomAxes(const mat
     factor[0] = sizeof(Type);
     if(dim > 1) factor[1] = this->pitch[0];
     if(dim > 2) factor[2] = this->pitch[1];
-    //\todo: is the conversation from size_t to uint32_t allowed?
+    //\todo: is the conversation from size_t to int32_t allowed?
     math::Int<dim> customFactor;
     for(int i = 0; i < dim; i++)
         customFactor[i] = (int)factor[axes[i]];
@@ -271,6 +283,13 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::zone() const
     myZone.offset = math::Int<T_dim>::create(0);
     myZone.size = this->_size;
     return myZone;
+}
+
+template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+bool
+CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::isContigousMemory() const
+{
+    return this->pitch == detail::PitchHelper<dim>()(this->_size);
 }
 
 template<typename Type, typename Allocator, typename Copier, typename Assigner>

--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -497,8 +497,27 @@ struct Vector<Type, 0 >
     template<typename OtherType >
     HDINLINE operator Vector<OtherType, 0 > () const
     {
-
         return Vector<OtherType, 0 > ();
+    }
+
+    /**
+     * == comparison operator.
+     *
+     * Returns always true
+     */
+    HDINLINE bool operator==(const Vector& rhs) const
+    {
+        return true;
+    }
+
+    /**
+     * != comparison operator.
+     *
+     * Returns always false
+     */
+    HDINLINE bool operator!=(const Vector& rhs) const
+    {
+        return false;
     }
 };
 


### PR DESCRIPTION
Before this patch the gather functor could not accept e.g. Views. 

It now also checks for pitches and copies the memory transparently if required. This was not required before as (currently) HostBuffers were densely packed, but now it is as e.g. a View is mostly not densely packed.

- [x] Needs rebase on #1197