### PR TITLE
Fix `pmacc_types.hpp` Includes

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/types.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/types.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "types.hpp"
+#include "pmacc_types.hpp"
 #include "dimensions/DataSpace.hpp"
 #include "memory/buffers/GridBuffer.hpp"
 

--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
@@ -21,7 +21,8 @@
  */
 
 #pragma once
-#include "types.h"
+
+#include "pmacc_types.hpp"
 #include "memory/buffers/HostBufferIntern.hpp"
 #include "memory/buffers/DeviceBufferIntern.hpp"
 #include <boost/type_traits.hpp>


### PR DESCRIPTION
Follow-Up to #1367, fixes forgotten GoL and parallely merged PR #1370 that still used the old include.

Fixes the broken `dev` from the morning, spotted by @Heikman (thx!) :)