### PR TITLE
refactor particle box interface

### DIFF
--- a/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
@@ -38,16 +38,16 @@ template< class ParBox>
 __global__ void kernelAddOneParticle(ParBox pb,
                                      DataSpace<simDim> superCell, DataSpace<simDim> parLocalCell)
 {
-    typedef typename ParBox::FrameType FRAME;
+    typedef typename ParBox::FramePtr FramePtr;
 
-    FRAME *frame;
+    FramePtr frame;
 
     int linearIdx = DataSpaceOperations<simDim>::template map<MappingDesc::SuperCellSize > (parLocalCell);
 
     float_X parWeighting = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
 
-    frame = &(pb.getEmptyFrame());
-    pb.setAsLastFrame(*frame, superCell);
+    frame = pb.getEmptyFrame();
+    pb.setAsLastFrame(frame, superCell);
 
 
 
@@ -56,7 +56,7 @@ __global__ void kernelAddOneParticle(ParBox pb,
     for (unsigned i = 0; i < 1; ++i)
     {
 
-        PMACC_AUTO(par, (*frame)[i]);
+        PMACC_AUTO(par, frame[i]);
 
         /** we now initialize all attributes of the new particle to their default values
          *   some attributes, such as the position, localCellIdx, weighting or the

--- a/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
@@ -41,16 +41,16 @@ template< class ParBox>
 __global__ void kernelAddOneParticle(ParBox pb,
                                      DataSpace<simDim> superCell, DataSpace<simDim> parLocalCell)
 {
-    typedef typename ParBox::FrameType FRAME;
+    typedef typename ParBox::FramePtr FramePtr;
 
-    FRAME *frame;
+    FramePtr frame;
 
     int linearIdx = DataSpaceOperations<simDim>::template map<MappingDesc::SuperCellSize > (parLocalCell);
 
     float_X parWeighting = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
 
-    frame = &(pb.getEmptyFrame());
-    pb.setAsLastFrame(*frame, superCell);
+    frame = pb.getEmptyFrame();
+    pb.setAsLastFrame(frame, superCell);
 
 
 
@@ -58,7 +58,7 @@ __global__ void kernelAddOneParticle(ParBox pb,
     // many particle loop:
     for (unsigned i = 0; i < 1; ++i)
     {
-        PMACC_AUTO(par, (*frame)[i]);
+        PMACC_AUTO(par, frame[i]);
 
         /** we now initialize all attributes of the new particle to their default values
          *   some attributes, such as the position, localCellIdx, weighting or the

--- a/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
@@ -38,16 +38,16 @@ template< class ParBox>
 __global__ void kernelAddOneParticle(ParBox pb,
                                      DataSpace<simDim> superCell, DataSpace<simDim> parLocalCell)
 {
-    typedef typename ParBox::FrameType FRAME;
+    typedef typename ParBox::FramePtr FramePtr;
 
-    FRAME *frame;
+    FramePtr frame;
 
     int linearIdx = DataSpaceOperations<simDim>::template map<MappingDesc::SuperCellSize > (parLocalCell);
 
     float_X parWeighting = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
 
-    frame = &(pb.getEmptyFrame());
-    pb.setAsLastFrame(*frame, superCell);
+    frame = pb.getEmptyFrame();
+    pb.setAsLastFrame(frame, superCell);
 
 
 
@@ -55,7 +55,7 @@ __global__ void kernelAddOneParticle(ParBox pb,
     // many particle loop:
     for (unsigned i = 0; i < 1; ++i)
     {
-        PMACC_AUTO(par, (*frame)[i]);
+        PMACC_AUTO(par, frame[i]);
 
         /** we now initialize all attributes of the new particle to their default values
          *   some attributes, such as the position, localCellIdx, weighting or the

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -38,14 +38,14 @@ namespace PMacc
 {
 
 template<typename T_ParticleBox, typename T_SuperCellIdxType>
-DINLINE bool getPreviousFrameAndRemoveLastFrame(typename T_ParticleBox::FrameType*& frame,
-                                                T_ParticleBox& pb,
-                                                const T_SuperCellIdxType& superCellIdx)
+DINLINE typename T_ParticleBox::FramePtr
+getPreviousFrameAndRemoveLastFrame( const typename T_ParticleBox::FramePtr& frame,
+                                    T_ParticleBox& pb,
+                                    const T_SuperCellIdxType& superCellIdx )
 {
-    bool isFrameValid = false;
-    frame = &(pb.getPreviousFrame(*frame, isFrameValid));
-    const bool hasMoreFrames = pb.removeLastFrame(superCellIdx);
-    return isFrameValid && hasMoreFrames;
+    typename T_ParticleBox::FramePtr result = pb.getPreviousFrame( frame );
+    pb.removeLastFrame( superCellIdx );
+    return result;
 }
 
 /*! This kernel move particles to the next supercell
@@ -54,7 +54,11 @@ DINLINE bool getPreviousFrameAndRemoveLastFrame(typename T_ParticleBox::FrameTyp
 template<class T_ParBox, class Mapping>
 __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
 {
-    typedef typename T_ParBox::FrameType FrameType;
+    typedef T_ParBox ParBox;
+    typedef typename ParBox::FrameType FrameType;
+    typedef typename ParBox::FramePtr FramePtr;
+    typedef typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type FramePtrShared;
+
     const uint32_t dim = Mapping::Dim;
     const uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
     /* number exchanges in 2D=9 and in 3D=27 */
@@ -64,14 +68,13 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
      * index range [0,numExchanges-1] are being referred to as `low frames`
      * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
      */
-    __shared__ FrameType * destFrames[numExchanges * 2];
+    __shared__ FramePtrShared destFrames[numExchanges * 2];
     __shared__ int destFramesCounter[numExchanges]; //count particles per frame
 
     /* lastFrameSize is only valid for threads with `linearThreadIdx` < numExchanges */
     uint32_t lastFrameSize = 0;
 
-    __shared__ FrameType *frame;
-    __shared__ bool isFrameValid;
+    __shared__ FramePtrShared frame;
     __shared__ bool mustShift;
 
     DataSpace<dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<dim> (blockIdx) );
@@ -79,18 +82,16 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
 
     if ( linearThreadIdx == 0 )
     {
-        isFrameValid = false;
         mustShift = pb.getSuperCell( superCellIdx ).mustShift( );
         if ( mustShift )
         {
             pb.getSuperCell( superCellIdx ).setMustShift( false );
-            frame = &(pb.getFirstFrame( superCellIdx, isFrameValid ));
+            frame = pb.getFirstFrame( superCellIdx );
         }
     }
 
     __syncthreads( );
-
-    if ( !mustShift || isFrameValid == false ) return;
+    if ( !mustShift || !frame.isValid( ) ) return;
 
     const DataSpace<dim> relative = superCellIdx + Mask::getRelativeDirections<dim> (linearThreadIdx + 1);
 
@@ -99,20 +100,19 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
      */
     if ( linearThreadIdx < numExchanges )
     {
-        bool hasNeighborFrame = false;
         destFramesCounter[linearThreadIdx] = 0;
-        destFrames[linearThreadIdx] = NULL;
-        destFrames[linearThreadIdx + numExchanges] = NULL;
+        destFrames[linearThreadIdx] = FramePtr();
+        destFrames[linearThreadIdx + numExchanges] = FramePtr();
         /* load last frame of neighboring supercell */
-        FrameType& tmpFrame = pb.getLastFrame( relative, hasNeighborFrame );
+        FramePtrShared tmpFrame(pb.getLastFrame( relative ));
 
-        if ( hasNeighborFrame )
+        if ( tmpFrame.isValid() )
         {
             lastFrameSize = pb.getSuperCell( relative ).getSizeLastFrame( );
             // do not use the neighbor's last frame if it is full
             if ( lastFrameSize < frameSize )
             {
-                destFrames[linearThreadIdx] = &tmpFrame;
+                destFrames[linearThreadIdx] = tmpFrame;
                 destFramesCounter[linearThreadIdx] = lastFrameSize;
             }
         }
@@ -120,7 +120,7 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
     __syncthreads( );
 
     /* iterate over the frame list of the current supercell */
-    while ( isFrameValid )
+    while ( frame.isValid() )
     {
         lcellId_t destParticleIdx = INV_LOC_IDX;
 
@@ -130,7 +130,7 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
          * >=0 particle moves in a certain direction
          *     (@see ExchangeType in types.h)
          */
-        int direction = (*frame)[linearThreadIdx][multiMask_] - 2;
+        int direction = frame[linearThreadIdx][multiMask_] - 2;
         if ( direction >= 0 )
         {
             destParticleIdx = atomicAdd( &(destFramesCounter[direction]), 1 );
@@ -151,18 +151,18 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
             {
                 lastFrameSize = destFramesCounter[linearThreadIdx];
                 /* if we had no `low frame` we load a new empty one */
-                if ( destFrames[linearThreadIdx] == NULL )
+                if ( !destFrames[linearThreadIdx].isValid() )
                 {
-                    FrameType& tmpFrame = pb.getEmptyFrame( );
-                    destFrames[linearThreadIdx] = &tmpFrame;
+                    FramePtrShared tmpFrame(pb.getEmptyFrame( ));
+                    destFrames[linearThreadIdx] = tmpFrame;
                     pb.setAsLastFrame( tmpFrame, relative );
                 }
                 /* check if a `high frame` is needed */
                 if ( destFramesCounter[linearThreadIdx] > frameSize )
                 {
                         lastFrameSize = destFramesCounter[linearThreadIdx] - frameSize;
-                        FrameType& tmpFrame = pb.getEmptyFrame( );
-                        destFrames[linearThreadIdx + numExchanges] = &tmpFrame;
+                        FramePtrShared tmpFrame(pb.getEmptyFrame( ));
+                        destFrames[linearThreadIdx + numExchanges] = tmpFrame;
                         pb.setAsLastFrame( tmpFrame, relative );
                 }
             }
@@ -184,8 +184,8 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
                 direction += numExchanges;
                 destParticleIdx -= frameSize;
             }
-            PMACC_AUTO( dstParticle, (*(destFrames[direction]))[destParticleIdx] );
-            PMACC_AUTO( srcParticle, (*frame)[linearThreadIdx] );
+            PMACC_AUTO( dstParticle, destFrames[direction][destParticleIdx] );
+            PMACC_AUTO( srcParticle, frame[linearThreadIdx] );
             dstParticle[multiMask_] = 1;
             srcParticle[multiMask_] = 0;
             PMACC_AUTO( dstFilteredParticle,
@@ -204,11 +204,11 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
             {
                 destFramesCounter[linearThreadIdx] -= frameSize;
                 destFrames[linearThreadIdx] = destFrames[linearThreadIdx + numExchanges];
-                destFrames[linearThreadIdx + numExchanges] = NULL;
+                destFrames[linearThreadIdx + numExchanges] = FramePtr();
             }
             if ( linearThreadIdx == 0 )
             {
-                frame = &(pb.getNextFrame( *frame, isFrameValid ));
+                frame = pb.getNextFrame( frame );
             }
         }
         __syncthreads( );
@@ -223,8 +223,8 @@ __global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
     }
 }
 
-template<class FRAME, class Mapping>
-__global__ void kernelFillGapsLastFrame(ParticlesBox<FRAME, Mapping::Dim> pb, Mapping mapper)
+template<class ParBox, class Mapping>
+__global__ void kernelFillGapsLastFrame( ParBox pb, Mapping mapper )
 {
     using namespace particles::operations;
 
@@ -234,10 +234,11 @@ __global__ void kernelFillGapsLastFrame(ParticlesBox<FRAME, Mapping::Dim> pb, Ma
         Dim = Mapping::Dim
     };
 
-    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx));
+    typedef typename ParBox::FramePtr FramePtr;
 
-    __shared__ FRAME *lastFrame;
-    __shared__ bool isValid;
+    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
+
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
 
     __shared__ int gapIndices_sh[TileSize];
     __shared__ int counterGaps;
@@ -246,55 +247,55 @@ __global__ void kernelFillGapsLastFrame(ParticlesBox<FRAME, Mapping::Dim> pb, Ma
     __shared__ int srcGap;
 
 
-    if (threadIdx.x == 0)
+    if ( threadIdx.x == 0 )
     {
-        lastFrame = &(pb.getLastFrame(DataSpace<Dim > (superCellIdx), isValid));
+        lastFrame = pb.getLastFrame( DataSpace<Dim > (superCellIdx) );
         counterGaps = 0;
         counterParticles = 0;
         srcGap = 0;
     }
-    __syncthreads();
+    __syncthreads( );
 
 
-    if (isValid)
+    if ( lastFrame.isValid( ) )
     {
         //count particles in last frame
-        const bool isParticle = (*lastFrame)[threadIdx.x][multiMask_];
-        if (isParticle == true) //\todo: bits zählen
+        const bool isParticle = lastFrame[threadIdx.x][multiMask_];
+        if ( isParticle == true ) //\todo: bits zählen
         {
-            nvidia::atomicAllInc(&counterParticles);
+            nvidia::atomicAllInc( &counterParticles );
         }
-        __syncthreads();
+        __syncthreads( );
 
-        if (threadIdx.x < counterParticles && isParticle == false)
+        if ( threadIdx.x < counterParticles && isParticle == false )
         {
-            const int localGapIdx = nvidia::atomicAllInc(&counterGaps);
+            const int localGapIdx = nvidia::atomicAllInc( &counterGaps );
             gapIndices_sh[localGapIdx] = threadIdx.x;
         }
-        __syncthreads();
-        if (threadIdx.x >= counterParticles && isParticle)
+        __syncthreads( );
+        if ( threadIdx.x >= counterParticles && isParticle )
         {
             //any particle search a gap
-            const int srcGapIdx = nvidia::atomicAllInc(&srcGap);
+            const int srcGapIdx = nvidia::atomicAllInc( &srcGap );
             const int gapIdx = gapIndices_sh[srcGapIdx];
-            PMACC_AUTO(parDestFull, ((*lastFrame)[gapIdx]));
+            PMACC_AUTO( parDestFull, lastFrame[gapIdx] );
             /*enable particle*/
             parDestFull[multiMask_] = 1;
             /* we not update multiMask because copy from mem to mem is to slow
              * we have enabled particle explicit */
-            PMACC_AUTO(parDest, deselect<multiMask>(parDestFull));
-            PMACC_AUTO(parSrc, ((*lastFrame)[threadIdx.x]));
-            assign(parDest, parSrc);
+            PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
+            PMACC_AUTO( parSrc, (lastFrame[threadIdx.x]) );
+            assign( parDest, parSrc );
             parSrc[multiMask_] = 0; //delete old partice
         }
     }
-    if (threadIdx.x == 0)
-        pb.getSuperCell(superCellIdx).setSizeLastFrame(counterParticles);
+    if ( threadIdx.x == 0 )
+        pb.getSuperCell( superCellIdx ).setSizeLastFrame( counterParticles );
 
 }
 
-template<class FRAME, class Mapping>
-__global__ void kernelFillGaps(ParticlesBox<FRAME, Mapping::Dim> pb, Mapping mapper)
+template<class ParBox, class Mapping>
+__global__ void kernelFillGaps( ParBox pb, Mapping mapper )
 {
     using namespace particles::operations;
 
@@ -304,32 +305,30 @@ __global__ void kernelFillGaps(ParticlesBox<FRAME, Mapping::Dim> pb, Mapping map
         Dim = Mapping::Dim
     };
 
-    DataSpace<Dim> superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
+    typedef typename ParBox::FramePtr FramePtr;
+
+    DataSpace<Dim> superCellIdx( mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) ) );
 
     //data copied from right (last) to left (first)
-    __shared__ FRAME *firstFrame;
-    __shared__ FRAME *lastFrame;
-    __shared__ bool isValid;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type firstFrame;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
 
     __shared__ int particleIndices_sh[TileSize];
     __shared__ int counterGaps;
     __shared__ int counterParticles;
 
 
-    if (threadIdx.x == 0)
+    if ( threadIdx.x == 0 )
     {
-        bool tmpValid;
-        firstFrame = &(pb.getFirstFrame(DataSpace<Dim > (superCellIdx), tmpValid));
-        lastFrame = &(pb.getLastFrame(DataSpace<Dim > (superCellIdx), isValid));
-        isValid = isValid && tmpValid;
+        firstFrame = pb.getFirstFrame( DataSpace<Dim > (superCellIdx) );
+        lastFrame = pb.getLastFrame( DataSpace<Dim > (superCellIdx) );
     }
-    __syncthreads();
+    __syncthreads( );
 
-    while (isValid)
+    while ( firstFrame.isValid( ) && firstFrame != lastFrame )
     {
-        if (firstFrame == lastFrame) break; /*exit loop if both frames are equal*/
 
-        if (threadIdx.x == 0)
+        if ( threadIdx.x == 0 )
         {
             //\todo: check if we need control thread or can write to shared with all threads
             counterGaps = 0;
@@ -337,127 +336,123 @@ __global__ void kernelFillGaps(ParticlesBox<FRAME, Mapping::Dim> pb, Mapping map
         }
         int localGapIdx = INV_LOC_IDX; //later we cann call localGapIdx < X because X<INV_LOC_IDX
 
-        __syncthreads();
+        __syncthreads( );
 
         // find gaps
-        if ((*firstFrame)[threadIdx.x][multiMask_] == 0)
+        if ( firstFrame[threadIdx.x][multiMask_] == 0 )
         {
-            localGapIdx = nvidia::atomicAllInc(&counterGaps);
+            localGapIdx = nvidia::atomicAllInc( &counterGaps );
         }
-        __syncthreads();
+        __syncthreads( );
 
-        if (counterGaps == 0)
+        if ( counterGaps == 0 )
         {
-            if (threadIdx.x == 0)
+            if ( threadIdx.x == 0 )
             {
-                firstFrame = &(pb.getNextFrame(*firstFrame, isValid));
+                firstFrame = pb.getNextFrame( firstFrame );
             }
-            __syncthreads(); //wait control thread search new frame
+            __syncthreads( ); //wait control thread search new frame
             continue; //check next frame
         }
 
         // search particles for gaps
-        if ((*lastFrame)[threadIdx.x][multiMask_] == 1)
+        if ( lastFrame[threadIdx.x][multiMask_] == 1 )
         {
-            int localParticleIdx = nvidia::atomicAllInc(&counterParticles);
+            int localParticleIdx = nvidia::atomicAllInc( &counterParticles );
             particleIndices_sh[localParticleIdx] = threadIdx.x;
         }
-        __syncthreads();
-        if (localGapIdx < counterParticles)
+        __syncthreads( );
+        if ( localGapIdx < counterParticles )
         {
             const int parIdx = particleIndices_sh[localGapIdx];
-            PMACC_AUTO(parDestFull, ((*firstFrame)[threadIdx.x]));
+            PMACC_AUTO( parDestFull, (firstFrame[threadIdx.x]) );
             /*enable particle*/
             parDestFull[multiMask_] = 1;
             /* we not update multiMask because copy from mem to mem is to slow
              * we have enabled particle explicit */
-            PMACC_AUTO(parDest, deselect<multiMask>(parDestFull));
-            PMACC_AUTO(parSrc, ((*lastFrame)[parIdx]));
-            assign(parDest, parSrc);
+            PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
+            PMACC_AUTO( parSrc, (lastFrame[parIdx]) );
+            assign( parDest, parSrc );
             parSrc[multiMask_] = 0;
         }
-        __syncthreads();
-        if (threadIdx.x == 0)
+        __syncthreads( );
+        if ( threadIdx.x == 0 )
         {
-            bool isFrameValid = false;
-            if (counterGaps < counterParticles)
+            if ( counterGaps < counterParticles )
             {
                 //any gap in the first frame is filled
-                firstFrame = &(pb.getNextFrame(*firstFrame, isFrameValid));
+                firstFrame = pb.getNextFrame( firstFrame );
             }
-            else if (counterGaps > counterParticles)
+            else if ( counterGaps > counterParticles )
             {
                 //we need more particles
-                isFrameValid = getPreviousFrameAndRemoveLastFrame(lastFrame, pb, superCellIdx);
+                lastFrame = getPreviousFrameAndRemoveLastFrame( lastFrame, pb, superCellIdx );
             }
-            else if (counterGaps == counterParticles)
+            else if ( counterGaps == counterParticles )
             {
-                isFrameValid = getPreviousFrameAndRemoveLastFrame(lastFrame, pb, superCellIdx);
-                if (isFrameValid && lastFrame != firstFrame)
+                lastFrame = getPreviousFrameAndRemoveLastFrame( lastFrame, pb, superCellIdx );
+                if ( lastFrame.isValid( ) && lastFrame != firstFrame )
                 {
-                    firstFrame = &(pb.getNextFrame(*firstFrame, isFrameValid));
+                    firstFrame = pb.getNextFrame( firstFrame );
                 }
-
             }
-            isValid = isFrameValid;
         }
-        __syncthreads();
+        __syncthreads( );
     }
 }
 
 template< class T_ParticleBox, class Mapping>
-__global__ void kernelDeleteParticles(T_ParticleBox pb,
-                                      Mapping mapper)
+__global__ void kernelDeleteParticles( T_ParticleBox pb,
+                                       Mapping mapper )
 {
     using namespace particles::operations;
 
     typedef T_ParticleBox ParticleBox;
     typedef typename ParticleBox::FrameType FrameType;
+    typedef typename ParticleBox::FramePtr FramePtr;
 
     enum
     {
         Dim = Mapping::Dim
     };
 
-    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx));
+    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
     const int linearThreadIdx = threadIdx.x;
 
-    __shared__ FrameType *frame;
-    __shared__ bool isValid;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
 
-
-    if (linearThreadIdx == 0)
+    if ( linearThreadIdx == 0 )
     {
-        frame = &(pb.getLastFrame(superCellIdx, isValid));
+        frame = pb.getLastFrame( superCellIdx );
     }
 
-    __syncthreads();
+    __syncthreads( );
 
-    while (isValid)
+    while ( frame.isValid( ) )
     {
 
-        PMACC_AUTO(particle, ((*frame)[linearThreadIdx]));
+        PMACC_AUTO( particle, (frame[linearThreadIdx]) );
         particle[multiMask_] = 0; //delete particle
 
-        __syncthreads();
+        __syncthreads( );
 
-        if (linearThreadIdx == 0)
+        if ( linearThreadIdx == 0 )
         {
             //always remove the last frame
-            isValid = getPreviousFrameAndRemoveLastFrame(frame, pb, superCellIdx);
+            frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
         }
-        __syncthreads();
+        __syncthreads( );
     }
 
-    if (linearThreadIdx == 0)
-        pb.getSuperCell(superCellIdx).setSizeLastFrame(0);
+    if ( linearThreadIdx == 0 )
+        pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
 
 }
 
-template< class FRAME, class BORDER, class Mapping>
-__global__ void kernelBashParticles(ParticlesBox<FRAME, Mapping::Dim> pb,
-                                    ExchangePushDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
-                                    Mapping mapper)
+template< class ParBox, class BORDER, class Mapping>
+__global__ void kernelBashParticles( ParBox pb,
+                                     ExchangePushDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
+                                     Mapping mapper )
 {
     using namespace particles::operations;
 
@@ -466,84 +461,84 @@ __global__ void kernelBashParticles(ParticlesBox<FRAME, Mapping::Dim> pb,
         TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
         Dim = Mapping::Dim
     };
+    typedef typename ParBox::FramePtr FramePtr;
 
-    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx));
+    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
 
     __shared__ int numBashedParticles;
-    __shared__ FRAME *frame;
-    __shared__ bool isValid;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
     __shared__ bool hasMemory;
     __shared__ TileDataBox<BORDER> tmpBorder;
 
-    if (threadIdx.x == 0)
+    if ( threadIdx.x == 0 )
     {
         hasMemory = true;
-        frame = &(pb.getLastFrame(superCellIdx, isValid));
+        frame = pb.getLastFrame( superCellIdx );
     }
     //\todo: eventuell ist es schneller, parallelen und seriellen Code zu trennen
-    __syncthreads();
-    while (isValid && hasMemory)
+    __syncthreads( );
+    while ( frame.isValid( ) && hasMemory )
     {
         lcellId_t bashIdx = INV_LOC_IDX;
-        if (threadIdx.x == 0)
+        if ( threadIdx.x == 0 )
             numBashedParticles = 0;
-        __syncthreads();
+        __syncthreads( );
 
-        if ((*frame)[threadIdx.x][multiMask_] == 1)
+        if ( frame[threadIdx.x][multiMask_] == 1 )
         {
-            bashIdx = nvidia::atomicAllInc(&numBashedParticles);
+            bashIdx = nvidia::atomicAllInc( &numBashedParticles );
         }
-        __syncthreads();
+        __syncthreads( );
 
-        if (numBashedParticles > 0)
+        if ( numBashedParticles > 0 )
         {
 
-            if (threadIdx.x == 0)
+            if ( threadIdx.x == 0 )
             {
                 // DataSpaceOperations<DIM2>::reduce computes target position for domainTile and exchangeType
-                tmpBorder = border.pushN(numBashedParticles,
-                                         DataSpaceOperations<Dim>::reduce(
-                                                                          superCellIdx,
-                                                                          mapper.getExchangeType()));
-                if (tmpBorder.getSize() < numBashedParticles)
+                tmpBorder = border.pushN( numBashedParticles,
+                                          DataSpaceOperations<Dim>::reduce(
+                                                                            superCellIdx,
+                                                                            mapper.getExchangeType( ) ) );
+                if ( tmpBorder.getSize( ) < numBashedParticles )
                     hasMemory = false;
             }
-            __syncthreads();
+            __syncthreads( );
 
-            if (bashIdx != INV_LOC_IDX && bashIdx < tmpBorder.getSize())
+            if ( bashIdx != INV_LOC_IDX && bashIdx < tmpBorder.getSize( ) )
             {
-                PMACC_AUTO(parDest, tmpBorder[bashIdx][0]);
-                PMACC_AUTO(parSrc, ((*frame)[threadIdx.x]));
-                assign(parDest, parSrc);
+                PMACC_AUTO( parDest, tmpBorder[bashIdx][0] );
+                PMACC_AUTO( parSrc, (frame[threadIdx.x]) );
+                assign( parDest, parSrc );
                 parSrc[multiMask_] = 0;
             }
-            __syncthreads();
+            __syncthreads( );
 
-            if (threadIdx.x == 0 && hasMemory)
+            if ( threadIdx.x == 0 && hasMemory )
             {
                 //always remove the last frame
-                isValid=getPreviousFrameAndRemoveLastFrame(frame,pb,superCellIdx);
+                frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
             }
         }
         else
         {
             //if we had no particles to copy than we are the last and only frame
-            if (threadIdx.x == 0)
+            if ( threadIdx.x == 0 )
             {
-                isValid=getPreviousFrameAndRemoveLastFrame(frame,pb,superCellIdx);
+                frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
             }
         }
-        __syncthreads();
+        __syncthreads( );
     }
-    if (threadIdx.x == 0)
-        pb.getSuperCell(superCellIdx).setSizeLastFrame(0);
+    if ( threadIdx.x == 0 )
+        pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
 
 }
 
-template<class FRAME, class BORDER, class Mapping>
-__global__ void kernelInsertParticles(ParticlesBox<FRAME, Mapping::Dim> pb,
-                                      ExchangePopDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
-                                      Mapping mapper)
+template<class ParBox, class BORDER, class Mapping>
+__global__ void kernelInsertParticles( ParBox pb,
+                                       ExchangePopDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
+                                       Mapping mapper )
 {
 
     using namespace particles::operations;
@@ -554,46 +549,47 @@ __global__ void kernelInsertParticles(ParticlesBox<FRAME, Mapping::Dim> pb,
         Dim = Mapping::Dim
     };
 
-    __shared__ FRAME* frame;
+    typedef typename ParBox::FramePtr FramePtr;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
     __shared__ int elementCount;
     __shared__ TileDataBox<BORDER> tmpBorder;
 
 
     DataSpace < Mapping::Dim - 1 > superCell;
 
-    if (threadIdx.x == 0)
+    if ( threadIdx.x == 0 )
     {
         tmpBorder = border.get(blockIdx.x,superCell);
-        elementCount = tmpBorder.getSize();
-        if (elementCount > 0)
+        elementCount = tmpBorder.getSize( );
+        if ( elementCount > 0 )
         {
-            frame = &(pb.getEmptyFrame());
+            frame = pb.getEmptyFrame( );
         }
     }
-    __syncthreads();
-    if (threadIdx.x < elementCount)
+    __syncthreads( );
+    if ( threadIdx.x < elementCount )
     {
-        PMACC_AUTO(parDestFull, ((*frame)[threadIdx.x]));
+        PMACC_AUTO( parDestFull, (frame[threadIdx.x]) );
         parDestFull[multiMask_] = 1;
-        PMACC_AUTO(parSrc, ((tmpBorder[threadIdx.x])[0]));
+        PMACC_AUTO( parSrc, ((tmpBorder[threadIdx.x])[0]) );
         /*we know that source has no multiMask*/
-        PMACC_AUTO(parDest, deselect<multiMask>(parDestFull));
-        assign(parDest, parSrc);
+        PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
+        assign( parDest, parSrc );
     }
     /*if this syncronize fix the kernel crash in spezial cases,
      * I can't tell why.
      */
-    __syncthreads();
-    if ((threadIdx.x == 0) && (elementCount > 0))
+    __syncthreads( );
+    if ( (threadIdx.x == 0) && (elementCount > 0) )
     {
         // compute the super cell position in target frame to insert into
         ///\todo: offset == simulation border should be passed to this func instead of being created here
-        DataSpace<Dim> dstSuperCell = DataSpaceOperations < Dim - 1 > ::extend(superCell,
-                                                                               mapper.getExchangeType(),
-                                                                               mapper.getGridSuperCells(),
-                                                                               DataSpace<Dim>::create(mapper.getGuardingSuperCells()));
+        DataSpace<Dim> dstSuperCell = DataSpaceOperations < Dim - 1 > ::extend( superCell,
+                                                                                mapper.getExchangeType( ),
+                                                                                mapper.getGridSuperCells( ),
+                                                                                DataSpace<Dim>::create( mapper.getGuardingSuperCells( ) ) );
 
-        pb.setAsLastFrame(*frame, dstSuperCell);
+        pb.setAsLastFrame( frame, dstSuperCell );
     }
 
 

--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -28,8 +28,7 @@
 #include "dimensions/DataSpace.hpp"
 #include "particles/memory/dataTypes/SuperCell.hpp"
 #include "memory/boxes/PitchedBox.hpp"
-#include "memory/boxes/DataBox.hpp"
-#include "particles/memory/dataTypes/Pointer.hpp"
+#include "particles/memory/dataTypes/FramePointer.hpp"
 
 namespace PMacc
 {
@@ -40,17 +39,17 @@ namespace PMacc
  * @tparam FRAME datatype for frames
  * @tparam DIM dimension of data (1-3)
  */
-template<class FRAME, unsigned DIM>
-class ParticlesBox : protected DataBox<PitchedBox<SuperCell<FRAME>, DIM> >
+template<class T_Frame, unsigned DIM>
+class ParticlesBox : protected DataBox<PitchedBox<SuperCell<T_Frame>, DIM> >
 {
 private:
-    PMACC_ALIGN(hostMemoryOffset,int64_t);
+    PMACC_ALIGN( hostMemoryOffset, int64_t );
 public:
 
-    typedef FRAME FrameType;
-    typedef Pointer<FrameType> FramePtr;
+    typedef T_Frame FrameType;
+    typedef FramePointer<FrameType> FramePtr;
     typedef SuperCell<FrameType> SuperCellType;
-    typedef DataBox<PitchedBox<SuperCell<FRAME>, DIM> > BaseType;
+    typedef DataBox<PitchedBox<SuperCell<FrameType>, DIM> > BaseType;
 
     BOOST_STATIC_CONSTEXPR uint32_t Dim = DIM;
 
@@ -59,19 +58,19 @@ public:
      * \warning after this call the object is in a invalid state and must be
      * initialized with an assignment of a valid ParticleBox
      */
-    HDINLINE ParticlesBox() : hostMemoryOffset(0)
+    HDINLINE ParticlesBox( ) : hostMemoryOffset( 0 )
     {
 
     }
 
-    HDINLINE ParticlesBox(const DataBox<PitchedBox<SuperCellType, DIM> > &superCells) :
-    BaseType(superCells), hostMemoryOffset(0)
+    HDINLINE ParticlesBox( const DataBox<PitchedBox<SuperCellType, DIM> > &superCells ) :
+    BaseType( superCells ), hostMemoryOffset( 0 )
     {
 
     }
 
-    HDINLINE ParticlesBox(const DataBox<PitchedBox<SuperCellType, DIM> > &superCells, int64_t memoryOffset) :
-    BaseType(superCells), hostMemoryOffset(memoryOffset)
+    HDINLINE ParticlesBox( const DataBox<PitchedBox<SuperCellType, DIM> > &superCells, int64_t memoryOffset ) :
+    BaseType( superCells ), hostMemoryOffset( memoryOffset )
     {
 
     }
@@ -81,50 +80,55 @@ public:
      *
      * @return an empty frame
      */
-    DINLINE FRAME &getEmptyFrame()
+    DINLINE FramePtr getEmptyFrame( )
     {
         FrameType* tmp = NULL;
         const int maxTries = 13; //magic number is not performance critical
-        for (int numTries = 0; numTries < maxTries; ++numTries)
+        for ( int numTries = 0; numTries < maxTries; ++numTries )
         {
-            tmp = (FrameType*) mallocMC::malloc(sizeof (FrameType));
-            if (tmp != NULL)
+            tmp = (FrameType*) mallocMC::malloc( sizeof (FrameType) );
+            if ( tmp != NULL )
             {
                 /* disable all particles since we can not assume that newly allocated memory contains zeros */
-                for (int i = 0; i < (int) math::CT::volume<typename FrameType::SuperCellSize>::type::value; ++i)
-                    (*tmp)[i][multiMask_] = 0;
+                for ( int i = 0; i < (int) math::CT::volume<typename FrameType::SuperCellSize>::type::value; ++i )
+                    ( *tmp )[i][multiMask_] = 0;
                 /* takes care that changed values are visible to all threads inside this block*/
-                __threadfence_block();
+                __threadfence_block( );
                 break;
             }
             else
             {
-                printf("%s: mallocMC out of memory (try %i of %i)\n",
-                       (numTries+1)==maxTries?"WARNING":"ERROR",
-                       numTries+1,
-                       maxTries);
+                printf( "%s: mallocMC out of memory (try %i of %i)\n",
+                        (numTries + 1) == maxTries ? "WARNING" : "ERROR",
+                        numTries + 1,
+                        maxTries );
             }
         }
 
-        return *(FramePtr(tmp));
+        return FramePtr( tmp );
     }
 
     /**
      * Removes frame from heap data heap.
      *
-     * @param frame FRAME to remove
+     * @param frame frame to remove
      */
-    DINLINE void removeFrame(FRAME &frame)
+    template<typename T_InitMethod>
+    DINLINE void removeFrame( FramePointer<FrameType, T_InitMethod>& frame )
     {
-        mallocMC::free((void*) &frame);
+        mallocMC::free( (void*) frame.ptr );
+        frame.ptr = NULL;
     }
 
     HDINLINE
-    FrameType* mapPtr(FrameType* devPtr)
+    FramePtr mapPtr( const FramePtr& devPtr )
     {
 #ifndef __CUDA_ARCH__
-        int64_t useOffset=hostMemoryOffset*static_cast<int64_t>(devPtr!=0);
-        return (FrameType*)(((char*)devPtr) - useOffset);
+        int64_t useOffset = hostMemoryOffset * static_cast<int64_t> (devPtr.ptr != 0);
+        return FramePtr( reinterpret_cast<FrameType*> (
+                                                       reinterpret_cast<char*> (devPtr.ptr) - useOffset
+                                                       )
+                        );
 #else
         return devPtr;
 #endif
@@ -133,54 +137,45 @@ public:
     /**
      * Returns the next frame in the linked list.
      *
-     * @param frame the active FRAME
+     * @param frame the active frame
      * @return the next frame in the list
      */
-    HDINLINE FRAME& getNextFrame(FRAME &frame, bool &isValid)
+    HDINLINE FramePtr getNextFrame( const FramePtr& frame )
     {
-        FramePtr tmp(mapPtr(frame.nextFrame.ptr));
-        isValid = tmp.isValid();
-        return *tmp;
+        return mapPtr( frame->nextFrame.ptr );
     }
 
     /**
      * Returns the previous frame in the linked list.
      *
-     * @param frame the active FRAME
+     * @param frame the active frame
      * @return the previous frame in the list
      */
-    HDINLINE FRAME& getPreviousFrame(FRAME &frame, bool &isValid)
+    HDINLINE FramePtr getPreviousFrame( const FramePtr& frame )
     {
-        FramePtr tmp(mapPtr(frame.previousFrame.ptr));
-        isValid = tmp.isValid();
-        return *tmp;
+        return mapPtr( frame->previousFrame.ptr );
     }
 
     /**
      * Returns the last frame of a supercell.
      *
      * @param idx position of supercell
-     * @return the last FRAME of the linked list from supercell
+     * @return the last frame of the linked list from supercell
      */
-    HDINLINE FRAME& getLastFrame(const DataSpace<DIM> &idx, bool &isValid)
+    HDINLINE FramePtr getLastFrame( const DataSpace<DIM> &idx )
     {
-        FramePtr tmp = FramePtr(mapPtr(getSuperCell(idx).LastFramePtr()));
-        isValid = tmp.isValid();
-        return *tmp;
+        return mapPtr( getSuperCell( idx ).LastFramePtr( ) );
     }
 
     /**
      * Returns the first frame of a supercell.
      *
      * @param idx position of supercell
-     * @return the first FRAME of the linked list from supercell
+     * @return the first frame of the linked list from supercell
      */
-    HDINLINE FRAME& getFirstFrame(const DataSpace<DIM> &idx, bool &isValid)
+    HDINLINE FramePtr getFirstFrame( const DataSpace<DIM> &idx )
     {
-        FramePtr tmp = FramePtr(mapPtr(getSuperCell(idx).FirstFramePtr()));
-        isValid = tmp.isValid();
-        return *tmp;
-
+        return mapPtr( getSuperCell( idx ).FirstFramePtr( ) );
     }
 
     /**
@@ -189,31 +184,31 @@ public:
      * @param frame frame to set as first frame
      * @param idx position of supercell
      */
-    DINLINE void setAsFirstFrame(FRAME &frameIn, const DataSpace<DIM> &idx)
+    template<typename T_InitMethod>
+    DINLINE void setAsFirstFrame( FramePointer<FrameType, T_InitMethod>& frame, const DataSpace<DIM> &idx )
     {
-        FramePtr frame(&frameIn);
-        FrameType** firstFrameNativPtr = &(getSuperCell(idx).firstFramePtr);
+        FrameType** firstFrameNativPtr = &(getSuperCell( idx ).firstFramePtr);
 
-        frame->previousFrame = FramePtr();
-        frame->nextFrame = FramePtr(*firstFrameNativPtr);
+        frame->previousFrame = FramePtr( );
+        frame->nextFrame = FramePtr( *firstFrameNativPtr );
 
         /* - takes care that `next[index]` is visible to all threads on the gpu
          * - this is needed because later on in this method we change `previous`
          *   of an other frame, this must be done in order!
          */
-        __threadfence();
+        __threadfence( );
 
-        FramePtr oldFirstFramePtr((FrameType*) atomicExch((unsigned long long int*) firstFrameNativPtr, (unsigned long long int) frame.ptr));
+        FramePtr oldFirstFramePtr( (FrameType*) atomicExch( (unsigned long long int*) firstFrameNativPtr, (unsigned long long int) frame.ptr ) );
 
         frame->nextFrame = oldFirstFramePtr;
-        if (oldFirstFramePtr.isValid())
+        if ( oldFirstFramePtr.isValid( ) )
         {
             oldFirstFramePtr->previousFrame = frame;
         }
         else
         {
             //we add the first frame in supercell
-            getSuperCell(idx).lastFramePtr = frame.ptr;
+            getSuperCell( idx ).lastFramePtr = frame.ptr;
         }
     }
 
@@ -223,30 +218,30 @@ public:
      * @param frame frame to set as last frame
      * @param idx position of supercell
      */
-    DINLINE void setAsLastFrame(FRAME &frameIn, const DataSpace<DIM> &idx)
+    template<typename T_InitMethod>
+    DINLINE void setAsLastFrame( FramePointer<FrameType, T_InitMethod>& frame, const DataSpace<DIM> &idx )
     {
-        FramePtr frame(&frameIn);
-        FrameType** lastFrameNativPtr = &(getSuperCell(idx).lastFramePtr);
+        FrameType** lastFrameNativPtr = &(getSuperCell( idx ).lastFramePtr);
 
-        frame->nextFrame = FramePtr();
-        frame->previousFrame = FramePtr(*lastFrameNativPtr);
+        frame->nextFrame = FramePtr( );
+        frame->previousFrame = FramePtr( *lastFrameNativPtr );
         /* - takes care that `next[index]` is visible to all threads on the gpu
          * - this is needed because later on in this method we change `next`
          *   of an other frame, this must be done in order!
          */
-        __threadfence();
+        __threadfence( );
 
-        FramePtr oldLastFramePtr((FrameType*) atomicExch((unsigned long long int*) lastFrameNativPtr, (unsigned long long int) frame.ptr));
+        FramePtr oldLastFramePtr( (FrameType*) atomicExch( (unsigned long long int*) lastFrameNativPtr, (unsigned long long int) frame.ptr ) );
 
         frame->previousFrame = oldLastFramePtr;
-        if (oldLastFramePtr.isValid())
+        if ( oldLastFramePtr.isValid( ) )
         {
             oldLastFramePtr->nextFrame = frame;
         }
         else
         {
             //we add the first frame in supercell
-            getSuperCell(idx).firstFramePtr = frame.ptr;
+            getSuperCell( idx ).firstFramePtr = frame.ptr;
         }
     }
 
@@ -256,33 +251,33 @@ public:
      * @param idx position of supercell
      * @return true if more frames in list, else false
      */
-    DINLINE bool removeLastFrame(const DataSpace<DIM> &idx)
+    DINLINE bool removeLastFrame( const DataSpace<DIM> &idx )
     {
         //!\todo this is not thread save
-        FrameType** lastFrameNativPtr = &(getSuperCell(idx).lastFramePtr);
+        FrameType** lastFrameNativPtr = &(getSuperCell( idx ).lastFramePtr);
 
-        FramePtr last(*lastFrameNativPtr);
-        if (last.isValid())
+        FramePtr last( *lastFrameNativPtr );
+        if ( last.isValid( ) )
         {
-            FramePtr prev(last->previousFrame);
+            FramePtr prev( last->previousFrame );
 
-            if (prev.isValid())
+            if ( prev.isValid( ) )
             {
-                prev->nextFrame = FramePtr(); //set to invalid frame
+                prev->nextFrame = FramePtr( ); //set to invalid frame
                 *lastFrameNativPtr = prev.ptr; //set new last frame
-                removeFrame(*last);
+                removeFrame( last );
                 return true;
             }
             //remove last frame of supercell
-            getSuperCell(idx).firstFramePtr = NULL;
-            getSuperCell(idx).lastFramePtr = NULL;
+            getSuperCell( idx ).firstFramePtr = NULL;
+            getSuperCell( idx ).lastFramePtr = NULL;
 
-            removeFrame(*last);
+            removeFrame( last );
         }
         return false;
     }
 
-    HDINLINE SuperCellType& getSuperCell(DataSpace<DIM> idx)
+    HDINLINE SuperCellType& getSuperCell( DataSpace<DIM> idx )
     {
         return BaseType::operator()(idx);
     }

--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -198,7 +198,12 @@ public:
          */
         __threadfence( );
 
-        FramePtr oldFirstFramePtr( (FrameType*) atomicExch( (unsigned long long int*) firstFrameNativPtr, (unsigned long long int) frame.ptr ) );
+        FramePtr oldFirstFramePtr(
+            (FrameType*) atomicExch(
+                (unsigned long long int*) firstFrameNativPtr,
+                (unsigned long long int) frame.ptr
+            )
+        );
 
         frame->nextFrame = oldFirstFramePtr;
         if ( oldFirstFramePtr.isValid( ) )
@@ -231,7 +236,12 @@ public:
          */
         __threadfence( );
 
-        FramePtr oldLastFramePtr( (FrameType*) atomicExch( (unsigned long long int*) lastFrameNativPtr, (unsigned long long int) frame.ptr ) );
+        FramePtr oldLastFramePtr(
+            (FrameType*) atomicExch(
+                (unsigned long long int*) lastFrameNativPtr,
+                (unsigned long long int) frame.ptr
+            )
+        );
 
         frame->previousFrame = oldLastFramePtr;
         if ( oldLastFramePtr.isValid( ) )

--- a/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
@@ -23,8 +23,6 @@
 #pragma once
 
 #include "types.h"
-#include "particles/memory/dataTypes/Pointer.hpp"
-
 
 namespace PMacc
 {

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -52,6 +52,7 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
                                      ParBox boxPar, FrameSolver frameSolver, Mapping mapper)
 {
     typedef typename ParBox::FrameType FrameType;
+    typedef typename ParBox::FramePtr FramePtr;
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
     const uint32_t cellsPerSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
@@ -67,19 +68,18 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
     const int virtualLinearId = linearThreadIdx - (virtualBlockId * cellsPerSuperCell);
 
 
-    FrameType* frame = NULL;
-    bool isValid = false;
+    FramePtr frame;
     lcellId_t particlesInSuperCell = 0;
 
-    frame = &(boxPar.getLastFrame(block, isValid));
-    if (isValid && virtualBlockId == 0)
+    frame = boxPar.getLastFrame(block);
+    if (frame.isValid() && virtualBlockId == 0)
         particlesInSuperCell = boxPar.getSuperCell(block).getSizeLastFrame();
 
     /* select N-th (N=virtualBlockId) frame from the end of the list*/
-    for (int i = 1; (i <= virtualBlockId) && isValid; ++i)
+    for (int i = 1; (i <= virtualBlockId) && frame.isValid(); ++i)
     {
         particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
-        frame = &(boxPar.getPreviousFrame(*frame, isValid));
+        frame = boxPar.getPreviousFrame(frame);
     }
 
     /* This memory is used by all virtual blocks*/
@@ -91,7 +91,7 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
 
     __syncthreads();
 
-    while (isValid)
+    while (frame.isValid())
     {
         /* this test is only importend for the last frame
          * if frame is not the last one particlesInSuperCell==particles count in supercell
@@ -104,9 +104,9 @@ __global__ void kernelComputeCurrent(JBox fieldJ,
         }
 
         particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
-        for (int i = 0; (i < workerMultiplier) && isValid; ++i)
+        for (int i = 0; (i < workerMultiplier) && frame.isValid(); ++i)
         {
-            frame = &(boxPar.getPreviousFrame(*frame, isValid));
+            frame = boxPar.getPreviousFrame(frame);
         }
     }
 

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -47,7 +47,7 @@ namespace picongpu
     template<class BlockDescription_, uint32_t AREA, class TmpBox, class ParBox, class FrameSolver, class Mapping>
     __global__ void kernelComputeSupercells( TmpBox fieldTmp, ParBox boxPar, FrameSolver frameSolver, Mapping mapper )
     {
-
+        typedef typename ParBox::FramePtr FramePtr;
         typedef typename BlockDescription_::SuperCellSize SuperCellSize;
         const DataSpace<simDim> block( mapper.getSuperCellIndex( DataSpace<simDim > ( blockIdx ) ) );
 
@@ -55,19 +55,19 @@ namespace picongpu
         const DataSpace<simDim > threadIndex( threadIdx );
         const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > ( threadIndex );
 
-        __shared__ typename ParBox::FrameType *frame;
-        __shared__ bool isValid;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+
         __shared__ lcellId_t particlesInSuperCell;
 
 
         if( linearThreadIdx == 0 )
         {
-            frame = &( boxPar.getLastFrame( block, isValid ) );
+            frame = boxPar.getLastFrame( block );
             particlesInSuperCell = boxPar.getSuperCell( block ).getSizeLastFrame( );
         }
         __syncthreads( );
 
-        if( !isValid )
+        if( frame.isValid() )
             return; //end kernel if we have no frames
 
         PMACC_AUTO( cachedVal, CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) ) );
@@ -77,7 +77,7 @@ namespace picongpu
         collective( set, cachedVal );
 
         __syncthreads( );
-        while( isValid )
+        while( frame.isValid() )
         {
             if( linearThreadIdx < particlesInSuperCell )
             {
@@ -86,7 +86,7 @@ namespace picongpu
             __syncthreads( );
             if( linearThreadIdx == 0 )
             {
-                frame = &( boxPar.getPreviousFrame( *frame, isValid ) );
+                frame = boxPar.getPreviousFrame( frame );
                 particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
             }
             __syncthreads( );

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -57,15 +57,18 @@ namespace picongpu
 
 using namespace PMacc;
 
-template<class MYFRAME, class OTHERFRAME, class T_ManipulateFunctor, class Mapping>
-__global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, ParticlesBox<OTHERFRAME, simDim> otherBox, T_ManipulateFunctor manipulateFunctor, Mapping mapper)
+template<class T_MyParBox, class T_OtherFrameBox, class T_ManipulateFunctor, class Mapping>
+__global__ void kernelCloneParticles(T_MyParBox myBox, T_OtherFrameBox otherBox, T_ManipulateFunctor manipulateFunctor, Mapping mapper)
 {
     using namespace PMacc::particles::operations;
+    typedef typename T_MyParBox::FramePtr MyFramePtr;
+    typedef typename T_OtherFrameBox::FramePtr OtherFramePtr;
 
-    __shared__ OTHERFRAME *frame;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<OtherFramePtr>::type frame;
 
-    __shared__ MYFRAME *myFrame;
-    __shared__ bool isValid;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<MyFramePtr>::type myFrame;
+
+
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
 
@@ -73,19 +76,18 @@ __global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, Partic
 
     if (threadIdx.x == 0)
     {
-        frame = &(otherBox.getFirstFrame(block, isValid));
-        if (isValid)
+        frame = otherBox.getFirstFrame(block);
+        if (frame.isValid())
         {
             //we have everything to clone
-            myFrame = &(myBox.getEmptyFrame());
-            //myBox.setAsFirstFrame(*myFrame, block);
+            myFrame = myBox.getEmptyFrame();
         }
     }
     __syncthreads();
-    while (isValid) //move over all Frames
+    while (frame.isValid()) //move over all Frames
     {
-        PMACC_AUTO(parDest, ((*myFrame)[threadIdx.x]));
-        PMACC_AUTO(parSrc, ((*frame)[threadIdx.x]));
+        PMACC_AUTO(parDest, myFrame[threadIdx.x]);
+        PMACC_AUTO(parSrc, frame[threadIdx.x]);
         assign(parDest, parSrc);
 
         const DataSpace<simDim> localCellIdx = block
@@ -99,12 +101,12 @@ __global__ void kernelCloneParticles(ParticlesBox<MYFRAME, simDim> myBox, Partic
 
         if (threadIdx.x == 0)
         {
-            myBox.setAsLastFrame(*myFrame, block);
+            myBox.setAsLastFrame(myFrame, block);
 
-            frame = &(otherBox.getNextFrame(*frame, isValid));
-            if (isValid)
+            frame = otherBox.getNextFrame(frame);
+            if (frame.isValid())
             {
-                myFrame = &(myBox.getEmptyFrame());
+                myFrame = myBox.getEmptyFrame();
             }
         }
         __syncthreads();
@@ -117,8 +119,9 @@ __global__ void kernelManipulateAllParticles(T_ParBox pb,
                                              T_ParticleFunctor particleFunctor,
                                              Mapping mapper)
 {
-    __shared__ typename T_ParBox::FrameType* frame;
-    __shared__ bool isValid;
+    typedef typename T_ParBox::FramePtr FramePtr;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
 
@@ -129,11 +132,11 @@ __global__ void kernelManipulateAllParticles(T_ParBox pb,
 
     if (linearThreadIdx == 0)
     {
-        frame = &(pb.getLastFrame(superCellIdx, isValid));
+        frame = pb.getLastFrame(superCellIdx);
     }
 
     __syncthreads();
-    if (!isValid)
+    if (!frame.isValid())
         return; //end kernel if we have no frames
 
     /* BUGFIX to issue #538
@@ -146,15 +149,15 @@ __global__ void kernelManipulateAllParticles(T_ParBox pb,
 
     __syncthreads();
 
-    while (isValid)
+    while (frame.isValid())
     {
-        PMACC_AUTO(particle, ((*frame)[linearThreadIdx]));
+        PMACC_AUTO(particle, frame[linearThreadIdx]);
         particleFunctor(localCellIdx, particle, particle, isParticle, isParticle);
 
         __syncthreads();
         if (linearThreadIdx == 0)
         {
-            frame = &(pb.getPreviousFrame(*frame, isValid));
+            frame = pb.getPreviousFrame(frame);
         }
         isParticle = true;
         __syncthreads();
@@ -172,6 +175,8 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
      *
      * conversion from block to linear frames */
     typedef typename BlockDescription_::SuperCellSize SuperCellSize;
+    typedef typename ParBox::FramePtr FramePtr;
+
     const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
 
 
@@ -183,8 +188,8 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
 
 
 
-    typename ParBox::FrameType *frame;
-    bool isValid;
+    FramePtr frame;
+
     __shared__ int mustShift;
     lcellId_t particlesInSuperCell;
 
@@ -193,14 +198,14 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
     {
         mustShift = 0;
     }
-    frame = &(pb.getLastFrame(block, isValid));
+    frame = pb.getLastFrame(block);
     particlesInSuperCell = pb.getSuperCell(block).getSizeLastFrame();
 
     PMACC_AUTO(cachedB, CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_()));
     PMACC_AUTO(cachedE, CachedBox::create < 1, typename EBox::ValueType > (BlockDescription_()));
 
     __syncthreads();
-    if (!isValid)
+    if (!frame.isValid())
         return; //end kernel if we have no frames
 
 
@@ -223,13 +228,13 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
     __syncthreads();
 
     /*move over frames and call frame solver*/
-    while (isValid)
+    while (frame.isValid())
     {
         if (linearThreadIdx < particlesInSuperCell)
         {
             frameSolver(*frame, linearThreadIdx, cachedB, cachedE, mustShift);
         }
-        frame = &(pb.getPreviousFrame(*frame, isValid));
+        frame = pb.getPreviousFrame(frame);
         particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
     }

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -68,10 +68,10 @@ __global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
                                             ParBox pb,
                                             Mapping mapper)
 {
-    typedef typename ParBox::FrameType FRAME;
+    typedef typename ParBox::FramePtr FramePtr;
     const DataSpace<simDim> superCells(mapper.getGridSuperCells());
 
-    __shared__ FRAME *frame;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
 
     
     typedef typename Mapping::SuperCellSize SuperCellSize;
@@ -119,8 +119,8 @@ __global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
 
     if (linearThreadIdx == 0)
     {
-        frame = &(pb.getEmptyFrame());
-        pb.setAsLastFrame(*frame, superCellIdx);
+        frame = pb.getEmptyFrame();
+        pb.setAsLastFrame(frame, superCellIdx);
     }
 
     __syncthreads();
@@ -138,7 +138,7 @@ __global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
 
         if (numParsPerCell > 0)
         {
-            PMACC_AUTO(particle, ((*frame)[linearThreadIdx]));
+            PMACC_AUTO(particle, (frame[linearThreadIdx]));
 
             /** we now initialize all attributes of the new particle to their default values
              *   some attributes, such as the position, localCellIdx, weighting or the
@@ -172,8 +172,8 @@ __global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
         __syncthreads();
         if (linearThreadIdx == 0 && finished == 0)
         {
-            frame = &(pb.getEmptyFrame());
-            pb.setAsLastFrame(*frame, superCellIdx);
+            frame = pb.getEmptyFrame();
+            pb.setAsLastFrame(frame, superCellIdx);
         }
     }
     while (finished == 0);

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -84,7 +84,7 @@ namespace picongpu
                     const uint32_t el_p,
                     const std::pair<float_X, float_X>& axis_p_range )
         {
-            PMACC_AUTO( particle, (*frame)[particleID] );
+            PMACC_AUTO( particle, frame[particleID] );
             /** \todo this can become a functor to be even more flexible */
             const float_X mom_i = particle[momentum_][el_p];
 

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -77,31 +77,33 @@ struct ConcatListOfFrames
 
             typedef T_DestFrame DestFrameType;
             typedef typename T_SrcBox::FrameType SrcFrameType;
+            typedef typename T_SrcBox::FramePtr SrcFramePtr;
+
             typedef T_Mapping Mapping;
             typedef typename Mapping::SuperCellSize Block;
 
-            SrcFrameType *srcFramePtr;
+
+            SrcFramePtr srcFramePtr;
             int localCounter;
             int globalOffset;
             const int particlePerFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
             int storageOffset[particlePerFrame];
 
-            bool isValid;
 
             const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(blockIdx);
             const DataSpace<Mapping::Dim> superCellPosition((block - mapper.getGuardingSuperCells()) * mapper.getSuperCellSize());
             filter.setSuperCellPosition(superCellPosition);
 
-            srcFramePtr = &(srcBox.getFirstFrame(block, isValid));
+            srcFramePtr = srcBox.getFirstFrame(block);
 
-            while (isValid) //move over all Frames
+            while (srcFramePtr.isValid()) //move over all Frames
             {
                 localCounter = 0;
                 /* clear storageOffset array*/
                 for (int threadIdx = 0; threadIdx < particlePerFrame; ++threadIdx)
                 {
                     storageOffset[threadIdx] = -1;
-                    PMACC_AUTO(parSrc, ((*srcFramePtr)[threadIdx]));
+                    PMACC_AUTO(parSrc, (srcFramePtr[threadIdx]));
                     /*count particle in frame*/
                     if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx))
                         storageOffset[threadIdx] = localCounter++;
@@ -118,7 +120,7 @@ struct ConcatListOfFrames
                 {
                     if (storageOffset[threadIdx] != -1)
                     {
-                        PMACC_AUTO(parSrc, ((*srcFramePtr)[threadIdx]));
+                        PMACC_AUTO(parSrc, (srcFramePtr[threadIdx]));
                         PMACC_AUTO(parDest, destFrame[globalOffset + storageOffset[threadIdx]]);
                         PMACC_AUTO(parDestNoGlobalIdx, deselect<globalCellIdx<> >(parDest));
                         assign(parDestNoGlobalIdx, parSrc);
@@ -128,7 +130,7 @@ struct ConcatListOfFrames
                     }
                 }
                 /*get next frame in supercell*/
-                srcFramePtr = &(srcBox.getNextFrame(*srcFramePtr, isValid));
+                srcFramePtr = srcBox.getNextFrame(srcFramePtr);
 
             }
         }
@@ -158,16 +160,16 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
 
     typedef T_DestFrame DestFrameType;
     typedef typename T_SrcBox::FrameType SrcFrameType;
+    typedef typename T_SrcBox::FramePtr SrcFramePtr;
+
     typedef T_Mapping Mapping;
     typedef typename Mapping::SuperCellSize Block;
 
-    __shared__ SrcFrameType *srcFramePtr;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SrcFramePtr>::type srcFramePtr;
     __shared__ int localCounter;
     __shared__ int globalOffset;
 
     int storageOffset;
-
-    __shared__ bool isValid;
 
 
     const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
@@ -176,12 +178,12 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
     if (threadIdx.x == 0)
     {
         localCounter = 0;
-        srcFramePtr = &(srcBox.getFirstFrame(block, isValid));
+        srcFramePtr = srcBox.getFirstFrame(block);
     }
     __syncthreads();
-    while (isValid) //move over all Frames
+    while (srcFramePtr.isValid()) //move over all Frames
     {
-        PMACC_AUTO(parSrc, ((*srcFramePtr)[threadIdx.x]));
+        PMACC_AUTO(parSrc, (srcFramePtr[threadIdx.x]));
         storageOffset = -1;
         /*count particle in frame*/
         if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx.x))
@@ -206,7 +208,7 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
         if (threadIdx.x == 0)
         {
             /*get next frame in supercell*/
-            srcFramePtr = &(srcBox.getNextFrame(*srcFramePtr, isValid));
+            srcFramePtr = srcBox.getNextFrame(srcFramePtr);
             localCounter = 0;
         }
         __syncthreads();

--- a/src/picongpu/include/plugins/kernel/CopySpeciesGlobal2Local.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpeciesGlobal2Local.kernel
@@ -52,11 +52,11 @@ __global__ void copySpeciesGlobal2Local(T_CounterBox counter, T_DestBox destBox,
 
     typedef T_SrcFrame SrcFrameType;
     typedef typename T_DestBox::FrameType DestFrameType;
+    typedef typename T_DestBox::FramePtr DestFramePtr;
     typedef typename T_CellDescription::SuperCellSize SuperCellSize;
     const uint32_t cellsInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
-    typedef DestFrameType* DestFramePtr;
-    __shared__ DestFramePtr destFramePtr[cellsInSuperCell];
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<DestFramePtr>::type destFramePtr[cellsInSuperCell];
     __shared__ int linearSuperCellIds[cellsInSuperCell];
     __shared__ int hdf5ParticleOffset;
 
@@ -72,7 +72,7 @@ __global__ void copySpeciesGlobal2Local(T_CounterBox counter, T_DestBox destBox,
          */
         hdf5ParticleOffset = atomicAdd(&(counter[0]), cellsInSuperCell);
     }
-    destFramePtr[linearThreadIdx] = NULL;
+    destFramePtr[linearThreadIdx] = DestFramePtr();
     linearSuperCellIds[linearThreadIdx] = -1;
 
     __syncthreads();
@@ -114,9 +114,9 @@ __global__ void copySpeciesGlobal2Local(T_CounterBox counter, T_DestBox destBox,
         {
             /* counter[2] -> number of used frames */
             nvidia::atomicAllInc(&(counter[2]));
-            DestFramePtr tmpFrame = &(destBox.getEmptyFrame());
+            DestFramePtr tmpFrame = destBox.getEmptyFrame();
             destFramePtr[linearThreadIdx] = tmpFrame;
-            destBox.setAsFirstFrame(*tmpFrame, superCellIdx + cellDesc.getGuardingSuperCells());
+            destBox.setAsFirstFrame(tmpFrame, superCellIdx + cellDesc.getGuardingSuperCells());
         }
     }
     __syncthreads();
@@ -124,7 +124,7 @@ __global__ void copySpeciesGlobal2Local(T_CounterBox counter, T_DestBox destBox,
     if (hasValidParticle)
     {
         /* copy attributes and activate particle*/
-        PMACC_AUTO(parDest, (*(destFramePtr[masterIdx]))[linearThreadIdx]);
+        PMACC_AUTO(parDest, destFramePtr[masterIdx][linearThreadIdx]);
         parDest[localCellIdx_] = lCellIdx;
         parDest[multiMask_] = 1;
         PMACC_AUTO(parDestDeselect, deselect<bmpl::vector2<localCellIdx, multiMask> >(parDest));

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -272,9 +272,9 @@ kernelPaintParticles3D(ParBox pb,
                        uint32_t sliceDim,
                        Mapping mapper)
 {
-    typedef typename ParBox::FrameType FRAME;
+    typedef typename ParBox::FramePtr FramePtr;
     typedef typename MappingDesc::SuperCellSize Block;
-    __shared__ FRAME *frame;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
     __shared__ bool isValid;
 
     bool isImageThread = false;
@@ -332,13 +332,13 @@ kernelPaintParticles3D(ParBox pb,
 
     if (localId == 0)
     {
-        frame = &(pb.getFirstFrame(block, isValid));
+        frame = pb.getFirstFrame(block);
     }
     __syncthreads();
 
-    while (isValid) //move over all Frames
+    while (frame.isValid()) //move over all Frames
     {
-        PMACC_AUTO(particle, (*frame)[localId]);
+        PMACC_AUTO(particle, frame[localId]);
         if (particle[multiMask_] == 1)
         {
             int cellIdx = particle[localCellIdx_];
@@ -357,7 +357,7 @@ kernelPaintParticles3D(ParBox pb,
 
         if (localId == 0)
         {
-            frame = &(pb.getNextFrame(*frame, isValid));
+            frame = pb.getNextFrame(frame);
         }
         __syncthreads();
     }

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -109,9 +109,9 @@ void kernelRadiationParticles(ParBox pb,
 
     typedef typename MappingDesc::SuperCellSize Block;
     typedef typename ParBox::FrameType FRAME;
+    typedef typename ParBox::FramePtr FramePtr;
 
-    __shared__ FRAME *frame; // pointer to  frame storing particles
-    __shared__ bool isValid; // bool saying if frame is valid
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame; // pointer to  frame storing particles
     __shared__ lcellId_t particlesInFrame; // number  of particles in current frame
 
     using namespace parameters; // parameters of radiation
@@ -201,7 +201,7 @@ void kernelRadiationParticles(ParBox pb,
         if (linearThreadIdx == 0)
           {
             // set frame pointer
-            frame = &(pb.getLastFrame(superCell, isValid));
+            frame = pb.getLastFrame(superCell);
 
             // number of particles in this frame
             particlesInFrame = pb.getSuperCell(superCell).getSizeLastFrame();
@@ -216,13 +216,13 @@ void kernelRadiationParticles(ParBox pb,
          * if "isValid" is false then there is no frame
          * inside the superCell (anymore)
          */
-        while (isValid)
+        while (frame.isValid())
         {
             // only threads with particles are running
             if (linearThreadIdx < particlesInFrame)
             {
 
-                PMACC_AUTO(par,(*frame)[linearThreadIdx]);
+                PMACC_AUTO(par,frame[linearThreadIdx]);
                 // get old and new particle momenta
                 const vector_X particle_momentumNow = vector_X(par[momentum_]);
                 const vector_X particle_momentumOld = vector_X(par[momentumPrev1_]);
@@ -473,7 +473,7 @@ void kernelRadiationParticles(ParBox pb,
                  *   all previous SuperCells are full with particles
                  */
                 particlesInFrame = blockSize;
-                frame = &(pb.getPreviousFrame(*frame, isValid));
+                frame = pb.getPreviousFrame(frame);
                 counter_s = 0;
               }
 
@@ -482,7 +482,7 @@ void kernelRadiationParticles(ParBox pb,
 
             // run through while-loop(is Valid) again
 
-          } // end while(isValid)
+          } // end while(frame.isValid())
 
       } // end loop over all super cells
 


### PR DESCRIPTION
- refactor interface of the `ParticlesBox`
- use `FramePointer<...>` instead of plain C pointer
- use coding guide line for code formation

Sry that this pull request contains code style changes, I pressed button for auto formation in my IDE.

This pull close #1191

**Tests:**
- [x] KHI electrons/positrons heating
- [x] KHI macro particles count