### PR TITLE
add reduced Landau Lifshitz pusher

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/species.param
+++ b/examples/Bunch/include/simulation_defines/param/species.param
@@ -71,6 +71,8 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
@@ -76,6 +76,8 @@ typedef currentSolver::PARAM_CURRENTSOLVER UsedParticleCurrentSolver;
  *
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed

--- a/examples/LaserWakefield/include/simulation_defines/param/species.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/species.param
@@ -86,6 +86,8 @@ typedef currentSolver::PARAM_CURRENTSOLVER<UsedParticleShape> UsedParticleCurren
  *
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
@@ -71,6 +71,8 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
@@ -71,6 +71,8 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed

--- a/examples/SingleParticleTest/cmakeFlags
+++ b/examples/SingleParticleTest/cmakeFlags
@@ -48,6 +48,9 @@ flags[9]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Photo
 # Axel Pusher 
 flags[10]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=Axel"
 # does not support 2D
+# Reduced Landau Lifshitz Pusher
+flags[11]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=ReducedLandauLifshitz"
+flags[12]="-DCUDA_ARCH=sm_20 -DPARAM_OVERWRITES:LIST=-DPARAM_PARTICLEPUSHER=ReducedLandauLifshitz;-DPARAM_DIMENSION=DIM2"
 
 ################################################################################
 # execution

--- a/examples/SingleParticleTest/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/species.param
@@ -71,6 +71,8 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed

--- a/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "types.h"
+#include "simulation_defines.hpp"
+#include "math/Vector.hpp"
+#include "math/RungeKutta.hpp"
+#include "particles/interpolationMemoryPolicy/ShiftToValidRange.hpp"
+
+
+namespace picongpu
+{
+namespace particlePusherReducedLandauLifshitz
+{
+/* This pusher uses the Lorentz force and a reduced
+ * Landau Lifshitz term to push particles based on the
+ * Runge Kutta solver 4th order. It takes into account
+ * the energy loss due to radiation.
+ *
+ * More details on this approach can be found in
+ * Marija Vranic's paper: Classical Radiation Reaction
+ * in Particle-In-Cell Simulations
+ * http://arxiv.org/abs/1502.02432
+ */
+template<class Velocity, class Gamma>
+struct Push
+{
+  /* this is an optional extention for sub-sampling pushes that enables grid to particle interpolation
+   * for particle positions outside the super cell in one push
+   */
+  typedef typename PMacc::math::CT::make_Int<simDim,1>::type LowerMargin;
+  typedef typename PMacc::math::CT::make_Int<simDim,1>::type UpperMargin;
+
+  template<typename T_FunctorFieldB, typename T_FunctorFieldE, typename T_Pos, typename T_Mom,
+           typename T_Mass, typename T_Charge, typename T_Weighting >
+  __host__ DINLINE void operator()(
+                                   const T_FunctorFieldB functorBField, /* at t=0 */
+                                   const T_FunctorFieldE functorEField, /* at t=0 */
+                                   T_Pos& pos, /* at t=0 */
+                                   T_Mom& mom, /* at t=-1/2 */
+                                   const T_Mass mass,
+                                   const T_Charge charge,
+                                   const T_Weighting weighting)
+  {
+    typedef T_FunctorFieldB TypeBFieldFunctor;
+    typedef T_FunctorFieldE TypeEFieldFunctor;
+    typedef T_Pos TypePosition;
+    typedef T_Mom TypeMomentum;
+    typedef T_Mass TypeMass;
+    typedef T_Charge TypeCharge;
+    typedef T_Weighting TypeWeighting;
+
+    const float_X deltaT = DELTA_T;
+    const uint32_t dimMomentum = GetNComponents<TypeMomentum>::value;
+    // the transver data type adjust to 3D3V, 2D3V, 2D2V, ...
+    typedef PMacc::math::Vector< picongpu::float_X, simDim + dimMomentum > VariableType;
+    VariableType var;
+    
+    // transfer position
+    for(uint32_t i=0; i<picongpu::simDim; ++i)
+      var[i] = pos[i];
+    
+    // transfer momentum
+    for(uint32_t i=0; i<dimMomentum; ++i)
+      var[simDim + i] = mom[i];
+        
+    typedef DiffEquation<VariableType, float_X, TypeEFieldFunctor, TypeBFieldFunctor, TypePosition, TypeMomentum, TypeMass, TypeCharge, TypeWeighting, Velocity, Gamma> DiffEqType;
+    DiffEqType diffEq(functorEField, functorBField, mass, charge, weighting);
+    
+    VariableType varNew = PMacc::math::RungeKutta4()(diffEq, var, float_X(0.0), deltaT);
+
+    // transfer position
+    for(uint32_t i=0; i<picongpu::simDim; ++i)
+      pos[i] = varNew[i];
+
+    // transfer momentum
+    for(uint32_t i=0; i<dimMomentum; ++i)
+      mom[i] = varNew[simDim+i];
+
+  }
+  
+  template<typename T_Var, typename T_Time,
+           typename T_FieldEFunc, typename T_FieldBFunc,
+           typename T_Pos, typename T_Mom,
+           typename T_Mass, typename T_Charge, typename T_Weighting,
+           typename T_Velocity, typename T_Gamma>
+  struct DiffEquation
+  {
+    
+    // alias for types to  follow coding guide line
+    typedef T_Var VariableType;
+    typedef T_Time TimeType;
+    typedef T_FieldEFunc EFieldFuncType;
+    typedef T_FieldBFunc BFieldFuncType;
+    typedef T_Pos PositionType;
+    typedef T_Mom MomentumType;
+    typedef T_Mass MassType;
+    typedef T_Charge ChargeType;
+    typedef T_Weighting WeightingType;
+    typedef T_Velocity VelocityType;
+    typedef T_Gamma GammaType;
+
+
+    HDINLINE DiffEquation(EFieldFuncType funcE, BFieldFuncType funcB, MassType m, ChargeType q, WeightingType w)
+      : fieldEFunc(funcE), fieldBFunc(funcB), mass(m), charge(q), weighting(w)
+    { }
+
+    HDINLINE VariableType operator()(TimeType time, VariableType var) const
+    {
+      PositionType pos;
+      PositionType posInterpolation;
+      MomentumType mom;
+      // transfer position
+      for(uint32_t i=0; i<picongpu::simDim; ++i)
+      {
+          posInterpolation[i] = var[i];
+          pos[i] = var[i] * cellSize[i];
+      }
+
+      PMACC_AUTO( fieldE , fieldEFunc( posInterpolation,
+                                       picongpu::particles::interpolationMemoryPolicy::ShiftToValidRange() ) );
+      PMACC_AUTO( fieldB , fieldBFunc( posInterpolation,
+                                       picongpu::particles::interpolationMemoryPolicy::ShiftToValidRange() ) );
+
+      // transfer momentum
+      const uint32_t dimMomentum = GetNComponents<MomentumType>::value;
+      for(uint32_t i=0; i<dimMomentum; ++i)
+        mom[i] = var[simDim+i];
+      
+      VelocityType velocityCalc;
+      GammaType gammaCalc;
+      const float_X c = SPEED_OF_LIGHT;
+      const float3_X velocity = velocityCalc(mom, mass);
+      const float_X gamma = gammaCalc(mom, mass);
+      const float_X conversionMomentum2Beta = 1.0 / (gamma * mass * c);
+
+      const float_X c2 = c*c;
+      const float_X charge2 = charge*charge;
+      const float3_X beta = velocity / c;
+
+      const float_X prefactorRR = 2./3. * charge2 * charge2 / (4.*PI*EPS0 * mass*mass * c2*c2);
+      const float3_X lorentz = fieldE + conversionMomentum2Beta * c * math::cross(mom, fieldB);
+      const float_X fieldETimesBeta = math::dot(fieldE, mom) * conversionMomentum2Beta;
+      const float3_X radReactionVec = c * (math::cross(fieldE, fieldB) + 
+                                           c * conversionMomentum2Beta * math::cross(fieldB, math::cross(fieldB, mom)))
+                                      + conversionMomentum2Beta * fieldE * math::dot(mom, fieldE)
+                                      - gamma * gamma * conversionMomentum2Beta * (mom * (math::dot(lorentz, lorentz) - fieldETimesBeta*fieldETimesBeta));
+
+      const float3_X diffMom = charge * lorentz + (prefactorRR / weighting) * radReactionVec;
+      const float3_X diffPos = velocity;
+      
+      VariableType returnVar;
+      for(uint32_t i=0; i<picongpu::simDim; ++i)
+        returnVar[i] = diffPos[i] / cellSize[i];
+
+      for(uint32_t i=0; i<dimMomentum; ++i)
+        returnVar[simDim+i] = diffMom[i];
+
+      return returnVar;
+    }
+
+
+  private:    
+    EFieldFuncType fieldEFunc; /* functor E field interpolation */
+    BFieldFuncType fieldBFunc; /* functor B field interpolation */
+    MassType mass;             /* mass of the macro particle */
+    ChargeType charge;         /* charge of the macro particle */
+    WeightingType weighting;   /* weighting of the macro particle */
+  };
+
+};
+} //namespace particlePusherReducedLandauLifshitz
+} //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/pusherConfig.param
+++ b/src/picongpu/include/simulation_defines/param/pusherConfig.param
@@ -62,6 +62,7 @@ namespace picongpu
         struct Boris;
         struct Photon;
         struct Free;
+        struct ReducedLandauLifshitz;
 #if(SIMDIM==DIM3)
         struct Axel;
 #endif

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -73,6 +73,8 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  *
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
  *
  * For development purposes: ---------------------------------------------------
  * - particles::pusher::None : no particle is pushed

--- a/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -31,7 +31,7 @@
 #include "particles/pusher/particlePusherVay.hpp"
 #include "particles/pusher/particlePusherFree.hpp"
 #include "particles/pusher/particlePusherPhoton.hpp"
-#include "particlePusherReducedLandauLifshitz.hpp"
+#include "particles/pusher/particlePusherReducedLandauLifshitz.hpp"
 #if(SIMDIM==DIM3)
 #include "particles/pusher/particlePusherAxel.hpp"
 #endif
@@ -67,11 +67,6 @@ struct Vay
     typedef particlePusherVay::Push<Velocity, Gamma<> > type;
 };
 
-struct ReducedLandauLifshitz
-{
-    typedef particlePusherReducedLandauLifshitz::Push<Velocity, Gamma<> > type;
-};
-
 struct Free
 {
     typedef particlePusherFree::Push<Velocity, Gamma<> > type;
@@ -80,6 +75,11 @@ struct Free
 struct Photon
 {
     typedef particlePusherPhoton::Push<Velocity, Gamma<> > type;
+};
+
+struct ReducedLandauLifshitz
+{
+    typedef particlePusherReducedLandauLifshitz::Push<Velocity, Gamma<> > type;
 };
 
 } //namespace pusher

--- a/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
@@ -31,6 +31,7 @@
 #include "particles/pusher/particlePusherVay.hpp"
 #include "particles/pusher/particlePusherFree.hpp"
 #include "particles/pusher/particlePusherPhoton.hpp"
+#include "particlePusherReducedLandauLifshitz.hpp"
 #if(SIMDIM==DIM3)
 #include "particles/pusher/particlePusherAxel.hpp"
 #endif
@@ -64,6 +65,11 @@ struct Boris
 struct Vay
 {
     typedef particlePusherVay::Push<Velocity, Gamma<> > type;
+};
+
+struct ReducedLandauLifshitz
+{
+    typedef particlePusherReducedLandauLifshitz::Push<Velocity, Gamma<> > type;
 };
 
 struct Free


### PR DESCRIPTION
This pull request adds the reduced Landau Lifshitz pusher (see [paper by M. Vranic](http://arxiv.org/abs/1502.02432)). It takes care of the classical radiation reaction, that reduces the energy of accelerated, charged particles due to radiation.

This pull request requires to  following pull requests to be merged:
- [x] #1201 field to particle interpolation in pusher
- [x] #1210 update pusher  interface
- [x] #1213 add weighting to pusher
- [x] #1215 extend margin for interpolation for each pusher
- [x] #1339 write interpolation routine to shift field data before interpolation

**Without these pull requests, the pusher will not work.**

The following physics tests need to be performed **before** merging to `dev`:
- [x] check independence of weighting
- [x] quantify energy loss in constant magnetic field
- [x] run KHI (there should be no significant difference below `B<10⁷ T` and `gamma<100`.

**Requires code update:**
- [x] add compile suit test, after #1205 is merged