### PR TITLE
Tools: Fix Naming of HDF5 Density

### DIFF
--- a/src/tools/bin/plot_chargeConservation.py
+++ b/src/tools/bin/plot_chargeConservation.py
@@ -89,7 +89,7 @@ def plotError(h5file, slice_pos=[0.5, 0.5, 0.5]):
     charge = np.zeros_like(Ex)
     norm = 0.0
     for field_name in f["/data/{}/fields/".format(timestep)].keys():
-        if field_name[0:8] == "Density_":
+        if field_name[-14:] == "_chargeDensity":
             # load species density
             species_Density = np.array(f["/data/{}/fields/".format(timestep) + field_name])
             # choose norm to be the maximal charge density of all species

--- a/src/tools/bin/plot_chargeConservation_overTime.py
+++ b/src/tools/bin/plot_chargeConservation_overTime.py
@@ -106,7 +106,7 @@ def deviation_charge_conservation(h5file):
     charge = np.zeros_like(Ex)
     norm = 0.0
     for field_name in f["/data/{}/fields/".format(timestep)].keys():
-        if field_name[0:8] == "Density_":
+        if field_name[-14:] == "_chargeDensity":
             # load species density
             species_Density_pointer = f["/data/{}/fields/".format(timestep) + field_name]
             species_Density = np.array(species_Density_pointer)

--- a/src/tools/png2gas/png2gas.cpp
+++ b/src/tools/png2gas/png2gas.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 Felix Schmitt, Axel Huebl
+ * Copyright 2014-2016 Felix Schmitt, Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -46,7 +46,7 @@ bool parseCmdLine(int argc, char **argv, Options &options)
         std::vector<size_t> sizes, offset;
         options.filename = "";
         options.densityFilename = "gas";
-        options.densityDataset = "fields/Density_e";
+        options.densityDataset = "fields/e_chargeDensity";
         options.dataOffset.set(0, 0, 0);
         options.iteration = 0;
 


### PR DESCRIPTION
Follow up to #1259: Due to the update of the naming of some fields in hdf5, the charge conservation tools were outdated. This pull request changes the naming to the new convention. 
```
Density_e -> e_chargeDensity
``` 
