### PR TITLE
replace sqrtf with algorithms::math::sqrt

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -129,7 +129,7 @@ namespace picongpu
             return elong;
 #else
             //beam waist in the near field: w_y(y=0) == W0
-            const float_X w_y = W0 * sqrtf( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
+            const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
             //! the Gouy phase shift
             const float_X xi_y = atanf( -FOCUS_POS / y_R );
 

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -136,7 +136,7 @@ namespace picongpu
             return elong;
 #else
             //beam waist in the near field: w_y(y=0) == W0
-            const float_X w_y = W0 * sqrtf( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
+            const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
             //! the Gouy phase shift
             const float_X xi_y = atanf( -FOCUS_POS / y_R );
 

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -73,7 +73,7 @@ struct Push
         // second step in Vay paper:
         const MomType momentum_prime = momentum_atZero + factor * eField;
         const float_X gamma_prime = gamma(momentum_prime, mass);
-        //sqrtf(1.0 + abs2(momentum_prime*(1.0/(mass * SPEED_OF_LIGHT))));
+        //algorithms::math::sqrt(1.0 + abs2(momentum_prime*(1.0/(mass * SPEED_OF_LIGHT))));
         const sqrt_Vay::float3_X tau(factor / mass * bField);
         const sqrt_Vay::float_X u_star = math::dot( precisionCast<sqrt_Vay::float_X>(momentum_prime), tau ) / precisionCast<sqrt_Vay::float_X>( SPEED_OF_LIGHT * mass );
         const sqrt_Vay::float_X sigma = gamma_prime * gamma_prime - math::abs2( tau );

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -116,7 +116,8 @@ __global__ void kernelEnergyParticles(ParBox pb,
             {
                 /* kinetic energy for particles: E = (gamma - 1) * m * c^2
                  *                                    gamma = sqrt( 1 + (p/m/c)^2 )
-                 * _local_energyKin += (sqrtf(mom2 / (mass * mass * c2) + 1.) - 1.) * mass * c2;
+                 * _local_energyKin += (algorithms::math::sqrt(mom2 / (mass * mass * c2) 
+                 *                                             + 1.) - 1.) * mass * c2;
                  */
                 _local_energyKin += (gamma - float_X(1.0)) * mass*c2;
             }
@@ -124,7 +125,7 @@ __global__ void kernelEnergyParticles(ParBox pb,
             /* total energy for particles: E^2 = p^2*c^2 + m^2*c^4
              *                                   = c^2 * [p^2 + m^2*c^2]
              */
-            _local_energy += sqrtf(mom2 + mass * mass * c2) * SPEED_OF_LIGHT;
+            _local_energy += algorithms::math::sqrt(mom2 + mass * mass * c2) * SPEED_OF_LIGHT;
 
         }
         __syncthreads(); /* wait till all threads have added their particle energies */


### PR DESCRIPTION
This is a pull request replaces `sqrtf` by `algorithms::math::sqrt` in the picongpu main code.
This is similar to #1461 where @Flamefire replaced `sqrtf` in libPMacc.