### PR TITLE
fix gamma filter for radiation

### DIFF
--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -161,10 +161,14 @@ __global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
             particle[weighting_] = macroWeighting;
 
 #if(ENABLE_RADIATION == 1)
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#    if(RAD_MARK_PARTICLE>1) && (RAD_ACTIVATE_GAMMA_FILTER==0)
             particle[radiationFlag_] = (bool)(rng() < (1.0 / (float_32) RAD_MARK_PARTICLE));
+#    endif
+#    if(RAD_ACTIVATE_GAMMA_FILTER!=0)
+            particle[radiationFlag_] = (bool)(false);
+#    endif
 #endif
-#endif
+
             numParsPerCell--;
             if (numParsPerCell > 0)
                 atomicExch(&finished, 0); //one or more cell has particles to create


### PR DESCRIPTION
This pull request re-enables the gamma filter flag for the radiation plugin. 
It was not usable before. 

This **does not** fix #1420.