### PR TITLE
HostbufferIntern depends on HostBuffer not on Buffer

### DIFF
--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "memory/buffers/Buffer.hpp"
+#include "memory/buffers/HostBuffer.hpp"
 #include "eventSystem/tasks/Factory.hpp"
 #include "eventSystem/EventSystem.hpp"
 


### PR DESCRIPTION
**It does not effects PIConGPU**. It is only a PMacc bug.

--

Found that failure while test case generation.
Leads to : 

    /home/zenker64/projects/picongpu/src/libPMacc/include/memory/buffers/HostBuffer.hpp(44): error: Buffer is not a template

    /home/zenker64/projects/picongpu/src/libPMacc/include/memory/buffers/HostBuffer.hpp(44): error: not a class or struct name

    /home/zenker64/projects/picongpu/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp(51): error: Buffer is not a template

    /home/zenker64/projects/picongpu/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp(51): error: not a class or struct name

    /home/zenker64/projects/picongpu/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp(63): error: Buffer is not a template

Changing from Buffer to HostBuffer include solved the Problem.