### PR TITLE
Add a policy to GetKeyFromAlias

### DIFF
--- a/src/libPMacc/include/compileTime/GetKeyFromAlias.hpp
+++ b/src/libPMacc/include/compileTime/GetKeyFromAlias.hpp
@@ -45,7 +45,7 @@ namespace PMacc
  */
 template<typename T_MPLSeq,
          typename T_Key,
-	     typename T_KeyNotFoundPolicy = errorHandlerPolicies::ReturnType<>
+         typename T_KeyNotFoundPolicy = errorHandlerPolicies::ReturnType<>
 >
 struct GetKeyFromAlias
 {

--- a/src/libPMacc/include/compileTime/conversion/ResolveAliases.hpp
+++ b/src/libPMacc/include/compileTime/conversion/ResolveAliases.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera, Felix Schmitt
+ * Copyright 2013-2015 Rene Widera, Felix Schmitt, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -23,41 +23,41 @@
 #pragma once
 
 #include "types.h"
+#include "compileTime/GetKeyFromAlias.hpp"
+#include "compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp"
 
 #include <boost/mpl/vector.hpp>
-#include <boost/mpl/copy.hpp>
-#include <boost/mpl/size.hpp>
 #include <boost/mpl/transform.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/insert.hpp>
 
-#include <boost/type_traits.hpp>
-
 namespace PMacc
 {
 
-/* translate all pmacc alias types to full specialized types
+/** Translate all PMacc alias types to full specialized types
  *
- * use lookup sequense to translate types
- * if type from T_MPLSeq is not in T_MPLSeqLookup a compile time error is triggered
+ * Use lookup sequence to translate types
+ * The policy is used if the type from T_MPLSeq is not in T_MPLSeqLookup a compile time error is triggered
  *
  * @tparam T_MPLSeq source sequence with types to translate
  * @tparam T_MPLSeqLookup lookup sequence to translate aliases
  */
 template<
-typename T_MPLSeq,
-typename T_MPLSeqLookup
+    typename T_MPLSeq,
+    typename T_MPLSeqLookup,
+    typename T_AliasNotFoundPolicy = errorHandlerPolicies::ThrowValueNotFound
 >
 struct ResolveAliases
 {
     typedef T_MPLSeq MPLSeq;
     typedef T_MPLSeqLookup MPLSeqLookup;
+    typedef T_AliasNotFoundPolicy AliasNotFoundPolicy;
     typedef bmpl::back_inserter< bmpl::vector<> > Inserter;
 
     template<typename T_Identifier>
     struct GetKeyFromAliasAccessor
     {
-        typedef typename GetKeyFromAlias_assert<MPLSeqLookup, T_Identifier>::type type;
+        typedef typename GetKeyFromAlias<MPLSeqLookup, T_Identifier, AliasNotFoundPolicy>::type type;
     };
 
     typedef typename bmpl::transform<

--- a/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnType.hpp
+++ b/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnType.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera, Alexander Grund
+ * Copyright 2015 Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -24,28 +24,23 @@
 
 #include "types.h"
 
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-#include "compileTime/conversion/ResolveAliases.hpp"
-#include "compileTime/errorHandlerPolicies/ReturnValue.hpp"
-
 namespace PMacc
 {
-
-/** Resolve and remove types from a sequence
- *
- * @tparam T_MPLSeqSrc source sequence from were we delete types
- * @tparam T_MPLSeqObjectsToRemove sequence with types which should be deleted (PMacc aliases are allowed)
- */
-template<
-typename T_MPLSeqSrc,
-typename T_MPLSeqObjectsToRemove
->
-struct ResolveAndRemoveFromSeq
+namespace errorHandlerPolicies
 {
-    typedef T_MPLSeqSrc MPLSeqSrc;
-    typedef T_MPLSeqObjectsToRemove MPLSeqObjectsToRemove;
-    typedef typename ResolveAliases<MPLSeqObjectsToRemove, MPLSeqSrc, errorHandlerPolicies::ReturnValue>::type ResolvedSeqWithObjectsToRemove;
-    typedef typename RemoveFromSeq<MPLSeqSrc, ResolvedSeqWithObjectsToRemove>::type type;
+
+/** Returns the given type
+ *  Binary meta function that takes any boost mpl sequence and a type
+ */
+template<typename T_ReturnType = bmpl::void_>
+struct ReturnType
+{
+    template<typename T_MPLSeq, typename T_Value>
+    struct apply
+    {
+        typedef T_ReturnType type;
+    };
 };
 
-}//namespace PMacc
+} // namespace errorHandlerPolicies
+} // namespace PMacc

--- a/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnValue.hpp
+++ b/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnValue.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera, Alexander Grund
+ * Copyright 2015 Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -24,28 +24,22 @@
 
 #include "types.h"
 
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-#include "compileTime/conversion/ResolveAliases.hpp"
-#include "compileTime/errorHandlerPolicies/ReturnValue.hpp"
-
 namespace PMacc
 {
-
-/** Resolve and remove types from a sequence
- *
- * @tparam T_MPLSeqSrc source sequence from were we delete types
- * @tparam T_MPLSeqObjectsToRemove sequence with types which should be deleted (PMacc aliases are allowed)
- */
-template<
-typename T_MPLSeqSrc,
-typename T_MPLSeqObjectsToRemove
->
-struct ResolveAndRemoveFromSeq
+namespace errorHandlerPolicies
 {
-    typedef T_MPLSeqSrc MPLSeqSrc;
-    typedef T_MPLSeqObjectsToRemove MPLSeqObjectsToRemove;
-    typedef typename ResolveAliases<MPLSeqObjectsToRemove, MPLSeqSrc, errorHandlerPolicies::ReturnValue>::type ResolvedSeqWithObjectsToRemove;
-    typedef typename RemoveFromSeq<MPLSeqSrc, ResolvedSeqWithObjectsToRemove>::type type;
+
+/** Returns the second parameter (normally the value that the sequence was searched for
+ *  Binary meta function that takes any boost mpl sequence and a type
+ */
+struct ReturnValue
+{
+    template<typename T_MPLSeq, typename T_Value>
+    struct apply
+    {
+        typedef T_Value type;
+    };
 };
 
-}//namespace PMacc
+} // namespace errorHandlerPolicies
+} // namespace PMacc

--- a/src/libPMacc/include/compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp
+++ b/src/libPMacc/include/compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015 Rene Widera, Alexander Grund
+ * Copyright 2015 Rene Widera
  *
  * This file is part of libPMacc.
  *
@@ -23,29 +23,25 @@
 #pragma once
 
 #include "types.h"
-
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-#include "compileTime/conversion/ResolveAliases.hpp"
-#include "compileTime/errorHandlerPolicies/ReturnValue.hpp"
+#include "static_assert.hpp"
 
 namespace PMacc
 {
-
-/** Resolve and remove types from a sequence
- *
- * @tparam T_MPLSeqSrc source sequence from were we delete types
- * @tparam T_MPLSeqObjectsToRemove sequence with types which should be deleted (PMacc aliases are allowed)
- */
-template<
-typename T_MPLSeqSrc,
-typename T_MPLSeqObjectsToRemove
->
-struct ResolveAndRemoveFromSeq
+namespace errorHandlerPolicies
 {
-    typedef T_MPLSeqSrc MPLSeqSrc;
-    typedef T_MPLSeqObjectsToRemove MPLSeqObjectsToRemove;
-    typedef typename ResolveAliases<MPLSeqObjectsToRemove, MPLSeqSrc, errorHandlerPolicies::ReturnValue>::type ResolvedSeqWithObjectsToRemove;
-    typedef typename RemoveFromSeq<MPLSeqSrc, ResolvedSeqWithObjectsToRemove>::type type;
+
+/** Throws an assertion that the value was not found in the sequence
+ *  Binary meta function that takes any boost mpl sequence and a type
+ */
+struct ThrowValueNotFound
+{
+    template<typename T_MPLSeq, typename T_Value>
+    struct apply
+    {
+        PMACC_CASSERT_MSG_TYPE(value_not_found_in_seq, T_Value, false);
+        typedef bmpl::void_ type;
+    };
 };
 
-}//namespace PMacc
+} // namespace errorHandlerPolicies
+} // namespace PMacc

--- a/src/libPMacc/include/particles/memory/frames/Frame.hpp
+++ b/src/libPMacc/include/particles/memory/frames/Frame.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Rene Widera
+ * Copyright 2013-2015 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -107,7 +107,7 @@ public InheritLinearly<
     template<class F, class TKey>
     struct result<const F(TKey)>
     {
-        typedef typename GetKeyFromAlias_assert<ValueTypeSeq, TKey>::type Key;
+        typedef typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type Key;
         typedef typename boost::result_of<const BaseType(Key)>::type type;
     };
 
@@ -115,7 +115,7 @@ public InheritLinearly<
     template<class F, class TKey>
     struct result< F(TKey)>
     {
-        typedef typename GetKeyFromAlias_assert<ValueTypeSeq, TKey>::type Key;
+        typedef typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type Key;
         typedef typename boost::result_of< BaseType(Key)>::type type;
     };
 


### PR DESCRIPTION
This allows e.g. `ResolveAndRemoveFromSeq` to not fail if a value did not exist in the first place.

Current policies are:

1. Fail if alias is not in the sequence
2. Return the (supposed to be) alias
3. Return a given type

Default policy is to return bmpl::void_ so it does not change current behaviour.

Partly based on offline discussion with @psychocoderHPC 