### PR TITLE
Lawrencium (LBNL): Module Updates

### DIFF
--- a/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
+++ b/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
@@ -4,14 +4,14 @@ then
         module purge
 
         # Core Dependencies
-        module load git/1.7.9
         module load gcc/4.4.7
         module load cuda/5.5
-        module load boost/1.56.0-gcc
+        # not yet available, build boost as in `INSTALL.md`
+        #module load boost/1.56.0-gcc
         module load openmpi/1.6.5-gcc
 
         # Core tools
-        module load git/1.7.9
+        module load git
         module load cmake
         module load python/2.6.6
         module load ipython/0.12 matplotlib/1.1.0 numpy/1.6.1 scipy/0.10.0


### PR DESCRIPTION
- [x] fix git module
- [x] Boost 1.56.0 is not yet available but a support ticket is opened -> they will not update the old gcc chain and do not (yet) have a newer one; we need to build boost ourselves or support icc (#732)