### PR TITLE
Fix MovingWindow localDimension

### DIFF
--- a/src/picongpu/include/simulationControl/MovingWindow.hpp
+++ b/src/picongpu/include/simulationControl/MovingWindow.hpp
@@ -220,8 +220,8 @@ public:
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         Window window;
 
-        window.localDimensions = Selection<simDim>(subGrid.getLocalDomain().size);
-        window.globalDimensions = Selection<simDim>(subGrid.getGlobalDomain().size);
+        window.localDimensions = Selection<simDim>(subGrid.getLocalDomain());
+        window.globalDimensions = Selection<simDim>(subGrid.getGlobalDomain());
 
         /* If sliding is inactive, moving window is the same as global domain (substract 0)*/
         window.globalDimensions.size.y() -= subGrid.getLocalDomain().size.y() * slidingWindowActive;
@@ -231,8 +231,8 @@ public:
             float_64 offsetFirstGPU = 0.0;
             getCurrentSlideInfo(currentStep, NULL, &offsetFirstGPU);
 
-            /* global offset is all 0 except for y dimension */
-            window.globalDimensions.offset.y() = offsetFirstGPU;
+            /* moving window can only slide in y direction */
+            window.globalDimensions.offset.y() += offsetFirstGPU;
 
             /* set top/bottom if there are no communication partners
              * for this GPU in the respective direction */


### PR DESCRIPTION
- close #568 *MovingWindow localDimension Values Not Updated*
- fix that offsets for local and global dimensions always set to zero
- copy full selction from `SubGrid` instead only the size
- remove hard overwrite of the global window offset by add tu current value

Additional to the `window.localDimensions.offset` the `window.globalDimensions.offset` was also always zero.

- [x] merge after #1272

Tests:
- [x] HDF5 checkpoints LWFA with moving window; simulate 2k steps and restart from step 2k (simulate to step 3k)
- [x] ADIOS checkpoints LWFA with moving window; simulate 2k steps and restart from step 2k (simulate to step 3k)
- [x] LWFA with moving window - HDF5 plugin enabled; simulate 4k steps (checked with HDFView  -> picture; slice each dimension)
- [x] LWFA with moving window - ADIOS plugin enabled; simulate 4k steps