### PR TITLE
Fix move emulated classes copy assignment

### DIFF
--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -85,7 +85,7 @@ public:
     HDINLINE void init();
     HDINLINE void exit();
     HDINLINE CartBuffer() : refCount(NULL) {}
-private:
+
     /* makes this class able to emulate a r-value reference */
     BOOST_COPYABLE_AND_MOVABLE(CartBuffer)
 public:
@@ -101,7 +101,7 @@ public:
 
     /* copy another container into this one (hard data copy) */
     HDINLINE CartBuffer&
-    operator=(const CartBuffer& rhs);
+    operator=(BOOST_COPY_ASSIGN_REF(CartBuffer) rhs);
     /* use the memory from another container and increment the reference counter */
     HDINLINE CartBuffer&
     operator=(BOOST_RV_REF(CartBuffer) rhs);

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -190,7 +190,7 @@ void CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::exit()
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>&
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::operator=
-(const CartBuffer<Type, T_dim, Allocator, Copier, Assigner>& rhs)
+(BOOST_COPY_ASSIGN_REF(CartBuffer) rhs)
 {
 #ifndef __CUDA_ARCH__
     if(rhs.size() != this->size())
@@ -209,7 +209,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::operator=
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>&
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::operator=
-(BOOST_RV_REF(CartBuffer<Type COMMA T_dim COMMA Allocator COMMA Copier COMMA Assigner>) rhs)
+(BOOST_RV_REF(CartBuffer) rhs)
 {
 #ifndef __CUDA_ARCH__
     if(rhs.size() != this->size())

--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -75,7 +75,6 @@ public:
     HDINLINE DeviceBuffer(size_t x) : Base(x) {}
     HDINLINE DeviceBuffer(size_t x, size_t y) : Base(x, y) {}
     HDINLINE DeviceBuffer(size_t x, size_t y, size_t z) : Base(x, y, z) {}
-    HDINLINE DeviceBuffer(const Base& base) : Base(base) {}
     /**
      * Creates a device buffer from a pointer with a size. Assumes dense layout (no padding)
      *
@@ -98,6 +97,7 @@ public:
         *this->refCount = (ownMemory) ? 1 : 2;
 #endif
     }
+    HDINLINE DeviceBuffer(const Base& base) : Base(base) {}
     HDINLINE DeviceBuffer(BOOST_RV_REF(DeviceBuffer) obj): Base(boost::move(static_cast<Base&>(obj))) {}
 
     HDINLINE DeviceBuffer&
@@ -113,7 +113,7 @@ public:
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::memoryTag, allocator::tag::host>::value));
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::type, Type>::value));
-        BOOST_STATIC_ASSERT(T_dim == HBuffer::dim);
+        BOOST_STATIC_ASSERT(HBuffer::dim == T_dim);
         if(rhs.size() != this->size())
             throw std::invalid_argument(static_cast<std::stringstream&>(
                 std::stringstream() << "Assignment: Sizes of buffers do not match: "
@@ -131,7 +131,7 @@ public:
         return *this;
     }
 
-    HINLINE DeviceBuffer& operator=(const DeviceBuffer& rhs)
+    HINLINE DeviceBuffer& operator=(BOOST_COPY_ASSIGN_REF(DeviceBuffer) rhs)
     {
         Base::operator=(rhs);
         return *this;
@@ -140,3 +140,4 @@ public:
 
 } // container
 } // PMacc
+

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -101,6 +101,7 @@ public:
     }
 
     template<typename DBuffer>
+    HINLINE
     HostBuffer& operator=(const DBuffer& rhs)
     {
         BOOST_STATIC_ASSERT((boost::is_same<typename DBuffer::memoryTag, allocator::tag::device>::value));
@@ -117,12 +118,17 @@ public:
         return *this;
     }
 
-    HostBuffer& operator=(const Base& rhs)
+    HINLINE HostBuffer& operator=(const Base& rhs)
     {
         Base::operator=(rhs);
         return *this;
     }
 
+    HINLINE HostBuffer& operator=(BOOST_COPY_ASSIGN_REF(HostBuffer) rhs)
+    {
+        Base::operator=(rhs);
+        return *this;
+    }
 };
 
 } // container


### PR DESCRIPTION
This supersedes #1432 and closes #1434.

As the documentation of boost.Move states (http://www.boost.org/doc/libs/1_49_0/doc/html/move/how_the_library_works.html), one has to use `BOOST_COPY_ASSIGN_REF` for the copy assignment. This was not done in #1375 and #1401 and resulted in failures as the one in #1434/#1376

With this PR #1376 compiles on hypnos5

Note: Minor changes to have `HostBuffer.hpp` and `DeviceBuffer.hpp` symmetric for easier comparison

TLDR: RTFM :+1: 

@Heikman 