### PR TITLE
Doc Laser Waist: GaussianBeam, PulseFrontTilt

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Anton Helm, Richard Pausch
+ * Copyright 2013-2015 Anton Helm, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -50,7 +50,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                              2.354820045
+ *                                          [   2.354820045      ]
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
@@ -59,8 +59,10 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15;
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
  *              at the focus position of the laser
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 4.246e-6;
+BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
 /** the distance to the laser focus in y-direction
  *  unit: meter */
 BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
@@ -97,17 +99,19 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
     *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-    *                                              2.354820045
+    *                                          [    2.354820045     ]
     *  Info:             FWHM_of_Intensity = FWHM_Illumination
     *                      = what a experimentalist calls "pulse duration"
     *  unit: seconds (1 sigma) */
 BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
-    *              decreases to its 1/e^2-th part,
-    *              at the focus position of the laser
-    *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 4.246e-6;
+ *              decreases to its 1/e^2-th part,
+ *              at the focus position of the laser
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
+ *  unit: meter */
+BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
 
 /** the distance to the laser focus in y-direction
     *  unit: meter */
@@ -164,7 +168,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 50.0*WAVE_LENGTH_S
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                              2.354820045
+ *                                          [    2.354820045     ]
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
@@ -218,7 +222,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                              2.354820045
+ *                                          [    2.354820045     ]
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -50,7 +50,7 @@ namespace picongpu
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-             *                                              2.354820045
+             *                                          [    2.354820045     ]
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
@@ -59,8 +59,10 @@ namespace picongpu
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
              *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6;
+            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
             /** the distance to the laser focus in y-direction
              *  unit: meter */
             BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
@@ -97,7 +99,7 @@ namespace picongpu
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-             *                                              2.354820045
+             *                                          [    2.354820045     ]
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
@@ -106,8 +108,10 @@ namespace picongpu
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
              *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 4.246e-6;
+            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
 
             /** the distance to the laser focus in y-direction
              *  unit: meter */
@@ -164,7 +168,7 @@ namespace picongpu
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-             *                                              2.354820045
+             *                                          [    2.354820045     ]
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
@@ -218,7 +222,7 @@ namespace picongpu
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-             *                                              2.354820045
+             *                                          [    2.354820045     ]
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -50,7 +50,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                              2.354820045
+ *                                          [    2.354820045     ]
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
@@ -59,8 +59,10 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15;
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
  *              at the focus position of the laser
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 4.246e-6;
+BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
 /** the distance to the laser focus in y-direction
  *  unit: meter */
 BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
@@ -106,17 +108,19 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
     *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-    *                                              2.354820045
+    *                                          [    2.354820045     ]
     *  Info:             FWHM_of_Intensity = FWHM_Illumination
     *                      = what a experimentalist calls "pulse duration"
     *  unit: seconds (1 sigma) */
 BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
-    *              decreases to its 1/e^2-th part,
-    *              at the focus position of the laser
-    *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 4.246e-6;
+ *              decreases to its 1/e^2-th part,
+ *              at the focus position of the laser
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
+ *  unit: meter */
+BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
 
 /** the distance to the laser focus in y-direction
     *  unit: meter */
@@ -173,7 +177,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = /*13.34e-15;*/6.0 
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                              2.354820045
+ *                                          [    2.354820045     ]
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
@@ -227,7 +231,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                              2.354820045
+ *                                          [    2.354820045     ]
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -50,7 +50,7 @@ namespace picongpu
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-             *                                              2.354820045
+             *                                          [    2.354820045     ]
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
@@ -59,8 +59,10 @@ namespace picongpu
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
              *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 4.246e-6;
+            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
             /** the distance to the laser focus in y-direction
              *  unit: meter */
             BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
@@ -97,17 +99,19 @@ namespace picongpu
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
                 *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-                *                                              2.354820045
+                *                                          [   2.354820045      ]
                 *  Info:             FWHM_of_Intensity = FWHM_Illumination
                 *                      = what a experimentalist calls "pulse duration"
                 *  unit: seconds (1 sigma) */
             BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
-                *              decreases to its 1/e^2-th part,
-                *              at the focus position of the laser
-                *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 4.246e-6;
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
 
             /** the distance to the laser focus in y-direction
                 *  unit: meter */
@@ -164,7 +168,7 @@ namespace picongpu
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-             *                                              2.354820045
+             *                                          [    2.354820045     ]
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
@@ -218,7 +222,7 @@ namespace picongpu
 
         /** Pulse length: sigma of std. gauss for intensity (E^2)
          *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-         *                                              2.354820045
+         *                                          [    2.354820045     ]
          *  Info:             FWHM_of_Intensity = FWHM_Illumination
          *                      = what a experimentalist calls "pulse duration"
          *  unit: seconds (1 sigma) */


### PR DESCRIPTION
This ~~changes~~ adds additional information to the the doc-string for the [beam waist](https://github.com/ComputationalRadiationPhysics/picongpu/blob/71af8e8bf07d9fb36c33df561cc1f796133fc16f/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp#L138) W0 of the Gaussian Beam and the tilted version of it for laser implementations.
    
~~Before that, the in-focus intensity was still correct but the waist would have been to small if one was following the documentation. This is an old documentation bug that someone changed in pre-review (svn) times that slipped through.~~ The very short documentation before caused some confusion when trying to compare to experiments (for me :) ).

~~Users: if you are using the GaussianBeam profile in your simulation, please cross-check if the beam waist was set to what you intended it to be. It might be too small (resulting in a still correct in-focus intensity but smaller spot size and steeper divergence).~~

![laserwaist4](https://cloud.githubusercontent.com/assets/1353258/11837505/af2eecfa-a3e1-11e5-8b03-d81be6d91203.png)

(image: [v1](https://cloud.githubusercontent.com/assets/1353258/11030380/f1ad804a-86cd-11e5-94c2-334cf050fb66.png), ~~[v2](https://cloud.githubusercontent.com/assets/1353258/11211733/c1aca8f2-8d31-11e5-8453-eea6bcfa5df9.png)~~, [v3](https://cloud.githubusercontent.com/assets/1353258/11213215/0b601c64-8d3b-11e5-88b6-a1ba032568c5.png), [v4](https://cloud.githubusercontent.com/assets/1353258/11837505/af2eecfa-a3e1-11e5-8b03-d81be6d91203.png))


### Tasks

- [x] update examples (values kept, default LWFA slight increase for consistency)
- [x] check [wavepacket definition](https://github.com/ComputationalRadiationPhysics/picongpu/blob/71af8e8bf07d9fb36c33df561cc1f796133fc16f/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp#L113-L116) -> wrong -> separate PR
- ~~[LaserPolynom](https://github.com/ComputationalRadiationPhysics/picongpu/blob/71af8e8bf07d9fb36c33df561cc1f796133fc16f/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp#L77)~~
- ~~write announcement on mailing list (after review)~~