### PR TITLE
add option to extend margin for pusher interpolation

### DIFF
--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -53,6 +53,7 @@
 #include "particles/traits/FilterByFlag.hpp"
 
 #include "traits/GetMargin.hpp"
+#include "particles/traits/GetMarginPusher.hpp"
 
 namespace picongpu
 {
@@ -87,10 +88,31 @@ fieldE( NULL )
     typedef PMacc::math::CT::max<
         LowerMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_B>::LowerMargin
-        >::type LowerMargin;
+        >::type LowerMarginInterpolationAndSolver;
     typedef PMacc::math::CT::max<
         UpperMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_B>::UpperMargin
+        >::type UpperMarginInterpolationAndSolver;
+
+    /* Calculate upper and lower margin for pusher 
+       (currently all pusher use the interpolation of the species)  
+       and find maximum margin 
+    */
+    typedef typename PMacc::particles::traits::FilterByFlag
+    <
+        VectorSpeciesWithInterpolation,
+        particlePusher<>
+    >::type VectorSpeciesWithPusherAndInterpolation;
+    typedef bmpl::accumulate<
+        VectorSpeciesWithPusherAndInterpolation,
+        LowerMarginInterpolationAndSolver,
+        PMacc::math::CT::max<bmpl::_1, GetLowerMarginPusher<bmpl::_2> >
+        >::type LowerMargin;
+
+    typedef bmpl::accumulate<
+        VectorSpeciesWithPusherAndInterpolation,
+        UpperMarginInterpolationAndSolver,
+        PMacc::math::CT::max<bmpl::_1, GetUpperMarginPusher<bmpl::_2> >
         >::type UpperMargin;
 
     const DataSpace<simDim> originGuard( LowerMargin( ).toRT( ) );

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -47,6 +47,7 @@
 #include "particles/traits/GetInterpolation.hpp"
 #include "particles/traits/FilterByFlag.hpp"
 #include "traits/GetMargin.hpp"
+#include "particles/traits/GetMarginPusher.hpp"
 #include <boost/mpl/accumulate.hpp>
 #include "fields/LaserPhysics.hpp"
 
@@ -81,10 +82,31 @@ fieldB( NULL )
     typedef PMacc::math::CT::max<
         LowerMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_E>::LowerMargin
-        >::type LowerMargin;
+        >::type LowerMarginInterpolationAndSolver;
     typedef PMacc::math::CT::max<
         UpperMarginInterpolation,
         GetMargin<fieldSolver::FieldSolver, FIELD_E>::UpperMargin
+        >::type UpperMarginInterpolationAndSolver;
+
+    /* Calculate upper and lower margin for pusher 
+       (currently all pusher use the interpolation of the species)  
+       and find maximum margin 
+    */
+    typedef typename PMacc::particles::traits::FilterByFlag
+    <
+        VectorSpeciesWithInterpolation,
+        particlePusher<>
+    >::type VectorSpeciesWithPusherAndInterpolation;
+    typedef bmpl::accumulate<
+        VectorSpeciesWithPusherAndInterpolation,
+        LowerMarginInterpolationAndSolver,
+        PMacc::math::CT::max<bmpl::_1, GetLowerMarginPusher<bmpl::_2> >
+        >::type LowerMargin;
+
+    typedef bmpl::accumulate<
+        VectorSpeciesWithPusherAndInterpolation,
+        UpperMarginInterpolationAndSolver,
+        PMacc::math::CT::max<bmpl::_1, GetUpperMarginPusher<bmpl::_2> >
         >::type UpperMargin;
 
     const DataSpace<simDim> originGuard( LowerMargin( ).toRT( ) );

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -52,6 +52,7 @@
 
 #include "traits/GetUniqueTypeId.hpp"
 #include "traits/Resolve.hpp"
+#include "particles/traits/GetMarginPusher.hpp"
 
 namespace picongpu
 {
@@ -163,12 +164,13 @@ void Particles<T_ParticleDescription>::update(uint32_t )
         typename GetFlagType<FrameType,interpolation<> >::type
         >::type InterpolationScheme;
 
-    typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
-    typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
-
     typedef PushParticlePerFrame<ParticlePush, MappingDesc::SuperCellSize,
         InterpolationScheme,
         fieldSolver::NumericalCellType > FrameSolver;
+
+    // adjust interpolation area in particle pusher to allow sub-sampling pushes
+    typedef typename GetLowerMarginPusher<Particles>::type LowerMargin;
+    typedef typename GetUpperMarginPusher<Particles>::type UpperMargin;
 
     typedef SuperCellDescription<
         typename MappingDesc::SuperCellSize,

--- a/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
@@ -37,7 +37,11 @@ namespace picongpu
         template<class Velocity, class Gamma>
         struct Push
         {
-
+            /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+             * for particle positions outside the super cell in one push
+             */
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type LowerMargin;
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
             enum coords
             {

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -32,6 +32,11 @@ namespace particlePusherBoris
 template<class Velocity, class Gamma>
 struct Push
 {
+    /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+     * for particle positions outside the super cell in one push
+     */
+    typedef typename PMacc::math::CT::make_Int<simDim,0>::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
     template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
              typename T_Charge, typename T_Weighting>

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -31,6 +31,11 @@ namespace picongpu
         template<class Velocity, class Gamma>
         struct Push
         {
+            /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+             * for particle positions outside the super cell in one push
+             */
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type LowerMargin;
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
             template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
                      typename T_Charge, typename T_Weighting>

--- a/src/picongpu/include/particles/pusher/particlePusherNone.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherNone.hpp
@@ -29,6 +29,11 @@ namespace picongpu
     {
         struct Push
         {
+            /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+             * for particle positions outside the super cell in one push
+             */
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type LowerMargin;
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
             template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
                      typename T_Charge, typename T_Weighting>

--- a/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
@@ -31,6 +31,11 @@ namespace picongpu
         template<class Velocity, class Gamma>
         struct Push
         {
+            /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+             * for particle positions outside the super cell in one push
+             */
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type LowerMargin;
+            typedef typename PMacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
             template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
                      typename T_Charge,  typename T_Weighting>

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -32,6 +32,11 @@ namespace particlePusherVay
 template<class Velocity, class Gamma>
 struct Push
 {
+    /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+     * for particle positions outside the super cell in one push
+     */
+    typedef typename PMacc::math::CT::make_Int<simDim,0>::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
     template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
              typename T_Charge, typename T_Weighting >

--- a/src/picongpu/include/particles/traits/GetMarginPusher.hpp
+++ b/src/picongpu/include/particles/traits/GetMarginPusher.hpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015 Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "traits/GetMargin.hpp"
+#include "particles/traits/GetInterpolation.hpp"
+#include "particles/traits/GetPusher.hpp"
+
+
+namespace picongpu
+{
+
+namespace traits
+{
+template<typename T_Species>
+struct GetMarginPusher
+{
+    typedef PMacc::math::CT::add< 
+        GetLowerMargin< GetInterpolation< bmpl::_1 > >, 
+        GetLowerMargin< GetPusher< bmpl::_1 > > 
+    > AddLowerMargins;
+    typedef typename bmpl::apply<AddLowerMargins, T_Species>::type LowerMargin;
+
+    typedef PMacc::math::CT::add< 
+        GetUpperMargin< GetInterpolation< bmpl::_1 > >, 
+        GetUpperMargin< GetPusher< bmpl::_1 > > 
+    > AddUpperMargins;
+    typedef typename bmpl::apply<AddUpperMargins, T_Species>::type UpperMargin;
+};
+
+template<typename T_Species>
+struct GetLowerMarginPusher
+{
+    typedef typename traits::GetMarginPusher<T_Species>::LowerMargin type;
+};
+
+template<typename T_Species>
+struct GetUpperMarginPusher
+{
+    typedef typename traits::GetMarginPusher<T_Species>::UpperMargin type;
+};
+
+}// namespace traits
+}// namespace picongpu

--- a/src/picongpu/include/particles/traits/GetPusher.hpp
+++ b/src/picongpu/include/particles/traits/GetPusher.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Rene Widera
+ * Copyright 2014-2015 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -34,7 +34,7 @@ struct GetPusher
 {
     typedef typename PMacc::traits::Resolve<
         typename GetFlagType<typename T_Species::FrameType, particlePusher<> >::type
-    >::type type;
+      >::type::type type;
 };
 
 }// namespace traits


### PR DESCRIPTION
This pull request adds an option in ~~`pusher.unitless`~~ *the particle pusher* to extend the margin for field to particle interpolation for the in-pusher interpolation.

This will be necessary for sub-sampling if a particle moves out of the currently stored field data (by one cell) and then wants to interpolate again. 

**Update:**
I use the pusher margins for calculating the neighbors in fields too.