### PR TITLE
Resource log plugin

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -230,6 +230,15 @@ TBG_<species>_calorimeter="--<species>_calorimeter.period 100 --<species>_calori
                         --<species>_calorimeter.numBinsEnergy 32 --<species>_calorimeter.minEnergy 10 --<species>_calorimeter.maxEnergy 1000
                         --<species>_calorimeter.logScale"
 
+# Resource log: log resource information to streams or files
+# set the resources to log by --resourceLog.properties [rank, position, currentStep, particleCount, cellCount]
+# set the output stream by --resourceLog.stream [stdout, stderr, file]
+# set the prefix of filestream --resourceLog.prefix [prefix]
+# set the output format by (pp == pretty print) --resourceLog.format jsonpp [json,jsonpp,xml,xmlpp]
+# The example below logs all resources for each time step to stdout in the pretty print json format
+TBG_resourceLog="--resourceLog.period 1 --resourceLog.stream stdout
+                 --resourceLog.properties rank position currentStep particleCount cellCount
+                 --resourceLog.format jsonpp"
 
 ################################################################################
 ## Section: Program Parameters

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -89,6 +89,8 @@
 #include "plugins/IsaacPlugin.hpp"
 #endif
 
+#include "plugins/ResourceLog.hpp"
+
 namespace picongpu
 {
 
@@ -146,6 +148,7 @@ private:
 #if (ENABLE_ISAAC == 1) && (SIMDIM==DIM3)
       , isaacP::IsaacPlugin
 #endif
+    , ResourceLog
     > StandAlonePlugins;
 
 

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -1,7 +1,7 @@
 /**
  * Copyright 2013-2017 Axel Huebl, Benjamin Schneider, Felix Schmitt,
  *                     Heiko Burau, Rene Widera, Richard Pausch,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Erik Zenker
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/ResourceLog.hpp
+++ b/src/picongpu/include/plugins/ResourceLog.hpp
@@ -1,0 +1,243 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// PMacc
+#include "Environment.hpp"
+#include "mappings/simulation/ResourceMonitor.hpp"
+
+// PIConGPU
+#include "plugins/ILightweightPlugin.hpp"
+#include "ILightweightPlugin.hpp"
+#include "simulation_defines.hpp"
+
+// Boost
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/filesystem.hpp>
+
+// STL
+#include <iostream>  /* std::cout, std::ostream */
+#include <numeric>   /* std::accumulate */
+#include <string>    /* std::string */
+#include <sstream>   /* std::stringstream */
+#include <fstream>   /* std::filebuf */
+#include <map>       /* std::map */
+
+// C LIB
+#include <stdlib.h> /* itoa */
+#include <stdint.h> /* uint32_t */
+
+namespace picongpu
+{
+    using namespace PMacc;
+
+
+    class ResourceLog : public ILightweightPlugin
+    {
+    private:
+        MappingDesc *cellDescription;
+        ResourceMonitor<simDim> resourceMonitor;
+
+        // programm options
+        std::string outputFilePrefix;
+        std::string streamType;
+        std::string outputFormat;
+        std::vector<std::string> properties;
+
+        std::filebuf fileBuf;
+        std::map<std::string, bool> propertyMap;
+
+    public:
+
+        ResourceLog() :
+                cellDescription(NULL)
+        {
+            Environment<>::get().PluginConnector().registerPlugin(this);
+        }
+
+        std::string pluginGetName() const
+        {
+            return "ResourceLog";
+        }
+
+        void notify(uint32_t currentStep)
+        {
+            //
+            // Create property tree which contains the resource information
+            using boost::property_tree::ptree;
+            ptree pt;
+
+            if(contains(propertyMap, "rank"))
+            {
+                size_t rank = static_cast<size_t>(Environment<simDim>::get().GridController().getGlobalRank());
+                pt.put("resourceLog.rank", rank);
+            }
+
+            if(contains(propertyMap,"position"))
+            {
+                DataSpace<simDim> currentPosition = Environment<simDim>::get().GridController().getPosition();
+                pt.put("resourceLog.position.x", currentPosition[0]);
+                pt.put("resourceLog.position.y", currentPosition[1]);
+                pt.put("resourceLog.position.z", currentPosition[2]);
+            }
+
+            if(contains(propertyMap, "currentStep"))
+            {
+                pt.put("resourceLog.currentStep", currentStep);
+            }
+
+            if(contains(propertyMap, "cellCount"))
+            {
+                size_t cellCount = resourceMonitor.getCellCount();
+                pt.put("resourceLog.cellCount", cellCount);
+            }
+
+            if(contains(propertyMap,"particleCount"))
+            {
+                std::vector<size_t> particleCounts = resourceMonitor.getParticleCounts<VectorAllSpecies>(*cellDescription);
+                pt.put("resourceLog.particleCount", std::accumulate(particleCounts.begin(), particleCounts.end(), 0));
+            }
+
+            //
+            // Write property tree to string stream
+            std::stringstream ss;
+            if(outputFormat == "json")
+            {
+                write_json(ss, pt, false);
+            }
+            else if(outputFormat == "jsonpp")
+            {
+                write_json(ss, pt, true);
+            }
+            else if(outputFormat == "xml")
+            {
+                write_xml(ss, pt);
+            }
+            else if(outputFormat == "xmlpp")
+            {
+                write_xml(ss, pt, boost::property_tree::xml_writer_make_settings<std::string>('\t', 1));
+            }
+            else
+            {
+                throw std::runtime_error(std::string("resourcelog.format ") + outputFormat + std::string(" is not known, use json or xml."));
+            }
+
+            //
+            // Write property tree to the output stream
+            if(streamType == "stdout")
+            {
+                std::cout << ss.str();
+            }
+            else if (streamType == "stderr")
+            {
+                std::cerr << ss.str();
+            }
+            else if (streamType == "file")
+            {
+                std::ostream os(&fileBuf);
+                os << ss.str();
+            }
+            else
+            {
+                throw std::runtime_error(std::string("resourcelog.stream ") + streamType + std::string(" is not known, use stdout, stderr or file instead."));
+            }
+        }
+
+        void pluginRegisterHelp(po::options_description& desc)
+        {
+            /* register command line parameters for your plugin */
+            desc.add_options()
+                    ("resourceLog.period", po::value<uint32_t>(&notifyPeriod)->default_value(0),
+                     "Enable ResourceLog plugin [for each n-th step]")
+                    ("resourceLog.prefix", po::value<std::string>(&outputFilePrefix)->default_value("resourceLog_"),
+                     "Set the filename prefix for output file if a filestream was selected")
+                    ("resourceLog.stream", po::value<std::string>(&streamType)->default_value("file"),
+                     "Output stream [stdout, stderr, file]")
+                    ("resourceLog.properties", po::value<std::vector<std::string> >(&properties)->multitoken(),
+                     "List of properties to log [rank, position, currentStep, cellCount, particleCount]")
+                    ("resourceLog.format", po::value<std::string>(&outputFormat)->default_value("json"),
+                     "Output format of log (pp for pretty print) [json, jsonpp, xml, xmlpp]");
+        }
+
+        void setMappingDescription(MappingDesc *cellDescription)
+        {
+            this->cellDescription = cellDescription;
+        }
+
+    private:
+        uint32_t notifyPeriod;
+
+        void pluginLoad() {
+            if(notifyPeriod != 0) {
+                Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
+
+                // Set default resources to log
+                if (properties.empty()) {
+                    properties.push_back("rank");
+                    properties.push_back("position");
+                    properties.push_back("currentStep");
+                    properties.push_back("cellCount");
+                    properties.push_back("particleCount");
+                    propertyMap["rank"] = true;
+                    propertyMap["position"] = true;
+                    propertyMap["currentStep"] = true;
+                    propertyMap["particleCount"] = true;
+                    propertyMap["cellCount"] = true;
+                }
+                else {
+                    for (size_t i = 0; i < properties.size(); ++i) {
+                        propertyMap[properties[i]] = true;
+                    }
+                }
+
+                // Prepare file for output stream
+                if (streamType == "file") {
+                    size_t rank = static_cast<size_t>(Environment<simDim>::get().GridController().getGlobalRank());
+                    std::stringstream ss;
+                    ss << outputFilePrefix << rank;
+                    boost::filesystem::path resourceLogPath(ss.str());
+                    fileBuf.open(resourceLogPath.string().c_str(), std::ios::out);
+                }
+            }
+        }
+
+        void pluginUnload()
+        {
+            if(fileBuf.is_open()){
+                fileBuf.close();
+            }
+            /* called when plugin is unloaded, cleanup here */
+        }
+
+        template <typename T_MAP>
+        bool contains(T_MAP const map, std::string const value)
+        {
+            return (map.find(value) != map.end());
+        }
+
+    };
+}
+
+#include "mappings/simulation/ResourceMonitor.tpp"


### PR DESCRIPTION
This PR is a split of #1403 and needs to be merged after #1456 
- [x] Merge after #1456 

The resource log is a user adaptable resource information log plugin which collects resource information and writes these information to a stream.

The user can choose which resource properties to write e.g.:
`--resourceLog.properties rank position currentStep particleCount cellCount`

which format to use e.g.:
`--resourceLog.format json` other options are `jsonpp`, `xml` and `xmlpp`

which stream the information should be written e.g.:
`--resourceLog.stream file` other options are `stdout` and `stderr`

and which prefix to use for filestreams:
`--resourceLog.prefix myprefix_`

Using the options `--resourceLog.period 1 --resourceLog.stream stdout --resourceLog.properties rank position currentStep particleCount cellCount --resourceLog.format jsonpp` will write resource objects to stdout such as:

```
[1,1]<stdout>:    "resourceLog": {
[1,1]<stdout>:        "rank": "1",
[1,1]<stdout>:        "position": {
[1,1]<stdout>:            "x": "0",
[1,1]<stdout>:            "y": "1",
[1,1]<stdout>:            "z": "0"
[1,1]<stdout>:        },
[1,1]<stdout>:        "currentStep": "357",
[1,1]<stdout>:        "cellCount": "1048576",
[1,1]<stdout>:        "particleCount": "2180978"
[1,1]<stdout>:    }
[1,1]<stdout>:}
```

For each format there exists always a non pretty print version to simplify further processing:

```
[1,3]<stdout>:{"resourceLog":{"rank":"3","position":{"x":"1","y":"1","z":"0"},"currentStep":"415","cellCount":"1048576","particleCount":"2322324"}}
```
