### PR TITLE
reduce `GatherSlice` host memory footprint

### DIFF
--- a/src/picongpu/include/plugins/output/GatherSlice.hpp
+++ b/src/picongpu/include/plugins/output/GatherSlice.hpp
@@ -188,6 +188,7 @@ struct GatherSlice
                 insertData(dstBox, srcBox, head->node.offset, head->node.maxSize);
             }
 
+            __deleteArray(fullData);
         }
 
         delete[] recvHeader;


### PR DESCRIPTION
free mpi gatherv memory after usage

related to #1279

**Tests:**

- [x] 3D LWFA with sliding window (checked png images)
- 2D LWFA with sliding window 
  - [x] checked png images
  - [x] check memory usage with `top -d 0.5`