### PR TITLE
Use correct pitch for cartBuffer conversion

### DIFF
--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -87,10 +87,7 @@ namespace PMacc
             cudaPitchedPtr cudaData = this->getCudaPitched();
             math::Size_t<DIM - 1> pitch;
             if(DIM >= 2)
-            {
-                assert(this->getPhysicalMemorySize()[0] == cudaData.pitch);
-                pitch[0] = this->getPhysicalMemorySize()[0];
-            }
+                pitch[0] = cudaData.pitch;
             if(DIM == 3)
                 pitch[1] = pitch[0] * this->getPhysicalMemorySize()[1];
             container::DeviceBuffer<TYPE, DIM> result((TYPE*)cudaData.ptr, this->getDataSpace(), false, pitch);

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -75,7 +75,7 @@ namespace PMacc
         {
             math::Size_t<DIM - 1> pitch;
             if(DIM >= 2)
-                pitch[0] = this->getPhysicalMemorySize()[0];
+                pitch[0] = this->getPhysicalMemorySize()[0] * sizeof(TYPE);
             if(DIM == 3)
                 pitch[1] = pitch[0] * this->getPhysicalMemorySize()[1];
             container::HostBuffer<TYPE, DIM> result(this->getBasePointer(), this->getDataSpace(), false, pitch);


### PR DESCRIPTION
`getPhysicalMemorySize()` returns the size in elements, not in bytes.
Also `getPhysicalMemorySize()[0] * sizeof(Type)` may not be the pitch for device pointers (See #1344)

@Heikman: Please merge urgently

introduced by #1094.