### PR TITLE
fix DeviceMemAssigner

### DIFF
--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -252,12 +252,6 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::view
 }
 
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
-void CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::assign(const Type& value)
-{
-    Assigner::assign(this->dataPointer, this->pitch, value, this->_size);
-}
-
-template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
 cursor::BufferCursor<Type, T_dim> CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::origin() const
 {
     detail::notifyEventSystem<typename Allocator::tag>();

--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -49,12 +49,12 @@ template<typename Type, int dim>
 class DeviceBuffer
  : public CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>,
                                 copier::D2DCopier<dim>,
-                                assigner::DeviceMemAssigner<dim> >
+                                assigner::DeviceMemAssigner<> >
 {
 private:
     typedef CartBuffer<Type, dim, allocator::DeviceMemAllocator<Type, dim>,
                                   copier::D2DCopier<dim>,
-                                  assigner::DeviceMemAssigner<dim> > Base;
+                                  assigner::DeviceMemAssigner<> > Base;
     typedef DeviceBuffer<Type, dim> This;
 
 ///\todo: make protected

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -47,12 +47,12 @@ template<typename Type, int dim>
 class HostBuffer
  : public CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>,
                                 copier::H2HCopier<dim>,
-                                assigner::HostMemAssigner<dim> >
+                                assigner::HostMemAssigner<> >
 {
 private:
     typedef CartBuffer<Type, dim, allocator::HostMemAllocator<Type, dim>,
                                   copier::H2HCopier<dim>,
-                                  assigner::HostMemAssigner<dim> > Base;
+                                  assigner::HostMemAssigner<> > Base;
 ///\todo: make protected
 public:
     HostBuffer() {}

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -31,6 +31,7 @@
 #include "types.h"
 
 #include <boost/math/common_factor.hpp>
+#include <boost/mpl/placeholders.hpp>
 
 #include <cassert>
 #include <stdint.h>
@@ -40,26 +41,22 @@ namespace PMacc
 namespace assigner
 {
 
-template<int T_dim>
+namespace bmpl = boost::mpl;
+
+template<typename T_Dim = bmpl::_1, typename T_CartBuffer = bmpl::_2>
 struct DeviceMemAssigner
 {
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    BOOST_STATIC_CONSTEXPR int dim = T_Dim::value;
+    typedef T_CartBuffer CartBuffer;
 
     template<typename Type>
-    HDINLINE static void assign(
-        Type* data,
-        const math::Size_t<dim-1>& pitch,
-        const Type& value,
-        const math::Size_t<dim>& size)
+    HINLINE void assign(const Type& value)
     {
-#ifdef __CUDA_ARCH__
-        /* The HostmemAssigner iterates over the entries and assigns them
-         * This also works on the device (in a kernel) so we just use it here
-         * instead of implementing it again */
-        HostMemAssigner<dim>::assign(data, pitch, value, size);
-#else
-        zone::SphericZone<dim> myZone(size);
-        cursor::BufferCursor<Type, dim> cursor(data, pitch);
+        // "Curiously recurring template pattern"
+        CartBuffer* buffer = static_cast<CartBuffer*>(this);
+
+        zone::SphericZone<dim> myZone(buffer->size());
+        cursor::BufferCursor<Type, dim> cursor(buffer->dataPointer, buffer->pitch);
 
         /* The greatest common divisor of each component of the volume size
          * and a certain power of two value gives the best suitable block size */
@@ -68,7 +65,7 @@ struct DeviceMemAssigner
         int maxValues[] = {16, 16, 4}; // maximum values for each dimension
         for(int i = 0; i < dim; i++)
         {
-            blockDim[i] = gcd(size[i], maxValues[dim-1]);
+            blockDim[i] = gcd(buffer->size()[i], maxValues[dim-1]);
         }
         /* the maximum number of threads per block for devices with
          * compute capability > 2.0 is 1024 */
@@ -76,7 +73,6 @@ struct DeviceMemAssigner
 
         algorithm::kernel::RT::Foreach foreach(blockDim);
         foreach(myZone, cursor, lambda::_1 = value);
-#endif
     }
 };
 

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -82,7 +82,7 @@ namespace PMacc
         HINLINE
         container::CartBuffer<TYPE, DIM, allocator::DeviceMemAllocator<TYPE, DIM>,
                                 copier::D2DCopier<DIM>,
-                                assigner::DeviceMemAssigner<DIM> >
+                                assigner::DeviceMemAssigner<> >
         cartBuffer() const
         {
             container::DeviceBuffer<TYPE, DIM> result;


### PR DESCRIPTION
fix crash in cuSTL `DeviceBuffer::assign()`, a kernel was called within an #ifdef block.
Introduced by #1197.

Solves the general problem of calling a host function from a
host device function for the Assigner policy in CartBuffer by inheriting from the policy.
Implements [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern).

Tested with PhaseSpace plugin.

@Flamefire 