### PR TITLE
Implement random buffer

### DIFF
--- a/src/libPMacc/include/random/RNGHandle.hpp
+++ b/src/libPMacc/include/random/RNGHandle.hpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "random/Random.hpp"
+#include "Environment.hpp"
+
+namespace PMacc
+{
+namespace random
+{
+
+    /**
+     * A reference to a state of a RNG provider
+     */
+    template<class T_RNGProvider>
+    struct RNGHandle
+    {
+        typedef T_RNGProvider RNGProvider;
+        BOOST_STATIC_CONSTEXPR uint32_t rngDim = RNGProvider::dim;
+        typedef typename RNGProvider::DataBoxType RNGBox;
+        typedef typename RNGProvider::RNGMethod RNGMethod;
+        typedef typename RNGMethod::StateType RNGState;
+        typedef PMacc::DataSpace<rngDim> RNGSpace;
+
+        template<class T_Distribution>
+        struct GetRandomType
+        {
+            typedef typename bmpl::apply<T_Distribution, RNGMethod>::type Distribution;
+            typedef Random<Distribution, RNGMethod, RNGState*> type;
+        };
+
+        /**
+         * Creates an instance of the functor
+         *
+         * @param rngBox Databox of the RNG provider
+         */
+        RNGHandle(const RNGBox& rngBox): m_rngBox(rngBox)
+        {}
+
+        /**
+         * Initializes this instance
+         *
+         * \param cellIdx index into the underlying RNG provider
+         */
+        HDINLINE void
+        init(const RNGSpace& cellIdx)
+        {
+            m_rngBox = m_rngBox.shift(cellIdx);
+        }
+
+        HDINLINE RNGState&
+        getState()
+        {
+            return m_rngBox(RNGSpace::create(0));
+        }
+
+        HDINLINE RNGState&
+        operator*()
+        {
+            return m_rngBox(RNGSpace::create(0));
+        }
+
+        HDINLINE RNGState&
+        operator->()
+        {
+            return m_rngBox(RNGSpace::create(0));
+        }
+
+        template<class T_Distribution>
+        HDINLINE typename GetRandomType<T_Distribution>::type
+        applyDistribution()
+        {
+            return GetRandomType<T_Distribution>::type(&getState());
+        }
+
+    protected:
+        PMACC_ALIGN8(m_rngBox, RNGBox);
+    };
+
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/RNGProvider.hpp
+++ b/src/libPMacc/include/random/RNGProvider.hpp
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "random/methods/Xor.hpp"
+#include "random/Random.hpp"
+#include "random/RNGHandle.hpp"
+#include "memory/buffers/GridBuffer.hpp"
+#include "dataManagement/ISimulationData.hpp"
+
+namespace PMacc
+{
+namespace random
+{
+
+    /**
+     * Provider of a per cell random number generator
+     *
+     * \tparam T_dim Number of dimensions of the grid
+     * \tparam T_RNGMethod Method to use for random number generation
+     */
+    template<uint32_t T_dim, class T_RNGMethod = methods::Xor>
+    class RNGProvider: ISimulationData
+    {
+    public:
+        BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+        typedef T_RNGMethod RNGMethod;
+        typedef DataSpace<dim> Space;
+
+    private:
+        typedef typename RNGMethod::StateType RNGState;
+        typedef GridBuffer< RNGState, dim > Buffer;
+
+        const Space m_size;
+        Buffer* buffer;
+        const std::string m_uniqueId;
+
+    public:
+        typedef typename Buffer::DataBoxType DataBoxType;
+        typedef RNGHandle<RNGProvider> Handle;
+
+        template<class T_Distribution>
+        struct GetRandomType
+        {
+            typedef typename bmpl::apply<T_Distribution, RNGMethod>::type Distribution;
+            typedef Random<Distribution, RNGMethod, Handle> type;
+        };
+
+        /**
+         * Create the RNGProvider and allocate memory for the given size
+         *
+         * @param size Size of the grid for which RNGs should be provided
+         * @param uniqueId Unique ID for this instance. If none is given the default
+         *          (as returned by \ref getName()) is used
+         */
+        RNGProvider(const Space& size, const std::string& uniqueId = "");
+        virtual ~RNGProvider()
+        {
+            __delete(buffer)
+        }
+        /**
+         * Initializes the random number generators
+         * Must be called before usage
+         * @param seed Base seed to be used
+         */
+        void init(uint32_t seed);
+
+        /**
+         * Factory method
+         * Creates a handle to a state that can be used to create actual RNGs
+         *
+         * @param id SimulationDataId of the RNGProvider to use. Defaults to the default Id of the type
+         */
+        static Handle
+        createHandle(const std::string& id = getName());
+
+        /**
+         * Factory method
+         * Creates functor that creates random numbers with a given distribution
+         * Similar to the Handle but can be used directly
+         *
+         * @param id SimulationDataId of the RNGProvider to use. Defaults to the default Id of the type
+         */
+        template<class T_Distribution>
+        static typename GetRandomType<T_Distribution>::type
+        createRandom(const std::string& id = getName());
+
+        /**
+         * Returns the default id for this type
+         */
+        static std::string getName();
+        SimulationDataId getUniqueId();
+        void synchronize();
+
+    private:
+        /**
+         * Gets the device data box
+         */
+        DataBoxType getDeviceDataBox();
+    };
+
+}  // namespace random
+}  // namespace PMacc
+
+#include "random/RNGProvider.tpp"

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "random/RNGProvider.hpp"
+#include "dimensions/DataSpaceOperations.hpp"
+
+namespace PMacc
+{
+namespace random
+{
+
+    namespace kernel {
+
+        template<class T_RNGMethod, class T_RNGBox, class T_Space>
+        __global__ void
+        initRNGProvider(T_RNGBox rngBox, uint32_t seed, const T_Space size)
+        {
+            const uint32_t linearTid = blockIdx.x * blockDim.x + threadIdx.x;
+            if(linearTid >= size.productOfComponents())
+                return;
+
+            const T_Space cellIdx = DataSpaceOperations<T_Space::dim>::map(size, linearTid);
+            T_RNGMethod().init(rngBox(cellIdx), seed, linearTid);
+        }
+
+    }  // namespace kernel
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    RNGProvider<T_dim, T_RNGMethod>::RNGProvider(const Space& size, const std::string& uniqueId):
+    		m_size(size), m_uniqueId(uniqueId.empty() ? getName() : uniqueId),
+    		buffer(new Buffer(size))
+    {
+        if(m_size.productOfComponents() == 0)
+            throw std::invalid_argument("Cannot create RNGProvider with zero size");
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    void RNGProvider<T_dim, T_RNGMethod>::init(uint32_t seed)
+    {
+
+        const uint32_t blockSize = 256;
+        const uint32_t gridSize = (m_size.productOfComponents() + blockSize - 1u) / blockSize; // Round up
+
+        PMACC_AUTO(bufferBox, buffer->getDeviceBuffer().getDataBox());
+
+        __cudaKernel(kernel::initRNGProvider<RNGMethod>)
+        (gridSize, blockSize)
+        (bufferBox, seed, m_size);
+
+        Environment<dim>::get().DataConnector().registerData(*this);
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    typename RNGProvider<T_dim, T_RNGMethod>::Handle
+    RNGProvider<T_dim, T_RNGMethod>::createHandle(const std::string& id)
+    {
+        RNGProvider& provider = Environment<>::get().DataConnector().getData<RNGProvider>(id, true);
+        Handle result(provider.getDeviceDataBox());
+        Environment<>::get().DataConnector().releaseData(id);
+        return result;
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    template<class T_Distribution>
+    typename RNGProvider<T_dim, T_RNGMethod>::GetRandomType<T_Distribution>::type
+    RNGProvider<T_dim, T_RNGMethod>::createRandom(const std::string& id)
+    {
+        typedef typename GetRandomType<T_Distribution>::type ResultType;
+        return ResultType(createHandle());
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    RNGProvider<T_dim, T_RNGMethod>::DataBoxType
+    RNGProvider<T_dim, T_RNGMethod>::getDeviceDataBox()
+    {
+        return buffer->getDeviceBuffer().getDataBox();
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    std::string
+    RNGProvider<T_dim, T_RNGMethod>::getName()
+    {
+        /* generate a unique name (for this type!) to use as a default ID */
+        return std::string("RNGProvider")
+                + boost::lexical_cast<std::string>(dim+0) /* +0 to create a rvalue of the class const(expr) */
+                + RNGMethod::getName();
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    SimulationDataId
+    RNGProvider<T_dim, T_RNGMethod>::getUniqueId()
+    {
+        return m_uniqueId;
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
+    void
+    RNGProvider<T_dim, T_RNGMethod>::synchronize()
+    {
+        buffer->deviceToHost();
+    }
+
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/RNGState.hpp
+++ b/src/libPMacc/include/random/RNGState.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+namespace PMacc
+{
+namespace random
+{
+
+    /**
+     * Wrapper class for a state of a random number generator
+     * Can be used for aligned storing of states
+     */
+    template<class T_RNGMethod>
+    class RNGState
+    {
+    public:
+        typedef T_RNGMethod RNGMethod;
+        typedef typename RNGMethod::StateType StateType;
+
+        HDINLINE RNGState()
+        {}
+
+        HDINLINE RNGState(const StateType& other): state(other)
+        {}
+
+        HDINLINE StateType&
+        getState()
+        {
+            return state;
+        }
+    private:
+        PMACC_ALIGN8(StateType) state;
+    };
+
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/Random.hpp
+++ b/src/libPMacc/include/random/Random.hpp
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "random/RNGState.hpp"
+#include <boost/utility/result_of.hpp>
+
+namespace PMacc
+{
+namespace random
+{
+
+    /**
+     * Random Number Generator. Functor that returns a random number per call
+     *
+     * Default implementation assumes a RNGHandle
+     */
+    template<
+        class T_Distribution,
+        class T_RNGMethod,
+        class T_RNGStatePtrOrHandle = typename T_RNGMethod::StateType*
+    >
+    struct Random: private T_Distribution, private T_RNGStatePtrOrHandle
+    {
+        typedef T_RNGMethod RNGMethod;
+        /* RNGHandle assumed */
+        typedef T_RNGStatePtrOrHandle RNGHandle;
+        typedef T_Distribution Distribution;
+        typedef typename boost::result_of<Distribution(typename RNGHandle::RNGState&)>::type result_type;
+
+        /** This can be constructed with either the RNGBox (like the RNGHandle) or from an RNGHandle instance */
+        template<class T_RNGBoxOrHandle>
+        explicit HINLINE Random(const T_RNGBoxOrHandle& rngBox): RNGHandle(rngBox)
+        {}
+
+        /**
+         * Initializes this instance
+         *
+         * \param cellIdx index into the underlying RNG Provider
+         */
+        template<typename T_Offset>
+        HDINLINE void
+        init(const T_Offset& cellIdx)
+        {
+            RNGHandle::init(cellIdx);
+        }
+
+        /** Returns a new random number advancing the state */
+        DINLINE result_type
+        operator()()
+        {
+            return Distribution::operator()(RNGHandle::getState());
+        }
+    };
+
+    /**
+     * Specialization when the state is a pointer
+     */
+    template<
+        class T_Distribution,
+        class T_RNGMethod,
+        class T_RNGState
+    >
+    struct Random<T_Distribution, T_RNGMethod, T_RNGState*>: private T_Distribution
+    {
+        typedef T_RNGMethod RNGMethod;
+        typedef T_RNGState RNGState;
+        typedef T_Distribution Distribution;
+        typedef typename boost::result_of<Distribution(RNGState&)>::type result_type;
+
+        HDINLINE Random(): m_rngState(NULL)
+        {}
+
+        HDINLINE Random(RNGState* m_rngState): m_rngState(m_rngState)
+        {}
+
+        /** Returns a new random number advancing the state */
+        DINLINE result_type
+        operator()()
+        {
+            return Distribution::operator()(*m_rngState);
+        }
+
+    protected:
+        PMACC_ALIGN(m_rngState, RNGState*);
+    };
+
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/distributions/Normal.hpp
+++ b/src/libPMacc/include/random/distributions/Normal.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+namespace PMacc
+{
+namespace random
+{
+namespace distributions
+{
+    namespace detail
+    {
+        /** Only this must be specialized for different types */
+        template<typename T_Type, class T_RNGMethod, class T_SFINAE = void>
+        class Normal;
+    }
+
+    /**
+     * Returns a random, normal distributed value of the given type
+     */
+    template<typename T_Type, class T_RNGMethod = bmpl::_1>
+    class Normal: public detail::Normal<T_Type, T_RNGMethod>
+    {};
+
+}  // namespace distributions
+}  // namespace random
+}  // namespace PMacc
+
+#include "random/distributions/normal/Normal_float.hpp"

--- a/src/libPMacc/include/random/distributions/Uniform.hpp
+++ b/src/libPMacc/include/random/distributions/Uniform.hpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+namespace PMacc
+{
+namespace random
+{
+namespace distributions
+{
+    namespace detail {
+
+        /** Only this must be specialized for different types */
+        template<typename T_Type, class T_RNGMethod, class T_SFINAE = void>
+        class Uniform;
+
+    }  // namespace detail
+
+    /**
+     * Returns a random, uniformly distributed value of the given type
+     */
+    template<typename T_Type, class T_RNGMethod = bmpl::_1>
+    class Uniform: public detail::Uniform<T_Type, T_RNGMethod>
+    {};
+
+}  // namespace distributions
+}  // namespace random
+}  // namespace PMacc
+
+#include "random/distributions/uniform/Uniform_float.hpp"
+#include "random/distributions/uniform/Uniform_Integral32Bit.hpp"

--- a/src/libPMacc/include/random/distributions/normal/Normal_float.hpp
+++ b/src/libPMacc/include/random/distributions/normal/Normal_float.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "random/distributions/Normal.hpp"
+
+namespace PMacc
+{
+namespace random
+{
+namespace distributions
+{
+namespace detail
+{
+
+    /**
+     * Returns a random float value in [0,1) with normal distribution
+     */
+    template<class T_RNGMethod>
+    class Normal<float, T_RNGMethod, void>
+    {
+        typedef T_RNGMethod RNGMethod;
+        typedef typename RNGMethod::StateType StateType;
+    public:
+        typedef float result_type;
+
+        DINLINE result_type
+        operator()(StateType& state)
+        {
+            return curand_normal(&state);
+        }
+    };
+
+}  // namespace detail
+}  // namespace distributions
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/distributions/uniform/Uniform_Integral32Bit.hpp
+++ b/src/libPMacc/include/random/distributions/uniform/Uniform_Integral32Bit.hpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "random/distributions/Uniform.hpp"
+#include <boost/type_traits.hpp>
+
+namespace PMacc
+{
+namespace random
+{
+namespace distributions
+{
+namespace detail
+{
+
+    /**
+     * Returns a random, uniformly distributed (up to) 32 bit integral value
+     */
+    template<typename T_Type, class T_RNGMethod>
+    class Uniform<
+        T_Type,
+        T_RNGMethod,
+        typename bmpl::if_c<
+            boost::is_integral<T_Type>::value && sizeof(T_Type) <= 4,
+            void,
+            T_Type
+        >::type
+    >
+    {
+        typedef T_RNGMethod RNGMethod;
+        typedef typename RNGMethod::StateType StateType;
+    public:
+        typedef T_Type result_type;
+
+        DINLINE result_type
+        operator()(StateType& state)
+        {
+            return static_cast<result_type>(RNGMethod().get32Bits(state));
+        }
+    };
+
+}  // namespace detail
+}  // namespace distributions
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/distributions/uniform/Uniform_float.hpp
+++ b/src/libPMacc/include/random/distributions/uniform/Uniform_float.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "random/distributions/Uniform.hpp"
+
+namespace PMacc
+{
+namespace random
+{
+namespace distributions
+{
+namespace detail
+{
+
+    /**
+     * Returns a random float value uniformly distributed in [0,1)
+     */
+    template<class T_RNGMethod>
+    class Uniform<float, T_RNGMethod, void>
+    {
+        typedef T_RNGMethod RNGMethod;
+        typedef typename RNGMethod::StateType StateType;
+    public:
+        typedef float result_type;
+
+        DINLINE result_type
+        operator()(StateType& state)
+        {
+            return _curand_uniform(RNGMethod().get32Bits(state));
+        }
+    };
+
+}  // namespace detail
+}  // namespace distributions
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/methods/Xor.hpp
+++ b/src/libPMacc/include/random/methods/Xor.hpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include <curand_kernel.h>
+
+namespace PMacc
+{
+namespace random
+{
+namespace methods
+{
+
+    /** Uses the CUDA XORWOW RNG */
+    class Xor
+    {
+    public:
+        typedef curandStateXORWOW_t StateType;
+
+        DINLINE void
+        init(StateType& state, uint32_t seed, uint32_t subsequence = 0, uint32_t offset = 0) const
+        {
+            curand_init(seed, subsequence, offset, &state);
+        }
+
+        DINLINE uint32_t
+        get32Bits(StateType& state) const
+        {
+            return curand(&state);
+        }
+
+        static std::string
+        getName()
+        {
+            return "Xor";
+        }
+    };
+
+}  // namespace methods
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/methods/XorMin.hpp
+++ b/src/libPMacc/include/random/methods/XorMin.hpp
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2015 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include <curand_kernel.h>
+#include <random/methods/Xor.hpp>
+
+namespace PMacc
+{
+namespace random
+{
+namespace methods
+{
+
+    /** Uses the CUDA XORWOW RNG but does not store state members required for normal distribution*/
+    class XorMin
+    {
+    public:
+        class StateType
+        {
+        public:
+            PMACC_ALIGN(d, unsigned int);
+            PMACC_ALIGN(v[5], unsigned int);
+
+            HDINLINE StateType()
+            {}
+
+            HDINLINE StateType(const curandStateXORWOW_t& other): d(other.d), v{other.v[0], other.v[1], other.v[2], other.v[3], other.v[4]}
+            {
+                static_assert(sizeof(v) == sizeof(other.v), "Unexpected sizes");
+            }
+        };
+
+        DINLINE void
+        init(StateType& state, uint32_t seed, uint32_t subsequence = 0, uint32_t offset = 0) const
+        {
+            curandStateXORWOW_t tmpState;
+            curand_init(seed, subsequence, offset, &tmpState);
+            state = tmpState;
+        }
+
+        HDINLINE uint32_t
+        get32Bits(StateType& state) const
+        {
+            /* This generator uses the xorwow formula of
+            www.jstatsoft.org/v08/i14/paper page 5
+            Has period 2^192 - 2^32.
+            */
+            uint32_t t;
+            t = (state.v[0] ^ (state.v[0] >> 2));
+            state.v[0] = state.v[1];
+            state.v[1] = state.v[2];
+            state.v[2] = state.v[3];
+            state.v[3] = state.v[4];
+            state.v[4] = (state.v[4] ^ (state.v[4] <<4)) ^ (t ^ (t << 1));
+            state.d += 362437;
+            return state.v[4] + state.d;
+        }
+
+        static std::string
+        getName()
+        {
+            return "XorMin";
+        }
+    };
+
+}  // namespace methods
+}  // namespace random
+}  // namespace PMacc


### PR DESCRIPTION
This implements a buffer for storing the random states `RNGProvider` to avoid reinitialising the RNG on every step.
All functionality currently provided by the RNG implementation of PMacc is also provided by this, so it can be used instead of the current implementation.

Typical usage: 
***1) Setup***

1. Create a typedef for the RNGProvider(s) you want to use: `using RNGProvider = PMacc::random::RNGProvider<simDim>;`
2. Create a (per rank) instance of the provider with the required size: `new RNGProvider(Environment::get().SubGrid().getLocalDomain().size)`   
You can optionally specify an id for this instance. The default id is sufficient if there is only one instance per `RNGProvider` type.
3. Initialize it with a (per rank) seed: `rngProvider_->init(seed);`

***2a) Usage with reusable handle (one handle, many distributions)***

1. Get the Handle type out of the RNGProvider:   
`using RNGHandle = typename RNGProvider::Handle;`
2. Choose a distribution:   
`using Distribution = PMacc::random::distributions::Uniform_float<>;`
3. Get the Random (Functor) type by combining those:   
`using Random = typename RNGHandle::GetRandomType<Distribution>::type;`
4. Construct the handle:   
`RNGHandle randHandle(RNGProvider::createHandle())`   
Here you specify the id of the RNGProvider instance to use. Again the default id is used.
5. (Usually on the device) initialize the handle:   
`randHandle.init(localCellIdx);`
6. Get the random functor:   
`Random rand = randHandle.applyDistribution<Distribution>();`
7. Use it by calling it: `rand()`

It is possible, to store the state into shared memory by calling `randHandle.getState()` after 5. and use that for multiple `Random` functors by passing a pointer to the state to `Random`s constructor.

***2b) Shortcut without reusable handle (one handle, one distribution)***

1. Choose a distribution:   
`using Distribution = PMacc::random::distributions::Uniform_float<>;`
2. Get the Random (Functor) type out of the Provider:   
`using Random = typename RNGProvider::GetRandomType<Distribution>::type;`
3. Construct the functor:   
`Random random(RNGProvider::createRandom())`   
Here you specify the id of the RNGProvider instance to use. Again the default id is used.
4. (Usually on the device) initialize the functor:   
`random.init(localCellIdx);`
5. Use it by calling it: `rand()`

