### PR TITLE
Improve overflow detection

### DIFF
--- a/src/libPMacc/include/particles/IdProvider.def
+++ b/src/libPMacc/include/particles/IdProvider.def
@@ -23,32 +23,38 @@
 #pragma once
 
 #include "pmacc_types.hpp"
-#include <boost/tuple/tuple.hpp>
 
 namespace PMacc {
 
     /**
      * Provider for globally unique ids (even across ranks)
-     * Implemented for use in static contexts
+     * Implemented for use in static contexts which allows e.g. calling from CUDA kernels
      */
     template<unsigned T_dim>
     class IdProvider
     {
     public:
+        struct State{
+            /** Next id to be returned */
+            uint64_t nextId;
+            /** First id used */
+            uint64_t startId;
+            /** Maximum number of processes ever used (never decreases) */
+            uint64_t maxNumProc;
+        };
+
         /** Initializes the state so it is ready for use
          */
         static void init();
 
         /** Sets the internal state (e.g. after a restart)
-         * @param nextId     Next id to be returned
-         * @param maxNumProc Maximum number of processes ever used (never decreases)
          */
-        static void setState(const uint64_t nextId, const uint64_t maxNumProc);
+        static void setState(const State& state);
 
         /** Returns the state (e.g. for saving)
-         *  Tuple is the same as the parameters to @ref setState
+         *  Result is the same as the parameter to @ref setState
          */
-        static boost::tuple<uint64_t, uint64_t> getState();
+        static State getState();
 
         /** Functor that returns a new id each time it is called
          *  Modifies the state of the IdProvider */
@@ -70,13 +76,17 @@ namespace PMacc {
         static bool isOverflown();
 
     private:
-        /** Returns the first id for the current rank */
-        static uint64_t getStartId();
+        /** Calculates the first id for the current position in the grid */
+        static uint64_t calcStartId();
+
+        /** Sets the next id to be returned */
+        static void setNextId(uint64_t nextId);
 
         /** Host version for getting a new id (changing the state) */
         static uint64_t getNewIdHost();
 
-        static uint64_t maxNumProc_;
+        static uint64_t m_maxNumProc;
+        static uint64_t m_startId;
     };
 
 }  // namespace PMacc

--- a/src/libPMacc/include/particles/IdProvider.def
+++ b/src/libPMacc/include/particles/IdProvider.def
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include <boost/tuple/tuple.hpp>
 
 namespace PMacc {
 
@@ -38,13 +39,16 @@ namespace PMacc {
          */
         static void init();
 
-        /** Sets the next id to a given value (e.g. after a restart)
+        /** Sets the internal state (e.g. after a restart)
+         * @param nextId     Next id to be returned
+         * @param maxNumProc Maximum number of processes ever used (never decreases)
          */
-        static void setNextId(const uint64_t nextId);
+        static void setState(const uint64_t nextId, const uint64_t maxNumProc);
 
-        /** Returns the next id without changing the current state (e.g. for saving)
+        /** Returns the state (e.g. for saving)
+         *  Tuple is the same as the parameters to @ref setState
          */
-        static uint64_t getNextId();
+        static boost::tuple<uint64_t, uint64_t> getState();
 
         /** Functor that returns a new id each time it is called
          *  Modifies the state of the IdProvider */
@@ -71,6 +75,8 @@ namespace PMacc {
 
         /** Host version for getting a new id (changing the state) */
         static uint64_t getNewIdHost();
+
+        static uint64_t maxNumProc_;
     };
 
 }  // namespace PMacc

--- a/src/libPMacc/include/particles/IdProvider.hpp
+++ b/src/libPMacc/include/particles/IdProvider.hpp
@@ -64,7 +64,7 @@ namespace PMacc {
         maxNumProc_ = Environment<T_dim>::get().GridController().getGpuNodes().productOfComponents();
         setState(globalUniqueStartId, maxNumProc_);
         // Instantiate kernel
-        getNewId();
+        getNewIdHost();
         // Reset to start value
         setState(globalUniqueStartId, maxNumProc_);
     }


### PR DESCRIPTION
This stores an ever-increasing number maxNumProc in addition to the current next id. This is the maximum number of processes ever used to generate ids. With this, an overflow can be detected on all ranks in cases where it was not possible before.

Due to this change the get/setNextId was changed to get/setState which is more appropriate.

ccing @psychocoderHPC 