### PR TITLE
fix `StrideMapping` usage for 2D

### DIFF
--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -275,7 +275,7 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
         typename GetMargin<ParticleCurrentSolver>::UpperMargin
         > BlockArea;
 
-    StrideMapping<AREA, simDim, MappingDesc> mapper( cellDescription );
+    StrideMapping<AREA, 3, MappingDesc> mapper( cellDescription );
     typename ParticlesClass::ParticlesBoxType pBox = parClass.getDeviceParticlesBox( );
     FieldJ::DataBoxType jBox = this->fieldJ.getDeviceBuffer( ).getDataBox( );
     FrameSolver solver( DELTA_T );

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -70,7 +70,7 @@ namespace picongpu
             VectorAllSpecies,
             interpolation<>
         >::type VectorSpeciesWithInterpolation;
-            
+
         /* ------------------ lower margin  ----------------------------------*/
         typedef bmpl::accumulate<
             VectorSpeciesWithInterpolation,
@@ -172,7 +172,7 @@ namespace picongpu
             typename FrameSolver::UpperMargin
             > BlockArea;
 
-        StrideMapping<AREA, simDim, MappingDesc> mapper( cellDescription );
+        StrideMapping<AREA, 3, MappingDesc> mapper( cellDescription );
         typename ParticlesClass::ParticlesBoxType pBox = parClass.getDeviceParticlesBox( );
         FieldTmp::DataBoxType tmpBox = this->fieldTmp->getDeviceBuffer( ).getDataBox( );
         FrameSolver solver;


### PR DESCRIPTION
- fix `FieldTmp::computeValue`
- fix `FieldJ::computeCurrent`

### Extended Description

added by @ax3l:
The result of the wrong usage are race conditions in 2D during *current deposition*: the stride of super cells was accidentally set to `2` super cells instead of `3`. The result of that is, that current writes in the strided ("skipped") super-cell (with the reminiscence of particles close to the super-cells border) are not protected by atomic adds.
For this to have a negative effect in form of a race condition (resulting in *lowered* current deposited in this area), the support of the particle shape must be at least the size of the shortest super-cell-edge, *this is usually not the case*.

3D simulations are not effected.