### PR TITLE
Add LazySharedMemAllocator

### DIFF
--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -40,27 +40,24 @@ namespace CT
  * \tparam _Size compile-time vector specifying the size of the container
  */
 template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>
-class CartBuffer
+class CartBuffer : public Allocator
 {
 public:
     typedef Type type;
     typedef _Size Size;
     typedef typename Allocator::Pitch Pitch;
-    typedef cursor::CT::BufferCursor<Type, Pitch> Cursor;
+    typedef typename Allocator::Cursor Cursor;
     BOOST_STATIC_CONSTEXPR int dim = Size::dim;
     typedef zone::CT::SphericZone<_Size, typename math::CT::make_Int<dim, 0>::type> Zone;
-private:
-    Type* dataPointer;
-    //HDINLINE void init();
+
 public:
-    DINLINE CartBuffer();
-    DINLINE CartBuffer(const CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>& other);
+    HDINLINE CartBuffer();
 
     DINLINE CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>&
     operator=(const CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>& rhs);
 
     DINLINE void assign(const Type& value);
-    DINLINE Type* getDataPointer() const {return dataPointer;}
+    DINLINE Type* getDataPointer() const {return &(*this->cursor);}
 
     DINLINE cursor::CT::BufferCursor<Type, Pitch> origin() const;
     /*

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
@@ -30,9 +30,9 @@ namespace CT
 {
 
 template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>
-DINLINE CartBuffer<Type, _Size, Allocator, Copier, Assigner>::CartBuffer()
+HDINLINE CartBuffer<Type, _Size, Allocator, Copier, Assigner>::CartBuffer()
 {
-    this->dataPointer = Allocator::allocate().getMarker();
+    this->allocate();
 }
 
 template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>
@@ -40,7 +40,7 @@ DINLINE
 cursor::CT::BufferCursor<Type, typename Allocator::Pitch>
 CartBuffer<Type, _Size, Allocator, Copier, Assigner>::origin() const
 {
-    return cursor::CT::BufferCursor<Type, Pitch>(this->dataPointer);
+    return this->cursor;
 }
 
 } // CT


### PR DESCRIPTION
Add a new compile-time allocator which enables a shared memory buffer object to be constructed at host site and to allocate its memory later on the device.

Tested for the use case that allocation and access are in the same function.
If this is not the case, the program freezes. Therefore we need further investigation on this.