### PR TITLE
minor fix: float_32 -> float_X

### DIFF
--- a/src/picongpu/include/particles/gasProfiles/GaussianCloudImpl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/GaussianCloudImpl.hpp
@@ -53,8 +53,8 @@ struct GaussianCloudImpl : public T_ParamClass
     {
         const float_64 unit_length = UNIT_LENGTH;
         const float_X vacuum_y = float_X(ParamClass::vacuumCellsY) * cellSize.y();
-        const floatD_X center = precisionCast<float_32>(ParamClass::center_SI / unit_length);
-        const floatD_X sigma = precisionCast<float_32>(ParamClass::sigma_SI / unit_length);
+        const floatD_X center = precisionCast<float_X>(ParamClass::center_SI / unit_length);
+        const floatD_X sigma = precisionCast<float_X>(ParamClass::sigma_SI / unit_length);
 
         const floatD_X globalCellPos(
                                      precisionCast<float_X>(totalCellOffset) *


### PR DESCRIPTION
minor fix: `float_32` -> `float_X`

`float_32` causes a compiler error in the Bunch example with 64 bit precision.

