### PR TITLE
cleanup usage of `StrideMapping`

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -92,7 +92,7 @@ protected:
     template<uint32_t AREA>
     void shiftParticles()
     {
-        StrideMapping<AREA, DIM3, MappingDesc> mapper(this->cellDescription);
+        StrideMapping<AREA, 3, MappingDesc> mapper(this->cellDescription);
         ParticlesBoxType pBox = particlesBuffer->getDeviceParticleBox();
 
         __startTransaction(__getTransactionEvent());


### PR DESCRIPTION
Use `StrideMapping<AREA, 3,...>` instead of `StrideMapping<AREA, DIM3,..`.
Second parameter of `StrideMapping` is the distance between the SuperCells.

This is a follow up of #1405 but not depend on it.