### PR TITLE
C Includes Tools: Fix Correct C++ Style

### DIFF
--- a/src/tools/livevis/server/include/VisualizationServer.h
+++ b/src/tools/livevis/server/include/VisualizationServer.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Benjamin Schneider
+ * Copyright 2013-2016 Benjamin Schneider, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -27,16 +27,16 @@
 #include <sstream>
 #include <vector>
 
-#include <string.h>
+#include <cstring>
 #include <unistd.h>
-#include <errno.h>
+#include <cerrno>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <arpa/inet.h>
-#include <signal.h>
+#include <csignal>
 #include <ifaddrs.h>
 #include <pthread.h>
 

--- a/src/tools/livevis/server/src/net/tcp_acceptor.cpp
+++ b/src/tools/livevis/server/src/net/tcp_acceptor.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Benjamin Schneider
+ * Copyright 2013-2016 Benjamin Schneider, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -20,7 +20,7 @@
 
 #include "../../include/net/tcp_acceptor.hpp"
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 #include <iostream>
 
 namespace picongpu {

--- a/src/tools/livevis/server/src/net/tcp_connector.cpp
+++ b/src/tools/livevis/server/src/net/tcp_connector.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Benjamin Schneider
+ * Copyright 2013-2016 Benjamin Schneider, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -19,7 +19,7 @@
  */
 
 #include "../../include/net/tcp_connector.hpp"
-#include <string.h>
+#include <cstring>
 
 namespace picongpu {
 namespace insituvolvis {

--- a/src/tools/splash2txt/tools_adios_parallel.cpp
+++ b/src/tools/splash2txt/tools_adios_parallel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Felix Schmitt, Conrad Schumann
+ * Copyright 2014-2016 Felix Schmitt, Conrad Schumann, Axel Huebl
  *
  * This file is part of splash2txt.
  *
@@ -21,7 +21,7 @@
  */
 
 #include <algorithm>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "tools_adios_parallel.hpp"
 


### PR DESCRIPTION
Fix all includes in PIConGPU tools to use correct [C++ include style](https://en.wikipedia.org/wiki/C%2B%2B_Standard_Library#C_standard_library) instead of C-style.

~~`stdint` is not standard before C++11 and is replaced with `<boost/cstdint.hpp>` instead.~~ (later when switched to C++11, else will change prefix to `boost` for those types)