### PR TITLE
Finish Renaming of Photon/Axel Pusher

### DIFF
--- a/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
@@ -31,7 +31,7 @@
 
 namespace picongpu
 {
-    namespace particlePusherAxl
+    namespace particlePusherAxel
     {
 
         template<class Velocity, class Gamma>

--- a/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
@@ -26,7 +26,7 @@
 
 namespace picongpu
 {
-    namespace particlePusherPhot
+    namespace particlePusherPhoton
     {
         template<class Velocity, class Gamma>
         struct Push

--- a/src/picongpu/include/simulation_defines/param/pusherConfig.param
+++ b/src/picongpu/include/simulation_defines/param/pusherConfig.param
@@ -41,7 +41,7 @@ namespace picongpu
     }
 
 
-    namespace particlePusherAxl
+    namespace particlePusherAxel
     {
 
         enum TrajectoryInterpolationType

--- a/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Axel Huebl, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -30,9 +30,9 @@
 #include "particles/pusher/particlePusherNone.hpp"
 #include "particles/pusher/particlePusherVay.hpp"
 #include "particles/pusher/particlePusherFree.hpp"
-#include "particles/pusher/particlePusherPhot.hpp"
+#include "particles/pusher/particlePusherPhoton.hpp"
 #if(SIMDIM==DIM3)
-#include "particles/pusher/particlePusherAxl.hpp"
+#include "particles/pusher/particlePusherAxel.hpp"
 #endif
 
 namespace picongpu
@@ -52,7 +52,7 @@ struct None
 
 struct Axel
 {
-    typedef particlePusherAxl::Push<Velocity, Gamma<> > type;
+    typedef particlePusherAxel::Push<Velocity, Gamma<> > type;
 };
 #endif
 
@@ -73,7 +73,7 @@ struct Free
 
 struct Photon
 {
-    typedef particlePusherPhot::Push<Velocity, Gamma<> > type;
+    typedef particlePusherPhoton::Push<Velocity, Gamma<> > type;
 };
 
 } //namespace pusher


### PR DESCRIPTION
Follow-Up to #1202 #1211:
- Forgot to move and rename Photon/Axel pusher
- forgot to update `pusher.param`

Makes the docs/namings/namespaces consistent again in the backend.