### PR TITLE
openPMD: Particle Patch Reader

### DIFF
--- a/src/picongpu/include/plugins/common/particlePatches.hpp
+++ b/src/picongpu/include/plugins/common/particlePatches.hpp
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+
+#include <vector>
+#include <list>
+#include <iostream>
+
+namespace picongpu
+{
+namespace openPMD
+{
+
+    /** Struct for a list of particle patches
+     *
+     * Object for all particle patches.
+     * @see https://github.com/openPMD/openPMD-standard/blob/1.0.0/STANDARD.md#sub-group-for-each-particle-species
+     */
+    class ParticlePatches
+    {
+    private:
+        /** Disallow (empty) default contructor
+         */
+        ParticlePatches ();
+
+    public:
+        std::vector<uint64_t> numParticles;
+        std::vector<uint64_t> numParticlesOffset;
+
+        std::vector<uint64_t> offsetX;
+        std::vector<uint64_t> offsetY;
+        std::vector<uint64_t> offsetZ;
+
+        std::vector<uint64_t> extentX;
+        std::vector<uint64_t> extentY;
+        std::vector<uint64_t> extentZ;
+
+        /** Fill-Constructor with n empty-sized patches
+         *
+         * @param n number of patches to store
+         */
+        ParticlePatches( const size_t n );
+
+        /** Return the beginning of one of the components of the
+         *  offset as pointer
+         *
+         * Be aware that the pointer is pointing to the beginning
+         * of a C-array of size `size()` and is only allocated as long
+         * as the `ParticlePatches` object is alive.
+         *
+         * @param comp component (0=x, 1=y, 2=z) of offset array
+         *             for the list of patches
+         * @return uint64_t* pointing to the beginning of a c-array
+         *                   with length as given in size()
+         */
+        uint64_t* getOffsetComp( const uint32_t comp );
+
+        /** Return the beginning of one of the components of the
+         *  extent as pointer
+         *
+         * Be aware that the pointer is pointing to the beginning
+         * of a C-array of size `size()` and is only allocated as long
+         * as the `ParticlePatches` object is alive.
+         *
+         * @param comp component (0=x, 1=y, 2=z) of extent array
+         *             for the list of patches
+         * @return uint64_t* pointing to the beginning of a c-array
+         *                   with length as given in size()
+         */
+        uint64_t* getExtentComp( const uint32_t comp );
+
+        /** Returns the number of patches
+         */
+        size_t size() const;
+
+        /** Helper function printing to std::cout
+         */
+        void print();
+    };
+
+} // namespace openPMD
+} // namespace picongpu

--- a/src/picongpu/include/plugins/hdf5/openPMD/patchReader.hpp
+++ b/src/picongpu/include/plugins/hdf5/openPMD/patchReader.hpp
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "plugins/common/particlePatches.hpp"
+
+#if( ENABLE_HDF5 == 1 )
+#  include <splash/splash.h>
+#endif
+
+#include <vector>
+#include <list>
+#include <string>
+#include <iostream>
+#include <typeinfo>
+
+namespace picongpu
+{
+namespace hdf5
+{
+namespace openPMD
+{
+    class PatchReader;
+
+#if( ENABLE_HDF5 == 1 )
+    /** Functor to populate and validate the list of particle patches
+     */
+    class PatchReader
+    {
+    private:
+        /** Determine the variable type for `offset` and `extent`
+         *
+         * In particle patches, the `offset` and `extent` can be of
+         * user-defined types. This function allows to determine which
+         * one was used and how many patches exist.
+         *
+         * @note currently we force the type to be `uint64_t`,
+         *       we can implement type conversions later on
+         * @note currently we force the number of patches
+         *       to stay constant during restarts
+         *
+         * @param dc parallel libSplash DataCollector
+         * @param availableRanks MPI ranks in the restarted simulation
+         *        that are currently waiting to find patches
+         * @param id iteration in file
+         * @param particlePatchPathComponent string such as
+         *             "particles/e/particlePatches/numParticles" or
+         *             "particles/e/particlePatches/offset/x"
+         */
+        void checkSpatialTypeSize(
+            splash::DataCollector* const dc,
+            const uint32_t availableRanks,
+            const int32_t id,
+            const std::string particlePatchPathComponent
+        ) const;
+
+        /** Read a specific record component of the particle patch
+         *
+         * Read for example: numParticles or offset/x
+         *
+         * @param[in]  dc pointer to an open splash::DataCollector
+         * @param[in]  availableRanks MPI ranks in the restarted simulation
+         *             that are currently waiting to find patches
+         * @param[in]  id time step to read
+         * @param[in]  particlePatchPathComponent string such as
+         *             "particles/e/particlePatches/numParticles" or
+         *             "particles/e/particlePatches/offset/x"
+         * @param[out] dest beginning of c-array of length size()
+         *             to write the patch record component to
+         */
+        void readPatchAttribute(
+            splash::DataCollector* const dc,
+            const uint32_t availableRanks,
+            const int32_t id,
+            const std::string particlePatchPathComponent,
+            uint64_t* const dest
+        ) const;
+
+    public:
+        /** Build up the global list of patches
+         *
+         * @param dc parallel libSplash DataCollector
+         * @param availableRanks MPI ranks in the restarted simulation
+         *        that are currently waiting to find patches
+         * @param dimensionality the PIConGPU simDim
+         * @param id iteration in file
+         * @param particlePatchPath in-file path to a specific particle patch dir
+         *
+         * @return picongpu::openPMD::ParticlePatches struct of arrays with patches
+         */
+        picongpu::openPMD::ParticlePatches operator()(
+            splash::DataCollector* const dc,
+            const uint32_t availableRanks,
+            const uint32_t dimensionality,
+            const int32_t id,
+            const std::string particlePatchPath
+        ) const;
+    };
+#endif
+
+} // namespace openPMD
+} // namespace hdf5
+} // namespace picongpu

--- a/src/picongpu/particlePatches.cpp
+++ b/src/picongpu/particlePatches.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "include/plugins/common/particlePatches.hpp"
+
+namespace picongpu
+{
+namespace openPMD
+{
+
+    ParticlePatches::ParticlePatches( const size_t n )
+    {
+        /* zero particles */
+        numParticles = std::vector<uint64_t>( n, 0u );
+        numParticlesOffset = std::vector<uint64_t>( n, 0u );
+
+        /* zero offsets */
+        offsetX = std::vector<uint64_t>( n, 0u );
+        offsetY = std::vector<uint64_t>( n, 0u );
+        offsetZ = std::vector<uint64_t>( n, 0u );
+
+        /* zero extents */
+        extentX = std::vector<uint64_t>( n, 0u );
+        extentY = std::vector<uint64_t>( n, 0u );
+        extentZ = std::vector<uint64_t>( n, 0u );
+    }
+
+    uint64_t* ParticlePatches::getOffsetComp( const uint32_t comp )
+    {
+        if( comp == 0 )
+            return &(*offsetX.begin());
+        if( comp == 1 )
+            return &(*offsetY.begin());
+        if( comp == 2 )
+            return &(*offsetZ.begin());
+
+        return NULL;
+    }
+
+    uint64_t* ParticlePatches::getExtentComp( const uint32_t comp )
+    {
+        if( comp == 0 )
+            return &(*extentX.begin());
+        if( comp == 1 )
+            return &(*extentY.begin());
+        if( comp == 2 )
+            return &(*extentZ.begin());
+
+        return NULL;
+    }
+
+    size_t ParticlePatches::size() const
+    {
+        return numParticles.size();
+    }
+
+    void ParticlePatches::print()
+    {
+        std::cout << "id | numParticles numParticlesOffset "
+                  << "offsetX offsetY offsetZ extentX extentY extentZ"
+                  << std::endl;
+        for( size_t i = 0; i < this->size(); ++i )
+        {
+            std::cout << i << " | "
+                      << numParticles.at(i) << " "
+                      << numParticlesOffset.at(i) << " "
+                      << offsetX.at(i) << " "
+                      << offsetY.at(i) << " "
+                      << offsetZ.at(i) << " "
+                      << extentX.at(i) << " "
+                      << extentY.at(i) << " "
+                      << extentZ.at(i) << std::endl;
+        }
+    }
+
+} // namespace openPMD
+} // namespace picongpu

--- a/src/picongpu/patchReader.cpp
+++ b/src/picongpu/patchReader.cpp
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if( ENABLE_HDF5 == 1 )
+
+#  include "include/plugins/hdf5/openPMD/patchReader.hpp"
+
+namespace picongpu
+{
+namespace hdf5
+{
+namespace openPMD
+{
+    void PatchReader::checkSpatialTypeSize(
+            splash::DataCollector* const dc,
+            const uint32_t availableRanks,
+            const int32_t id,
+            const std::string particlePatchPathComponent
+    ) const
+    {
+        // will later read into 1D buffer from first position on
+        splash::Dimensions dstBuffer(availableRanks, 1, 1);
+        splash::Dimensions dstOffset(0, 0, 0);
+        // sizeRead will be set
+        splash::Dimensions sizeRead(0, 0, 0);
+
+        splash::CollectionType* colType = dc->readMeta(
+            id,
+            particlePatchPathComponent.c_str(),
+            dstBuffer,
+            dstOffset,
+            sizeRead );
+
+        // check if the 1D list of patches has the right length
+        assert( sizeRead[0] == availableRanks );
+
+        // currently only support uint64_t types to spare type conversation
+        assert( typeid(*colType) == typeid(splash::ColTypeUInt64) );
+
+        // free collections
+        __delete( colType );
+    }
+
+    void PatchReader::readPatchAttribute(
+        splash::DataCollector* const dc,
+        const uint32_t availableRanks,
+        const int32_t id,
+        const std::string particlePatchPathComponent,
+        uint64_t* const dest
+    ) const
+    {
+        // will later read into 1D buffer from first position on
+        splash::Dimensions dstBuffer(availableRanks, 1, 1);
+        splash::Dimensions dstOffset(0, 0, 0);
+        // sizeRead will be set
+        splash::Dimensions sizeRead(0, 0, 0);
+
+        // check if types, number of patches and names are supported
+        checkSpatialTypeSize( dc, availableRanks, id, particlePatchPathComponent.c_str() );
+
+        // read actual offset and extent data of particle patch component
+        dc->read( id,
+                  particlePatchPathComponent.c_str(),
+                  sizeRead,
+                  (void*)dest );
+    }
+
+    picongpu::openPMD::ParticlePatches PatchReader::operator()(
+        splash::DataCollector* const dc,
+        const uint32_t availableRanks,
+        const uint32_t dimensionality,
+        const int32_t id,
+        const std::string particlePatchPath
+    ) const
+    {
+        // allocate memory for patches
+        picongpu::openPMD::ParticlePatches particlePatches( availableRanks );
+        const std::string name_lookup[] = {"x", "y", "z"};
+        for( uint32_t d = 0; d < dimensionality; ++d )
+        {
+            readPatchAttribute(
+                dc, availableRanks, id,
+                particlePatchPath + std::string("offset/") + name_lookup[d],
+                particlePatches.getOffsetComp( d )
+            );
+            readPatchAttribute(
+                dc, availableRanks, id,
+                particlePatchPath + std::string("extent/") + name_lookup[d],
+                particlePatches.getExtentComp( d )
+            );
+        }
+
+        // read number of particles and their starting point (offset), too
+        readPatchAttribute(
+            dc, availableRanks, id,
+            particlePatchPath + std::string("numParticles"),
+            &(*particlePatches.numParticles.begin())
+        );
+        readPatchAttribute(
+            dc, availableRanks, id,
+            particlePatchPath + std::string("numParticlesOffset"),
+            &(*particlePatches.numParticlesOffset.begin())
+        );
+
+        // return struct of array with particle patches
+        return particlePatches;
+    }
+
+} // namespace openPMD
+} // namespace hdf5
+} // namespace picongpu
+
+#endif


### PR DESCRIPTION
@psychocoderHPC @erikzenker 

Implements a helper class `PatchReader` to read libSplash HDF5 files with particle patches and to build up a class containing the full list of particle patches for each rank.

For storing the read patches in RAM on each node, a common `ParticlePatches` storage class was implemented (that can also be used with the ADIOS plugin later on).

Compilation of the HDF5 class only occures when libSplash was found (guarded by `ENABLE_HDF5` macros).

Usage, see `plugins/hdf5/restart/LoadSpecies.hpp` in #1428

```C++
#include "plugins/common/particlePatches.hpp"
#include "plugins/hdf5/openPMD/patchReader.hpp"

// [...]
const std::string speciesSubGroup(
    std::string("particles/") + FrameType::getName() + std::string("/")
);
// load particle patches offsets to find own patch
const std::string particlePatchesPath(
    speciesSubGroup + std::string("particlePatches/")
);

// read particle patches
openPMD::PatchReader patchReader;

openPMD::ParticlePatches particlePatches(
    patchReader(
        params->dataCollector,
        gc.getGlobalSize(),
        simDim,
        params->currentStep,
        particlePatchesPath
    )
);

// do something with the particlePatches object to find your particles
```

If you are wondering about the `.cpp` files in `src/picongpu`: this is a bit of CMake globber messy-ness and we need to clean that up an other time for the few object files we generate.