### PR TITLE
Boost: Add pre-compiled math_tr1 (double)

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -51,13 +51,13 @@ Requirements
   - *Debian/Ubuntu:* `sudo apt-get install zlib1g-dev`
   - *Arch Linux:* `sudo pacman --sync zlib`
 
-- **boost** 1.56.0+ ("program options", "regex" , "filesystem", "system" and nearly all header-only libs)
+- **boost** 1.56.0+ ("program options", "regex" , "filesystem", "system", "thread", "math" and nearly all header-only libs)
   - download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz/download),
       e.g. version 1.56.0
   - *Debian/Ubuntu:* `sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev`
   - *Arch Linux:* `sudo pacman --sync boost`
   - *From source:*
-    - `./bootstrap.sh --with-libraries=filesystem,program_options,regex,system,thread --prefix=$HOME/lib/boost`
+    - `./bootstrap.sh --with-libraries=filesystem,program_options,regex,system,thread,math --prefix=$HOME/lib/boost`
     - `./b2 -j4 && ./b2 install`
 
 - **git** 1.7.9.5 or [higher](https://help.github.com/articles/https-cloning-errors)

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -255,7 +255,7 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 ################################################################################
 
 find_package(Boost 1.56.0 REQUIRED COMPONENTS program_options regex filesystem
-                                              system thread)
+                                              system thread math_tr1)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
Adds pre-compiled `boost::math` libraries in our CMake dependency chain. `boost::math` is mainly header-only but some functionality *can* be used as pre-compiled [which saves a lot of compile time](http://www.boost.org/doc/libs/1_59_0/libs/math/doc/html/math_toolkit/overview_tr1.html#math_toolkit.overview_tr1.usage_recomendations) for PIConGPU itself.

Currently, we only need `tr1 double` precision libs, otherwise we have to add more libs in the future. [Here is the full list](http://www.boost.org/doc/libs/1_59_0/libs/math/doc/html/math_toolkit/overview_tr1.html).

The first update explicitly using the pre-compiled `boost::math` functions from `special_functions/bessel` is #1299 to save compile time (see https://github.com/ComputationalRadiationPhysics/picongpu/pull/1299#discussion_r47672450 )