### PR TITLE
close #1271 broken FieldTmp

### DIFF
--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -67,7 +67,7 @@ namespace picongpu
         }
         __syncthreads( );
 
-        if( frame.isValid() )
+        if( !frame.isValid() )
             return; //end kernel if we have no frames
 
         PMACC_AUTO( cachedVal, CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) ) );


### PR DESCRIPTION
- close #1271 *hdf5 plugin - FieldTmp broken*
- fix missing negation ( [result of refactoring](https://github.com/ComputationalRadiationPhysics/picongpu/pull/1243/files#diff-5b3d392fb808a21b5b3d279ee32a34d8L70) in #1243 )

- [x] LWFA test with HDF5 enabled