### PR TITLE
Gas Gaussian Cloud: Add Missing Documentation

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/gasConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gasConfig.param
@@ -51,7 +51,7 @@ PMACC_STRUCT(GaussianCloudParam,
      *     exponent = |globalCellPos - center| / sigma
      *     density = e^[ gasFactor * exponent^gasPower ]
      */
-    (PMACC_C_VALUE(float_X, gasFactor, -1.0))
+    (PMACC_C_VALUE(float_X, gasFactor, -0.5))
     (PMACC_C_VALUE(float_X, gasPower, 2.0))
 
     /** height of vacuum area on top border

--- a/examples/Bunch/include/simulation_defines/param/gasConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gasConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.
@@ -47,6 +47,13 @@ namespace gasProfiles
 {
 
 PMACC_STRUCT(GaussianCloudParam,
+    /** Gas Formula:
+     *     exponent = |globalCellPos - center| / sigma
+     *     density = e^[ gasFactor * exponent^gasPower ]
+     */
+    (PMACC_C_VALUE(float_X, gasFactor, -1.0))
+    (PMACC_C_VALUE(float_X, gasPower, 2.0))
+
     /** height of vacuum area on top border
      *
      * this vacuum is important because of the laser initialization,
@@ -54,9 +61,6 @@ PMACC_STRUCT(GaussianCloudParam,
      * unit: cells
      */
     (PMACC_C_VALUE(uint32_t, vacuumCellsY, 50))
-
-    (PMACC_C_VALUE(float_X, gasFactor, -1.0))
-    (PMACC_C_VALUE(float_X, gasPower, 2.0))
 
     /** The central position of the gas distribution
      *  unit: meter

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -138,6 +138,13 @@ typedef LinearExponentialImpl<LinearExponentialParam> LinearExponential;
 
 
 PMACC_STRUCT(GaussianCloudParam,
+    /** Gas Formula:
+     *     exponent = |globalCellPos - center| / sigma
+     *     density = e^[ gasFactor * exponent^gasPower ]
+     */
+    (PMACC_C_VALUE(float_X, gasFactor, 1.0))
+    (PMACC_C_VALUE(float_X, gasPower, 4.0))
+
     /** height of vacuum area on top border
      *
      * this vacuum is important because of the laser initialization,
@@ -146,9 +153,6 @@ PMACC_STRUCT(GaussianCloudParam,
      * unit: cells
      */
     (PMACC_C_VALUE(uint32_t, vacuumCellsY, 50))
-
-    (PMACC_C_VALUE(float_X, gasFactor, 1.0))
-    (PMACC_C_VALUE(float_X, gasPower, 4.0))
 
     /** The central position of the gas distribution
      *  unit: meter
@@ -162,6 +166,7 @@ PMACC_STRUCT(GaussianCloudParam,
 
 /* definition of gas cloud profile*/
 typedef GaussianCloudImpl<GaussianCloudParam> GaussianCloud;
+
 
 /** The profile consists out of the composition of 3 1D profiles
  *  with the scheme: exponential increasing flank, constant sphere,
@@ -212,6 +217,7 @@ PMACC_STRUCT(SphereFlanksParam,
 /* definition of gas sphere with flanks*/
 typedef SphereFlanksImpl<SphereFlanksParam> SphereFlanks;
 
+
 PMACC_STRUCT(FromHDF5Param,
     /* prefix of filename
      * full file name: gas_0.h5
@@ -229,6 +235,7 @@ PMACC_STRUCT(FromHDF5Param,
 
 /* definition of gas cloud profile*/
 typedef FromHDF5Impl<FromHDF5Param> FromHDF5;
+
 
 struct FreeFormulaFunctor
 {

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -142,8 +142,8 @@ PMACC_STRUCT(GaussianCloudParam,
      *     exponent = |globalCellPos - center| / sigma
      *     density = e^[ gasFactor * exponent^gasPower ]
      */
-    (PMACC_C_VALUE(float_X, gasFactor, 1.0))
-    (PMACC_C_VALUE(float_X, gasPower, 4.0))
+    (PMACC_C_VALUE(float_X, gasFactor, -0.5))
+    (PMACC_C_VALUE(float_X, gasPower, 2.0))
 
     /** height of vacuum area on top border
      *


### PR DESCRIPTION
This adds the missing documentation in `gasConfig.param` for the GaussianCloud profile.

Was removed during refactoring since even the [original documentation](https://github.com/ComputationalRadiationPhysics/picongpu/blob/f31b31ab5afe8951ba58754fc6266a4ac07ffd20/src/picongpu/include/simulation_defines/param/gasConfig.param#L167-L173) was copy-pasted from an other profile (and therefore wrong).