### PR TITLE
add memory shift option to particle to field interpolation

### DIFF
--- a/src/picongpu/include/particles/InterpolationForPusher.hpp
+++ b/src/picongpu/include/particles/InterpolationForPusher.hpp
@@ -20,19 +20,18 @@
 
 
 
+
+#pragma once
+
+namespace picongpu
+{
+
 /** functor for particle field interpolator
  *
  * This functor is a simplification of the full
  * field to particle interpolator that can be used in the
  * particle pusher
  */
-
-namespace picongpu
-{
-
-using namespace PMacc;
-
-
 template< typename T_Field2PartInt, typename T_MemoryType, typename T_FieldPosition >
 struct InterpolationForPusher
 {
@@ -44,13 +43,27 @@ struct InterpolationForPusher
     {
     }
 
+    /* apply shift policy before interpolation */
+    template< typename T_PosType, typename T_ShiftPolicy >
+    HDINLINE
+    float3_X operator()( const T_PosType& pos, const T_ShiftPolicy& shiftPolicy ) const
+    {
+        return Field2PartInt()( shiftPolicy.memory(m_mem, pos),
+                                shiftPolicy.position(pos),
+                                m_fieldPos );
+    }
+
+    /* interpolation using given memory and position */
     template< typename T_PosType >
     HDINLINE
     float3_X operator()( const T_PosType& pos ) const
     {
-        /* to do: memory shift, position shift */
-        return Field2PartInt()( m_mem, pos, m_fieldPos );
+        return Field2PartInt()( m_mem,
+                                pos,
+                                m_fieldPos );
     }
+
+
 
 private:
     PMACC_ALIGN( m_mem, T_MemoryType );

--- a/src/picongpu/include/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
+++ b/src/picongpu/include/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+namespace picongpu
+{
+namespace particles
+{
+
+namespace interpolationMemoryPolicy
+{
+/** Shift position to valid range [0,1)
+ *  and repositions memory accordingly.
+ *  This is necessary if a particle moves
+ *  outside of its cell during a sub-stepping cycle
+ *  Returns: shifted position and shifted memory. */
+struct ShiftToValidRange
+{
+    template< typename T_MemoryType, typename T_PosType >
+    HDINLINE
+    T_MemoryType memory( const T_MemoryType& mem, const T_PosType& pos ) const
+    {
+        const T_PosType pos_floor = PMacc::math::floor(pos);
+        return mem( precisionCast<int>(pos_floor) );
+    }
+
+    template< typename T_PosType >
+    HDINLINE
+    T_PosType position( const T_PosType& pos ) const
+    {
+        const T_PosType pos_floor = PMacc::math::floor(pos);
+        return pos - pos_floor;
+    }
+};
+
+} // namespace interpolationMemoryShift
+
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
This pull request allows to shift memory during the particle to field interpolation, that  allows to perform interpolation during sub-stepping **if a particle leaves its cell**.
It was suggested by @psychocoderHPC in [this comment](https://github.com/ComputationalRadiationPhysics/picongpu/pull/1201/files#r44545194).

The following test have to be performed  before merging:
 - [x] thermal test `NoShift`
 - [x] charge conservation `NoShift`
 - [x] thermal test `ShiftToValidRange`
 - [x] charge conservation`ShiftToValidRange`

Issue #1338 requires using `PMacc::math`.