### PR TITLE
refactor traits::GetIonizer

### DIFF
--- a/src/picongpu/include/particles/traits/GetIonizer.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizer.hpp
@@ -41,23 +41,14 @@ struct GetIonizer
     typedef T_SpeciesType SpeciesType;
     typedef typename SpeciesType::FrameType FrameType;
 
-    typedef typename HasFlag<FrameType, ionizer<> >::type hasIonizer;
-
     /* The following line only fetches the alias */
     typedef typename GetFlagType<FrameType,ionizer<> >::type FoundIonizerAlias;
 
     /* This now resolves the alias into the actual object type */
     typedef typename PMacc::traits::Resolve<FoundIonizerAlias>::type FoundIonizer;
 
-    /* This specifies the source species as the second template parameter of the ionization model */
-     typedef typename bmpl::if_<
-        hasIonizer,
-        FoundIonizer,
-        particles::ionization::None<SpeciesType>
-    >::type UserIonizer;
-
     /* specializes the designated ionization model with the particle species it is called upon */
-    typedef typename bmpl::apply1<typename UserIonizer::type, SpeciesType>::type type;
+    typedef typename bmpl::apply1<typename FoundIonizer::type, SpeciesType>::type type;
 
 }; // struct GetIonizer
 

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -402,10 +402,13 @@ public:
     {
         namespace nvfct = PMacc::nvidia::functors;
 
-        /* Initialize ionization routine for each species
-         *      - valid species will be ionized
-         *      - invalid species (e.g. electrons): fallback */
-        ForEach<VectorAllSpecies, particles::CallIonization<bmpl::_1>, MakeIdentifier<bmpl::_1> > particleIonization;
+        /* Initialize ionization routine for each species with the flag `ionizer<>` */
+        typedef typename PMacc::particles::traits::FilterByFlag
+        <
+            VectorAllSpecies,
+            ionizer<>
+        >::type VectorSpeciesWithIonizer;
+        ForEach<VectorSpeciesWithIonizer, particles::CallIonization<bmpl::_1>, MakeIdentifier<bmpl::_1> > particleIonization;
         particleIonization(forward(particleStorage), cellDescription, currentStep);
 
         EventTask initEvent = __getTransactionEvent();


### PR DESCRIPTION
- remove fallback to `particles::ionization::None<...>`
- `MySimulation.hpp` - filter species with ionizer before call of `CallIonization<>`