### PR TITLE
Synchrotron photon emission

### DIFF
--- a/examples/Bunch/cmakeFlags
+++ b/examples/Bunch/cmakeFlags
@@ -32,6 +32,7 @@
 flags[0]="-DCUDA_ARCH=sm_35"
 flags[1]="-DCUDA_ARCH=sm_35 -DPARAM_OVERWRITES:LIST=-DPARAM_INCLUDE_FIELDBACKGROUND=true"
 flags[2]="-DCUDA_ARCH=sm_35 -DPARAM_OVERWRITES:LIST=-DPARAM_INCLUDE_FIELDBACKGROUND=true;-DPARAM_DIMENSION=DIM2"
+flags[3]="-DCUDA_ARCH=sm_35 -DPARAM_OVERWRITES:LIST=-DENABLE_SYNCHROTRON_PHOTONS=1"
 
 ################################################################################
 # execution

--- a/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
@@ -79,6 +79,9 @@ namespace picongpu
 
     BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
+    //! reduced Planck constant
+    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+
     //! Charge of electron
     BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron

--- a/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
@@ -79,6 +79,9 @@ namespace picongpu
 
     BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
+    //! reduced Planck constant
+    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+
     //! Charge of electron
     BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
@@ -79,6 +79,9 @@ namespace picongpu
 
     BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
+    //! reduced Planck constant
+    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+
     //! Charge of electron
     BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron

--- a/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -339,10 +339,10 @@ struct CallSynchrotronPhotons
      * \param tuple An n-tuple containing the type-info of multiple particle species
      * \param cellDesc points to logical block information like dimension and cell sizes
      * \param currentStep The current time step
+     * \param synchrotronFunctions synchrotron functions wrapper object
      */
     template<typename T_StorageTuple, typename T_CellDescription>
-    HINLINE void operator()(
-                            T_StorageTuple& tuple,
+    HINLINE void operator()(T_StorageTuple& tuple,
                             T_CellDescription* cellDesc,
                             const uint32_t currentStep,
                             const synchrotronPhotons::SynchrotronFunctions& synchrotronFunctions) const

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -319,7 +319,7 @@ struct CallIonization
 
 }; // struct CallIonization
 
-/** Handles the synchrotronPhotons effect for electrons.
+/** Handles the synchrotron radiation emission of photons from electrons
  *
  * \tparam T_SpeciesName name of electron species
  */
@@ -330,7 +330,7 @@ struct CallSynchrotronPhotons
     typedef typename SpeciesName::type SpeciesType;
     typedef typename SpeciesType::FrameType FrameType;
     /* SelectedPhotonCreator will be either PhotonCreator or fallback: CreatorBase */
-    typedef typename GetPhotonCreator<SpeciesType>::type SelectedPhotonCreator;
+    typedef typename traits::GetPhotonCreator<SpeciesType>::type SelectedPhotonCreator;
 
     /** Functor implementation
      *
@@ -350,15 +350,6 @@ struct CallSynchrotronPhotons
     {
         typedef typename SelectedPhotonCreator::PhotonSpecies PhotonSpecies;
 
-        /* get E- and B-field */
-        DataConnector &dc = Environment<>::get().DataConnector();
-        BOOST_AUTO(fieldE,
-                 dc.getData<FieldE>(FieldE::getName(), true).getGridBuffer().
-                 getDeviceBuffer().cartBuffer());
-        BOOST_AUTO(fieldB,
-                 dc.getData<FieldB>(FieldB::getName(), true).getGridBuffer().
-                 getDeviceBuffer().cartBuffer());
-
         /* alias for pointer on source species */
         PMACC_AUTO(electronSpeciesPtr, tuple[SpeciesName()]);
         /* alias for pointer on destination species */
@@ -369,7 +360,7 @@ struct CallSynchrotronPhotons
             synchrotronFunctions.getCursor(SynchrotronFunctions::first),
             synchrotronFunctions.getCursor(SynchrotronFunctions::second));
 
-        creation::createParticles(*electronSpeciesPtr, *photonSpeciesPtr, photonCreator, cellDesc);
+        creation::createParticlesFromSpecies(*electronSpeciesPtr, *photonSpeciesPtr, photonCreator, cellDesc);
     }
 
 }; // struct CallSynchrotronPhotons

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -30,11 +30,13 @@
 #include <boost/mpl/plus.hpp>
 #include <boost/mpl/accumulate.hpp>
 
+
 #include "communication/AsyncCommunication.hpp"
 #include "particles/traits/GetIonizer.hpp"
 #include "particles/traits/FilterByFlag.hpp"
 #include "particles/traits/GetPhotonCreator.hpp"
 #include "particles/synchrotronPhotons/SynchrotronFunctions.hpp"
+#include "particles/synchrotronPhotons/PhotonCreator.hpp"
 #include "particles/creation/creation.hpp"
 
 namespace picongpu
@@ -360,14 +362,12 @@ struct CallSynchrotronPhotons
         /* alias for pointer on source species */
         PMACC_AUTO(electronSpeciesPtr, tuple[SpeciesName()]);
         /* alias for pointer on destination species */
-        PMACC_AUTO(photonSpeciesPtr,  tuple[typename MakeIdentifier<PhotonSpecies>::type()]);
+        PMACC_AUTO(photonSpeciesPtr, tuple[typename MakeIdentifier<PhotonSpecies>::type()]);
 
         using namespace synchrotronPhotons;
-
         SelectedPhotonCreator photonCreator(
             synchrotronFunctions.getCursor(SynchrotronFunctions::first),
-            synchrotronFunctions.getCursor(SynchrotronFunctions::second),
-            currentStep);
+            synchrotronFunctions.getCursor(SynchrotronFunctions::second));
 
         creation::createParticles(*electronSpeciesPtr, *photonSpeciesPtr, photonCreator, cellDesc);
     }

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -36,7 +36,6 @@
 #include "particles/traits/FilterByFlag.hpp"
 #include "particles/traits/GetPhotonCreator.hpp"
 #include "particles/synchrotronPhotons/SynchrotronFunctions.hpp"
-#include "particles/synchrotronPhotons/PhotonCreator.hpp"
 #include "particles/creation/creation.hpp"
 
 namespace picongpu

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.def
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.def
@@ -24,17 +24,17 @@ namespace picongpu
 {
 namespace particles
 {
-namespace bremsstrahlung
+namespace synchrotronPhotons
 {
 
-/** Sample point stepping */
-BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_STEP_WIDTH =
-    SYNC_FUNCS_CUTOFF / static_cast<float_64>(SYNC_FUNCS_NUM_SAMPLES - 1u);
+/**
+ *
+ * \tparam T_ElectronSpecies
+ * \tparam T_PhotonSpecies
+ */
+template<typename T_ElectronSpecies, typename T_PhotonSpecies>
+struct PhotonCreator;
 
-/** In the definition of the first synchrotron function the bessel function is integrated
- * up to infinity but in fact it is sufficient to integrate up to this constant. */
-BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_F1_INTEGRAL_BOUND = 50.0;
-
-} // namespace bremsstrahlung
+} // namespace synchrotronPhotons
 } // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.def
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.def
@@ -27,7 +27,15 @@ namespace particles
 namespace synchrotronPhotons
 {
 
-/**
+/** Functor creating photons from electrons according to synchrotron radiation.
+ *
+ * The numerical model is taken from:
+ *
+ * Gonoskov, A., et al. "Extended particle-in-cell schemes for physics
+ * in ultrastrong laser fields: Review and developments."
+ * Physical Review E 92.2 (2015): 023305.
+ *
+ * This functor is called by the general particle creation module.
  *
  * \tparam T_ElectronSpecies
  * \tparam T_PhotonSpecies

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -29,6 +29,8 @@
 #include "algorithms/math/defines/cross.hpp"
 #include "traits/frame/GetMass.hpp"
 #include "traits/frame/GetCharge.hpp"
+#include "particles/operations/Assign.hpp"
+#include "particles/operations/Deselect.hpp"
 
 #include "random/methods/XorMin.hpp"
 #include "random/distributions/Uniform.hpp"
@@ -320,11 +322,17 @@ public:
     DINLINE void operator()(Electron& electron, Photon& photon) const
     {
         photon[multiMask_] = 1;
-        photon[localCellIdx_] = electron[localCellIdx_];
-        photon[position_] = electron[position_];
         photon[momentum_] = this->photon_mom;
         electron[momentum_] -= this->photon_mom;
-        photon[weighting_] = electron[weighting_];
+        PMACC_AUTO(destPhoton,
+            deselect<
+                boost::mpl::vector<
+                    multiMask,
+                    momentum
+                >
+            >(photon)
+        );
+        particles::operations::assign( destPhoton, electron );
     }
 };
 

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -284,8 +284,12 @@ public:
 
         if(this->randomGen() < x)
         {
-            this->photon_mom = mom_norm * z*z*z * mass*c * gamma * particle[weighting_];
-            return 1;
+            const float_X photonMom_abs = z*z*z * mass*c * gamma;
+            if(photonMom_abs > SOFT_PHOTONS_CUTOFF_MOM)
+            {
+                this->photon_mom = mom_norm * photonMom_abs * particle[weighting_];
+                return 1;
+            }
         }
 
         return 0;

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -1,0 +1,290 @@
+/**
+ * Copyright 2015-2016 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "SynchrotronFunctions.hpp"
+#include "pmacc_types.hpp"
+#include "algorithms/Gamma.hpp"
+#include "algorithms/math/defines/sqrt.hpp"
+#include "algorithms/math/defines/dot.hpp"
+#include "algorithms/math/defines/cross.hpp"
+#include "traits/frame/GetMass.hpp"
+#include "traits/frame/GetCharge.hpp"
+
+#include "traits/Resolve.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+
+#include "fields/FieldB.hpp"
+#include "fields/FieldE.hpp"
+
+#include "compileTime/conversion/TypeToPointerPair.hpp"
+#include "memory/boxes/DataBox.hpp"
+
+// Random number generator
+#include "particles/ionization/ionizationMethods.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace synchrotronPhotons
+{
+
+/**
+ *
+ * \tparam T_ElectronSpecies
+ * \tparam T_PhotonSpecies
+ */
+template<typename T_ElectronSpecies, typename T_PhotonSpecies>
+struct PhotonCreator
+{
+    typedef T_ElectronSpecies ElectronSpecies;
+    typedef T_PhotonSpecies PhotonSpecies;
+
+    typedef typename ElectronSpecies::FrameType FrameType;
+
+    /* specify field to particle interpolation scheme */
+    typedef typename PMacc::traits::Resolve<
+        typename GetFlagType<FrameType,interpolation<> >::type
+        >::type Field2ParticleInterpolation;
+
+    /* margins around the supercell for the interpolation of the field on the cells */
+    typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
+    typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+
+    /* relevant area of a block */
+    typedef SuperCellDescription<
+        typename MappingDesc::SuperCellSize,
+        LowerMargin,
+        UpperMargin
+        > BlockArea;
+
+    BlockArea BlockDescription;
+
+    typedef MappingDesc::SuperCellSize TVec;
+
+    typedef FieldE::ValueType ValueType_E;
+    typedef FieldB::ValueType ValueType_B;
+
+private:
+    /* global memory EM-field device databoxes */
+    PMACC_ALIGN(eBox, FieldE::DataBoxType);
+    PMACC_ALIGN(bBox, FieldB::DataBoxType);
+    /* shared memory EM-field device databoxes */
+    PMACC_ALIGN(cachedE, DataBox<SharedBox<ValueType_E, typename BlockArea::FullSuperCellSize,1> >);
+    PMACC_ALIGN(cachedB, DataBox<SharedBox<ValueType_B, typename BlockArea::FullSuperCellSize,0> >);
+
+    PMACC_ALIGN(curF_1, SynchrotronFunctions::SyncFuncCursor);
+    PMACC_ALIGN(curF_2, SynchrotronFunctions::SyncFuncCursor);
+
+    PMACC_ALIGN(photon_mom, float3_X);
+
+    /* random number generator for Monte Carlo */
+    typedef ionization::RandomNrForMonteCarlo<T_ElectronSpecies> RandomGen;
+    /* \todo fix: cannot PMACC_ALIGN() because it seems to be too large */
+    RandomGen randomGen;
+
+public:
+    /* host constructor initializing member : random number generator */
+    PhotonCreator(
+        const SynchrotronFunctions::SyncFuncCursor& curF_1,
+        const SynchrotronFunctions::SyncFuncCursor& curF_2,
+        const uint32_t currentStep)
+            : curF_1(curF_1),
+              curF_2(curF_2),
+              randomGen(currentStep),
+              photon_mom(float3_X::create(0))
+    {
+        DataConnector &dc = Environment<>::get().DataConnector();
+        /* initialize pointers on host-side E-(B-)field databoxes */
+        FieldE* fieldE = &(dc.getData<FieldE > (FieldE::getName(), true));
+        FieldB* fieldB = &(dc.getData<FieldB > (FieldB::getName(), true));
+        /* initialize device-side E-(B-)field databoxes */
+        eBox = fieldE->getDeviceDataBox();
+        bBox = fieldB->getDeviceDataBox();
+    }
+
+    /** Initialization function on device
+     *
+     * \brief Cache EM-fields on device
+     *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+     *
+     * This function will be called inline on the device which must happen BEFORE threads diverge
+     * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+     * initializing the E-/B-field shared boxes in shared memory.
+     */
+    DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& localCellOffset)
+    {
+        /* caching of E and B fields */
+        cachedB = CachedBox::create < 0, ValueType_B > (BlockArea());
+        cachedE = CachedBox::create < 1, ValueType_E > (BlockArea());
+
+        /* instance of nvidia assignment operator */
+        nvidia::functors::Assign assign;
+        /* copy fields from global to shared */
+        PMACC_AUTO(fieldBBlock, bBox.shift(blockCell));
+        ThreadCollective<BlockArea> collective(linearThreadIdx);
+        collective(
+                  assign,
+                  cachedB,
+                  fieldBBlock
+                  );
+        /* copy fields from global to shared */
+        PMACC_AUTO(fieldEBlock, eBox.shift(blockCell));
+        collective(
+                  assign,
+                  cachedE,
+                  fieldEBlock
+                  );
+
+        /* wait for shared memory to be initialized */
+        __syncthreads();
+
+        /* initialize random number generator with the local cell index in the simulation*/
+        this->randomGen.init(localCellOffset);
+    }
+
+    DINLINE float_X emission_prob(
+        const float_X delta,
+        const float_X chi,
+        const float_X gamma,
+        const float_X mass,
+        const float_X charge) const
+    {
+
+        if(enableQEDTerm)
+        {
+            // quantum
+            const float_X z = float_X(2.0/3.0) * delta / ((float_X(1.0) - delta) * chi);
+
+            return DELTA_T * charge*charge * mass*SPEED_OF_LIGHT / (float_X(4.0)*PI*EPS0 * HBAR*HBAR) *
+                float_X(1.732050807) / (float_X(2.0) * PI) * chi/gamma * (float_X(1.0) - delta) / delta *
+                (this->curF_1[z] + float_X(1.5) * delta * chi * z * this->curF_2[z]);
+        }
+        else
+        {
+            // classical
+            const float_X z = float_X(2.0/3.0) * delta / chi;
+
+            return DELTA_T * charge*charge * mass*SPEED_OF_LIGHT / (float_X(4.0)*PI*EPS0 * HBAR*HBAR) *
+                float_X(1.732050807) / (float_X(2.0) * PI) * chi/gamma / delta * this->curF_1[z];
+        }
+    }
+
+    DINLINE float_X emission_prob_modified(
+        const float_X z,
+        const float_X chi,
+        const float_X gamma,
+        const float_X mass,
+        const float_X charge) const
+    {
+        return float_X(3.0) * z*z * emission_prob(
+            z*z*z,
+            chi, gamma, mass, charge);
+    }
+
+    /** Return the number of target particles to be created from each source particle.
+     *
+     * Called for each frame of the source species.
+     *
+     * @param sourceFrame Frame of the source species
+     * @param localIdx Index of the source particle within frame
+     * @return number of particle to be created from each source particle
+     */
+    DINLINE unsigned int numNewParticles(FrameType& sourceFrame, int localIdx)
+    {
+        using namespace PMacc::algorithms;
+
+        PMACC_AUTO(particle, sourceFrame[localIdx]);
+
+        /* particle position, used for field-to-particle interpolation */
+        floatD_X pos = particle[position_];
+        const int particleCellIdx = particle[localCellIdx_];
+        /* multi-dim coordinate of the local cell inside the super cell */
+        DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
+        /* interpolation of E- */
+        const fieldSolver::numericalCellType::traits::FieldPosition<FieldE> fieldPosE;
+        ValueType_E fieldE = Field2ParticleInterpolation()
+            (cachedE.shift(localCell).toCursor(), pos, fieldPosE());
+        /*                     and B-field on the particle position */
+        const fieldSolver::numericalCellType::traits::FieldPosition<FieldB> fieldPosB;
+        ValueType_B fieldB = Field2ParticleInterpolation()
+            (cachedB.shift(localCell).toCursor(), pos, fieldPosB());
+
+        const float3_X mom = particle[momentum_] / particle[weighting_];
+        const float_X mom2 = math::dot(mom, mom);
+        const float3_X mom_norm = mom * math::rsqrt(mom2);
+        const float_X mass = frame::getMass<FrameType>();
+
+        const float_X gamma = Gamma<>()(mom, mass);
+        const float3_X vel = mom / (gamma * mass); // low accuracy?
+
+        const float3_X lorentz = fieldE + math::cross(vel, fieldB);
+        const float_X lorentz2 = math::dot(lorentz, lorentz);
+        const float_X fieldE_long = math::dot(mom_norm, fieldE);
+
+        const float_X H_eff = math::sqrt(lorentz2 - fieldE_long*fieldE_long);
+
+        const float_X charge = math::abs(frame::getCharge<FrameType>());
+
+        // Schwinger limit, unit: V/m
+        const float_X c = SPEED_OF_LIGHT;
+        const float_X E_S = mass*mass * c*c*c / (charge * HBAR);
+        const float_X chi = gamma * H_eff / E_S;
+
+        const float_X z = this->randomGen();
+        if(z == float_X(0.0) || z == float_X(1.0))
+            return 0;
+
+        const float_X x = emission_prob_modified(z, chi, gamma, mass, charge);
+
+        if(this->randomGen() < x)
+        {
+            this->photon_mom = mom_norm * z*z*z * mass*c * gamma * particle[weighting_];
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /** Functor implementation.
+     *
+     * Called once for each single particle creation.
+     *
+     * \tparam Electron type of electron which creates the photon
+     * \tparam Photon type of photon that is created
+     */
+    template<typename Electron, typename Photon>
+    DINLINE void operator()(Electron& electron, Photon& photon) const
+    {
+        photon[multiMask_] = 1;
+        photon[localCellIdx_] = electron[localCellIdx_];
+        photon[position_] = electron[position_];
+        photon[momentum_] = this->photon_mom;
+        electron[momentum_] -= this->photon_mom;
+        photon[weighting_] = electron[weighting_];
+    }
+};
+
+} // namespace synchrotronPhotons
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "simulation_defines.hpp"
+
 #include "cuSTL/container/HostBuffer.hpp"
 #include "cuSTL/cursor/Cursor.hpp"
 #include "cuSTL/cursor/navigator/PlusNavigator.hpp"
@@ -33,7 +34,7 @@ namespace picongpu
 {
 namespace particles
 {
-namespace bremsstrahlung
+namespace synchrotronPhotons
 {
 
 namespace detail
@@ -120,6 +121,6 @@ public:
 
 }; // class SynchrotronFunctions
 
-} // namespace bremsstrahlung
+} // namespace synchrotronPhotons
 } // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -25,7 +25,7 @@
 #include "cuSTL/container/HostBuffer.hpp"
 #include "cuSTL/cursor/Cursor.hpp"
 #include "cuSTL/cursor/navigator/PlusNavigator.hpp"
-#include "cuSTL/cursor/tools/LinearInterp1D.hpp"
+#include "cuSTL/cursor/tools/LinearInterp.hpp"
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include <boost/shared_ptr.hpp>
 #include <boost/math/tr1.hpp> /* cyl_bessel_k */
@@ -46,7 +46,7 @@ namespace detail
 struct MapToLookupTable
 {
     typedef typename ::PMacc::result_of::Functor<
-        ::PMacc::cursor::tools::LinearInterp1D<float_X>,
+        ::PMacc::cursor::tools::LinearInterp<float_X>,
         ::PMacc::cursor::BufferCursor<float_X, DIM1> >::type LinInterpCursor;
 
     typedef float_X type;

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "particles/bremsstrahlung/SynchrotronFunctions.hpp"
+#include "particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 #include "simulation_defines.hpp"
 #include <boost/array.hpp>
 #include <boost/numeric/odeint/integrate/integrate.hpp>

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -127,7 +127,7 @@ SynchrotronFunctions::getCursor(SynchrotronFunctions::Select syncFunction) const
     using namespace PMacc;
 
     detail::MapToLookupTable::LinInterpCursor linInterpCursor =
-        cursor::tools::LinearInterp1D<float_X>()(this->dBuf_SyncFuncs[syncFunction]->origin());
+        cursor::tools::LinearInterp<float_X>()(this->dBuf_SyncFuncs[syncFunction]->origin());
 
     return cursor::make_Cursor(
         detail::MapToLookupTable(linInterpCursor),

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -30,7 +30,7 @@ namespace picongpu
 {
 namespace particles
 {
-namespace bremsstrahlung
+namespace synchrotronPhotons
 {
 
 namespace detail
@@ -135,8 +135,6 @@ SynchrotronFunctions::getCursor(SynchrotronFunctions::Select syncFunction) const
         float_X(0.0));
 }
 
-
-
-} // namespace bremsstrahlung
+} // namespace synchrotronPhotons
 } // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -38,8 +38,6 @@ struct GetPhotonCreator
     typedef T_SpeciesType SpeciesType;
     typedef typename SpeciesType::FrameType FrameType;
 
-    typedef typename HasFlag<FrameType, synchrotronPhotons<> >::type hasSynchrotronPhotons;
-
     /* The following line only fetches the alias */
     typedef typename GetFlagType<FrameType, synchrotronPhotons<> >::type FoundSynchrotronPhotonsAlias;
 

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -30,11 +30,12 @@
 
 namespace picongpu
 {
+namespace traits
+{
 
 template<typename T_SpeciesType>
 struct GetPhotonCreator
 {
-
     typedef T_SpeciesType SpeciesType;
     typedef typename SpeciesType::FrameType FrameType;
 
@@ -49,4 +50,5 @@ struct GetPhotonCreator
 
 }; // struct GetPhotonCreator
 
-}// namespace picongpu
+} // namespace traits
+} // namespace picongpu

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -45,8 +45,8 @@ struct GetPhotonCreator
     /* This now resolves the alias into the actual object type */
     typedef typename PMacc::traits::Resolve<FoundSynchrotronPhotonsAlias>::type FoundPhotonSpecies;
 
-    /* This specifies the source species as the second template parameter of the photon creator */
-    typedef particles::synchrotronPhotons::PhotonCreator<T_SpeciesType, FoundPhotonSpecies> type;
+    /* This specifies the target species as the second template parameter of the photon creator */
+    typedef particles::synchrotronPhotons::PhotonCreator<SpeciesType, FoundPhotonSpecies> type;
 
 }; // struct GetPhotonCreator
 

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Heiko Burau
+ * Copyright 2015-2016 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "pmacc_types.hpp"
+#include "particles/memory/frames/Frame.hpp"
+#include "traits/GetFlagType.hpp"
+#include "traits/Resolve.hpp"
+
+#include "particles/synchrotronPhotons/PhotonCreator.def"
+
+namespace picongpu
+{
+
+template<typename T_SpeciesType>
+struct GetPhotonCreator
+{
+
+    typedef T_SpeciesType SpeciesType;
+    typedef typename SpeciesType::FrameType FrameType;
+
+    typedef typename HasFlag<FrameType, synchrotronPhotons<> >::type hasSynchrotronPhotons;
+
+    /* The following line only fetches the alias */
+    typedef typename GetFlagType<FrameType, synchrotronPhotons<> >::type FoundSynchrotronPhotonsAlias;
+
+    /* This now resolves the alias into the actual object type */
+    typedef typename PMacc::traits::Resolve<FoundSynchrotronPhotonsAlias>::type FoundPhotonSpecies;
+
+    /* This specifies the source species as the second template parameter of the photon creator */
+    typedef particles::synchrotronPhotons::PhotonCreator<T_SpeciesType, FoundPhotonSpecies> type;
+
+}; // struct GetPhotonCreator
+
+}// namespace picongpu

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -348,8 +348,10 @@ public:
         PMacc::GridController<simDim>& gridCon = PMacc::Environment<simDim>::get().GridController();
         this->rngFactory->init(gridCon.getScalarPosition());
 
-        // Initialize synchrotron functions
+#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
+        // Initialize synchrotron functions, allocate lookup table
         this->synchrotronFunctions.init();
+#endif
     }
 
     virtual uint32_t fillSimulation()

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -446,14 +446,14 @@ public:
         ForEach<VectorSpeciesWithIonizer, particles::CallIonization<bmpl::_1>, MakeIdentifier<bmpl::_1> > particleIonization;
         particleIonization(forward(particleStorage), cellDescription, currentStep);
 
-        /* SynchrotronPhotons */
+        /* call the synchrotron radiation module for each radiating species (normally electrons) */
         typedef typename PMacc::particles::traits::FilterByFlag<VectorAllSpecies,
                                                                 synchrotronPhotons<> >::type AllSynchrotronPhotonsSpecies;
 
         ForEach<AllSynchrotronPhotonsSpecies,
                 particles::CallSynchrotronPhotons<bmpl::_1>,
-                MakeIdentifier<bmpl::_1> > electronSynchrotronPhotons;
-        electronSynchrotronPhotons(forward(particleStorage), cellDescription, currentStep, this->synchrotronFunctions);
+                MakeIdentifier<bmpl::_1> > synchrotronRadiation;
+        synchrotronRadiation(forward(particleStorage), cellDescription, currentStep, this->synchrotronFunctions);
 
 
         EventTask initEvent = __getTransactionEvent();

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -348,10 +348,13 @@ public:
         PMacc::GridController<simDim>& gridCon = PMacc::Environment<simDim>::get().GridController();
         this->rngFactory->init(gridCon.getScalarPosition());
 
-#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
-        // Initialize synchrotron functions, allocate lookup table
-        this->synchrotronFunctions.init();
-#endif
+        // Initialize synchrotron functions, if there are synchrotron photon species
+        typedef typename PMacc::particles::traits::FilterByFlag<VectorAllSpecies,
+                                                                synchrotronPhotons<> >::type AllSynchrotronPhotonsSpecies;
+        if(!bmpl::empty<AllSynchrotronPhotonsSpecies>::value)
+        {
+            this->synchrotronFunctions.init();
+        }
     }
 
     virtual uint32_t fillSimulation()

--- a/src/picongpu/include/simulation_defines/_defaultParam.loader
+++ b/src/picongpu/include/simulation_defines/_defaultParam.loader
@@ -39,6 +39,7 @@
 #include "simulation_defines/param/speciesAttributes.param"
 #include "simulation_defines/param/gasConfig.param"
 #include "simulation_defines/param/particleConfig.param"
+#include "simulation_defines/param/synchrotronPhotons.param"
 #include "simulation_defines/param/species.param"
 #include "simulation_defines/param/speciesDefinition.param"
 #include "simulation_defines/param/speciesInitialization.param"
@@ -49,5 +50,4 @@
 #include "simulation_defines/param/fileOutput.param"
 #include "simulation_defines/param/fieldBackground.param"
 #include "simulation_defines/param/radiationObserver.param"
-#include "simulation_defines/param/synchrotronPhotons.param"
 #include "simulation_defines/param/particleCalorimeter.param"

--- a/src/picongpu/include/simulation_defines/_defaultParam.loader
+++ b/src/picongpu/include/simulation_defines/_defaultParam.loader
@@ -49,5 +49,5 @@
 #include "simulation_defines/param/fileOutput.param"
 #include "simulation_defines/param/fieldBackground.param"
 #include "simulation_defines/param/radiationObserver.param"
-#include "simulation_defines/param/bremsstrahlung.param"
+#include "simulation_defines/param/synchrotronPhotons.param"
 #include "simulation_defines/param/particleCalorimeter.param"

--- a/src/picongpu/include/simulation_defines/_defaultUnitless.loader
+++ b/src/picongpu/include/simulation_defines/_defaultUnitless.loader
@@ -43,4 +43,4 @@
 #include "simulation_defines/unitless/fieldBackground.unitless"
 #include "simulation_defines/unitless/fileOutput.unitless"
 #include "simulation_defines/unitless/checkpoints.unitless"
-#include "simulation_defines/unitless/bremsstrahlung.unitless"
+#include "simulation_defines/unitless/synchrotronPhotons.unitless"

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -38,6 +38,11 @@ namespace picongpu
         BOOST_CONSTEXPR_OR_CONST float_64 EPS0_SI = 1.0 / MUE0_SI / SPEED_OF_LIGHT_SI
             / SPEED_OF_LIGHT_SI;
 
+        /** reduced Planck constant
+         * unit: J * s
+         */
+        BOOST_CONSTEXPR_OR_CONST float_64 HBAR_SI = 1.054571800e-34;
+
         // Electron properties
         /** unit: kg */
         BOOST_CONSTEXPR_OR_CONST float_64 ELECTRON_MASS_SI = 9.109382e-31;

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl
+ * Copyright 2014-2016 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl, Heiko Burau
  *
  * This file is part of PIConGPU.
  *
@@ -96,6 +96,9 @@ alias(ionizer);
 
 /*! alias for ionization energy container @see ionizationEnergies.param */
 alias(ionizationEnergies);
+
+/*! alias for synchrotronPhotons @see speciesDefinition.param */
+alias(synchrotronPhotons)
 
 /*! alias for particle to field interpolation @see species.param */
 alias(interpolation);

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2016 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *
@@ -71,6 +71,29 @@ AttributRadiationFlag
 
 /*########################### define species #################################*/
 
+/*--------------------------- photons -------------------------------------------*/
+
+value_identifier(float_X, DummyMass, 1.0);
+value_identifier(float_X, DummyCharge, 0.0);
+
+typedef bmpl::vector<
+    particlePusher<particles::pusher::Photon>,
+    shape<UsedParticleShape>,
+    interpolation<UsedField2Particle>,
+    current<UsedParticleCurrentSolver>,
+    massRatio<DummyMass>,
+    chargeRatio<DummyCharge>
+> ParticleFlagsPhotons;
+
+/*define species photons*/
+typedef Particles<
+    ParticleDescription<
+        bmpl::string<'p', 'h'>,
+        SuperCellSize,
+        DefaultAttributesSeq,
+        ParticleFlagsPhotons
+    >
+> PIC_Photons;
 
 /*--------------------------- electrons --------------------------------------*/
 
@@ -84,7 +107,8 @@ typedef bmpl::vector<
     interpolation<UsedField2Particle>,
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioElectrons>,
-    chargeRatio<ChargeRatioElectrons>
+    chargeRatio<ChargeRatioElectrons>,
+    synchrotronPhotons<PIC_Photons>
 > ParticleFlagsElectrons;
 
 /*define specie electrons*/
@@ -142,7 +166,8 @@ PIC_Ions
 
 typedef MakeSeq<
 Species1,
-Species2
+Species2,
+PIC_Photons
 >::type VectorAllSpecies;
 
 

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -73,6 +73,8 @@ AttributRadiationFlag
 
 /*--------------------------- photons -------------------------------------------*/
 
+#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
+
 value_identifier(float_X, DummyMass, 1.0);
 value_identifier(float_X, DummyCharge, 0.0);
 
@@ -95,6 +97,8 @@ typedef Particles<
     >
 > PIC_Photons;
 
+#endif // ENABLE_SYNCHROTRON_PHOTONS
+
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
@@ -107,8 +111,10 @@ typedef bmpl::vector<
     interpolation<UsedField2Particle>,
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioElectrons>,
-    chargeRatio<ChargeRatioElectrons>,
-    synchrotronPhotons<PIC_Photons>
+    chargeRatio<ChargeRatioElectrons>
+#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
+    , synchrotronPhotons<PIC_Photons>
+#endif
 > ParticleFlagsElectrons;
 
 /*define specie electrons*/
@@ -166,8 +172,10 @@ PIC_Ions
 
 typedef MakeSeq<
 Species1,
-Species2,
-PIC_Photons
+Species2
+#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
+, PIC_Photons
+#endif
 >::type VectorAllSpecies;
 
 

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -172,10 +172,21 @@ PIC_Ions
 typedef MakeSeq<
 Species1,
 Species2
-#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
-, PIC_Photons
-#endif
->::type VectorAllSpecies;
+>::type VectorSpeciesTmp;
 
+// If there are species containing the `synchrotronPhotons` alias, add photon species to `VectorAllSpecies`
+typedef typename PMacc::particles::traits::FilterByFlag<
+    VectorSpeciesTmp,
+    synchrotronPhotons<>
+>::type AllSynchrotronPhotonsSpecies;
+
+typedef bmpl::if_<
+    bmpl::empty<AllSynchrotronPhotonsSpecies>,
+    VectorSpeciesTmp,
+    typename MakeSeq<
+        VectorSpeciesTmp,
+        PIC_Photons
+    >::type
+>::type VectorAllSpecies;
 
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -30,6 +30,7 @@
 #include "identifier/alias.hpp"
 #include "identifier/value_identifier.hpp"
 
+#include "particles/traits/FilterByFlag.hpp"
 #include "particles/Particles.hpp"
 #include "particles/ParticleDescription.hpp"
 #include <boost/mpl/string.hpp>
@@ -73,8 +74,6 @@ AttributRadiationFlag
 
 /*--------------------------- photons -------------------------------------------*/
 
-#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
-
 value_identifier(float_X, DummyMass, 1.0);
 value_identifier(float_X, DummyCharge, 0.0);
 
@@ -82,6 +81,7 @@ typedef bmpl::vector<
     particlePusher<particles::pusher::Photon>,
     shape<UsedParticleShape>,
     interpolation<UsedField2Particle>,
+    current<UsedParticleCurrentSolver>,
     massRatio<DummyMass>,
     chargeRatio<DummyCharge>
 > ParticleFlagsPhotons;
@@ -95,8 +95,6 @@ typedef Particles<
         ParticleFlagsPhotons
     >
 > PIC_Photons;
-
-#endif // ENABLE_SYNCHROTRON_PHOTONS
 
 /*--------------------------- electrons --------------------------------------*/
 
@@ -180,7 +178,7 @@ typedef typename PMacc::particles::traits::FilterByFlag<
     synchrotronPhotons<>
 >::type AllSynchrotronPhotonsSpecies;
 
-typedef bmpl::if_<
+typedef typename bmpl::if_<
     bmpl::empty<AllSynchrotronPhotonsSpecies>,
     VectorSpeciesTmp,
     typename MakeSeq<

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -170,21 +170,9 @@ PIC_Ions
 typedef MakeSeq<
 Species1,
 Species2
->::type VectorSpeciesTmp;
-
-// If there are species containing the `synchrotronPhotons` alias, add photon species to `VectorAllSpecies`
-typedef typename PMacc::particles::traits::FilterByFlag<
-    VectorSpeciesTmp,
-    synchrotronPhotons<>
->::type AllSynchrotronPhotonsSpecies;
-
-typedef typename bmpl::if_<
-    bmpl::empty<AllSynchrotronPhotonsSpecies>,
-    VectorSpeciesTmp,
-    typename MakeSeq<
-        VectorSpeciesTmp,
-        PIC_Photons
-    >::type
+#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
+,PIC_Photons
+#endif
 >::type VectorAllSpecies;
 
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -82,7 +82,6 @@ typedef bmpl::vector<
     particlePusher<particles::pusher::Photon>,
     shape<UsedParticleShape>,
     interpolation<UsedField2Particle>,
-    current<UsedParticleCurrentSolver>,
     massRatio<DummyMass>,
     chargeRatio<DummyCharge>
 > ParticleFlagsPhotons;

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -24,8 +24,10 @@ namespace picongpu
 {
 namespace particles
 {
-namespace bremsstrahlung
+namespace synchrotronPhotons
 {
+
+BOOST_CONSTEXPR_OR_CONST bool enableQEDTerm = false;
 
 /** Above this value (to the power of three, see comments on mapping) the synchrotron functions are nearly zero. */
 BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_CUTOFF = 5.0;
@@ -36,6 +38,6 @@ BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_BESSEL_INTEGRAL_STEPWIDTH = 1.0e-3;
 /** Number of sampling points of the lookup table */
 BOOST_CONSTEXPR_OR_CONST uint32_t SYNC_FUNCS_NUM_SAMPLES = 8192;
 
-} // namespace bremsstrahlung
+} // namespace synchrotronPhotons
 } // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -27,8 +27,10 @@ namespace particles
 namespace synchrotronPhotons
 {
 
+/** enable synchtrotron photon emission */
 #define ENABLE_SYNCHROTRON_PHOTONS 0
 
+/** enable (disable) QED (classical) photon emission spectrum */
 BOOST_CONSTEXPR_OR_CONST bool enableQEDTerm = false;
 
 /** Above this value (to the power of three, see comments on mapping) the synchrotron functions are nearly zero. */
@@ -40,8 +42,13 @@ BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_BESSEL_INTEGRAL_STEPWIDTH = 1.0e-3;
 /** Number of sampling points of the lookup table */
 BOOST_CONSTEXPR_OR_CONST uint32_t SYNC_FUNCS_NUM_SAMPLES = 8192;
 
-/** Photons softer than this ratio: (2pi / omega) / DELTA_T, are neglected */
+/** Photons of oszillation periods greater than a timestep are not created since the grid already accounts for them.
+ * This cutoff ratio is defined as: photon-oszillation-period / timestep */
 BOOST_CONSTEXPR_OR_CONST float_64 SOFT_PHOTONS_CUTOFF_RATIO = 1.0;
+
+/** if the emission probability per timestep is higher than this value and the log level is set to
+ *  "CRITICAL" a warning will be raised. */
+BOOST_CONSTEXPR_OR_CONST float_64 SINGLE_EMISSION_PROB_LIMIT = 0.4;
 
 } // namespace synchrotronPhotons
 } // namespace particles

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -28,7 +28,9 @@ namespace synchrotronPhotons
 {
 
 /** enable synchtrotron photon emission */
+#ifndef ENABLE_SYNCHROTRON_PHOTONS
 #define ENABLE_SYNCHROTRON_PHOTONS 0
+#endif
 
 /** enable (disable) QED (classical) photon emission spectrum */
 BOOST_CONSTEXPR_OR_CONST bool enableQEDTerm = false;

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -40,6 +40,9 @@ BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_BESSEL_INTEGRAL_STEPWIDTH = 1.0e-3;
 /** Number of sampling points of the lookup table */
 BOOST_CONSTEXPR_OR_CONST uint32_t SYNC_FUNCS_NUM_SAMPLES = 8192;
 
+/** Photons softer than this ratio: (2pi / omega) / DELTA_T, are neglected */
+BOOST_CONSTEXPR_OR_CONST float_64 SOFT_PHOTONS_CUTOFF_RATIO = 1.0;
+
 } // namespace synchrotronPhotons
 } // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -27,6 +27,8 @@ namespace particles
 namespace synchrotronPhotons
 {
 
+#define ENABLE_SYNCHROTRON_PHOTONS 0
+
 BOOST_CONSTEXPR_OR_CONST bool enableQEDTerm = false;
 
 /** Above this value (to the power of three, see comments on mapping) the synchrotron functions are nearly zero. */

--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -80,6 +80,9 @@ namespace picongpu
 
     BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
+    //! reduced Planck constant
+    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+
     //! Charge of electron
     BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron

--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015-2016 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace synchrotronPhotons
+{
+
+/** Sample point stepping */
+BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_STEP_WIDTH =
+    SYNC_FUNCS_CUTOFF / static_cast<float_64>(SYNC_FUNCS_NUM_SAMPLES - 1u);
+
+/** In the definition of the first synchrotron function the bessel function is integrated
+ * up to infinity but in fact it is sufficient to integrate up to this constant. */
+BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_F1_INTEGRAL_BOUND = 50.0;
+
+} // namespace synchrotronPhotons
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
@@ -35,6 +35,11 @@ BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_STEP_WIDTH =
  * up to infinity but in fact it is sufficient to integrate up to this constant. */
 BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_F1_INTEGRAL_BOUND = 50.0;
 
+BOOST_CONSTEXPR_OR_CONST float_X SOFT_PHOTONS_CUTOFF_MOM = static_cast<float_X>(
+    HBAR * 2.0 * M_PI / SOFT_PHOTONS_CUTOFF_RATIO / DELTA_T / SPEED_OF_LIGHT);
+
 } // namespace synchrotronPhotons
 } // namespace particles
 } // namespace picongpu
+
+#include "particles/synchrotronPhotons/PhotonCreator.hpp"


### PR DESCRIPTION
Implement synchrotron radiation of photons for electrons. It takes the numerical model from:
 > Gonoskov, A., et al. "Extended particle-in-cell schemes for physics in ultrastrong laser fields: Review and developments." Physical Review E 92.2 (2015): 023305.

**Dependencies:**
 - [x] #1353 
 - [x] #1459 
 - [x] ~~add support for optional memory usage for the RNG~~ -> done via check of radiation electrons
 - [x] check register memory usage for critical log output
 - [x] remove pre-compiler flag as switch from param
 - [x] use pre-compiler flag in cmake compile test

### Tests
#### Synchrotron radiation in the classical regime

Photon spectrum:
![photon_spec_t_0](https://cloud.githubusercontent.com/assets/5159590/11719968/7d2eb16e-9f5d-11e5-840c-7feeaad7e148.png)
Zoom:
![photon_spec_t_0_zoom](https://cloud.githubusercontent.com/assets/5159590/11719981/88348d9a-9f5d-11e5-9d4b-59e105d634a5.png)

**legend:**
green: analytical result
blue: simulation result, error bars: statistical error

### Known Issues
 - ~~photons are created, but they don't move despite of the photon pusher.~~
 - ~~ugly compiler warnings.~~