### PR TITLE
add cmake Test for all pushers in 2D and 3D

### DIFF
--- a/examples/SingleParticleTest/cmakeFlags
+++ b/examples/SingleParticleTest/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013 Axel Huebl, Rene Widera
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU. 
 # 
@@ -29,8 +29,25 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
+# test all pushers in 3D and 2D
+# Boris Pusher
 flags[0]="-DCUDA_ARCH=sm_20"
-
+flags[1]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_DIMENSION=DIM2"
+# Vay Pusher
+flags[2]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Vay"
+flags[3]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Vay;-DPARAM_DIMENSION=DIM2"
+# None Pusher
+flags[4]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=None"
+flags[5]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=None;-DPARAM_DIMENSION=DIM2"
+# Free Pusher
+flags[6]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Free"
+flags[7]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Free;-DPARAM_DIMENSION=DIM2"
+# Photon Pusher
+flags[8]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Photon"
+flags[9]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Photon;-DPARAM_DIMENSION=DIM2"
+# Axel Pusher 
+flags[10]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Axel"
+# does not support 2D
 
 ################################################################################
 # execution

--- a/examples/SingleParticleTest/include/simulation_defines/param/dimension.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/dimension.param
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2014-2015 Axel Huebl, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef PARAM_DIMENSION
+#define PARAM_DIMENSION DIM3
+#endif
+
+#define SIMDIM PARAM_DIMENSION
+
+namespace picongpu
+{
+    BOOST_CONSTEXPR_OR_CONST uint32_t simDim = SIMDIM;
+} // namespace picongpu

--- a/examples/SingleParticleTest/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/species.param
@@ -79,6 +79,9 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  * (= free stream model)
  * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
-typedef particles::pusher::Boris UsedParticlePusher;
+#ifndef PARAM_PARTICLEPUSHER
+#define PARAM_PARTICLEPUSHER Boris
+#endif
+typedef particles::pusher::PARAM_PARTICLEPUSHER UsedParticlePusher;
 
 }//namespace picongpu


### PR DESCRIPTION
This pull request adds cmake tests for all pushers in 2D and 3D (except the `Axel` pusher, which does not support 2D).

The tests are added  to the `example/SingleParticleTest`. This should avoid bugs as #1204 or missing 2D support as #1126 in the future.  

This pull request requires:
- [x]  #1203 
- [x]  #1204 

to be merged.

