### PR TITLE
Boost: 1.56.0+ Requirement

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -51,13 +51,13 @@ Requirements
   - *Debian/Ubuntu:* `sudo apt-get install zlib1g-dev`
   - *Arch Linux:* `sudo pacman --sync zlib`
 
-- **boost** 1.52.0+ ("program options", "regex" , "filesystem", "system" and nearly all header-only libs)
-  - download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.52.0/boost_1_52_0.tar.gz/download),
-      e.g. version 1.52.0
+- **boost** 1.56.0+ ("program options", "regex" , "filesystem", "system" and nearly all header-only libs)
+  - download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz/download),
+      e.g. version 1.56.0
   - *Debian/Ubuntu:* `sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev`
   - *Arch Linux:* `sudo pacman --sync boost`
   - *From source:*
-    - `./bootstrap.sh --with-libraries=filesystem,program_options,regex,system --prefix=$HOME/lib/boost`
+    - `./bootstrap.sh --with-libraries=filesystem,program_options,regex,system,thread --prefix=$HOME/lib/boost`
     - `./b2 -j4 && ./b2 install`
 
 - **git** 1.7.9.5 or [higher](https://help.github.com/articles/https-cloning-errors)

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -1,4 +1,3 @@
-#
 # Copyright 2013-2015 Axel Huebl, Benjamin Schneider, Felix Schmitt, Heiko Burau,
 #                     Rene Widera, Alexander Grund
 #
@@ -255,39 +254,24 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.52.0 REQUIRED COMPONENTS program_options regex filesystem system)
+find_package(Boost 1.56.0 REQUIRED COMPONENTS program_options regex filesystem
+                                              system thread)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 
-# work-arounds
-if( (Boost_VERSION EQUAL 105500) AND
-    (CUDA_VERSION VERSION_LESS 6.5) )
-    # Boost Bug https://svn.boost.org/trac/boost/ticket/9392
-    # nvbug #1422182 submission ID #391854
-    message(STATUS "Boost: Applying noinline work around")
-    set(CUDA_NVCC_FLAGS
-      "${CUDA_NVCC_FLAGS} \"-DBOOST_NOINLINE=__attribute__((noinline))\" ")
-endif()
-
-# PMacc (ab)uses boost::result_of for non-functors (e.g. []-operators). This
-# define forces boost to use the result<> member template of the target type
-if(Boost_VERSION LESS 105500)
-    add_definitions(-DBOOST_RESULT_OF_USE_TR1)
+# Boost 1.55 added support for a define that makes result_of look for
+# the result<> template and falls back to decltype if none is found. This is
+# great for the transition from the "wrong" usage to the "correct" one as
+# both can be used. But:
+# 1) Cannot be used in 7.0 due to nvcc bug:
+#    http://stackoverflow.com/questions/31940457/
+# 2) Requires C++11 enabled as there is no further check in boost besides
+#    the version check of nvcc
+if( (NOT CUDA_VERSION VERSION_EQUAL 7.0) AND (CMAKE_CXX_STANDARD EQUAL 11) )
+    add_definitions(-DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
 else()
-    # Boost 1.55 adds support for another define that makes result_of look for
-    # the result<> template and falls back to decltype if none is found. This is
-    # great for the transition from the "wrong" usage to the "correct" one as
-    # both can be used. But:
-    # 1) Cannot be used in 7.0 due to nvcc bug:
-    #    http://stackoverflow.com/questions/31940457/
-    # 2) Requires C++11 enabled as there is no further check in boost besides
-    #    the version check of nvcc
-    if( (NOT CUDA_VERSION VERSION_EQUAL 7.0) AND (CMAKE_CXX_STANDARD EQUAL 11) )
-        add_definitions(-DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
-    else()
-        # Fallback
-        add_definitions(-DBOOST_RESULT_OF_USE_TR1)
-    endif()
+    # Fallback
+    add_definitions(-DBOOST_RESULT_OF_USE_TR1)
 endif()
 
 ################################################################################

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -10,7 +10,7 @@ then
         # Core Dependencies
         module load gcc/4.6.2
         module load cmake/3.0.1
-        module load boost/1.54.0
+        module load boost/1.56.0
         module load cuda/6.5
         module load openmpi/1.8.4.kepler
 

--- a/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
+++ b/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
@@ -7,7 +7,7 @@ then
         module load git/1.7.9
         module load gcc/4.4.7
         module load cuda/5.5
-        module load boost/1.54.0-gcc
+        module load boost/1.56.0-gcc
         module load openmpi/1.6.5-gcc
 
         # Core tools

--- a/src/picongpu/submit/taurus-tud/picongpu.profile.example
+++ b/src/picongpu/submit/taurus-tud/picongpu.profile.example
@@ -2,24 +2,24 @@ module purge
 
 # General modules #############################################################
 #
-module load oscar-modules llview
+module load oscar-modules
 module load cmake/3.3.1 git
-module load cuda/6.5.14  # gcc 4.8, intel 14.0 == 2013-sp1
+module load cuda/7.0.28 # gcc <=4.9, intel 15.0
 module load bullxmpi
 module load gnuplot/4.6.1
 
 # Compilers ###################################################################
 ### GCC
-module load gcc/4.8.0 boost/1.55.0-gnu4.8
+module load gcc/4.9.1 boost/1.56.0-gnu4.9.1
 ### ICC
-#module load intel/2013-sp1 boost/1.57.0-intel2013-sp1
+#module load intel/2015.3.187 boost/1.59.0-intel2015.3.187
 ### PGI
-#export BOOST_ROOT=$HOME/lib/boost_1_54_pgi_13_6
+#export BOOST_ROOT=$HOME/lib/boost_1_56_pgi_14_9
 #export BOOST_INC=$BOOST_ROOT/include
 #export BOOST_LIB=$BOOST_ROOT/lib
 # must be set in `which <pgiDir>/bin/localrc`:
 #   set NOSWITCHERROR=YES;
-#module load pgi/14.1 boost/1.55.0-pgi14.1
+#module load pgi/14.9 boost/<noneBuildYet>
 
 # Other Software ##############################################################
 #


### PR DESCRIPTION
This PR increases the boost requirement to be at least 1.56.0+ (first required by #995).

This allows us to drop a list of work-arounds as a result.