### PR TITLE
Split off HostDeviceBuffer from GridBuffer

### DIFF
--- a/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
@@ -47,7 +47,7 @@ namespace PMacc
     {
     public:
 
-        ExchangeIntern(DeviceBufferIntern<TYPE, DIM>& source, GridLayout<DIM> memoryLayout, DataSpace<DIM> guardingCells, uint32_t exchange,
+        ExchangeIntern(DeviceBuffer<TYPE, DIM>& source, GridLayout<DIM> memoryLayout, DataSpace<DIM> guardingCells, uint32_t exchange,
                        uint32_t communicationTag, uint32_t area = BORDER, bool sizeOnDevice = false) :
         Exchange<TYPE, DIM>(exchange, communicationTag), deviceDoubleBuffer(NULL)
         {

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2016 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -27,8 +27,7 @@
 #include "mappings/simulation/EnvironmentController.hpp"
 #include "memory/dataTypes/Mask.hpp"
 #include "memory/buffers/ExchangeIntern.hpp"
-#include "memory/buffers/HostBufferIntern.hpp"
-#include "memory/buffers/DeviceBufferIntern.hpp"
+#include "memory/buffers/HostDeviceBuffer.hpp"
 
 #include <sstream>
 #include <stdexcept>
@@ -88,11 +87,12 @@ private:
  * @tparam BORDERTYPE optional type for border data in the buffers. TYPE is used by default.
  */
 template <class TYPE, unsigned DIM, class BORDERTYPE = TYPE>
-class GridBuffer
+class GridBuffer: public HostDeviceBuffer<TYPE, DIM>
 {
+    typedef HostDeviceBuffer<TYPE, DIM> Parent;
 public:
 
-    typedef DataBox<PitchedBox<TYPE, DIM> > DataBoxType;
+    typedef typename Parent::DataBoxType DataBoxType;
 
     /**
      * Constructor.
@@ -101,11 +101,10 @@ public:
      * @param sizeOnDevice if true, size information exists on device, too.
      */
     GridBuffer(const GridLayout<DIM>& gridLayout, bool sizeOnDevice = false) :
-    gridLayout(gridLayout),
-    hasOneExchange(false),
-    maxExchange(0)
+    Parent(gridLayout.getDataSpace(), sizeOnDevice),
+    gridLayout(gridLayout)
     {
-        init(sizeOnDevice);
+        init();
     }
 
     /**
@@ -118,12 +117,11 @@ public:
      *        performance on host-device copies, but some algorithms on the device
      *        might need to know the size of the buffer)
      */
-    GridBuffer(DataSpace<DIM>& dataSpace, bool sizeOnDevice = false) :
-    gridLayout(GridLayout<DIM>(dataSpace)),
-    hasOneExchange(false),
-    maxExchange(0)
+    GridBuffer(const DataSpace<DIM>& dataSpace, bool sizeOnDevice = false) :
+    Parent(dataSpace, sizeOnDevice),
+    gridLayout(dataSpace)
     {
-        init(sizeOnDevice);
+        init();
     }
 
     /**
@@ -137,39 +135,24 @@ public:
      *        performance on host-device copies, but some algorithms on the device
      *        might need to know the size of the buffer)
      */
-    GridBuffer(DeviceBuffer<TYPE, DIM>& otherDeviceBuffer, GridLayout<DIM> gridLayout, bool sizeOnDevice = false) :
-    gridLayout(gridLayout),
-    hasOneExchange(false),
-    maxExchange(0)
+    GridBuffer(DeviceBuffer<TYPE, DIM>& otherDeviceBuffer, const GridLayout<DIM>& gridLayout, bool sizeOnDevice = false) :
+    Parent(otherDeviceBuffer, gridLayout.getDataSpace(), sizeOnDevice),
+    gridLayout(gridLayout)
     {
-        init(sizeOnDevice, false);
-        this->deviceBuffer = new DeviceBufferIntern<TYPE, DIM >
-            (otherDeviceBuffer,
-             this->gridLayout.getDataSpace(),
-             DataSpace<DIM > (),
-             sizeOnDevice);
+        init();
     }
 
     GridBuffer(
                HostBuffer<TYPE, DIM>& otherHostBuffer,
-               DataSpace<DIM > offsetHost,
+               const DataSpace<DIM>& offsetHost,
                DeviceBuffer<TYPE, DIM>& otherDeviceBuffer,
-               DataSpace<DIM > offsetDevice,
-               GridLayout<DIM> gridLayout,
+               const DataSpace<DIM>& offsetDevice,
+               const GridLayout<DIM>& gridLayout,
                bool sizeOnDevice = false) :
-    gridLayout(gridLayout),
-    hasOneExchange(false),
-    maxExchange(0)
+    Parent(otherHostBuffer, offsetHost, otherDeviceBuffer, offsetDevice, gridLayout.getDataSpace(), sizeOnDevice),
+    gridLayout(gridLayout)
     {
-        init(sizeOnDevice, false, false);
-        this->deviceBuffer = new DeviceBufferIntern<TYPE, DIM >
-            (otherDeviceBuffer,
-             this->gridLayout.getDataSpace(),
-             offsetDevice, sizeOnDevice);
-        this->hostBuffer = new HostBufferIntern<TYPE, DIM >
-            (*((HostBufferIntern<TYPE, DIM>*) & otherHostBuffer),
-             this->gridLayout.getDataSpace(),
-             offsetHost);
+        init();
     }
 
     /**
@@ -181,23 +164,7 @@ public:
         {
             __delete(sendExchanges[i]);
             __delete(receiveExchanges[i]);
-        }
-
-        __delete(hostBuffer);
-        __delete(deviceBuffer);
-    }
-
-    /**
-     * Resets both internal buffers.
-     *
-     * See DeviceBuffer::reset and HostBuffer::reset for details.
-     *
-     * @param preserveData determines if data on internal buffers should not be erased
-     */
-    void reset(bool preserveData = true)
-    {
-        deviceBuffer->reset(preserveData);
-        hostBuffer->reset(preserveData);
+        };
     }
 
     /**
@@ -245,7 +212,7 @@ public:
                     std::stringstream message;
                     message << "unique exchange communication tag ("
                         << uniqCommunicationTag << ") witch is created from communicationTag ("
-                        << communicationTag << ") allready used for other gridbuffer exchange";
+                        << communicationTag << ") already used for other GridBuffer exchange";
                     throw std::runtime_error(message.str());
                 }
                 hasOneExchange = true;
@@ -254,16 +221,16 @@ public:
                 {
                     throw std::runtime_error("Exchange already added!");
                 }
-                //std::cout<<"Add Exchange: send="<<ex<<" receive="<<Mask::getMirroredExchangeType((ExchangeType)ex)<<std::endl;
+
                 maxExchange = std::max(maxExchange, ex + 1u);
-                sendExchanges[ex] = new ExchangeIntern<BORDERTYPE, DIM > (*deviceBuffer, gridLayout, guardingCells,
+                sendExchanges[ex] = new ExchangeIntern<BORDERTYPE, DIM > (this->getDeviceBuffer(), gridLayout, guardingCells,
                                                                           (ExchangeType) ex, uniqCommunicationTag,
                                                                           dataPlace == GUARD ? BORDER : GUARD, sizeOnDeviceSend);
                 ExchangeType recvex = Mask::getMirroredExchangeType(ex);
                 maxExchange = std::max(maxExchange, recvex + 1u);
                 receiveExchanges[recvex] =
                     new ExchangeIntern<BORDERTYPE, DIM > (
-                                                          *deviceBuffer,
+                                                          this->getDeviceBuffer(),
                                                           gridLayout,
                                                           guardingCells,
                                                           recvex,
@@ -338,7 +305,7 @@ public:
                         std::stringstream message;
                         message << "unique exchange communication tag ("
                             << uniqCommunicationTag << ") witch is created from communicationTag ("
-                            << communicationTag << ") allready used for other gridbuffer exchange";
+                            << communicationTag << ") already used for other GridBuffer exchange";
                         throw std::runtime_error(message.str());
                     }
                     hasOneExchange = true;
@@ -453,31 +420,11 @@ public:
     }
 
     /**
-     * Returns the internal data buffer on host side
+     * Starts sync data from own device buffer to neighbor device buffer.
      *
-     * @return internal HostBuffer
-     */
-    HostBuffer<TYPE, DIM>& getHostBuffer() const
-    {
-        return *(this->hostBuffer);
-    }
-
-    /**
-     * Returns the internal data buffer on device side
-     *
-     * @return internal DeviceBuffer
-     */
-    DeviceBuffer<TYPE, DIM>& getDeviceBuffer() const
-    {
-        return *(this->deviceBuffer);
-    }
-
-    /**
-     * Starts sync data from own device buffer to neigbhor device buffer.
-     *
-     * Asynchronously starts syncronization data from internal DeviceBuffer using added
+     * Asynchronously starts synchronization data from internal DeviceBuffer using added
      * Exchange buffers.
-     * This operation runs sequential to other code but intern asyncron
+     * This operation runs sequential to other code but intern asynchronous
      *
      */
     EventTask communication()
@@ -488,9 +435,9 @@ public:
     }
 
     /**
-     * Starts sync data from own device buffer to neigbhor device buffer.
+     * Starts sync data from own device buffer to neighbor device buffer.
      *
-     * Asynchronously starts syncronization data from internal DeviceBuffer using added
+     * Asynchronously starts synchronization data from internal DeviceBuffer using added
      * Exchange buffers.
      *
      */
@@ -536,23 +483,6 @@ public:
     }
 
     /**
-     * Asynchronously copies data from internal host to internal device buffer.
-     *
-     */
-    void hostToDevice()
-    {
-        deviceBuffer->copyFrom(*hostBuffer);
-    }
-
-    /**
-     * Asynchronously copies data from internal device to internal host buffer.
-     */
-    void deviceToHost()
-    {
-        hostBuffer->copyFrom(*deviceBuffer);
-    }
-
-    /**
      * Returns the GridLayout describing this GridBuffer.
      *
      * @return the layout of this buffer
@@ -566,8 +496,10 @@ private:
 
     friend class Environment<DIM>;
 
-    void init(bool sizeOnDevice, bool buildDeviceBuffer = true, bool buildHostBuffer = true)
+    void init()
     {
+        hasOneExchange = false;
+        maxExchange = 0;
         for (uint32_t i = 0; i < 27; ++i)
         {
             sendExchanges[i] = NULL;
@@ -577,22 +509,10 @@ private:
             receiveEvents[i] = EventTask();
             sendEvents[i] = EventTask();
         }
-        if (buildDeviceBuffer)
-        {
-            this->deviceBuffer = new DeviceBufferIntern<TYPE, DIM > (gridLayout.getDataSpace(), sizeOnDevice);
-        }
-        if (buildHostBuffer)
-        {
-            this->hostBuffer = new HostBufferIntern<TYPE, DIM > (gridLayout.getDataSpace());
-        }
     }
 
 protected:
-
-
-    HostBufferIntern<TYPE, DIM>* hostBuffer;
-    DeviceBufferIntern<TYPE, DIM>* deviceBuffer;
-    /*if we hase one exchange we not check if communicationtag has used before*/
+    /*if we have one exchange we don't check if communicationTag has been used before*/
     bool hasOneExchange;
     uint32_t lastUsedCommunicationTag;
     GridLayout<DIM> gridLayout;

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -102,7 +102,9 @@ public:
      */
     GridBuffer(const GridLayout<DIM>& gridLayout, bool sizeOnDevice = false) :
     Parent(gridLayout.getDataSpace(), sizeOnDevice),
-    gridLayout(gridLayout)
+    gridLayout(gridLayout),
+    hasOneExchange(false),
+    maxExchange(0)
     {
         init();
     }
@@ -119,7 +121,9 @@ public:
      */
     GridBuffer(const DataSpace<DIM>& dataSpace, bool sizeOnDevice = false) :
     Parent(dataSpace, sizeOnDevice),
-    gridLayout(dataSpace)
+    gridLayout(dataSpace),
+    hasOneExchange(false),
+    maxExchange(0)
     {
         init();
     }
@@ -137,7 +141,9 @@ public:
      */
     GridBuffer(DeviceBuffer<TYPE, DIM>& otherDeviceBuffer, const GridLayout<DIM>& gridLayout, bool sizeOnDevice = false) :
     Parent(otherDeviceBuffer, gridLayout.getDataSpace(), sizeOnDevice),
-    gridLayout(gridLayout)
+    gridLayout(gridLayout),
+    hasOneExchange(false),
+    maxExchange(0)
     {
         init();
     }
@@ -150,7 +156,9 @@ public:
                const GridLayout<DIM>& gridLayout,
                bool sizeOnDevice = false) :
     Parent(otherHostBuffer, offsetHost, otherDeviceBuffer, offsetDevice, gridLayout.getDataSpace(), sizeOnDevice),
-    gridLayout(gridLayout)
+    gridLayout(gridLayout),
+    hasOneExchange(false),
+    maxExchange(0)
     {
         init();
     }
@@ -498,8 +506,6 @@ private:
 
     void init()
     {
-        hasOneExchange = false;
-        maxExchange = 0;
         for (uint32_t i = 0; i < 27; ++i)
         {
             sendExchanges[i] = NULL;

--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "types.h"
+#include "memory/buffers/HostBufferIntern.hpp"
+#include "memory/buffers/DeviceBufferIntern.hpp"
+#include <boost/type_traits.hpp>
+
+namespace PMacc {
+
+    /** Buffer that contains a host and device buffer and allows synchronizing those 2 */
+    template<typename T_Type, unsigned T_dim>
+    class HostDeviceBuffer
+    {
+        typedef HostBufferIntern<T_Type, T_dim> HostBufferType;
+        typedef DeviceBufferIntern<T_Type, T_dim> DeviceBufferType;
+    public:
+        typedef typename HostBufferType::DataBoxType DataBoxType;
+        PMACC_CASSERT_MSG(DataBoxTypes_must_match, boost::is_same<DataBoxType, typename DeviceBufferType::DataBoxType>::value);
+
+        /**
+         * Constructor that creates the buffers with the given size
+         *
+         * @param size DataSpace representing buffer size
+         * @param sizeOnDevice if true, internal buffers must store their
+         *        size additionally on the device
+         *        (as we keep this information coherent with the host, it influences
+         *        performance on host-device copies, but some algorithms on the device
+         *        might need to know the size of the buffer)
+         */
+        HostDeviceBuffer(const DataSpace<T_dim>& size, bool sizeOnDevice = false);
+
+        /**
+         * Constructor that reuses the given device buffer instead of creating an own one.
+         * Sizes should match. If size is smaller than the buffer size, then only the part near the origin is used.
+         * Passing a size bigger than the buffer is undefined.
+         */
+        HostDeviceBuffer(DeviceBuffer<T_Type, T_dim>& otherDeviceBuffer, const DataSpace<T_dim>& size, bool sizeOnDevice = false);
+
+        /**
+         * Constructor that reuses the given buffers instead of creating own ones.
+         * The data from [offset, offset+size) is used
+         * Passing a size bigger than the buffer (minus the offset) is undefined.
+         */
+        HostDeviceBuffer(
+                   HostBuffer<T_Type, T_dim>& otherHostBuffer,
+                   const DataSpace<T_dim>& offsetHost,
+                   DeviceBuffer<T_Type, T_dim>& otherDeviceBuffer,
+                   const DataSpace<T_dim>& offsetDevice,
+                   const GridLayout<T_dim> size,
+                   bool sizeOnDevice = false);
+
+        HINLINE virtual ~HostDeviceBuffer();
+
+        /**
+         * Returns the internal data buffer on host side
+         *
+         * @return internal HostBuffer
+         */
+        HINLINE HostBuffer<T_Type, T_dim>& getHostBuffer() const;
+
+        /**
+         * Returns the internal data buffer on device side
+         *
+         * @return internal DeviceBuffer
+         */
+        HINLINE DeviceBuffer<T_Type, T_dim>& getDeviceBuffer() const;
+
+        /**
+         * Resets both internal buffers.
+         *
+         * See DeviceBuffer::reset and HostBuffer::reset for details.
+         *
+         * @param preserveData determines if data on internal buffers should not be erased
+         */
+        void reset(bool preserveData = true);
+
+        /**
+         * Asynchronously copies data from internal host to internal device buffer.
+         *
+         */
+        HINLINE void hostToDevice();
+
+        /**
+         * Asynchronously copies data from internal device to internal host buffer.
+         */
+        HINLINE void deviceToHost();
+    private:
+        HostBufferType* hostBuffer;
+        DeviceBufferType* deviceBuffer;
+
+        HINLINE void
+        createBuffers(DataSpace<T_dim> size, bool sizeOnDevice, bool buildDeviceBuffer = true, bool buildHostBuffer = true);
+    };
+
+}  // namespace PMacc
+
+#include "memory/buffers/HostDeviceBuffer.tpp"

--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
@@ -109,8 +109,6 @@ namespace PMacc {
         HostBufferType* hostBuffer;
         DeviceBufferType* deviceBuffer;
 
-        HINLINE void
-        createBuffers(DataSpace<T_dim> size, bool sizeOnDevice, bool buildDeviceBuffer = true, bool buildHostBuffer = true);
     };
 
 }  // namespace PMacc

--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "HostDeviceBuffer.hpp"
+
+namespace PMacc {
+
+    template<typename T_Type, unsigned T_dim>
+    HostDeviceBuffer<T_Type, T_dim>::HostDeviceBuffer(const DataSpace<T_dim>& size, bool sizeOnDevice)
+    {
+        createBuffers(size, sizeOnDevice);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    HostDeviceBuffer<T_Type, T_dim>::HostDeviceBuffer(
+            DeviceBuffer<T_Type, T_dim>& otherDeviceBuffer,
+            const DataSpace<T_dim>& size,
+            bool sizeOnDevice)
+    {
+        createBuffers(size, sizeOnDevice, false);
+        deviceBuffer = new DeviceBufferType(otherDeviceBuffer, size, DataSpace<T_dim>(), sizeOnDevice);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    HostDeviceBuffer<T_Type, T_dim>::HostDeviceBuffer(
+               HostBuffer<T_Type, T_dim>& otherHostBuffer,
+               const DataSpace<T_dim>& offsetHost,
+               DeviceBuffer<T_Type, T_dim>& otherDeviceBuffer,
+               const DataSpace<T_dim>& offsetDevice,
+               const GridLayout<T_dim> size,
+               bool sizeOnDevice)
+   {
+        this->deviceBuffer = new DeviceBufferType(otherDeviceBuffer, size, offsetDevice, sizeOnDevice);
+        this->hostBuffer = new HostBufferType(dynamic_cast<HostDeviceBuffer&>(otherHostBuffer), size, offsetHost);
+   }
+
+    template<typename T_Type, unsigned T_dim>
+    HostDeviceBuffer<T_Type, T_dim>::~HostDeviceBuffer()
+    {
+        __delete(hostBuffer);
+        __delete(deviceBuffer);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    HostBuffer<T_Type, T_dim>& HostDeviceBuffer<T_Type, T_dim>::getHostBuffer() const
+    {
+        return *(this->hostBuffer);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    DeviceBuffer<T_Type, T_dim>& HostDeviceBuffer<T_Type, T_dim>::getDeviceBuffer() const
+    {
+        return *(this->deviceBuffer);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    void HostDeviceBuffer<T_Type, T_dim>::reset(bool preserveData)
+    {
+        deviceBuffer->reset(preserveData);
+        hostBuffer->reset(preserveData);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    void HostDeviceBuffer<T_Type, T_dim>::hostToDevice()
+    {
+        deviceBuffer->copyFrom(*hostBuffer);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    void HostDeviceBuffer<T_Type, T_dim>::deviceToHost()
+    {
+        hostBuffer->copyFrom(*deviceBuffer);
+    }
+
+    template<typename T_Type, unsigned T_dim>
+    void HostDeviceBuffer<T_Type, T_dim>::createBuffers(DataSpace<T_dim> size, bool sizeOnDevice, bool buildDeviceBuffer, bool buildHostBuffer)
+    {
+        if (buildDeviceBuffer)
+            deviceBuffer = new DeviceBufferIntern<T_Type, T_dim>(size, sizeOnDevice);
+        else
+            deviceBuffer = NULL;
+
+        if (buildHostBuffer)
+            hostBuffer = new HostBufferIntern<T_Type, T_dim>(size);
+        else
+            hostBuffer = NULL;
+    }
+
+}  // namespace PMacc

--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
@@ -29,7 +29,8 @@ namespace PMacc {
     template<typename T_Type, unsigned T_dim>
     HostDeviceBuffer<T_Type, T_dim>::HostDeviceBuffer(const DataSpace<T_dim>& size, bool sizeOnDevice)
     {
-        createBuffers(size, sizeOnDevice);
+        hostBuffer   = new HostBufferIntern<T_Type, T_dim>(size);
+        deviceBuffer = new DeviceBufferIntern<T_Type, T_dim>(size, sizeOnDevice);
     }
 
     template<typename T_Type, unsigned T_dim>
@@ -38,7 +39,7 @@ namespace PMacc {
             const DataSpace<T_dim>& size,
             bool sizeOnDevice)
     {
-        createBuffers(size, sizeOnDevice, false);
+        hostBuffer   = new HostBufferIntern<T_Type, T_dim>(size);
         deviceBuffer = new DeviceBufferType(otherDeviceBuffer, size, DataSpace<T_dim>(), sizeOnDevice);
     }
 
@@ -51,8 +52,8 @@ namespace PMacc {
                const GridLayout<T_dim> size,
                bool sizeOnDevice)
    {
-        this->deviceBuffer = new DeviceBufferType(otherDeviceBuffer, size, offsetDevice, sizeOnDevice);
-        this->hostBuffer = new HostBufferType(dynamic_cast<HostDeviceBuffer&>(otherHostBuffer), size, offsetHost);
+        hostBuffer   = new HostBufferType(dynamic_cast<HostDeviceBuffer&>(otherHostBuffer), size, offsetHost);
+        deviceBuffer = new DeviceBufferType(otherDeviceBuffer, size, offsetDevice, sizeOnDevice);
    }
 
     template<typename T_Type, unsigned T_dim>
@@ -65,13 +66,13 @@ namespace PMacc {
     template<typename T_Type, unsigned T_dim>
     HostBuffer<T_Type, T_dim>& HostDeviceBuffer<T_Type, T_dim>::getHostBuffer() const
     {
-        return *(this->hostBuffer);
+        return *hostBuffer;
     }
 
     template<typename T_Type, unsigned T_dim>
     DeviceBuffer<T_Type, T_dim>& HostDeviceBuffer<T_Type, T_dim>::getDeviceBuffer() const
     {
-        return *(this->deviceBuffer);
+        return *deviceBuffer;
     }
 
     template<typename T_Type, unsigned T_dim>
@@ -91,20 +92,6 @@ namespace PMacc {
     void HostDeviceBuffer<T_Type, T_dim>::deviceToHost()
     {
         hostBuffer->copyFrom(*deviceBuffer);
-    }
-
-    template<typename T_Type, unsigned T_dim>
-    void HostDeviceBuffer<T_Type, T_dim>::createBuffers(DataSpace<T_dim> size, bool sizeOnDevice, bool buildDeviceBuffer, bool buildHostBuffer)
-    {
-        if (buildDeviceBuffer)
-            deviceBuffer = new DeviceBufferIntern<T_Type, T_dim>(size, sizeOnDevice);
-        else
-            deviceBuffer = NULL;
-
-        if (buildHostBuffer)
-            hostBuffer = new HostBufferIntern<T_Type, T_dim>(size);
-        else
-            hostBuffer = NULL;
     }
 
 }  // namespace PMacc


### PR DESCRIPTION
The GridBuffer had actually 2 functions: Combine a Host- with a DeviceBuffer and provide exchange methods. This is a design flaw.

Also: Sometimes you know, you never need exchange methods, but only want a simple Buffer, that is on host and device. The GridBuffer is overkill for that usecase.

This splits off the DoubleBuffering to a new class `HostDeviceBuffer`

- [x] Charge conservation test ![density](https://cloud.githubusercontent.com/assets/309017/12975585/25fea49e-d0bd-11e5-82a2-58357790f948.png)

- [x] Heating test ![heating](https://cloud.githubusercontent.com/assets/309017/12951809/71fb5f26-d014-11e5-8c0b-bd5d976420a2.png)
