### PR TITLE
Fields: Add getUnitDimension() Interface

### DIFF
--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 /*pic default*/
 #include "pmacc_types.hpp"
@@ -66,6 +67,14 @@ namespace picongpu
         virtual void reset(uint32_t currentStep);
 
         HDINLINE static UnitValueType getUnit();
+
+        /** powers of the 7 base measures
+         *
+         * characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         *  thermodynamic temperature theta, amount of substance N,
+         *  luminous intensity J) */
+        HDINLINE static std::vector<float_64> getUnitDimension();
 
         static std::string getName();
 

--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -53,6 +53,7 @@
 #include "particles/traits/FilterByFlag.hpp"
 
 #include "traits/GetMargin.hpp"
+#include "traits/SIBaseUnits.hpp"
 #include "particles/traits/GetMarginPusher.hpp"
 
 namespace picongpu
@@ -218,9 +219,9 @@ FieldB::getUnitDimension( )
      *   -> M * T^-2 * I^-1
      */
     std::vector<float_64> unitDimension( 7, 0.0 );
-    unitDimension.at(1) =  1.0; // M^1
-    unitDimension.at(2) = -2.0; // T^-2
-    unitDimension.at(3) = -1.0; // I^-1
+    unitDimension.at(SIBaseUnits::mass) =  1.0;
+    unitDimension.at(SIBaseUnits::time) = -2.0;
+    unitDimension.at(SIBaseUnits::electricCurrent) = -1.0;
 
     return unitDimension;
 }

--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -208,6 +208,23 @@ FieldB::getUnit( )
     return UnitValueType( UNIT_BFIELD, UNIT_BFIELD, UNIT_BFIELD );
 }
 
+HDINLINE
+std::vector<float_64>
+FieldB::getUnitDimension( )
+{
+    /* L, M, T, I, theta, N, J
+     *
+     * B is in Tesla : kg / (A * s^2)
+     *   -> M * T^-2 * I^-1
+     */
+    std::vector<float_64> unitDimension( 7, 0.0 );
+    unitDimension.at(1) =  1.0; // M^1
+    unitDimension.at(2) = -2.0; // T^-2
+    unitDimension.at(3) = -1.0; // I^-1
+
+    return unitDimension;
+}
+
 std::string
 FieldB::getName( )
 {

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 /*pic default*/
 #include "pmacc_types.hpp"
@@ -66,6 +67,14 @@ namespace picongpu
         virtual void reset(uint32_t currentStep);
 
         HDINLINE static UnitValueType getUnit();
+
+        /** powers of the 7 base measures
+         *
+         * characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         *  thermodynamic temperature theta, amount of substance N,
+         *  luminous intensity J) */
+        HDINLINE static std::vector<float_64> getUnitDimension();
 
         static std::string getName();
 

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -65,7 +65,7 @@ fieldB( NULL )
         VectorAllSpecies,
         interpolation<>
     >::type VectorSpeciesWithInterpolation;
-    
+
     typedef bmpl::accumulate<
         VectorSpeciesWithInterpolation,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
@@ -218,6 +218,24 @@ FieldE::UnitValueType
 FieldE::getUnit( )
 {
     return UnitValueType( UNIT_EFIELD, UNIT_EFIELD, UNIT_EFIELD );
+}
+
+HDINLINE
+std::vector<float_64>
+FieldE::getUnitDimension( )
+{
+    /* L, M, T, I, theta, N, J
+     *
+     * E is in volts per meters: V / m = kg * m / (A * s^3)
+     *   -> L * M * T^-3 * I^-1
+     */
+    std::vector<float_64> unitDimension( 7, 0.0 );
+    unitDimension.at(0) =  1.0; // L^1
+    unitDimension.at(1) =  1.0; // M^1
+    unitDimension.at(2) = -3.0; // T^-3
+    unitDimension.at(3) = -1.0; // I^-1
+
+    return unitDimension;
 }
 
 std::string

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -47,6 +47,7 @@
 #include "particles/traits/GetInterpolation.hpp"
 #include "particles/traits/FilterByFlag.hpp"
 #include "traits/GetMargin.hpp"
+#include "traits/SIBaseUnits.hpp"
 #include "particles/traits/GetMarginPusher.hpp"
 #include <boost/mpl/accumulate.hpp>
 #include "fields/LaserPhysics.hpp"
@@ -230,10 +231,10 @@ FieldE::getUnitDimension( )
      *   -> L * M * T^-3 * I^-1
      */
     std::vector<float_64> unitDimension( 7, 0.0 );
-    unitDimension.at(0) =  1.0; // L^1
-    unitDimension.at(1) =  1.0; // M^1
-    unitDimension.at(2) = -3.0; // T^-3
-    unitDimension.at(3) = -1.0; // I^-1
+    unitDimension.at(SIBaseUnits::length) =  1.0;
+    unitDimension.at(SIBaseUnits::mass)   =  1.0;
+    unitDimension.at(SIBaseUnits::time)   = -3.0;
+    unitDimension.at(SIBaseUnits::electricCurrent) = -1.0;
 
     return unitDimension;
 }

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 /*pic default*/
 #include "pmacc_types.hpp"
@@ -90,6 +91,14 @@ public:
     void assign(ValueType value);
 
     HDINLINE static UnitValueType getUnit();
+
+    /** powers of the 7 base measures
+     *
+     * characterizing the record's unit in SI
+     * (length L, mass M, time T, electric current I,
+     *  thermodynamic temperature theta, amount of substance N,
+     *  luminous intensity J) */
+    HDINLINE static std::vector<float_64> getUnitDimension();
 
     static std::string getName();
 

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -242,6 +242,22 @@ FieldJ::getUnit( )
     return UnitValueType( UNIT_CURRENT, UNIT_CURRENT, UNIT_CURRENT );
 }
 
+HDINLINE
+std::vector<float_64>
+FieldJ::getUnitDimension( )
+{
+    /* L, M, T, I, theta, N, J
+     *
+     * J is in A/m^2
+     *   -> L^-2 * I
+     */
+    std::vector<float_64> unitDimension( 7, 0.0 );
+    unitDimension.at(0) = -2.0; // L^-2
+    unitDimension.at(3) =  1.0; // I^1
+
+    return unitDimension;
+}
+
 std::string
 FieldJ::getName( )
 {

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -44,6 +44,7 @@
 #include "particles/traits/GetCurrentSolver.hpp"
 #include "traits/GetMargin.hpp"
 #include "traits/Resolve.hpp"
+#include "traits/SIBaseUnits.hpp"
 
 
 namespace picongpu
@@ -252,8 +253,8 @@ FieldJ::getUnitDimension( )
      *   -> L^-2 * I
      */
     std::vector<float_64> unitDimension( 7, 0.0 );
-    unitDimension.at(0) = -2.0; // L^-2
-    unitDimension.at(3) =  1.0; // I^1
+    unitDimension.at(SIBaseUnits::length) = -2.0;
+    unitDimension.at(SIBaseUnits::electricCurrent) =  1.0;
 
     return unitDimension;
 }

--- a/src/picongpu/include/fields/FieldTmp.hpp
+++ b/src/picongpu/include/fields/FieldTmp.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 /*pic default*/
 #include "pmacc_types.hpp"
@@ -71,6 +72,15 @@ namespace picongpu
 
         template<class FrameSolver >
         HDINLINE static UnitValueType getUnit();
+
+        /** powers of the 7 base measures
+         *
+         * characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         *  thermodynamic temperature theta, amount of substance N,
+         *  luminous intensity J) */
+        template<class FrameSolver >
+        HDINLINE static std::vector<float_64> getUnitDimension();
 
         static std::string getName();
 

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -283,6 +283,12 @@ namespace picongpu
         return FrameSolver().getUnit();
     }
 
+    template<class FrameSolver >
+    HDINLINE std::vector<float_64>
+    FieldTmp::getUnitDimension( )
+    {
+        return FrameSolver().getUnitDimension();
+    }
 
     std::string
     FieldTmp::getName( )

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -27,6 +27,8 @@
 #include "particles/traits/GetShape.hpp"
 #include "particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
 
+#include <vector>
+
 namespace picongpu
 {
 namespace particleToGrid
@@ -54,6 +56,14 @@ public:
      * @return solver unit
      */
     HDINLINE float1_64 getUnit() const;
+
+    /** return powers of the 7 base measures for this solver
+     *
+     * characterizing the unit of the result of the solver in SI
+     * (length L, mass M, time T, electric current I,
+     *  thermodynamic temperature theta, amount of substance N,
+     *  luminous intensity J) */
+    HDINLINE std::vector<float_64> getUnitDimension() const;
 
     /** return name of the this solver
      * @return name of solver

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -31,6 +31,8 @@
 
 #include "algorithms/Gamma.hpp"
 
+#include <vector>
+
 namespace picongpu
 {
 namespace particleToGrid
@@ -41,6 +43,13 @@ HDINLINE float1_64
 ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::getUnit() const
 {
     return T_DerivedAttribute().getUnit();
+}
+
+template<class T_ParticleShape, class T_DerivedAttribute>
+HDINLINE std::vector<float_64>
+ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::getUnitDimension() const
+{
+    return T_DerivedAttribute().getUnitDimension();
 }
 
 template<class T_ParticleShape, class T_DerivedAttribute>

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include <vector>
 
 
 namespace picongpu
@@ -34,6 +35,22 @@ namespace derivedAttributes
 
         HDINLINE float1_64
         getUnit() const;
+
+        HDINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * ChargeDensity is in Coulomb / cubic meter: Q / m^3 = I * t / m^3
+            *   -> L^-3 * T * I
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+           unitDimension.at(0) = -3.0; // L^-3
+           unitDimension.at(2) =  1.0; // T^1
+           unitDimension.at(3) =  1.0; // I^1
+
+           return unitDimension;
+        }
 
         HINLINE std::string
         getName() const

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "traits/SIBaseUnits.hpp"
 #include <vector>
 
 
@@ -45,9 +46,9 @@ namespace derivedAttributes
             *   -> L^-3 * T * I
             */
            std::vector<float_64> unitDimension( 7, 0.0 );
-           unitDimension.at(0) = -3.0; // L^-3
-           unitDimension.at(2) =  1.0; // T^1
-           unitDimension.at(3) =  1.0; // I^1
+           unitDimension.at(SIBaseUnits::length) = -3.0;
+           unitDimension.at(SIBaseUnits::time)   =  1.0;
+           unitDimension.at(SIBaseUnits::electricCurrent) =  1.0;
 
            return unitDimension;
         }

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include <vector>
 
 
 namespace picongpu
@@ -34,6 +35,18 @@ namespace derivedAttributes
 
         HDINLINE float1_64
         getUnit() const;
+
+        HDINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * Counter is unitless
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+
+           return unitDimension;
+        }
 
         HINLINE std::string
         getName() const

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include <vector>
 
 
 namespace picongpu
@@ -34,6 +35,20 @@ namespace derivedAttributes
 
         HDINLINE float1_64
         getUnit() const;
+
+        HDINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * Density is in inverse cubic meter: m^-3
+            *   -> L^-3
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+           unitDimension.at(0) = -3.0; // L^-3
+
+           return unitDimension;
+        }
 
         HINLINE std::string
         getName() const

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "traits/SIBaseUnits.hpp"
 #include <vector>
 
 
@@ -45,7 +46,7 @@ namespace derivedAttributes
             *   -> L^-3
             */
            std::vector<float_64> unitDimension( 7, 0.0 );
-           unitDimension.at(0) = -3.0; // L^-3
+           unitDimension.at(SIBaseUnits::length) = -3.0;
 
            return unitDimension;
         }

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include <vector>
 
 
 namespace picongpu
@@ -34,6 +35,22 @@ namespace derivedAttributes
 
         HDINLINE float1_64
         getUnit() const;
+
+        HDINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * Energy is in Joule: J = kg * m^2 / s^2
+            *   -> L^2 * M * T^-2
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+           unitDimension.at(0) =  2.0; // L^2
+           unitDimension.at(1) =  1.0; // M^1
+           unitDimension.at(2) = -2.0; // T^-2
+
+           return unitDimension;
+        }
 
         HINLINE std::string
         getName() const

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "traits/SIBaseUnits.hpp"
 #include <vector>
 
 
@@ -45,9 +46,9 @@ namespace derivedAttributes
             *   -> L^2 * M * T^-2
             */
            std::vector<float_64> unitDimension( 7, 0.0 );
-           unitDimension.at(0) =  2.0; // L^2
-           unitDimension.at(1) =  1.0; // M^1
-           unitDimension.at(2) = -2.0; // T^-2
+           unitDimension.at(SIBaseUnits::length) =  2.0;
+           unitDimension.at(SIBaseUnits::mass)   =  1.0;
+           unitDimension.at(SIBaseUnits::time)   = -2.0;
 
            return unitDimension;
         }

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "traits/SIBaseUnits.hpp"
 #include <vector>
 
 
@@ -46,9 +47,9 @@ namespace derivedAttributes
             *   -> L^-1 * M * T^-2
             */
            std::vector<float_64> unitDimension( 7, 0.0 );
-           unitDimension.at(0) = -1.0; // L^-1
-           unitDimension.at(1) =  1.0; // M^1
-           unitDimension.at(2) = -2.0; // T^-2
+           unitDimension.at(SIBaseUnits::length) = -1.0;
+           unitDimension.at(SIBaseUnits::mass)   =  1.0;
+           unitDimension.at(SIBaseUnits::time)   = -2.0;
 
            return unitDimension;
         }

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include <vector>
 
 
 namespace picongpu
@@ -34,6 +35,23 @@ namespace derivedAttributes
 
         HDINLINE float1_64
         getUnit() const;
+
+        HDINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * EnergyDensity is in Joule / cubic meter: J / m^3 = kg * m^2 / s^2 / m^3
+            *                                                  = kg / (s^2 * m)
+            *   -> L^-1 * M * T^-2
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+           unitDimension.at(0) = -1.0; // L^-1
+           unitDimension.at(1) =  1.0; // M^1
+           unitDimension.at(2) = -2.0; // T^-2
+
+           return unitDimension;
+        }
 
         HINLINE std::string
         getName() const

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include <vector>
 
 
 namespace picongpu
@@ -34,6 +35,22 @@ namespace derivedAttributes
 
         HDINLINE float1_64
         getUnit() const;
+
+        HDINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * LarmorEnergy is in Joule: J = kg * m^2 / s^2
+            *   -> L^2 * M * T^-2
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+           unitDimension.at(0) =  2.0; // L^2
+           unitDimension.at(1) =  1.0; // M^1
+           unitDimension.at(2) = -2.0; // T^-2
+
+           return unitDimension;
+        }
 
         HINLINE std::string
         getName() const

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "traits/SIBaseUnits.hpp"
 #include <vector>
 
 
@@ -45,9 +46,9 @@ namespace derivedAttributes
             *   -> L^2 * M * T^-2
             */
            std::vector<float_64> unitDimension( 7, 0.0 );
-           unitDimension.at(0) =  2.0; // L^2
-           unitDimension.at(1) =  1.0; // M^1
-           unitDimension.at(2) = -2.0; // T^-2
+           unitDimension.at(SIBaseUnits::length) =  2.0;
+           unitDimension.at(SIBaseUnits::mass)   =  1.0;
+           unitDimension.at(SIBaseUnits::time)   = -2.0;
 
            return unitDimension;
         }

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -25,31 +25,13 @@
 #include <vector>
 #include "traits/Unit.hpp"
 #include "traits/UnitDimension.hpp"
+#include "traits/SIBaseUnits.hpp"
 
 namespace picongpu
 {
 
 namespace traits
 {
-
-/* openPMD uses the powers of the 7 SI base measures to describe
- * the unit of a record
- * \see http://git.io/vROmP */
-BOOST_CONSTEXPR_OR_CONST uint32_t NUnitDimension = 7;
-
-// pre-C++11 "scoped enumerator" work-around
-namespace SIBaseUnits {
-enum SIBaseUnits_t
-{
-    length = 0,                   // L
-    mass = 1,                     // M
-    time = 2,                     // T
-    electricCurrent = 3,          // I
-    thermodynamicTemperature = 4, // theta
-    amountOfSubstance = 5,        // N
-    luminousIntensity = 6,        // J
-};
-}
 
 template<typename T_Type>
 struct Unit<position<T_Type> >

--- a/src/picongpu/include/traits/SIBaseUnits.hpp
+++ b/src/picongpu/include/traits/SIBaseUnits.hpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015-2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace traits
+{
+
+    /* openPMD uses the powers of the 7 SI base measures to describe
+     * the unit of a record
+     * \see http://git.io/vROmP */
+    BOOST_CONSTEXPR_OR_CONST uint32_t NUnitDimension = 7;
+
+    // pre-C++11 "scoped enumerator" work-around
+    namespace SIBaseUnits {
+    enum SIBaseUnits_t
+    {
+        length = 0,                   // L
+        mass = 1,                     // M
+        time = 2,                     // T
+        electricCurrent = 3,          // I
+        thermodynamicTemperature = 4, // theta
+        amountOfSubstance = 5,        // N
+        luminousIntensity = 6,        // J
+    };
+    }
+
+} // namespace traits
+} // namespace picongpu


### PR DESCRIPTION
Added alongside `getUnit()` the new interface to get the openPMD dimensionality of a data set for all basic fields and `FieldTmp` solvers.