### PR TITLE
refactor particle update call

### DIFF
--- a/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/OneParticleSimulation.hpp
@@ -140,19 +140,15 @@ public:
         FieldJ::ValueType zeroJ( FieldJ::ValueType::create(0.) );
         fieldJ->assign( zeroJ );
 
-#if (ENABLE_ELECTRONS == 1)
         __startTransaction(__getTransactionEvent());
-        //std::cout << "Begin update Electrons" << std::endl;
-        particleStorage[TypeAsIdentifier<PIC_Electrons>()]->update(currentStep);
-        //std::cout << "End update Electrons" << std::endl;
-        EventTask eRecvElectrons = communication::asyncCommunication(*particleStorage[TypeAsIdentifier<PIC_Electrons>()], __getTransactionEvent());
-        EventTask eElectrons = __endTransaction();
-#endif
+        EventTask initEvent = __getTransactionEvent();
+        EventTask updateEvent;
+        EventTask commEvent;
 
-#if (ENABLE_ELECTRONS == 1)
-        __setTransactionEvent(eRecvElectrons + eElectrons);
-
-#endif
+        /* push all species */
+        particles::PushAllSpecies pushAllSpecies;
+        pushAllSpecies(particleStorage, currentStep, initEvent, updateEvent, commEvent);
+        __setTransactionEvent(updateEvent + commEvent);
 
         this->myFieldSolver->update_beforeCurrent(currentStep);
         this->myFieldSolver->update_afterCurrent(currentStep);

--- a/examples/SingleParticleTest/include/OneParticleSimulation.hpp
+++ b/examples/SingleParticleTest/include/OneParticleSimulation.hpp
@@ -138,12 +138,14 @@ public:
 
         __startTransaction(__getTransactionEvent());
 
-        particleStorage[TypeAsIdentifier<PIC_Electrons>()]->update(currentStep);
+        EventTask initEvent = __getTransactionEvent();
+        EventTask updateEvent;
+        EventTask commEvent;
 
-        EventTask eRecvElectrons = communication::asyncCommunication(*particleStorage[TypeAsIdentifier<PIC_Electrons>()], __getTransactionEvent());
-        EventTask eElectrons = __endTransaction();
-
-        __setTransactionEvent(eRecvElectrons + eElectrons);
+        /* push all species */
+        particles::PushAllSpecies pushAllSpecies;
+        pushAllSpecies(particleStorage, currentStep, initEvent, updateEvent, commEvent);
+        __setTransactionEvent(updateEvent + commEvent);
 
 #if (ENABLE_CURRENT == 1)
         fieldJ->computeCurrent < CORE + BORDER, PIC_Electrons > (*particleStorage[TypeAsIdentifier<PIC_Electrons>()], currentStep);


### PR DESCRIPTION
use generic call for particle update

With the current implementation it is not possible to use a particle species without a pusher.
This pull request is needed for #1227.