### PR TITLE
Bremsstrahlung

### DIFF
--- a/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
@@ -84,6 +84,9 @@ namespace picongpu
     //! Mass of electron
     BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
 
+    //! reduced Planck constant
+    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+
     //! magnetic constant must be double 3.92907e-39
     BOOST_CONSTEXPR_OR_CONST float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
 

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -46,7 +46,8 @@ __global__ void kernelForeach(Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c
 { \
     math::Int<Mapper::dim> cellIndex(mapper(blockIdx, threadIdx)); \
 /*          forward(c0[cellIndex]), ..., forward(cN[cellIndex])     */ \
-    functor(BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _)); \
+    PMACC_AUTO(functor2, functor); \
+    functor2(BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _)); \
 }
 
 BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), KERNEL_FOREACH, _)

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -74,6 +74,7 @@ public:
     typedef Type type;
     BOOST_STATIC_CONSTEXPR int dim = T_dim;
     typedef cursor::BufferCursor<Type, T_dim> Cursor;
+    typedef cursor::SafeCursor<Cursor> SafeCursor;
     typedef typename Allocator::tag memoryTag;
     typedef math::Size_t<T_dim> SizeType;
     typedef math::Size_t<T_dim-1> PitchType;

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -264,7 +264,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::originSafe() const
 {
     return cursor::make_SafeCursor(this->origin(),
                                    math::Int<T_dim>::create(0),
-                                   math::Int<T_dim>(size()));
+                                   math::Int<T_dim>(size()) - 1);
 }
 
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -24,10 +24,13 @@
 
 #include "types.h"
 #include "math/Vector.hpp"
+#include "math/vector/compile-time/Int.hpp"
 #include "cuSTL/cursor/compile-time/BufferCursor.hpp"
 #include "cuSTL/cursor/navigator/CartNavigator.hpp"
 #include "cuSTL/cursor/accessor/PointerAccessor.hpp"
-#include <cuSTL/zone/compile-time/SphericZone.hpp>
+#include "cuSTL/zone/compile-time/SphericZone.hpp"
+#include "cuSTL/cursor/compile-time/SafeCursor.hpp"
+#include <boost/mpl/int.hpp>
 
 namespace PMacc
 {
@@ -47,6 +50,12 @@ public:
     typedef _Size Size;
     typedef typename Allocator::Pitch Pitch;
     typedef cursor::CT::BufferCursor<Type, Pitch> Cursor;
+
+    typedef typename PMacc::math::CT::make_Vector<Size::dim, boost::mpl::integral_c<int, 0> >::type ZeroVec;
+    typedef typename PMacc::math::CT::make_Vector<Size::dim, boost::mpl::integral_c<int,-1> >::type MinusOneVec;
+    typedef cursor::CT::SafeCursor<Cursor,
+                                   ZeroVec,
+                                   typename PMacc::math::CT::add<Size, MinusOneVec>::type> SafeCursor;
     BOOST_STATIC_CONSTEXPR int dim = Size::dim;
     typedef zone::CT::SphericZone<_Size, typename math::CT::make_Int<dim, 0>::type> Zone;
 private:
@@ -62,7 +71,8 @@ public:
     DINLINE void assign(const Type& value);
     DINLINE Type* getDataPointer() const {return dataPointer;}
 
-    DINLINE cursor::CT::BufferCursor<Type, Pitch> origin() const;
+    DINLINE Cursor origin() const;
+    DINLINE SafeCursor originSafe() const;
     /*
     HDINLINE Cursor<PointerAccessor<Type>, CartNavigator<dim>, char*>
     originCustomAxes(const math::UInt32<dim>& axes) const;
@@ -77,4 +87,3 @@ public:
 } // PMacc
 
 #include "CartBuffer.tpp"
-

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
@@ -37,10 +37,18 @@ DINLINE CartBuffer<Type, _Size, Allocator, Copier, Assigner>::CartBuffer()
 
 template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>
 DINLINE
-cursor::CT::BufferCursor<Type, typename Allocator::Pitch>
+CartBuffer<Type, _Size, Allocator, Copier, Assigner>::Cursor
 CartBuffer<Type, _Size, Allocator, Copier, Assigner>::origin() const
 {
-    return cursor::CT::BufferCursor<Type, Pitch>(this->dataPointer);
+    return CartBuffer<Type, _Size, Allocator, Copier, Assigner>::Cursor(this->dataPointer);
+}
+
+template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>
+DINLINE
+CartBuffer<Type, _Size, Allocator, Copier, Assigner>::SafeCursor
+CartBuffer<Type, _Size, Allocator, Copier, Assigner>::originSafe() const
+{
+    return CartBuffer<Type, _Size, Allocator, Copier, Assigner>::SafeCursor(this->origin());
 }
 
 } // CT

--- a/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
@@ -56,7 +56,7 @@ public:
     typedef _Marker Marker;
     typedef Cursor<Accessor, Navigator, Marker> This;
     typedef This result_type;
-protected:
+public:
     Marker marker;
 public:
     HDINLINE

--- a/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
@@ -40,8 +40,8 @@ public:
     BOOST_STATIC_CONSTEXPR int dim = PMacc::cursor::traits::dim<Cursor>::value;
 private:
     /* \todo: Use a zone instead of lowerExtent and UpperExtent */
-    const math::Int<dim> lowerExtent;
-    const math::Int<dim> upperExtent;
+    math::Int<dim> lowerExtent;
+    math::Int<dim> upperExtent;
     math::Int<dim> offset;
     bool enabled;
 public:
@@ -50,13 +50,14 @@ public:
      * \param lowerExtent Top left corner of valid range, inside the range.
      * \param upperExtent Bottom right corner of valid range, inside the range.
      */
+    template<typename LowerExtent, typename UpperExtent>
     HDINLINE SafeCursor(const Cursor& cursor,
-                        const math::Int<dim>& lowerExtent,
-                        const math::Int<dim>& upperExtent)
+                        const LowerExtent& lowerExtent,
+                        const UpperExtent& upperExtent)
         : Cursor(cursor),
           lowerExtent(lowerExtent),
           upperExtent(upperExtent),
-          offset(math::Int<dim>(0)),
+          offset(math::Int<dim>::create(0)),
           enabled(true)
     {}
 
@@ -127,7 +128,7 @@ private:
     HDINLINE void checkValidity() const
     {
         if(!this->enabled) return;
-        #pragma unroll
+
         for(int i = 0; i < dim; i++)
         {
             if(this->offset[i] < this->lowerExtent[i] ||
@@ -151,11 +152,11 @@ struct dim<SafeCursor<Cursor> >
 } // traits
 
 /* convenient function to construct a safe-cursor by passing its constructor arguments */
-template<typename Cursor>
+template<typename Cursor, typename LowerExtent, typename UpperExtent>
 HDINLINE SafeCursor<Cursor> make_SafeCursor(
     const Cursor& cursor,
-    const math::Int<traits::dim<SafeCursor<Cursor> >::value>& lowerExtent,
-    const math::Int<traits::dim<SafeCursor<Cursor> >::value>& upperExtent)
+    const LowerExtent& lowerExtent,
+    const UpperExtent& upperExtent)
 {
     return SafeCursor<Cursor>(cursor, lowerExtent, upperExtent);
 }

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -44,7 +44,7 @@ private:
     math::Int<dim> offset;
 public:
     HDINLINE SafeCursor(const Cursor& cursor)
-        : Cursor(cursor), offset(math::Int<dim>(0))
+        : Cursor(cursor), offset(math::Int<dim>::create(0))
     {}
 
     HDINLINE
@@ -107,7 +107,6 @@ public:
 private:
     HDINLINE void checkValidity() const
     {
-        #pragma unroll
         for(int i = 0; i < dim; i++)
         {
             if(this->offset[i] < LowerExtent().toRT()[i] ||

--- a/src/picongpu/include/Cached_F2P_Interp.hpp
+++ b/src/picongpu/include/Cached_F2P_Interp.hpp
@@ -76,9 +76,12 @@ private:
         >::FullSuperCellSize FullSuperCellSize;
 
     typedef container::CT::SharedBuffer<type, FullSuperCellSize, sharedMemIdx> CachedBuffer;
+    typedef typename CachedBuffer::Cursor CCursor;
 
     PMACC_ALIGN(globalFieldCursor, typename Buffer::Cursor);
-    PMACC_ALIGN(cachedFieldCursor, typename CachedBuffer::Cursor);
+    PMACC_ALIGN(cachedFieldCursor, typename CachedBuffer::SafeCursor);
+    //typename Buffer::Cursor globalFieldCursor;
+    //typename CachedBuffer::SafeCursor cachedFieldCursor;
 
 public:
     /**
@@ -86,7 +89,8 @@ public:
      */
     Cached_F2P_Interp(const Buffer& buffer) :
         globalFieldCursor(buffer.origin()),
-        cachedFieldCursor(NULL) /* gets valid in `init()` */
+        cachedFieldCursor(CCursor(NULL)) /* gets valid in `init()` */
+        /*cachedFieldCursor(NULL)*/ /* gets valid in `init()` */
         {}
 
     /** Fill shared memory cache with global memory field data.
@@ -98,8 +102,15 @@ public:
     DINLINE
     void init(const PMacc::math::Int<dim>& blockCell, const int linearThreadIdx)
     {
-        CachedBuffer cachedBuffer; /* allocate shared memory. Valid for kernel lifetime. */
-        this->cachedFieldCursor = cachedBuffer.origin();
+        CachedBuffer cachedBuffer; /* \TODO: allocate shared memory. Valid for kernel lifetime. */
+        /*__shared__ type buf[600];
+        if(linearThreadIdx == 0)
+        {
+            printf("buf: %x\n", buf);
+            printf("buf+600: %x\n", buf+600);
+        }
+        this->cachedFieldCursor = CachedBuffer::Cursor(reinterpret_cast<type*>(buf));*/
+        this->cachedFieldCursor = cachedBuffer.originSafe();
 
         const PMacc::math::Int<dim> lowerMargin = LowerMargin::toRT();
 
@@ -110,12 +121,61 @@ public:
         algorithm::cudaBlock::Foreach<MappingDesc::SuperCellSize> foreach(linearThreadIdx);
         foreach(
             CachedBuffer::Zone(), /* super cell size + margins */
-            this->cachedFieldCursor,
+            cachedFieldCursor,
             this->globalFieldCursor(blockCell - lowerMargin),
             _1 = _2);
 
+        __syncthreads();
+
         /* jump to origin of the SuperCell */
-        this->cachedFieldCursor = this->cachedFieldCursor(lowerMargin);
+        //this->cachedFieldCursor = this->cachedFieldCursor(lowerMargin);
+        if(linearThreadIdx == 0)
+        {
+            printf("cached marker: %x\n", this->cachedFieldCursor.marker);
+        }
+        PMACC_AUTO(shCursor, this->cachedFieldCursor(lowerMargin));
+        if(linearThreadIdx == 0)
+        {
+            /*printf("shCursor marker: %x\n", shCursor.marker);
+            printf("shCursor adress: %x\n", &(*shCursor));*/
+            //printf("shCursor back-shifted: %x\n", &((*shCursor(-1,-1,-1))[2]));
+            printf("cached adress: %x\n", &((*this->cachedFieldCursor(0,0,0))[2]));
+
+            /*printf("fieldB global A: %f, %f, %f\n", (*this->globalFieldCursor(blockCell - lowerMargin)(0,0,0))[0],
+                                                    (*this->globalFieldCursor(blockCell - lowerMargin)(0,0,0))[1],
+                                                    (*this->globalFieldCursor(blockCell - lowerMargin)(0,0,0))[2]);
+            printf("fieldB global B: %f, %f, %f\n", (*this->globalFieldCursor(blockCell - lowerMargin)(4,5,3))[0],
+                                                    (*this->globalFieldCursor(blockCell - lowerMargin)(4,5,3))[1],
+                                                    (*this->globalFieldCursor(blockCell - lowerMargin)(4,5,3))[2]);
+            printf("fieldB global C: %f, %f, %f\n", (*this->globalFieldCursor(blockCell - lowerMargin)(9,9,5))[0],
+                                                    (*this->globalFieldCursor(blockCell - lowerMargin)(9,9,5))[1],
+                                                    (*this->globalFieldCursor(blockCell - lowerMargin)(9,9,5))[2]);*/
+
+            ((*this->cachedFieldCursor(0,0,0))[2])=42;
+            float_X* data = &((*shCursor(-1,-1,-1))[2]);
+            printf("data adress: %x\n", data);
+            printf("data value: %f\n", *data);
+
+            printf("fieldB shared A: %f, %f, %f\n", (*shCursor(0,0,0))[2],
+                                                    (*shCursor(0,0,0))[1],
+                                                    (*shCursor(0,0,0))[0]);
+            printf("fieldB shared B: %f, %f, %f\n", *data,
+                                                    (*shCursor(-1,-1,-1))[1],
+                                                    (*shCursor(-1,-1,-1))[0]);
+            printf("fieldB shared C: %f, %f, %f\n", (*shCursor(8,8,4))[2],
+                                                    (*shCursor(8,8,4))[1],
+                                                    (*shCursor(8,8,4))[0]);
+
+            printf("fieldB shared D: %f, %f, %f\n", (*this->cachedFieldCursor(0,0,0))[2],
+                                                    (*this->cachedFieldCursor(0,0,0))[1],
+                                                    (*this->cachedFieldCursor(0,0,0))[0]);
+            printf("fieldB shared E: %f, %f, %f\n", (*this->cachedFieldCursor(4,5,3))[2],
+                                                    (*this->cachedFieldCursor(4,5,3))[1],
+                                                    (*this->cachedFieldCursor(4,5,3))[0]);
+            printf("fieldB shared F: %f, %f, %f\n", (*this->cachedFieldCursor(9,9,5))[2],
+                                                    (*this->cachedFieldCursor(9,9,5))[1],
+                                                    (*this->cachedFieldCursor(9,9,5))[0]);
+        }
     }
 
     /** Perform field-to-particle interpolation.
@@ -127,9 +187,26 @@ public:
     DINLINE
     type operator()(const floatD_X& particlePos, const PMacc::math::Int<dim> localCell)
     {
+        if(threadIdx.x==0 && threadIdx.y==0 && threadIdx.z==0)
+        {
+            printf("op(), cached shifted: %x\n", &(*this->cachedFieldCursor));
+            /*printf("op(), fieldB shared A: %f, %f, %f\n", (*this->cachedFieldCursor(0,0,0))[0],
+                                                          (*this->cachedFieldCursor(0,0,0))[1],
+                                                          (*this->cachedFieldCursor(0,0,0))[2]);
+            printf("op(), fieldB shared B: %f, %f, %f\n", (*this->cachedFieldCursor(-1,-1,-1))[0],
+                                                          (*this->cachedFieldCursor(-1,-1,-1))[1],
+                                                          (*this->cachedFieldCursor(-1,-1,-1))[2]);
+            printf("op(), fieldB shared C: %f, %f, %f\n", (*this->cachedFieldCursor(8,8,4))[0],
+                                                          (*this->cachedFieldCursor(8,8,4))[1],
+                                                          (*this->cachedFieldCursor(8,8,4))[2]);*/
+        }
+        return *this->cachedFieldCursor(0,0,0);/* +
+               *this->cachedFieldCursor(-1,-1,-1) +
+               *this->cachedFieldCursor(8,8,4);*/
         /* interpolation of the field */
-        return FieldToParticleInterpolation()
-            (this->cachedFieldCursor(localCell), particlePos, NumericalFieldPosition()());
+        /*return FieldToParticleInterpolation()(this->cachedFieldCursor(localCell),
+                                              particlePos,
+                                              fieldSolver::NumericalCellType::getBFieldPosition() NumericalFieldPosition()());*/
     }
 };
 

--- a/src/picongpu/include/Cached_F2P_Interp.hpp
+++ b/src/picongpu/include/Cached_F2P_Interp.hpp
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2015 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "traits/GetMargin.hpp"
+#include "dimensions/SuperCellDescription.hpp"
+#include "cuSTL/container/compile-time/SharedBuffer.hpp"
+#include "cuSTL/algorithm/cudaBlock/Foreach.hpp"
+#include "vector/Int.hpp"
+#include "lambda/placeholder.h"
+
+namespace picongpu
+{
+
+using namespace PMacc;
+
+/** Provides field-to-particle interpolation of a cached (shared memory)
+ * field on device. The caching is done by this class.
+ *
+ * \tparam T_Buffer container type (cuSTL) of field data
+ * \tparam T_FieldToParticleInterpolation interpolation algorithm
+ * \tparam T_NumericalFieldPosition A type with an operator(), that returns
+ *      a VectorVector indicating the numerical field position.
+ * \tparam T_CudaBlockDim compile-time vector of the used blockDim
+ * \tparam T_sharedMemIdx Arbitrary, unique integer. Has to be unique to
+ *      every identical shared memory block in use (due to a nvcc bug).
+ *
+ * \see: "algorithms/FieldToParticleInterpolation.hpp"
+ * \see: "fields/numericalCellTypes/GetNumericalFieldPos.hpp"
+ */
+template<
+    typename T_Buffer,
+    typename T_FieldToParticleInterpolation,
+    typename T_NumericalFieldPosition,
+    typename T_CudaBlockDim,
+    int T_sharedMemIdx>
+class Cached_F2P_Interp
+{
+public:
+    typedef T_Buffer Buffer;
+    typedef T_FieldToParticleInterpolation FieldToParticleInterpolation;
+    typedef T_NumericalFieldPosition NumericalFieldPosition;
+    typedef T_CudaBlockDim CudaBlockDim;
+    BOOST_STATIC_CONSTEXPR int sharedMemIdx = T_sharedMemIdx;
+    typedef typename Buffer::type type;
+    BOOST_STATIC_CONSTEXPR int dim = Buffer::dim;
+
+private:
+    /* margins around the supercell for the interpolation of the field on the cells */
+    typedef typename GetMargin<FieldToParticleInterpolation>::LowerMargin LowerMargin;
+    typedef typename GetMargin<FieldToParticleInterpolation>::UpperMargin UpperMargin;
+
+    /* relevant area of a block */
+    typedef SuperCellDescription<
+        typename MappingDesc::SuperCellSize,
+        LowerMargin,
+        UpperMargin
+        > BlockArea;
+
+    typedef container::CT::SharedBuffer<type, typename BlockArea::FullSuperCellSize, sharedMemIdx> CachedBuffer;
+
+    PMACC_ALIGN(globalFieldCursor, typename Buffer::Cursor);
+    PMACC_ALIGN(cachedFieldCursor, typename CachedBuffer::Cursor);
+
+public:
+    /**
+     * @param buffer cuSTL buffer of the field data
+     */
+    Cached_F2P_Interp(const Buffer& buffer) : globalFieldCursor(buffer.origin()) {}
+
+    /** Fill the cache with the field data.
+     *
+     * @param blockCell multi-dim offset from the origin of the local domain on GPU
+     *                  to the origin of the block of the in unit of cells
+     * @param linearThreadIdx linear coordinate of the thread in the threadBlock
+     */
+    DINLINE
+    void init(const math::Int<dim>& blockCell, const int linearThreadIdx)
+    {
+        CachedBuffer cachedBuffer; /* allocate shared memory. Valid for kernel lifetime. */
+        this->cachedFieldCursor = cachedBuffer.origin();
+
+        const math::Int<dim> lowerMargin = LowerMargin::toRT();
+
+        using namespace lambda;
+        DECLARE_PLACEHOLDERS(); // declares _1, _2, _3, ... in device code
+
+        /* fill shared memory with global field data */
+        algorithm::cudaBlock::Foreach<CudaBlockDim> foreach(linearThreadIdx);
+        foreach(
+            CachedBuffer::Zone(), /* super cell size + margins */
+            this->cachedFieldCursor,
+            this->globalFieldCursor(blockCell - lowerMargin),
+            _1 = _2);
+
+        /* jump to the origin of the SuperCell */
+        this->cachedFieldCursor = this->cachedFieldCursor(lowerMargin);
+    }
+
+    /** Perform the field-to-particle interpolation.
+     *
+     * @param particlePos particle position within cell
+     * @param localCell multi-dim coordinate of the local cell inside the super cell
+     * @return interpolated field value
+     */
+    DINLINE
+    type operator()(const floatD_X& particlePos, const math::Int<dim> localCell)
+    {
+        /* interpolation of the field */
+        return FieldToParticleInterpolation()
+            (this->cachedFieldCursor(localCell), particlePos, NumericalFieldPosition()());
+    }
+};
+
+} // namespace picongpu

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -61,7 +61,7 @@ struct DirSplittingKernel
     DINLINE void operator()(CursorE globalE, CursorB globalB) const
     {
         //\todo: optimize cache size
-        typedef typename PMacc::math::CT::add<
+        /*typedef typename PMacc::math::CT::add<
             typename BlockDim::vector_type,
             typename PMacc::math::CT::Int < 2, 0, 0 > ::vector_type>::type CacheSize;
 
@@ -107,7 +107,7 @@ struct DirSplittingKernel
             __syncthreads();
 
             threadPos_x = BlockDim::x::value - 1 - threadPos_x;
-        }
+        }*/
     }
 
 };

--- a/src/picongpu/include/fields/numericalCellTypes/GetNumericalFieldPos.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/GetNumericalFieldPos.hpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_types.hpp"
+#include "NumericalCellTypes.hpp"
+
+namespace picongpu
+{
+
+/** Get the numerical field position of a given numerical
+ * cell type by field type index.
+ *
+ * \tparam NumericalCellType \see: YeeCell.hpp or EMFCenteredCell.hpp
+ * \tparam fieldType \see: FieldType in simulation_types.hpp
+ */
+template<typename NumericalCellType, int fieldType>
+struct GetNumericalFieldPos;
+
+template<typename NumericalCellType>
+struct GetNumericalFieldPos<NumericalCellType, FIELD_TYPE_E>
+{
+    typedef typename NumericalCellType::VectorVector VectorVector;
+
+    HDINLINE VectorVector operator()() const
+    {
+        return NumericalCellType::getEFieldPosition();
+    }
+};
+
+template<typename NumericalCellType>
+struct GetNumericalFieldPos<NumericalCellType, FIELD_TYPE_B>
+{
+    typedef typename NumericalCellType::VectorVector VectorVector;
+
+    HDINLINE VectorVector operator()() const
+    {
+        return NumericalCellType::getBFieldPosition();
+    }
+};
+
+} // namespace picongpu

--- a/src/picongpu/include/particles/bremsstrahlung/PhotonCreator.def
+++ b/src/picongpu/include/particles/bremsstrahlung/PhotonCreator.def
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015 Heiko Burau, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+/**
+ *
+ * \tparam T_ElectronSpecies
+ * \tparam T_PhotonSpecies
+ */
+template<typename T_ElectronSpecies, typename T_PhotonSpecies>
+struct PhotonCreator;
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/bremsstrahlung/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/PhotonCreator.hpp
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2015 Heiko Burau, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/creation/CreatorBase.hpp"
+#include "SynchrotonFunctions.hpp"
+#include "algorithms/math/defines/sqrt.hpp"
+#include "algorithms/math/defines/dot.hpp"
+#include "algorithms/math/defines/cross.hpp"
+#include "traits/frame/GetMass.hpp"
+#include "traits/frame/GetCharge.hpp"
+
+// Random number generator
+#include "particles/ionization/ionizationMethods.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+/**
+ *
+ * \tparam T_ElectronSpecies
+ * \tparam T_PhotonSpecies
+ */
+template<typename T_ElectronSpecies, typename T_PhotonSpecies>
+struct PhotonCreator : public creation::CreatorBase<T_ElectronSpecies, T_PhotonSpecies>
+{
+    typedef T_ElectronSpecies ElectronSpecies;
+    typedef T_PhotonSpecies PhotonSpecies;
+
+    typedef creation::CreatorBase<ElectronSpecies, PhotonSpecies> Base;
+
+    typedef typename Base::FrameType FrameType;
+    typedef typename Base::ValueType_E ValueType_E;
+    typedef typename Base::ValueType_B ValueType_B;
+
+private:
+    PMACC_ALIGN(curF_1, SynchrotonFunctions::SyncFuncCursor);
+    PMACC_ALIGN(curF_2, SynchrotonFunctions::SyncFuncCursor);
+
+    /* random number generator for Monte Carlo */
+    typedef ionization::RandomNrForMonteCarlo<T_ElectronSpecies> RandomGen;
+    /* \todo fix: cannot PMACC_ALIGN() because it seems to be too large */
+    RandomGen randomGen;
+
+    float3_X photon_mom;
+
+public:
+    /* host constructor initializing member : random number generator */
+    PhotonCreator(
+        const SynchrotonFunctions::SyncFuncCursor& curF_1,
+        const SynchrotonFunctions::SyncFuncCursor& curF_2,
+        const uint32_t currentStep)
+            : curF_1(curF_1), curF_2(curF_2), randomGen(currentStep)
+    {}
+
+    /** Initialization function on device
+     *
+     * \brief Cache EM-fields on device
+     *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+     *
+     * This function will be called inline on the device which must happen BEFORE threads diverge
+     * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+     * initializing the E-/B-field shared boxes in shared memory.
+     */
+    DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& localCellOffset)
+    {
+        Base::init(blockCell, linearThreadIdx, localCellOffset);
+
+        /* initialize random number generator with the local cell index in the simulation*/
+        this->randomGen.init(localCellOffset);
+    }
+
+    DINLINE float_X emission_prob(
+        const float_X delta,
+        const float_X chi,
+        const float_X gamma,
+        const float_X mass,
+        const float_X charge) const
+    {
+        // quantum
+        //const float_X z = float_X(2.0/3.0) * delta / ((float_X(1.0) - delta) * chi);
+        // classical
+        const float_X z = float_X(2.0/3.0) * delta / chi;
+
+        // quantum
+        /*return DELTA_T * charge*charge * mass*SPEED_OF_LIGHT / (float_X(4.0)*PI*EPS0 * HBAR*HBAR) *
+            float_X(1.732050807) / (float_X(2.0) * PI) * chi/gamma * (float_X(1.0) - delta) / delta *
+            (this->curF_1[z] + float_X(1.5) * delta * chi * z * this->curF_2[z]);*/
+        // classical
+        return DELTA_T * charge*charge * mass*SPEED_OF_LIGHT / (float_X(4.0)*PI*EPS0 * HBAR*HBAR) *
+            float_X(1.732050807) / (float_X(2.0) * PI) * chi/gamma / delta * this->curF_1[z];
+    }
+
+    DINLINE float_X emission_prob_modified(
+        const float_X z,
+        const float_X chi,
+        const float_X gamma,
+        const float_X mass,
+        const float_X charge) const
+    {
+        return float_X(3.0) * z*z * emission_prob(
+            z*z*z,
+            chi, gamma, mass, charge);
+    }
+
+    /** Return the number of target particles to be created from each source particle.
+     *
+     * Called for each frame of the source species.
+     *
+     * @param sourceFrame Frame of the source species
+     * @param localIdx Index of the source particle within frame
+     * @return number of particle to be created from each source particle
+     */
+    DINLINE unsigned int numNewParticles(FrameType& sourceFrame, int localIdx)
+    {
+        using namespace PMacc::algorithms;
+
+        PMACC_AUTO(particle, sourceFrame[localIdx]);
+
+        ValueType_E fieldE;
+        ValueType_B fieldB;
+        this->getFieldsForParticle(particle, fieldE, fieldB);
+
+        const float3_X mom = particle[momentum_] / particle[weighting_];
+        const float_X mom2 = math::dot(mom, mom);
+        const float3_X mom_norm = mom * math::rsqrt(mom2);
+        const float_X mass = frame::getMass<FrameType>();
+        const float_X mc = mass * SPEED_OF_LIGHT;
+
+        const float_X gamma = math::sqrt(float_X(1.0) + mom2 / (mc*mc));
+        const float3_X vel = mom / (gamma * mass); // low accuracy?
+
+        const float3_X lorentz = fieldE + math::cross(vel, fieldB);
+        const float_X lorentz2 = math::dot(lorentz, lorentz);
+        const float_X fieldE_long = math::dot(mom_norm, fieldE);
+
+        const float_X H_eff = math::sqrt(lorentz2 - fieldE_long*fieldE_long);
+
+        const float_X charge = math::abs(frame::getCharge<FrameType>());
+        const float_X c = SPEED_OF_LIGHT;
+        // Schwinger limit, unit: V/m
+        const float_X E_S = mass*mass * c*c*c / (charge * HBAR);
+
+        const float_X chi = gamma * H_eff / E_S;
+
+        const float_X z = this->randomGen();
+        if(z == float_X(0.0) || z == float_X(1.0))
+            return 0;
+
+        const float_X x = emission_prob_modified(z, chi, gamma, mass, charge);
+
+        if(this->randomGen() < x)
+        {
+            //printf("E_S: %f, H_eff: %f, chi: %f, gamma: %f, delta: %f, p: %f\n", E_S, H_eff, chi, gamma, z*z*z, x);
+
+            this->photon_mom = mom_norm * z*z*z * mass*c * gamma * particle[weighting_];
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /** Functor implementation.
+     *
+     * Called once for each single particle creation.
+     *
+     * \tparam Electron type of electron which creates the photon
+     * \tparam Photon type of photon that is created
+     */
+    template<typename Electron, typename Photon>
+    DINLINE void operator()(Electron& electron, Photon& photon) const
+    {
+        photon[multiMask_] = 1;
+        photon[localCellIdx_] = electron[localCellIdx_];
+        photon[position_] = electron[position_];
+        photon[momentum_] = this->photon_mom;
+        electron[momentum_] -= this->photon_mom;
+        photon[weighting_] = electron[weighting_];
+    }
+};
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/bremsstrahlung/SynchrotronFunctions.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/SynchrotronFunctions.hpp
@@ -20,18 +20,20 @@
 
 #pragma once
 
-#include "types.h"
+#include "simulation_defines.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
 #include "cuSTL/cursor/Cursor.hpp"
 #include "cuSTL/cursor/navigator/PlusNavigator.hpp"
 #include "cuSTL/cursor/tools/LinearInterp1D.hpp"
 #include "cuSTL/cursor/BufferCursor.hpp"
-#include "simulation_defines.hpp"
+#include "types.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/array.hpp>
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 #include <boost/math/tr1.hpp> /* cyl_bessel_k */
+
+#include "simulation_defines/unitless/bremsstrahlung.unitless"
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/creation/creation.hpp
+++ b/src/picongpu/include/particles/creation/creation.hpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015 Marco Garten, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/creation/creation.kernel"
+#include "cuSTL/algorithm/kernel/Foreach.hpp"
+#include "cuSTL/cursor/MultiIndexCursor.hpp"
+#include "types.h"
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+
+using namespace PMacc;
+
+namespace particles
+{
+namespace creation
+{
+
+template<typename SourceSpecies, typename TargetSpecies, typename ParticleCreator,
+         typename CellDescription>
+void createParticles(SourceSpecies& sourceSpecies, TargetSpecies& targetSpecies,
+                     ParticleCreator& particleCreator, CellDescription* cellDesc)
+{
+    typedef typename MappingDesc::SuperCellSize SuperCellSize;
+    const math::Int<simDim> coreBorderGuardSuperCells = cellDesc->getGridSuperCells();
+    const math::Int<simDim> guardSuperCells = cellDesc->getGuardingSuperCells();
+    const math::Int<simDim> coreBorderSuperCells = coreBorderGuardSuperCells - 2*guardSuperCells;
+
+    /* Functor holding the actual generic particle creation kernel */
+    CreateParticlesKernel createParticlesKernel(
+        sourceSpecies.getDeviceParticlesBox(),
+        targetSpecies.getDeviceParticlesBox(),
+        particleCreator);
+
+    /* This zone represents the core+border area with guard offset in unit of cells */
+    const SphericZone<simDim> zone(
+        static_cast<math::Size_t<simDim> >(coreBorderSuperCells * SuperCellSize::toRT()),
+        guardSuperCells * SuperCellSize::toRT());
+
+    algorithm::kernel::Foreach<SuperCellSize> foreach;
+    foreach(zone, cursor::make_MultiIndexCursor(), createParticlesKernel);
+
+    /* fill the gaps in the created species' particle frames to ensure that only
+     * the last frame is not completely filled but every other before is full
+     */
+    targetSpecies.fillAllGaps();
+}
+
+} // namespace creation
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/creation/creation.hpp
+++ b/src/picongpu/include/particles/creation/creation.hpp
@@ -50,7 +50,8 @@ void createParticles(SourceSpecies& sourceSpecies, TargetSpecies& targetSpecies,
     PMACC_AUTO(createParticlesKernel, make_CreateParticlesKernel(
         sourceSpecies.getDeviceParticlesBox(),
         targetSpecies.getDeviceParticlesBox(),
-        particleCreator));
+        particleCreator,
+        guardSuperCells));
 
     /* This zone represents the core+border area with guard offset in unit of cells */
     const zone::SphericZone<simDim> zone(

--- a/src/picongpu/include/particles/creation/creation.kernel
+++ b/src/picongpu/include/particles/creation/creation.kernel
@@ -56,12 +56,18 @@ struct CreateParticlesKernel
     ParBoxSource sourceBox;
     ParBoxTarget targetBox;
     ParticleCreator particleCreator;
+    uint32_t guardSuperCells;
 
     CreateParticlesKernel(
         ParBoxSource sourceBox,
         ParBoxTarget targetBox,
-        ParticleCreator particleCreator) :
-            sourceBox(sourceBox), targetBox(targetBox), particleCreator(particleCreator) {}
+        ParticleCreator particleCreator,
+        const uint32_t guardSuperCells) :
+            sourceBox(sourceBox),
+            targetBox(targetBox),
+            particleCreator(particleCreator),
+            guardSuperCells(guardSuperCells)
+    {}
 
     DINLINE void operator()(const PMacc::math::Int<simDim>& cellIndex)
     {
@@ -108,8 +114,10 @@ struct CreateParticlesKernel
         if(!sourceFrame.isValid())
             return; //end kernel if we have no frames
 
+        const PMacc::math::Int<simDim> localCellIndex = cellIndex - this->guardSuperCells * SuperCellSize::toRT();
+
         /* caching of E- and B- fields and initialization of random generator if needed */
-        particleCreator.init(blockCell, linearThreadIdx, cellIndex);
+        particleCreator.init(blockCell, linearThreadIdx, localCellIndex);
 
         /* Declare counter in shared memory that will later tell the current fill level or
          * occupation of the newly created target target particle frames.
@@ -274,10 +282,11 @@ CreateParticlesKernel<ParBoxSource, ParBoxTarget, ParticleCreator>
 make_CreateParticlesKernel(
     ParBoxSource parBoxSource,
     ParBoxTarget parBoxTarget,
-    ParticleCreator particleCreator)
+    ParticleCreator particleCreator,
+    const uint32_t guardSuperCells)
 {
     return CreateParticlesKernel<ParBoxSource, ParBoxTarget, ParticleCreator>(
-        parBoxSource, parBoxTarget, particleCreator);
+        parBoxSource, parBoxTarget, particleCreator, guardSuperCells);
 }
 
 } // namespace creation

--- a/src/picongpu/include/particles/creation/creation.kernel
+++ b/src/picongpu/include/particles/creation/creation.kernel
@@ -20,9 +20,6 @@
 
 #pragma once
 
-
-#include <iostream>
-
 #include "simulation_defines.hpp"
 #include "particles/Particles.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
@@ -30,9 +27,10 @@
 #include "mappings/simulation/GridController.hpp"
 #include "simulationControl/MovingWindow.hpp"
 #include "traits/Resolve.hpp"
-#include "nvidia/atomic.hpp"
-
+#include "math/vector/Int.hpp"
 #include "types.h"
+#include "nvidia/atomic.hpp"
+#include <iostream>
 
 namespace picongpu
 {
@@ -65,25 +63,25 @@ struct CreateParticlesKernel
         ParticleCreator particleCreator) :
             sourceBox(sourceBox), targetBox(targetBox), particleCreator(particleCreator) {}
 
-    DINLINE void operator()(const math::Int<simDim>& cellIndex)
+    DINLINE void operator()(const PMacc::math::Int<simDim>& cellIndex)
     {
         /* definitions for domain variables, like indices of blocks and threads */
         typedef typename MappingDesc::SuperCellSize SuperCellSize;
 
         /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
-        const math::Int<simDim> block = cellIndex / SuperCellSize::toRT();
+        const PMacc::math::Int<simDim> block = cellIndex / SuperCellSize::toRT();
 
         /* multi-dim offset from the origin of the local domain on GPU
          * to the origin of the block of the in unit of cells
          */
-        const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
+        const PMacc::math::Int<simDim> blockCell = block * SuperCellSize::toRT();
 
         /* multi-dim vector from origin of the block to a cell in units of cells */
-        const math::Int<simDim> threadIndex = cellIndex % SuperCellSize::toRT();
+        const PMacc::math::Int<simDim> threadIndex = cellIndex % SuperCellSize::toRT();
 
         /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
-        const int linearThreadIdx = math::linearize(
-            math::CT::shrinkTo<SuperCellSize, simDim-1>::type::toRT(),
+        const int linearThreadIdx = PMacc::math::linearize(
+            PMacc::math::CT::shrinkTo<SuperCellSize, simDim-1>::type::toRT(),
             threadIndex);
 
         /* "particle box" : container/iterator where the particles live in
@@ -96,7 +94,7 @@ struct CreateParticlesKernel
 
         __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SourceFramePtr>::type sourceFrame;
         __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<TargetFramePtr>::type targetFrame;
-        static const lcellId_t maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+        const lcellId_t maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
         /* find last frame in super cell
          * define maxParticlesInFrame as the maximum frame size
@@ -270,6 +268,17 @@ struct CreateParticlesKernel
         }
     }
 };
+
+template<class ParBoxSource, class ParBoxTarget, class ParticleCreator>
+CreateParticlesKernel<ParBoxSource, ParBoxTarget, ParticleCreator>
+make_CreateParticlesKernel(
+    ParBoxSource parBoxSource,
+    ParBoxTarget parBoxTarget,
+    ParticleCreator particleCreator)
+{
+    return CreateParticlesKernel<ParBoxSource, ParBoxTarget, ParticleCreator>(
+        parBoxSource, parBoxTarget, particleCreator);
+}
 
 } // namespace creation
 } // namespace particles

--- a/src/picongpu/include/particles/creation/creation.kernel
+++ b/src/picongpu/include/particles/creation/creation.kernel
@@ -1,0 +1,276 @@
+/**
+ * Copyright 2015 Heiko Burau, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include <iostream>
+
+#include "simulation_defines.hpp"
+#include "particles/Particles.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "particles/ParticlesInit.kernel"
+#include "mappings/simulation/GridController.hpp"
+#include "simulationControl/MovingWindow.hpp"
+#include "traits/Resolve.hpp"
+#include "nvidia/atomic.hpp"
+
+#include "types.h"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace creation
+{
+
+using namespace PMacc;
+
+/** Functor with main kernel for particle creation
+ *
+ * \tparam ParBoxSource container of the source species
+ * \tparam ParBoxTarget container of the target species
+ * \tparam ParticleCreator instance of the particle creation functor
+ *
+ * - maps the frame dimensions and gathers the particle boxes
+ * - contains / calls the Creator
+ */
+template<class ParBoxSource, class ParBoxTarget, class ParticleCreator>
+struct CreateParticlesKernel
+{
+    ParBoxSource sourceBox;
+    ParBoxTarget targetBox;
+    ParticleCreator particleCreator;
+
+    CreateParticlesKernel(
+        ParBoxSource sourceBox,
+        ParBoxTarget targetBox,
+        ParticleCreator particleCreator) :
+            sourceBox(sourceBox), targetBox(targetBox), particleCreator(particleCreator) {}
+
+    DINLINE void operator()(const math::Int<simDim>& cellIndex)
+    {
+        /* definitions for domain variables, like indices of blocks and threads */
+        typedef typename MappingDesc::SuperCellSize SuperCellSize;
+
+        /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+        const math::Int<simDim> block = cellIndex / SuperCellSize::toRT();
+
+        /* multi-dim offset from the origin of the local domain on GPU
+         * to the origin of the block of the in unit of cells
+         */
+        const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
+
+        /* multi-dim vector from origin of the block to a cell in units of cells */
+        const math::Int<simDim> threadIndex = cellIndex % SuperCellSize::toRT();
+
+        /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
+        const int linearThreadIdx = math::linearize(
+            math::CT::shrinkTo<SuperCellSize, simDim-1>::type::toRT(),
+            threadIndex);
+
+        /* "particle box" : container/iterator where the particles live in
+         * and where one can get the frame in a super cell from
+         */
+        typedef typename ParBoxSource::FrameType SOURCEFRAME;
+        typedef typename ParBoxTarget::FrameType TARGETFRAME;
+        typedef typename ParBoxSource::FramePtr SourceFramePtr;
+        typedef typename ParBoxTarget::FramePtr TargetFramePtr;
+
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SourceFramePtr>::type sourceFrame;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<TargetFramePtr>::type targetFrame;
+        static const lcellId_t maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+
+        /* find last frame in super cell
+         * define maxParticlesInFrame as the maximum frame size
+         */
+        if(linearThreadIdx == 0)
+        {
+            sourceFrame = sourceBox.getLastFrame(block);
+        }
+
+        __syncthreads();
+        if(!sourceFrame.isValid())
+            return; //end kernel if we have no frames
+
+        /* caching of E- and B- fields and initialization of random generator if needed */
+        particleCreator.init(blockCell, linearThreadIdx, cellIndex);
+
+        /* Declare counter in shared memory that will later tell the current fill level or
+         * occupation of the newly created target target particle frames.
+         */
+        __shared__ int newFrameFillLvl;
+
+        /* Declare local variable oldFrameFillLvl for each thread */
+        int oldFrameFillLvl;
+
+        /* Initialize local (register) counter for each thread
+         * - describes how many new target particles should be created
+         */
+        unsigned int numNewParticles = 0;
+
+        /* Declare local target particle ID
+         * - describes at which position in the new frame the new target particle is to be created
+         */
+        int targetParId;
+
+        /* Master initializes the frame fill level with 0 */
+        if(linearThreadIdx == 0)
+        {
+            newFrameFillLvl = 0;
+            targetFrame = NULL;
+        }
+        __syncthreads();
+
+        /* move over source species frames and call particleCreator
+         * frames are worked on in backwards order to avoid asking if there is another frame
+         * --> performance
+         * Because all frames are completely filled except the last and apart from that last frame
+         * one wants to make sure that all threads are working and every frame is worked on.
+         */
+        while(sourceFrame.isValid())
+        {
+            /* casting uint8_t multiMask to boolean */
+            const bool isParticle = sourceFrame[linearThreadIdx][multiMask_];
+
+            /* if the threads contain particles, the particleCreator can handle them */
+            if (isParticle)
+                numNewParticles = particleCreator.numNewParticles(*sourceFrame, linearThreadIdx);
+
+            __syncthreads();
+            /* always true while-loop over all particles inside source frame until each thread breaks out individually
+             *
+             * **Attention**: Speaking of 1st and 2nd frame only may seem odd.
+             * The question might arise what happens if more target particles are created than would fit into two frames.
+             * Well, multi-particle creation during a time step is accounted for. The number of new target particles is
+             * determined inside the outer loop over the valid frames while in the inner loop each thread can create only ONE
+             * new macro target particle. But the loop repeats until each thread has created all the target particles needed in the time step.
+             */
+            while (true)
+            {
+                /* < INIT >
+                 * - targetParId is initialized as -1 (meaning: invalid)
+                 * - (local) oldFrameFillLvl set equal to (shared) newFrameFillLvl for each thread
+                 * --> each thread remembers the old "counter"
+                 * - then sync
+                 */
+                targetParId = -1;
+                oldFrameFillLvl = newFrameFillLvl;
+                __syncthreads();
+                /* < CHECK & ADD >
+                 * - if a thread wants to create target particles in each cycle it can do that only once
+                 * and before that it atomically adds to the shared counter and uses the current
+                 * value as targetParId in the new frame
+                 * - then sync
+                 */
+                if (numNewParticles > 0)
+                    targetParId = nvidia::atomicAllInc(&newFrameFillLvl);
+
+                __syncthreads();
+                /* < EXIT? >
+                 * - if the counter hasn't changed all threads break out of the loop */
+                if (oldFrameFillLvl == newFrameFillLvl)
+                    break;
+
+                __syncthreads();
+                /* < FIRST NEW FRAME >
+                 * - if there is no frame, yet, the master will create a new target target particle frame
+                 * and attach it to the back of the frame list
+                 * - sync all threads again for them to know which frame to use
+                 */
+                if (linearThreadIdx == 0)
+                {
+                    if (!targetFrame.isValid())
+                    {
+                        targetFrame = targetBox.getEmptyFrame();
+                        targetBox.setAsLastFrame(targetFrame, block);
+                    }
+                }
+                __syncthreads();
+                /* < CREATE 1 >
+                 * - all target particles fitting into the current frame are created there
+                 * - internal particle creation counter is decremented by 1
+                 * - sync
+                 */
+                if ((0 <= targetParId) && (targetParId < maxParticlesInFrame))
+                {
+                    /* each thread makes the attributes of its source particle accessible */
+                    PMACC_AUTO(sourceParticle,(sourceFrame[linearThreadIdx]));
+                    /* each thread initializes a target particle if one should be created */
+                    PMACC_AUTO(targetParticle,(targetFrame[targetParId]));
+
+                    /* create a target particle in the new target frame: */
+                    particleCreator(sourceParticle, targetParticle);
+
+                    numNewParticles -= 1;
+                }
+                __syncthreads();
+                /* < SECOND NEW FRAME >
+                 * - if the shared counter is larger than the frame size a new target particle frame is reserved
+                 * and attached to the back of the frame list
+                 * - then the shared counter is set back by one frame size
+                 * - sync so that every thread knows about the new frame
+                 */
+                if (linearThreadIdx == 0)
+                {
+                    if (newFrameFillLvl >= maxParticlesInFrame)
+                    {
+                        targetFrame = targetBox.getEmptyFrame();
+                        targetBox.setAsLastFrame(targetFrame, block);
+                        newFrameFillLvl -= maxParticlesInFrame;
+                    }
+                }
+                __syncthreads();
+                /* < CREATE 2 >
+                 * - if the EID is larger than the frame size
+                 *      - the EID is set back by one frame size
+                 *      - the thread writes an target particle to the new frame
+                 *      - the internal counter is decremented by 1
+                 */
+                if (targetParId >= maxParticlesInFrame)
+                {
+                    targetParId -= maxParticlesInFrame;
+
+                    /* each thread makes the attributes of its source particle accessible */
+                    PMACC_AUTO(sourceParticle,(sourceFrame[linearThreadIdx]));
+                    /* each thread initializes a target particle if one should be created */
+                    PMACC_AUTO(targetParticle,(targetFrame[targetParId]));
+
+                    /* create a target particle in the new target frame: */
+                    particleCreator(sourceParticle, targetParticle);
+
+                    numNewParticles -= 1;
+                }
+                __syncthreads();
+            }
+            __syncthreads();
+
+            if (linearThreadIdx == 0)
+            {
+                sourceFrame = sourceBox.getPreviousFrame(sourceFrame);
+            }
+            __syncthreads();
+        }
+    }
+};
+
+} // namespace creation
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "simulation_defines.hpp"
+#include "particles/memory/frames/Frame.hpp"
+#include "traits/GetFlagType.hpp"
+#include "traits/Resolve.hpp"
+#include "simulation_defines/param/speciesDefinition.param"
+#include "simulation_defines/unitless/speciesDefinition.unitless"
+
+#include "particles/creation/CreatorBase.def"
+#include "particles/bremsstrahlung/PhotonCreator.def"
+#include "particles/bremsstrahlung/PhotonCreator.hpp"
+
+namespace picongpu
+{
+
+template<typename T_SpeciesType>
+struct GetPhotonCreator
+{
+
+    typedef T_SpeciesType SpeciesType;
+    typedef typename SpeciesType::FrameType FrameType;
+
+    typedef typename HasFlag<FrameType, bremsstrahlung_effect<> >::type hasBremsstrahlung;
+
+    /* The following line only fetches the alias */
+    typedef typename GetFlagType<FrameType, bremsstrahlung_effect<> >::type FoundBremsstrahlungAlias;
+
+    /* This now resolves the alias into the actual object type */
+    typedef typename PMacc::traits::Resolve<FoundBremsstrahlungAlias>::type FoundPhotonSpecies;
+
+    /* This specifies the source species as the second template parameter of the photon creator */
+    typedef particles::bremsstrahlung::PhotonCreator<T_SpeciesType, FoundPhotonSpecies> type;
+
+}; // struct GetPhotonCreator
+
+}// namespace picongpu

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -28,7 +28,6 @@
 #include "simulation_defines/param/speciesDefinition.param"
 #include "simulation_defines/unitless/speciesDefinition.unitless"
 
-#include "particles/creation/CreatorBase.def"
 #include "particles/bremsstrahlung/PhotonCreator.def"
 #include "particles/bremsstrahlung/PhotonCreator.hpp"
 

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -49,7 +49,7 @@
 #include "fields/background/cellwiseOperation.hpp"
 #include "initialization/IInitPlugin.hpp"
 #include "initialization/ParserGridDistribution.hpp"
-#include "particles/bremsstrahlung/SynchrotonFunctions.hpp"
+#include "particles/bremsstrahlung/SynchrotronFunctions.hpp"
 
 #include "nvidia/reduce/Reduce.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
@@ -403,8 +403,8 @@ public:
         EventTask eRfieldB = fieldB->asyncCommunication(__getTransactionEvent());
         __setTransactionEvent(eRfieldB);
 
-        // Initialize synchroton functions
-        this->synchrotonFunctions.init();
+        // Initialize synchrotron functions
+        this->synchrotronFunctions.init();
 
         return step;
     }
@@ -436,7 +436,7 @@ public:
         typedef typename PMacc::particles::traits::FilterByFlag<VectorAllSpecies, bremsstrahlung_effect<> >::type AllBremsstrahlungSpecies;
 
         ForEach<AllBremsstrahlungSpecies, particles::CallBremsstrahlung<bmpl::_1>, MakeIdentifier<bmpl::_1> > electronBremsstrahlung;
-        electronBremsstrahlung(forward(particleStorage), cellDescription, currentStep, this->synchrotonFunctions);
+        electronBremsstrahlung(forward(particleStorage), cellDescription, currentStep, this->synchrotronFunctions);
 
         EventTask initEvent = __getTransactionEvent();
         EventTask updateEvent;
@@ -648,8 +648,8 @@ protected:
 
     LaserPhysics *laser;
 
-    // Synchroton functions (used in bremsstrahlung module)
-    particles::bremsstrahlung::SynchrotonFunctions synchrotonFunctions;
+    // Synchrotron functions (used in bremsstrahlung module)
+    particles::bremsstrahlung::SynchrotronFunctions synchrotronFunctions;
 
     // output classes
 

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -44,6 +44,11 @@ namespace picongpu
         /** unit: C */
         BOOST_CONSTEXPR_OR_CONST float_64 ELECTRON_CHARGE_SI = -1.602176e-19;
 
+        /** reduced Planck constant
+         * unit: J * s
+         */
+        BOOST_CONSTEXPR_OR_CONST float_64 HBAR_SI = 1.054571800e-34;
+
         /* atomic unit for energy:
          * 1 Rydberg = 27.21 eV --> converted to Joule
          */

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -83,6 +83,9 @@ alias(ionizer);
 /*! alias for ionization energy container @see ionizationEnergies.param */
 alias(ionizationEnergies);
 
+/*! alias for bremsstrahlung @see speciesDefinition.param */
+alias(bremsstrahlung_effect)
+
 /*! alias for particle to field interpolation @see species.param */
 alias(interpolation);
 

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -71,6 +71,29 @@ AttributRadiationFlag
 
 /*########################### define species #################################*/
 
+/*--------------------------- photons -------------------------------------------*/
+
+value_identifier(float_X, DummyMass, 1.0);
+value_identifier(float_X, DummyCharge, 0.0);
+
+typedef bmpl::vector<
+    particlePusher<particles::pusher::Photon>,
+    shape<UsedParticleShape>,
+    interpolation<UsedField2Particle>,
+    current<UsedParticleCurrentSolver>,
+    massRatio<DummyMass>,
+    chargeRatio<DummyCharge>
+> ParticleFlagsPhotons;
+
+/*define specie ions*/
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'p'>,
+        SuperCellSize,
+        DefaultParticleAttributes,
+        ParticleFlagsPhotons
+    >
+> PIC_Photons;
 
 /*--------------------------- electrons --------------------------------------*/
 
@@ -84,7 +107,8 @@ typedef bmpl::vector<
     interpolation<UsedField2Particle>,
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioElectrons>,
-    chargeRatio<ChargeRatioElectrons>
+    chargeRatio<ChargeRatioElectrons>,
+    bremsstrahlung_effect<PIC_Photons>
 > ParticleFlagsElectrons;
 
 /*define specie electrons*/
@@ -142,7 +166,8 @@ PIC_Ions
 
 typedef MakeSeq<
 Species1,
-Species2
+Species2,
+PIC_Photons
 >::type VectorAllSpecies;
 
 

--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -85,6 +85,9 @@ namespace picongpu
     //! Mass of electron
     BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
 
+    //! reduced Planck constant
+    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+
     //! magnetic BOOST_CONSTEXPR_OR_CONSTant must be double 3.92907e-39
     BOOST_CONSTEXPR_OR_CONST float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
 


### PR DESCRIPTION
Implement the bremstrahlung effect for electrons. It takes the numerical model from:
 > Gonoskov, A., et al. "Extended particle-in-cell schemes for physics in ultrastrong laser fields: Review and developments." Physical Review E 92.2 (2015): 023305.

**Dependencies:**
 - [ ] #1302 
 - [x] #1299

### Tests
#### Synchrotron radiation in the classical regime

In a constant B-field the energy loss due to bremsstrahlung is: 
![gamma_loss_dgl](https://cloud.githubusercontent.com/assets/5159590/11719882/1b064e48-9f5d-11e5-8419-b634d09584db.png)
Analytical solution:
![gamma_loss_analy png](https://cloud.githubusercontent.com/assets/5159590/11721479/46c3f902-9f64-11e5-976e-098dbf40ece8.png)
Simulation:
![gamma_loss](https://cloud.githubusercontent.com/assets/5159590/11719919/456d346c-9f5d-11e5-82fb-b44b87fe33ea.png)
Zoom:
![gamma_loss_zoom](https://cloud.githubusercontent.com/assets/5159590/11719932/53225448-9f5d-11e5-8d19-4eb5ef4737bf.png)
Photon spectrum:
![photon_spec_t_0](https://cloud.githubusercontent.com/assets/5159590/11719968/7d2eb16e-9f5d-11e5-840c-7feeaad7e148.png)
Zoom:
![photon_spec_t_0_zoom](https://cloud.githubusercontent.com/assets/5159590/11719981/88348d9a-9f5d-11e5-9d4b-59e105d634a5.png)

**legend:**
green: analytical result
blue: simulation result, error bars: statistical error

### Known Issues
 - photons are created, but they don't move despite of the photon pusher.