### PR TITLE
Speed up sliceFieldReader.py

### DIFF
--- a/src/tools/share/python/sliceFieldReader.py
+++ b/src/tools/share/python/sliceFieldReader.py
@@ -78,8 +78,7 @@ def readFieldSlices(File):
         # go through all valid field vectors
         for x in range(N_x):
             fieldValue = line[x]
-            data[y,x,:] = _numpy.genfromtxt(_StringIO.StringIO(fieldValue[1:-1]), delimiter=",")
-            
+            data[y,x,:] = map(float,fieldValue[1:-1].split(','))
     return data
 
 


### PR DESCRIPTION
The sample script for reading the output files of the SliceFieldPrinter was very slow. This change speeds up execution by approximately a factor of 60. In tests, the readout of a single file is now performed in 30 seconds.
