### PR TITLE
libSplash: Update to 1.4.0

### DIFF
--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -93,7 +93,7 @@ touch "$thisDir"runGuard
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=sm_35"
             . /etc/profile
-            module load gcc/4.6.4 boost/1.55.0 cmake/2.8.12.2 cuda/6.0 openmpi/1.6.5 mallocmc/2.0.1 libSplash/1.2.4 adios/1.9.0 pngwriter/0.5.6 rivlib/1.0.0
+            module load gcc/4.6.4 boost/1.56.0 cmake/3.1.0 cuda/6.0 openmpi/1.6.5 libSplash/1.4.0 adios/1.9.0 pngwriter/0.5.6 rivlib/1.0.0
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/compile -l -q -j $cnf_numParallel \

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -86,7 +86,7 @@ Some of our examples will also need **libSplash**.
       [PNGWRITER\_ROOT](#additional-required-environment-variables-for-optional-libraries)
       to `$HOME/lib/pngwriter`
 
-- **libSplash** >= 1.2.4 (requires *HDF5*, *boost program-options*)
+- **libSplash** >= 1.4.0 (requires *HDF5*, *boost program-options*)
     - *Debian/Ubuntu dependencies:* `sudo apt-get install libhdf5-openmpi-dev libboost-program-options-dev`
     - *Arch Linux dependencies:* `sudo pacman --sync hdf5-openmpi boost`
     - *or compile hdf5 yourself:*  follow instructions one paragraph below 

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -417,7 +417,7 @@ include_directories(${PMACC_ROOT_DIR}/include)
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.2.4 COMPONENTS PARALLEL)
+find_package(Splash 1.4.0 COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -16,7 +16,7 @@ then
 
         # Plugins (optional)
         module load pngwriter/0.5.6
-        module load hdf5-parallel/1.8.14 libsplash/1.2.4
+        module load hdf5-parallel/1.8.14 libsplash/1.4.0
 
         # either use libSplash or ADIOS for file I/O
         #module load libmxml/2.8 adios/1.9.0

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -84,7 +84,7 @@ set(LIBS ${LIBS} ${Boost_LIBRARIES})
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.2.4 REQUIRED COMPONENTS PARALLEL)
+find_package(Splash 1.4.0 REQUIRED COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -92,7 +92,7 @@ endif(MPI_CXX_FOUND)
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.2.4 REQUIRED COMPONENTS PARALLEL)
+find_package(Splash 1.4.0 REQUIRED COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})


### PR DESCRIPTION
The changes in 1.3 (PDC) and 1.4 (SDC) are needed to write the [openPMD standard](https://github.com/openPMD/openPMD-standard/tree/1.0.0).

This changes the API of libSplash and also the files created by it (bool representations, some internal vars, pathes of global attributes).
For more information, please read the libSplash [change log](https://github.com/ComputationalRadiationPhysics/libSplash/blob/v1.4.0/CHANGELOG.md).

### PR's that will need to rebase *after* this PR was merged

- #1053 (enables correct global attributes for this PR)
- #1376 (enables correct global attributes for this PR)
- #1410 (might be unaffected)
- the upcoming `topic-openPMD` PR of mine