### PR TITLE
Add reference accessors to complex type

### DIFF
--- a/src/libPMacc/include/math/complex/Complex.hpp
+++ b/src/libPMacc/include/math/complex/Complex.hpp
@@ -88,9 +88,21 @@ public:
     }
 
     // real part
+    HDINLINE T_Type& get_real()
+    {
+        return real;
+    }
+
+    // real part
     HDINLINE T_Type get_real(void) const
     {
         return real;
+    }
+
+    // imaginary part
+    HDINLINE T_Type& get_imag()
+    {
+        return imaginary;
     }
 
     // imaginary part


### PR DESCRIPTION
This is required if one has a buffer of complex numbers and needs to change only real or imag parts e.g. with `atomicAdd`