### PR TITLE
fix typo Axl-> Axel and Phot->Photon

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/species.param
+++ b/examples/Bunch/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -74,10 +74,10 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed
- * - particles::pusher::Axl : a pusher developed at HZDR during 2011 (testing)
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
- * - particles::pusher::Phot : propagate with c in direction of normalized mom.
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
 typedef particles::pusher::Boris UsedParticlePusher;
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -79,10 +79,10 @@ typedef currentSolver::PARAM_CURRENTSOLVER UsedParticleCurrentSolver;
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed
- * - particles::pusher::Axl : a pusher developed at HZDR during 2011 (testing)
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
- * - particles::pusher::Phot : propagate with c in direction of normalized mom.
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
 typedef particles::pusher::Boris UsedParticlePusher;
 

--- a/examples/LaserWakefield/include/simulation_defines/param/species.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -89,10 +89,10 @@ typedef currentSolver::PARAM_CURRENTSOLVER<UsedParticleShape> UsedParticleCurren
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed
- * - particles::pusher::Axl : a pusher developed at HZDR during 2011 (testing)
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
- * - particles::pusher::Phot : propagate with c in direction of normalized mom.
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
 #ifndef PARAM_PARTICLEPUSHER
 #define PARAM_PARTICLEPUSHER Boris

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -74,10 +74,10 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed
- * - particles::pusher::Axl : a pusher developed at HZDR during 2011 (testing)
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
- * - particles::pusher::Phot : propagate with c in direction of normalized mom.
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
 typedef particles::pusher::Boris UsedParticlePusher;
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -74,10 +74,10 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed
- * - particles::pusher::Axl : a pusher developed at HZDR during 2011 (testing)
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
- * - particles::pusher::Phot : propagate with c in direction of normalized mom.
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
 typedef particles::pusher::Boris UsedParticlePusher;
 

--- a/examples/SingleParticleTest/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -74,10 +74,10 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed
- * - particles::pusher::Axl : a pusher developed at HZDR during 2011 (testing)
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
- * - particles::pusher::Phot : propagate with c in direction of normalized mom.
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
 typedef particles::pusher::Boris UsedParticlePusher;
 

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -76,10 +76,10 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed
- * - particles::pusher::Axl : a pusher developed at HZDR during 2011 (testing)
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
- * - particles::pusher::Phot : propagate with c in direction of normalized mom.
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
 typedef particles::pusher::Boris UsedParticlePusher;
 


### PR DESCRIPTION
This pull request fixes to typos in the selection of possible pushers.

This avoids selecting a wrongly spelled and thus non-existing pusher. 