### PR TITLE
PNGwriter 0.5.6: Bug Fix and Refactoring

### DIFF
--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -93,7 +93,7 @@ touch "$thisDir"runGuard
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=sm_35"
             . /etc/profile
-            module load gcc/4.6.4 boost/1.55.0 cmake/2.8.12.2 cuda/6.0 openmpi/1.6.5 mallocmc/2.0.1 libSplash/1.2.4 adios/1.9.0 pngwriter/0.5.5 rivlib/1.0.0
+            module load gcc/4.6.4 boost/1.55.0 cmake/2.8.12.2 cuda/6.0 openmpi/1.6.5 mallocmc/2.0.1 libSplash/1.2.4 adios/1.9.0 pngwriter/0.5.6 rivlib/1.0.0
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/compile -l -q -j $cnf_numParallel \

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -70,7 +70,7 @@ If you do not install the optional libraries, you will not have the full amount 
 We recomment to install at least **pngwriter**.
 Some of our examples will also need **libSplash**.
 
-- **pngwriter** >= 0.5.5
+- **pngwriter** >= 0.5.6
     - download our modified version from
       [github.com/pngwriter/pngwriter](https://github.com/pngwriter/pngwriter)
     - Requires [libpng](http://www.libpng.org/),

--- a/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
@@ -203,7 +203,7 @@ include_directories(${PMACC_ROOT_DIR}/include)
 ################################################################################
 
 # find PNGwriter installation
-find_package(PNGwriter 0.5.5 REQUIRED)
+find_package(PNGwriter 0.5.6 REQUIRED)
 
 if(PNGwriter_FOUND)
     include_directories(SYSTEM ${PNGwriter_INCLUDE_DIRS})

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -444,7 +444,7 @@ endif(Splash_FOUND)
 ################################################################################
 
 # find PNGwriter installation
-find_package(PNGwriter 0.5.5)
+find_package(PNGwriter 0.5.6)
 
 if(PNGwriter_FOUND)
     include_directories(SYSTEM ${PNGwriter_INCLUDE_DIRS})

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -15,7 +15,7 @@ then
         module load openmpi/1.8.4.kepler
 
         # Plugins (optional)
-        module load pngwriter/0.5.5
+        module load pngwriter/0.5.6
         module load hdf5-parallel/1.8.14 libsplash/1.2.4
 
         # either use libSplash or ADIOS for file I/O

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -93,7 +93,7 @@ endif(Splash_FOUND)
 ################################################################################
 
 # find PNGwriter installation
-find_package(PNGwriter REQUIRED)
+find_package(PNGwriter 0.5.6 REQUIRED)
 
 if(PNGwriter_FOUND)
     include_directories(SYSTEM ${PNGwriter_INCLUDE_DIRS})

--- a/src/tools/png2gas/README.md
+++ b/src/tools/png2gas/README.md
@@ -11,10 +11,10 @@ The density information is created from a png file.
 ### Install
 
 Required libraries:
- - **cmake** 2.8.5 or higher
+ - **cmake** 2.8.12.2 or higher
  - **OpenMPI** 1.4 or higher
  - **boost** 1.47.0 or higher ("program options")
- - **PNGwriter** 0.5.4 or higher (use [our forked version](https://github.com/ax3l/pngwriter))
+ - **PNGwriter** 0.5.6 or higher ([GitHub project](https://github.com/pngwriter/pngwriter))
  - **libSplash** (requires *hdf5*)
  - **hdf5** >= 1.8.6, standard shared version (no c++, enable parallel)
 


### PR DESCRIPTION
Updates the requirements to use PNGwriter 0.5.6+

The latest release fixes a bug with creation time meta data that can potentially cause data corruption (malformed time entry occurred randomly; outside-png data corruption was not seen in the wild with valgrind) and refactors several parts of internal code due to coverity-scan results. The full change log can be [seen here](https://github.com/pngwriter/pngwriter/blob/0.5.6/CHANGELOG.md#056).

The compile suite is already updated and a ticket for a new module on `hypnos-hzdr` was opened (no5200) -> update: is now installed.