### PR TITLE
Remove C++11 syntax

### DIFF
--- a/src/libPMacc/include/random/methods/XorMin.hpp
+++ b/src/libPMacc/include/random/methods/XorMin.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "static_assert.hpp"
 #include <curand_kernel.h>
 #include <random/methods/Xor.hpp>
 
@@ -46,9 +47,11 @@ namespace methods
             HDINLINE StateType()
             {}
 
-            HDINLINE StateType(const curandStateXORWOW_t& other): d(other.d), v{other.v[0], other.v[1], other.v[2], other.v[3], other.v[4]}
+            HDINLINE StateType(const curandStateXORWOW_t& other): d(other.d)
             {
-                static_assert(sizeof(v) == sizeof(other.v), "Unexpected sizes");
+                PMACC_CASSERT_MSG(Unexpected_sizes, sizeof(v) == sizeof(other.v));
+                for(int i = 0; i < sizeof(v)/sizeof(v[0]); i++)
+                    v[i] = other.v[i];
             }
         };
 

--- a/src/libPMacc/include/random/methods/XorMin.hpp
+++ b/src/libPMacc/include/random/methods/XorMin.hpp
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "pmacc_types.hpp"
-#include "static_assert.hpp"
 #include <curand_kernel.h>
 #include <random/methods/Xor.hpp>
 
@@ -49,8 +48,8 @@ namespace methods
 
             HDINLINE StateType(const curandStateXORWOW_t& other): d(other.d)
             {
-                PMACC_CASSERT_MSG(Unexpected_sizes, sizeof(v) == sizeof(other.v));
-                for(int i = 0; i < sizeof(v)/sizeof(v[0]); i++)
+                PMACC_STATIC_ASSERT(sizeof(v) == sizeof(other.v), Unexpected_sizes);
+                for(unsigned i = 0; i < sizeof(v)/sizeof(v[0]); i++)
                     v[i] = other.v[i];
             }
         };

--- a/src/libPMacc/include/random/methods/XorMin.hpp
+++ b/src/libPMacc/include/random/methods/XorMin.hpp
@@ -48,7 +48,7 @@ namespace methods
 
             HDINLINE StateType(const curandStateXORWOW_t& other): d(other.d)
             {
-                PMACC_STATIC_ASSERT(sizeof(v) == sizeof(other.v), Unexpected_sizes);
+                PMACC_STATIC_ASSERT_MSG(sizeof(v) == sizeof(other.v), Unexpected_sizes);
                 for(unsigned i = 0; i < sizeof(v)/sizeof(v[0]); i++)
                     v[i] = other.v[i];
             }


### PR DESCRIPTION
There were some C++11 only features that slipped in. Replaced this with C++98 compatible ones