### PR TITLE
Plugins: Common String Helpers (Dates)

### DIFF
--- a/src/picongpu/include/plugins/common/stringHelpers.hpp
+++ b/src/picongpu/include/plugins/common/stringHelpers.hpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2015-2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <sstream>
+#include <ctime>
+
+
+namespace picongpu
+{
+    /** Return the current date as string
+     *
+     * \param format, \see http://www.cplusplus.com/reference/ctime/strftime/
+     * \return std::string with formatted date
+     */
+    std::string getDateString( std::string format )
+    {
+        time_t rawtime;
+        struct tm* timeinfo;
+        const size_t maxLen = 30;
+        char buffer [maxLen];
+
+        time( &rawtime );
+        timeinfo = localtime( &rawtime );
+
+        strftime( buffer, maxLen, format.c_str(), timeinfo );
+
+        std::stringstream dateString;
+        dateString << buffer;
+
+        return dateString.str();
+    }
+
+} // namespace picongpu


### PR DESCRIPTION
Adds common helpers to create strings (implemented: dates) for plugins as [used in openPMD](https://github.com/openPMD/openPMD-standard/blob/1.0.0/STANDARD.md#hierarchy-of-the-data-file).

Example usage for openPMD files (and libSplash/HDF5):
```C++
#include "plugins/common/stringHelpers.hpp"

// [...]
{
        std::string date = getDateString("%F %T %z");
        ColTypeString ctDate(date.length());
        dc->writeGlobalAttribute( threadParams->currentStep,
                                  ctDate, "date",
                                  date.c_str() );
}
```