### PR TITLE
Catch By Reference

### DIFF
--- a/src/picongpu/ArgsParser.cpp
+++ b/src/picongpu/ArgsParser.cpp
@@ -120,7 +120,7 @@ namespace picongpu
                 return SUCCESS_EXIT;
             }
         }
-        catch ( boost::program_options::error& e )
+        catch ( const boost::program_options::error& e )
         {
             std::cerr << e.what() << std::endl;
             return ERROR;

--- a/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
@@ -222,7 +222,7 @@ private:
             __getTransactionEvent().waitForFinished();
 
         }
-        catch (DCException e)
+        catch (const DCException& e)
         {
             std::cerr << e.what() << std::endl;
             return;

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -186,7 +186,7 @@ public:
             log<picLog::INPUT_OUTPUT > ("HDF5 open DataCollector with file: %1%") % restartFilename;
             mThreadParams.dataCollector->open(restartFilename.c_str(), attr);
         }
-        catch (DCException e)
+        catch (const DCException& e)
         {
             std::cerr << e.what() << std::endl;
             throw std::runtime_error("Failed to open datacollector");
@@ -268,7 +268,7 @@ private:
             log<picLog::INPUT_OUTPUT > ("HDF5 open DataCollector with file: %1%") % h5Filename;
             mThreadParams.dataCollector->open(h5Filename.c_str(), attr);
         }
-        catch (DCException e)
+        catch (const DCException& e)
         {
             std::cerr << e.what() << std::endl;
             throw std::runtime_error("Failed to open datacollector");

--- a/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -323,7 +323,7 @@ private:
                 filename;
             dataCollector->open(filename.c_str(), h5_attr);
         }
-        catch (DCException e)
+        catch (const DCException& e)
         {
             std::cerr << e.what() << std::endl;
             throw std::runtime_error("Failed to open datacollector");

--- a/src/tools/livevis/client/mainwindow.cpp
+++ b/src/tools/livevis/client/mainwindow.cpp
@@ -351,7 +351,7 @@ void MainWindow::on_msg(rivlib::control_connection::ptr comm, unsigned int id, u
             break;
         }
 
-    } catch(the::exception ex) {
+    } catch(const the::exception& ex) {
         fprintf(stderr, "Ctrl-Message error: %s (%s, %d)\n", ex.get_msg_astr(), ex.get_file(), ex.get_line());
         //this->on_disconnect_clicked();
     } catch(...) {
@@ -455,7 +455,7 @@ void MainWindow::connectToURI(QString uri)
         reset_connection();
         this->m_controlConn->connect(uri.toStdString().c_str());
         this->m_imgStream->disconnect(false);
-    } catch(the::exception ex) {
+    } catch(const the::exception& ex) {
         fprintf(stderr, "Connect-Message error: %s (%s, %d)\n", ex.get_msg_astr(), ex.get_file(), ex.get_line());
         //this->m_imgStream->disconnect(true);
     } catch(...) {

--- a/src/tools/png2gas/png2gas.cpp
+++ b/src/tools/png2gas/png2gas.cpp
@@ -111,7 +111,7 @@ bool parseCmdLine(int argc, char **argv, Options &options)
         }
         
 
-    } catch (boost::program_options::error& e)
+    } catch (const boost::program_options::error& e)
     {
         std::cerr << e.what() << std::endl;
         return false;

--- a/src/tools/splash2txt/splash2txt.cpp
+++ b/src/tools/splash2txt/splash2txt.cpp
@@ -159,8 +159,9 @@ bool parseOptions( int argc, char** argv, ProgramOptions &options )
         }
 
     }
-    catch ( boost::program_options::error e )
+    catch ( const boost::program_options::error& )
     {
+        errorStream << desc << "\n";
         throw std::runtime_error( "Error parsing command line options!" );
     }
 
@@ -205,7 +206,7 @@ int main( int argc, char** argv )
     {
         parseSuccessfull = parseOptions( argc, argv, options );
     }
-    catch ( std::runtime_error e )
+    catch ( const std::runtime_error& e )
     {
         errorStream << "Error: " << e.what( ) << std::endl;
         mpi_finalize();
@@ -252,7 +253,7 @@ int main( int argc, char** argv )
             file.close( );
         }
     }
-    catch ( std::runtime_error e )
+    catch ( const std::runtime_error& e )
     {
         errorStream << "Error: " << e.what( ) << std::endl;
         delete tools;

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -235,7 +235,7 @@ void ToolsSplashParallel::convertToText()
     {
         dc.readAttribute(m_options.step, m_options.data[0].c_str(), DOMCOL_ATTR_CLASS,
                 &ref_data_class, NULL);
-    } catch (DCException)
+    } catch (const DCException&)
     {
         errorStream << "Error: No domain information for dataset '" << m_options.data[0] << "' available." << std::endl;
         errorStream << "This might not be a valid libSplash domain." << std::endl;
@@ -314,7 +314,7 @@ void ToolsSplashParallel::convertToText()
             {
                 dc.readAttribute(m_options.step, iter->c_str(), "sim_unit",
                         &(excontainer.unit), NULL);
-            } catch (DCException e)
+            } catch (const DCException&)
             {
                 if (m_options.verbose)
                     errorStream << "no unit for '" << iter->c_str() << "', defaulting to 1.0" << std::endl;
@@ -434,7 +434,7 @@ void ToolsSplashParallel::listAvailableDatasets()
         m_outStream << std::endl
                     << "Global domain: "
                     << totalDomain.toString() << std::endl;
-    } catch (DCException)
+    } catch (const DCException&)
     {
         m_outStream << std::endl << "(No domain information)" << std::endl;
     }


### PR DESCRIPTION
C++ catch parameters should be passed by const reference.

Sorry for the cross-over change.

Did not see relevant implications right now, but should be fixed.

References:
  - http://en.cppreference.com/w/cpp/language/try_catch