### PR TITLE
clean up send interfaces

### DIFF
--- a/src/libPMacc/include/eventSystem/tasks/Factory.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.hpp
@@ -85,7 +85,6 @@ namespace PMacc
         /**
          * Creates a TaskReceive.
          * @param ex Exchange to create new TaskReceive with
-         * @param task_out returns the newly created task
          * @param registeringTask optional pointer to an ITask which should be registered at the new task as an observer
          */
         template <class TYPE, unsigned DIM>
@@ -95,11 +94,10 @@ namespace PMacc
         /**
          * Creates a TaskSend.
          * @param ex Exchange to create new TaskSend with
-         * @param task_in TaskReceive to register at new TaskSend
          * @param registeringTask optional pointer to an ITask which should be registered at the new task as an observer
          */
         template <class TYPE, unsigned DIM>
-        EventTask createTaskSend(Exchange<TYPE, DIM> &ex, EventTask &copyEvent,
+        EventTask createTaskSend(Exchange<TYPE, DIM> &ex,
         ITask *registeringTask = NULL);
 
         /**

--- a/src/libPMacc/include/eventSystem/tasks/Factory.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.tpp
@@ -95,7 +95,6 @@ namespace PMacc
     /**
      * Creates a TaskReceive.
      * @param ex Exchange to create new TaskReceive with
-     * @param task_out returns the newly created task
      * @param registeringTask optional pointer to an ITask which should be registered at the new task as an observer
      */
     template <class TYPE, unsigned DIM>
@@ -110,14 +109,13 @@ namespace PMacc
     /**
      * Creates a TaskSend.
      * @param ex Exchange to create new TaskSend with
-     * @param task_in TaskReceive to register at new TaskSend
      * @param registeringTask optional pointer to an ITask which should be registered at the new task as an observer
      */
     template <class TYPE, unsigned DIM>
-    inline EventTask Factory::createTaskSend(Exchange<TYPE, DIM> &ex, EventTask &copyEvent,
+    inline EventTask Factory::createTaskSend(Exchange<TYPE, DIM> &ex,
     ITask *registeringTask)
     {
-        TaskSend<TYPE, DIM>* task = new TaskSend<TYPE, DIM > (ex, copyEvent);
+        TaskSend<TYPE, DIM>* task = new TaskSend<TYPE, DIM > (ex);
 
         return startTask(*task, registeringTask);
     }

--- a/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
@@ -41,9 +41,8 @@ namespace PMacc
     {
     public:
 
-        TaskSend(Exchange<TYPE, DIM> &ex, EventTask& copyEvent) :
+        TaskSend(Exchange<TYPE, DIM> &ex) :
         exchange(&ex),
-        copyEvent(copyEvent),
         state(Constructor)
         {
         }
@@ -54,17 +53,17 @@ namespace PMacc
             if (exchange->hasDeviceDoubleBuffer())
             {
                 Environment<>::get().Factory().createTaskCopyDeviceToDevice(exchange->getDeviceBuffer(),
-                                                                               exchange->getDeviceDoubleBuffer()
-                                                                               );
-                copyEvent = Environment<>::get().Factory().createTaskCopyDeviceToHost(exchange->getDeviceDoubleBuffer(),
-                                                                                         exchange->getHostBuffer(),
-                                                                                         this);
+                                                                            exchange->getDeviceDoubleBuffer()
+                                                                            );
+                Environment<>::get().Factory().createTaskCopyDeviceToHost(exchange->getDeviceDoubleBuffer(),
+                                                                          exchange->getHostBuffer(),
+                                                                          this);
             }
             else
             {
-                copyEvent = Environment<>::get().Factory().createTaskCopyDeviceToHost(exchange->getDeviceBuffer(),
-                                                                                         exchange->getHostBuffer(),
-                                                                                         this);
+                Environment<>::get().Factory().createTaskCopyDeviceToHost(exchange->getDeviceBuffer(),
+                                                                          exchange->getHostBuffer(),
+                                                                          this);
             }
 
         }
@@ -132,7 +131,6 @@ namespace PMacc
         };
 
         Exchange<TYPE, DIM> *exchange;
-        EventTask& copyEvent;
         state_t state;
     };
 

--- a/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
@@ -216,10 +216,9 @@ namespace PMacc
             return *deviceDoubleBuffer;
         }
 
-        EventTask startSend(EventTask &copyEvent)
+        EventTask startSend()
         {
-            //assert(recvTask != NULL);
-            return Environment<>::get().Factory().createTaskSend(*this, copyEvent);
+            return Environment<>::get().Factory().createTaskSend(*this);
         }
 
         EventTask startReceive()

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -504,22 +504,18 @@ public:
 
             ExchangeType sendEx = Mask::getMirroredExchangeType(i);
 
-            EventTask copyEvent;
-            asyncSend(serialEvent, sendEx, copyEvent);
-            /* add only the copy event, because all work on gpu can run after data is copied */
-            evR += copyEvent;
+            evR += asyncSend(serialEvent, sendEx);
 
         }
         return evR;
     }
 
-    EventTask asyncSend(EventTask serialEvent, uint32_t sendEx, EventTask &gpuFree)
+    EventTask asyncSend(EventTask serialEvent, uint32_t sendEx)
     {
         if (hasSendExchange(sendEx))
         {
             __startTransaction(serialEvent + sendEvents[sendEx]);
-            sendEvents[sendEx] = sendExchanges[sendEx]->startSend(gpuFree);
-            gpuFree = sendEvents[sendEx];
+            sendEvents[sendEx] = sendExchanges[sendEx]->startSend();
             __endTransaction();
             return sendEvents[sendEx];
         }

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -275,14 +275,14 @@ public:
                exchangeMemoryIndexer->asyncCommunication(serialEvent);
     }
 
-    EventTask asyncSendParticles(EventTask serialEvent, uint32_t ex, EventTask &gpuFree)
+    EventTask asyncSendParticles(EventTask serialEvent, uint32_t ex)
     {
-        /*store every gpu free event seperat to avoid raceconditions*/
+        /* store each gpu-free event separately to avoid race conditions */
         EventTask framesExchangesGPUEvent;
         EventTask exchangeMemoryIndexerGPUEvent;
-        EventTask returnEvent = framesExchanges->asyncSend(serialEvent, ex, framesExchangesGPUEvent) +
-            exchangeMemoryIndexer->asyncSend(serialEvent, ex, exchangeMemoryIndexerGPUEvent);
-        gpuFree = returnEvent;
+        EventTask returnEvent = framesExchanges->asyncSend(serialEvent, ex) +
+            exchangeMemoryIndexer->asyncSend(serialEvent, ex);
+
         return returnEvent;
     }
 

--- a/src/libPMacc/include/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/src/libPMacc/include/particles/tasks/TaskSendParticlesExchange.hpp
@@ -70,8 +70,7 @@ namespace PMacc
                         //bash is finished
                         __startTransaction();
                         lastSize = parBase.getParticlesBuffer().getSendExchangeStack(exchange).getDeviceParticlesCurrentSize();
-                       // std::cout<<"bsend = "<<parBase.getParticlesBuffer().getSendExchangeStack(exchange).getDeviceCurrentSize()<<std::endl;
-                        lastSendEvent = parBase.getParticlesBuffer().asyncSendParticles(__getTransactionEvent(), exchange, tmpEvent);
+                        lastSendEvent = parBase.getParticlesBuffer().asyncSendParticles(__getTransactionEvent(), exchange);
                         initDependency = lastSendEvent;
                         __endTransaction();
                         state = WaitForSend;

--- a/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
@@ -64,7 +64,8 @@ namespace PMacc
                 if (NULL == Environment<>::get().Manager().getITaskIfNotFinished(m_initDependency.getTaskId()) )
                 {
                     m_state = InitSend;
-                    m_sendEvent = m_buffer.getGridBuffer().asyncSend(EventTask(), m_exchange, m_initDependency);
+                    m_sendEvent = m_buffer.getGridBuffer().asyncSend(EventTask(), m_exchange);
+                    m_initDependency = m_sendEvent;
                     m_state = WaitForSendEnd;
                 }
 


### PR DESCRIPTION
- remove copyEvent from all send methods in buffer and tasks
- `TaskSend`: remove member `EventTask copyEvent`
- `tasks/Factory`:
  - remove copy event from interface
  - update documentation

Follow up of ~~#1326~~

Tests:

- [x] LWFA with 16 K20