### PR TITLE
Refactor FieldTmp Particle Solvers

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -25,24 +25,14 @@
 #include "simulation_defines.hpp"
 #include "fields/Fields.def"
 #include "particles/traits/GetShape.hpp"
+#include "particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
 
 namespace picongpu
 {
 namespace particleToGrid
 {
 
-struct ComputeGridValueOptions
-{
-    BOOST_STATIC_CONSTEXPR uint32_t calcDensity = 0u;
-    BOOST_STATIC_CONSTEXPR uint32_t calcEnergy = 1u;
-    BOOST_STATIC_CONSTEXPR uint32_t calcEnergyDensity = 2u;
-    BOOST_STATIC_CONSTEXPR uint32_t calcCounter = 3u;
-#if(ENABLE_RADIATION == 1)
-    BOOST_STATIC_CONSTEXPR uint32_t calcLarmorEnergy = 4u;
-#endif
-};
-
-template<class T_ParticleShape, uint32_t calcType>
+template<class T_ParticleShape, class T_DerivedAttribute>
 class ComputeGridValuePerFrame
 {
 public:
@@ -79,14 +69,14 @@ public:
 /** Predefined Calculations for \see fieldOutput.param
  */
 
-/* Density */
+/* ChargeDensity */
 template<typename T_Species>
 struct CreateDensityOperation
 {
     typedef typename GetShape<T_Species>::type shapeType;
     typedef ComputeGridValuePerFrame<
         shapeType,
-        ComputeGridValueOptions::calcDensity
+        particleToGrid::derivedAttributes::ChargeDensity
     > ParticleDensity;
 
     typedef FieldTmpOperation< ParticleDensity, T_Species > type;
@@ -98,7 +88,7 @@ struct CreateCounterOperation
 {
     typedef ComputeGridValuePerFrame<
         particles::shapes::Counter,
-        ComputeGridValueOptions::calcCounter
+        particleToGrid::derivedAttributes::Counter
     > ParticleCounter;
 
     typedef FieldTmpOperation< ParticleCounter, T_Species > type;
@@ -111,7 +101,7 @@ struct CreateEnergyDensityOperation
     typedef typename GetShape<T_Species>::type shapeType;
     typedef ComputeGridValuePerFrame<
         shapeType,
-        ComputeGridValueOptions::calcEnergyDensity
+        particleToGrid::derivedAttributes::EnergyDensity
     > ParticleEnergyDensity;
 
     typedef FieldTmpOperation< ParticleEnergyDensity, T_Species > type;
@@ -124,7 +114,7 @@ struct CreateEnergyOperation
     typedef typename GetShape<T_Species>::type shapeType;
     typedef ComputeGridValuePerFrame<
         shapeType,
-        ComputeGridValueOptions::calcEnergy
+        particleToGrid::derivedAttributes::Energy
     > ParticleEnergy;
 
     typedef FieldTmpOperation< ParticleEnergy, T_Species > type;
@@ -137,7 +127,7 @@ struct CreateLarmorEnergyOperation
     typedef typename GetShape<T_Species>::type shapeType;
     typedef ComputeGridValuePerFrame<
         shapeType,
-        ComputeGridValueOptions::calcLarmorEnergy
+        particleToGrid::derivedAttributes::LarmorEnergy
     > ParticleLarmorEnergy;
 
     typedef FieldTmpOperation< ParticleLarmorEnergy, T_Species > type;

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct ChargeDensity
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::string
+        getName() const
+        {
+            return "chargeDensity";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    ChargeDensity::getUnit() const
+    {
+        const float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
+        return UNIT_CHARGE / UNIT_VOLUME;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    ChargeDensity::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float_X weighting = particle[weighting_];
+        const float_X charge = attribute::getCharge( weighting, particle );
+
+        /* calculate new attribute */
+        const float_X particleChargeDensity = charge / CELL_VOLUME;
+
+        /* return attribute */
+        return particleChargeDensity;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct Counter
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::string
+        getName() const
+        {
+            return "particleCounter";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.hpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    Counter::getUnit() const
+    {
+        return particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    Counter::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float_X weighting = particle[weighting_];
+
+        /* calculate new attribute */
+        const float_X particleCounter = weighting /
+            particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+
+        /* return attribute */
+        return particleCounter;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct Density
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::string
+        getName() const
+        {
+            return "density";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    Density::getUnit() const
+    {
+        const float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
+        return particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE / UNIT_VOLUME;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    Density::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float_X weighting = particle[weighting_];
+
+        /* calculate new attribute */
+        const float_X particleDensity = weighting /
+            ( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME );
+
+        /* return attribute */
+        return particleDensity;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/Density.def"
+#include "particles/particleToGrid/derivedAttributes/Counter.def"
+#include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "particles/particleToGrid/derivedAttributes/EnergyDensity.def"
+#include "particles/particleToGrid/derivedAttributes/Energy.def"
+#include "particles/particleToGrid/derivedAttributes/LarmorEnergy.def"

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/Density.hpp"
+#include "particles/particleToGrid/derivedAttributes/Counter.hpp"
+#include "particles/particleToGrid/derivedAttributes/ChargeDensity.hpp"
+#include "particles/particleToGrid/derivedAttributes/EnergyDensity.hpp"
+#include "particles/particleToGrid/derivedAttributes/Energy.hpp"
+#include "particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp"

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct Energy
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::string
+        getName() const
+        {
+            return "particleEnergy";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/Energy.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    Energy::getUnit() const
+    {
+        return UNIT_ENERGY;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    Energy::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float_X weighting = particle[weighting_];
+        const float3_X mom = particle[momentum_];
+        const float_X mass = attribute::getMass( weighting, particle );
+
+        /* calculate new attribute */
+        Gamma<float_X> calcGamma;
+        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
+        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+
+        const float_X energy = ( gamma <= float_X(GAMMA_THRESH) ) ?
+            math::abs2(mom) / ( float_X(2.0) * mass ) :   /* non-relativistic */
+            (gamma - float_X(1.0)) * mass * c2;           /* relativistic     */
+
+        /* return attribute */
+        return energy;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct EnergyDensity
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::string
+        getName() const
+        {
+            return "energyDensity";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/EnergyDensity.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    EnergyDensity::getUnit() const
+    {
+        const float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
+        return UNIT_ENERGY * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
+               / UNIT_VOLUME;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    EnergyDensity::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float_X weighting = particle[weighting_];
+        const float3_X mom = particle[momentum_];
+        const float_X mass = attribute::getMass( weighting, particle );
+
+        /* calculate new attribute */
+        Gamma<float_X> calcGamma;
+        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
+        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+
+        const float_X energy = ( gamma <= float_X(GAMMA_THRESH) ) ?
+            math::abs2(mom) / ( float_X(2.0) * mass ) :   /* non-relativistic */
+            (gamma - float_X(1.0)) * mass * c2;           /* relativistic     */
+
+        const float_X particleDensity = weighting /
+            ( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME );
+
+        const float_X particleEnergyDensity = energy * particleDensity;
+
+        /* return attribute */
+        return particleEnergyDensity;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.def
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct LarmorEnergy
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::string
+        getName() const
+        {
+            return "larmorEnergy";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp
@@ -52,13 +52,14 @@ namespace derivedAttributes
         /* calculate new attribute */
         Gamma<float_X> calcGamma;
         const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
+        const float_X gamma2 = gamma * gamma;
         const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
 
         const float3_X mom_dt = mom - mom_mt1;
         const float_X el_factor = charge * charge
-            / (6.0 * PI * EPS0 *
+            / (float_X(6.0) * PI * EPS0 *
                c2 * c2 * SPEED_OF_LIGHT * mass * mass);
-        const float_X energyLarmor = el_factor * math::pow( gamma, 4 )
+        const float_X energyLarmor = el_factor * gamma2 * gamma2
             * (math::abs2(mom_dt) -
                math::abs2(math::cross(mom, mom_dt)));
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/LarmorEnergy.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    LarmorEnergy::getUnit() const
+    {
+        return UNIT_ENERGY;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    LarmorEnergy::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float3_X mom = particle[momentum_];
+        const float3_X mom_mt1 = particle[momentumPrev1_];
+        const float_X weighting = particle[weighting_];
+        const float_X charge = attribute::getCharge( weighting, particle );
+        const float_X mass = attribute::getMass( weighting, particle );
+
+        /* calculate new attribute */
+        Gamma<float_X> calcGamma;
+        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
+        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+
+        const float3_X mom_dt = mom - mom_mt1;
+        const float_X el_factor = charge * charge
+            / (6.0 * PI * EPS0 *
+               c2 * c2 * SPEED_OF_LIGHT * mass * mass);
+        const float_X energyLarmor = el_factor * math::pow( gamma, 4 )
+            * (math::abs2(mom_dt) -
+               math::abs2(math::cross(mom, mom_dt)));
+
+        /* return attribute */
+        return energyLarmor;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -214,9 +214,9 @@ private:
         static std::string getName()
         {
             std::stringstream str;
-            str << Solver().getName();
-            str << "_";
             str << Species::FrameType::getName();
+            str << "_";
+            str << Solver().getName();
             return str.str();
         }
 

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -127,9 +127,9 @@ private:
     static std::string getName()
     {
         std::stringstream str;
-        str << Solver().getName();
-        str << "_";
         str << Species::FrameType::getName();
+        str << "_";
+        str << Solver().getName();
         return str.str();
     }
 


### PR DESCRIPTION
Refactors the particle solvers that populate `FieldTmp`, e.g., the HDF5 and ADIOS plugins.

The primarily goal of this refactoring is to make the current structure cleaner with separate classes and to allow later on to add solvers that populate `FieldTmp`, e.g., from pure field sources (e.g., div of E, |S|, etc.).

Additionally, namings and results of solvers have been clearified and standardized.

### Changes
 - all namings (according to openPMD ED-PIC extension, [version 1.0.0](https://github.com/openPMD/openPMD-standard/blob/1.0.0/EXT_ED-PIC.md#naming-conventions-for-mesh-records-field-records))
 - `<species>_chargeDensity` (previously called wrong "density", related to #909)
 - `<species>_energyDensity` (now without charge, previously created an
                          energy-charge-density)

### Adds
 - `<species>_density` (an actual density)

### To Do
- [x] run (looked ok)
- [x] run time comparison of results (dev/PR) (help wanted)