### PR TITLE
Add fmod-function to libPMacc

### DIFF
--- a/src/libPMacc/include/algorithms/math.hpp
+++ b/src/libPMacc/include/algorithms/math.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2016 Rene Widera, Benjamin Worpitz, Alexander Debus
  *
  * This file is part of libPMacc.
  *
@@ -35,6 +35,7 @@
 #include "algorithms/math/defines/floatingPoint.hpp"
 #include "algorithms/math/defines/pow.hpp"
 #include "algorithms/math/defines/modf.hpp"
+#include "algorithms/math/defines/fmod.hpp"
 
 #include "algorithms/math/floatMath/abs.tpp"
 #include "algorithms/math/floatMath/sqrt.tpp"
@@ -45,6 +46,7 @@
 #include "algorithms/math/floatMath/floatingPoint.tpp"
 #include "algorithms/math/floatMath/pow.tpp"
 #include "algorithms/math/floatMath/modf.tpp"
+#include "algorithms/math/floatMath/fmod.tpp"
 
 #include "algorithms/math/doubleMath/abs.tpp"
 #include "algorithms/math/doubleMath/sqrt.tpp"
@@ -55,5 +57,5 @@
 #include "algorithms/math/doubleMath/floatingPoint.tpp"
 #include "algorithms/math/doubleMath/pow.tpp"
 #include "algorithms/math/doubleMath/modf.tpp"
-
+#include "algorithms/math/doubleMath/fmod.tpp"
 

--- a/src/libPMacc/include/algorithms/math/defines/fmod.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/fmod.hpp
@@ -33,10 +33,12 @@ template<typename Type>
 struct Fmod;
 
 /**
- * Equivalent of the modulus-operator for float types.
- * Returns the floating-point remainder of x / y (rounded towards zero):
- * fmod = x - tquot * y
- * Where tquot is the truncated (i.e., rounded towards zero) result of: x / y.
+ * Equivalent to the modulus-operator for float types
+ * returns the floating-point remainder of x / y.
+ * The functionality corresponds to the C++
+ * math function fmod().
+ * For details, see <a href="http://www.cplusplus.com/reference/cmath/fmod/">
+ * external documentation.</a>
  * @return float value
  */
 template<typename T1>

--- a/src/libPMacc/include/algorithms/math/defines/fmod.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/fmod.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Alexander Debus
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<typename Type>
+struct Fmod;
+
+/**
+ * Equivalent of the modulus-operator for float types.
+ * Returns the floating-point remainder of x / y (rounded towards zero):
+ * fmod = x - tquot * y
+ * Where tquot is the truncated (i.e., rounded towards zero) result of: x / y.
+ * @return float value
+ */
+template<typename T1>
+HDINLINE typename Fmod< T1>::result fmod(T1 x,T1 y)
+{
+    return Fmod< T1 > ()(x, y);
+}
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc
+

--- a/src/libPMacc/include/algorithms/math/defines/fmod.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/fmod.hpp
@@ -41,7 +41,7 @@ struct Fmod;
  * @return float value
  */
 template<typename T1>
-HDINLINE typename Fmod< T1>::result fmod(T1 x,T1 y)
+HDINLINE typename Fmod< T1>::result fmod(T1 x, T1 y)
 {
     return Fmod< T1 > ()(x, y);
 }

--- a/src/libPMacc/include/algorithms/math/defines/fmod.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/fmod.hpp
@@ -37,8 +37,7 @@ struct Fmod;
  * returns the floating-point remainder of x / y.
  * The functionality corresponds to the C++
  * math function fmod().
- * For details, see <a href="http://www.cplusplus.com/reference/cmath/fmod/">
- * external documentation.</a>
+ * For details, see http://www.cplusplus.com/reference/cmath/fmod/ .
  * @return float value
  */
 template<typename T1>

--- a/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
 #include <cmath>
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
@@ -41,9 +41,9 @@ struct Fmod<double>
     HDINLINE result operator( )(result x, result y)
     {
 #if __CUDA_ARCH__
-        return ::fmod( x , y );
+        return ::fmod(x, y);
 #else
-        return std::fmod( x , y );
+        return std::fmod(x, y);
 #endif
     }
 };

--- a/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Alexander Debus
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "math.h"
+#include <cmath>
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<>
+struct Fmod<double>
+{
+    typedef double result;
+
+    HDINLINE result operator( )(result x, result y)
+    {
+#if __CUDA_ARCH__
+        return ::fmod( x , y );
+#else
+        return std::fmod( x , y );
+#endif
+    }
+};
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc
+

--- a/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
 #include <cmath>
 
 namespace PMacc
@@ -43,7 +42,7 @@ struct Fmod<float>
 #if __CUDA_ARCH__
         return ::fmodf(x, y);
 #else
-        return std::fmodf(x, y);
+        return std::fmod(x, y);
 #endif
     }
 };

--- a/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
@@ -41,9 +41,9 @@ struct Fmod<float>
     HDINLINE result operator( )(result x, result y)
     {
 #if __CUDA_ARCH__
-        return ::fmod( x , y );
+        return ::fmodf(x, y);
 #else
-        return std::fmod( x , y );
+        return std::fmodf(x, y);
 #endif
     }
 };

--- a/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Alexander Debus
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "math.h"
+#include <cmath>
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<>
+struct Fmod<float>
+{
+    typedef float result;
+
+    HDINLINE result operator( )(result x, result y)
+    {
+#if __CUDA_ARCH__
+        return ::fmod( x , y );
+#else
+        return std::fmod( x , y );
+#endif
+    }
+};
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc
+


### PR DESCRIPTION
Recently I used the `fmod()` function at several occasions (TWTS pulse, upcoming fix for the moving Window). So we have to include this math-function in the templates of libPMacc.

Note: The `fmod` function is entirely distinct from the `modf` function, which is already part of libPMacc.