### PR TITLE
Taurus-TUD: K20X and K80 Queues

### DIFF
--- a/src/picongpu/submit/taurus-tud/k20x_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k20x_profile.tpl
@@ -19,19 +19,19 @@
 #
 
 ## calculations will be performed by tbg ##
-TBG_queue="gpu2"
+TBG_queue="gpu1"
 
 # settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
 TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
-# 4 gpus per node
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+# 2 gpus per node
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
 
-# number of cores to block per GPU - we got 6 cpus per gpu
-#   and we will be accounted 6 CPUs per GPU anyway
-TBG_coresPerGPU=6
+# number of cores to block per GPU - we got 8 cpus per gpu
+#   and we will be accounted 8 CPUs per GPU anyway
+TBG_coresPerGPU=8
 
 # We only start 1 MPI task per GPU
 TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
@@ -51,7 +51,7 @@ TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #SBATCH --ntasks=!TBG_tasks
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
-#SBATCH --mem-per-cpu=2583
+#SBATCH --mem-per-cpu=3000
 #SBATCH --gres=gpu:!TBG_gpusPerNode
 # send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
 # TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50


### PR DESCRIPTION
This pull requests avoids mixing of two gpu types (k20x and k80) on taurus/ZIH/TU Dresden.
The old k20x are back and are also available in the `gpu` queue. To only acces k80 one needs to specify `gpu2` as queue. Additionly the k20x are available via queue `gpu1`.

This pull requetst:
 - add k20x queue (gpu1)
 - specify k80 queue to only run on gpu2

see:
https://doc.zih.tu-dresden.de/hpc-wiki/bin/view/Compendium/SystemTaurus#Partitions
for more details on the current setup of the taurus cluster