### PR TITLE
openPMD 1.0.0: Base Standard in HDF5

### DIFF
--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -229,7 +229,7 @@ FieldB::getUnitDimension( )
 std::string
 FieldB::getName( )
 {
-    return "FieldB";
+    return "B";
 }
 
 uint32_t

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -242,7 +242,7 @@ FieldE::getUnitDimension( )
 std::string
 FieldE::getName( )
 {
-    return "FieldE";
+    return "E";
 }
 
 uint32_t

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -262,7 +262,7 @@ FieldJ::getUnitDimension( )
 std::string
 FieldJ::getName( )
 {
-    return "FieldJ";
+    return "J";
 }
 
 uint32_t

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -443,12 +443,14 @@ private:
                                   iterationFormat.c_str() );
 
         /*   recommended */
-        /*
-        std::string author("PIConGPU User");
-        ColTypeString ctAuthor(author.length());
-        dc->writeGlobalAttribute( threadParams->currentStep,
-                                  ctAuthor.getDataType(), "author",
-                                  author.c_str() ); */
+        std::string author = Environment<>::get().SimulationDescription().getAuthor();
+        if( author.length() > 0 )
+        {
+            ColTypeString ctAuthor(author.length());
+            dc->writeGlobalAttribute( threadParams->currentStep,
+                                      ctAuthor, "author",
+                                      author.c_str() );
+        }
         std::string software("PIConGPU");
         ColTypeString ctSoftware(software.length());
         dc->writeGlobalAttribute( threadParams->currentStep,

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -536,12 +536,12 @@ private:
         if (threadParams->isCheckpoint)
         {
             ForEach<FileCheckpointParticles, WriteSpecies<bmpl::_1> > writeSpecies;
-            writeSpecies(threadParams, std::string(), particleOffset);
+            writeSpecies(threadParams, particleOffset);
         }
         else
         {
             ForEach<FileOutputParticles, WriteSpecies<bmpl::_1> > writeSpecies;
-            writeSpecies(threadParams, std::string(), particleOffset);
+            writeSpecies(threadParams, particleOffset);
         }
         log<picLog::INPUT_OUTPUT > ("HDF5: ( end ) writing particle species.");
 

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -83,6 +83,7 @@ public:
         Field::writeField(params,
                           T::getName(),
                           getUnit(),
+                          T::getUnitDimension(),
                           field->getHostDataBox(),
                           ValueType());
 
@@ -170,6 +171,7 @@ private:
         Field::writeField(params,
                           getName(),
                           getUnit(),
+                          FieldTmp::getUnitDimension<Solver>(),
                           fieldTmp->getHostDataBox(),
                           ValueType());
 

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -80,10 +80,16 @@ public:
         T* field = &(dc.getData<T > (T::getName()));
         params->gridLayout = field->getGridLayout();
 
+        /** \todo check if always correct at this point, depends on solver
+         *        implementation */
+        const float_X timeOffset = 0.0;
+
         Field::writeField(params,
                           T::getName(),
                           getUnit(),
                           T::getUnitDimension(),
+                          /* inCellPosition, */
+                          timeOffset,
                           field->getHostDataBox(),
                           ValueType());
 
@@ -165,6 +171,12 @@ private:
         dc.releaseData(Species::FrameType::getName());
         /*## finish update field ##*/
 
+        //PMACC_AUTO(inCellPosition, fieldSolver::NumericalCellType::getEFieldPosition());
+        //fieldSolver::NumericalCellType::getJFieldPosition()[n]
+
+        /** \todo check if always correct at this point, depends on solver
+         *        implementation */
+        const float_X timeOffset = 0.0;
 
         params->gridLayout = fieldTmp->getGridLayout();
         /*write data to HDF5 file*/
@@ -172,6 +184,8 @@ private:
                           getName(),
                           getUnit(),
                           FieldTmp::getUnitDimension<Solver>(),
+                          /* inCellPosition, */
+                          timeOffset,
                           fieldTmp->getHostDataBox(),
                           ValueType());
 

--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -26,6 +26,7 @@
 #include "pmacc_types.hpp"
 #include "simulation_types.hpp"
 #include "plugins/hdf5/HDF5Writer.def"
+#include "traits/PICToOpenPMD.hpp"
 
 #include "plugins/ISimulationPlugin.hpp"
 #include <boost/mpl/vector.hpp>
@@ -102,26 +103,30 @@ public:
         /* load particle without copy particle data to host */
         ThisSpecies* speciesTmp = &(dc.getData<ThisSpecies >(ThisSpecies::FrameType::getName(), true));
 
-        /* count total number of particles on the device */
-        uint64_cu totalNumParticles = 0;
+        /* count number of particles for this species on the device */
+        uint64_t numParticles = 0;
 
         log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) count particles: %1%") % Hdf5FrameType::getName();
-        totalNumParticles = PMacc::CountParticles::countOnDevice < CORE + BORDER > (
-                                                                                    *speciesTmp,
-                                                                                    *(params->cellDescription),
-                                                                                    params->localWindowToDomainOffset,
-                                                                                    params->window.localDimensions.size);
+        /* at this point we cast to uint64_t, before we assume that per GPU
+         * less then 1e9 (int range) particles will be counted
+         */
+        numParticles = uint64_t( PMacc::CountParticles::countOnDevice< CORE + BORDER >(
+            *speciesTmp,
+            *(params->cellDescription),
+            params->localWindowToDomainOffset,
+            params->window.localDimensions.size
+        ));
 
 
-        log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) count particles: %1% = %2%") % Hdf5FrameType::getName() % totalNumParticles;
+        log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) count particles: %1% = %2%") % Hdf5FrameType::getName() % numParticles;
         Hdf5FrameType hostFrame;
         log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) malloc mapped memory: %1%") % Hdf5FrameType::getName();
         /*malloc mapped memory*/
         ForEach<typename Hdf5FrameType::ValueTypeSeq, MallocMemory<bmpl::_1> > mallocMem;
-        mallocMem(forward(hostFrame), totalNumParticles);
+        mallocMem(forward(hostFrame), numParticles);
         log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) malloc mapped memory: %1%") % Hdf5FrameType::getName();
 
-        if (totalNumParticles != 0)
+        if (numParticles != 0)
         {
 
             log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) get mapped memory device pointer: %1%") % Hdf5FrameType::getName();
@@ -142,9 +147,11 @@ public:
 
             dim3 block(PMacc::math::CT::volume<SuperCellSize>::type::value);
 
+            /* int: assume < 2e9 particles per GPU */
             GridBuffer<int, DIM1> counterBuffer(DataSpace<DIM1>(1));
             AreaMapping < CORE + BORDER, MappingDesc > mapper(*(params->cellDescription));
 
+            /* this sanity check costs a little bit of time but hdf5 writing is slower */
             __cudaKernel(copySpecies)
                 (mapper.getGridDim(), block)
                 (counterBuffer.getDeviceBuffer().getPointer(),
@@ -157,48 +164,176 @@ public:
             log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) copy particle to host: %1%") % Hdf5FrameType::getName();
             __getTransactionEvent().waitForFinished();
             log<picLog::INPUT_OUTPUT > ("HDF5:  all events are finished: %1%") % Hdf5FrameType::getName();
-            /*this cost a little bit of time but hdf5 writing is slower^^*/
-            assert((uint64_cu) counterBuffer.getHostBuffer().getDataBox()[0] == totalNumParticles);
+
+            assert((uint64_t) counterBuffer.getHostBuffer().getDataBox()[0] == numParticles);
         }
-        /*dump to hdf5 file*/
+
+        /* We rather do an allgather at this point then letting libSplash
+         * do an allgather during write to find out the global number of
+         * particles.
+         */
+        log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) collect particle sizes for %1%") % Hdf5FrameType::getName();
+
+        ColTypeUInt64 ctUInt64;
+        ColTypeDouble ctDouble;
+        GridController<simDim>& gc = Environment<simDim>::get().GridController();
+
+        /* For collective write calls we need the information:
+         *   - how many particles will be written globally
+         *   - what is my particle offset within this global data set
+         *
+         * interleaved in array:
+         *   numParticles for mpi rank, mpi rank
+         *
+         * the mpi rank is an arbitrary quantity and might change after a
+         * restart, but we only use it to order our patches and offsets
+         */
+        std::vector<uint64_t> particleCounts( 2 * gc.getGlobalSize(), 0u );
+        uint64_t myParticlePatch[ 2 ];
+        myParticlePatch[ 0 ] = numParticles;
+        myParticlePatch[ 1 ] = uint64_t(gc.getGlobalRank());
+
+        /* we do the scan over MPI ranks since it does not matter how the
+         * global rank or scalar position (which are not idential) are
+         * ordered as long as the particle attributes are also written in
+         * the same order (which is by global rank) */
+        uint64_t numParticlesOffset = 0;
+        uint64_t numParticlesGlobal = 0;
+
+        MPI_CHECK(MPI_Allgather(
+            myParticlePatch, 2, MPI_UINT64_T,
+            &(*particleCounts.begin()), 2, MPI_UINT64_T,
+            gc.getCommunicator().getMPIComm()
+        ));
+
+        for( uint64_t r = 0; r < gc.getGlobalSize(); ++r )
+        {
+            numParticlesGlobal += particleCounts.at(2 * r);
+            if( particleCounts.at(2 * r + 1) < myParticlePatch[ 1 ] )
+                numParticlesOffset += particleCounts.at(2 * r);
+        }
+        log<picLog::INPUT_OUTPUT > ("HDF5:  (end) collect particle sizes for %1%") % Hdf5FrameType::getName();
+
+        /* dump main particle data to hdf5 file */
+        log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) write particle attributes for %1%") % Hdf5FrameType::getName();
+
         ForEach<typename Hdf5FrameType::ValueTypeSeq, hdf5::ParticleAttribute<bmpl::_1> > writeToHdf5;
-        writeToHdf5(params, forward(hostFrame), std::string("particles/") + FrameType::getName() + std::string("/") + subGroup,
-                totalNumParticles);
+        writeToHdf5(
+            params,
+            forward(hostFrame),
+            std::string("particles/") + FrameType::getName() + std::string("/") + subGroup,
+            numParticles,
+            numParticlesOffset,
+            numParticlesGlobal
+        );
 
         /* write meta attributes for species */
         writeMetaAttributes(params);
 
-        /*write species counter table to hdf5 file*/
-        log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) writing particle index table for %1%") % Hdf5FrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("HDF5:  (end) write particle attributes for %1%") % Hdf5FrameType::getName();
+
+        /* write species particle patch meta information */
+        log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) writing particlePatches for %1%") % Hdf5FrameType::getName();
+
+        std::string particlePatchesPath( std::string("particles/") +
+            FrameType::getName() + std::string("/") + subGroup +
+            std::string("/particlePatches") );
+
+        /* numParticles: number of particles in this patch */
+        params->dataCollector->write(
+            params->currentStep,
+            Dimensions(gc.getGlobalSize(), 1, 1),
+            Dimensions(gc.getGlobalRank(), 0, 0),
+            ctUInt64, 1,
+            Dimensions(1, 1, 1),
+            (particlePatchesPath + std::string("/numParticles")).c_str(),
+            &numParticles);
+
+        /* numParticlesOffset: number of particles before this patch */
+        params->dataCollector->write(
+            params->currentStep,
+            Dimensions(gc.getGlobalSize(), 1, 1),
+            Dimensions(gc.getGlobalRank(), 0, 0),
+            ctUInt64, 1,
+            Dimensions(1, 1, 1),
+            (particlePatchesPath + std::string("/numParticlesOffset")).c_str(),
+            &numParticlesOffset);
+
+        /* offset: absolute position where this particle patch begins including
+         *         global domain offsets (slides), etc.
+         * extent: size of this particle patch, upper bound is excluded
+         */
+        const std::string name_lookup[] = {"x", "y", "z"};
+        for (uint32_t d = 0; d < simDim; ++d)
         {
-            ColTypeUInt64_5Array ctUInt64_5;
-            GridController<simDim>& gc = Environment<simDim>::get().GridController();
-
-            const size_t pos_offset = 2;
-
-            /* particlesMetaInfo = (num particles, scalar position, particle offset x, y, z) */
-            uint64_t particlesMetaInfo[5] = {totalNumParticles, gc.getScalarPosition(), 0, 0, 0};
-            for (size_t d = 0; d < simDim; ++d)
-                particlesMetaInfo[pos_offset + d] = particleOffset[d];
-
-            /* prevent that top (y) gpus have negative value here */
-            if (gc.getPosition().y() == 0)
-                particlesMetaInfo[pos_offset + 1] = 0;
-
-            if (particleOffset[1] < 0) // 1 == y
-                particlesMetaInfo[pos_offset + 1] = 0;
+            const uint64_t patchOffset =
+                params->window.globalDimensions.offset[d] +
+                params->window.localDimensions.offset[d] +
+                params->localWindowToDomainOffset[d];
+            const uint64_t patchExtent =
+                params->window.localDimensions.size[d];
 
             params->dataCollector->write(
                 params->currentStep,
                 Dimensions(gc.getGlobalSize(), 1, 1),
                 Dimensions(gc.getGlobalRank(), 0, 0),
-                ctUInt64_5, 1,
+                ctUInt64, 1,
                 Dimensions(1, 1, 1),
-                (std::string("particles/") + FrameType::getName() + std::string("/") +
-                    subGroup + std::string("/particles_info")).c_str(),
-                particlesMetaInfo);
+                (particlePatchesPath + std::string("/offset/") +
+                 name_lookup[d]).c_str(),
+                &patchOffset);
+            params->dataCollector->write(
+                params->currentStep,
+                Dimensions(gc.getGlobalSize(), 1, 1),
+                Dimensions(gc.getGlobalRank(), 0, 0),
+                ctUInt64, 1,
+                Dimensions(1, 1, 1),
+                (particlePatchesPath + std::string("/extent/") +
+                 name_lookup[d]).c_str(),
+                &patchExtent);
+
+            /* offsets and extent of the patch are positions (lengths)
+             * and need to be scaled like the cell idx of a particle
+             */
+            OpenPMDUnit<globalCellIdx<globalCellIdx_pic> > openPMDUnitCellIdx;
+            std::vector<float_64> unitCellIdx = openPMDUnitCellIdx();
+
+            params->dataCollector->writeAttribute(
+                params->currentStep,
+                ctDouble,
+                (particlePatchesPath + std::string("/offset/") +
+                 name_lookup[d]).c_str(),
+                "unitSI",
+                &(unitCellIdx.at(d)));
+            params->dataCollector->writeAttribute(
+                params->currentStep,
+                ctDouble,
+                (particlePatchesPath + std::string("/extent/") +
+                 name_lookup[d]).c_str(),
+                "unitSI",
+                &(unitCellIdx.at(d)));
         }
-        log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) writing particle index table for %1%") % Hdf5FrameType::getName();
+
+        OpenPMDUnitDimension<globalCellIdx<globalCellIdx_pic> > openPMDUnitDimension;
+        std::vector<float_64> unitDimensionCellIdx = openPMDUnitDimension();
+
+        params->dataCollector->writeAttribute(
+            params->currentStep,
+            ctDouble,
+            (particlePatchesPath + std::string("/offset")).c_str(),
+            "unitDimension",
+            1u, Dimensions(7,0,0),
+            &(*unitDimensionCellIdx.begin()));
+        params->dataCollector->writeAttribute(
+            params->currentStep,
+            ctDouble,
+            (particlePatchesPath + std::string("/extent")).c_str(),
+            "unitDimension",
+            1u, Dimensions(7,0,0),
+            &(*unitDimensionCellIdx.begin()));
+
+
+        log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) writing particlePatches for %1%") % Hdf5FrameType::getName();
 
         /*free host memory*/
         ForEach<typename Hdf5FrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;

--- a/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
@@ -27,6 +27,7 @@
 #include "simulation_types.hpp"
 #include "plugins/hdf5/HDF5Writer.def"
 #include "traits/PICToSplash.hpp"
+#include "traits/PICToOpenPMD.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
 #include "traits/Resolve.hpp"
@@ -83,8 +84,9 @@ struct LoadParticleAttributesFromHDF5
         ParallelDomainCollector* dataCollector = params->dataCollector;
         for (uint32_t d = 0; d < components; d++)
         {
+            OpenPMDName<T_Identifier> openPMDName;
             std::stringstream datasetName;
-            datasetName << subGroup << "/" << T_Identifier::getName();
+            datasetName << subGroup << "/" << openPMDName();
             if (components > 1)
                 datasetName << "/" << name_lookup[d];
 

--- a/src/picongpu/include/plugins/hdf5/writer/Field.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/Field.hpp
@@ -43,7 +43,8 @@ struct Field
     static void writeField(ThreadParams *params,
                            const std::string name,
                            std::vector<float_64> unit,
-                           /* unitDimension, position, timeOffset */
+                           std::vector<float_64> unitDimension,
+                           /* position, timeOffset */
                            T_DataBoxType dataBox,
                            const T_ValueType&
                            )
@@ -57,6 +58,9 @@ struct Field
 
         log<picLog::INPUT_OUTPUT > ("HDF5 write field: %1% %2%") %
             name % nComponents;
+
+        assert(unit.size() == nComponents);
+        assert(unitDimension.size() == 7); // seven openPMD base units
 
         std::vector<std::string> name_lookup;
         {
@@ -148,7 +152,14 @@ struct Field
 
         std::string recordName = std::string("fields/") + name;
 
-        /* unitDimension, timeOffset */
+        /* timeOffset */
+
+        ColTypeDouble ctDouble;
+        params->dataCollector->writeAttribute(params->currentStep,
+                                              ctDouble, recordName.c_str(),
+                                              "unitDimension",
+                                              1u, Dimensions(7,0,0),
+                                              &(*unitDimension.begin()));
 
         std::string geometry("cartesian");
         ColTypeString ctGeometry(geometry.length());
@@ -164,7 +175,6 @@ struct Field
 
         /* axisLabels, gridSpacing, gridGlobalOffset */
 
-        ColTypeDouble ctDouble;
         params->dataCollector->writeAttribute(params->currentStep,
                                               ctDouble, recordName.c_str(),
                                               "gridUnitSI", &UNIT_LENGTH);

--- a/src/picongpu/include/plugins/hdf5/writer/Field.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/Field.hpp
@@ -43,6 +43,7 @@ struct Field
     static void writeField(ThreadParams *params,
                            const std::string name,
                            std::vector<float_64> unit,
+                           /* unitDimension, position, timeOffset */
                            T_DataBoxType dataBox,
                            const T_ValueType&
                            )
@@ -140,9 +141,33 @@ struct Field
 
             params->dataCollector->writeAttribute(params->currentStep,
                                                   ctDouble, datasetName.str().c_str(),
-                                                  "sim_unit", &(unit.at(n)));
+                                                  "unitSI", &(unit.at(n)));
+            /* position */
         }
         __deleteArray(tmpArray);
+
+        std::string recordName = std::string("fields/") + name;
+
+        /* unitDimension, timeOffset */
+
+        std::string geometry("cartesian");
+        ColTypeString ctGeometry(geometry.length());
+        params->dataCollector->writeAttribute(params->currentStep,
+                                              ctGeometry, recordName.c_str(),
+                                              "geometry", geometry.c_str());
+
+        std::string dataOrder("C");
+        ColTypeString ctDataOrder(dataOrder.length());
+        params->dataCollector->writeAttribute(params->currentStep,
+                                              ctDataOrder, recordName.c_str(),
+                                              "dataOrder", dataOrder.c_str());
+
+        /* axisLabels, gridSpacing, gridGlobalOffset */
+
+        ColTypeDouble ctDouble;
+        params->dataCollector->writeAttribute(params->currentStep,
+                                              ctDouble, recordName.c_str(),
+                                              "gridUnitSI", &UNIT_LENGTH);
     }
 
 };

--- a/src/picongpu/include/plugins/hdf5/writer/Field.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/Field.hpp
@@ -39,7 +39,7 @@ using namespace splash;
 struct Field
 {
 
-    /* \param inCellPosition std::vector<std::vector<float_32> > with the outer
+    /* \param inCellPosition std::vector<std::vector<float_X> > with the outer
      *                       vector for each component and the inner vector for
      *                       the simDim position offset within the cell [0.0; 1.0)
      */
@@ -48,7 +48,7 @@ struct Field
                            const std::string name,
                            std::vector<float_64> unit,
                            std::vector<float_64> unitDimension,
-                           /* std::vector<std::vector<float_X> > inCellPosition, */
+                           std::vector<std::vector<float_X> > inCellPosition,
                            float_X timeOffset,
                            T_DataBoxType dataBox,
                            const T_ValueType&
@@ -71,9 +71,9 @@ struct Field
 
         /* parameter checking */
         assert(unit.size() == nComponents);
-        //assert(inCellPosition.size() == nComponents);
-        //for( uint32_t n = 0; n < nComponents; ++n )
-        //    assert(inCellPosition.at(n).size() == simDim );
+        assert(inCellPosition.size() == nComponents);
+        for( uint32_t n = 0; n < nComponents; ++n )
+            assert(inCellPosition.at(n).size() == simDim );
         assert(unitDimension.size() == 7); // seven openPMD base units
 
         /* component names */
@@ -156,11 +156,11 @@ struct Field
                                                tmpArray);
 
             /* attributes */
-            /* params->dataCollector->writeAttribute(params->currentStep,
-                                                  splashFloatXType, recordName.c_str(),
+            params->dataCollector->writeAttribute(params->currentStep,
+                                                  splashFloatXType, datasetName.str().c_str(),
                                                   "position",
                                                   1u, Dimensions(simDim,0,0),
-                                                  &(*inCellPosition.at(n).begin())); */
+                                                  &(*inCellPosition.at(n).begin()));
 
             params->dataCollector->writeAttribute(params->currentStep,
                                                   ctDouble, datasetName.str().c_str(),

--- a/src/picongpu/include/plugins/hdf5/writer/Field.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/Field.hpp
@@ -196,8 +196,7 @@ struct Field
         ColTypeString ctAxisLabels(1);
         for( uint32_t d = 0; d < simDim; ++d )
         {
-            /* \todo is the order correct? */
-            axisLabels[d][0] = char(120 + d); // x, y, z
+            axisLabels[d][0] = char('x' + d); // x, y, z
             axisLabels[d][1] = '\0';          // terminator is important!
         }
         params->dataCollector->writeAttribute(params->currentStep,

--- a/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
@@ -141,11 +141,12 @@ struct ParticleAttribute
             if (unit.size() >= (d + 1))
                 threadParams->dataCollector->writeAttribute(threadParams->currentStep,
                                                             ctDouble, datasetName.str().c_str(),
-                                                            "sim_unit", &(unit.at(d)));
-
+                                                            "unitSI", &(unit.at(d)));
 
         }
         __deleteArray(tmpArray);
+
+        /* unitDimension, timeOffset */
 
         log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) write species attribute: %1%") %
             Identifier::getName();

--- a/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
@@ -82,6 +82,7 @@ struct ParticleAttribute
 
         SplashType splashType;
         ColTypeDouble ctDouble;
+        ColTypeUInt32 ctUInt32;
         SplashFloatXType splashFloatXType;
 
         OpenPMDName<T_Identifier> openPMDName;
@@ -89,10 +90,14 @@ struct ParticleAttribute
 
         const std::string name_lookup[] = {"x", "y", "z"};
 
+        // get the SI scaling, dimensionality and weighting of the attribute
         OpenPMDUnit<T_Identifier> openPMDUnit;
         std::vector<float_64> unit = openPMDUnit();
         OpenPMDUnitDimension<T_Identifier> openPMDUnitDimension;
         std::vector<float_64> unitDimension = openPMDUnitDimension();
+        const bool macroWeightedBool = MacroWeighted<T_Identifier>::get();
+        const uint32_t macroWeighted = (macroWeightedBool ? 1 : 0);
+        const float_64 weightingPower = WeightingPower<T_Identifier>::get();
 
         assert(unit.size() == components); // unitSI for each component
         assert(unitDimension.size() == 7); // seven openPMD base units
@@ -180,6 +185,18 @@ struct ParticleAttribute
             "unitDimension",
             1u, Dimensions(7,0,0),
             &(*unitDimension.begin()));
+
+        threadParams->dataCollector->writeAttribute(
+            params->currentStep,
+            ctUInt32, recordName.c_str(),
+            "macroWeighted",
+            &macroWeighted);
+
+        threadParams->dataCollector->writeAttribute(
+            params->currentStep,
+            ctDouble, recordName.c_str(),
+            "weightingPower",
+            &weightingPower);
 
         /** \todo check if always correct at this point, depends on attribute
          *        and MW-solver/pusher implementation */

--- a/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
@@ -44,7 +44,7 @@ using namespace splash;
 
 /** write attribute of a particle to hdf5 file
  *
- * @tparam T_Identifier identifier of a particle attribute
+ * @tparam T_Identifier identifier of a particle record
  */
 template< typename T_Identifier>
 struct ParticleAttribute
@@ -53,7 +53,7 @@ struct ParticleAttribute
      *
      * @param params wrapped thread params such as domainwriter, ...
      * @param frame frame with all particles
-     * @param subGroup
+     * @param speciesPath path for the current species (of FrameType)
      * @param elements number of particles in this patch
      * @param elementsOffset number of particles in this patch
      * @param numParticlesGlobal number of particles globally
@@ -62,7 +62,7 @@ struct ParticleAttribute
     HINLINE void operator()(
                             ThreadParams* params,
                             FrameType& frame,
-                            const std::string subGroup,
+                            const std::string speciesPath,
                             const uint64_t elements,
                             const uint64_t elementsOffset,
                             const uint64_t numParticlesGlobal
@@ -86,7 +86,7 @@ struct ParticleAttribute
         SplashFloatXType splashFloatXType;
 
         OpenPMDName<T_Identifier> openPMDName;
-        std::string recordName = subGroup + std::string("/") + openPMDName();
+        const std::string recordPath( speciesPath + std::string("/") + openPMDName() );
 
         const std::string name_lookup[] = {"x", "y", "z"};
 
@@ -132,7 +132,7 @@ struct ParticleAttribute
         for (uint32_t d = 0; d < components; d++)
         {
             std::stringstream datasetName;
-            datasetName << recordName;
+            datasetName << recordPath;
             if (components > 1)
                 datasetName << "/" << name_lookup[d];
 
@@ -181,20 +181,20 @@ struct ParticleAttribute
 
         threadParams->dataCollector->writeAttribute(
             params->currentStep,
-            ctDouble, recordName.c_str(),
+            ctDouble, recordPath.c_str(),
             "unitDimension",
             1u, Dimensions(7,0,0),
             &(*unitDimension.begin()));
 
         threadParams->dataCollector->writeAttribute(
             params->currentStep,
-            ctUInt32, recordName.c_str(),
+            ctUInt32, recordPath.c_str(),
             "macroWeighted",
             &macroWeighted);
 
         threadParams->dataCollector->writeAttribute(
             params->currentStep,
-            ctDouble, recordName.c_str(),
+            ctDouble, recordPath.c_str(),
             "weightingPower",
             &weightingPower);
 
@@ -202,7 +202,7 @@ struct ParticleAttribute
          *        and MW-solver/pusher implementation */
         const float_X timeOffset = 0.0;
         threadParams->dataCollector->writeAttribute(params->currentStep,
-                                                    splashFloatXType, recordName.c_str(),
+                                                    splashFloatXType, recordPath.c_str(),
                                                     "timeOffset", &timeOffset);
 
         log<picLog::INPUT_OUTPUT > ("HDF5:  ( end ) write species attribute: %1%") %

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -89,10 +89,10 @@ struct WeightingPower<position<T_Type> >
 template<>
 struct Unit<radiationFlag>
 {
-    // zero-sized vector indicating unitless flag for hdf5 and adios output
+    // unitless and not scaled by a factor: by convention 1.0
     static std::vector<double> get()
     {
-        std::vector<double> unit;
+        std::vector<double> unit( 1, 1.0 );
         return unit;
     }
 };
@@ -127,7 +127,7 @@ struct WeightingPower<radiationFlag>
 };
 
 template<>
-struct Unit<momentum >
+struct Unit<momentum>
 {
     static std::vector<double> get()
     {
@@ -141,7 +141,7 @@ struct Unit<momentum >
     }
 };
 template<>
-struct UnitDimension<momentum >
+struct UnitDimension<momentum>
 {
     static std::vector<float_64> get()
     {
@@ -233,17 +233,17 @@ struct WeightingPower<momentumPrev1>
 };
 
 template<>
-struct Unit<weighting >
+struct Unit<weighting>
 {
-    // zero-sized vector indicating unitless flag for hdf5 and adios output
+    // unitless and not scaled by a factor: 1.0
     static std::vector<double> get()
     {
-        std::vector<double> unit;
+        std::vector<double> unit( 1, 1.0 );
         return unit;
     }
 };
 template<>
-struct UnitDimension<weighting >
+struct UnitDimension<weighting>
 {
     static std::vector<float_64> get()
     {
@@ -362,10 +362,10 @@ struct WeightingPower<globalCellIdx<T_Type> >
 template<>
 struct Unit<boundElectrons>
 {
-    // zero-sized vector indicating unitless flag for hdf5 and adios output
+    // unitless and not scaled by a factor: 1.0
     static std::vector<double> get()
     {
-        std::vector<double> unit;
+        std::vector<double> unit( 1, 1.0 );
         return unit;
     }
 };

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -316,11 +316,10 @@ struct WeightingPower<particleId>
 template<typename T_Type>
 struct Unit<globalCellIdx<T_Type> >
 {
+    /* unitless index and not scaled by a factor: by convention 1.0 */
     static std::vector<double> get()
     {
-        std::vector<double> unit(simDim);
-        for(uint32_t i=0;i<simDim;++i)
-            unit[i]=1.0;
+        std::vector<double> unit( simDim, 1.0 );
         return unit;
     }
 };
@@ -329,13 +328,9 @@ struct UnitDimension<globalCellIdx<T_Type> >
 {
     static std::vector<float_64> get()
     {
-        /* L, M, T, I, theta, N, J
-         *
-         * globalCellIdx is a lengths: m
-         *   -> L
+        /* globalCellIdx is a cell index and therefore unitless
          */
         std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
-        unitDimension.at(SIBaseUnits::length) = 1.0;
 
         return unitDimension;
     }

--- a/src/picongpu/include/traits/PICToOpenPMD.hpp
+++ b/src/picongpu/include/traits/PICToOpenPMD.hpp
@@ -33,78 +33,21 @@ namespace picongpu
 {
 namespace traits
 {
-/** Reinterpret attributes for openPMD
- *
- * Currently, this conversion table is used to translate the PIConGPU
- * globalCellIdx (unitless cell index) to the openPMD positionOffset (length)
- */
+    /** Reinterpret attributes for openPMD
+     *
+     * Currently, this conversion tables are used to translate the PIConGPU
+     * globalCellIdx (unitless cell index) to the openPMD positionOffset (length)
+     */
     template<typename T_Identifier>
-    struct OpenPMDName
-    {
-        std::string operator()() const
-        {
-            return T_Identifier::getName();
-        }
-    };
-
-    template<typename T_Type>
-    struct OpenPMDName<globalCellIdx<T_Type> >
-    {
-        std::string operator()() const
-        {
-            return std::string("positionOffset");
-        }
-    };
+    struct OpenPMDName;
 
     template<typename T_Identifier>
-    struct OpenPMDUnit
-    {
-        std::vector<double> operator()() const
-        {
-            return Unit<T_Identifier>::get();
-        }
-    };
-
-    template<typename T_Type>
-    struct OpenPMDUnit<globalCellIdx<T_Type> >
-    {
-        std::vector<double> operator()() const
-        {
-            std::vector<double> unit(simDim);
-            /* cell positionOffset needs two transformations to get to SI:
-               cell begin -> dimensionless scaling to grid -> SI */
-            for( uint32_t i=0; i < simDim; ++i )
-                unit[i] = cellSize[i] * UNIT_LENGTH;
-
-            return unit;
-        }
-    };
+    struct OpenPMDUnit;
 
     template<typename T_Identifier>
-    struct OpenPMDUnitDimension
-    {
-        std::vector<float_64> operator()() const
-        {
-            return UnitDimension<T_Identifier>::get();
-        }
-    };
-
-    template<typename T_Type>
-    struct OpenPMDUnitDimension<globalCellIdx<T_Type> >
-    {
-        std::vector<float_64> operator()() const
-        {
-            /* L, M, T, I, theta, N, J
-             *
-             * positionOffset is in meter: m
-             *   -> L
-             */
-            std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
-            unitDimension.at(SIBaseUnits::length) = 1.0;
-
-            return unitDimension;
-        }
-    };
+    struct OpenPMDUnitDimension;
 
 } // namespace traits
 } // namespace picongpu
+
+#include "PICToOpenPMD.tpp"

--- a/src/picongpu/include/traits/PICToOpenPMD.hpp
+++ b/src/picongpu/include/traits/PICToOpenPMD.hpp
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "traits/Unit.hpp"
+#include "traits/UnitDimension.hpp"
+
+#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
+
+#include <string>
+#include <vector>
+
+namespace picongpu
+{
+namespace traits
+{
+/** Reinterpret attributes for openPMD
+ *
+ * Currently, this conversion table is used to translate the PIConGPU
+ * globalCellIdx (unitless cell index) to the openPMD positionOffset (length)
+ */
+    template<typename T_Identifier>
+    struct OpenPMDName
+    {
+        std::string operator()() const
+        {
+            return T_Identifier::getName();
+        }
+    };
+
+    template<typename T_Type>
+    struct OpenPMDName<globalCellIdx<T_Type> >
+    {
+        std::string operator()() const
+        {
+            return std::string("positionOffset");
+        }
+    };
+
+    template<typename T_Identifier>
+    struct OpenPMDUnit
+    {
+        std::vector<double> operator()() const
+        {
+            return Unit<T_Identifier>::get();
+        }
+    };
+
+    template<typename T_Type>
+    struct OpenPMDUnit<globalCellIdx<T_Type> >
+    {
+        std::vector<double> operator()() const
+        {
+            std::vector<double> unit(simDim);
+            /* cell positionOffset needs two transformations to get to SI:
+               cell begin -> dimensionless scaling to grid -> SI */
+            for( uint32_t i=0; i < simDim; ++i )
+                unit[i] = cellSize[i] * UNIT_LENGTH;
+
+            return unit;
+        }
+    };
+
+    template<typename T_Identifier>
+    struct OpenPMDUnitDimension
+    {
+        std::vector<float_64> operator()() const
+        {
+            return UnitDimension<T_Identifier>::get();
+        }
+    };
+
+    template<typename T_Type>
+    struct OpenPMDUnitDimension<globalCellIdx<T_Type> >
+    {
+        std::vector<float_64> operator()() const
+        {
+            /* L, M, T, I, theta, N, J
+             *
+             * positionOffset is in meter: m
+             *   -> L
+             */
+            std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
+            unitDimension.at(SIBaseUnits::length) = 1.0;
+
+            return unitDimension;
+        }
+    };
+
+} // namespace traits
+} // namespace picongpu

--- a/src/picongpu/include/traits/PICToOpenPMD.tpp
+++ b/src/picongpu/include/traits/PICToOpenPMD.tpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace traits
+{
+    /** Forward names that are identical in PIConGPU & openPMD
+     */
+    template<typename T_Identifier>
+    struct OpenPMDName
+    {
+        std::string operator()() const
+        {
+            return T_Identifier::getName();
+        }
+    };
+
+    /** Translate the globalCellIdx (unitless index) into the openPMD
+     *  positionOffset (3D position vector, length)
+     */
+    template<typename T_Type>
+    struct OpenPMDName<globalCellIdx<T_Type> >
+    {
+        std::string operator()() const
+        {
+            return std::string("positionOffset");
+        }
+    };
+
+    /** Forward units that are identical in PIConGPU & openPMD
+     */
+    template<typename T_Identifier>
+    struct OpenPMDUnit
+    {
+        std::vector<double> operator()() const
+        {
+            return Unit<T_Identifier>::get();
+        }
+    };
+
+    /** the globalCellIdx can be converted into a positionOffset
+     *  until the beginning of the cell by multiplying with the component-wise
+     *  cell size in SI
+     */
+    template<typename T_Type>
+    struct OpenPMDUnit<globalCellIdx<T_Type> >
+    {
+        std::vector<double> operator()() const
+        {
+            std::vector<double> unit(simDim);
+            /* cell positionOffset needs two transformations to get to SI:
+               cell begin -> dimensionless scaling to grid -> SI */
+            for( uint32_t i=0; i < simDim; ++i )
+                unit[i] = cellSize[i] * UNIT_LENGTH;
+
+            return unit;
+        }
+    };
+
+    /** Forward dimensionalities that are identical in PIConGPU & openPMD
+     */
+    template<typename T_Identifier>
+    struct OpenPMDUnitDimension
+    {
+        std::vector<float_64> operator()() const
+        {
+            return UnitDimension<T_Identifier>::get();
+        }
+    };
+
+    /** the openPMD positionOffset is an actual (vector) with a lengths that
+     *  is added to the position (vector) attribute
+     */
+    template<typename T_Type>
+    struct OpenPMDUnitDimension<globalCellIdx<T_Type> >
+    {
+        std::vector<float_64> operator()() const
+        {
+            /* L, M, T, I, theta, N, J
+             *
+             * positionOffset is in meter: m
+             *   -> L
+             */
+            std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
+            unitDimension.at(SIBaseUnits::length) = 1.0;
+
+            return unitDimension;
+        }
+    };
+
+} // namespace traits
+} // namespace picongpu

--- a/src/picongpu/include/traits/Unit.hpp
+++ b/src/picongpu/include/traits/Unit.hpp
@@ -27,12 +27,13 @@ namespace picongpu
 
 namespace traits
 {
-    /** Get unit of date which are represented by a identifier
+    /** Get unit of a date that is represented by an identifier
      *
-     * \tparam T_Identifier any picongpu identifier
+     * \tparam T_Identifier any PIConGPU identifier
      * \return \p std::vector<float_64> ::get() as static public method
      *
-     * a zero-size vector with no specified unit is valid for unitless items
+     * Unitless identifies, see \UnitDimension, can still be scaled by a
+     * factor. If they are not scaled, implement the unit as 1.0;
      * \see simulation_defines/unitless/speciesAttributes.unitless
      */
     template<typename T_Identifier>

--- a/src/tools/bin/plot_chargeConservation.py
+++ b/src/tools/bin/plot_chargeConservation.py
@@ -81,9 +81,9 @@ def plotError(h5file, slice_pos=[0.5, 0.5, 0.5]):
     CELL_VOLUME = CELL_WIDTH * CELL_HEIGHT * CELL_DEPTH
 
     # load electric field
-    Ex = np.array(f["/data/{}/fields/FieldE/x".format(timestep)])
-    Ey = np.array(f["/data/{}/fields/FieldE/y".format(timestep)])
-    Ez = np.array(f["/data/{}/fields/FieldE/z".format(timestep)])
+    Ex = np.array(f["/data/{}/fields/E/x".format(timestep)])
+    Ey = np.array(f["/data/{}/fields/E/y".format(timestep)])
+    Ez = np.array(f["/data/{}/fields/E/z".format(timestep)])
 
     # load and add charge density
     charge = np.zeros_like(Ex)

--- a/src/tools/bin/plot_chargeConservation_overTime.py
+++ b/src/tools/bin/plot_chargeConservation_overTime.py
@@ -98,9 +98,9 @@ def deviation_charge_conservation(h5file):
     is2D = False
 
     # load electric field
-    Ex = np.array(f["/data/{}/fields/FieldE/x".format(timestep)])
-    Ey = np.array(f["/data/{}/fields/FieldE/y".format(timestep)])
-    Ez = np.array(f["/data/{}/fields/FieldE/z".format(timestep)])
+    Ex = np.array(f["/data/{}/fields/E/x".format(timestep)])
+    Ey = np.array(f["/data/{}/fields/E/y".format(timestep)])
+    Ez = np.array(f["/data/{}/fields/E/z".format(timestep)])
 
     # load and add charge density
     charge = np.zeros_like(Ex)

--- a/src/tools/bin/splash2vtk.sh
+++ b/src/tools/bin/splash2vtk.sh
@@ -21,8 +21,7 @@
 
 filename="$1"
 step=1000
-dataNames="fields_FieldE_y"
-#dataNames="fields_FieldE_y"
+dataNames="fields_E_y"
 dataEl=`echo "$dataNames" | wc -w`
 
 # dimensions & meta data


### PR DESCRIPTION
### Description

@psychocoderHPC 

This PR implements:

- the openPMD base standard, [v1.0.0](https://github.com/openPMD/openPMD-standard/tree/1.0.0), for our HDF5 output
- much of the [`ED-PIC` extension](https://github.com/openPMD/openPMD-standard/blob/1.0.0/EXT_ED-PIC.md) (just missing a few string-attributes)
- constant particle records: `mass`, `charge`
- [`particlePatches`](https://github.com/openPMD/openPMD-standard/blob/1.0.0/STANDARD.md#sub-group-for-each-particle-species) instead of the old `particle_info` object
- restarts from same GPU configuration (tested with `-m` in LWFA example)
- checkpoints and dumps tested with openPMD validator scripts (base standard is passing)
- change: unitless attributes now have the `unitSI` of `1.0` since we can identify those already via an all-zero `unitDimension`

### Requirements

- [x] requires libSplash `1.4.0` #1427 
- [x] fields: `getUnitDimension()` trait/interface #1429 (will remove the e6e396fdc3561214cf4ef93640297fe0ba39d890 commit)
- [x] particles: `PatchReader` helper #1430 (will remove the ~260 new lines in the helper class of the bebaaf39056ac5cc696277a7e31bed58339b7efc commit and speeds up compile time due to separate object files)
- [x] particle weighting traits: #1445
- [x] rebase
- [x] after review, before merge: redo 3D3V rt test
- [x] after review, before merge: perform missing 2D3V rt test
- [x] read with [openPMD-viewer](https://github.com/openPMD/openPMD-viewer)

### Possible Collisions

- [x] check against #1410 (rebase works smoothly, so I will review & merge #1410 while you review this PR)
- [x] apply RT fix from #1440
- [x] rebase against #1453

### Follow-Ups

- fields: further, general ED-PIC attributes:
  - `fieldSolver`, `fieldBoundary`, `particleBoundary`, `currentSmoothing`, `chargeCorrection`
- fields: per-field smoothing attribute: `fieldSmoothing`
- particles: further, general ED-PIC per-species attributes:
  - `particleShape`, `currentDeposition`, `particlePush`, `particleInterpolation`, `particleSmoothing`
- ~~particles: per-species-record attribute: `weightingPower`, `macroWeighted`~~ -> #1445
- particles: non-`uint64_t` types in `extent` and `offset` of `particlePatches`