### PR TITLE
Replace trigonometric float functions

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -131,7 +131,7 @@ namespace picongpu
             //beam waist in the near field: w_y(y=0) == W0
             const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
             //! the Gouy phase shift
-            const float_X xi_y = atanf( -FOCUS_POS / y_R );
+            const float_X xi_y = algorithms::math::atan( -FOCUS_POS / y_R );
 
             if( Polarisation == LINEAR_X || Polarisation == LINEAR_Z )
             {

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -93,7 +93,7 @@ namespace picongpu
             //const float_X modMue = float_X(PI) * float_X(SPEED_OF_LIGHT / WAVE_LENGTH) * INIT_TIME;
             const float_X f = SPEED_OF_LIGHT / WAVE_LENGTH;
             const float_X timeShift = phase / (2.0f * float_X(PI) * float_X(f)) + FOCUS_POS / SPEED_OF_LIGHT;
-            const float_X spaceShift = SPEED_OF_LIGHT * tanf(TILT_X) * timeShift / CELL_HEIGHT;
+            const float_X spaceShift = SPEED_OF_LIGHT * algorithms::math::tan(TILT_X) * timeShift / CELL_HEIGHT;
             const float_X r2 = (posX + spaceShift) * (posX + spaceShift) + posZ * posZ;
 
             // pure gaussian
@@ -138,7 +138,7 @@ namespace picongpu
             //beam waist in the near field: w_y(y=0) == W0
             const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
             //! the Gouy phase shift
-            const float_X xi_y = atanf( -FOCUS_POS / y_R );
+            const float_X xi_y = algorithms::math::atan( -FOCUS_POS / y_R );
 
             if( Polarisation == LINEAR_X || Polarisation == LINEAR_Z )
             {


### PR DESCRIPTION
This pull request replaces the use of `tanf()` and `atanf()` in picongpu as suggested by @psychocoderHPC in #1462 by `algorithms::math::(a)tan()`.
Since `atan` did not exist in `algorithms::math` before, this pull request adds it as well. 

There are no other trigonometric functions in float format.

**This pull request requires a rebase after:**
 - [x] **#1473 has been merged.**
