### PR TITLE
fix usage of wrong `abs()` function

### DIFF
--- a/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
@@ -41,7 +41,14 @@ struct Abs<double>
 
     HDINLINE double operator( )(double value)
     {
-        return ::abs( value );
+#ifdef __CUDA_ARCH__
+      return ::fabs( value );
+#else
+      /* \bug on cpu `::abs(double)` always return zero -> maybe this is the
+	* integer version of `abs()`
+	*/
+      return std::abs( value );
+#endif
     }
 };
 

--- a/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
@@ -41,7 +41,7 @@ struct Abs<float>
 
     HDINLINE float operator( )(float value)
     {
-        return ::fabs( value );
+        return ::fabsf( value );
     }
 };
 


### PR DESCRIPTION
- on device use `::fabs()` for double values
- on host use `std:abs()` for double values
- use `::fabsf()` for float values

[Documenation `fabsf`](http://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html)
[Documenation `fabs`](http://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html)

I can't find a documentation for `::abs()` in the cuda header files. The wrong usage for float values should only result in an implicit cast and a slow abs call (maybe optimized by the compiler beauce we use fast_math)

This bug effects the latest release but we saw no issues in the past.

- [x] compare runtime dev/pull - runtime changes
- [x] test charge conservation