### PR TITLE
Score-P 2.0 instrumentation

### DIFF
--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -173,54 +173,6 @@ if(VAMPIR_ENABLE)
     add_definitions(-DMPICH_IGNORE_CXX_SEEK)
 endif(VAMPIR_ENABLE)
 
-
-################################################################################
-# Score-P
-################################################################################
-
-option(SCOREP_ENABLE "Create PMacc with Score-P support" OFF)
-
-if(SCOREP_ENABLE)
-    message(STATUS "Building with Score-P support")
-    set(SCOREP_ROOT "$ENV{SCOREP_ROOT}")
-    if(NOT SCOREP_ROOT)
-        message(FATAL_ERROR "Environment variable SCOREP_ROOT not set!")
-    endif(NOT SCOREP_ROOT)
-
-    # compile flags
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --nocompiler --cflags
-                    OUTPUT_VARIABLE SCOREP_COMPILEFLAGS
-                    RESULT_VARIABLE SCOREP_CONFIG_RETURN
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT SCOREP_CONFIG_RETURN EQUAL 0)
-        message(FATAL_ERROR "Can NOT execute 'scorep-config' at $ENV{SCOREP_ROOT}/bin/scorep-config - check file permissions")
-    endif()
-
-    # link flags
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --ldflags
-                    OUTPUT_VARIABLE SCOREP_LINKFLAGS
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    # libraries
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --libs
-                    OUTPUT_VARIABLE SCOREP_LIBFLAGS
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(STRIP "${SCOREP_LIBFLAGS}" SCOREP_LIBFLAGS)
-
-    # subsystem iniialization file
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --adapter-init
-                    OUTPUT_VARIABLE SCOREP_INIT_FILE
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    file(WRITE ${CMAKE_BINARY_DIR}/scorep_init.c "${SCOREP_INIT_FILE}")
-
-    if(SCOREP_ENABLE)
-        set(SCOREP_SRCFILES "${CMAKE_BINARY_DIR}/scorep_init.c")
-    endif(SCOREP_ENABLE)
-
-    # modify our flags
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${SCOREP_LINKFLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCOREP_COMPILEFLAGS}")
-endif(SCOREP_ENABLE)
-
 ################################################################################
 # MPI LIB
 ################################################################################

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -170,54 +170,6 @@ endif(VAMPIR_ENABLE)
 
 
 ################################################################################
-# Score-P
-################################################################################
-
-option(SCOREP_ENABLE "Create PIConGPU with Score-P support" OFF)
-
-if(SCOREP_ENABLE)
-    message(STATUS "Building with Score-P support")
-    set(SCOREP_ROOT "$ENV{SCOREP_ROOT}")
-    if(NOT SCOREP_ROOT)
-        message(FATAL_ERROR "Environment variable SCOREP_ROOT not set!")
-    endif(NOT SCOREP_ROOT)
-
-    # compile flags
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --nocompiler --cflags
-                    OUTPUT_VARIABLE SCOREP_COMPILEFLAGS
-                    RESULT_VARIABLE SCOREP_CONFIG_RETURN
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT SCOREP_CONFIG_RETURN EQUAL 0)
-        message(FATAL_ERROR "Can NOT execute 'scorep-config' at $ENV{SCOREP_ROOT}/bin/scorep-config - check file permissions")
-    endif()
-
-    # link flags
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --ldflags
-                    OUTPUT_VARIABLE SCOREP_LINKFLAGS
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    # libraries
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --libs
-                    OUTPUT_VARIABLE SCOREP_LIBFLAGS
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(STRIP "${SCOREP_LIBFLAGS}" SCOREP_LIBFLAGS)
-
-    # subsystem iniialization file
-    execute_process(COMMAND $ENV{SCOREP_ROOT}/bin/scorep-config --cuda --mpp=mpi --adapter-init
-                    OUTPUT_VARIABLE SCOREP_INIT_FILE
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    file(WRITE ${CMAKE_BINARY_DIR}/scorep_init.c "${SCOREP_INIT_FILE}")
-
-    if(SCOREP_ENABLE)
-        set(SCOREP_SRCFILES "${CMAKE_BINARY_DIR}/scorep_init.c")
-    endif(SCOREP_ENABLE)
-
-    # modify our flags
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${SCOREP_LINKFLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCOREP_COMPILEFLAGS}")
-endif(SCOREP_ENABLE)
-
-
-################################################################################
 # Build type (debug, release)
 ################################################################################
 
@@ -513,16 +465,9 @@ file(GLOB SRCFILES "*.cpp")
 cuda_add_executable(picongpu
     ${CUDASRCFILES}
     ${SRCFILES}
-    ${SCOREP_SRCFILES}
 )
 
 target_link_libraries(picongpu  ${LIBS} ${CUDA_CUDART_LIBRARY} z m)
-
-if(SCOREP_ENABLE)
-    # Score-P libraries must be linked after the object to prevent symbols
-    # from being stripped on Titan
-    target_link_libraries(picongpu ${SCOREP_LIBFLAGS})
-endif(SCOREP_ENABLE)
 
 ################################################################################
 # Install PIConGPU

--- a/src/picongpu/main.cu
+++ b/src/picongpu/main.cu
@@ -110,6 +110,8 @@ int main(int argc, char **argv)
             break;
     };
 
+    // Required by scorep for flushing the buffers
+    cudaDeviceSynchronize();
     MPI_CHECK(MPI_Finalize());
     return errorCode;
 }

--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -36,8 +36,21 @@ export MPI_ROOT=$MPICH_DIR
 #   configure with -c "-DVAMPIR_ENABLE=ON"
 #   e.g.:
 #     $PICSRC/configure -c "-DVAMPIR_ENABLE=ON" ~/paramSets/case001
-module load vampirtrace/5.14.4
-export VT_ROOT=$VAMPIRTRACE_DIR
+#module load vampirtrace/5.14.4
+#export VT_ROOT=$VAMPIRTRACE_DIR
+ 
+# scorep (optional) ############################################
+#   configure with -c "-DCMAKE_CXX_COMPILER=`which scorep-CC` \
+#                      -DCUDA_NVCC_EXECUTABLE=`which scorep-nvcc`"
+#   e.g.:
+#     SCOREP_WRAPPER=OFF $PICSRC/configure -a sm_35 \
+#         -c "-DCMAKE_CXX_COMPILER=`which scorep-CC` \
+#         -DCUDA_NVCC_EXECUTABLE=`which scorep-nvcc`" \
+#         ~/paramSets/case001
+#     export SCOREP_WRAPPER_INSTRUMENTER_FLAGS="--cuda --mpp=mpi"
+#     make -j
+#     make install
+module load scorep/2.0
 
 # plugins (optional) ################################################
 module load cray-hdf5-parallel/1.8.14


### PR DESCRIPTION
All cmake files were cleaned up from scorep. We are now using scorep wrapper scripts to instrument the code, see https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Performance-Analysis.

For longer runs manual instrumentation is useful. Since manual instrumentation is guarded by SCOREP_USER_ENABLE we can put this into the source code.

cudaDeviceSynchornize() at program exit is required for scorep to flush the cuda buffers. This prevents the use of flushatexit.