### PR TITLE
add templates for the system piz daint

### DIFF
--- a/src/picongpu/submit/pizdaint-cscs/SLURM_Tutorial.md
+++ b/src/picongpu/submit/pizdaint-cscs/SLURM_Tutorial.md
@@ -1,0 +1,26 @@
+SLURM examples
+==============
+
+- `tbg -s sbatch -c submit/0008gpus.cfg -t submit/pizdaint-cscs/normal_profile.tpl $SCRATCH/runs/test123`
+
+- interactive job:
+  - `salloc --time=1:00:00 --nodes=1 --ntasks-per-node=16 --ntasks-per-core=2 --partition normal`
+  - `--ntasks-per-core=2` activate intel hyper threading
+  - e.g. `aprun "hostname"`
+
+
+- details for my jobs:
+  - `scontrol -d show job 12345`
+  - `squeue -u `whoami` -l`
+
+- details for queues:
+  - `squeue -p queueName -l` (list full queue)
+  - `squeue -p queueName --start` (show start times for pending jobs)
+  - `squeue -p queueName -l -t R` (only show running jobs in queue)
+  - `sinfo -p queueName` (show online/offline nodes in queue)
+  - `scontrol show partition queueName`
+
+- Communicate with job:
+  - `scancel 12345` abort job
+  - `scancel -s Number 12345` send signal or signal name to job
+  - `scontrol update timelimit=4:00:00 jobid=12345`

--- a/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
@@ -1,0 +1,73 @@
+#!/bin/bash -l
+# Copyright 2013-2016 Axel Huebl, Richard Pausch, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+## calculations will be performed by tbg ##
+TBG_queue="normal"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+# 1 gpus per node
+TBG_gpusPerNode=1
+
+# number of cores to block per GPU - we got 8 cpus per gpu
+#   and we will be accounted 8 CPUs per GPU anyway
+TBG_coresPerGPU=8
+
+# We only start 1 MPI task per GPU
+TBG_mpiTasksPerNode=1
+
+# use ceil to caculate nodes
+TBG_nodes=!TBG_tasks
+
+## end calculations ##
+
+# PIConGPU batch script for pizdaint SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks-per-node=!TBG_coresPerGPU
+#SBATCH --ntasks-per-core=1
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source $SCRATCH/picongpu.profile
+unset MODULES_NO_OUTPUT
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+# Run PIConGPU
+aprun  -N 1 -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams

--- a/src/picongpu/submit/pizdaint-cscs/picongpu.profile.example
+++ b/src/picongpu/submit/pizdaint-cscs/picongpu.profile.example
@@ -1,0 +1,77 @@
+# this file is loaded from all PIConGPU template files `*.tpl` therefore please
+# copy this file to `$SCRATCH/picongpu.profile`
+#
+
+# General modules #############################################################
+#
+# if the wrong environment is loaded we switch to the gnu environment
+module li 2>&1 | grep "PrgEnv-cray" > /dev/null
+if [ $? -eq 0 ] ; then
+    module swap PrgEnv-cray PrgEnv-gnu/5.2.82
+else
+    module load PrgEnv-gnu/5.2.82
+fi
+
+module load cmake/3.3.2
+module load cudatoolkit/7.0.28-1.0502.10742.5.1
+
+# Libraries ###################################################################
+module load boost/1.58.0
+module load cray-mpich/7.2.2
+
+# Other Software ##############################################################
+#
+module load cray-hdf5-parallel/1.8.14
+module load zlib/1.2.8-CrayGNU-5.2.40
+
+# Environment #################################################################
+#
+# needs to be compiled by the user
+export PNGWRITER_ROOT=$SCRATCH/lib/pngwriter
+export SPLASH_ROOT=$SCRATCH/lib/splash
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGWRITER_ROOT/lib/
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SPLASH_ROOT/lib/
+
+export MPI_ROOT=$MPICH_DIR
+export HDF5_ROOT=$HDF5_DIR
+
+# define cray compiler target architecture
+# if not defined the linker crashed because wrong from `*/lib` instead
+# of `*/lib64` are used
+export CRAY_CPU_TARGET=x86-64
+
+# Compile for cluster nodes
+#   (CMake likes to unwrap the Cray wrappers)
+export CC=`which cc`
+export CXX=`which CC`
+
+export PICSRC=$HOME/src/picongpu
+# needed to call `tbg`
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="FAIL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "normal" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="submit/pizdaint-cscs/normal_profile.tpl"
+
+# helper tools ################################################################
+
+# allocate an interactive shell for one hour
+# `getInteractive 2` # allocates to interactive nodes (default: 1)
+getInteractive() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    # `--ntasks-per-core=2` activates intel hyper threading
+    salloc --time=1:00:00 --nodes="$numNodes" --ntasks-per-node=16 --ntasks-per-core=2 --partition normal
+}

--- a/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
@@ -1,0 +1,73 @@
+#!/bin/bash -l
+# Copyright 2013-2016 Axel Huebl, Richard Pausch, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+## calculations will be performed by tbg ##
+TBG_queue="total"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+# 1 gpus per node
+TBG_gpusPerNode=1
+
+# number of cores to block per GPU - we got 8 cpus per gpu
+#   and we will be accounted 8 CPUs per GPU anyway
+TBG_coresPerGPU=8
+
+# We only start 1 MPI task per GPU
+TBG_mpiTasksPerNode=1
+
+# use ceil to caculate nodes
+TBG_nodes=!TBG_tasks
+
+## end calculations ##
+
+# PIConGPU batch script for pizdaint SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks-per-node=!TBG_coresPerGPU
+#SBATCH --ntasks-per-core=1
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source $SCRATCH/picongpu.profile
+unset MODULES_NO_OUTPUT
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+# Run PIConGPU
+aprun  -N 1 -n !TBG_tasks !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams


### PR DESCRIPTION
- close issue #1442
- add template file `*.tpl` for the queue `normal` and `total`
- copy and update SLURM tutorial from `../tarus-tud/`
- add `picongpu.profile.example` for a currently working environment

#1442 gives a short summary over the **Piz Daint** HPC system