### PR TITLE
Add include and fix wrong assignment operator

### DIFF
--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -34,6 +34,7 @@
 #include <exception>
 #include <sstream>
 #include <boost/assert.hpp>
+#include <boost/move/move.hpp>
 
 namespace PMacc
 {
@@ -130,7 +131,7 @@ public:
         return *this;
     }
 
-    HINLINE DeviceBuffer& operator=(const boost::rv<DeviceBuffer>& rhs)
+    HINLINE DeviceBuffer& operator=(const DeviceBuffer& rhs)
     {
         Base::operator=(rhs);
         return *this;


### PR DESCRIPTION
The include is required for the boost move semantics.

The function fixed caused problems in C++11 mode (compile failure) as there the class does not exist. The correct move assignment is here: https://github.com/ComputationalRadiationPhysics/picongpu/blob/dev/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp#L103
The bug was introduced by @Heikman in #1375.