### PR TITLE
add atan to algorithms::math

### DIFF
--- a/src/libPMacc/include/algorithms/math/defines/trigo.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/trigo.hpp
@@ -46,6 +46,9 @@ template<typename Type>
 struct Tan;
 
 template<typename Type>
+struct ATan;
+
+template<typename Type>
 struct Atan2;
 
 template<typename ArgType, typename SinType, typename CosType>
@@ -93,6 +96,14 @@ typename Tan<T1>::result
 tan(const T1& value)
 {
     return Tan< T1 > ()(value);
+}
+
+template<typename T1>
+HDINLINE
+typename ATan<T1>::result
+atan(const T1& value)
+{
+    return ATan< T1 > ()(value);
 }
 
 template<typename ArgType, typename SinType, typename CosType>

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -90,6 +90,17 @@ struct Tan<double>
 };
 
 template<>
+struct ATan<double>
+{
+    typedef double result;
+
+    HDINLINE double operator( )(const double& value)
+    {
+        return ::atan( value );
+    }
+};
+
+template<>
 struct SinCos<double, double, double>
 {
     typedef void result;

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -99,6 +99,17 @@ struct Tan<float>
 };
 
 template<>
+struct ATan<float>
+{
+    typedef float result;
+
+    HDINLINE float operator( )(const float& value)
+    {
+        return ::atanf( value );
+    }
+};
+
+template<>
 struct SinCos<float, float, float>
 {
     typedef void result;


### PR DESCRIPTION
This pull request adds `atan` to `algorithm::math::` in **libPMacc** as requested by @psychocoderHPC in #1468.  