### PR TITLE
Feature: Calorimeter Plugin

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -198,6 +198,11 @@ TBG_liveViewYZ="--<species>_liveView.period 1 --<species>_liveView.slicePoint 0.
 # Print the maximum charge deviation between particles and div E to textfile 'chargeConservation.dat':
 TBG_chargeConservation="--chargeConservation.period 100"
 
+# Particle calorimeter: (virtually) propagates and collects particles to infinite distance
+TBG_<species>_calorimeter="--<species>_calorimeter.period 100 --<species>_calorimeter.openingYaw 90 --<species>_calorimeter.openingPitch 30
+                        --<species>_calorimeter.numBinsEnergy 32 --<species>_calorimeter.minEnergy 10 --<species>_calorimeter.maxEnergy 1000
+                        --<species>_calorimeter.logScale"
+
 ################################################################################
 ## Section: Program Parameters
 ## This section contains TBG internal variables, often composed from required

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -36,6 +36,7 @@
 #include "plugins/BinEnergyParticles.hpp"
 #include "plugins/ChargeConservation.hpp"
 #if(ENABLE_HDF5 == 1)
+#include "plugins/particleCalorimeter/ParticleCalorimeter.hpp"
 #include "plugins/PhaseSpace/PhaseSpaceMulti.hpp"
 #endif
 
@@ -173,6 +174,7 @@ private:
      , PngPlugin< Visualisation<bmpl::_1, PngCreator> >
 #endif
 #if(ENABLE_HDF5 == 1)
+      , ParticleCalorimeter<bmpl::_1>
       , PerSuperCell<bmpl::_1>
       , PhaseSpaceMulti<particles::shapes::Counter::ChargeAssignment, bmpl::_1>
 #endif

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -1,0 +1,530 @@
+/**
+ * Copyright 2016 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "ParticleCalorimeterFunctors.hpp"
+#include "ParticleCalorimeter.kernel"
+
+#include "traits/PICToSplash.hpp"
+#include "plugins/ISimulationPlugin.hpp"
+#include "cuSTL/container/DeviceBuffer.hpp"
+#include "cuSTL/container/HostBuffer.hpp"
+#include "cuSTL/algorithm/kernel/Foreach.hpp"
+#include "cuSTL/cursor/MultiIndexCursor.hpp"
+#include "cuSTL/algorithm/mpi/Reduce.hpp"
+#include "cuSTL/algorithm/host/Foreach.hpp"
+#include "particles/policies/ExchangeParticles.hpp"
+#include "math/Vector.hpp"
+#include "algorithms/math.hpp"
+#include <boost/shared_ptr.hpp>
+
+/* libSplash data output */
+#include <splash/splash.h>
+#include <boost/filesystem.hpp>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <stdlib.h>
+
+namespace picongpu
+{
+using namespace PMacc;
+
+namespace po = boost::program_options;
+
+
+/** Virtual particle calorimeter plugin.
+ *
+ * (virtually) propagates and collects particles to infinite distance.
+ *
+ */
+template<class ParticlesType>
+class ParticleCalorimeter : public ISimulationPlugin
+{
+private:
+    std::string name;
+    std::string prefix;
+    std::string foldername;
+    uint32_t notifyPeriod;
+    MappingDesc* cellDescription;
+    std::ofstream outFile;
+    const std::string leftParticlesDatasetName;
+
+    uint32_t numBinsYaw;
+    uint32_t numBinsPitch;
+    uint32_t numBinsEnergy;
+    float_X minEnergy;
+    float_X maxEnergy;
+    bool logScale;
+    float_X openingYaw_deg;
+    float_X openingPitch_deg;
+    float_X maxYaw_deg;
+    float_X maxPitch_deg;
+
+    float_64 posYaw_deg;
+    float_64 posPitch_deg;
+
+    /* Rotated calorimeter frame */
+    float3_X calorimeterFrameVecX;
+    float3_X calorimeterFrameVecY;
+    float3_X calorimeterFrameVecZ;
+
+    typedef PMacc::container::DeviceBuffer<float_X, DIM3> DBufCalorimeter;
+    typedef PMacc::container::HostBuffer<float_X, DIM3> HBufCalorimeter;
+
+    /* device calorimeter buffer for a single gpu */
+    DBufCalorimeter* dBufCalorimeter;
+    /* device calorimeter buffer for all particles which have left the simulation volume  */
+    DBufCalorimeter* dBufLeftParsCalorimeter;
+    /* host calorimeter buffer for a single mpi rank */
+    HBufCalorimeter* hBufCalorimeter;
+    /* host calorimeter buffer for summation of all mpi ranks */
+    HBufCalorimeter* hBufTotalCalorimeter;
+
+public:
+    typedef CalorimeterFunctor<typename DBufCalorimeter::Cursor> MyCalorimeterFunctor;
+private:
+    typedef boost::shared_ptr<MyCalorimeterFunctor> MyCalorimeterFunctorPtr;
+    MyCalorimeterFunctorPtr calorimeterFunctor;
+
+    typedef boost::shared_ptr<PMacc::algorithm::mpi::Reduce<simDim> > AllGPU_reduce;
+    AllGPU_reduce allGPU_reduce;
+
+    void restart(uint32_t restartStep, const std::string restartDirectory)
+    {
+        if(this->notifyPeriod == 0)
+            return;
+
+        HBufCalorimeter hBufLeftParsCalorimeter(this->dBufLeftParsCalorimeter->size());
+
+        PMacc::GridController<simDim>& gridCon = PMacc::Environment<simDim>::get().GridController();
+        pmacc::CommunicatorMPI<simDim>& comm = gridCon.getCommunicator();
+        uint32_t rank = comm.getRank();
+
+        if(rank == 0)
+        {
+            splash::SerialDataCollector hdf5DataFile(1);
+            splash::DataCollector::FileCreationAttr fAttr;
+
+            splash::DataCollector::initFileCreationAttr(fAttr);
+            fAttr.fileAccType = splash::DataCollector::FAT_READ;
+
+            std::stringstream filename;
+            filename << restartDirectory << "/" << prefix << "_" << restartStep;
+
+            hdf5DataFile.open(filename.str().c_str(), fAttr);
+
+            splash::Dimensions dimensions;
+
+            hdf5DataFile.read(restartStep,
+                              this->leftParticlesDatasetName.c_str(),
+                              dimensions,
+                              &(*hBufLeftParsCalorimeter.origin()));
+
+            hdf5DataFile.close();
+
+            /* rank 0 divides and distributes the calorimeter to all ranks in equal parts */
+            uint32_t numRanks = gridCon.getGlobalSize();
+            using namespace lambda;
+            PMacc::algorithm::host::Foreach()(hBufLeftParsCalorimeter.zone(),
+                                              hBufLeftParsCalorimeter.origin(),
+                                              _1 = _1 / float_X(numRanks));
+        }
+
+        MPI_Bcast(&(*hBufLeftParsCalorimeter.origin()),
+                  hBufLeftParsCalorimeter.size().productOfComponents() * sizeof(float_X),
+                  MPI_CHAR,
+                  0, /* rank 0 */
+                  comm.getMPIComm());
+
+        *this->dBufLeftParsCalorimeter = hBufLeftParsCalorimeter;
+    }
+
+
+    void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
+    {
+        if(this->notifyPeriod == 0)
+            return;
+
+        HBufCalorimeter hBufLeftParsCalorimeter(this->dBufLeftParsCalorimeter->size());
+        HBufCalorimeter hBufTotal(hBufLeftParsCalorimeter.size());
+
+        hBufLeftParsCalorimeter = *this->dBufLeftParsCalorimeter;
+
+        /* mpi reduce */
+        using namespace lambda;
+        (*this->allGPU_reduce)(hBufTotal, hBufLeftParsCalorimeter, _1 + _2);
+        if(!this->allGPU_reduce->root())
+            return;
+
+        splash::SerialDataCollector hdf5DataFile(1);
+        splash::DataCollector::FileCreationAttr fAttr;
+
+        splash::DataCollector::initFileCreationAttr(fAttr);
+
+        std::stringstream filename;
+        filename << checkpointDirectory << "/" << prefix << "_" << currentStep;
+
+        hdf5DataFile.open(filename.str().c_str(), fAttr);
+
+        typename PICToSplash<float_X>::type SplashTypeX;
+
+        splash::Dimensions bufferSize(hBufTotal.size().x(),
+                                      hBufTotal.size().y(),
+                                      hBufTotal.size().z());
+
+        /* if there is only one energy bin, omit the energy axis */
+        uint32_t dimension = this->numBinsEnergy == 1 ? DIM2 : DIM3;
+        hdf5DataFile.write(currentStep,
+                           SplashTypeX,
+                           dimension,
+                           splash::Selection(bufferSize),
+                           this->leftParticlesDatasetName.c_str(),
+                           &(*hBufTotal.origin()));
+
+        hdf5DataFile.close();
+    }
+
+
+    void pluginLoad()
+    {
+        namespace pm = PMacc::math;
+        namespace pam = PMacc::algorithms::math;
+
+        if(this->notifyPeriod == 0)
+            return;
+
+        if(!(this->openingYaw_deg > float_X(0.0) && this->openingYaw_deg <= float_X(360.0)))
+        {
+            std::stringstream msg;
+            msg << "[Plugin] [" << this->prefix
+                << "] openingYaw has to be within (0, 360]."
+                << std::endl;
+            throw std::runtime_error(msg.str());
+        }
+        if(!(this->openingPitch_deg > float_X(0.0) && this->openingPitch_deg <= float_X(180.0)))
+        {
+            std::stringstream msg;
+            msg << "[Plugin] [" << this->prefix
+                << "] openingPitch has to be within (0, 180]."
+                << std::endl;
+            throw std::runtime_error(msg.str());
+        }
+        if(this->numBinsEnergy > 1 && this->maxEnergy <= this->minEnergy)
+        {
+            std::stringstream msg;
+            msg << "[Plugin] [" << this->prefix
+                << "] minEnergy has to be less than maxEnergy."
+                << std::endl;
+            throw std::runtime_error(msg.str());
+        }
+
+        this->maxYaw_deg = float_X(0.5) * this->openingYaw_deg;
+        this->maxPitch_deg = float_X(0.5) * this->openingPitch_deg;
+        /* convert units */
+        const float_64 minEnergy_SI = this->minEnergy * UNITCONV_keV_to_Joule;
+        const float_64 maxEnergy_SI = this->maxEnergy * UNITCONV_keV_to_Joule;
+        this->minEnergy = minEnergy_SI / UNIT_ENERGY;
+        this->maxEnergy = maxEnergy_SI / UNIT_ENERGY;
+
+        /* allocate memory buffers */
+        this->dBufCalorimeter = new DBufCalorimeter(this->numBinsYaw, this->numBinsPitch, this->numBinsEnergy);
+        this->dBufLeftParsCalorimeter = new DBufCalorimeter(this->dBufCalorimeter->size());
+        this->hBufCalorimeter = new HBufCalorimeter(this->dBufCalorimeter->size());
+        this->hBufTotalCalorimeter = new HBufCalorimeter(this->dBufCalorimeter->size());
+
+        /* fill calorimeter for left particles with zero */
+        this->dBufLeftParsCalorimeter->assign(float_X(0.0));
+
+        /* create mpi reduce algorithm */
+        PMacc::GridController<simDim>& con = PMacc::Environment<simDim>::get().GridController();
+        pm::Size_t<simDim> gpuDim = (pm::Size_t<simDim>)con.getGpuNodes();
+        zone::SphericZone<simDim> zone_allGPUs(gpuDim);
+        this->allGPU_reduce = AllGPU_reduce(new PMacc::algorithm::mpi::Reduce<simDim>(zone_allGPUs));
+
+        /* calculate rotated calorimeter frame from posYaw_deg and posPitch_deg */
+        const float_64 posYaw_rad = this->posYaw_deg * float_64(M_PI / 180.0);
+        const float_64 posPitch_rad = this->posPitch_deg * float_64(M_PI / 180.0);
+        this->calorimeterFrameVecY = float3_X(pam::sin(posYaw_rad) * pam::cos(posPitch_rad),
+                                              pam::cos(posYaw_rad) * pam::cos(posPitch_rad),
+                                              pam::sin(posPitch_rad));
+        /* If the y-axis is pointing exactly up- or downwards we need to define the x-axis manually */
+        if(pam::abs(this->calorimeterFrameVecY.z()) == float_X(1.0))
+        {
+            this->calorimeterFrameVecX = float3_X(1.0, 0.0, 0.0);
+        }
+        else
+        {
+            /* choose `calorimeterFrameVecX` so that the roll is zero. */
+            const float3_X vecUp(0.0, 0.0, -1.0);
+            this->calorimeterFrameVecX = pam::cross(vecUp, this->calorimeterFrameVecY);
+            /* normalize vector */
+            this->calorimeterFrameVecX /= pam::abs(this->calorimeterFrameVecX);
+        }
+        this->calorimeterFrameVecZ = pam::cross(this->calorimeterFrameVecX, this->calorimeterFrameVecY);
+
+        /* create calorimeter functor instance */
+        this->calorimeterFunctor = MyCalorimeterFunctorPtr(new MyCalorimeterFunctor(
+            this->maxYaw_deg * float_X(M_PI / 180.0),
+            this->maxPitch_deg * float_X(M_PI / 180.0),
+            this->numBinsYaw,
+            this->numBinsPitch,
+            this->numBinsEnergy,
+            this->logScale ? pam::log10(this->minEnergy) : this->minEnergy,
+            this->logScale ? pam::log10(this->maxEnergy) : this->maxEnergy,
+            this->logScale,
+            this->calorimeterFrameVecX,
+            this->calorimeterFrameVecY,
+            this->calorimeterFrameVecZ));
+
+        /* create folder for hdf5 files*/
+        Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(this->foldername);
+
+        Environment<>::get().PluginConnector().setNotificationPeriod(this, this->notifyPeriod);
+    }
+
+
+    void pluginUnload()
+    {
+        if(this->notifyPeriod == 0)
+            return;
+
+        __delete(this->dBufCalorimeter);
+        __delete(this->dBufLeftParsCalorimeter);
+        __delete(this->hBufCalorimeter);
+        __delete(this->hBufTotalCalorimeter);
+    }
+
+
+    void writeToHDF5File(uint32_t currentStep)
+    {
+        splash::SerialDataCollector hdf5DataFile(1);
+        splash::DataCollector::FileCreationAttr fAttr;
+
+        splash::DataCollector::initFileCreationAttr(fAttr);
+
+        std::stringstream filename;
+        filename << this->foldername << "/" << this->prefix << "_" << currentStep;
+
+        hdf5DataFile.open(filename.str().c_str(), fAttr);
+
+        typename PICToSplash<float_X>::type SplashTypeX;
+        typename PICToSplash<float_64>::type SplashType64;
+        typename PICToSplash<bool>::type SplashTypeBool;
+
+        splash::Dimensions bufferSize(this->hBufTotalCalorimeter->size().x(),
+                                      this->hBufTotalCalorimeter->size().y(),
+                                      this->hBufTotalCalorimeter->size().z());
+
+        hdf5DataFile.write(currentStep,
+                           SplashTypeX,
+                           this->numBinsEnergy == 1 ? DIM2 : DIM3,
+                           splash::Selection(bufferSize),
+                           "calorimeter",
+                           &(*this->hBufTotalCalorimeter->origin()));
+
+        const float_64 unitSI = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * UNIT_ENERGY;
+
+        hdf5DataFile.writeAttribute(currentStep,
+                                    SplashType64,
+                                    "calorimeter",
+                                    "unitSI",
+                                    &unitSI);
+
+        hdf5DataFile.writeAttribute(currentStep,
+                                    SplashType64,
+                                    "calorimeter",
+                                    "posYaw[deg]",
+                                    &posYaw_deg);
+
+        hdf5DataFile.writeAttribute(currentStep,
+                                    SplashType64,
+                                    "calorimeter",
+                                    "posPitch[deg]",
+                                    &posPitch_deg);
+
+        hdf5DataFile.writeAttribute(currentStep,
+                                    SplashTypeX,
+                                    "calorimeter",
+                                    "maxYaw[deg]",
+                                    &this->maxYaw_deg);
+
+        hdf5DataFile.writeAttribute(currentStep,
+                                    SplashTypeX,
+                                    "calorimeter",
+                                    "maxPitch[deg]",
+                                    &this->maxPitch_deg);
+
+        if(this->numBinsEnergy > 1)
+        {
+            const float_64 minEnergy_SI = this->minEnergy * UNIT_ENERGY;
+            const float_64 maxEnergy_SI = this->maxEnergy * UNIT_ENERGY;
+            const float_64 minEnergy_keV = minEnergy_SI * UNITCONV_Joule_to_keV;
+            const float_64 maxEnergy_keV = maxEnergy_SI * UNITCONV_Joule_to_keV;
+
+            hdf5DataFile.writeAttribute(currentStep,
+                                        SplashType64,
+                                        "calorimeter",
+                                        "minEnergy[keV]",
+                                        &minEnergy_keV);
+
+            hdf5DataFile.writeAttribute(currentStep,
+                                        SplashType64,
+                                        "calorimeter",
+                                        "maxEnergy[keV]",
+                                        &maxEnergy_keV);
+
+            hdf5DataFile.writeAttribute(currentStep,
+                                        SplashTypeBool,
+                                        "calorimeter",
+                                        "logScale",
+                                        &this->logScale);
+        }
+
+        hdf5DataFile.close();
+    }
+
+public:
+    ParticleCalorimeter() :
+        name("ParticleCalorimeter: (virtually) propagates and collects particles to infinite distance"),
+        prefix(ParticlesType::FrameType::getName() + std::string("_calorimeter")),
+        foldername(prefix),
+        notifyPeriod(0),
+        cellDescription(NULL),
+        leftParticlesDatasetName("calorimeterLeftParticles"),
+        dBufCalorimeter(NULL),
+        dBufLeftParsCalorimeter(NULL),
+        hBufCalorimeter(NULL),
+        hBufTotalCalorimeter(NULL)
+    {
+        Environment<>::get().PluginConnector().registerPlugin(this);
+    }
+
+
+    void notify(uint32_t currentStep)
+    {
+        /* initialize calorimeter with already detected particles */
+        *this->dBufCalorimeter = *this->dBufLeftParsCalorimeter;
+
+        /* data is written to dBufCalorimeter */
+        this->calorimeterFunctor->setCalorimeterCursor(this->dBufCalorimeter->origin());
+
+        /* create kernel functor instance */
+        DataConnector &dc = Environment<>::get().DataConnector();
+        ParticlesType* particles = &(dc.getData<ParticlesType > (ParticlesType::FrameType::getName(), true));
+
+        ParticleCalorimeterKernel<typename ParticlesType::ParticlesBoxType,
+                                  MyCalorimeterFunctor>
+                                  particleCalorimeterKernel(particles->getDeviceParticlesBox(),
+                                                            *this->calorimeterFunctor);
+
+        /* create zone */
+        typedef typename MappingDesc::SuperCellSize SuperCellSize;
+
+        const PMacc::math::Int<simDim> coreBorderGuardSuperCells = this->cellDescription->getGridSuperCells();
+        const uint32_t guardSuperCells = this->cellDescription->getGuardingSuperCells();
+        const PMacc::math::Int<simDim> coreBorderSuperCells = coreBorderGuardSuperCells - 2*guardSuperCells;
+
+        /* this zone represents the core+border area with guard offset in unit of cells */
+        const zone::SphericZone<simDim> zone(
+            static_cast<PMacc::math::Size_t<simDim> >(coreBorderSuperCells * SuperCellSize::toRT()),
+            guardSuperCells * SuperCellSize::toRT());
+
+        /* kernel call */
+        algorithm::kernel::Foreach<SuperCellSize> foreach;
+        foreach(zone, cursor::make_MultiIndexCursor<simDim>(), particleCalorimeterKernel);
+
+        /* copy to host */
+        *this->hBufCalorimeter = *this->dBufCalorimeter;
+
+        /* mpi reduce */
+        using namespace lambda;
+        (*this->allGPU_reduce)(*this->hBufTotalCalorimeter, *this->hBufCalorimeter, _1 + _2);
+        if(!this->allGPU_reduce->root())
+            return;
+
+        this->writeToHDF5File(currentStep);
+    }
+
+
+    void setMappingDescription(MappingDesc* cellDescription)
+    {
+        this->cellDescription = cellDescription;
+    }
+
+
+    void pluginRegisterHelp(po::options_description& desc)
+    {
+        desc.add_options()
+        ((this->prefix + ".period").c_str(), po::value<uint32_t > (&this->notifyPeriod)->default_value(0),
+            "enable plugin [for each n-th step]")
+        ((this->prefix + ".numBinsYaw").c_str(), po::value<uint32_t > (&this->numBinsYaw)->default_value(64),
+            "number of bins for angle yaw.")
+        ((this->prefix + ".numBinsPitch").c_str(), po::value<uint32_t > (&this->numBinsPitch)->default_value(64),
+            "number of bins for angle pitch.")
+        ((this->prefix + ".numBinsEnergy").c_str(), po::value<uint32_t > (&this->numBinsEnergy)->default_value(1),
+            "number of bins for the energy spectrum. Disabled by default.")
+        ((this->prefix + ".minEnergy").c_str(), po::value<float_X > (&this->minEnergy)->default_value(float_X(0.0)),
+            "minimal detectable energy in keV.")
+        ((this->prefix + ".maxEnergy").c_str(), po::value<float_X > (&this->maxEnergy)->default_value(float_X(1.0e3)),
+            "maximal detectable energy in keV.")
+        ((this->prefix + ".logScale").c_str(), po::bool_switch(&this->logScale),
+            "enable logarithmic energy scale.")
+        ((this->prefix + ".openingYaw").c_str(), po::value<float_X > (&this->openingYaw_deg)->default_value(float_X(360.0)),
+            "opening angle yaw in degrees. 0 < x < 360.")
+        ((this->prefix + ".openingPitch").c_str(), po::value<float_X > (&this->openingPitch_deg)->default_value(float_X(180.0)),
+            "opening angle pitch in degrees. 0 < x < 180.")
+        ((this->prefix + ".posYaw").c_str(), po::value<float_64 > (&this->posYaw_deg)->default_value(float_64(0.0)),
+            "yaw coordinate of calorimeter position in degrees. Defaults to +y direction.")
+        ((this->prefix + ".posPitch").c_str(), po::value<float_64 > (&this->posPitch_deg)->default_value(float_64(0.0)),
+            "pitch coordinate of calorimeter position in degrees. Defaults to +y direction.");
+    }
+
+
+    std::string pluginGetName() const
+    {
+        return this->name;
+    }
+
+
+    void onParticleLeave(const std::string& speciesName, int32_t direction)
+    {
+        if(this->notifyPeriod == 0)
+            return;
+        if(speciesName != ParticlesType::FrameType::getName())
+            return;
+
+        /* data is written to dBufLeftParsCalorimeter */
+        this->calorimeterFunctor->setCalorimeterCursor(this->dBufLeftParsCalorimeter->origin());
+
+        ExchangeMapping<GUARD, MappingDesc> mapper(*this->cellDescription, direction);
+        dim3 grid(mapper.getGridDim());
+
+        DataConnector &dc = Environment<>::get().DataConnector();
+        ParticlesType* particles = &(dc.getData<ParticlesType > (speciesName, true));
+
+        __cudaKernel(kernelParticleCalorimeter)
+                (grid, mapper.getSuperCellSize())
+                (particles->getDeviceParticlesBox(), (MyCalorimeterFunctor)*this->calorimeterFunctor, mapper);
+    }
+};
+
+} // namespace picongpu

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2016 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "math/Vector.hpp"
+
+namespace picongpu
+{
+using namespace PMacc;
+
+/** This kernel is only called for guard particles.
+ */
+template<typename ParticlesBox, typename CalorimeterFunctor, typename Mapper>
+__global__ void kernelParticleCalorimeter(ParticlesBox particlesBox,
+                                       CalorimeterFunctor calorimeterFunctor,
+                                       Mapper mapper)
+{
+    /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+
+    /* multi-dim vector from origin of the block to a cell in units of cells */
+    const DataSpace<simDim > threadIndex(threadIdx);
+    /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
+    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
+
+    typedef typename ParticlesBox::FramePtr ParticlesFramePtr;
+    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ParticlesFramePtr>::type particlesFrame;
+
+    /* find last frame in super cell
+     */
+    if (linearThreadIdx == 0)
+    {
+        particlesFrame = particlesBox.getLastFrame(block);
+    }
+
+    __syncthreads();
+
+    while(particlesFrame.isValid())
+    {
+        /* casting uint8_t multiMask to boolean */
+        const bool isParticle = particlesFrame[linearThreadIdx][multiMask_];
+
+        if(isParticle)
+        {
+            calorimeterFunctor(particlesFrame, linearThreadIdx);
+        }
+
+        __syncthreads();
+
+        if (linearThreadIdx == 0)
+        {
+            particlesFrame = particlesBox.getPreviousFrame(particlesFrame);
+        }
+        __syncthreads();
+    }
+}
+
+} // namespace picongpu

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2016 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "math/Vector.hpp"
+#include "algorithms/math.hpp"
+
+namespace picongpu
+{
+using namespace PMacc;
+
+template<typename CalorimeterCur>
+struct CalorimeterFunctor
+{
+    CalorimeterCur calorimeterCur;
+
+    const float_X maxYaw;
+    const float_X maxPitch;
+    const uint32_t numBinsYaw;
+    const uint32_t numBinsPitch;
+    const int32_t numBinsEnergy;
+    /* depending on `logScale` the energy range is initialized
+     * with the logarithmic or the linear value. */
+    const float_X minEnergy;
+    const float_X maxEnergy;
+    const bool logScale;
+
+    const float3_X calorimeterFrameVecX;
+    const float3_X calorimeterFrameVecY;
+    const float3_X calorimeterFrameVecZ;
+
+    CalorimeterFunctor(const float_X maxYaw,
+                       const float_X maxPitch,
+                       const uint32_t numBinsYaw,
+                       const uint32_t numBinsPitch,
+                       const uint32_t numBinsEnergy,
+                       const float_X minEnergy,
+                       const float_X maxEnergy,
+                       const bool logScale,
+                       const float3_X calorimeterFrameVecX,
+                       const float3_X calorimeterFrameVecY,
+                       const float3_X calorimeterFrameVecZ) :
+        calorimeterCur(NULL, PMacc::math::Size_t<DIM2>()),
+        maxYaw(maxYaw),
+        maxPitch(maxPitch),
+        numBinsYaw(numBinsYaw),
+        numBinsPitch(numBinsPitch),
+        numBinsEnergy(numBinsEnergy),
+        minEnergy(minEnergy),
+        maxEnergy(maxEnergy),
+        logScale(logScale),
+        calorimeterFrameVecX(calorimeterFrameVecX),
+        calorimeterFrameVecY(calorimeterFrameVecY),
+        calorimeterFrameVecZ(calorimeterFrameVecZ)
+    {}
+
+    HINLINE void setCalorimeterCursor(const CalorimeterCur& calorimeterCur)
+    {
+        this->calorimeterCur = calorimeterCur;
+    }
+
+    template<typename ParticlesFrame>
+    DINLINE void operator()(ParticlesFrame& particlesFrame, const uint32_t linearThreadIdx)
+    {
+        const float3_X mom = particlesFrame[linearThreadIdx][momentum_];
+        const float_X mom2 = math::dot(mom, mom);
+        float3_X dirVec = mom * math::rsqrt(mom2);
+
+        /* rotate dirVec into the calorimeter frame. This coordinate transformation
+         * is performed by a matrix vector multiplication. */
+        using namespace PMacc::algorithms::math;
+        dirVec = float3_X(dot(this->calorimeterFrameVecX, dirVec),
+                          dot(this->calorimeterFrameVecY, dirVec),
+                          dot(this->calorimeterFrameVecZ, dirVec));
+
+        /* convert dirVec to yaw and pitch */
+        const float_X yaw = atan2(dirVec.x(), dirVec.y());
+        const float_X pitch = asin(dirVec.z());
+
+        if(abs(yaw) < this->maxYaw && abs(pitch) < this->maxPitch)
+        {
+            const float2_X calorimeterPos = particleCalorimeter::mapYawPitchToNormedRange(
+                yaw, pitch, this->maxYaw, this->maxPitch);
+
+            // yaw
+            int32_t yawBin = calorimeterPos.x() * static_cast<float_X>(numBinsYaw);
+            // catch out-of-range values
+            yawBin = yawBin >= numBinsYaw ? numBinsYaw - 1 : yawBin;
+            yawBin = yawBin < 0 ? 0 : yawBin;
+
+            // pitch
+            int32_t pitchBin = calorimeterPos.y() * static_cast<float_X>(numBinsPitch);
+            // catch out-of-range values
+            pitchBin = pitchBin >= numBinsPitch ? numBinsPitch - 1 : pitchBin;
+            pitchBin = pitchBin < 0 ? 0 : pitchBin;
+
+            // energy
+            const float_X weighting = particlesFrame[linearThreadIdx][weighting_];
+            const float_X normedWeighting = weighting /
+                                            static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+            const float_X energy = SPEED_OF_LIGHT * math::sqrt(mom2) / weighting;
+
+            int32_t energyBin = 0;
+            if(this->numBinsEnergy > 1)
+            {
+                const int32_t numBinsOutOfRange = 2;
+                energyBin = math::float2int_rd(((logScale ? log10(energy) : energy) - minEnergy) /
+                    (maxEnergy - minEnergy) * static_cast<float_X>(this->numBinsEnergy - numBinsOutOfRange)) + 1;
+
+                // all entries larger than maxEnergy go into last bin
+                energyBin = energyBin < this->numBinsEnergy ? energyBin : this->numBinsEnergy - 1;
+
+                // all entries smaller than minEnergy go into bin zero
+                energyBin = energyBin > 0 ? energyBin : 0;
+            }
+
+            atomicAddWrapper(&(*this->calorimeterCur(yawBin, pitchBin, energyBin)),
+                             energy * normedWeighting);
+        }
+    }
+};
+
+
+template<typename T_ParticlesBox, typename T_CalorimeterFunctor>
+struct ParticleCalorimeterKernel
+{
+    typedef T_ParticlesBox ParticlesBox;
+    typedef T_CalorimeterFunctor CalorimeterFunctor;
+
+    ParticlesBox particlesBox;
+    CalorimeterFunctor calorimeterFunctor;
+
+    ParticleCalorimeterKernel(ParticlesBox particlesBox,
+                           CalorimeterFunctor calorimeterFunctor) :
+        particlesBox(particlesBox),
+        calorimeterFunctor(calorimeterFunctor)
+    {}
+
+    DINLINE void operator()(const PMacc::math::Int<simDim>& cellIndex)
+    {
+        /* definitions for domain variables, like indices of blocks and threads */
+        typedef typename MappingDesc::SuperCellSize SuperCellSize;
+
+        /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+        const PMacc::math::Int<simDim> block = cellIndex / SuperCellSize::toRT();
+
+        /* multi-dim offset from the origin of the local domain on GPU
+         * to the origin of the block of the in unit of cells
+         */
+        const PMacc::math::Int<simDim> blockCell = block * SuperCellSize::toRT();
+
+        /* multi-dim vector from origin of the block to a cell in units of cells */
+        const PMacc::math::Int<simDim> threadIndex = cellIndex % SuperCellSize::toRT();
+
+        /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
+        const int linearThreadIdx = PMacc::math::linearize(
+            PMacc::math::CT::shrinkTo<SuperCellSize, simDim-1>::type::toRT(),
+            threadIndex);
+
+        typedef typename ParticlesBox::FramePtr ParticlesFramePtr;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ParticlesFramePtr>::type particlesFrame;
+
+        /* find last frame in super cell
+         */
+        if (linearThreadIdx == 0)
+        {
+            particlesFrame = this->particlesBox.getLastFrame(block);
+        }
+
+        __syncthreads();
+
+        while(particlesFrame.isValid())
+        {
+            /* casting uint8_t multiMask to boolean */
+            const bool isParticle = particlesFrame[linearThreadIdx][multiMask_];
+
+            if(isParticle)
+            {
+                calorimeterFunctor(particlesFrame, linearThreadIdx);
+            }
+
+            __syncthreads();
+
+            if (linearThreadIdx == 0)
+            {
+                particlesFrame = this->particlesBox.getPreviousFrame(particlesFrame);
+            }
+            __syncthreads();
+        }
+    }
+};
+
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/_defaultParam.loader
+++ b/src/picongpu/include/simulation_defines/_defaultParam.loader
@@ -50,3 +50,4 @@
 #include "simulation_defines/param/fieldBackground.param"
 #include "simulation_defines/param/radiationObserver.param"
 #include "simulation_defines/param/bremsstrahlung.param"
+#include "simulation_defines/param/particleCalorimeter.param"

--- a/src/picongpu/include/simulation_defines/param/particleCalorimeter.param
+++ b/src/picongpu/include/simulation_defines/param/particleCalorimeter.param
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particleCalorimeter
+{
+
+/** Map yaw and pitch into [0,1] respectively. These ranges correspond to
+ * the normalized histogram range of the calorimeter (0: first bin, 1: last bin).
+ * Out-of-range values are mapped to the first or the last bin.
+ *
+ * Useful for fine tuning the spatial calorimeter resolution.
+ *
+ * \param yaw -maxYaw...maxYaw
+ * \param pitch -maxPitch...maxPitch
+ * \param maxYaw maximum value of angle yaw
+ * \param maxPitch maximum value of angle pitch
+ * \return Two values within [-1,1]
+ */
+HDINLINE float2_X mapYawPitchToNormedRange(const float_X yaw,
+                                           const float_X pitch,
+                                           const float_X maxYaw,
+                                           const float_X maxPitch)
+{
+    return float2_X(float_X(0.5) + float_X(0.5) * yaw / maxYaw,
+                    float_X(0.5) + float_X(0.5) * pitch / maxPitch);
+}
+
+} // namespace particleCalorimeter
+} // namespace picongpu


### PR DESCRIPTION
Adds the particle ~~detector~~ calorimeter plugin.
See the [wiki entry](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-ParticleCalorimeter) for a detailed description.

Dependencies:
- [x] #1375 
- [x] #1374 
- [x] #1363 
- [x] #1393 
- [x] #1394 
- [x] #1435 

Tested with #1354. The spectrum has also been tested against this python script:
```python
import numpy as np
import h5py as h5
import matplotlib.pyplot as plt
%matplotlib notebook

timestep = 1
species = "ph"

f = h5.File("<path/to/hdf5-calorimeter-file>")
calorimeter = np.array(f["/data/{}/calorimeter".format(timestep)])
unitSI = f["/data/{}/calorimeter".format(timestep)].attrs["unitSI"]
minEnergy = f["/data/{}/calorimeter".format(timestep)].attrs["minEnergy[keV]"]
maxEnergy = f["/data/{}/calorimeter".format(timestep)].attrs["maxEnergy[keV]"]
UNITCONV_Joule_to_keV = 6.241509e15
calorimeter *= unitSI * UNITCONV_Joule_to_keV

calorimeter = np.sum(calorimeter, axis=(1,2))
plt.plot(calorimeter[1:])

f = h5.File("<path/to/hdf5-output-file>")
p_unit = f["/data/{}/particles/{}/momentum/x".format(timestep, species)].attrs["sim_unit"]
px = np.array(f["/data/{}/particles/{}/momentum/x".format(timestep, species)])
py = np.array(f["/data/{}/particles/{}/momentum/y".format(timestep, species)])
weights = np.array(f["/data/{}/particles/{}/weighting".format(timestep, species)])
energies = np.sqrt(px**2 + py**2) * p_unit * 3e8 / weights * UNITCONV_Joule_to_keV

hist, bins = np.histogram(energies, bins=np.linspace(minEnergy, maxEnergy, len(calorimeter) - 2), weights=energies*weights)
plt.plot(hist)
```