### PR TITLE
Compile Suite: New CUDA 7.5 Chain

### DIFF
--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -93,7 +93,7 @@ touch "$thisDir"runGuard
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=sm_35"
             . /etc/profile
-            module load gcc/4.6.4 boost/1.55.0 cmake/2.8.12.2 cuda/6.0 openmpi/1.6.5 mallocmc/2.0.1 libSplash/1.2.4 adios/1.9.0 pngwriter/0.5.5 rivlib/1.0.0
+            module load gcc/4.8.5 boost/1.59.0 cmake/3.4.1 cuda/7.5.18 openmpi/1.10.1 libSplash/1.3.0 adios/1.9.0 pngwriter/0.5.5 rivlib/1.0.1
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/compile -l -q -j $cnf_numParallel \


### PR DESCRIPTION
Updates the compile suite modules to load a `gcc/4.8.5` and `cuda/7.5.18` compile chain.

Requirement for C++98/C++11 compile tests.