### PR TITLE
Close #1424: add species name to file name of hdf5 rad files

### DIFF
--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -179,14 +179,14 @@ public:
             // end
             if (currentStep <= radEnd || radEnd == 0)
             {
-                log<radLog::SIMULATION_STATE > ("Radiation: calculate time step %1% ") % currentStep;
+                log<radLog::SIMULATION_STATE > ("Radiation (%1%): calculate time step %2% ") % speciesName % currentStep;
 
                 /* CORE + BORDER is PIC black magic, currently not needed
                  *
                  */
                 calculateRadiationParticles < CORE + BORDER > (currentStep);
 
-                log<radLog::SIMULATION_STATE > ("Radiation: finished time step %1% ") % currentStep;
+                log<radLog::SIMULATION_STATE > ("Radiation (%1%): finished time step %2% ") % speciesName % currentStep;
             }
         }
     }
@@ -234,7 +234,7 @@ public:
             // not a dump point. The correct lastRad data can be reconstructed from hdf5 data
             // since text based lastRad output will be obsolete soon, this is not a problem
             readHDF5file(timeSumArray, restartDirectory + "/" + speciesName + std::string("_radRestart_"), timeStep);
-            log<radLog::SIMULATION_STATE > ("Radiation: restart finished");
+            log<radLog::SIMULATION_STATE > ("Radiation (%1%): restart finished") % speciesName;
         }
     }
 
@@ -620,7 +620,8 @@ private:
       /* check if restart file exists */
       if( !boost::filesystem::exists(filename.str()) )
       {
-          log<picLog::INPUT_OUTPUT > ("Radiation: restart file not found (%1%) - start with zero values") % filename.str();
+          log<picLog::INPUT_OUTPUT > ("Radiation (%1%): restart file not found (%2%) - start with zero values") % 
+                                      speciesName % filename.str();
       }
       else
       {
@@ -653,7 +654,7 @@ private:
           delete[] tmpBuffer;
           HDF5dataFile.close();
 
-          log<picLog::INPUT_OUTPUT > ("Radiation: read radiation data from HDF5");
+          log<picLog::INPUT_OUTPUT > ("Radiation (%1%): read radiation data from HDF5") % speciesName;
       }
   }
 

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -99,6 +99,7 @@ private:
     uint32_t radStart;
     uint32_t radEnd;
 
+    std::string speciesName;
     std::string pluginName;
     std::string pluginPrefix;
     std::string filename_prefix;
@@ -133,7 +134,8 @@ public:
 
     Radiation() :
     pluginName("Radiation: calculate the radiation of a species"),
-    pluginPrefix(ParticlesType::FrameType::getName() + std::string("_radiation")),
+    speciesName(ParticlesType::FrameType::getName()),
+    pluginPrefix(speciesName + std::string("_radiation")),
     filename_prefix(pluginPrefix),
     particles(NULL),
     radiation(NULL),
@@ -231,7 +233,7 @@ public:
             // this will lead to wrong lastRad output right after the checkpoint if the restart point is
             // not a dump point. The correct lastRad data can be reconstructed from hdf5 data
             // since text based lastRad output will be obsolete soon, this is not a problem
-            readHDF5file(timeSumArray, restartDirectory + "/" + std::string("radRestart_"), timeStep);
+            readHDF5file(timeSumArray, restartDirectory + "/" + speciesName + std::string("_radRestart_"), timeStep);
             log<radLog::SIMULATION_STATE > ("Radiation: restart finished");
         }
     }
@@ -251,7 +253,7 @@ public:
         // write backup file
         if (isMaster)
         {
-            writeHDF5file(tmp_result, restartDirectory + "/" + std::string("radRestart_"));
+            writeHDF5file(tmp_result, restartDirectory + "/" + speciesName + std::string("_radRestart_"));
         }
     }
 
@@ -383,7 +385,7 @@ private:
             for(uint32_t dimIndex=0; dimIndex<simDim; ++dimIndex)
                 GPUpos_str << "_" <<currentGPUpos[dimIndex];
 
-            writeFile(radiation->getHostBuffer().getBasePointer(), folderRadPerGPU + "/" + filename_prefix
+            writeFile(radiation->getHostBuffer().getBasePointer(), folderRadPerGPU + "/" + speciesName
                       + "_radPerGPU_pos" + GPUpos_str.str()
                       + "_time_" + last_time_step_str.str()
                       + "-" + current_time_step_str.str() + ".dat");
@@ -474,7 +476,7 @@ private:
   {
       if (isMaster)
       {
-          writeHDF5file(timeSumArray, std::string("radiationHDF5/radAmplitudes_"));
+        writeHDF5file(timeSumArray, std::string("radiationHDF5/") + speciesName + std::string("_radAmplitudes_"));
       }
   }
 


### PR DESCRIPTION
This pull request enables radiation restart and any multi species hdf5 output with more than one radiating species. This closes issue #1424.

 - [x] test with LWFA ions and electrons
