### PR TITLE
fix `AllCombinations<...>`

### DIFF
--- a/src/libPMacc/include/compileTime/AllCombinations.hpp
+++ b/src/libPMacc/include/compileTime/AllCombinations.hpp
@@ -33,6 +33,8 @@
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/copy.hpp>
 #include <boost/mpl/pop_back.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/empty.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace PMacc
@@ -90,6 +92,7 @@ struct AllCombinations<T_MplSeq, T_TmpResult, false >
 
     BOOST_STATIC_CONSTEXPR uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
     typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1 > > ::type LastElement;
+    typedef bmpl::empty<LastElement> IsLastElementEmpty;
     typedef typename MakeSeq<LastElement>::type LastElementAsSequence;
     typedef typename bmpl::pop_back<MplSeq>::type ShrinkedRangeVector;
 
@@ -105,7 +108,8 @@ struct AllCombinations<T_MplSeq, T_TmpResult, false >
 
     typedef typename MakeSeqFromNestedSeq<NestedSeq>::type OneSeq;
 
-    typedef typename detail::AllCombinations<ShrinkedRangeVector, OneSeq>::type type;
+    typedef typename detail::AllCombinations<ShrinkedRangeVector, OneSeq>::type ResultIfNotEmpty;
+    typedef typename bmpl::if_<IsLastElementEmpty,bmpl::vector0<>,ResultIfNotEmpty>::type type;
 };
 
 /** recursive end implementation
@@ -148,6 +152,7 @@ struct AllCombinations
 
     BOOST_STATIC_CONSTEXPR uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
     typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1 > > ::type LastElement;
+    typedef bmpl::empty<LastElement> IsLastElementEmpty;
     typedef typename MakeSeq<LastElement>::type LastElementAsSequence;
 
     typedef typename bmpl::pop_back<MplSeq>::type ShrinkedRangeVector;
@@ -166,7 +171,8 @@ struct AllCombinations
     >::type FirstList;
 
     /* result type: MplSequence of N-tuples */
-    typedef typename detail::AllCombinations<ShrinkedRangeVector, FirstList>::type type;
+    typedef typename detail::AllCombinations<ShrinkedRangeVector, FirstList>::type ResultIfNotEmpty;
+    typedef typename bmpl::if_<IsLastElementEmpty,bmpl::vector0<>,ResultIfNotEmpty>::type type;
 };
 
 


### PR DESCRIPTION
fix compile time error if input sequence is empty (e.g. boost::mpl::vector0<>)