### PR TITLE
fix cuSTL/DeviceBuffer assign operator.

### DIFF
--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -124,12 +124,17 @@ public:
         return *this;
     }
 
-    HDINLINE DeviceBuffer& operator=(const Base& rhs)
+    HINLINE DeviceBuffer& operator=(const Base& rhs)
     {
         Base::operator=(rhs);
         return *this;
     }
 
+    HINLINE DeviceBuffer& operator=(const boost::rv<DeviceBuffer>& rhs)
+    {
+        Base::operator=(rhs);
+        return *this;
+    }
 };
 
 } // container


### PR DESCRIPTION
before this PR a device-to-device copy was not possible.