### PR TITLE
FieldPosition Trait: ReturnType of FieldTmp Consistent

### DIFF
--- a/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -123,8 +123,9 @@ namespace traits
         }
     };
 
-    /** position (floatD_X in case of T_simDim == simDim) in cell for the
-     *  scalar field FieldTmp
+    /** position (floatD_X in case of T_simDim == simDim) in cell, wrapped in
+     * one-component vector since it's a scalar field with only one component, for the
+     * scalar field FieldTmp
      */
     template<uint32_t T_simDim>
     struct FieldPosition<FieldTmp, T_simDim>

--- a/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -129,7 +129,8 @@ namespace traits
     template<uint32_t T_simDim>
     struct FieldPosition<FieldTmp, T_simDim>
     {
-        typedef PMacc::math::Vector<float_X, T_simDim> ReturnType;
+        typedef PMacc::math::Vector<float_X, T_simDim> FieldPos;
+        typedef PMacc::math::Vector<FieldPos, DIM1> ReturnType;
 
         /// boost::result_of hints
         template<class> struct result;
@@ -141,7 +142,7 @@ namespace traits
 
         HDINLINE ReturnType operator()() const
         {
-            return ReturnType::create( 0.0 );
+            return ReturnType( FieldPos::create(0.0) );
         }
     };
 } // traits

--- a/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
@@ -144,8 +144,9 @@ namespace traits
         }
     };
 
-    /** position (floatD_X in case of T_simDim == simDim) in cell for the
-     *  scalar field FieldTmp
+    /** position (floatD_X in case of T_simDim == simDim) in cell, wrapped in
+     * one-component vector since it's a scalar field with only one component, for the
+     * scalar field FieldTmp
      */
     template<uint32_t T_simDim>
     struct FieldPosition<FieldTmp, T_simDim>

--- a/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
@@ -150,7 +150,8 @@ namespace traits
     template<uint32_t T_simDim>
     struct FieldPosition<FieldTmp, T_simDim>
     {
-        typedef PMacc::math::Vector<float_X, T_simDim> ReturnType;
+        typedef PMacc::math::Vector<float_X, T_simDim> FieldPos;
+        typedef PMacc::math::Vector<FieldPos, DIM1> ReturnType;
 
         /// boost::result_of hints
         template<class> struct result;
@@ -162,7 +163,7 @@ namespace traits
 
         HDINLINE ReturnType operator()() const
         {
-            return ReturnType::create( 0.0 );
+            return ReturnType( FieldPos::create(0.0) );
         }
     };
 } // traits


### PR DESCRIPTION
Fix `FieldPosition` trait for `FieldTmp`. ~~The vector dimensions were mixed up.~~

The `FieldTmp` trait was not wrappend in it's one-dimensional vector-vector wrapper.