### PR TITLE
Test checks setValue of HostBufferIntern

### DIFF
--- a/src/libPMacc/CMakeLists.txt
+++ b/src/libPMacc/CMakeLists.txt
@@ -55,6 +55,5 @@ target_link_libraries(check ${LIBS})
 # CTest
 enable_testing()
 add_test(PMacc_test_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target check)
-# --alow-run-as-root because some ci run test as root
 add_test(PMacc_test_run  mpiexec -n 1 ./check --log_level=test_suite)
-set_tests_properties(PMacc_test_run PROPERTIES DEPENDS graybat_check_build)
+set_tests_properties(PMacc_test_run PROPERTIES DEPENDS PMacc_test_build)

--- a/src/libPMacc/CMakeLists.txt
+++ b/src/libPMacc/CMakeLists.txt
@@ -56,5 +56,5 @@ target_link_libraries(check ${LIBS})
 enable_testing()
 add_test(PMacc_test_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target check)
 # --alow-run-as-root because some ci run test as root
-add_test(PMacc_test_run  mpiexec --allow-run-as-root -n 2 check )
+add_test(PMacc_test_run  mpiexec -n 1 ./check --log_level=test_suite)
 set_tests_properties(PMacc_test_run PROPERTIES DEPENDS graybat_check_build)

--- a/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
@@ -47,9 +47,10 @@ struct setValueTest
             const Data value = 255;
             hostBufferIntern.setValue(value);
 
+	    PMACC_AUTO( ptr, hostBufferIntern.getPointer( ) );
             for(size_t j = 0; j < static_cast<size_t>(dataSpace.productOfComponents()); ++j)
             {
-                BOOST_CHECK_EQUAL( hostBufferIntern.getPointer()[j], value );
+                BOOST_CHECK_EQUAL( ptr[j], value );
             }
             
         }

--- a/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015 Erik Zenker
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/* #includes in "test/memoryUT.cu" */
+
+/**
+ * Checks if the HostBufferIntern is set to a constant value.
+ */
+struct setValueTest
+{
+
+    template<typename T_Dim>
+    void operator()(T_Dim)
+    {
+
+        typedef uint8_t Data;
+        typedef size_t Extents;
+
+        std::vector<size_t> nElementsPerDim = getElementsPerDim<T_Dim>();
+        
+        for(size_t i = 0; i < nElementsPerDim.size(); ++i)
+        {
+            ::PMacc::DataSpace<T_Dim::value> const dataSpace = ::PMacc::DataSpace<T_Dim::value>::create(nElementsPerDim[i]);
+            ::PMacc::HostBufferIntern<Data, T_Dim::value> hostBufferIntern(dataSpace);
+            
+            const Data value = 255;
+            hostBufferIntern.setValue(value);
+
+            for(size_t j = 0; j < static_cast<size_t>(dataSpace.productOfComponents()); ++j)
+            {
+                BOOST_CHECK_EQUAL( hostBufferIntern.getPointer()[j], value );
+            }
+            
+        }
+        
+    }
+
+};
+
+BOOST_AUTO_TEST_CASE( setValue )
+{
+    ::boost::mpl::for_each< Dims >( setValueTest() );
+
+}

--- a/src/libPMacc/test/memory/memoryUT.cu
+++ b/src/libPMacc/test/memory/memoryUT.cu
@@ -123,8 +123,9 @@ BOOST_GLOBAL_FIXTURE( Fixture );
 BOOST_AUTO_TEST_SUITE( memory )
 
   BOOST_AUTO_TEST_SUITE( HostBufferIntern )
-  #include "HostBufferIntern/reset.hpp"
   #include "HostBufferIntern/copyFrom.hpp"
+  #include "HostBufferIntern/reset.hpp"
+  #include "HostBufferIntern/setValue.hpp"
   BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR test the method `setValue` of HostBufferIntern by calling `setValue(255)` and checking afterwards wether the values have been set correctly by iterating over all elements in the HostBufferIntern.