### PR TITLE
Trait: FieldPosition

### DIFF
--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -272,10 +272,11 @@ namespace twts
                             const uint32_t currentStep ) const
     {
         const float_64 time_SI = float_64(currentStep) * dt - tdelay;
+        const fieldSolver::numericalCellType::traits::FieldPosition<FieldB> fieldPosB;
 
         const PMacc::math::Vector<floatD_64,detail::numComponents> bFieldPositions_SI =
-              detail::getFieldPositions_SI(cellIdx,halfSimSize,
-                fieldSolver::NumericalCellType::getBFieldPosition(),unit_length,focus_y_SI,phi);
+              detail::getFieldPositions_SI(cellIdx, halfSimSize,
+                fieldPosB(), unit_length, focus_y_SI, phi);
         /* Single TWTS-Pulse */
         switch (pol)
         {

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -177,10 +177,11 @@ namespace twts
                             const uint32_t currentStep ) const
     {
         const float_64 time_SI = float_64(currentStep) * dt - tdelay;
+        const fieldSolver::numericalCellType::traits::FieldPosition<FieldE> fieldPosE;
 
         const PMacc::math::Vector<floatD_64,detail::numComponents> eFieldPositions_SI =
-              detail::getFieldPositions_SI(cellIdx,halfSimSize,
-                fieldSolver::NumericalCellType::getEFieldPosition(),unit_length,focus_y_SI,phi);
+              detail::getFieldPositions_SI(cellIdx, halfSimSize,
+                fieldPosE(), unit_length, focus_y_SI, phi);
 
         /* Single TWTS-Pulse */
         switch (pol)

--- a/src/picongpu/include/fields/background/templates/TWTS/getFieldPositions_SI.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/getFieldPositions_SI.tpp
@@ -50,21 +50,21 @@ namespace detail
            or casting on floatD_ does work. */
         const floatD_64 cellDim(picongpu::cellSize);
         const floatD_64 cellDimensions = cellDim * unit_length;
-        
+
         /* TWTS laser coordinate origin is centered transversally and defined longitudinally by
            the laser center in y (usually maximum of intensity). */
         floatD_X laserOrigin = precisionCast<float_X>(halfSimSize);
         laserOrigin.y() = float_X( focus_y_SI/cellDimensions.y() );
-        
+
         /* For staggered fields (e.g. Yee-grid), obtain the fractional cell index components and add
          * that to the total cell indices. The physical field coordinate origin is transversally
          * centered with respect to the global simulation volume.
          * PMacc::math::Vector<floatD_X, numComponents> fieldPositions =
-         *                fieldSolver::NumericalCellType::getEFieldPosition(); */
+         *                fieldSolver::numericalCellType::traits::FieldPosition<FieldE>(); */
         PMacc::math::Vector<floatD_X, numComponents> fieldPositions = fieldOnGridPositions;
-        
+
         PMacc::math::Vector<floatD_64,numComponents> fieldPositions_SI;
-        
+
         for( uint32_t i = 0; i < numComponents; ++i ) /* cellIdx Ex, Ey and Ez */
         {
             fieldPositions[i]   += ( precisionCast<float_X>(cellIdx) - laserOrigin );
@@ -72,10 +72,10 @@ namespace detail
 
             fieldPositions_SI[i] = rotateField(fieldPositions_SI[i],phi);
         }
-        
+
         return fieldPositions_SI;
     }
-    
+
 } /* namespace detail */
 } /* namespace twts */
 } /* namespace templates */

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -198,7 +198,8 @@ struct ZigZag
              *   - run calculations in a shape optimized coordinate system
              *     with fixed interpolation points
              */
-            ShiftCoordinateSystem<Supports_direction>()(cursor, pos, fieldSolver::NumericalCellType::getJFieldPosition()[dir]);
+            const fieldSolver::numericalCellType::traits::FieldPosition<FieldJ> fieldPosJ;
+            ShiftCoordinateSystem<Supports_direction>()(cursor, pos, fieldPosJ()[dir]);
 
             /* define grid points where we evaluate the shape function*/
             typedef typename PMacc::math::CT::make_Vector<

--- a/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -23,122 +23,127 @@
 #pragma once
 
 #include "simulation_defines.hpp"
+#include "fields/Fields.def"
 #include "math/Vector.hpp"
 
 namespace picongpu
 {
-using namespace PMacc;
 namespace emfCenteredCell
 {
-
-// ___________posE____________
-const float_X posE_x_x = 0.5;
-const float_X posE_x_y = 0.5;
-const float_X posE_x_z = 0.5;
-
-const float_X posE_y_x = 0.5;
-const float_X posE_y_y = 0.5;
-const float_X posE_y_z = 0.5;
-
-const float_X posE_z_x = 0.5;
-const float_X posE_z_y = 0.5;
-const float_X posE_z_z = 0.5;
-
-// ___________posB____________
-const float_X posB_x_x = 0.5;
-const float_X posB_x_y = 0.5;
-const float_X posB_x_z = 0.5;
-
-const float_X posB_y_x = 0.5;
-const float_X posB_y_y = 0.5;
-const float_X posB_y_z = 0.5;
-
-const float_X posB_z_x = 0.5;
-const float_X posB_z_y = 0.5;
-const float_X posB_z_z = 0.5;
-
-// ___________posJ____________
-const float_X posJ_x_x = 0.5;
-const float_X posJ_x_y = 0.0;
-const float_X posJ_x_z = 0.0;
-
-const float_X posJ_y_x = 0.0;
-const float_X posJ_y_y = 0.5;
-const float_X posJ_y_z = 0.0;
-
-const float_X posJ_z_x = 0.0;
-const float_X posJ_z_y = 0.0;
-const float_X posJ_z_z = 0.5;
-
-/** \todo posRho for FieldTmp depositions
-const float_X posRho_x_x = 0.0; ? or at center pos ?
-const float_X posRho_x_y = 0.0; ?
-const float_X posRho_x_z = 0.0; ?
-
-const float_X posRho_y_x = 0.0; ?
-const float_X posRho_y_y = 0.0; ?
-const float_X posRho_y_z = 0.0; ?
-
-const float_X posRho_z_x = 0.0; ?
-const float_X posRho_z_y = 0.0; ?
-const float_X posRho_z_z = 0.0; ?
-*/
-
-struct EMFCenteredCell
+namespace traits
 {
     /** \tparam floatD_X position of the component in the cell
-     *  \tparam DIM3     Fields (E/B) have 3 components, even in 1 or 2D ! */
-    typedef ::PMacc::math::Vector<floatD_X,DIM3> VectorVector;
+     *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+     */
+    typedef const ::PMacc::math::Vector<float2_X,DIM3> VectorVector2D3V;
+    typedef const ::PMacc::math::Vector<float3_X,DIM3> VectorVector3D3V;
 
-    static HDINLINE VectorVector getEFieldPosition()
+    template<typename T_Field, uint32_t T_simDim = simDim>
+    struct FieldPosition;
+
+    /** position (floatD_X in case of T_simDim == simDim) in cell for
+     *  E_x, E_y, E_z
+     */
+    template<uint32_t T_simDim>
+    struct FieldPosition<FieldE, T_simDim>
     {
-#if( SIMDIM == DIM3 )
-        const float3_X posE_x(posE_x_x, posE_x_y, posE_x_z);
-        const float3_X posE_y(posE_y_x, posE_y_y, posE_y_z);
-        const float3_X posE_z(posE_z_x, posE_z_y, posE_z_z);
-#elif( SIMDIM == DIM2 )
-        const float2_X posE_x(posE_x_x, posE_x_y);
-        const float2_X posE_y(posE_y_x, posE_y_y);
-        const float2_X posE_z(posE_z_x, posE_z_y);
-#endif
+        typedef PMacc::math::Vector<float_X, T_simDim> PosType;
+        typedef const PMacc::math::Vector<PosType, DIM3> ReturnType;
 
-        /** position (floatD_x) in cell for E_x, E_y, E_z */
-        return VectorVector(posE_x, posE_y, posE_z);
-    }
+        /// boost::result_of hints
+        template<class> struct result;
 
-    static HDINLINE VectorVector getBFieldPosition()
+        template<class F>
+        struct result<F()> {
+            typedef ReturnType type;
+        };
+
+        HDINLINE ReturnType operator()() const
+        {
+            const PMACC_AUTO(center, PosType::create( 0.5 ));
+
+            return ReturnType::create( center );
+        }
+    };
+
+    /** position (floatD_X in case of T_simDim == simDim) in cell for
+     *  B_x, B_y, B_z
+     */
+    template<uint32_t T_simDim>
+    struct FieldPosition<FieldB, T_simDim> :
+        public FieldPosition<FieldE, T_simDim>
     {
-#if( SIMDIM == DIM3 )
-        const float3_X posB_x(posB_x_x, posB_x_y, posB_x_z);
-        const float3_X posB_y(posB_y_x, posB_y_y, posB_y_z);
-        const float3_X posB_z(posB_z_x, posB_z_y, posB_z_z);
-#elif( SIMDIM == DIM2 )
-        const float2_X posB_x(posB_x_x, posB_x_y);
-        const float2_X posB_y(posB_y_x, posB_y_y);
-        const float2_X posB_z(posB_z_x, posB_z_y);
-#endif
+        HDINLINE FieldPosition()
+        {
+        }
+    };
 
-        /** position (floatD_x) in cell for B_x, B_y, B_z */
-        return VectorVector(posB_x, posB_y, posB_z);
-    }
-
-    static HDINLINE VectorVector getJFieldPosition()
+    /** position (float2_X) in cell for J_x, J_y, J_z */
+    template<>
+    struct FieldPosition<FieldJ, DIM2>
     {
-#if( SIMDIM == DIM3 )
-        const float3_X posJ_x(posJ_x_x, posJ_x_y, posJ_x_z);
-        const float3_X posJ_y(posJ_y_x, posJ_y_y, posJ_y_z);
-        const float3_X posJ_z(posJ_z_x, posJ_z_y, posJ_z_z);
-#elif( SIMDIM == DIM2 )
-        const float2_X posJ_x(posJ_x_x, posJ_x_y);
-        const float2_X posJ_y(posJ_y_x, posJ_y_y);
-        const float2_X posJ_z(posJ_z_x, posJ_z_y);
-#endif
+        /// boost::result_of hints
+        template<class> struct result;
 
-        /** position (floatD_x) in cell for J_x, J_y, J_z */
-        return VectorVector(posJ_x, posJ_y, posJ_z);
-    }
+        template<class F>
+        struct result<F()> {
+            typedef VectorVector2D3V type;
+        };
 
-};
+        HDINLINE VectorVector2D3V operator()() const
+        {
+            const float2_X posJ_x( 0.5, 0.0 );
+            const float2_X posJ_y( 0.0, 0.5 );
+            const float2_X posJ_z( 0.0, 0.0 );
 
+            return VectorVector2D3V( posJ_x, posJ_y, posJ_z );
+        }
+    };
+
+    /** position (float3_X) in cell for J_x, J_y, J_z
+     */
+    template<>
+    struct FieldPosition<FieldJ, DIM3>
+    {
+        /// boost::result_of hints
+        template<class> struct result;
+
+        template<class F>
+        struct result<F()> {
+            typedef VectorVector3D3V type;
+        };
+
+        HDINLINE VectorVector3D3V operator()() const
+        {
+            const float3_X posJ_x( 0.5, 0.0, 0.0 );
+            const float3_X posJ_y( 0.0, 0.5, 0.0 );
+            const float3_X posJ_z( 0.0, 0.0, 0.5 );
+
+            return VectorVector3D3V( posJ_x, posJ_y, posJ_z );
+        }
+    };
+
+    /** position (floatD_X in case of T_simDim == simDim) in cell for the
+     *  scalar field FieldTmp
+     */
+    template<uint32_t T_simDim>
+    struct FieldPosition<FieldTmp, T_simDim>
+    {
+        typedef PMacc::math::Vector<float_X, T_simDim> ReturnType;
+
+        /// boost::result_of hints
+        template<class> struct result;
+
+        template<class F>
+        struct result<F()> {
+            typedef ReturnType type;
+        };
+
+        HDINLINE ReturnType operator()() const
+        {
+            return ReturnType::create( 0.0 );
+        }
+    };
+} // traits
 } // emfCenteredCell
 } // picongpu

--- a/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
@@ -22,124 +22,149 @@
 #pragma once
 
 #include "simulation_defines.hpp"
+#include "fields/Fields.def"
 #include "math/Vector.hpp"
 
 namespace picongpu
 {
-using namespace PMacc;
 namespace yeeCell
 {
-
-// ___________posE____________
-const float_X posE_x_x = 0.5;
-const float_X posE_x_y = 0.0;
-const float_X posE_x_z = 0.0;
-
-const float_X posE_y_x = 0.0;
-const float_X posE_y_y = 0.5;
-const float_X posE_y_z = 0.0;
-
-const float_X posE_z_x = 0.0;
-const float_X posE_z_y = 0.0;
-const float_X posE_z_z = 0.5;
-
-// ___________posB____________
-const float_X posB_x_x = 0.0;
-const float_X posB_x_y = 0.5;
-const float_X posB_x_z = 0.5;
-
-const float_X posB_y_x = 0.5;
-const float_X posB_y_y = 0.0;
-const float_X posB_y_z = 0.5;
-
-const float_X posB_z_x = 0.5;
-const float_X posB_z_y = 0.5;
-const float_X posB_z_z = 0.0;
-
-// ___________posJ____________
-const float_X posJ_x_x = 0.5;
-const float_X posJ_x_y = 0.0;
-const float_X posJ_x_z = 0.0;
-
-const float_X posJ_y_x = 0.0;
-const float_X posJ_y_y = 0.5;
-const float_X posJ_y_z = 0.0;
-
-const float_X posJ_z_x = 0.0;
-const float_X posJ_z_y = 0.0;
-const float_X posJ_z_z = 0.5;
-
-/** \todo posRho for FieldTmp depositions
-const float_X posRho_x_x = 0.0;
-const float_X posRho_x_y = 0.0;
-const float_X posRho_x_z = 0.0;
-
-const float_X posRho_y_x = 0.0;
-const float_X posRho_y_y = 0.0;
-const float_X posRho_y_z = 0.0;
-
-const float_X posRho_z_x = 0.0;
-const float_X posRho_z_y = 0.0;
-const float_X posRho_z_z = 0.0;
-*/
-
-struct YeeCell
+namespace traits
 {
     /** \tparam floatD_X position of the component in the cell
-     *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D ! */
-    typedef ::PMacc::math::Vector<floatD_X,DIM3> VectorVector;
+     *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+     */
+    typedef const ::PMacc::math::Vector<float2_X,DIM3> VectorVector2D3V;
+    typedef const ::PMacc::math::Vector<float3_X,DIM3> VectorVector3D3V;
 
-    static HDINLINE VectorVector getEFieldPosition()
+    template<typename T_Field, uint32_t T_simDim = simDim>
+    struct FieldPosition;
+
+    /** position (float2_X) in cell for E_x, E_y, E_z
+     */
+    template<>
+    struct FieldPosition<FieldE, DIM2>
     {
-#if( SIMDIM == DIM3 )
-        const float3_X posE_x(posE_x_x, posE_x_y, posE_x_z);
-        const float3_X posE_y(posE_y_x, posE_y_y, posE_y_z);
-        const float3_X posE_z(posE_z_x, posE_z_y, posE_z_z);
-#elif( SIMDIM == DIM2 )
-        const float2_X posE_x(posE_x_x, posE_x_y);
-        const float2_X posE_y(posE_y_x, posE_y_y);
-        const float2_X posE_z(posE_z_x, posE_z_y);
-#endif
+        /// boost::result_of hints
+        template<class> struct result;
 
-        /** position (floatD_x) in cell for E_x, E_y, E_z */
-        return VectorVector(posE_x, posE_y, posE_z);
-    }
+        template<class F>
+        struct result<F()> {
+            typedef VectorVector2D3V type;
+        };
 
-    static  HDINLINE VectorVector getBFieldPosition()
+        HDINLINE VectorVector2D3V operator()() const
+        {
+            const float2_X posE_x( 0.5, 0.0 );
+            const float2_X posE_y( 0.0, 0.5 );
+            const float2_X posE_z( 0.0, 0.0 );
+
+            return VectorVector2D3V( posE_x, posE_y, posE_z );
+        }
+    };
+
+    /** position (float3_X) in cell for E_x, E_y, E_z
+     */
+    template<>
+    struct FieldPosition<FieldE, DIM3>
     {
-#if( SIMDIM == DIM3 )
-        const float3_X posB_x(posB_x_x, posB_x_y, posB_x_z);
-        const float3_X posB_y(posB_y_x, posB_y_y, posB_y_z);
-        const float3_X posB_z(posB_z_x, posB_z_y, posB_z_z);
-#elif( SIMDIM == DIM2 )
-        const float2_X posB_x(posB_x_x, posB_x_y);
-        const float2_X posB_y(posB_y_x, posB_y_y);
-        const float2_X posB_z(posB_z_x, posB_z_y);
-#endif
+        /// boost::result_of hints
+        template<class> struct result;
 
-        /** position (floatD_x) in cell for B_x, B_y, B_z */
-        return VectorVector(posB_x, posB_y, posB_z);
-    }
+        template<class F>
+        struct result<F()> {
+            typedef VectorVector3D3V type;
+        };
 
-    static HDINLINE VectorVector getJFieldPosition()
+        HDINLINE VectorVector3D3V operator()() const
+        {
+            const float3_X posE_x( 0.5, 0.0, 0.0 );
+            const float3_X posE_y( 0.0, 0.5, 0.0 );
+            const float3_X posE_z( 0.0, 0.0, 0.5 );
+
+            return VectorVector3D3V( posE_x, posE_y, posE_z );
+        }
+    };
+
+    /** position (float2_X) in cell for B_x, B_y, B_z
+     */
+    template<>
+    struct FieldPosition<FieldB, DIM2>
     {
-#if( SIMDIM == DIM3 )
-        const float3_X posJ_x(posJ_x_x, posJ_x_y, posJ_x_z);
-        const float3_X posJ_y(posJ_y_x, posJ_y_y, posJ_y_z);
-        const float3_X posJ_z(posJ_z_x, posJ_z_y, posJ_z_z);
-#elif( SIMDIM == DIM2 )
-        const float2_X posJ_x(posJ_x_x, posJ_x_y);
-        const float2_X posJ_y(posJ_y_x, posJ_y_y);
-        const float2_X posJ_z(posJ_z_x, posJ_z_y);
-#endif
+        /// boost::result_of hints
+        template<class> struct result;
 
-        /** position (floatD_x) in cell for J_x, J_y, J_z */
-        return VectorVector(posJ_x, posJ_y, posJ_z);
-    }
+        template<class F>
+        struct result<F()> {
+            typedef VectorVector2D3V type;
+        };
 
-};
+        HDINLINE VectorVector2D3V operator()() const
+        {
+            const float2_X posB_x( 0.0, 0.5 );
+            const float2_X posB_y( 0.5, 0.0 );
+            const float2_X posB_z( 0.5, 0.5 );
 
+            return VectorVector2D3V( posB_x, posB_y, posB_z );
+        }
+    };
 
+    /** position (float3_X) in cell for B_x, B_y, B_z
+     */
+    template<>
+    struct FieldPosition<FieldB, DIM3>
+    {
+        /// boost::result_of hints
+        template<class> struct result;
+
+        template<class F>
+        struct result<F()> {
+            typedef VectorVector3D3V type;
+        };
+
+        HDINLINE VectorVector3D3V operator()() const
+        {
+            const float3_X posB_x( 0.0, 0.5, 0.5 );
+            const float3_X posB_y( 0.5, 0.0, 0.5 );
+            const float3_X posB_z( 0.5, 0.5, 0.0 );
+
+            return VectorVector3D3V( posB_x, posB_y, posB_z );
+        }
+    };
+
+    /** position (floatD_X in case of T_simDim == simDim) in cell for
+     *  J_x, J_y, J_z
+     */
+    template<uint32_t T_simDim>
+    struct FieldPosition<FieldJ, T_simDim> :
+        public FieldPosition<FieldE, T_simDim>
+    {
+        HDINLINE FieldPosition()
+        {
+        }
+    };
+
+    /** position (floatD_X in case of T_simDim == simDim) in cell for the
+     *  scalar field FieldTmp
+     */
+    template<uint32_t T_simDim>
+    struct FieldPosition<FieldTmp, T_simDim>
+    {
+        typedef PMacc::math::Vector<float_X, T_simDim> ReturnType;
+
+        /// boost::result_of hints
+        template<class> struct result;
+
+        template<class F>
+        struct result<F()> {
+            typedef ReturnType type;
+        };
+
+        HDINLINE ReturnType operator()() const
+        {
+            return ReturnType::create( 0.0 );
+        }
+    };
+} // traits
 } // yeeCell
 } // picongpu
-

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -247,7 +247,7 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
     }
 }
 
-template<class PushAlgo, class TVec, class T_Field2ParticleInterpolation, class NumericalCellType>
+template<class PushAlgo, class TVec, class T_Field2ParticleInterpolation>
 struct PushParticlePerFrame
 {
 
@@ -269,8 +269,11 @@ struct PushParticlePerFrame
 
         DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
 
-        PMACC_AUTO(functorEfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( eBox.shift(localCell).toCursor(), NumericalCellType::getEFieldPosition()));
-        PMACC_AUTO(functorBfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( bBox.shift(localCell).toCursor(), NumericalCellType::getBFieldPosition()));
+        const fieldSolver::numericalCellType::traits::FieldPosition<FieldE> fieldPosE;
+        const fieldSolver::numericalCellType::traits::FieldPosition<FieldB> fieldPosB;
+
+        PMACC_AUTO(functorEfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( eBox.shift(localCell).toCursor(), fieldPosE() ));
+        PMACC_AUTO(functorBfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( bBox.shift(localCell).toCursor(), fieldPosB() ));
 
         float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass(weighting,particle);

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -165,8 +165,7 @@ void Particles<T_ParticleDescription>::update(uint32_t )
         >::type InterpolationScheme;
 
     typedef PushParticlePerFrame<ParticlePush, MappingDesc::SuperCellSize,
-        InterpolationScheme,
-        fieldSolver::NumericalCellType > FrameSolver;
+        InterpolationScheme > FrameSolver;
 
     // adjust interpolation area in particle pusher to allow sub-sampling pushes
     typedef typename GetLowerMarginPusher<Particles>::type LowerMargin;

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -163,10 +163,6 @@ namespace ionization
              */
             DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
             {
-
-                /* type of PIC-scheme cell */
-                typedef typename fieldSolver::NumericalCellType NumericalCellType;
-
                 /* alias for the single macro-particle */
                 PMACC_AUTO(particle,ionFrame[localIdx]);
                 /* particle position, used for field-to-particle interpolation */
@@ -175,11 +171,13 @@ namespace ionization
                 /* multi-dim coordinate of the local cell inside the super cell */
                 DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
                 /* interpolation of E- */
+                const fieldSolver::numericalCellType::traits::FieldPosition<FieldE> fieldPosE;
                 ValueType_E eField = Field2ParticleInterpolation()
-                    (cachedE.shift(localCell).toCursor(), pos, NumericalCellType::getEFieldPosition());
+                    (cachedE.shift(localCell).toCursor(), pos, fieldPosE());
                 /*                     and B-field on the particle position */
+                const fieldSolver::numericalCellType::traits::FieldPosition<FieldB> fieldPosB;
                 ValueType_B bField = Field2ParticleInterpolation()
-                    (cachedB.shift(localCell).toCursor(), pos, NumericalCellType::getBFieldPosition());
+                    (cachedB.shift(localCell).toCursor(), pos, fieldPosB());
 
                 /* define number of bound macro electrons before ionization */
                 float_X prevBoundElectrons = particle[boundElectrons_];

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -160,10 +160,6 @@ namespace ionization
              */
             DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
             {
-
-                /* type of PIC-scheme cell */
-                typedef typename fieldSolver::NumericalCellType NumericalCellType;
-
                 /* alias for the single macro-particle */
                 PMACC_AUTO(particle,ionFrame[localIdx]);
                 /* particle position, used for field-to-particle interpolation */
@@ -172,11 +168,13 @@ namespace ionization
                 /* multi-dim coordinate of the local cell inside the super cell */
                 DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
                 /* interpolation of E- */
+                const fieldSolver::numericalCellType::traits::FieldPosition<FieldE> fieldPosE;
                 ValueType_E eField = Field2ParticleInterpolation()
-                    (cachedE.shift(localCell).toCursor(), pos, NumericalCellType::getEFieldPosition());
+                    (cachedE.shift(localCell).toCursor(), pos, fieldPosE());
                 /*                     and B-field on the particle position */
+                const fieldSolver::numericalCellType::traits::FieldPosition<FieldB> fieldPosB;
                 ValueType_B bField = Field2ParticleInterpolation()
-                    (cachedB.shift(localCell).toCursor(), pos, NumericalCellType::getBFieldPosition());
+                    (cachedB.shift(localCell).toCursor(), pos, fieldPosB());
 
                 /* define number of bound macro electrons before ionization */
                 float_X prevBoundElectrons = particle[boundElectrons_];

--- a/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
@@ -38,32 +38,32 @@ namespace picongpu
 namespace fieldSolverNone
 {
     typedef picongpu::noSolver::NoSolver FieldSolver;
-    typedef yeeCell::YeeCell NumericalCellType;
+    namespace numericalCellType = yeeCell;
 }
 
 namespace fieldSolverYeeNative
 {
     typedef picongpu::yeeSolver::YeeSolver<> FieldSolver;
-    typedef yeeCell::YeeCell NumericalCellType;
+    namespace numericalCellType = yeeCell;
 }
 
 namespace fieldSolverYee
 {
     typedef picongpu::yeeSolver::YeeSolver<> FieldSolver;
-    typedef yeeCell::YeeCell NumericalCellType;
+    namespace numericalCellType = yeeCell;
 }
 
 #if(SIMDIM==DIM3)
 namespace fieldSolverDirSplitting
 {
     typedef picongpu::dirSplitting::DirSplitting FieldSolver;
-    typedef emfCenteredCell::EMFCenteredCell NumericalCellType;
+    namespace numericalCellType = emfCenteredCell;
 }
 
 namespace fieldSolverLehe
 {
     typedef picongpu::leheSolver::LeheSolver FieldSolver;
-    typedef yeeCell::YeeCell NumericalCellType;
+    namespace numericalCellType = yeeCell;
 }
 #endif
 } //namespace picongpu


### PR DESCRIPTION
Refactors the getter of field positions into a trait. Read commit-wise (commit 1: refactor, commit 2: update usage in code).

Adds the previously just commented positions of FieldTmp (currently used in ParticleToGrid always at zero corner.)

Used in the upcoming openPMD branch.