### PR TITLE
Laser Wavepacket: Implementation != Doc

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -233,6 +233,8 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15;
  *              WO_X_SI is this distance in x-direction
  *              W0_Z_SI is this distance in z-direction
  *              if both values are equal, the laser has a circular shape in x-z
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
  *  unit: meter */
 BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;
 BOOST_CONSTEXPR_OR_CONST float_64 W0_Z_SI = W0_X_SI;

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -232,6 +232,8 @@ namespace picongpu
              *              decreases to its 1/e^2-th part,
              *              WO_X_SI is this distance in x-direction
              *              W0_Z_SI is this distance in z-direction
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
              *              if both values are equal, the laser has a circular shape in x-z
              *  unit: meter */
             BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -242,6 +242,8 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15;
  *              WO_X_SI is this distance in x-direction
  *              W0_Z_SI is this distance in z-direction
  *              if both values are equal, the laser has a circular shape in x-z
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
  *  unit: meter */
 BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;
 BOOST_CONSTEXPR_OR_CONST float_64 W0_Z_SI = W0_X_SI;

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -113,7 +113,7 @@ HDINLINE float3_X laserTransversal(float3_X elong, const float_X, const float_X 
     const float_X exp_x = posX * posX / (W0_X * W0_X);
     const float_X exp_z = posZ * posZ / (W0_Z * W0_Z);
 
-    return elong * math::exp(float_X(-0.5) * (exp_x + exp_z));
+    return elong * math::exp(exp_x + exp_z);
 
 }
 

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -233,6 +233,8 @@ namespace picongpu
          *              WO_X_SI is this distance in x-direction
          *              W0_Z_SI is this distance in z-direction
          *              if both values are equal, the laser has a circular shape in x-z
+         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+         *                             [   1.17741    ]
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;
         BOOST_CONSTEXPR_OR_CONST float_64 W0_Z_SI = W0_X_SI;


### PR DESCRIPTION
Follow-Up to #1232: the implementation of the laser wavepacket regarding the *beam waist* does not fit its [documentation in `laserConfig.param`](https://github.com/ComputationalRadiationPhysics/picongpu/blob/7bf113456bf64d82b6571171fc039c1f3fba929c/src/picongpu/include/simulation_defines/param/laserConfig.param#L227-L234).

This commit updates the implementation to match the documentation which is then identical to the other laser pulses. Currently, the parameter that was specified is a factor `sqrt(2)` off making the pulse waist effectively *tighter* by this factor than intended.

### To Do
- [ ] announcement of mailing list (after review)
- [x] add some documentation as in #1232