### PR TITLE
fixe code formating in nvidia/functors

### DIFF
--- a/src/libPMacc/include/nvidia/functors/Add.hpp
+++ b/src/libPMacc/include/nvidia/functors/Add.hpp
@@ -27,33 +27,30 @@
 
 namespace PMacc
 {
-    namespace nvidia
-    {
-        namespace functors
+namespace nvidia
+{
+namespace functors
+{
+    struct Add
+    {    
+        template<typename Dst, typename Src >
+        HDINLINE void operator()(Dst & dst, const Src & src) const
         {
-
-            struct Add
-            {
-
-                template<typename Dst, typename Src >
-                        HDINLINE void operator()(Dst & dst, const Src & src) const
-                {
-                    dst += src;
-                }
-            };
+            dst += src;
         }
-    }
-}
+    };
+} // namespace functors
+} // namespace nvidia
+} // namespace PMacc
 
 namespace PMacc
 {
-    namespace mpi
+namespace mpi
+{
+    template<>
+    MPI_Op getMPI_Op<PMacc::nvidia::functors::Add>()
     {
-
-        template<>
-        MPI_Op getMPI_Op<PMacc::nvidia::functors::Add>()
-        {
-            return MPI_SUM;
-        }
+        return MPI_SUM;
     }
-}
+} // namespace mpi
+} // namespace PMacc

--- a/src/libPMacc/include/nvidia/functors/Assign.hpp
+++ b/src/libPMacc/include/nvidia/functors/Assign.hpp
@@ -26,20 +26,18 @@
 
 namespace PMacc
 {
-    namespace nvidia
+namespace nvidia
+{
+namespace functors
+{
+    struct Assign
     {
-        namespace functors
+        template<typename Dst, typename Src >
+        HDINLINE void operator()(Dst & dst, const Src & src) const
         {
-
-            struct Assign
-            {
-
-                template<typename Dst, typename Src >
-                        HDINLINE void operator()(Dst & dst, const Src & src) const
-                {
-                    dst = src;
-                }
-            };
+            dst = src;
         }
-    }
-}
+    };
+} // namespace functors
+} // namespace nvidia
+} // namespace PMacc

--- a/src/libPMacc/include/nvidia/functors/Max.hpp
+++ b/src/libPMacc/include/nvidia/functors/Max.hpp
@@ -29,33 +29,30 @@
 
 namespace PMacc
 {
-    namespace nvidia
+namespace nvidia
+{
+namespace functors
+{
+    struct Max
     {
-        namespace functors
+        template<typename Dst, typename Src >
+        DINLINE void operator()(Dst & dst, const Src & src) const
         {
-
-            struct Max
-            {
-
-                template<typename Dst, typename Src >
-                        DINLINE void operator()(Dst & dst, const Src & src) const
-                {
-                    dst = algorithms::math::max(dst, src);
-                }
-            };
+            dst = algorithms::math::max(dst, src);
         }
-    }
-}
+    };
+} // namespace functors
+} // namespace nvidia
+} // namespace PMacc
 
 namespace PMacc
 {
-    namespace mpi
+namespace mpi
+{
+    template<>
+    MPI_Op getMPI_Op<PMacc::nvidia::functors::Max>()
     {
-
-        template<>
-        MPI_Op getMPI_Op<PMacc::nvidia::functors::Max>()
-        {
-            return MPI_MAX;
-        }
+        return MPI_MAX;
     }
-}
+} // namespace mpi
+} // namespace PMacc

--- a/src/libPMacc/include/nvidia/functors/Min.hpp
+++ b/src/libPMacc/include/nvidia/functors/Min.hpp
@@ -30,33 +30,30 @@
 
 namespace PMacc
 {
-    namespace nvidia
+namespace nvidia
+{
+namespace functors
+{
+    struct Min
     {
-        namespace functors
+        template<typename Dst, typename Src >
+        DINLINE void operator()(Dst & dst, const Src & src) const
         {
-
-            struct Min
-            {
-
-                template<typename Dst, typename Src >
-                        DINLINE void operator()(Dst & dst, const Src & src) const
-                {
-                    dst = algorithms::math::max(dst, src);
-                }
-            };
+            dst = algorithms::math::max(dst, src);
         }
-    }
-}
+    };
+} // namespace functors
+} // namespace nvidia
+} // namespace PMacc
 
 namespace PMacc
 {
-    namespace mpi
+namespace mpi
+{
+    template<>
+    MPI_Op getMPI_Op<PMacc::nvidia::functors::Min>()
     {
-
-        template<>
-        MPI_Op getMPI_Op<PMacc::nvidia::functors::Min>()
-        {
-            return MPI_MIN;
-        }
+        return MPI_MIN;
     }
-}
+} // namespace mpi
+} // namespace PMacc

--- a/src/libPMacc/include/nvidia/functors/Mul.hpp
+++ b/src/libPMacc/include/nvidia/functors/Mul.hpp
@@ -27,31 +27,31 @@
 
 namespace PMacc
 {
-    namespace nvidia
+namespace nvidia
+{
+namespace functors
+{
+    struct Mul
     {
-        namespace functors
+        template<typename Dst, typename Src>
+        HDINLINE void
+        operator()( Dst& dst, const Src& src ) const
         {
-            struct Mul
-            {
-                template<typename Dst, typename Src>
-                HDINLINE void
-                operator()( Dst& dst, const Src& src ) const
-                {
-                    dst *= src;
-                }
-            };
+            dst *= src;
         }
-    }
-}
+    };
+} // namespace functors
+} // namespace nvidia
+} // namespace PMacc
 
 namespace PMacc
 {
-    namespace mpi
+namespace mpi
+{
+    template<>
+    MPI_Op getMPI_Op<PMacc::nvidia::functors::Mul>()
     {
-        template<>
-        MPI_Op getMPI_Op<PMacc::nvidia::functors::Mul>()
-        {
-            return MPI_PROD;
-        }
+        return MPI_PROD;
     }
-}
+} // namespace mpi
+} // namespace PMacc

--- a/src/libPMacc/include/nvidia/functors/Sub.hpp
+++ b/src/libPMacc/include/nvidia/functors/Sub.hpp
@@ -26,19 +26,19 @@
 
 namespace PMacc
 {
-    namespace nvidia
+namespace nvidia
+{
+namespace functors
+{
+    struct Sub
     {
-        namespace functors
+        template<typename Dst, typename Src>
+        HDINLINE void
+        operator()( Dst& dst, const Src& src ) const
         {
-            struct Sub
-            {
-                template<typename Dst, typename Src>
-                HDINLINE void
-                operator()( Dst& dst, const Src& src ) const
-                {
-                    dst -= src;
-                }
-            };
+            dst -= src;
         }
-    }
-}
+    };
+} // namespace functors
+} // namespace nvidia
+} // namespace PMacc


### PR DESCRIPTION
This pull request fixes the wrong namespace indentation, removes superfluous empty lines and adds ending comments to namespaces in `libPMacc/include/nvidia/functors` as discussed in #1455 with @ax3l . 