### PR TITLE
fix documentation (and values) in radiationObserver.param

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -65,7 +65,10 @@ namespace picongpu
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */
-      return vector_64(sinf(theta), cosf(theta), 0.0);
+      picongpu::float_32 sinTheta;
+      picongpu::float_32 cosTheta;
+      math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+      return vector_64(sinTheta, cosTheta, 0.0);
       
     }
     

--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -42,8 +42,8 @@ namespace picongpu
     DINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** Computes observation angles along the x-y plane.
-       *  Assuming electron(s) fly in -x direction and the laser
-       *  propages in +x direction, the observation angles are centered
+       *  Assuming electron(s) fly in -y direction and the laser
+       *  propages in +y direction, the observation angles are centered
        *  around the -y-axis (0,-1,0) .
        *  By setting gamma, the angle range can be adjusted to the
        *  energy of the electrons.

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
@@ -65,7 +65,14 @@ namespace picongpu
       const picongpu::float_64 phi(    my_index_phi   * delta_angle  );
       
       /* compute unit vector */
-      return vector_64( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;
+            picongpu::float_32 sinPhi;
+      picongpu::float_32 cosPhi;
+      picongpu::float_32 sinTheta;
+      picongpu::float_32 cosTheta;
+      math::sincos(precisionCast<picongpu::float_32>(phi), sinPhi, cosPhi);
+      math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+      return vector_64( sinTheta*cosPhi , sinTheta*sinPhi , cosTheta ) ;
+
 
     }
     

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
@@ -66,7 +66,10 @@ namespace picongpu
       /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
       /* compute observation unit vector */
-      return vector_64(sinf(theta), cosf(theta), 0.0);
+      picongpu::float_32 sinTheta;
+      picongpu::float_32 cosTheta;
+      math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+      return vector_64(sinTheta, cosTheta, 0.0);
       
     }
     

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -96,7 +96,13 @@ namespace picongpu
       const picongpu::float_64 phi(    my_index_phi   * delta_angle_phi   - angle_phi_start   );
 
       /* compute observation unit vector */
-      return vector_64( sinf(theta)*sinf(phi) , sinf(theta)*cosf(phi) , cosf(theta) ) ;
+      picongpu::float_32 sinPhi;
+      picongpu::float_32 cosPhi;
+      picongpu::float_32 sinTheta;
+      picongpu::float_32 cosTheta;
+      math::sincos(precisionCast<picongpu::float_32>(phi), sinPhi, cosPhi);
+      math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+      return vector_64( sinTheta*sinPhi , sinTheta*cosPhi , cosTheta ) ;
 
     }
 

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -42,7 +42,7 @@ namespace picongpu
     DINLINE vector_64 observation_direction(const int observation_id_extern)
     {
       /** compute observation directions for 2D virtual detector field
-       *  pointing toward the +x direction
+       *  with its center pointing toward the +y direction
        *  with observation angles ranging from
        *  theta = [angle_theta_start : angle_theta_end]
        *  phi   = [angle_phi_start   : angle_phi_end  ]
@@ -62,7 +62,7 @@ namespace picongpu
        *  The default setup describes an detector array of
        *  16x16 detectors ranging from -pi/8= -22.5 degrees
        *  to +pi/8= +22.5 degrees for both angles with the center
-       *  pointing toward the x-axis (laser propagation direction).
+       *  pointing toward the y-axis (laser propagation direction).
        */
 
       /* generate two indices from single block index */
@@ -96,7 +96,7 @@ namespace picongpu
       const picongpu::float_64 phi(    my_index_phi   * delta_angle_phi   - angle_phi_start   );
 
       /* compute observation unit vector */
-      return vector_64( sinf(theta)*cosf(phi) , sinf(theta)*sinf(phi) , cosf(theta) ) ;
+      return vector_64( sinf(theta)*sinf(phi) , sinf(theta)*cosf(phi) , cosf(theta) ) ;
 
     }
 


### PR DESCRIPTION
This pull request fixes wrong documentation in the `radiationObserver.param` 
The laser propagation was wrongly stated as towards `+x direction.
Thanks @Heikman for pointing me to these errors. 