### PR TITLE
update pusher interface to work with coding standard

### DIFF
--- a/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxl.hpp
@@ -57,15 +57,18 @@ namespace picongpu
                 return float_X(-1.0);
             }
 
-            template<typename EType, typename BType, typename PosType, typename MomType, typename MassType, typename ChargeType >
+            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+                 typename T_Charge>
                 __host__ DINLINE void operator( )(
-                                                      const BType bField, /* at t=0 */
-                                                      const EType eField, /* at t=0 */
-                                                      PosType& pos, /* at t=0 */
-                                                      MomType& mom, /* at t=-1/2 */
-                                                      const MassType mass,
-                                                      const ChargeType charge)
+                                                      const T_Bfield bField, /* at t=0 */
+                                                      const T_Efield eField, /* at t=0 */
+                                                      T_Pos& pos, /* at t=0 */
+                                                      T_Mom& mom, /* at t=-1/2 */
+                                                      const T_Mass mass,
+                                                      const T_Charge charge)
             {
+                typedef T_Mom MomType;
+
                 Gamma gammaCalc;
                 Velocity velocityCalc;
                 const float_X epsilon = 1.0e-6;

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -33,15 +33,19 @@ template<class Velocity, class Gamma>
 struct Push
 {
 
-    template<typename EType, typename BType, typename PosType, typename MomType, typename MassType, typename ChargeType >
+    template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+             typename T_Charge>
         __host__ DINLINE void operator()(
-                                            const BType bField,
-                                            const EType eField,
-                                            PosType& pos,
-                                            MomType& mom,
-                                            const MassType mass,
-                                            const ChargeType charge)
+                                            const T_Bfield bField,
+                                            const T_Efield eField,
+                                            T_Pos& pos,
+                                            T_Mom& mom,
+                                            const T_Mass mass,
+                                            const T_Charge charge)
     {
+        typedef T_Mom MomType;
+        typedef T_Bfield BType;
+
         const float_X QoM = charge / mass;
 
         const float_X deltaT = DELTA_T;

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -32,15 +32,17 @@ namespace picongpu
         struct Push
         {
 
-            template<typename EType, typename BType, typename PosType, typename MomType, typename MassType, typename ChargeType >
+            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+                   typename T_Charge>
                     __host__ DINLINE void operator()(
-                                                        const BType bField,
-                                                        const EType eField,
-                                                        PosType& pos,
-                                                        MomType& mom,
-                                                        const MassType mass,
-                                                        const ChargeType charge)
+                                                        const T_Bfield ,
+                                                        const T_Efield ,
+                                                        T_Pos& pos,
+                                                        T_Mom& mom,
+                                                        const T_Mass mass,
+                                                        const T_Charge )
             {
+                typedef T_Mom MomType;
 
                 Velocity velocity;
                 const MomType vel = velocity(mom, mass);

--- a/src/picongpu/include/particles/pusher/particlePusherNone.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherNone.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -30,14 +30,15 @@ namespace picongpu
         struct Push
         {
 
-            template<typename EType, typename BType, typename PosType, typename MomType, typename MassType, typename ChargeType >
+            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+                     typename T_Charge>
                     __host__ DINLINE void operator()(
-                                                        const BType bField, /* at t=0 */
-                                                        const EType eField, /* at t=0 */
-                                                        PosType& pos, /* at t=0 */
-                                                        MomType& mom, /* at t=-1/2 */
-                                                        const MassType mass,
-                                                        const ChargeType charge)
+                                                        const T_Bfield ,
+                                                        const T_Efield ,
+                                                        T_Pos& ,
+                                                        T_Mom& ,
+                                                        const T_Mass ,
+                                                        const T_Charge )
             {
             }
         };

--- a/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhot.hpp
@@ -32,15 +32,17 @@ namespace picongpu
         struct Push
         {
 
-            template<typename EType, typename BType, typename PosType, typename MomType, typename MassType, typename ChargeType >
+            template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+                     typename T_Charge>
                     __host__ DINLINE void operator()(
-                                                        const BType bField,
-                                                        const EType eField,
-                                                        PosType& pos,
-                                                        MomType& mom,
-                                                        const MassType mass,
-                                                        const ChargeType charge)
+                                                        const T_Bfield ,
+                                                        const T_Efield ,
+                                                        T_Pos& pos,
+                                                        T_Mom& mom,
+                                                        const T_Mass ,
+                                                        const T_Charge )
             {
+                typedef T_Mom MomType;
 
                 const float_X mom_abs = math::abs( mom );
                 const MomType vel = mom * ( SPEED_OF_LIGHT / mom_abs );

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -33,16 +33,17 @@ template<class Velocity, class Gamma>
 struct Push
 {
 
-    template<typename EType, typename BType, typename PosType, typename MomType, typename MassType, typename ChargeType >
+    template<typename T_Efield, typename T_Bfield, typename T_Pos, typename T_Mom, typename T_Mass,
+             typename T_Charge>
         __host__ DINLINE void operator()(
-                                            const BType bField, /* at t=0 */
-                                            const EType eField, /* at t=0 */
-                                            PosType& pos, /* at t=0 */
-                                            MomType& mom, /* at t=-1/2 */
-                                            const MassType mass,
-                                            const ChargeType charge)
+                                            const T_Bfield bField, /* at t=0 */
+                                            const T_Efield eField, /* at t=0 */
+                                            T_Pos& pos, /* at t=0 */
+                                            T_Mom& mom, /* at t=-1/2 */
+                                            const T_Mass mass,
+                                            const T_Charge charge)
     {
-
+        typedef T_Mom MomType;
         /*
              time index in paper is reduced by a half: i=0 --> i=-1/2 so that momenta are
              at half time steps and fields and locations are at full time steps


### PR DESCRIPTION
This pull request is a branching from #1201. It updates only the pusher interface to agree with the current coding standard of *PIConGPU*. 

- all template variable names are changed from `XxxType` to `T_Xxx`
- `typedef` are used instead of direct reference to template variable name
