### PR TITLE
FieldJ: `clear()` -> `assign(value)`

### DIFF
--- a/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
@@ -125,7 +125,8 @@ public:
      */
     virtual void runOneStep(uint32_t currentStep)
     {
-        fieldJ->clear();
+        FieldJ::ValueType zeroJ( FieldJ::ValueType::create(0.) );
+        fieldJ->assign( zeroJ );
 
         fieldJ->computeCurrent < CORE + BORDER, PIC_Electrons > (*particleStorage[TypeAsIdentifier<PIC_Electrons>()], currentStep);
 

--- a/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
@@ -137,7 +137,8 @@ public:
      */
     virtual void runOneStep(uint32_t currentStep)
     {
-        fieldJ->clear();
+        FieldJ::ValueType zeroJ( FieldJ::ValueType::create(0.) );
+        fieldJ->assign( zeroJ );
 
 #if (ENABLE_ELECTRONS == 1)
         __startTransaction(__getTransactionEvent());

--- a/examples/SingleParticleTest/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleTest/include/OneParticleSimulation.hpp
@@ -133,7 +133,9 @@ public:
      */
     virtual void runOneStep(uint32_t currentStep)
     {
-        fieldJ->clear();
+        FieldJ::ValueType zeroJ( FieldJ::ValueType::create(0.) );
+        fieldJ->assign( zeroJ );
+
         __startTransaction(__getTransactionEvent());
 
         particleStorage[TypeAsIdentifier<PIC_Electrons>()]->update(currentStep);

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -77,7 +77,17 @@ public:
 
     void reset(uint32_t currentStep);
 
-    void clear();
+    /** Assign a value to all cells
+     *
+     * Example usage:
+     * ```C++
+     *   FieldJ::ValueType zeroJ( FieldJ::ValueType::create(0.) );
+     *   fieldJ->assign( zeroJ );
+     * ```
+     *
+     * \param value date to fill all cells with
+     */
+    void assign(ValueType value);
 
     HDINLINE static UnitValueType getUnit();
 

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -228,10 +228,9 @@ void FieldJ::reset( uint32_t )
 {
 }
 
-void FieldJ::clear( )
+void FieldJ::assign( ValueType value )
 {
-    ValueType tmp(ValueType::create(0.));
-    fieldJ.getDeviceBuffer( ).setValue( tmp );
+    fieldJ.getDeviceBuffer( ).setValue( value );
     //fieldJ.reset(false);
 }
 

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -445,7 +445,8 @@ public:
 
         this->myFieldSolver->update_beforeCurrent(currentStep);
 
-        fieldJ->clear();
+        FieldJ::ValueType zeroJ( FieldJ::ValueType::create(0.) );
+        fieldJ->assign( zeroJ );
 
         __setTransactionEvent(commEvent);
         (*currentBGField)(fieldJ, nvfct::Add(), FieldBackgroundJ(fieldJ->getUnit()),


### PR DESCRIPTION
`Clear()` in STL language might resize members. What this member does is `assign` a value.

Related to #1333 (naming collision).

@psychocoderHPC @erikzenker 