### PR TITLE
SimulationHelper `softRestarts`: split `init` and add `resetAll`

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -185,7 +185,8 @@ TBG_restart="--restart"
 #   does either start from 0 again or from the checkpoint specified with
 #   --restart-step as soon as the simulation reached the last time step;
 #   in the example below, the simulation is run 5000 times before it shuts down
-TBG_softRestart="--softRestart 5000"
+# Note: does currently not work with `Radiation` plugin
+TBG_softRestarts="--softRestarts 5000"
 
 # Connect to a live-view server (start the server in advance)
 TBG_liveViewYX="--<species>_liveView.period 1 --<species>_liveView.slicePoint 0.5 --<species>_liveView.ip 10.0.2.254 \

--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -181,6 +181,12 @@ TBG_restart="--restart"
 # To restart in a new run directory point to the old run where to start from
 #   --restart-directory /path/to/simOutput/checkpoints
 
+# Presentation mode: loop a simulation via soft restart
+#   does either start from 0 again or from the checkpoint specified with
+#   --restart-step as soon as the simulation reached the last time step;
+#   in the example below, the simulation is run 5000 times before it shuts down
+TBG_softRestart="--softRestart 5000"
+
 # Connect to a live-view server (start the server in advance)
 TBG_liveViewYX="--<species>_liveView.period 1 --<species>_liveView.slicePoint 0.5 --<species>_liveView.ip 10.0.2.254 \
                 --<species>_liveView.port 2020 --<species>_liveView.axis yx"

--- a/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    virtual uint32_t init()
+    virtual void init()
     {
 
         MySimulation::init();
@@ -80,11 +80,15 @@ public:
 #endif
 
         }
+    }
+
+    virtual uint32_t fillSimulation()
+    {
+        MySimulation::fillSimulation();
 
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
 
         const DataSpace<simDim> halfSimSize(subGrid.getGlobalDomain().size / 2);
-
 
         GridLayout<simDim> layout(subGrid.getLocalDomain().size, MappingDesc::SuperCellSize::toRT());
         MappingDesc cellDescription = MappingDesc(layout.getDataSpace(), GUARD_SIZE, GUARD_SIZE);
@@ -112,7 +116,6 @@ public:
 
 
         return 0;
-
     }
 
     /**

--- a/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    virtual uint32_t init()
+    virtual void init()
     {
 
         MySimulation::init();
@@ -82,6 +82,11 @@ public:
 
         //diabled because we have a transaction bug
         //StreamController::getInstance().addStreams(6);
+    }
+
+    virtual uint32_t fillSimulation()
+    {
+        MySimulation::fillSimulation();
 
         //add one particle in simulation
         //
@@ -123,7 +128,6 @@ public:
         __setTransactionEvent(eRfieldB);
 
         return 0;
-
     }
 
     /**

--- a/examples/SingleParticleTest/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleTest/include/OneParticleSimulation.hpp
@@ -63,7 +63,7 @@ public:
     {
     }
 
-    virtual uint32_t init()
+    virtual void init()
     {
 
         MySimulation::init();
@@ -83,6 +83,11 @@ public:
 
         //diabled because we have a transaction bug
         //StreamController::getInstance().addStreams(6);
+    }
+
+    virtual uint32_t fillSimulation()
+    {
+        MySimulation::fillSimulation();
 
         //add one particle in simulation
         //
@@ -119,7 +124,6 @@ public:
 
 
         return 0;
-
     }
 
     /**

--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -75,7 +75,7 @@ public:
     {
     }
 
-    uint32_t init()
+    void init()
     {
         MySimulation::init();
 
@@ -87,8 +87,6 @@ public:
 
         this->eField_zt[0] = new container::HostBuffer<float, 2 > (Size_t < 2 > (fieldE_coreBorder.size().z(), this->collectTimesteps));
         this->eField_zt[1] = new container::HostBuffer<float, 2 >(this->eField_zt[0]->size());
-
-        return 0;
     }
 
     void pluginRegisterHelp(po::options_description& desc)

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -287,15 +287,16 @@ public:
                    (int) (tSimCalculation.getInterval() / 1000.) << " sec" << std::endl;
             }
 
-        } // softRestart loop
+        } // softRestarts loop
     }
 
     virtual void pluginRegisterHelp(po::options_description& desc)
     {
         desc.add_options()
             ("steps,s", po::value<uint32_t > (&runSteps), "Simulation steps")
-            ("softRestart", po::value<uint32_t > (&softRestarts)->default_value(0),
-             "Number of times to restart the simulation after simulation has finished (for presentations)")
+            ("softRestarts", po::value<uint32_t > (&softRestarts)->default_value(0),
+             "Number of times to restart the simulation after simulation has finished (for presentations). "
+             "Note: does not yet work with all plugins, see issue #1305")
             ("percent,p", po::value<uint16_t > (&progress)->default_value(5),
              "Print time statistics after p percent to stdout")
             ("restart", po::value<bool>(&restartRequested)->zero_tokens(), "Restart simulation")
@@ -340,7 +341,7 @@ protected:
     /* number of simulation steps to compute */
     uint32_t runSteps;
 
-    /** Presentations: loop the whole simulation `softRestart` times from
+    /** Presentations: loop the whole simulation `softRestarts` times from
      *                 initial step to runSteps */
     uint32_t softRestarts;
 

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -95,12 +95,27 @@ public:
     virtual void runOneStep(uint32_t currentStep) = 0;
 
     /**
-     * Initializes simulation state.
+     * Initialize simulation
+     *
+     * Does hardware selections/reservations, memory allocations and
+     * initializes data structures as empty.
+     */
+    virtual void init() = 0;
+
+    /**
+     * Fills simulation with initial data after init()
      *
      * @return returns the first step of the simulation
+     *         (can be >0 for, e.g., restarts from checkpoints)
      */
-    virtual uint32_t init() = 0;
+    virtual uint32_t fillSimulation() = 0;
 
+    /**
+     * Reset the simulation to a state such as it was after
+     * init() but for a specific time step.
+     * Can be used to call fillSimulation() again.
+     */
+    virtual void resetAll(uint32_t currentStep) = 0;
 
     /**
      * Check if moving window work must do
@@ -198,80 +213,89 @@ public:
      */
     void startSimulation()
     {
-        uint32_t currentStep = init();
-        Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
+        init();
 
-        tInit.toggleEnd();
-        if (output)
+        for (uint32_t nthSoftRestart = 0; nthSoftRestart <= softRestarts; ++nthSoftRestart)
         {
-            std::cout << "initialization time: " << tInit.printInterval() <<
-                " = " <<
-                (int) (tInit.getInterval() / 1000.) << " sec" << std::endl;
-        }
-
-        TimeIntervall tSimCalculation;
-        TimeIntervall tRound;
-        double roundAvg = 0.0;
-
-    /* dump initial step if simulation starts without restart */
-    if (currentStep == 0)
-    {
-        /* Since in the main loop movingWindow is called always before the dump, we also call it here for consistency.
-        This becomes only important, if movingWindowCheck does more than merely checking for a slide.
-        TO DO in a new feature: Turn this into a general hook for pre-checks (window slides are just one possible action). */
-        movingWindowCheck(currentStep);
-        dumpOneStep(currentStep);
-    }
-    else
-    {
-        currentStep--; //We dump before calculation, thus we must go one step back when doing a restart.
-        Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
-        movingWindowCheck(currentStep); //If we restart at any step check if we must slide.
-    }
-
-        /* dump 0% output */
-        dumpTimes(tSimCalculation, tRound, roundAvg, currentStep);
-
-
-        /** \todo currently we assume this is the only point in the simulation
-         *        that is allowed to manipulate this var. Else, add one needs to
-         *        add and act on changed values from `getCurrentStep()` in this loop
-         */
-        while (currentStep < Environment<>::get().SimulationDescription().getRunSteps())
-        {
-            tRound.toggleStart();
-            runOneStep(currentStep);
-            tRound.toggleEnd();
-            roundAvg += tRound.getInterval();
-
-            currentStep++;
+            resetAll(0);
+            uint32_t currentStep = fillSimulation();
             Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
-            /*output after a round*/
+
+            tInit.toggleEnd();
+            if (output)
+            {
+                std::cout << "initialization time: " << tInit.printInterval() <<
+                    " = " <<
+                    (int) (tInit.getInterval() / 1000.) << " sec" << std::endl;
+            }
+
+            TimeIntervall tSimCalculation;
+            TimeIntervall tRound;
+            double roundAvg = 0.0;
+
+            /* dump initial step if simulation starts without restart */
+            if (currentStep == 0)
+            {
+                /* Since in the main loop movingWindow is called always before the dump, we also call it here for consistency.
+                This becomes only important, if movingWindowCheck does more than merely checking for a slide.
+                TO DO in a new feature: Turn this into a general hook for pre-checks (window slides are just one possible action). */
+                movingWindowCheck(currentStep);
+                dumpOneStep(currentStep);
+            }
+            else
+            {
+                currentStep--; //We dump before calculation, thus we must go one step back when doing a restart.
+                Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
+                movingWindowCheck(currentStep); //If we restart at any step check if we must slide.
+            }
+
+            /* dump 0% output */
             dumpTimes(tSimCalculation, tRound, roundAvg, currentStep);
 
-            movingWindowCheck(currentStep);
-            /*dump after simulated step*/
-            dumpOneStep(currentStep);
-        }
 
-        //simulatation end
-        Environment<>::get().Manager().waitForAllTasks();
+            /** \todo currently we assume this is the only point in the simulation
+             *        that is allowed to manipulate `currentStep`. Else, one needs to
+             *        add and act on changed values via
+             *        `SimulationDescription().getCurrentStep()` in this loop
+             */
+            while (currentStep < Environment<>::get().SimulationDescription().getRunSteps())
+            {
+                tRound.toggleStart();
+                runOneStep(currentStep);
+                tRound.toggleEnd();
+                roundAvg += tRound.getInterval();
 
-        tSimCalculation.toggleEnd();
+                currentStep++;
+                Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
+                /*output after a round*/
+                dumpTimes(tSimCalculation, tRound, roundAvg, currentStep);
 
-        if (output)
-        {
-            std::cout << "calculation  simulation time: " <<
-                tSimCalculation.printInterval() << " = " <<
-                (int) (tSimCalculation.getInterval() / 1000.) << " sec" << std::endl;
-        }
+                movingWindowCheck(currentStep);
+                /*dump after simulated step*/
+                dumpOneStep(currentStep);
+            }
 
+            // simulatation end
+            Environment<>::get().Manager().waitForAllTasks();
+
+            tSimCalculation.toggleEnd();
+
+            if (output)
+            {
+                std::cout << "calculation  simulation time: " <<
+                   tSimCalculation.printInterval() << " = " <<
+                   (int) (tSimCalculation.getInterval() / 1000.) << " sec" << std::endl;
+            }
+
+        } // softRestart loop
     }
 
     virtual void pluginRegisterHelp(po::options_description& desc)
     {
         desc.add_options()
             ("steps,s", po::value<uint32_t > (&runSteps), "Simulation steps")
+            ("softRestart", po::value<uint32_t > (&softRestarts)->default_value(0),
+             "Number of times to restart the simulation after simulation has finished (for presentations)")
             ("percent,p", po::value<uint16_t > (&progress)->default_value(5),
              "Print time statistics after p percent to stdout")
             ("restart", po::value<bool>(&restartRequested)->zero_tokens(), "Restart simulation")
@@ -315,6 +339,10 @@ public:
 protected:
     /* number of simulation steps to compute */
     uint32_t runSteps;
+
+    /** Presentations: loop the whole simulation `softRestart` times from
+     *                 initial step to runSteps */
+    uint32_t softRestarts;
 
     /* period for checkpoint creation */
     uint32_t checkpointPeriod;

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -336,8 +336,21 @@ public:
 
     virtual uint32_t fillSimulation()
     {
+        /* assume start (restart in initialiserController might change that) */
         uint32_t step = 0;
 
+        /* set slideCounter properties for PIConGPU MovingWindow: assume start
+         * (restart in initialiserController might change this again)
+         */
+        MovingWindow::getInstance().setSlideCounter(0, 0);
+        /* Update MPI domain decomposition: will also update SubGrid domain
+         * information such as local offsets in y-direction
+         */
+        GridController<simDim> &gc = Environment<simDim>::get().GridController();
+        if( MovingWindow::getInstance().isSlidingWindowActive() )
+            gc.setStateAfterSlides(0);
+
+        /* fill all objects registed in DataConnector */
         if (initialiserController)
         {
             initialiserController->printInformation();

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -265,7 +265,7 @@ public:
 
     }
 
-    virtual uint32_t init()
+    virtual void init()
     {
         namespace nvmem = PMacc::nvidia::memory;
         // create simulation data such as fields and particles
@@ -332,7 +332,10 @@ public:
 
         /* add CUDA streams to the StreamController for concurrent execution */
         Environment<>::get().StreamController().addStreams(6);
+    }
 
+    virtual uint32_t fillSimulation()
+    {
         uint32_t step = 0;
 
         if (initialiserController)
@@ -363,6 +366,7 @@ public:
             }
         }
 
+        size_t freeGpuMem(0u);
         Environment<>::get().MemoryInfo().getMemoryInfo(&freeGpuMem);
         log<picLog::MEMORY > ("free mem after all particles are initialized %1% MiB") % (freeGpuMem / 1024 / 1024);
 
@@ -498,7 +502,7 @@ public:
                         currentStep, FieldBackgroundB::InfluenceParticlePusher );
     }
 
-    void resetAll(uint32_t currentStep)
+    virtual void resetAll(uint32_t currentStep)
     {
 
         fieldB->reset(currentStep);


### PR DESCRIPTION
This is a port of the `--softRestarts` option added to libPMacc `SimulationHelper`. It can be used to loop whole simulation for presentations, etc. by splitting `init()`:

- `init()`: allocate memory
- `fillSimulation()`: fill allocated memory with data (from checkpoint or t=0)
- `resetAll()`: reset to state after `init()` so `fillSimulation()`
                can be called again (does *not* deallocate memory)

We used it first in our 3D Live visualization and this PR ports it to the mainline.

Unfurtunately, we have to update PIConGPU examples ~~and GoL~~ at the same time since the `SimulationHelper` interface change requires it. The individual changes are in separate commits in this PR.

### To Do
- ~~update~~ GoL example: ~~add `resetAll` and `fillSimulation`~~ does not use `SimulationHelper` and does therefore not support `--softRestarts`
- [x] add `--softRestarts <N>` to `doc/TBG_macros.cfg`
- [x] SingleParticle tests and `ThermalTest` ~~might [not compile](https://github.swim-results.de/?status=$1$PblFPFnQ$QVjQDqvRgn3.4ujB0qOaP0) atm~~ updated
- [x] runtime test again (PIConGPU)