### PR TITLE
Find PMacc after #1367

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
@@ -197,7 +197,7 @@ add_definitions(-DPMACC_VERBOSE_LVL=${PMACC_VERBOSE})
 ################################################################################
 
 find_path(PMACC_ROOT_DIR
-  NAMES include/types.h
+  NAMES include/pmacc_types.hpp
   PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../../libPMacc"
   DOC "libPMacc root location."
   )


### PR DESCRIPTION
Followup so that the CMake for the GoL example finds PMacc as the `types.h` is now `pmacc_types.hpp`