### PR TITLE
Close #1330 Bugfix for slow moving window

### DIFF
--- a/src/libPMacc/include/algorithms/math.hpp
+++ b/src/libPMacc/include/algorithms/math.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2016 Rene Widera, Benjamin Worpitz, Alexander Debus
  *
  * This file is part of libPMacc.
  *
@@ -35,6 +35,7 @@
 #include "algorithms/math/defines/floatingPoint.hpp"
 #include "algorithms/math/defines/pow.hpp"
 #include "algorithms/math/defines/modf.hpp"
+#include "algorithms/math/defines/fmod.hpp"
 
 #include "algorithms/math/floatMath/abs.tpp"
 #include "algorithms/math/floatMath/sqrt.tpp"
@@ -45,6 +46,7 @@
 #include "algorithms/math/floatMath/floatingPoint.tpp"
 #include "algorithms/math/floatMath/pow.tpp"
 #include "algorithms/math/floatMath/modf.tpp"
+#include "algorithms/math/floatMath/fmod.tpp"
 
 #include "algorithms/math/doubleMath/abs.tpp"
 #include "algorithms/math/doubleMath/sqrt.tpp"
@@ -55,5 +57,5 @@
 #include "algorithms/math/doubleMath/floatingPoint.tpp"
 #include "algorithms/math/doubleMath/pow.tpp"
 #include "algorithms/math/doubleMath/modf.tpp"
-
+#include "algorithms/math/doubleMath/fmod.tpp"
 

--- a/src/libPMacc/include/algorithms/math/defines/fmod.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/fmod.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Alexander Debus
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<typename Type>
+struct Fmod;
+
+/**
+ * Equivalent of the modulus-operator for float types.
+ * Returns the floating-point remainder of x / y (rounded towards zero):
+ * fmod = x - tquot * y
+ * Where tquot is the truncated (i.e., rounded towards zero) result of: x / y.
+ * @return float value
+ */
+template<typename T1>
+HDINLINE typename Fmod< T1>::result fmod(T1 x,T1 y)
+{
+    return Fmod< T1 > ()(x, y);
+}
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc
+

--- a/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Alexander Debus
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "math.h"
+#include <cmath>
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<>
+struct Fmod<double>
+{
+    typedef double result;
+
+    HDINLINE result operator( )(result x, result y)
+    {
+#if __CUDA_ARCH__
+        return ::fmod( x , y );
+#else
+        return std::fmod( x , y );
+#endif
+    }
+};
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc
+

--- a/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Alexander Debus
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "math.h"
+#include <cmath>
+
+namespace PMacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+template<>
+struct Fmod<float>
+{
+    typedef float result;
+
+    HDINLINE result operator( )(result x, result y)
+    {
+#if __CUDA_ARCH__
+        return ::fmod( x , y );
+#else
+        return std::fmod( x , y );
+#endif
+    }
+};
+
+} //namespace math
+} //namespace algorithms
+} //namespace PMacc
+

--- a/src/picongpu/include/simulationControl/MovingWindow.hpp
+++ b/src/picongpu/include/simulationControl/MovingWindow.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+ * Copyright 2013-2016 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -63,20 +63,22 @@ private:
         /* later used to calculate smoother offsets */
         float_64 stepsInFutureAfterComma = stepsInFuture_tmp - (float_64) stepsInFuture;
 
-        /* round to nearest step so we get smaller sliding dfference
+        /* round to nearest step so we get smaller sliding difference
          * this is valid if we activate sliding window because y direction has
          * the same size for all gpus
          */
-        const uint32_t stepsPerGPU = (uint32_t) math::floor(
-                                                            (float_64) (subGrid.getLocalDomain().size.y() * cell_height) / light_way_per_step + 0.5);
-        const uint32_t firstSlideStep = stepsPerGPU * devices_y - stepsInFuture;
-        const uint32_t firstMoveStep = stepsPerGPU * (devices_y - 1) - stepsInFuture;
+        const float_64 stepsPerGPU = (float_64) (subGrid.getLocalDomain().size.y() * cell_height) / light_way_per_step;
+	const uint32_t firstSlideStep = (uint32_t) math::floor(   stepsPerGPU * (float_64) devices_y 
+                                                                - (float_64) stepsInFuture + 0.5           );
+        const uint32_t firstMoveStep =  (uint32_t) math::floor(   stepsPerGPU * (float_64) (devices_y - 1)
+                                                                - (float_64) stepsInFuture + 0.5           );
 
         if (slidingWindowActive==true && firstMoveStep <= currentStep)
         {
-            const uint32_t stepsInLastGPU = (currentStep + stepsInFuture) % stepsPerGPU;
+            const float_64 stepsInLastGPU = math::fmod( (float_64) currentStep + (float_64) stepsInFuture ,
+			                                           stepsPerGPU );
             /* moving window start */
-            if (firstSlideStep <= currentStep && stepsInLastGPU == 0)
+            if (firstSlideStep <= currentStep && stepsInLastGPU < float_64(1.0) )
             {
                 incrementSlideCounter(currentStep);
                 if (doSlide)
@@ -86,8 +88,8 @@ private:
             /* round to nearest cell to have smoother offset jumps */
             if (offsetFirstGPU)
             {
-                *offsetFirstGPU = math::floor(((float_64) stepsInLastGPU + stepsInFutureAfterComma) *
-                                              light_way_per_step / cell_height + 0.5);
+                *offsetFirstGPU = math::floor(  ( stepsInLastGPU + stepsInFutureAfterComma ) *
+                                                  light_way_per_step / cell_height + 0.5       );
             }
         }
     }

--- a/src/picongpu/include/simulationControl/MovingWindow.hpp
+++ b/src/picongpu/include/simulationControl/MovingWindow.hpp
@@ -68,10 +68,10 @@ private:
          * the same size for all gpus
          */
         const float_64 stepsPerGPU = (float_64) (subGrid.getLocalDomain().size.y() * cell_height) / light_way_per_step;
-	const uint32_t firstSlideStep = (uint32_t) math::floor(   stepsPerGPU * (float_64) devices_y 
-                                                                - (float_64) stepsInFuture + 0.5           );
+	const uint32_t firstSlideStep = (uint32_t) math::floor( stepsPerGPU * (float_64) devices_y 
+                                                              - (float_64) stepsInFuture );
         const uint32_t firstMoveStep =  (uint32_t) math::floor(   stepsPerGPU * (float_64) (devices_y - 1)
-                                                                - (float_64) stepsInFuture + 0.5           );
+                                                              - (float_64) stepsInFuture );
 
         if (slidingWindowActive==true && firstMoveStep <= currentStep)
         {
@@ -88,8 +88,8 @@ private:
             /* round to nearest cell to have smoother offset jumps */
             if (offsetFirstGPU)
             {
-                *offsetFirstGPU = math::floor(  ( stepsInLastGPU + stepsInFutureAfterComma ) *
-                                                  light_way_per_step / cell_height + 0.5       );
+                *offsetFirstGPU = math::floor( ( stepsInLastGPU + stepsInFutureAfterComma ) *
+                                               light_way_per_step / cell_height + 0.5 );
             }
         }
     }


### PR DESCRIPTION
Close #1330: As @ax3l described in #1330 we have a problem with the speed of the moving window in the current implementation. On a scale of several 100000 timesteps this can easily make an unaccounted window-offset of approx. 100 cells.

This pull request provides a minimal invasive fix for the physics side of the problem. I tested the code for the correct speed. The offset difference to the ideal is now smaller than the cell size and does not become larger with time.

- [x] depends on and needs rebase after #1334 was reviewed & merged