### PR TITLE
Notify plugins on leaving particles

### DIFF
--- a/src/libPMacc/include/pluginSystem/IPlugin.hpp
+++ b/src/libPMacc/include/pluginSystem/IPlugin.hpp
@@ -116,6 +116,21 @@ namespace PMacc
          */
         virtual std::string pluginGetName() const = 0;
 
+        /**
+         * Called each timestep if particles are leaving the global simulation volume.
+         *
+         * This method is only called for species which are marked with the
+         * `GuardHandlerCallPlugins` policy in their descpription.
+         *
+         * The order in which the plugins are called is undefined, so this means
+         * read-only access to the particles.
+         *
+         * \param speciesName name of the particle species
+         * \param direction the direction the particles are leaving the simulation
+         */
+        virtual void onParticleLeave(const std::string& /*speciesName*/, const int32_t /*direction*/)
+        {}
+
         /** When was the plugin checkpointed last?
          *
          * @return last checkpoint's time step

--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -203,6 +203,15 @@ namespace PMacc
             return result;
         }
 
+
+        /**
+         * Return a copied list of pointers to all registered plugins.
+         */
+        std::list<IPlugin*> getAllPlugins() const
+        {
+            return this->plugins;
+        }
+
     private:
 
         friend class Environment<DIM1>;

--- a/src/picongpu/include/simulationControl/GuardHandlerCallPlugins.hpp
+++ b/src/picongpu/include/simulationControl/GuardHandlerCallPlugins.hpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/policies/ExchangeParticles.hpp"
+#include "pluginSystem/IPlugin.hpp"
+#include <list>
+
+namespace picongpu
+{
+
+/**
+ * Guard handler policy calling all registered plugins when particles
+ * leave the global simulation volume. This class serves as policy for
+ * the `ParticleDescription` template class.
+ *
+ * For each plugin the method `IPlugin::onParticleLeave()` is called.
+ * After that the guard particles are deleted.
+ */
+struct GuardHandlerCallPlugins
+{
+    typedef PMacc::particles::policies::ExchangeParticles HandleExchanged;
+    typedef GuardHandlerCallPlugins HandleNotExchanged;
+
+    template< class T_Particles >
+    void
+    handleOutgoing(T_Particles& particles, const int32_t direction) const
+    {
+        typedef std::list<PMacc::IPlugin*> Plugins;
+        Plugins plugins = Environment<>::get().PluginConnector().getAllPlugins();
+
+        for(Plugins::iterator iter = plugins.begin(); iter != plugins.end(); iter++)
+        {
+            (*iter)->onParticleLeave(T_Particles::FrameType::getName(), direction);
+        }
+
+        particles.deleteGuardParticles(direction);
+    }
+
+    template< class T_Particles >
+    void
+    handleIncoming(T_Particles&, const int32_t) const
+    {}
+};
+
+} // namespace picongpu


### PR DESCRIPTION
add a new guard region policy class that calls the new method `IPlugin::onParticleLeave()` for each registered plugin whenever particles are leaving the global simulation volume.

Solves #517.
Tested with #1376.