### PR TITLE
Use enable_if to deselect template version

### DIFF
--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -23,18 +23,19 @@
 
 #pragma once
 
-#include <cuSTL/container/allocator/DeviceMemAllocator.hpp>
-#include <cuSTL/container/copier/D2DCopier.hpp>
-#include <cuSTL/container/assigner/DeviceMemAssigner.hpp>
+#include "cuSTL/container/allocator/DeviceMemAllocator.hpp"
+#include "cuSTL/container/copier/D2DCopier.hpp"
+#include "cuSTL/container/assigner/DeviceMemAssigner.hpp"
 #include "cuSTL/container/CartBuffer.hpp"
-#include "allocator/tag.h"
+#include "cuSTL/container/allocator/tag.h"
+#include "cuSTL/container/copier/Memcopy.hpp"
 
-#include <memory/buffers/DeviceBuffer.hpp>
-#include <memory/buffers/HostBuffer.hpp>
-#include <exception>
-#include <sstream>
 #include <boost/assert.hpp>
 #include <boost/move/move.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <exception>
+#include <sstream>
 
 namespace PMacc
 {
@@ -109,9 +110,12 @@ public:
 
     template<typename HBuffer>
     HINLINE
-    DeviceBuffer& operator=(const HBuffer& rhs)
+    typename boost::enable_if<
+		boost::is_same<typename HBuffer::memoryTag, allocator::tag::host>,
+		DeviceBuffer&
+		>::type
+	operator=(const HBuffer& rhs)
     {
-        BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::memoryTag, allocator::tag::host>::value));
         BOOST_STATIC_ASSERT((boost::is_same<typename HBuffer::type, Type>::value));
         BOOST_STATIC_ASSERT(HBuffer::dim == T_dim);
         if(rhs.size() != this->size())

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -22,16 +22,19 @@
 
 #pragma once
 
+#include "cuSTL/container/allocator/HostMemAllocator.hpp"
+#include "cuSTL/container/copier/H2HCopier.hpp"
+#include "cuSTL/container/assigner/HostMemAssigner.hpp"
+#include "cuSTL/container/CartBuffer.hpp"
+#include "cuSTL/container/allocator/tag.h"
+#include "cuSTL/container/copier/Memcopy.hpp"
+
+#include <boost/assert.hpp>
+#include <boost/move/move.hpp>
+#include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <cuSTL/container/allocator/HostMemAllocator.hpp>
-#include <cuSTL/container/copier/H2HCopier.hpp>
-#include <cuSTL/container/assigner/HostMemAssigner.hpp>
-#include "CartBuffer.hpp"
-#include "allocator/tag.h"
-#include "copier/Memcopy.hpp"
 #include <exception>
 #include <sstream>
-#include <boost/assert.hpp>
 
 namespace PMacc
 {
@@ -102,9 +105,12 @@ public:
 
     template<typename DBuffer>
     HINLINE
-    HostBuffer& operator=(const DBuffer& rhs)
+    typename boost::enable_if<
+		boost::is_same<typename DBuffer::memoryTag, allocator::tag::device>,
+		HostBuffer&
+		>::type
+    operator=(const DBuffer& rhs)
     {
-        BOOST_STATIC_ASSERT((boost::is_same<typename DBuffer::memoryTag, allocator::tag::device>::value));
         BOOST_STATIC_ASSERT((boost::is_same<typename DBuffer::type, Type>::value));
         BOOST_STATIC_ASSERT(DBuffer::dim == T_dim);
         if(rhs.size() != this->size())


### PR DESCRIPTION
The (or another) last PR in a series for fixing the copy and move assignment of cuSTLs Host<->Device transfers.

Problem was, that the template version of the assignment operator was to greedy, so it takes either the boost move instances `boost::rv` or the `const DeviceBuffer&`, but making the correct function take both is not possible, as on involves a conversion in C++98. In C++11 the boost class will not exist, so one can't use it directly either.

Solution: Only enable the function if we actually have a HostBuffer. Same is applied for the HostBuffer itself and the includes were also cleaned up in the process.

@Heikman 