### PR TITLE
Add error when trying to compile picongpu with CUDA 7.5 w/o C++11

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -352,6 +352,16 @@ if(PIC_ENABLE_INSITU_VOLVIS)
 	set(LIBS ${LIBS} ${ICET_CORE_LIBS} ${ICET_MPI_LIBS})
 endif(PIC_ENABLE_INSITU_VOLVIS)
 
+if( (CUDA_VERSION VERSION_GREATER 7.0) AND
+    (CMAKE_CXX_STANDARD EQUAL 98) )
+    # Kind of invalid usage of floats in constant expressions
+    # which causes problems in nvcc 7.5 and up:
+    # https://github.com/ComputationalRadiationPhysics/picongpu/issues/1290
+    message(FATAL_ERROR "Please enable C++11 with
+                        `-std=c++11` or `-DCMAKE_CXX_STANDARD=11`
+                        when compiling with nvcc 7.5")
+endif()
+
 
 ################################################################################
 # ADIOS

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -53,6 +53,21 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 
 
 ################################################################################
+# C++11 Enabler
+################################################################################
+
+# By using this if-else one can assume that:
+# CMAKE_CXX_STANDARD==11 <=> CUDA_NVCC_FLAGS contain "-std=c++11"
+if("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11")
+    set(CMAKE_CXX_STANDARD 11)
+elseif("${CMAKE_CXX_STANDARD}" STREQUAL "11")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -std=c++11)
+else()
+    # Note: Add support for C++14 once CUDA supports it (maybe 8.0?)
+    set(CMAKE_CXX_STANDARD 98)
+endif()
+
+################################################################################
 # Find CUDA 
 ################################################################################
 
@@ -96,19 +111,14 @@ if(CUDA_KEEP_FILES)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --keep --keep-dir "${PROJECT_BINARY_DIR}/nvcc_tmp")
 endif(CUDA_KEEP_FILES)
 
-################################################################################
-# C++11 Enabler
-################################################################################
-
-# By using this if-else one can assume that:
-# CMAKE_CXX_STANDARD==11 <=> CUDA_NVCC_FLAGS contain "-std=c++11"
-if("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11")
-    set(CMAKE_CXX_STANDARD 11)
-elseif("${CMAKE_CXX_STANDARD}" STREQUAL "11")
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -std=c++11)
-else()
-    # Note: Add support for C++14 once CUDA supports it (maybe 8.0?)
-    set(CMAKE_CXX_STANDARD 98)
+if( (CUDA_VERSION VERSION_GREATER 7.0) AND
+    (CMAKE_CXX_STANDARD EQUAL 98) )
+    # Kind of invalid usage of floats in constant expressions
+    # which causes problems in nvcc 7.5 and up:
+    # https://github.com/ComputationalRadiationPhysics/picongpu/issues/1290
+    message(FATAL_ERROR "Please enable C++11 with
+                        `-std=c++11` or `-DCMAKE_CXX_STANDARD=11`
+                        when compiling with nvcc 7.5")
 endif()
 
 ################################################################################
@@ -351,17 +361,6 @@ if(PIC_ENABLE_INSITU_VOLVIS)
 	include_directories(SYSTEM ${ICET_INCLUDE_DIRS})
 	set(LIBS ${LIBS} ${ICET_CORE_LIBS} ${ICET_MPI_LIBS})
 endif(PIC_ENABLE_INSITU_VOLVIS)
-
-if( (CUDA_VERSION VERSION_GREATER 7.0) AND
-    (CMAKE_CXX_STANDARD EQUAL 98) )
-    # Kind of invalid usage of floats in constant expressions
-    # which causes problems in nvcc 7.5 and up:
-    # https://github.com/ComputationalRadiationPhysics/picongpu/issues/1290
-    message(FATAL_ERROR "Please enable C++11 with
-                        `-std=c++11` or `-DCMAKE_CXX_STANDARD=11`
-                        when compiling with nvcc 7.5")
-endif()
-
 
 ################################################################################
 # ADIOS


### PR DESCRIPTION
This throws a CMake error when trying to compile with nvcc 7.5 but without C++11 due to the problem as described here: https://github.com/ComputationalRadiationPhysics/picongpu/issues/1290

Discussed with @ax3l 