### PR TITLE
Add Author to Examples and cfg/tpl files

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -206,8 +206,7 @@ TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
 TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
-                   !TBG_plugins | tee output.stdout"
-
+                   !TBG_plugins"
 
 # Total number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/Bunch/submit/bunch_0032.cfg
+++ b/examples/Bunch/submit/bunch_0032.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Richard Pausch, Felix Schmitt
+# Copyright 2013-2015 Richard Pausch, Felix Schmitt, Axel Huebl
 # 
 # This file is part of PIConGPU. 
 # 
@@ -70,7 +70,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/KelvinHelmholtz/submit/0004gpus.cfg
+++ b/examples/KelvinHelmholtz/submit/0004gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Rene Widera, Felix Schmitt, Axel Huebl
 # 
 # This file is part of PIConGPU. 
 # 
@@ -73,8 +73,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins    \
-                   | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/KelvinHelmholtz/submit/0016gpus.cfg
+++ b/examples/KelvinHelmholtz/submit/0016gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -81,7 +81,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/LaserWakefield/submit/0001gpus.cfg
+++ b/examples/LaserWakefield/submit/0001gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -59,7 +59,7 @@ TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
 TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/LaserWakefield/submit/0008gpus.cfg
+++ b/examples/LaserWakefield/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_movingWindow \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/LaserWakefield/submit/0016gpus.cfg
+++ b/examples/LaserWakefield/submit/0016gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -66,7 +66,7 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_movingWindow \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/LaserWakefield/submit/0032gpus.cfg
+++ b/examples/LaserWakefield/submit/0032gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_movingWindow \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/SingleParticleCurrent/submit/0001gpus.cfg
+++ b/examples/SingleParticleCurrent/submit/0001gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Heiko Burau, Felix Schmitt
+# Copyright 2013-2015 Heiko Burau, Felix Schmitt, Axel Huebl
 # 
 # This file is part of PIConGPU. 
 # 
@@ -53,7 +53,7 @@ TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
 
 TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
-                   !TBG_steps | tee output"
+                   !TBG_steps"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
+++ b/examples/SingleParticleRadiationWithLaser/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Rene Widera, Felix Schmitt, Axel Huebl
 # 
 # This file is part of PIConGPU. 
 # 
@@ -66,7 +66,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/SingleParticleTest/submit/0008gpus.cfg
+++ b/examples/SingleParticleTest/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/ThermalTest/submit/0001gpu.cfg
+++ b/examples/ThermalTest/submit/0001gpu.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/ThermalTest/submit/0004gpus.cfg
+++ b/examples/ThermalTest/submit/0004gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/ThermalTest/submit/0008gpus.cfg
+++ b/examples/ThermalTest/submit/0008gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/ThermalTest/submit/0032gpus.cfg
+++ b/examples/ThermalTest/submit/0032gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Heiko Burau, Felix Schmitt
+# Copyright 2013-2015 Heiko Burau, Felix Schmitt, Axel Huebl
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/ThermalTest/submit/0064gpus.cfg
+++ b/examples/ThermalTest/submit/0064gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2015 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 # 
 # This file is part of PIConGPU. 
 # 
@@ -64,7 +64,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/examples/WeibelTransverse/submit/0004gpus.cfg
+++ b/examples/WeibelTransverse/submit/0004gpus.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013 Rene Widera
+# Copyright 2013-2015 Rene Widera, Axel Huebl
 # 
 # This file is part of PIConGPU. 
 # 
@@ -78,7 +78,7 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins  | tee output"
+                   !TBG_plugins"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013 Rene Widera
+# Copyright 2013-2015 Rene Widera, Axel Huebl
 #
 # This file is part of libPMacc. 
 # 
@@ -8,7 +8,8 @@
 # it under the terms of either the GNU General Public License or 
 # the GNU Lesser General Public License as published by 
 # the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
+# (at your option) any later version.
+#
 # libPMacc is distributed in the hope that it will be useful, 
 # but WITHOUT ANY WARRANTY; without even the implied warranty of 
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -22,6 +23,9 @@
  
 
 ##calculations will be performed by tbg##
+
+# settings that can be controlled by environment variables before submit
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -48,5 +52,5 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-mpiexec --prefix $MPI_ROOT -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/bin/!TBG_PROGRAM
+mpiexec --prefix $MPI_ROOT -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/bin/!TBG_PROGRAM !TBG_author | tee output
 

--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013 Rene Widera
+# Copyright 2013-2015 Rene Widera, Axel Huebl
 #
 # This file is part of libPMacc. 
 # 
@@ -8,7 +8,8 @@
 # it under the terms of either the GNU General Public License or 
 # the GNU Lesser General Public License as published by 
 # the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
+# (at your option) any later version.
+#
 # libPMacc is distributed in the hope that it will be useful, 
 # but WITHOUT ANY WARRANTY; without even the implied warranty of 
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -22,6 +23,9 @@
  
 
 ##calculations will be performed by tbg##
+
+# settings that can be controlled by environment variables before submit
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -48,4 +52,4 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-mpirun  -tag-output --display-map -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/bin/!TBG_PROGRAM
+mpirun  -tag-output --display-map -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/bin/!TBG_PROGRAM !TBG_author | tee output

--- a/src/picongpu/submit/bash/bash_mpiexec.tpl
+++ b/src/picongpu/submit/bash/bash_mpiexec.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera
 # 
 # This file is part of PIConGPU. 
 # 
@@ -20,6 +20,9 @@
  
 
 ##calculations will be performed by tbg##
+
+# settings that can be controlled by environment variables before submit
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -49,7 +52,7 @@ cd simOutput
 mpiexec --prefix $MPI_ROOT -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPI_ROOT -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpiexec --prefix $MPI_ROOT -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpiexec --prefix $MPI_ROOT -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/bash/bash_mpirun.tpl
+++ b/src/picongpu/submit/bash/bash_mpirun.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera
 # 
 # This file is part of PIConGPU. 
 # 
@@ -20,6 +20,9 @@
  
 
 ##calculations will be performed by tbg##
+
+# settings that can be controlled by environment variables before submit
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -49,7 +52,7 @@ cd simOutput
 mpirun --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpirun  -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpirun  -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpirun  -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/davinci-rice/picongpu.tpl
+++ b/src/picongpu/submit/davinci-rice/picongpu.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -21,6 +21,13 @@
 
 # PIConGPU batch script for DAVinCI (non-PRO) PBS batch system
 
+## calculation are done by tbg ##
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
 #PBS -q TBG_queue
 #PBS -l walltime=TBG_wallTime
 
@@ -32,9 +39,9 @@
 #PBS -W x=NACCESSPOLICY:SINGLEJOB
 #PBS -V
 
-# send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m TBG_mailSettings
-##PBS -M TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m TBG_mailSettings
+#PBS -M TBG_mailAdress
 
 #PBS -o TBG_outDir/stdout
 #PBS -e TBG_outDir/stderr
@@ -62,5 +69,4 @@ unset MODULES_NO_OUTPUT
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-mpirun -n TBG_tasks --display-map -am tbg/openib.conf --mca mpi_leave_pinned 0 ../picongpu/bin/picongpu TBG_programParams
-
+mpirun -n TBG_tasks --display-map -am tbg/openib.conf --mca mpi_leave_pinned 0 ../picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output

--- a/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
@@ -22,8 +22,11 @@
 
 ## calculation are done by tbg ##
 TBG_queue="k20f"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -42,7 +45,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -n
@@ -74,7 +77,7 @@ sleep 1
 mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #
@@ -21,8 +21,11 @@
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # get the ID of the last job of the submitting user waiting in the k20 queue
 TBG_waitJob=`qstat -u $(whoami) | grep $TBG_queue | tail -n 1 | awk '{print $1}'`
@@ -44,7 +47,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -n
@@ -78,7 +81,7 @@ sleep 1
 mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.
 #
@@ -21,8 +21,11 @@
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -41,7 +44,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -n
@@ -73,7 +76,7 @@ sleep 1
 mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2015 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.
 #
@@ -21,8 +21,11 @@
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -41,7 +44,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -n
@@ -88,7 +91,7 @@ sleep 1
 mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -x VT_MPI_IGNORE_FILTER -x VT_PFORM_GDIR -x VT_FILE_PREFIX -x VT_BUFFER_SIZE -x VT_MAX_FLUSHES -x VT_GNU_DEMANGLE -x VT_PTHREAD_REUSE -x VT_FILTER_SPEC -x VT_UNIFY -x VT_GPUTRACE -x VT_VERBOSE -x VT_CUPTI_METRICS -x VT_CUDATRACE_BUFFER_SIZE -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -x VT_MPI_IGNORE_FILTER -x VT_PFORM_GDIR -x VT_FILE_PREFIX -x VT_BUFFER_SIZE -x VT_MAX_FLUSHES -x VT_GNU_DEMANGLE -x VT_PTHREAD_REUSE -x VT_FILTER_SPEC -x VT_UNIFY -x VT_GPUTRACE -x VT_VERBOSE -x VT_CUPTI_METRICS -x VT_CUDATRACE_BUFFER_SIZE -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #
@@ -21,8 +21,11 @@
 
 ## calculation are done by tbg ##
 TBG_queue="k20"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -41,7 +44,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -n
@@ -75,7 +78,7 @@ sleep 1
 mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
@@ -21,8 +21,11 @@
 
 ## calculation are done by tbg ##
 TBG_queue="k80"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
@@ -41,7 +44,7 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -n
@@ -73,7 +76,7 @@ sleep 1
 mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -x LD_LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -x LD_LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks killall -9 picongpu

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -35,9 +35,10 @@ alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
 export PICSRC=/home/`whoami`/src/picongpu
 
-# send me a mails on job (b)egin, (e)nd, (a)bortion or (n)o mails
-export MY_MAIL="someone@example.com"
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 export MY_MAILNOTIFY="n"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
 
 export PATH=$PATH:$PICSRC/src/splash2txt/build
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/src/picongpu/submit/joker-tud/fermi.tpl
+++ b/src/picongpu/submit/joker-tud/fermi.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,8 +23,11 @@
 ## calculation are done by tbg ##
 TBG_gpu_arch="fermi"
 TBG_queue="workq"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
     
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -45,9 +48,9 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobNameShort
 #PBS -l select=!TBG_nodes:mpiprocs=!TBG_gpusPerNode:ncpus=!TBG_coresPerNode:ngpus=!TBG_gpusPerNode:gputype=!TBG_gpu_arch -lplace=excl
 
-# send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m TBG_mailSettings
-##PBS -M TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m TBG_mailSettings
+#PBS -M TBG_mailAddress
 
 #PBS -o !TBG_dstPath/stdout
 #PBS -e !TBG_dstPath/stderr
@@ -76,6 +79,5 @@ cd simOutput
 $MPI_ROOT/bin/mpirun !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   $MPI_ROOT/bin/mpirun  --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+   $MPI_ROOT/bin/mpirun  --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
-

--- a/src/picongpu/submit/joker-tud/fermi_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/fermi_vampir.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,8 +23,11 @@
 ## calculation are done by tbg ##
 TBG_gpu_arch="fermi"
 TBG_queue="workq"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
     
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -45,9 +48,9 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobNameShort
 #PBS -l select=!TBG_nodes:mpiprocs=!TBG_gpusPerNode:ncpus=!TBG_coresPerNode:ngpus=!TBG_gpusPerNode:gputype=!TBG_gpu_arch -lplace=excl
 
-# send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m TBG_mailSettings
-##PBS -M TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m TBG_mailSettings
+#PBS -M TBG_mailAddress
 
 #PBS -o !TBG_dstPath/stdout
 #PBS -e !TBG_dstPath/stderr
@@ -91,6 +94,6 @@ cd simOutput
 $MPI_ROOT/bin/mpirun !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   $MPI_ROOT/bin/mpirun -x VT_MPI_IGNORE_FILTER -x VT_PFORM_GDIR -x VT_FILE_PREFIX -x VT_BUFFER_SIZE -x VT_MAX_FLUSHES -x VT_GNU_DEMANGLE -x VT_PTHREAD_REUSE -x VT_FILTER_SPEC -x VT_UNIFY -x VT_GPUTRACE -x VT_VERBOSE -x VT_CUPTI_METRICS -x VT_CUDATRACE_BUFFER_SIZE --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+   $MPI_ROOT/bin/mpirun -x VT_MPI_IGNORE_FILTER -x VT_PFORM_GDIR -x VT_FILE_PREFIX -x VT_BUFFER_SIZE -x VT_MAX_FLUSHES -x VT_GNU_DEMANGLE -x VT_PTHREAD_REUSE -x VT_FILTER_SPEC -x VT_UNIFY -x VT_GPUTRACE -x VT_VERBOSE -x VT_CUPTI_METRICS -x VT_CUDATRACE_BUFFER_SIZE --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi           
 

--- a/src/picongpu/submit/joker-tud/tesla.tpl
+++ b/src/picongpu/submit/joker-tud/tesla.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,9 +23,11 @@
 ## calculation are done by tbg ##
 TBG_gpu_arch="tesla"
 TBG_queue="workq"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
 
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
     
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -46,9 +48,9 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobNameShort
 #PBS -l select=!TBG_nodes:mpiprocs=!TBG_gpusPerNode:ncpus=!TBG_coresPerNode:ngpus=!TBG_gpusPerNode:gputype=!TBG_gpu_arch -lplace=excl
 
-# send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m TBG_mailSettings
-##PBS -M TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m TBG_mailSettings
+#PBS -M TBG_mailAddress
 
 #PBS -o !TBG_dstPath/stdout
 #PBS -e !TBG_dstPath/stderr
@@ -77,6 +79,5 @@ cd simOutput
 $MPI_ROOT/bin/mpirun !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   $MPI_ROOT/bin/mpirun  --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
-fi           
-
+   $MPI_ROOT/bin/mpirun  --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi

--- a/src/picongpu/submit/joker-tud/tesla_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/tesla_vampir.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,9 +23,11 @@
 ## calculation are done by tbg ##
 TBG_gpu_arch="tesla"
 TBG_queue="workq"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
 
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
     
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -46,9 +48,9 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -N !TBG_jobNameShort
 #PBS -l select=!TBG_nodes:mpiprocs=!TBG_gpusPerNode:ncpus=!TBG_coresPerNode:ngpus=!TBG_gpusPerNode:gputype=!TBG_gpu_arch -lplace=excl
 
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 ##PBS -m TBG_mailSettings
-##PBS -M TBG_mailAdress
+##PBS -M TBG_mailAddress
 
 #PBS -o !TBG_dstPath/stdout
 #PBS -e !TBG_dstPath/stderr
@@ -91,6 +93,5 @@ cd simOutput
 $MPI_ROOT/bin/mpirun !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   $MPI_ROOT/bin/mpirun -x VT_MPI_IGNORE_FILTER -x VT_PFORM_GDIR -x VT_FILE_PREFIX -x VT_BUFFER_SIZE -x VT_MAX_FLUSHES -x VT_GNU_DEMANGLE -x VT_PTHREAD_REUSE -x VT_FILTER_SPEC -x VT_UNIFY -x VT_GPUTRACE -x VT_VERBOSE -x VT_CUPTI_METRICS -x VT_CUDATRACE_BUFFER_SIZE --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
-fi           
-
+   $MPI_ROOT/bin/mpirun -x VT_MPI_IGNORE_FILTER -x VT_PFORM_GDIR -x VT_FILE_PREFIX -x VT_BUFFER_SIZE -x VT_MAX_FLUSHES -x VT_GNU_DEMANGLE -x VT_PTHREAD_REUSE -x VT_FILTER_SPEC -x VT_UNIFY -x VT_GPUTRACE -x VT_VERBOSE -x VT_CUPTI_METRICS -x VT_CUDATRACE_BUFFER_SIZE --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi

--- a/src/picongpu/submit/judge-fzj/m2050.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,8 +23,12 @@
 ## calculation are done by tbg ##
 TBG_gpuType="m2050"
 TBG_queue="largemem"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
     
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
@@ -47,8 +51,8 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -l mem=20gb
 #MSUB -l pmem=10gb
 ##MSUB -l naccesspolicy=singlejob
-#send me a mail on (b)egin, (e)nd, (a)bortion
-##MSUB -m !TBG_mailSettings -M !TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#MSUB -m !TBG_mailSettings -M !TBG_mailAddress
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
@@ -81,5 +85,5 @@ cd simOutput
 mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi 

--- a/src/picongpu/submit/judge-fzj/m2050_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,8 +23,12 @@
 ## calculation are done by tbg ##
 TBG_gpuType="m2050"
 TBG_queue="largemem"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
     
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
@@ -47,8 +51,8 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -l mem=20gb
 #MSUB -l pmem=10gb
 ##MSUB -l naccesspolicy=singlejob
-#send me a mail on (b)egin, (e)nd, (a)bortion
-##MSUB -m !TBG_mailSettings -M !TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#MSUB -m !TBG_mailSettings -M !TBG_mailAddress
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
@@ -73,5 +77,5 @@ cd simOutput
 mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi 

--- a/src/picongpu/submit/judge-fzj/m2070.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,8 +23,12 @@
 ## calculation are done by tbg ##
 TBG_gpuType="m2070"
 TBG_queue="largemem"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
     
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
@@ -47,8 +51,8 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -l mem=20gb
 #MSUB -l pmem=10gb
 ##MSUB -l naccesspolicy=singlejob
-#send me a mail on (b)egin, (e)nd, (a)bortion
-##MSUB -m !TBG_mailSettings -M !TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#MSUB -m !TBG_mailSettings -M !TBG_mailAddress
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
@@ -81,5 +85,5 @@ cd simOutput
 mpiexec -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi 

--- a/src/picongpu/submit/judge-fzj/m2070_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Richard Pausch
+# Copyright 2013-2015 Axel Huebl, Richard Pausch
 # 
 # This file is part of PIConGPU. 
 # 
@@ -23,8 +23,12 @@
 ## calculation are done by tbg ##
 TBG_gpuType="m2070"
 TBG_queue="largemem"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
     
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
@@ -47,8 +51,8 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -l mem=20gb
 #MSUB -l pmem=10gb
 ##MSUB -l naccesspolicy=singlejob
-#send me a mail on (b)egin, (e)nd, (a)bortion
-##MSUB -m !TBG_mailSettings -M !TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#MSUB -m !TBG_mailSettings -M !TBG_mailAddress
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
@@ -73,5 +77,5 @@ cd simOutput
 mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+   mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi 

--- a/src/picongpu/submit/keeneland-gt/parallel.tpl
+++ b/src/picongpu/submit/keeneland-gt/parallel.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013 Axel Huebl, Rene Widera, Robert Dietric
+# Copyright 2013-2015 Axel Huebl, Rene Widera, Robert Dietric
 # 
 # This file is part of PIConGPU. 
 # 
@@ -22,8 +22,11 @@
 
 ## calculation are done by tbg ##
 TBG_queue="parallel"
-TBG_mailSettings="bea"
-TBG_mailAdress="someone@example.com"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
     
 # 3 gpus per node if we need more than 3 gpus else same count as TBG_tasks   
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`
@@ -42,8 +45,8 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode:gpus=!TBG_gpusPerNode
-# send me a mail on (b)egin, (e)nd, (a)bortion
-##PBS -m !TBG_mailSettings -M !TBG_mailAdress
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 
 #PBS -o stdout
@@ -77,6 +80,6 @@ cd simOutput
 mpiexec  --mca btl openib,self,sm --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
-   mpiexec  --display-map --mca btl openib,self,sm --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
-fi           
+   mpiexec  --display-map --mca btl openib,self,sm --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi
 

--- a/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl
+# Copyright 2013-2015 Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -25,8 +25,10 @@ TBG_account="ac_blast"
 TBG_qos="mako_normal"
 TBG_feature="mako_fermi"
 
-TBG_mailSettings="ALL"
-TBG_mailAdress="someone@example.com"
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 2 gpus per node
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
@@ -58,9 +60,10 @@ TBG_memPerCPU="$(( 24000 / TBG_gpusPerNode ))M"
 #SBATCH --mem-per-cpu=!TBG_memPerCPU
 #SBATCH --constraint=!TBG_feature
 #SBATCH --qos=!TBG_qos
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAdress
+#SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
 #SBATCH --account=!TBG_account
 
@@ -90,5 +93,5 @@ mpirun !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 # Run PIConGPU
 if [ $? -eq 0 ] ; then
-  mpirun !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpirun !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi

--- a/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl
+# Copyright 2013-2015 Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -25,8 +25,10 @@ TBG_account="ac_blast"
 TBG_qos="lr_normal"
 TBG_feature="lr_kepler"
 
-TBG_mailSettings="ALL"
-TBG_mailAdress="someone@example.com"
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 1 gpu per node
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 1 ] ; then echo 1; else echo $TBG_tasks; fi`
@@ -56,9 +58,10 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #SBATCH --mem-per-cpu=7750M
 #SBATCH --constraint=!TBG_feature
 #SBATCH --qos=!TBG_qos
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAdress
+#SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
 #SBATCH --account=!TBG_account
 
@@ -88,5 +91,5 @@ mpirun !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 # Run PIConGPU
 if [ $? -eq 0 ] ; then
-  mpirun !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  mpirun !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi

--- a/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
+++ b/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
@@ -44,10 +44,11 @@ export PATH=$HOME/bin:$PATH
 export PATH=$PATH:$PICSRC/src/splash2txt/build
 export PATH=$PATH:$PICSRC/src/tools/bin
 
-export MY_MAIL="someone@example.com"
 # send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
 # TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)

--- a/src/picongpu/submit/taurus-tud/k80_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k80_profile.tpl
@@ -19,12 +19,12 @@
 #
 
 ## calculations will be performed by tbg ##
-
 TBG_queue="gpu"
-# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL, 
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
-TBG_mailAdress=${MY_MAIL:-"someone@example.com"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node
 TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -53,8 +53,10 @@ TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem-per-cpu=2583
 #SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAdress
+#SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
 
 #SBATCH -o stdout
@@ -84,6 +86,6 @@ srun -K1 !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 # Run PIConGPU
 if [ $? -eq 0 ] ; then
-  srun -K1 !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+  srun -K1 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 fi
 

--- a/src/picongpu/submit/taurus-tud/picongpu.profile.example
+++ b/src/picongpu/submit/taurus-tud/picongpu.profile.example
@@ -44,10 +44,11 @@ export PATH=$PATH:$PICSRC/src/tools/bin
 #   see https://www.mail-archive.com/cmake@cmake.org/msg50018.html
 unset LIBRARY_PATH
 
-export MY_MAIL="someone@example.com"
 # send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
 # TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)

--- a/src/picongpu/submit/titan-ornl/batch_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_profile.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2014 Axel Huebl, Rene Widera
+# Copyright 2013-2015 Axel Huebl, Rene Widera
 # 
 # This file is part of PIConGPU. 
 # 
@@ -20,8 +20,11 @@
 
 ## calculations will be performed by tbg ##
 TBG_queue="batch"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 TBG_nameProject=${proj:-""}
 
 # use ceil to caculate nodes
@@ -35,7 +38,7 @@ TBG_nodes=!TBG_tasks
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -A !TBG_nameProject
@@ -65,5 +68,5 @@ cd simOutput
 #aprun  -N 1 -n !TBG_nodes !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 #if [ $? -eq 0 ] ; then
-aprun  -N 1 -n !TBG_nodes  !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+aprun  -N 1 -n !TBG_nodes  !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 #fi

--- a/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
@@ -20,8 +20,11 @@
 
 ## calculations will be performed by tbg ##
 TBG_queue="batch"
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+
+# settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 TBG_nameProject=${proj:-""}
 
 # use ceil to caculate nodes
@@ -35,7 +38,7 @@ TBG_nodes=!TBG_tasks
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes
-# send me a mail on (b)egin, (e)nd, (a)bortion
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -A !TBG_nameProject
@@ -73,5 +76,5 @@ cd simOutput
 #aprun  -N 1 -n !TBG_nodes !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 #if [ $? -eq 0 ] ; then
-aprun  -N 1 -n !TBG_nodes  !TBG_dstPath/picongpu/bin/picongpu !TBG_programParams
+aprun  -N 1 -n !TBG_nodes  !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
 #fi

--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -1,8 +1,9 @@
 export proj=<yourProject>
 
-# send me a mails on job (b)egin, (e)nd, (a)bortion or (n)o mails
-export MY_MAIL="someone@example.com"
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 export MY_MAILNOTIFY="n"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # basic environment #################################################
 source /opt/modules/3.2.6.7/init/bash


### PR DESCRIPTION
Implements #1260 in examples.

The `.tpl` files are updated to add the `--author` flag if `MY_NAME` is set in the environment.
Additionally, since the same line is changed, `| tee output` is now moved to the `.tpl` to avoid mixing parameters and "the next bash command in the pipeline".

Default author name is recommended to take the form
  `name <email>`

but can be set to anything or alternatively, can be left unset.

### To Do
 - [x] do not merge before #1296
 - [x] rebase after #1296 was merged