### PR TITLE
Topic remove vector math implementations

### DIFF
--- a/examples/SingleParticleCurrent/include/CheckCurrent.hpp
+++ b/examples/SingleParticleCurrent/include/CheckCurrent.hpp
@@ -80,7 +80,7 @@ struct CheckCurrent
         std::cout << "velocity: (" << beta << ") * c\n";
         std::cout << "delta_pos: (" << beta * SPEED_OF_LIGHT / float3_X(CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH) << ") * cellSize\n";
 
-        const float_64 j = BASE_CHARGE / CELL_VOLUME * abs(beta) * SPEED_OF_LIGHT;
+        const float_64 j = BASE_CHARGE / CELL_VOLUME * math::abs(beta) * SPEED_OF_LIGHT;
         const float_64 unit_current = UNIT_CHARGE / (UNIT_LENGTH * UNIT_LENGTH * UNIT_TIME);
         std::cout << "j = rho * abs(velocity) = " << std::setprecision(6) << j * unit_current << " A/m²" << std::endl;
         std::cout << "------------------------------------------\n\n";

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -48,7 +48,9 @@ public:
     Data operator()(const Data& data, const math::Int<dim>& jump) const
     {
         char* result = (char*)data;
-        result += dot(jump, this->factor);
+        result += algorithms::math::dot(
+            static_cast<typename math::Int<dim>::BaseType>(jump),
+            static_cast<typename math::Int<dim>::BaseType>(this->factor));
         return (Data)result;
     }
 

--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -762,15 +762,6 @@ linearize(const Vector<T_Type, 2, T_Accessor, T_Navigator, T_Storage >& size,
     return pos.z() * size.x() * size.y() + pos.y() * size.x() + pos.x();
 }
 
-template<typename Vector>
-HDINLINE Vector floor(const Vector& vector)
-{
-    Vector result;
-
-    for (int i = 0; i < Vector::dim; i++)
-        result[i] = floorf(vector[i]);
-    return result;
-}
 
 template<typename Lhs, typename Rhs>
 HDINLINE Lhs operator%(const Lhs& lhs, const Rhs& rhs)
@@ -782,52 +773,21 @@ HDINLINE Lhs operator%(const Lhs& lhs, const Rhs& rhs)
     return result;
 }
 
-template<typename Type, int dim>
-HDINLINE Type abs2(const Vector<Type, dim>& vec)
-{
-    Type result = vec.x() * vec.x();
-
-    for (int i = 1; i < dim; i++)
-        result += vec[i] * vec[i];
-    return result;
-}
-
-template<typename Type, int dim>
-HDINLINE Type abs(const Vector<Type, dim>& vec)
-{
-
-    return algorithms::math::sqrt(abs2(vec));
-}
-
-template<typename Type, int dim>
-HDINLINE
-Type dot(const Vector<Type, dim>& a, const Vector<Type, dim>& b)
-{
-    Type result = a.x() * b.x();
-
-    for (int i = 1; i < dim; i++)
-        result += a[i] * b[i];
-    return result;
-}
-
 struct Abs2
 {
-
     template<typename Type, int dim >
     HDINLINE Type operator()(const Vector<Type, dim>& vec)
     {
-
-        return abs2(vec);
+        return PMacc::algorithms::math::abs2(vec);
     }
 };
 
 struct Abs
 {
-
     template<typename Type, int dim >
     HDINLINE Type operator()(const Vector<Type, dim>& vec)
     {
-        return abs(vec);
+        return PMacc::algorithms::math::abs(vec);
     }
 };
 

--- a/src/picongpu/include/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
+++ b/src/picongpu/include/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
@@ -38,7 +38,7 @@ struct ShiftToValidRange
     HDINLINE
     T_MemoryType memory( const T_MemoryType& mem, const T_PosType& pos ) const
     {
-        const T_PosType pos_floor = PMacc::math::floor(pos);
+        const T_PosType pos_floor = math::floor(pos);
         return mem( precisionCast<int>(pos_floor) );
     }
 
@@ -46,7 +46,7 @@ struct ShiftToValidRange
     HDINLINE
     T_PosType position( const T_PosType& pos ) const
     {
-        const T_PosType pos_floor = PMacc::math::floor(pos);
+        const T_PosType pos_floor = math::floor(pos);
         return pos - pos_floor;
     }
 };

--- a/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
@@ -88,7 +88,7 @@ namespace picongpu
                 const MomType mom_old = mom;
 
                 const float_X B2 = math::abs2( bField );
-                const float_X B = abs( bField );
+                const float_X B = math::abs( bField );
 
                 if( B2 > epsilon )
                 {

--- a/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
@@ -50,7 +50,7 @@ struct PushExtension
             // Radiation marks only a particle if it has a high velocity
             // marked particle means that momentumPrev1 is not 0.0 in one direction
 
-            const float_X abs2_mom = abs2(mom);
+            const float_X abs2_mom = math::abs2(mom);
             if (((abs2_mom)>((parameters::RadiationGamma * parameters::RadiationGamma - float_X(1.0)) * mass * mass * c2)))
             {
                 radFlag = true;


### PR DESCRIPTION
- remove math function implementations in Vector.hpp ￼…
  - remove `dot()`
  - remove `abs()`
  - remove `abs2()`
  - remove `floor()`
-  fix usage of deleted math functions

This pull requests close #1338

Todo:
- [x] need rebase against #1471