### PR TITLE
Disallow assigning a HostBuffer to a DeviceBuffer from device

### DIFF
--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -74,7 +74,7 @@ public:
     HDINLINE DeviceBuffer(const Base& base) : Base(base) {}
 
     template<typename HBuffer>
-    HDINLINE
+    HINLINE
     DeviceBuffer& operator=(const HBuffer& rhs)
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::memoryTag, allocator::tag::host>::value));
@@ -93,8 +93,6 @@ public:
         return *this;
     }
 
-    //friend class ::PMacc::DeviceBuffer<Type, dim>;
-    //friend class ::PMacc::HostBuffer<Type, dim>;
 };
 
 } // container


### PR DESCRIPTION
Assigning a HostBuffer to a DeviceBuffer is not logically possible from device side. So we need `HINLINE` rather than `HDINLINE`

This fixes also the related **warning** about calling a host function from a host-device function

@Heikman 