### PR TITLE
SliceFieldPrinter: Include in Namespace

### DIFF
--- a/src/picongpu/include/plugins/SliceFieldPrinter.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.hpp
@@ -25,14 +25,14 @@
 #include "math/vector/Float.hpp"
 #include "plugins/ILightweightPlugin.hpp"
 
+#include <string>
+
 namespace picongpu
 {
 
 using namespace PMacc;
 
 namespace po = boost::program_options;
-
-#include <string>
 
 template<typename Field>
 class SliceFieldPrinterMulti;


### PR DESCRIPTION
Corrects a wrong include of std `<string>` that *should never* be put into a namespace.