### PR TITLE
cmath: Use Correct C++ Include

### DIFF
--- a/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/erf.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/erf.tpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -25,7 +25,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 #include <limits>
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/modf.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/modf.tpp
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
 #include <cmath>
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "types.h"
-#include <math.h> /*provide host version of pow*/
+#include <cmath>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
@@ -25,7 +25,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -23,8 +23,8 @@
 #pragma once
 
 #include "types.h"
-#include <float.h>
-#include "math.h"
+#include <cfloat>
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/erf.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/erf.tpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -25,7 +25,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 #include <limits>
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/modf.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/modf.tpp
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
 #include <cmath>
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "types.h"
-#include <math.h> /*provide host version of pow*/
+#include <cmath>
 
 namespace PMacc
 {

--- a/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
@@ -25,7 +25,7 @@
 #pragma once
 
 #include "types.h"
-#include "math.h"
+#include <cmath>
 
 
 namespace PMacc

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -24,8 +24,8 @@
 #pragma once
 
 #include "types.h"
-#include <float.h>
-#include "math.h"
+#include <cfloat>
+#include <cmath>
 
 
 namespace PMacc

--- a/src/picongpu/include/fields/LaserPhysics.hpp
+++ b/src/picongpu/include/fields/LaserPhysics.hpp
@@ -25,7 +25,7 @@
 #include "fields/LaserPhysics.def"
 #include "dimensions/GridLayout.hpp"
 #include "mappings/simulation/SubGrid.hpp"
-#include <math.h>
+#include <cmath>
 
 
 


### PR DESCRIPTION
Fix all the `<cmath>` includes to be [C++](https://en.wikipedia.org/wiki/C%2B%2B_Standard_Library#C_standard_library).