### PR TITLE
Changed path for picongpu.profile on lustre.

### DIFF
--- a/src/picongpu/submit/titan-ornl/batch_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_profile.tpl
@@ -56,7 +56,7 @@ echo -n "present working directory:"
 pwd
 
 
-source $PROJWORK/!TBG_nameProject/picongpu.profile 2>/dev/null
+source $PROJWORK/!TBG_nameProject/$USER/picongpu.profile 2>/dev/null
 if [ $? -ne 0 ] ; then
   echo "Error: picongpu.profile not found in PROJWORK"
   exit 1

--- a/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
@@ -56,7 +56,7 @@ echo -n "present working directory:"
 pwd
 
 
-source $PROJWORK/!TBG_nameProject/picongpu.profile 2>/dev/null
+source $PROJWORK/!TBG_nameProject/$USER/picongpu.profile 2>/dev/null
 if [ $? -ne 0 ] ; then
   echo "Error: picongpu.profile not found in PROJWORK"
   exit 1


### PR DESCRIPTION
I think it is better to have picongpu.profile in $PROJWORK/$projid/$USER, since each user should use his own configuration.