### PR TITLE
C Includes Examples: Fix Correct C++ Style

### DIFF
--- a/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleCurrent/include/OneParticleSimulation.hpp
@@ -43,7 +43,7 @@
 #include "nvidia/memory/MemoryInfo.hpp"
 #include "mappings/kernel/MappingDescription.hpp"
 
-#include <assert.h>
+#include <cassert>
 
 #include "plugins/PluginController.hpp"
 

--- a/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
@@ -43,7 +43,7 @@
 #include "nvidia/memory/MemoryInfo.hpp"
 #include "mappings/kernel/MappingDescription.hpp"
 
-#include <assert.h>
+#include <cassert>
 
 #include "plugins/PluginController.hpp"
 #include "particles/ParticlesInitOneParticle.hpp"

--- a/examples/SingleParticleTest/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleTest/include/OneParticleSimulation.hpp
@@ -42,7 +42,7 @@
 #include "nvidia/memory/MemoryInfo.hpp"
 #include "mappings/kernel/MappingDescription.hpp"
 
-#include <assert.h>
+#include <cassert>
 
 #include "plugins/PluginController.hpp"
 #include "particles/ParticlesInitOneParticle.hpp"

--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Heiko Burau
+ * Copyright 2013-2016 Heiko Burau, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -38,7 +38,7 @@
 #include "mappings/kernel/MappingDescription.hpp"
 #include "ArgsParser.hpp"
 
-#include <assert.h>
+#include <cassert>
 
 #include "plugins/PluginController.hpp"
 


### PR DESCRIPTION
Fix all `cassert` (RT assert) includes in PIConGPU examples to use correct [C++ include style](https://en.wikipedia.org/wiki/C%2B%2B_Standard_Library#C_standard_library) instead of C-style.