### PR TITLE
Close #1262 Fix Larmor Power in FieldTmp

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera
+ * Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -122,15 +122,15 @@ struct CreateEnergyOperation
 
 #if(ENABLE_RADIATION == 1)
 template<typename T_Species>
-struct CreateLarmorEnergyOperation
+struct CreateLarmorPowerOperation
 {
     typedef typename GetShape<T_Species>::type shapeType;
     typedef ComputeGridValuePerFrame<
         shapeType,
-        particleToGrid::derivedAttributes::LarmorEnergy
-    > ParticleLarmorEnergy;
+        particleToGrid::derivedAttributes::LarmorPower
+    > ParticleLarmorPower;
 
-    typedef FieldTmpOperation< ParticleLarmorEnergy, T_Species > type;
+    typedef FieldTmpOperation< ParticleLarmorPower, T_Species > type;
 };
 #endif
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Axel Huebl
+ * Copyright 2015 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -25,4 +25,4 @@
 #include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
 #include "particles/particleToGrid/derivedAttributes/EnergyDensity.def"
 #include "particles/particleToGrid/derivedAttributes/Energy.def"
-#include "particles/particleToGrid/derivedAttributes/LarmorEnergy.def"
+#include "particles/particleToGrid/derivedAttributes/LarmorPower.def"

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Axel Huebl
+ * Copyright 2015 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -25,4 +25,4 @@
 #include "particles/particleToGrid/derivedAttributes/ChargeDensity.hpp"
 #include "particles/particleToGrid/derivedAttributes/EnergyDensity.hpp"
 #include "particles/particleToGrid/derivedAttributes/Energy.hpp"
-#include "particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp"
+#include "particles/particleToGrid/derivedAttributes/LarmorPower.hpp"

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorEnergy.hpp
@@ -55,13 +55,16 @@ namespace derivedAttributes
         const float_X gamma2 = gamma * gamma;
         const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
 
-        const float3_X mom_dt = mom - mom_mt1;
+        const float3_X mom_dt = (mom - mom_mt1) / float_X(DELTA_T);
         const float_X el_factor = charge * charge
             / (float_X(6.0) * PI * EPS0 *
-               c2 * c2 * SPEED_OF_LIGHT * mass * mass);
-        const float_X energyLarmor = el_factor * gamma2 * gamma2
-            * (math::abs2(mom_dt) -
-               math::abs2(math::cross(mom, mom_dt)));
+               c2 * SPEED_OF_LIGHT * mass * mass) * gamma2 * gamma2;
+        const float_X momentumToBetaConvert = float_X(1.0)/ (mass * SPEED_OF_LIGHT * gamma);
+        const float_X energyLarmor = el_factor
+                                     * ( math::abs2(mom_dt)
+                                         - momentumToBetaConvert * momentumToBetaConvert
+                                           * math::abs2(math::cross(mom, mom_dt))
+                                       );
 
         /* return attribute */
         return energyLarmor;

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -29,7 +29,7 @@ namespace particleToGrid
 {
 namespace derivedAttributes
 {
-    struct LarmorEnergy
+    struct LarmorPower
     {
 
         HDINLINE float1_64
@@ -38,7 +38,7 @@ namespace derivedAttributes
         HINLINE std::string
         getName() const
         {
-            return "larmorEnergy";
+            return "larmorPower";
         }
 
         /** Calculate a new attribute  per particle

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "particles/particleToGrid/derivedAttributes/LarmorEnergy.def"
+#include "particles/particleToGrid/derivedAttributes/LarmorPower.def"
 
 #include "simulation_defines.hpp"
 
@@ -33,14 +33,14 @@ namespace derivedAttributes
 {
 
     HDINLINE float1_64
-    LarmorEnergy::getUnit() const
+    LarmorPower::getUnit() const
     {
         return UNIT_ENERGY;
     }
 
     template< class T_Particle >
     DINLINE float_X
-    LarmorEnergy::operator()( T_Particle& particle ) const
+    LarmorPower::operator()( T_Particle& particle ) const
     {
         /* read existing attributes */
         const float3_X mom = particle[momentum_];
@@ -60,14 +60,14 @@ namespace derivedAttributes
             / (float_X(6.0) * PI * EPS0 *
                c2 * SPEED_OF_LIGHT * mass * mass) * gamma2 * gamma2;
         const float_X momentumToBetaConvert = float_X(1.0)/ (mass * SPEED_OF_LIGHT * gamma);
-        const float_X energyLarmor = el_factor
-                                     * ( math::abs2(mom_dt)
-                                         - momentumToBetaConvert * momentumToBetaConvert
-                                           * math::abs2(math::cross(mom, mom_dt))
-                                       );
+        const float_X larmorPower = el_factor
+                                    * ( math::abs2(mom_dt)
+                                        - momentumToBetaConvert * momentumToBetaConvert
+                                          * math::abs2(math::cross(mom, mom_dt))
+                                      );
 
         /* return attribute */
-        return energyLarmor;
+        return larmorPower;
     }
 } /* namespace derivedAttributes */
 } /* namespace particleToGrid */

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2015 Axel Huebl, Rene Widera, Felix Schmitt, Benjamin Worpitz
+ * Copyright 2013-2015 Axel Huebl, Rene Widera, Felix Schmitt, 
+ * Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -40,7 +41,7 @@ namespace picongpu
      *   - CreateCounterOperation: counts point like particles per cell
      *   - CreateEnergyDensityOperation: particle energy density with respect to shape
      *   - CreateEnergyOperation: particle energy with respect to shape
-     *   - CreateLarmorEnergyOperation: radiated larmor energy (needs ENABLE_RADIATION)
+     *   - CreateLarmorPowerOperation: radiated larmor power (needs ENABLE_RADIATION)
      */
     using namespace particleToGrid;
 


### PR DESCRIPTION
This pull request closes issue #1262. It fixes the calculation of the [Larmor energy](https://en.wikipedia.org/wiki/Larmor_formula). 

 - [x] check if the Larmor  energy of ions in KHI  is still negative