### PR TITLE
Resource monitor class

### DIFF
--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
@@ -30,7 +30,7 @@ namespace PMacc
     /**
      * Provides ressource information of the current subgrid
      *
-     * @tparam DIM number of dimensions of the simulation
+     * @tparam T_DIM number of dimensions of the simulation
      */
     template <unsigned T_DIM>
     class ResourceMonitor
@@ -41,13 +41,6 @@ namespace PMacc
          * Constructor
          */
         ResourceMonitor();
-
-    private:
-
-        /**
-         * Constructor
-         */
-        ResourceMonitor(const ResourceMonitor& fs);
 
     public:
         /**

--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
@@ -42,7 +42,6 @@ namespace PMacc
          */
         ResourceMonitor();
 
-    public:
         /**
          *  Returns the number of cells on the device
          */

--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <vector>  /* std::vector */
+#include <cstdlib> /* std::size_t */
+
+namespace PMacc
+{
+
+    /**
+     * Provides ressource information of the current subgrid
+     *
+     * @tparam DIM number of dimensions of the simulation
+     */
+    template <unsigned T_DIM>
+    class ResourceMonitor
+    {
+    public:
+
+        /**
+         * Constructor
+         */
+        ResourceMonitor();
+
+    private:
+
+        /**
+         * Constructor
+         */
+        ResourceMonitor(const ResourceMonitor& fs);
+
+    public:
+        /**
+         *  Returns the number of cells on the device
+         */
+        std::size_t getCellCount();
+
+        /**
+         * Returns the number of particles per species on the device
+         */
+        template <typename T_Species, typename T_MappingDesc>
+        std::vector<std::size_t> getParticleCounts(T_MappingDesc &cellDescription);
+
+    };
+
+} //namespace PMacc
+

--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
@@ -60,12 +60,6 @@ namespace PMacc
     }
 
     template<unsigned T_DIM>
-    ResourceMonitor<T_DIM>::ResourceMonitor(const ResourceMonitor& fs)
-    {
-
-    }
-
-    template<unsigned T_DIM>
     size_t ResourceMonitor<T_DIM>::getCellCount()
     {
         return Environment<T_DIM>::get().SubGrid().getLocalDomain().size.productOfComponents();

--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// PMacc
+#include "Environment.hpp"
+#include <particles/operations/CountParticles.hpp>
+#include "pmacc_types.hpp"
+#include "forward.hpp"
+#include "dimensions/DataSpace.hpp"
+#include "algorithms/ForEach.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "mappings/simulation/ResourceMonitor.hpp"
+
+namespace PMacc
+{
+    template<typename T_DIM, typename T_Species>
+    struct MyCountParticles
+    {
+        template <typename T_Vector, typename T_MappingDesc>
+        void operator()(T_Vector & particleCounts, T_MappingDesc & cellDescription)
+        {
+            DataConnector & dc = Environment<>::get().DataConnector();
+
+            const SubGrid<T_DIM::value> & subGrid = Environment<T_DIM::value>::get().SubGrid();
+            const DataSpace<T_DIM::value> localSize(subGrid.getLocalDomain().size);
+
+            uint64_cu totalNumParticles = 0;
+            totalNumParticles = PMacc::CountParticles::countOnDevice < CORE + BORDER > (
+                    dc.getData<T_Species >(T_Species::FrameType::getName(), true),
+                    cellDescription,
+                    DataSpace<T_DIM::value>(),
+                    localSize);
+            particleCounts.push_back(totalNumParticles);
+        }
+    };
+
+    template<unsigned T_DIM>
+    ResourceMonitor<T_DIM>::ResourceMonitor()
+    {
+
+    }
+
+    template<unsigned T_DIM>
+    ResourceMonitor<T_DIM>::ResourceMonitor(const ResourceMonitor& fs)
+    {
+
+    }
+
+    template<unsigned T_DIM>
+    size_t ResourceMonitor<T_DIM>::getCellCount()
+    {
+        return Environment<T_DIM>::get().SubGrid().getLocalDomain().size.productOfComponents();
+    }
+
+    template<unsigned T_DIM>
+    template <typename T_Species, typename T_MappingDesc>
+    std::vector<size_t> ResourceMonitor<T_DIM>::getParticleCounts(T_MappingDesc &cellDescription)
+    {
+        typedef bmpl::integral_c<unsigned, T_DIM> dim;
+        std::vector<size_t> particleCounts;
+        algorithms::forEach::ForEach<T_Species, MyCountParticles<dim, bmpl::_1> > countParticles;
+        countParticles(forward(particleCounts), forward(cellDescription));
+        return particleCounts;
+    }
+
+} //namespace PMacc

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Rene Widera
+ * Copyright 2013-2016 Rene Widera, Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -22,13 +22,17 @@
 
 #pragma once
 
+
 #include "pmacc_types.hpp"
 #include "memory/buffers/GridBuffer.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
+#include "particles/memory/dataTypes/FramePointer.hpp"
 
 #include "particles/particleFilter/FilterFactory.hpp"
 #include "particles/particleFilter/PositionFilter.hpp"
 #include "nvidia/atomic.hpp"
+
+
 
 namespace PMacc
 {


### PR DESCRIPTION
This PR was split from PR #1403.

The resource monitor is located in libPMacc and provides information about allocated resources of the library. Currently, particle count and cell count per rank are provided.
