### PR TITLE
Actually exit when pression no

### DIFF
--- a/compile
+++ b/compile
@@ -19,6 +19,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+set -o pipefail
 this_dir=$(cd `dirname $0` && pwd)
 
 # load libs and functions ######################################################
@@ -127,7 +128,7 @@ do
             $this_dir/buildsystem/CompileSuite/compileSet.sh \
                 "$example_name" "$testFlagNr" "$globalCMakeOptions" \
                 "$tmpRun_path" "$buildDir" "$examples_path" \
-                "$quiet_run" | tee $buildDir"/compile.log"
+                "$quiet_run" | tee $buildDir"/compile.log" || exit $?
         fi
 
         testFlagNr=$(( testFlagNr + 1 ))


### PR DESCRIPTION
@ax3l 
This fixes the bug, that "NO" is ignored by the compilesuite in non-parallel mode