### PR TITLE
Close #1314 Boost 1.60.0 Requires C++11

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -274,6 +274,15 @@ else()
     add_definitions(-DBOOST_RESULT_OF_USE_TR1)
 endif()
 
+# work-arounds and known issues
+if( (Boost_VERSION EQUAL 106000) AND
+    (CMAKE_CXX_STANDARD EQUAL 98) )
+    # Boost Bug https://svn.boost.org/trac/boost/ticket/11852
+    message(FATAL_ERROR "Boost: Please use a C++11 enabled Compiler with "
+                        "`-std=c++11` when compiling with Boost 1.60.0")
+endif()
+
+
 ################################################################################
 # Find OpenMP
 ################################################################################


### PR DESCRIPTION
Close #1314 Throws a well-described error during configure with cmake for boost 1.60.0 when used with a C++98 compiler.

See https://svn.boost.org/trac/boost/ticket/11852 for details and https://github.com/boostorg/config/pull/83 for a patch that allows compiling against this version of boost with nvcc and C++98.