### PR TITLE
Particle ids

### DIFF
--- a/src/libPMacc/include/particles/IdProvider.def
+++ b/src/libPMacc/include/particles/IdProvider.def
@@ -60,7 +60,7 @@ namespace PMacc {
          *  Modifies the state of the IdProvider */
         struct GetNewId
         {
-            DINLINE uint64_cu operator()() const
+            DINLINE uint64_t operator()() const
             {
                 return getNewId();
             }
@@ -68,7 +68,7 @@ namespace PMacc {
 
         /** Function that returns a new id each time it is called
          *  Modifies the state of the IdProvider  */
-        HDINLINE static uint64_cu getNewId();
+        HDINLINE static uint64_t getNewId();
 
         /**
          * Return true, if an overflow of the counter is detected and hence there might be duplicate ids

--- a/src/libPMacc/include/particles/IdProvider.hpp
+++ b/src/libPMacc/include/particles/IdProvider.hpp
@@ -96,17 +96,17 @@ namespace PMacc {
         __cudaKernel(idDetail::getNextId)(1, 1)(nextIdBuf.getDeviceBuffer().getDataBox());
         nextIdBuf.deviceToHost();
         State state;
-        state.nextId = nextIdBuf.getHostBuffer().getDataBox()(0);
+        state.nextId = static_cast<uint64_t>(nextIdBuf.getHostBuffer().getDataBox()(0));
         state.startId = m_startId;
         state.maxNumProc = m_maxNumProc;
         return state;
     }
 
     template<unsigned T_dim>
-    HDINLINE uint64_cu IdProvider<T_dim>::getNewId()
+    HDINLINE uint64_t IdProvider<T_dim>::getNewId()
     {
 #ifdef __CUDA_ARCH__
-        return nvidia::atomicAllInc(&idDetail::nextId);
+        return static_cast<uint64_t>(nvidia::atomicAllInc(&idDetail::nextId));
 #else
         // IMPORTANT: This calls a kernel. So make sure this kernel is instantiated somewhere before!
         return getNewIdHost();
@@ -174,7 +174,7 @@ namespace PMacc {
         HostDeviceBuffer<uint64_cu, 1> newIdBuf(DataSpace<1>(1));
         __cudaKernel(idDetail::getNewId)(1, 1)(newIdBuf.getDeviceBuffer().getDataBox(), GetNewId());
         newIdBuf.deviceToHost();
-        return newIdBuf.getHostBuffer().getDataBox()(0);
+        return static_cast<uint64_t>(newIdBuf.getHostBuffer().getDataBox()(0));
     }
 
 }  // namespace PMacc

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -74,16 +74,15 @@ namespace po = boost::program_options;
     }                                                                         \
 }
 
-#define ADIOS_CMD_EXPECT_NONZERO(_cmd)                                        \
+#define ADIOS_CMD_EXPECT_NONNULL(_cmd)                                        \
 {                                                                             \
-    int _err_code = _cmd;                                                     \
-    if (_err_code == 0)                                                       \
+    if (!(_cmd))                                                              \
     {                                                                         \
         std::string errMsg( adios_errmsg() );                                 \
         if( errMsg.empty() ) errMsg = '\n';                                   \
         std::stringstream s;                                                  \
         s << "ADIOS: error at cmd '" << #_cmd                                 \
-          << "' (" << _err_code << ", " << adios_errno << ") in "             \
+          << "' (" << adios_errno << ") in "                                  \
           << __FILE__ << ":" << __LINE__ << " " << errMsg;                    \
         throw std::runtime_error(s.str());                                    \
     }                                                                         \

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1032,6 +1032,8 @@ private:
         }
         log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) writing particle species.");
 
+        log<picLog::INPUT_OUTPUT>("ADIOS: Writing IdProvider state (NextId: %1%, maxNumProc: %2%)")
+                % idProviderState.get<0>() % idProviderState.get<1>();
         writeIdProviderState(*threadParams, idProviderState.get<0>());
 
         /* close adios file, most likely the actual write point */

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -590,7 +590,7 @@ public:
                 "maxNumProc", &idProvState.maxNumProc);
         ReadNDScalars<uint64_t>()(mThreadParams,
                 "picongpu/idProvider/nextId", &idProvState.nextId);
-        log<picLog::INPUT_OUTPUT > ("Setting id on current rank: %1%") % idProvState.nextId;
+        log<picLog::INPUT_OUTPUT > ("Setting next free id on current rank: %1%") % idProvState.nextId;
         IdProvider<simDim>::setState(idProvState);
 
         /* free memory allocated in ADIOS calls */

--- a/src/picongpu/include/plugins/adios/NDScalars.hpp
+++ b/src/picongpu/include/plugins/adios/NDScalars.hpp
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "plugins/adios/ADIOSWriter.def"
+#include "traits/PICToAdios.hpp"
+#include "Environment.hpp"
+
+namespace picongpu {
+namespace adios {
+
+/* Functors for reading and writing ND scalar fields
+ * In the current implementation each process (of the ND grid) reads/writes 1 scalar value
+ * Optionally the processes can also write an attribute for this dataset
+ */
+
+template<typename T_Skalar, typename T_Attribute = uint64_t>
+struct WriteNDScalars
+{
+    WriteNDScalars(const std::string& name, const std::string& attrName = ""):name(name), attrName(attrName){}
+
+    void prepare(ThreadParams& params, T_Attribute attribute = T_Attribute())
+    {
+        typedef traits::PICToAdios<T_Skalar> AdiosSkalarType;
+        typedef PMacc::math::UInt64<simDim> Dimensions;
+
+        log<picLog::INPUT_OUTPUT> ("ADIOS prepare write %1%D scalars: %2%") % simDim % name;
+
+        params.adiosGroupSize += sizeof(T_Skalar);
+        if(!attrName.empty())
+            params.adiosGroupSize += sizeof(T_Attribute);
+
+        // Size over all processes
+        Dimensions globalDomainSize(1, 1, 1);
+        // Offset for this process
+        Dimensions localDomainOffset(0, 0, 0);
+
+        for (uint32_t d = 0; d < simDim; ++d)
+        {
+            globalDomainSize[d] = Environment<simDim>::get().GridController().getGpuNodes()[d];
+            localDomainOffset[d] = Environment<simDim>::get().GridController().getPosition()[d];
+        }
+
+        std::string datasetName = params.adiosBasePath + name;
+
+        varId = defineAdiosVar<simDim>(
+                    params.adiosGroupHandle,
+                    datasetName.c_str(),
+                    NULL,
+                    AdiosSkalarType().type,
+                    Dimensions::create(1),
+                    globalDomainSize,
+                    localDomainOffset,
+                    true,
+                    params.adiosCompression);
+
+        if(!attrName.empty())
+        {
+            typedef traits::PICToAdios<T_Attribute> AdiosAttrType;
+
+            log<picLog::INPUT_OUTPUT> ("ADIOS write attribute %1% of %2%D scalars: %3%") % attrName % simDim % name;
+            ADIOS_CMD( adios_define_attribute_byvalue(params.adiosGroupHandle,
+                       attrName.c_str(), datasetName.c_str(),
+                       AdiosAttrType().type, 1, (void*)&attribute) );
+        }
+    }
+
+    void operator()(ThreadParams& params,T_Skalar value)
+    {
+        log<picLog::INPUT_OUTPUT> ("ADIOS write %1%D scalars: %2%") % simDim % name;
+
+        ADIOS_CMD( adios_write_byid(params.adiosFileHandle, varId, &value) );
+    }
+private:
+    const std::string name, attrName;
+    int64_t varId;
+};
+
+template<typename T_Skalar, typename T_Attribute = uint64_t>
+struct ReadNDScalars
+{
+    void operator()(ThreadParams& params,
+                const std::string& name, T_Skalar* value,
+                const std::string& attrName = "", T_Attribute* attribute = NULL)
+    {
+        log<picLog::INPUT_OUTPUT> ("ADIOS read %1%D scalars: %2%") % simDim % name;
+        std::string datasetName = params.adiosBasePath + name;
+
+        ADIOS_VARINFO* varInfo;
+        ADIOS_CMD_EXPECT_NONNULL( varInfo = adios_inq_var(params.fp, datasetName.c_str()) );
+        assert(varInfo->ndim == simDim);
+        assert(varInfo->type == traits::PICToAdios<T_Skalar>().type);
+
+        DataSpace<simDim> gridPos = Environment<simDim>::get().GridController().getPosition();
+        uint64_t start[varInfo->ndim];
+        uint64_t count[varInfo->ndim];
+        for(int d = 0; d < varInfo->ndim; ++d)
+        {
+            /* \see adios_define_var: z,y,x in C-order */
+            start[d] = gridPos.revert()[d];
+            count[d] = 1;
+        }
+
+        ADIOS_SELECTION* fSel = adios_selection_boundingbox(varInfo->ndim, start, count);
+
+        /* specify what we want to read, but start reading at below at `adios_perform_reads` */
+        /* magic parameters (0, 1): `from_step` (not used in streams), `nsteps` to read (must be 1 for stream) */
+        log<picLog::INPUT_OUTPUT > ("ADIOS: Schedule read skalar %1%)") % datasetName;
+        ADIOS_CMD( adios_schedule_read(params.fp, fSel, datasetName.c_str(), 0, 1, (void*)value) );
+
+        /* start a blocking read of all scheduled variables */
+        ADIOS_CMD( adios_perform_reads(params.fp, 1) );
+
+        adios_selection_delete(fSel);
+        adios_free_varinfo(varInfo);
+
+        if(!attrName.empty())
+        {
+            log<picLog::INPUT_OUTPUT> ("ADIOS read attribute %1% for scalars: %2%") % attrName % name;
+            enum ADIOS_DATATYPES attrType;
+            int attrSize;
+            T_Attribute* attrValuePtr;
+            ADIOS_CMD( adios_get_attr(params.fp,
+                                      (datasetName + "/" + attrName).c_str(),
+                                      &attrType,
+                                      &attrSize,
+                                      (void**) &attrValuePtr) );
+            *attribute = *attrValuePtr;
+            log<picLog::INPUT_OUTPUT > ("ADIOS: value of %1% = %2%") % attrName % *attribute;
+
+            assert(attrType == traits::PICToAdios<T_Attribute>().type);
+            assert(attrSize == sizeof(T_Attribute));
+            __delete(attrValuePtr);
+        }
+    }
+};
+
+}  // namespace adios
+}  // namespace picongpu

--- a/src/picongpu/include/plugins/adios/restart/ReadAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/restart/ReadAttribute.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "simulation_types.hpp"
+#include "plugins/adios/ADIOSWriter.def"
+#include "debug/VerboseLog.hpp"
+#include "traits/PICToAdios.hpp"
+#include <adios.h>
+#include <adios_read.h>
+#include <adios_error.h>
+#include <stdexcept>
+
+namespace picongpu {
+namespace adios {
+
+    /**
+     * Read an attribute from an open ADIOS file, check that its type is correct and return it
+     *
+     * @param fp       Open ADIOS file handle
+     * @param basePath Path where the attribute is located in the file (with or w/o trailing slash)
+     * @param attrName Name of the attribute. Used for status output and concatenated with basePath
+     * @retval Attribute value
+     */
+    template<typename T_Attribute>
+    T_Attribute readAttribute(ADIOS_FILE* fp, const std::string& basePath, const std::string& attrName)
+    {
+        // Build full path
+        std::string attrPath = basePath;
+        if(!attrPath.empty() && attrPath[attrPath.size() - 1] != '/')
+            attrPath += '/';
+        attrPath += attrName;
+        // Actually read the data
+        enum ADIOS_DATATYPES attrType;
+        int attrSize;
+        T_Attribute* attrValuePtr;
+        ADIOS_CMD( adios_get_attr(fp,
+                                  attrPath.c_str(),
+                                  &attrType,
+                                  &attrSize,
+                                  (void**) &attrValuePtr) );
+        // Sanity checks
+        if(attrType != traits::PICToAdios<T_Attribute>().type)
+            throw std::runtime_error(std::string("Invalid type of ADIOS attribute ") + attrName);
+        if(attrSize != sizeof(T_Attribute))
+            throw std::runtime_error(std::string("Invalid size of ADIOS attribute ") + attrName);
+
+        T_Attribute attribute = *attrValuePtr;
+        __delete(attrValuePtr);
+        log<picLog::INPUT_OUTPUT > ("ADIOS: value of %1% = %2%") % attrName % attribute;
+        return attribute;
+    }
+
+}  // namespace adios
+}  // namespace picongpu

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.def
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.def
@@ -26,7 +26,7 @@
 #include "simulation_types.hpp"
 #include "particles/frame_types.hpp"
 #include "simulationControl/MovingWindow.hpp"
-
+#include <splash/splash.h>
 
 
 namespace picongpu

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -227,7 +227,7 @@ public:
                 "maxNumProc", &idProvState.maxNumProc);
         ReadNDScalars<uint64_t>()(mThreadParams,
                 "picongpu/idProvider/nextId", &idProvState.nextId);
-        log<picLog::INPUT_OUTPUT > ("Setting id on current rank: %1%") % idProvState.nextId;
+        log<picLog::INPUT_OUTPUT > ("Setting bext free id on current rank: %1%") % idProvState.nextId;
         IdProvider<simDim>::setState(idProvState);
 
         /* close datacollector */

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -461,6 +461,8 @@ private:
         log<picLog::INPUT_OUTPUT > ("HDF5: ( end ) writing particle species.");
 
         PMACC_AUTO(idProviderState, IdProvider<simDim>::getState());
+        log<picLog::INPUT_OUTPUT>("HDF5: Writing IdProvider state (NextId: %1%, maxNumProc: %2%)")
+                % idProviderState.get<0>() % idProviderState.get<1>();
         WriteNDScalars<uint64_t, uint64_t>()(*threadParams,
                 "picongpu/idProviderState", idProviderState.get<0>(),
                 "maxNumProc", idProviderState.get<1>());

--- a/src/picongpu/include/plugins/hdf5/NDScalars.hpp
+++ b/src/picongpu/include/plugins/hdf5/NDScalars.hpp
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "plugins/hdf5/HDF5Writer.def"
+#include "traits/PICToSplash.hpp"
+#include "Environment.hpp"
+
+namespace picongpu {
+namespace hdf5 {
+
+/* Functors for reading and writing ND scalar fields
+ * In the current implementation each process (of the ND grid) reads/writes 1 scalar value
+ * Optionally the processes can also write an attribute for this dataset
+ */
+
+template<typename T_Skalar, typename T_Attribute = uint64_t>
+struct WriteNDScalars
+{
+    void operator()(ThreadParams& params,
+            const std::string& name, T_Skalar value,
+            const std::string& attrName = "", T_Attribute attribute = T_Attribute())
+    {
+        log<picLog::INPUT_OUTPUT> ("HDF5 write %1%D scalars: %2%") % simDim % name;
+
+        // Size over all processes
+        Dimensions splashGlobalDomainSize(1, 1, 1);
+        // Offset for this process
+        Dimensions splashGlobalOffsetFile(0, 0, 0);
+        // Offset for all processes
+        Dimensions splashGlobalDomainOffset(0, 0, 0);
+
+        for (uint32_t d = 0; d < simDim; ++d)
+        {
+            splashGlobalDomainSize[d] = Environment<simDim>::get().GridController().getGpuNodes()[d];
+            splashGlobalOffsetFile[d] = Environment<simDim>::get().GridController().getPosition()[d];
+        }
+
+        Dimensions localSize(1, 1, 1);
+
+        typename traits::PICToSplash<T_Skalar>::type splashType;
+        params.dataCollector->writeDomain(params.currentStep,               /* id == time step */
+                                           splashGlobalDomainSize,          /* total size of dataset over all processes */
+                                           splashGlobalOffsetFile,          /* write offset for this process */
+                                           splashType,                      /* data type */
+                                           simDim,                          /* NDims spatial dimensionality of the field */
+                                           splash::Selection(localSize),    /* data size of this process */
+                                           name.c_str(),                    /* data set name */
+                                           splash::Domain(
+                                                  splashGlobalDomainOffset, /* offset of the global domain */
+                                                  splashGlobalDomainSize    /* size of the global domain */
+                                           ),
+                                           DomainCollector::GridType,
+                                           &value);
+
+        if(!attrName.empty())
+        {
+            log<picLog::INPUT_OUTPUT> ("HDF5 write attribute %1% for scalars: %2%") % attrName % name;
+            /*simulation attributes for data*/
+            typename traits::PICToSplash<T_Attribute>::type attType;
+
+            params.dataCollector->writeAttribute(params.currentStep,
+                                                  attType, name.c_str(),
+                                                  attrName.c_str(), &attribute);
+        }
+    }
+};
+
+template<typename T_Skalar, typename T_Attribute = uint64_t>
+struct ReadNDScalars
+{
+    void operator()(ThreadParams& params,
+                const std::string& name, T_Skalar* value,
+                const std::string& attrName = "", T_Attribute* attribute = NULL)
+    {
+        log<picLog::INPUT_OUTPUT> ("HDF5 read %1%D scalars: %2%") % simDim % name;
+
+        Dimensions domain_offset(0, 0, 0);
+        for (uint32_t d = 0; d < simDim; ++d)
+            domain_offset[d] = Environment<simDim>::get().GridController().getPosition()[d];
+
+        DomainCollector::DomDataClass data_class;
+        DataContainer *dataContainer =
+            params.dataCollector->readDomain(params.currentStep,
+                                               name.c_str(),
+                                               Domain(domain_offset, Dimensions(1, 1, 1)),
+                                               &data_class);
+
+        typename traits::PICToSplash<T_Skalar>::type splashType;
+        *value = *static_cast<T_Skalar*>(dataContainer->getIndex(0)->getData());
+        __delete(dataContainer);
+
+        if(!attrName.empty())
+        {
+            log<picLog::INPUT_OUTPUT> ("HDF5 read attribute %1% for scalars: %2%") % attrName % name;
+            params.dataCollector->readAttribute(params.currentStep, name.c_str(), attrName.c_str(), attribute);
+        }
+    }
+};
+
+}  // namespace hdf5
+}  // namespace picongpu

--- a/src/picongpu/include/plugins/hdf5/NDScalars.hpp
+++ b/src/picongpu/include/plugins/hdf5/NDScalars.hpp
@@ -40,7 +40,7 @@ struct WriteNDScalars
             const std::string& name, T_Skalar value,
             const std::string& attrName = "", T_Attribute attribute = T_Attribute())
     {
-        log<picLog::INPUT_OUTPUT> ("HDF5: write %1%D scalars: %2%") % simDim % name;
+        log<picLog::INPUT_OUTPUT>("HDF5: write %1%D scalars: %2%") % simDim % name;
 
         // Size over all processes
         Dimensions globalSize(1, 1, 1);
@@ -77,7 +77,7 @@ struct WriteNDScalars
             /*simulation attribute for data*/
             typename traits::PICToSplash<T_Attribute>::type attType;
 
-            log<picLog::INPUT_OUTPUT> ("HDF5: write attribute %1% for scalars: %2%") % attrName % name;
+            log<picLog::INPUT_OUTPUT>("HDF5: write attribute %1% for scalars: %2%") % attrName % name;
             params.dataCollector->writeAttribute(params.currentStep,
                                                   attType, name.c_str(),
                                                   attrName.c_str(), &attribute);
@@ -92,7 +92,7 @@ struct ReadNDScalars
                 const std::string& name, T_Skalar* value,
                 const std::string& attrName = "", T_Attribute* attribute = NULL)
     {
-        log<picLog::INPUT_OUTPUT> ("HDF5: read %1%D scalars: %2%") % simDim % name;
+        log<picLog::INPUT_OUTPUT>("HDF5: read %1%D scalars: %2%") % simDim % name;
 
         Dimensions domain_offset(0, 0, 0);
         for (uint32_t d = 0; d < simDim; ++d)
@@ -111,8 +111,9 @@ struct ReadNDScalars
 
         if(!attrName.empty())
         {
-            log<picLog::INPUT_OUTPUT> ("HDF5: read attribute %1% for scalars: %2%") % attrName % name;
+            log<picLog::INPUT_OUTPUT>("HDF5: read attribute %1% for scalars: %2%") % attrName % name;
             params.dataCollector->readAttribute(params.currentStep, name.c_str(), attrName.c_str(), attribute);
+            log<picLog::INPUT_OUTPUT>("HDF5: attribute %1% = %2%") % attrName % *attribute;
         }
     }
 };

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -63,6 +63,7 @@
 #include "particles/InitFunctors.hpp"
 #include "particles/memory/buffers/MallocMCBuffer.hpp"
 #include "particles/traits/FilterByFlag.hpp"
+#include "particles/IdProvider.hpp"
 
 #include <boost/mpl/int.hpp>
 
@@ -313,6 +314,8 @@ public:
 
         Environment<>::get().MemoryInfo().getMemoryInfo(&freeGpuMem);
         log<picLog::MEMORY > ("free mem after all mem is allocated %1% MiB") % (freeGpuMem / 1024 / 1024);
+
+        IdProvider<simDim>::init();
 
         fieldB->init(*fieldE, *laser);
         fieldE->init(*fieldB, *laser);

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -45,7 +45,7 @@ alias(position);
  */
 alias(globalCellIdx);
 
-value_identifier(uint64_cu,particleId,IdProvider<simDim>::getNewId());
+value_identifier(uint64_t,particleId,IdProvider<simDim>::getNewId());
 
 /** specialization for the relative in-cell position */
 value_identifier(floatD_X,position_pic,floatD_X::create(0.));

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 Rene Widera, Marco Garten
+ * Copyright 2014-2016 Rene Widera, Marco Garten, Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -29,6 +29,7 @@
 #include "identifier/identifier.hpp"
 #include "identifier/alias.hpp"
 #include "identifier/value_identifier.hpp"
+#include "particles/IdProvider.def"
 
 namespace picongpu
 {
@@ -43,6 +44,8 @@ alias(position);
  * current time step.
  */
 alias(globalCellIdx);
+
+value_identifier(uint64_cu,particleId,IdProvider<simDim>::getNewId());
 
 /** specialization for the relative in-cell position */
 value_identifier(floatD_X,position_pic,floatD_X::create(0.));

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -198,10 +198,11 @@ struct UnitDimension<weighting >
 template<>
 struct Unit<particleId>
 {
-    /* zero-sized vector indicating unitless flag for hdf5 and adios output */
+    /* unitless and not scaled by a factor: by convention 1.0 */
     static std::vector<double> get()
     {
-        return std::vector<double>();
+        std::vector<double> unit( 1, 1.0 );
+        return unit;
     }
 };
 template<>

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2016 Rene Widera, Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Rene Widera, Felix Schmitt, Axel Huebl,
+ *                     Alexander Grund
  *
  * This file is part of PIConGPU.
  *
@@ -191,6 +192,25 @@ struct UnitDimension<weighting >
         std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
 
         return unitDimension;
+    }
+};
+
+template<>
+struct Unit<particleId>
+{
+    /* zero-sized vector indicating unitless flag for hdf5 and adios output */
+    static std::vector<double> get()
+    {
+        return std::vector<double>();
+    }
+};
+template<>
+struct UnitDimension<particleId>
+{
+    static std::vector<float_64> get()
+    {
+        /* unitless */
+        return std::vector<float_64>( NUnitDimension, 0.0 );
     }
 };
 

--- a/src/picongpu/include/traits/AdiosToPIC.tpp
+++ b/src/picongpu/include/traits/AdiosToPIC.tpp
@@ -30,14 +30,13 @@ namespace picongpu
 
 namespace traits
 {
-    /** Trait for adios_integer */
+
     template<>
     struct AdiosToPIC<adios_integer>
     {
         typedef int32_t type;
     };
     
-    /** Trait for adios_unsigned_integer */
     template<>
     struct AdiosToPIC<adios_unsigned_integer>
     {
@@ -56,14 +55,12 @@ namespace traits
         typedef uint64_t type;
     };
 
-    /** Trait for adios_real */
     template<>
     struct AdiosToPIC<adios_real>
     {
         typedef float_32 type;
     };
     
-    /** Trait for adios_double */
     template<>
     struct AdiosToPIC<adios_double>
     {

--- a/src/picongpu/include/traits/AdiosToPIC.tpp
+++ b/src/picongpu/include/traits/AdiosToPIC.tpp
@@ -44,6 +44,12 @@ namespace traits
         typedef unsigned int type;
     };
 
+    template<>
+    struct AdiosToPIC<adios_unsigned_long>
+    {
+        typedef uint64_t type;
+    };
+
     /** Trait for adios_real */
     template<>
     struct AdiosToPIC<adios_real>

--- a/src/picongpu/include/traits/AdiosToPIC.tpp
+++ b/src/picongpu/include/traits/AdiosToPIC.tpp
@@ -34,14 +34,20 @@ namespace traits
     template<>
     struct AdiosToPIC<adios_integer>
     {
-        typedef int type;
+        typedef int32_t type;
     };
     
     /** Trait for adios_unsigned_integer */
     template<>
     struct AdiosToPIC<adios_unsigned_integer>
     {
-        typedef unsigned int type;
+        typedef uint32_t type;
+    };
+
+    template<>
+    struct AdiosToPIC<adios_long>
+    {
+        typedef int64_t type;
     };
 
     template<>

--- a/src/picongpu/include/traits/PICToAdios.tpp
+++ b/src/picongpu/include/traits/PICToAdios.tpp
@@ -76,7 +76,10 @@ namespace traits
     template<>
     struct PICToAdios<
                         typename bmpl::if_<
-                            boost::is_same<uint64_t, uint64_cu>,
+                            typename bmpl::or_<
+                                boost::is_same<uint64_t, uint64_cu>,
+                                bmpl::bool_<sizeof(uint64_cu) != sizeof(uint64_t)>
+                            >::type,
                             uint64_cu_unused_adios,
                             uint64_cu
                         >::type

--- a/src/picongpu/include/traits/PICToAdios.tpp
+++ b/src/picongpu/include/traits/PICToAdios.tpp
@@ -32,7 +32,6 @@ namespace picongpu
 
 namespace traits
 {
-    /** Trait for int */
     template<>
     struct PICToAdios<int32_t>
     {
@@ -42,7 +41,6 @@ namespace traits
         type(adios_integer) {}
     };
     
-    /** Trait for uint32_t */
     template<>
     struct PICToAdios<uint32_t>
     {
@@ -85,7 +83,6 @@ namespace traits
                      >: public PICToAdios<uint64_t>
     {};
 
-    /** Trait for float_32 */
     template<>
     struct PICToAdios<float_32>
     {
@@ -95,7 +92,6 @@ namespace traits
         type(adios_real) {}
     };
 
-    /** Trait for float_64 */
     template<>
     struct PICToAdios<float_64>
     {

--- a/src/picongpu/include/traits/PICToAdios.tpp
+++ b/src/picongpu/include/traits/PICToAdios.tpp
@@ -24,6 +24,8 @@
 #include <adios.h>
 
 #include "simulation_defines.hpp"
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits.hpp>
 
 namespace picongpu
 {
@@ -32,7 +34,7 @@ namespace traits
 {
     /** Trait for int */
     template<>
-    struct PICToAdios<int>
+    struct PICToAdios<int32_t>
     {
         ADIOS_DATATYPES type;
         
@@ -50,7 +52,15 @@ namespace traits
         type(adios_unsigned_integer) {}
     };
     
-    /** Trait for uint64_t */
+    template<>
+    struct PICToAdios<int64_t>
+    {
+        ADIOS_DATATYPES type;
+
+        PICToAdios() :
+        type(adios_long) {}
+    };
+
     template<>
     struct PICToAdios<uint64_t>
     {
@@ -60,14 +70,20 @@ namespace traits
         type(adios_unsigned_long) {}
     };
 
+    /** Specialization for uint64_cu.
+     *  If uint64_cu happens to be the same as uint64_t we use an unused dummy type
+     *  to avoid duplicate specialization
+     */
+    struct uint64_cu_unused_adios;
     template<>
-    struct PICToAdios<uint64_cu>
-    {
-        ADIOS_DATATYPES type;
-
-        PICToAdios() :
-        type(adios_unsigned_long) {}
-    };
+    struct PICToAdios<
+                        typename bmpl::if_<
+                            boost::is_same<uint64_t, uint64_cu>,
+                            uint64_cu_unused_adios,
+                            uint64_cu
+                        >::type
+                     >: public PICToAdios<uint64_t>
+    {};
 
     /** Trait for float_32 */
     template<>

--- a/src/picongpu/include/traits/PICToAdios.tpp
+++ b/src/picongpu/include/traits/PICToAdios.tpp
@@ -60,6 +60,15 @@ namespace traits
         type(adios_unsigned_long) {}
     };
 
+    template<>
+    struct PICToAdios<uint64_cu>
+    {
+        ADIOS_DATATYPES type;
+
+        PICToAdios() :
+        type(adios_unsigned_long) {}
+    };
+
     /** Trait for float_32 */
     template<>
     struct PICToAdios<float_32>

--- a/src/picongpu/include/traits/PICToSplash.tpp
+++ b/src/picongpu/include/traits/PICToSplash.tpp
@@ -24,6 +24,8 @@
 #include <splash/splash.h>
 
 #include "simulation_defines.hpp"
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits.hpp>
 
 namespace picongpu
 {
@@ -58,16 +60,31 @@ namespace traits
     };
 
     template<>
+    struct PICToSplash<int64_t>
+    {
+        typedef splash::ColTypeInt64 type;
+    };
+
+    template<>
     struct PICToSplash<uint64_t>
     {
         typedef splash::ColTypeUInt64 type;
     };
 
+    /** Specialization for uint64_cu.
+     *  If uint64_cu happens to be the same as uint64_t we use an unused dummy type
+     *  to avoid duplicate specialization
+     */
+    struct uint64_cu_unused_splash;
     template<>
-    struct PICToSplash<uint64_cu>
-    {
-        typedef splash::ColTypeUInt64 type;
-    };
+    struct PICToSplash<
+                        typename bmpl::if_<
+                            boost::is_same<uint64_t, uint64_cu>,
+                            uint64_cu_unused_splash,
+                            uint64_cu
+                        >::type
+                     >: public PICToSplash<uint64_t>
+    {};
 
     /** Trait for splash::Dimensions */
     template<>

--- a/src/picongpu/include/traits/PICToSplash.tpp
+++ b/src/picongpu/include/traits/PICToSplash.tpp
@@ -83,7 +83,10 @@ namespace traits
     template<>
     struct PICToSplash<
                         typename bmpl::if_<
-                            boost::is_same<uint64_t, uint64_cu>,
+                            typename bmpl::or_<
+                                boost::is_same<uint64_t, uint64_cu>,
+                                bmpl::bool_<sizeof(uint64_cu) != sizeof(uint64_t)>
+                            >::type,
                             uint64_cu_unused_splash,
                             uint64_cu
                         >::type

--- a/src/picongpu/include/traits/PICToSplash.tpp
+++ b/src/picongpu/include/traits/PICToSplash.tpp
@@ -57,9 +57,14 @@ namespace traits
         typedef splash::ColTypeInt type;
     };
 
-    /** Trait for int */
     template<>
     struct PICToSplash<uint64_t>
+    {
+        typedef splash::ColTypeUInt64 type;
+    };
+
+    template<>
+    struct PICToSplash<uint64_cu>
     {
         typedef splash::ColTypeUInt64 type;
     };

--- a/src/picongpu/include/traits/PICToSplash.tpp
+++ b/src/picongpu/include/traits/PICToSplash.tpp
@@ -57,6 +57,13 @@ namespace traits
         typedef splash::ColTypeInt type;
     };
 
+    /** Trait for int */
+    template<>
+    struct PICToSplash<uint64_t>
+    {
+        typedef splash::ColTypeUInt64 type;
+    };
+
     /** Trait for splash::Dimensions */
     template<>
     struct PICToSplash<splash::Dimensions>

--- a/src/picongpu/include/traits/PICToSplash.tpp
+++ b/src/picongpu/include/traits/PICToSplash.tpp
@@ -32,31 +32,35 @@ namespace picongpu
 
 namespace traits
 {
-    /** Trait for bool */
+
     template<>
     struct PICToSplash<bool>
     {
         typedef splash::ColTypeBool type;
     };
-    /** Trait for float_32 */
+
     template<>
     struct PICToSplash<float_32>
     {
         typedef splash::ColTypeFloat type;
     };
 
-    /** Trait for float_64 */
     template<>
     struct PICToSplash<float_64>
     {
         typedef splash::ColTypeDouble type;
     };
 
-    /** Trait for int */
     template<>
-    struct PICToSplash<int>
+    struct PICToSplash<int32_t>
     {
-        typedef splash::ColTypeInt type;
+        typedef splash::ColTypeInt32 type;
+    };
+
+    template<>
+    struct PICToSplash<uint32_t>
+    {
+        typedef splash::ColTypeUInt32 type;
     };
 
     template<>
@@ -86,7 +90,6 @@ namespace traits
                      >: public PICToSplash<uint64_t>
     {};
 
-    /** Trait for splash::Dimensions */
     template<>
     struct PICToSplash<splash::Dimensions>
     {

--- a/src/picongpu/include/traits/SplashToPIC.tpp
+++ b/src/picongpu/include/traits/SplashToPIC.tpp
@@ -30,32 +30,41 @@ namespace picongpu
 
 namespace traits
 {
-    /** Trait for splash::ColTypeBool */
     template<>
     struct SplashToPIC<splash::ColTypeBool>
     {
         typedef bool type;
     };
 
-    /** Trait for splash::ColTypeFloat */
     template<>
     struct SplashToPIC<splash::ColTypeFloat>
     {
         typedef float_32 type;
     };
 
-    /** Trait for splash::ColTypeDouble */
     template<>
     struct SplashToPIC<splash::ColTypeDouble>
     {
         typedef float_64 type;
     };
 
-    /** Trait for splash::ColTypeInt */
+    /** Native int */
     template<>
     struct SplashToPIC<splash::ColTypeInt>
     {
         typedef int type;
+    };
+
+    template<>
+    struct SplashToPIC<splash::ColTypeInt32>
+    {
+        typedef int32_t type;
+    };
+
+    template<>
+    struct SplashToPIC<splash::ColTypeUInt32>
+    {
+        typedef uint32_t type;
     };
 
     template<>

--- a/src/picongpu/include/traits/SplashToPIC.tpp
+++ b/src/picongpu/include/traits/SplashToPIC.tpp
@@ -59,12 +59,17 @@ namespace traits
     };
 
     template<>
+    struct SplashToPIC<splash::ColTypeInt64>
+    {
+        typedef int64_t type;
+    };
+
+    template<>
     struct SplashToPIC<splash::ColTypeUInt64>
     {
         typedef uint64_t type;
     };
 
-    /** Trait for splash::ColTypeInt */
     template<>
     struct SplashToPIC<splash::ColTypeDim>
     {

--- a/src/picongpu/include/traits/SplashToPIC.tpp
+++ b/src/picongpu/include/traits/SplashToPIC.tpp
@@ -58,6 +58,12 @@ namespace traits
         typedef int type;
     };
 
+    template<>
+    struct SplashToPIC<splash::ColTypeUInt64>
+    {
+        typedef uint64_t type;
+    };
+
     /** Trait for splash::ColTypeInt */
     template<>
     struct SplashToPIC<splash::ColTypeDim>


### PR DESCRIPTION
Requires:
- [x] #1409 
- [x] #1415 
- [x] Runtime test with Splash 1.4.0

This adds a speciesAttribute `particleId`, the traits for units and initializes the `IdProvider` in `MySimulation`.
It also implements saving and loading from HDF5 and ADIOS just like the moving window slider.