### PR TITLE
Fix incorrect mangling of params

### DIFF
--- a/compile
+++ b/compile
@@ -48,7 +48,7 @@ examples_path=""
 tmpRun_path=""
 
 # parse the command line options ###############################################
-parseOptions $@
+parseOptions "$@"
 
 if [ "$num_parallel" -ne "1" ]; then
     echo -e $compileSuite"Run in parallel: "`echo_g "$num_parallel"`


### PR DESCRIPTION
It was not possible to e.g. specify multiple cmake options like `-c "-DFoo=1 -DBar=2`

@ax3l 