### PR TITLE
fix warning in TWTS

### DIFF
--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -159,7 +159,7 @@ namespace twts
 
         for (uint32_t k = 0; k<detail::numComponents;++k) {
             /* 2D (y,z) vectors are mapped on 3D (x,y,z) vectors. */
-            for (uint32_t i = 0; i<simDim;++i)
+            for (uint32_t i = 0; i<DIM2;++i)
                 pos[k][i+1] = bFieldPositions_SI[k][i];
         }
 
@@ -224,7 +224,7 @@ namespace twts
             /* The 2D output of getFieldPositions_SI only returns
              * the y- and z-component of a 3D vector.
              */
-            for (uint32_t i = 0; i<simDim;++i) pos[k][i+1] = bFieldPositions_SI[k][i];
+            for (uint32_t i = 0; i<DIM2;++i) pos[k][i+1] = bFieldPositions_SI[k][i];
         }
 
         /* General background comment for the rest of this function:

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -127,7 +127,7 @@ namespace twts
         /* Ex->Ez, so also the grid cell offset for Ez has to be used. */
         float3_64 pos(float3_64::create(0.0));
         /* 2D (y,z) vectors are mapped on 3D (x,y,z) vectors. */
-        for (uint32_t i = 0; i<simDim;++i) pos[i+1] = eFieldPositions_SI[2][i];
+        for (uint32_t i = 0; i<DIM2;++i) pos[i+1] = eFieldPositions_SI[2][i];
         return float3_X( float_X(0.), float_X(0.),
                          float_X( calcTWTSEx(pos,time) ) );
     }
@@ -147,7 +147,7 @@ namespace twts
          * the y- and z-component of a 3D vector.
          */
         for (uint32_t k = 0; k<detail::numComponents;++k) {
-            for (uint32_t i = 0; i<simDim;++i) pos[k][i+1] = eFieldPositions_SI[k][i];
+            for (uint32_t i = 0; i<DIM2;++i) pos[k][i+1] = eFieldPositions_SI[k][i];
         }
 
         /* Ey->Ey, but grid cell offsets for Ex and Ey have to be used.


### PR DESCRIPTION
use `DIM2` instead of `simDim` in methods which are specialized to a specific simulation dimension

The compiler evaluates all methods which are specialized for a simulation dimension. In the three dimensional case `pos[i+1]` in the 2d specialization inside a loop from `[0;simDim)` creates a out of array access even this specialization is not used in the three dimensional case.


CC-ing: @BeyondEspresso 