### PR TITLE
[cuSTL] Implement correct assignment operators

### DIFF
--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -105,7 +105,6 @@ public:
              math::Int<T_dim> b = math::Int<T_dim>(0)) const;
 
     /* assign value to each datum */
-    PMACC_NO_NVCC_HDWARNING
     HDINLINE void assign(const Type& value);
 
     /* get a cursor at the container's origin cell */

--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -74,7 +75,7 @@ public:
 
     template<typename HBuffer>
     HDINLINE
-    DeviceBuffer<Type, dim>& operator=(const HBuffer& rhs)
+    DeviceBuffer& operator=(const HBuffer& rhs)
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::memoryTag, allocator::tag::host>::value));
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::type, Type>::value));
@@ -83,6 +84,12 @@ public:
         cudaWrapper::Memcopy<dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
                                 this->_size, cudaWrapper::flags::Memcopy::hostToDevice);
 
+        return *this;
+    }
+
+    HDINLINE DeviceBuffer& operator=(const Base& rhs)
+    {
+        Base::operator=(rhs);
         return *this;
     }
 

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -68,7 +68,7 @@ public:
     HostBuffer(const Base& base) : Base(base) {}
 
     template<typename DBuffer>
-    HostBuffer<Type, dim>& operator=(const DBuffer& rhs)
+    HostBuffer& operator=(const DBuffer& rhs)
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename DBuffer::memoryTag, allocator::tag::device>::value));
         BOOST_STATIC_ASSERT((boost::is_same<typename DBuffer::type, Type>::value));
@@ -77,6 +77,12 @@ public:
         cudaWrapper::Memcopy<dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
                                 this->_size, cudaWrapper::flags::Memcopy::deviceToHost);
 
+        return *this;
+    }
+
+    HostBuffer& operator=(const Base& rhs)
+    {
+        Base::operator=(rhs);
         return *this;
     }
 

--- a/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -37,7 +37,7 @@ struct HostMemAssigner<1>
 {
     BOOST_STATIC_CONSTEXPR int dim = 1;
     template<typename Type>
-    static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
+    HDINLINE static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
                        const math::Size_t<dim>& size)
     {
         for(size_t i = 0; i < size.x(); i++) data[i] = value;
@@ -49,7 +49,7 @@ struct HostMemAssigner<2u>
 {
     BOOST_STATIC_CONSTEXPR int dim = 2u;
     template<typename Type>
-    static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
+    HDINLINE static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
                        const math::Size_t<dim>& size)
     {
         Type* tmpData = data;
@@ -66,7 +66,7 @@ struct HostMemAssigner<3>
 {
     BOOST_STATIC_CONSTEXPR int dim = 3;
     template<typename Type>
-    static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
+    HDINLINE static void assign(Type* data, const math::Size_t<dim-1>& pitch, const Type& value,
                        const math::Size_t<dim>& size)
     {
         for(size_t z = 0; z < size.z(); z++)

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -23,6 +24,9 @@
 #pragma once
 
 #include "Memcopy.hpp"
+#include "cuSTL/cursor/BufferCursor.hpp"
+#include "cuSTL/cursor/accessor/CursorAccessor.hpp"
+#include "cuSTL/cursor/navigator/MapTo1DNavigator.hpp"
 #include <types.h>
 
 namespace PMacc
@@ -34,13 +38,34 @@ template<int T_dim>
 struct D2DCopier
 {
     BOOST_STATIC_CONSTEXPR int dim = T_dim;
+
+    PMACC_NO_NVCC_HDWARNING /* Handled via CUDA_ARCH */
     template<typename Type>
-    static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
+    HDINLINE static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
          Type* source, const math::Size_t<dim-1>& pitchSource,
          const math::Size_t<dim>& size)
     {
+#ifdef __CUDA_ARCH__
+        typedef cursor::BufferCursor<Type, dim> Cursor;
+        Cursor bufCursorDest(dest, pitchDest);
+        Cursor bufCursorSrc(source, pitchSource);
+        cursor::MapTo1DNavigator<dim> myNavi(size);
+
+        BOOST_AUTO(srcCursor, cursor::make_Cursor(cursor::CursorAccessor<Cursor>(),
+                                                  myNavi,
+                                                  bufCursorSrc));
+        BOOST_AUTO(destCursor, cursor::make_Cursor(cursor::CursorAccessor<Cursor>(),
+                                                   myNavi,
+                                                   bufCursorDest));
+        size_t sizeProd = size.productOfComponents();
+        for(size_t i = 0; i < sizeProd; i++)
+        {
+            destCursor[i] = srcCursor[i];
+        }
+#else
         cudaWrapper::Memcopy<dim>()(dest, pitchDest, source, pitchSource,
                                     size, cudaWrapper::flags::Memcopy::deviceToDevice);
+#endif
     }
 };
 

--- a/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013, 2015 Heiko Burau, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -34,8 +35,10 @@ template<int T_dim>
 struct H2HCopier
 {
     BOOST_STATIC_CONSTEXPR int dim = T_dim;
+
+    PMACC_NO_NVCC_HDWARNING /* Should never be called from device functions */
     template<typename Type>
-    static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
+    HDINLINE static void copy(Type* dest, const math::Size_t<dim-1>& pitchDest,
          Type* source, const math::Size_t<dim-1>& pitchSource,
          const math::Size_t<dim>& size)
     {


### PR DESCRIPTION
This makes it possible to use the assignments of Host/DeviceBuffers on both host on device (where possible, so assigning Host->Host in a device function will still not work)