### PR TITLE
Doc: LiveVis Client F12

### DIFF
--- a/src/tools/livevis/client/README.md
+++ b/src/tools/livevis/client/README.md
@@ -36,6 +36,10 @@ make
 
 ### Run
 
+Build your tunnel(s) if your `server` is not directly reachable.
+An example can be found in `tunnel2cluster.sh` for a complex
+`LoginNode` -> `HeadNode` (->`Cluster`) setup.
+
 ```bash
 ./SimpleUIVisClient
 ```

--- a/src/tools/livevis/client/README.md
+++ b/src/tools/livevis/client/README.md
@@ -40,6 +40,9 @@ make
 ./SimpleUIVisClient
 ```
 
+Now press `F12` to connect to the `server` which will open an overlay menu to
+select a simulation stream. Choose via the arrow keys and select with
+`Enter/Return`.
 
 ### LICENSE
 


### PR DESCRIPTION
`F12` opens a menu with available simulation streams.
That option is so obfuscated, we need to document it.

Also added a note on our tunnel example.