### PR TITLE
generic particle creation

### DIFF
--- a/src/picongpu/include/particles/creation/CreatorBase.def
+++ b/src/picongpu/include/particles/creation/CreatorBase.def
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015 Heiko Burau, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace creation
+{
+
+/** This functor is a base class for an actual particle creator.
+ *
+ * \tparam T_DestSpecies electron species to be created
+ */
+template<typename T_SourceSpecies, typename T_TargetSpecies>
+struct CreatorBase;
+
+} // namespace creation
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/creation/CreatorBase.hpp
+++ b/src/picongpu/include/particles/creation/CreatorBase.hpp
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2015 Heiko Burau, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "traits/Resolve.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+
+#include "fields/FieldB.hpp"
+#include "fields/FieldE.hpp"
+
+#include "compileTime/conversion/TypeToPointerPair.hpp"
+#include "memory/boxes/DataBox.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace creation
+{
+
+/** This functor is a base class for an actual particle creator.
+ *
+ * \tparam T_DestSpecies electron species to be created
+ */
+template<typename T_SourceSpecies, typename T_TargetSpecies>
+struct CreatorBase
+{
+
+    typedef T_SourceSpecies SourceSpecies;
+    typedef T_TargetSpecies TargetSpecies;
+
+    typedef typename SourceSpecies::FrameType FrameType;
+
+    /* specify field to particle interpolation scheme */
+    typedef typename PMacc::traits::Resolve<
+        typename GetFlagType<FrameType,interpolation<> >::type
+    >::type Field2ParticleInterpolation;
+
+    /* margins around the supercell for the interpolation of the field on the cells */
+    typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
+    typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+
+    /* relevant area of a block */
+    typedef SuperCellDescription<
+        typename MappingDesc::SuperCellSize,
+        LowerMargin,
+        UpperMargin
+        > BlockArea;
+
+    //BlockArea BlockDescription;
+
+protected:
+
+    typedef MappingDesc::SuperCellSize TVec;
+
+    typedef FieldE::ValueType ValueType_E;
+    typedef FieldB::ValueType ValueType_B;
+    /* global memory EM-field device databoxes */
+    PMACC_ALIGN(eBox, FieldE::DataBoxType);
+    PMACC_ALIGN(bBox, FieldB::DataBoxType);
+    /* shared memory EM-field device databoxes */
+    PMACC_ALIGN(cachedE, DataBox<SharedBox<ValueType_E, typename BlockArea::FullSuperCellSize,1> >);
+    PMACC_ALIGN(cachedB, DataBox<SharedBox<ValueType_B, typename BlockArea::FullSuperCellSize,0> >);
+
+    /* host constructor initializing member : random number generator */
+    CreatorBase()
+    {
+        DataConnector &dc = Environment<>::get().DataConnector();
+        /* initialize pointers on host-side E-(B-)field databoxes */
+        FieldE* fieldE = &(dc.getData<FieldE > (FieldE::getName(), true));
+        FieldB* fieldB = &(dc.getData<FieldB > (FieldB::getName(), true));
+        /* initialize device-side E-(B-)field databoxes */
+        eBox = fieldE->getDeviceDataBox();
+        bBox = fieldB->getDeviceDataBox();
+    }
+
+    /** Initialization function on device
+     *
+     * \brief Cache EM-fields on device
+     *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+     *
+     * This function will be called inline on the device which must happen BEFORE threads diverge
+     * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+     * initializing the E-/B-field shared boxes in shared memory.
+     */
+    DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& localCellOffset)
+    {
+
+        /* caching of E and B fields */
+        cachedB = CachedBox::create < 0, ValueType_B > (BlockArea());
+        cachedE = CachedBox::create < 1, ValueType_E > (BlockArea());
+
+        /* instance of nvidia assignment operator */
+        nvidia::functors::Assign assign;
+        /* copy fields from global to shared */
+        PMACC_AUTO(fieldBBlock, bBox.shift(blockCell));
+        ThreadCollective<BlockArea> collective(linearThreadIdx);
+        collective(
+                  assign,
+                  cachedB,
+                  fieldBBlock
+                  );
+        /* copy fields from global to shared */
+        PMACC_AUTO(fieldEBlock, eBox.shift(blockCell));
+        collective(
+                  assign,
+                  cachedE,
+                  fieldEBlock
+                  );
+
+        /* wait for shared memory to be initialized */
+        __syncthreads();
+    }
+
+    /** Does EM-field-interpolation at the particle's position
+     * @param particle particle object
+     * @param eField result of the bField interpolation
+     * @param bField result of the eField interpolation
+     */
+    template<typename Particle>
+    DINLINE void getFieldsForParticle(const Particle& particle, ValueType_E& eField, ValueType_B& bField) const
+    {
+        /* type of PIC-scheme cell */
+        typedef typename fieldSolver::NumericalCellType NumericalCellType;
+
+        /* particle position, used for field-to-particle interpolation */
+        floatD_X pos = particle[position_];
+        const int particleCellIdx = particle[localCellIdx_];
+        /* multi-dim coordinate of the local cell inside the super cell */
+        DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
+        /* interpolation of E- */
+        eField = Field2ParticleInterpolation()
+            (cachedE.shift(localCell).toCursor(), pos, NumericalCellType::getEFieldPosition());
+        /*                     and B-field on the particle position */
+        bField = Field2ParticleInterpolation()
+            (cachedB.shift(localCell).toCursor(), pos, NumericalCellType::getBFieldPosition());
+    }
+
+    /** Return the number of target particles to be created from each source particle.
+     *
+     * Called for each frame of the source species. This is an abstract function indented
+     * to be implemented in a derived class.
+     *
+     * @param sourceFrame Frame of the source species
+     * @param localIdx Index of the source particle within frame
+     * @return number of particle to be created from each source particle
+     */
+    DINLINE unsigned int numNewParticles(FrameType& sourceFrame, int localIdx)
+    {
+        return 0;
+    }
+
+    /** Functor implementation.
+     *
+     * Called once for each single particle creation. This is an abstract function indented
+     * to be implemented in a derived class.
+     *
+     * \tparam SourceParticle type of the particle which induces particle creation
+     * \tparam TargetParticle type of the particle that will be created
+     */
+    template<typename SourceParticle, typename TargetParticle>
+    DINLINE void operator()(SourceParticle& sourceParticle, TargetParticle& targetParticle)
+    {
+
+    }
+};
+
+} // namespace creation
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/creation/creation.hpp
+++ b/src/picongpu/include/particles/creation/creation.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015 Marco Garten, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "simulation_defines.hpp"
+#include <boost/mpl/if.hpp>
+#include "traits/HasFlag.hpp"
+#include "fields/Fields.def"
+#include "math/MapTuple.hpp"
+#include <boost/mpl/plus.hpp>
+#include <boost/mpl/accumulate.hpp>
+
+#include "communication/AsyncCommunication.hpp"
+#include "particles/creation/creation.kernel"
+
+namespace picongpu
+{
+
+namespace particles
+{
+
+namespace creation
+{
+
+template<typename SourceSpecies, typename TargetSpecies, typename ParticleCreator,
+         typename CellDescription>
+void createParticles(SourceSpecies& sourceSpecies, TargetSpecies& targetSpecies,
+                     ParticleCreator& particleCreator, CellDescription* cellDesc)
+{
+    /* 3-dim vector : number of threads to be started in every dimension */
+    dim3 block( MappingDesc::SuperCellSize::toRT().toDim3() );
+
+    /** kernelCreateParticles
+     * \brief calls the particle creation kernel and handles that target particles are created correctly
+     *        while cycling through the particle frames
+     *
+     * kernel call : instead of name<<<blocks, threads>>> (args, ...)
+     * "blocks" will be calculated from "this->cellDescription" and "CORE + BORDER"
+     * "threads" is calculated from the previously defined vector "block"
+     */
+    __picKernelArea( particles::creation::kernelCreateParticles, *cellDesc, CORE + BORDER )
+        (block)
+        ( sourceSpecies.getDeviceParticlesBox( ),
+          targetSpecies.getDeviceParticlesBox( ),
+          particleCreator
+        );
+    /* fill the gaps in the created species' particle frames to ensure that only
+     * the last frame is not completely filled but every other before is full
+     */
+    targetSpecies.fillAllGaps();
+}
+
+} // namespace creation
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/creation/creation.kernel
+++ b/src/picongpu/include/particles/creation/creation.kernel
@@ -1,0 +1,299 @@
+/**
+ * Copyright 2015 Heiko Burau, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include <iostream>
+
+#include "simulation_defines.hpp"
+#include "particles/Particles.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "particles/ParticlesInit.kernel"
+#include "mappings/simulation/GridController.hpp"
+#include "simulationControl/MovingWindow.hpp"
+#include "traits/Resolve.hpp"
+#include "nvidia/atomic.hpp"
+
+#include "types.h"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace creation
+{
+
+using namespace PMacc;
+
+/** kernelCreateParticles
+ * \brief main kernel for particle creation
+ *
+ * - maps the frame dimensions and gathers the particle boxes
+ * - contains / calls the Creator
+ *
+ * \tparam ParBoxSource container of the source species
+ * \tparam ParBoxTarget container of the target species
+ * \tparam Mapping class containing methods for acquiring info from the block
+ * \tparam ParticleCreator \see e.g. CreatorBase in CreatorBase.hpp
+ *         instance of the particle creation functor
+ */
+template<class ParBoxSource, class ParBoxTarget, class ParticleCreator, class Mapping>
+__global__ void kernelCreateParticles(ParBoxSource sourceBox,
+                                      ParBoxTarget targetBox,
+                                      ParticleCreator particleCreator,
+                                      Mapping mapper)
+{
+
+    /* "particle box" : container/iterator where the particles live in
+     * and where one can get the frame in a super cell from
+     */
+    typedef typename ParBoxSource::FrameType SOURCEFRAME;
+    typedef typename ParBoxTarget::FrameType TARGETFRAME;
+    typedef typename ParBoxSource::FramePtr SourceFramePtr;
+    typedef typename ParBoxTarget::FramePtr TargetFramePtr;
+
+    /* specify field to particle interpolation scheme */
+    typedef typename PMacc::traits::Resolve<
+        typename GetFlagType<SOURCEFRAME,interpolation<> >::type
+    >::type InterpolationScheme;
+
+    /* margins around the supercell for the interpolation of the field on the cells */
+    typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
+    typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
+
+    /* relevant area of a block */
+    typedef SuperCellDescription<
+        typename MappingDesc::SuperCellSize,
+        LowerMargin,
+        UpperMargin
+        > BlockDescription_;
+
+    /* for not mixing operations::assign up with the nvidia functor assign */
+    namespace partOp = PMacc::particles::operations;
+
+    /* definitions for domain variables, like indices of blocks and threads */
+    typedef typename BlockDescription_::SuperCellSize SuperCellSize;
+    /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+
+    /* multi-dim vector from origin of the block to a cell in units of cells */
+    const DataSpace<simDim > threadIndex(threadIdx);
+    /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
+    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
+
+    /* multi-dim offset from the origin of the local domain on GPU
+     * to the origin of the block of the in unit of cells
+     */
+    const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
+
+    /* subtract guarding cells to only have the simulation volume */
+    const DataSpace<simDim> localCellIndex = (block * SuperCellSize::toRT() + threadIndex) - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SourceFramePtr>::type sourceFrame;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<TargetFramePtr>::type targetFrame;
+    __shared__ lcellId_t maxParticlesInFrame;
+
+    /* find last frame in super cell
+     * define maxParticlesInFrame as the maximum frame size
+     */
+    if (linearThreadIdx == 0)
+    {
+        sourceFrame = sourceBox.getLastFrame(block);
+        maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+    }
+
+    __syncthreads();
+    if (!sourceFrame.isValid())
+        return; //end kernel if we have no frames
+
+    /* caching of E- and B- fields and initialization of random generator if needed */
+    particleCreator.init(blockCell, linearThreadIdx, localCellIndex);
+
+    /* Declare counter in shared memory that will later tell the current fill level or
+     * occupation of the newly created target electron frames.
+     */
+    __shared__ int newFrameFillLvl;
+
+    /* Declare local variable oldFrameFillLvl for each thread */
+    int oldFrameFillLvl;
+
+    /* Initialize local (register) counter for each thread
+     * - describes how many new macro electrons should be created
+     */
+    unsigned int newMacroTarget = 0;
+
+    /* Declare local electron ID
+     * - describes at which position in the new frame the new electron is to be created
+     */
+    int targetParId;
+
+    /* Master initializes the frame fill level with 0 */
+    if (linearThreadIdx == 0)
+    {
+        newFrameFillLvl = 0;
+        targetFrame = NULL;
+    }
+    __syncthreads();
+
+    /* move over source species frames and call particleCreator
+     * frames are worked on in backwards order to avoid asking if there is another frame
+     * --> performance
+     * Because all frames are completely filled except the last and apart from that last frame
+     * one wants to make sure that all threads are working and every frame is worked on.
+     */
+    while (sourceFrame.isValid())
+    {
+        /* casting uint8_t multiMask to boolean */
+        const bool isParticle = sourceFrame[linearThreadIdx][multiMask_];
+        __syncthreads();
+
+        /* < IONIZATION and change of charge states >
+         * if the threads contain particles, the particleCreator can ionize them
+         * if they are non-particles their inner ionization counter remains at 0
+         */
+        if (isParticle)
+            /* ionization based on ionization model - this actually increases charge states*/
+            newMacroTarget = particleCreator.numNewParticles(*sourceFrame, linearThreadIdx);
+
+        __syncthreads();
+        /* always true while-loop over all particles inside source frame until each thread breaks out individually
+         *
+         * **Attention**: Speaking of 1st and 2nd frame only may seem odd.
+         * The question might arise what happens if more electrons are created than would fit into two frames.
+         * Well, multi-ionization during a time step is accounted for. The number of new electrons is
+         * determined inside the outer loop over the valid frames while in the inner loop each thread can create only ONE
+         * new macro electron. But the loop repeats until each thread has created all the electrons needed in the time step.
+         */
+        while (true)
+        {
+            /* < INIT >
+             * - targetParId is initialized as -1 (meaning: invalid)
+             * - (local) oldFrameFillLvl set equal to (shared) newFrameFillLvl for each thread
+             * --> each thread remembers the old "counter"
+             * - then sync
+             */
+            targetParId = -1;
+            oldFrameFillLvl = newFrameFillLvl;
+            __syncthreads();
+            /* < CHECK & ADD >
+             * - if a thread wants to create electrons in each cycle it can do that only once
+             * and before that it atomically adds to the shared counter and uses the current
+             * value as targetParId in the new frame
+             * - then sync
+             */
+            if (newMacroTarget > 0)
+                targetParId = nvidia::atomicAllInc(&newFrameFillLvl);
+
+            __syncthreads();
+            /* < EXIT? >
+             * - if the counter hasn't changed all threads break out of the loop */
+            if (oldFrameFillLvl == newFrameFillLvl)
+                break;
+
+            __syncthreads();
+            /* < FIRST NEW FRAME >
+             * - if there is no frame, yet, the master will create a new target electron frame
+             * and attach it to the back of the frame list
+             * - sync all threads again for them to know which frame to use
+             */
+            if (linearThreadIdx == 0)
+            {
+                if (!targetFrame.isValid())
+                {
+                    targetFrame = targetBox.getEmptyFrame();
+                    targetBox.setAsLastFrame(targetFrame, block);
+                }
+            }
+            __syncthreads();
+            /* < CREATE 1 >
+             * - all electrons fitting into the current frame are created there
+             * - internal ionization counter is decremented by 1
+             * - sync
+             */
+            if ((0 <= targetParId) && (targetParId < maxParticlesInFrame))
+            {
+                /* each thread makes the attributes of its ion accessible */
+                PMACC_AUTO(sourceParticle,(sourceFrame[linearThreadIdx]));
+                /* each thread initializes an electron if one should be created */
+                PMACC_AUTO(targetParticle,(targetFrame[targetParId]));
+
+                /* create an electron in the new electron frame:
+                 * - see particles/ionization/ionizationMethods.hpp
+                 */
+                particleCreator(sourceParticle, targetParticle);
+
+                newMacroTarget -= 1;
+            }
+            __syncthreads();
+            /* < SECOND NEW FRAME >
+             * - if the shared counter is larger than the frame size a new electron frame is reserved
+             * and attached to the back of the frame list
+             * - then the shared counter is set back by one frame size
+             * - sync so that every thread knows about the new frame
+             */
+            if (linearThreadIdx == 0)
+            {
+                if (newFrameFillLvl >= maxParticlesInFrame)
+                {
+                    targetFrame = targetBox.getEmptyFrame();
+                    targetBox.setAsLastFrame(targetFrame, block);
+                    newFrameFillLvl -= maxParticlesInFrame;
+                }
+            }
+            __syncthreads();
+            /* < CREATE 2 >
+             * - if the EID is larger than the frame size
+             *      - the EID is set back by one frame size
+             *      - the thread writes an electron to the new frame
+             *      - the internal counter is decremented by 1
+             */
+            if (targetParId >= maxParticlesInFrame)
+            {
+                targetParId -= maxParticlesInFrame;
+
+                /* each thread makes the attributes of its ion accessible */
+                PMACC_AUTO(sourceParticle,(sourceFrame[linearThreadIdx]));
+                /* each thread initializes an electron if one should be created */
+                PMACC_AUTO(targetParticle,(targetFrame[targetParId]));
+
+                /* create an electron in the new electron frame:
+                 * - see particles/ionization/ionizationMethods.hpp
+                 */
+                particleCreator(sourceParticle, targetParticle);
+
+                newMacroTarget -= 1;
+            }
+            __syncthreads();
+        }
+        __syncthreads();
+
+        if (linearThreadIdx == 0)
+        {
+            sourceFrame = sourceBox.getPreviousFrame(sourceFrame);
+            maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+        }
+        __syncthreads();
+    }
+} // void kernelCreateParticles
+
+} // namespace creation
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
This pull request adds a directory `particles/creation` for the creation of particles during runtime.
The created particle species is called `target species`, which is created out of `source species`. If needed, the E and B-Field can be interpolated at the source particle's position.
Most of the code is taken from the ionization module.

@ax3l @psychocoderHPC @erikzenker @PrometheusPi  who wants? :)