### PR TITLE
Resource monitor class and resource log plugin

### DIFF
--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <vector>  /* std::vector */
+#include <cstdlib> /* std::size_t */
+
+namespace PMacc
+{
+
+    /**
+     * Provides ressource information of the current subgrid
+     *
+     * @tparam DIM number of dimensions of the simulation
+     */
+    template <unsigned T_DIM>
+    class ResourceMonitor
+    {
+    public:
+
+        /**
+         * Constructor
+         */
+        ResourceMonitor();
+
+    private:
+
+        /**
+         * Constructor
+         */
+        ResourceMonitor(const ResourceMonitor& fs);
+
+    public:
+        /**
+         *  Returns the number of cells on the device
+         */
+        std::size_t getCellCount();
+
+        /**
+         * Returns the number of particles per species on the device
+         */
+        template <typename T_Species, typename T_MappingDesc>
+        std::vector<std::size_t> getParticleCounts(T_MappingDesc &cellDescription);
+
+    };
+
+} //namespace PMacc
+

--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// PMacc
+#include "Environment.hpp"
+#include <particles/operations/CountParticles.hpp>
+#include "pmacc_types.hpp"
+#include "forward.hpp"
+#include "dimensions/DataSpace.hpp"
+#include "algorithms/ForEach.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "mappings/simulation/ResourceMonitor.hpp"
+
+namespace PMacc
+{
+    template<typename T_DIM, typename T_Species>
+    struct MyCountParticles
+    {
+        template <typename T_Vector, typename T_MappingDesc>
+        void operator()(T_Vector & particleCounts, T_MappingDesc & cellDescription)
+        {
+            DataConnector & dc = Environment<>::get().DataConnector();
+
+            const SubGrid<T_DIM::value> & subGrid = Environment<T_DIM::value>::get().SubGrid();
+            const DataSpace<T_DIM::value> localSize(subGrid.getLocalDomain().size);
+
+            uint64_cu totalNumParticles = 0;
+            totalNumParticles = PMacc::CountParticles::countOnDevice < CORE + BORDER > (
+                    dc.getData<T_Species >(T_Species::FrameType::getName(), true),
+                    cellDescription,
+                    DataSpace<T_DIM::value>(),
+                    localSize);
+            particleCounts.push_back(totalNumParticles);
+        }
+    };
+
+    template<unsigned T_DIM>
+    ResourceMonitor<T_DIM>::ResourceMonitor()
+    {
+
+    }
+
+    template<unsigned T_DIM>
+    ResourceMonitor<T_DIM>::ResourceMonitor(const ResourceMonitor& fs)
+    {
+
+    }
+
+    template<unsigned T_DIM>
+    size_t ResourceMonitor<T_DIM>::getCellCount()
+    {
+        return Environment<T_DIM>::get().SubGrid().getLocalDomain().size.productOfComponents();
+    }
+
+    template<unsigned T_DIM>
+    template <typename T_Species, typename T_MappingDesc>
+    std::vector<size_t> ResourceMonitor<T_DIM>::getParticleCounts(T_MappingDesc &cellDescription)
+    {
+        typedef bmpl::integral_c<unsigned, T_DIM> dim;
+        std::vector<size_t> particleCounts;
+        algorithms::forEach::ForEach<T_Species, MyCountParticles<dim, bmpl::_1> > countParticles;
+        countParticles(forward(particleCounts), forward(cellDescription));
+        return particleCounts;
+    }
+
+} //namespace PMacc

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -22,13 +22,17 @@
 
 #pragma once
 
+
 #include "pmacc_types.hpp"
 #include "memory/buffers/GridBuffer.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
+#include "particles/memory/dataTypes/FramePointer.hpp"
 
 #include "particles/particleFilter/FilterFactory.hpp"
 #include "particles/particleFilter/PositionFilter.hpp"
 #include "nvidia/atomic.hpp"
+
+
 
 namespace PMacc
 {

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -85,6 +85,8 @@
 #include "plugins/adios/ADIOSWriter.hpp"
 #endif
 
+#include "plugins/ResourceLog.hpp"
+
 namespace picongpu
 {
 
@@ -139,6 +141,7 @@ private:
 #if (ENABLE_HDF5 == 1)
       , hdf5::HDF5Writer
 #endif
+    , ResourceLog
     > StandAlonePlugins;
 
 

--- a/src/picongpu/include/plugins/ResourceLog.hpp
+++ b/src/picongpu/include/plugins/ResourceLog.hpp
@@ -1,0 +1,244 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// PMacc
+#include "Environment.hpp"
+#include "mappings/simulation/ResourceMonitor.hpp"
+
+// PIConGPU
+#include "plugins/ILightweightPlugin.hpp"
+#include "ILightweightPlugin.hpp"
+#include "simulation_defines.hpp"
+
+// Boost
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/filesystem.hpp>
+
+// STL
+#include <iostream>  /* std::cout, std::ostream */
+#include <numeric>   /* std::accumulate */
+#include <string>    /* std::string */
+#include <sstream>   /* std::stringstream */
+#include <fstream>   /* std::filebuf */
+#include <map>       /* std::map */
+
+// C LIB
+#include <stdlib.h> /* itoa */
+#include <stdint.h> /* uint32_t */
+
+namespace picongpu
+{
+    using namespace PMacc;
+
+
+    class ResourceLog : public ILightweightPlugin
+    {
+    private:
+        MappingDesc *cellDescription;
+        ResourceMonitor<simDim> resourceMonitor;
+
+        // programm options
+        std::string outputFilePrefix;
+        std::string streamType;
+        std::string outputFormat;
+        std::vector<std::string> properties;
+
+        std::filebuf fileBuf;
+        std::map<std::string, bool> propertyMap;
+
+    public:
+
+        ResourceLog() :
+                cellDescription(NULL)
+        {
+            Environment<>::get().PluginConnector().registerPlugin(this);
+        }
+
+        std::string pluginGetName() const
+        {
+            return "ResourceLog";
+        }
+
+        void notify(uint32_t currentStep)
+        {
+            //
+            // Create property tree which contains the resource information
+            using boost::property_tree::ptree;
+            ptree pt;
+
+            if(contains(propertyMap, "rank"))
+            {
+                size_t rank = static_cast<size_t>(Environment<simDim>::get().GridController().getGlobalRank());
+                pt.put("resourceLog.rank", rank);
+            }
+
+            if(contains(propertyMap,"position"))
+            {
+                DataSpace<simDim> currentPosition = Environment<simDim>::get().GridController().getPosition();
+                pt.put("resourceLog.position.x", currentPosition[0]);
+                pt.put("resourceLog.position.y", currentPosition[1]);
+                pt.put("resourceLog.position.z", currentPosition[2]);
+            }
+
+            if(contains(propertyMap, "currentStep"))
+            {
+                pt.put("resourceLog.currentStep", currentStep);
+            }
+
+            if(contains(propertyMap, "cellCount"))
+            {
+                size_t cellCount = resourceMonitor.getCellCount();
+                pt.put("resourceLog.cellCount", cellCount);
+            }
+
+            if(contains(propertyMap,"particleCount"))
+            {
+                std::vector<size_t> particleCounts = resourceMonitor.getParticleCounts<VectorAllSpecies>(*cellDescription);
+                pt.put("resourceLog.particleCount", std::accumulate(particleCounts.begin(), particleCounts.end(), 0));
+            }
+
+            //
+            // Write property tree to string stream
+            std::stringstream ss;
+            if(outputFormat == "json")
+            {
+                write_json(ss, pt, false);
+            }
+            else if(outputFormat == "jsonpp")
+            {
+                write_json(ss, pt, true);
+            }
+            else if(outputFormat == "xml")
+            {
+                write_xml(ss, pt);
+            }
+            else if(outputFormat == "xmlpp")
+            {
+                write_xml(ss, pt, boost::property_tree::xml_writer_make_settings<std::string>('\t', 1));
+            }
+            else
+            {
+                throw std::runtime_error(std::string("resourcelog.format ") + outputFormat + std::string(" is not known, use json or xml."));
+            }
+
+            //
+            // Write property tree to the output stream
+            if(streamType == "stdout")
+            {
+                std::cout << ss.str();
+            }
+            else if (streamType == "stderr")
+            {
+                std::cerr << ss.str();
+            }
+            else if (streamType == "file")
+            {
+                std::ostream os(&fileBuf);
+                os << ss.str();
+            }
+            else
+            {
+                throw std::runtime_error(std::string("resourcelog.stream ") + streamType + std::string(" is not known, use stdout, stderr or file instead."));
+            }
+        }
+
+        void pluginRegisterHelp(po::options_description& desc)
+        {
+            /* register command line parameters for your plugin */
+            desc.add_options()
+                    ("resourceLog.period", po::value<uint32_t>(&notifyPeriod)->default_value(0),
+                     "Enable ResourceLog plugin [for each n-th step]")
+                    ("resourceLog.prefix", po::value<std::string>(&outputFilePrefix)->default_value("resourcelog_"),
+                     "Set the filename prefix for output file if a filestream was selected")
+                    ("resourceLog.stream", po::value<std::string>(&streamType)->default_value("file"),
+                     "Output stream [stdout, stderr, file]")
+                    ("resourceLog.properties", po::value<std::vector<std::string> >(&properties)->multitoken(),
+                     "List of properties to log [rank, position, currentStep, cellCount, particleCount]")
+                    ("resourceLog.format", po::value<std::string>(&outputFormat)->default_value("json"),
+                     "Output format of log (pp for pretty print) [json, jsonpp xml, xmlpp]");
+        }
+
+        void setMappingDescription(MappingDesc *cellDescription)
+        {
+            this->cellDescription = cellDescription;
+        }
+
+    private:
+        uint32_t notifyPeriod;
+
+        void pluginLoad() {
+            Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
+
+            //
+            // Set default resources to log
+            if(properties.empty())
+            {
+                properties.push_back("rank");
+                properties.push_back("position");
+                properties.push_back("currentStep");
+                properties.push_back("cellCount");
+                properties.push_back("particleCount");
+                propertyMap["rank"] = true;
+                propertyMap["position"] = true;
+                propertyMap["currentStep"] = true;
+                propertyMap["particleCount"] = true;
+                propertyMap["cellCount"] = true;
+            }
+            else
+            {
+                for(size_t i = 0; i < properties.size(); ++i)
+                {
+                    propertyMap[properties[i]] = true;
+                }
+            }
+
+            //
+            // Prepare file for output stream
+            if (streamType == "file")
+            {
+                size_t rank = static_cast<size_t>(Environment<simDim>::get().GridController().getGlobalRank());
+                std::stringstream ss;
+                ss << outputFilePrefix << rank;
+                boost::filesystem::path resourceLogPath(ss.str());
+                fileBuf.open(resourceLogPath.string().c_str(), std::ios::out);
+            }
+        }
+
+        void pluginUnload()
+        {
+            /* called when plugin is unloaded, cleanup here */
+        }
+
+        template <typename T_MAP>
+        bool contains(T_MAP const map, std::string const value)
+        {
+            return (map.find(value) != map.end());
+        }
+
+    };
+}
+
+#include "mappings/simulation/ResourceMonitor.tpp"


### PR DESCRIPTION
The resource monitor is located in libPMacc and provides information about allocated resources of the library. Currently, particle count and cell count per rank are provided.

The resource log is a user adaptable resource information log plugin which collects resource information and writes these information to a stream.

The user can choose which resource properties to write e.g.:
`--resourceLog.properties rank position currentStep particleCount cellCount`

which format to use e.g.:
`--resourceLog.format json` other options are `jsonpp`, `xml` and `xmlpp`

which stream the information should be written e.g.:
`--resourceLog.stream file` other options are `stdout` and `stderr`

and which prefix to use for filestreams:
`--resourceLog.prefix myprefix_`

Using the options ` --resourceLog.period 1 --resourceLog.stream stdout --resourceLog.properties rank position currentStep particleCount cellCount --resourceLog.format jsonpp` will write resource objects to stdout such as:

    [1,1]<stdout>:    "resourceLog": {
    [1,1]<stdout>:        "rank": "1",
    [1,1]<stdout>:        "position": {
    [1,1]<stdout>:            "x": "0",
    [1,1]<stdout>:            "y": "1",
    [1,1]<stdout>:            "z": "0"
    [1,1]<stdout>:        },
    [1,1]<stdout>:        "currentStep": "357",
    [1,1]<stdout>:        "cellCount": "1048576",
    [1,1]<stdout>:        "particleCount": "2180978"
    [1,1]<stdout>:    }
    [1,1]<stdout>:}

For each format there exists always a non pretty print version to simplify further processing:

    [1,3]<stdout>:{"resourceLog":{"rank":"3","position":{"x":"1","y":"1","z":"0"},"currentStep":"415","cellCount":"1048576","particleCount":"2322324"}}


