### PR TITLE
Use correct sqrt function for abs(Vector)

### DIFF
--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -29,6 +29,7 @@
 #include "result_of_Functor.hpp"
 #include "static_assert.hpp"
 #include "pmacc_types.hpp"
+#include "algorithms/math.hpp"
 
 #include <boost/mpl/size.hpp>
 #include <boost/call_traits.hpp>
@@ -795,7 +796,7 @@ template<typename Type, int dim>
 HDINLINE Type abs(const Vector<Type, dim>& vec)
 {
 
-    return sqrtf(abs2(vec));
+    return algorithms::math::sqrt(abs2(vec));
 }
 
 template<typename Type, int dim>


### PR DESCRIPTION
Currently `sqrtf` was used, which is the floating point function. This is crucially wrong for double vectors, especially as taking the square root already looses significant digits.

This uses the type generic version from `PMacc::algorithms::math`