### PR TITLE
fix deadlock in asyncSend

### DIFF
--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -519,6 +519,7 @@ public:
         {
             __startTransaction(serialEvent + sendEvents[sendEx]);
             sendEvents[sendEx] = sendExchanges[sendEx]->startSend(gpuFree);
+            gpuFree = sendEvents[sendEx];
             __endTransaction();
             return sendEvents[sendEx];
         }

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -282,7 +282,7 @@ public:
         EventTask exchangeMemoryIndexerGPUEvent;
         EventTask returnEvent = framesExchanges->asyncSend(serialEvent, ex, framesExchangesGPUEvent) +
             exchangeMemoryIndexer->asyncSend(serialEvent, ex, exchangeMemoryIndexerGPUEvent);
-        gpuFree = framesExchangesGPUEvent + exchangeMemoryIndexerGPUEvent;
+        gpuFree = returnEvent;
         return returnEvent;
     }
 


### PR DESCRIPTION
- `GridBuffer.hpp` and `ParticlesBuffer.hpp`: set gpuFree event to communication event
- close #1322 **Freeze of picongpu if used MPI_Allgather in plugin**

A deadlock in the async communication is triggered when process one opened a `MPI_Receive` while the destination process two not opened the `MPI_Send` and starts a MPI collective operation. In this case the event system stops and not start the `MPI_Send` from process two which wait in a side dependency chain. Process one wait for finish of the `MPI_Receive` before it can start the collective operation. Now we had a classical deadlock.

This patch only solve the deadlock a cleanup of the interfaces will done in a separate pull request.

**Tests:**
- [x] example plugin from #1322 ( command: `mpiexec -n  4 ./picongpu -d 2 2 1 -g  64 128 32 -s 10 --mpitest.period 1 --mpitest.mode 3`)
