### PR TITLE
move field to particle interpolation into pusher

### DIFF
--- a/src/picongpu/include/particles/InterpolationForPusher.hpp
+++ b/src/picongpu/include/particles/InterpolationForPusher.hpp
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2015 Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+/** functor for particle field interpolator
+ *
+ * This functor is a simplification of the full
+ * field to particle interpolator that can be used in the
+ * particle pusher
+ */
+
+namespace picongpu
+{
+
+using namespace PMacc;
+
+
+template< typename T_Field2PartInt, typename T_MemoryType, typename T_FieldPosition >
+struct InterpolationForPusher
+{
+    typedef T_Field2PartInt Field2PartInt;
+
+    HDINLINE
+    InterpolationForPusher( const T_MemoryType& mem, const T_FieldPosition& fieldPos )
+        : m_mem( mem ), m_fieldPos( fieldPos )
+    {
+    }
+
+    template< typename T_PosType >
+    HDINLINE
+    float3_X operator()( const T_PosType& pos ) const
+    {
+        /* to do: memory shift, position shift */
+        return Field2PartInt()( m_mem, pos, m_fieldPos );
+    }
+
+private:
+    PMACC_ALIGN( m_mem, T_MemoryType );
+    const PMACC_ALIGN( m_fieldPos, T_FieldPosition );
+};
+
+
+/** functor to create particle field interpolator
+ *
+ * required to get interpolator for pusher
+ */
+template<typename T_Field2PartInt>
+struct CreateInterpolationForPusher
+{
+    template< typename T_MemoryType, typename T_FieldPosition >
+    HDINLINE
+    InterpolationForPusher< T_Field2PartInt, T_MemoryType, T_FieldPosition >
+    operator()( const T_MemoryType& mem, const T_FieldPosition& fieldPos )
+    {
+        return InterpolationForPusher< T_Field2PartInt, T_MemoryType, T_FieldPosition >( mem, fieldPos );
+    }
+};
+
+} // namespace picongpu

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -51,6 +51,7 @@
 #include "particles/operations/Assign.hpp"
 #include "particles/operations/Deselect.hpp"
 #include "nvidia/atomic.hpp"
+#include "particles/InterpolationForPusher.hpp"
 
 namespace picongpu
 {
@@ -263,11 +264,8 @@ struct PushParticlePerFrame
 
         DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
 
-
-        EType eField = Field2ParticleInterpolation()
-            (eBox.shift(localCell).toCursor(), pos, NumericalCellType::getEFieldPosition());
-        BType bField = Field2ParticleInterpolation()
-            (bBox.shift(localCell).toCursor(), pos, NumericalCellType::getBFieldPosition());
+        PMACC_AUTO(functorEfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( eBox.shift(localCell).toCursor(), NumericalCellType::getEFieldPosition()));
+        PMACC_AUTO(functorBfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( bBox.shift(localCell).toCursor(), NumericalCellType::getBFieldPosition()));
 
         float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass(weighting,particle);
@@ -283,7 +281,8 @@ struct PushParticlePerFrame
 #endif
         PushAlgo push;
         push(
-             bField, eField,
+             functorBfield,
+             functorEfield,
              pos,
              mom,
              mass,

--- a/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
@@ -57,11 +57,11 @@ namespace picongpu
                 return float_X(-1.0);
             }
 
-            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+            template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
                  typename T_Charge , typename T_Weighting>
                 __host__ DINLINE void operator( )(
-                                                      const T_Bfield bField, /* at t=0 */
-                                                      const T_Efield eField, /* at t=0 */
+                                                      const T_FunctorFieldB functorBField, /* at t=0 */
+                                                      const T_FunctorFieldE functorEField, /* at t=0 */
                                                       T_Pos& pos, /* at t=0 */
                                                       T_Mom& mom, /* at t=-1/2 */
                                                       const T_Mass mass,
@@ -69,6 +69,9 @@ namespace picongpu
                                                       const T_Weighting)
             {
                 typedef T_Mom MomType;
+
+                PMACC_AUTO( bField , functorBField(pos));
+                PMACC_AUTO( eField , functorEField(pos));
 
                 Gamma gammaCalc;
                 Velocity velocityCalc;

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -33,11 +33,11 @@ template<class Velocity, class Gamma>
 struct Push
 {
 
-    template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+    template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
              typename T_Charge, typename T_Weighting>
         __host__ DINLINE void operator()(
-                                            const T_Bfield bField,
-                                            const T_Efield eField,
+                                            const T_FunctorFieldB functorBField,
+                                            const T_FunctorFieldE functorEField,
                                             T_Pos& pos,
                                             T_Mom& mom,
                                             const T_Mass mass,
@@ -45,7 +45,9 @@ struct Push
                                             const T_Weighting)
     {
         typedef T_Mom MomType;
-        typedef T_Bfield BType;
+
+        PMACC_AUTO( bField , functorBField(pos));
+        PMACC_AUTO( eField , functorEField(pos));
 
         const float_X QoM = charge / mass;
 
@@ -56,7 +58,7 @@ struct Push
         Gamma gamma;
         const float_X gamma_reci = float_X(1.0) / gamma(mom_minus, mass);
         const float3_X t = float_X(0.5) * QoM * bField * gamma_reci * deltaT;
-        const BType s = float_X(2.0) * t * (float_X(1.0) / (float_X(1.0) + math::abs2(t)));
+        PMACC_AUTO( s , float_X(2.0) * t * (float_X(1.0) / (float_X(1.0) + math::abs2(t))));
 
         const MomType mom_prime = mom_minus + math::cross(mom_minus, t);
         const MomType mom_plus = mom_minus + math::cross(mom_prime, s);

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -32,11 +32,11 @@ namespace picongpu
         struct Push
         {
 
-            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+            template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
                      typename T_Charge, typename T_Weighting>
                     __host__ DINLINE void operator()(
-                                                        const T_Bfield,
-                                                        const T_Efield,
+                                                        const T_FunctorFieldB,
+                                                        const T_FunctorFieldE,
                                                         T_Pos& pos,
                                                         T_Mom& mom,
                                                         const T_Mass mass,

--- a/src/picongpu/include/particles/pusher/particlePusherNone.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherNone.hpp
@@ -30,11 +30,11 @@ namespace picongpu
         struct Push
         {
 
-            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+            template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
                      typename T_Charge, typename T_Weighting>
                     __host__ DINLINE void operator()(
-                                                        const T_Bfield,
-                                                        const T_Efield,
+                                                        const T_FunctorFieldB,
+                                                        const T_FunctorFieldE,
                                                         T_Pos&,
                                                         T_Mom&,
                                                         const T_Mass,

--- a/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
@@ -32,11 +32,11 @@ namespace picongpu
         struct Push
         {
 
-            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+            template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
                      typename T_Charge,  typename T_Weighting>
                     __host__ DINLINE void operator()(
-                                                        const T_Bfield,
-                                                        const T_Efield,
+                                                        const T_FunctorFieldB,
+                                                        const T_FunctorFieldE,
                                                         T_Pos& pos,
                                                         T_Mom& mom,
                                                         const T_Mass,

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -33,11 +33,11 @@ template<class Velocity, class Gamma>
 struct Push
 {
 
-    template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+    template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
              typename T_Charge, typename T_Weighting >
         __host__ DINLINE void operator()(
-                                            const T_Bfield bField, /* at t=0 */
-                                            const T_Efield eField, /* at t=0 */
+                                            const T_FunctorFieldB functorBField, /* at t=0 */
+                                            const T_FunctorFieldE functorEField, /* at t=0 */
                                             T_Pos& pos, /* at t=0 */
                                             T_Mom& mom, /* at t=-1/2 */
                                             const T_Mass mass,
@@ -45,6 +45,9 @@ struct Push
                                             const  T_Weighting)
     {
         typedef T_Mom MomType;
+
+        PMACC_AUTO( bField , functorBField(pos));
+        PMACC_AUTO( eField , functorEField(pos));
         /*
              time index in paper is reduced by a half: i=0 --> i=-1/2 so that momenta are
              at half time steps and fields and locations are at full time steps


### PR DESCRIPTION
This pull request refactors the particle pusher interface to support:
 - inter pusher field to  particle interpolation
 - ~~use of weighting in pusher~~ --> #1213 

None of the current  pushers need this update, but with the coming radiation reaction pusher, these will be necessary.