### PR TITLE
`laserConfig.param`: Remove Confusing Comments

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -54,7 +54,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -103,7 +103,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
     *  Info:             FWHM_of_Intensity = FWHM_Illumination
     *                      = what a experimentalist calls "pulse duration"
     *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -172,13 +172,13 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 50.0*WAVE_LENGTH_S
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 }
 
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
 
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
 BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
@@ -218,7 +218,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
 /** The profile of the test Lasers 0 and 2 can be stretched by a
  *      constant area between the up and downramp
  *  unit: seconds */
-BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI; //0.0;//50.0e-15;
+BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -226,7 +226,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -54,7 +54,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 5.0e-15; //25.0e-15 / 1.17741;
+            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 5.0e-15;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -103,7 +103,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -164,7 +164,7 @@ namespace picongpu
             /** The profile of the test Lasers 0 and 2 can be stretched by a
              *      constant area between the up and downramp
              *  unit: seconds */
-            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15; //7.0*WAVE_LENGTH_SI/::picongpu::SI::SPEED_OF_LIGHT_SI;//13.34e-15;//25.0e-15;
+            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -172,13 +172,13 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
 
         }
 
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+        BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
 
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
         BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
@@ -218,7 +218,7 @@ namespace picongpu
             /** The profile of the test Lasers 0 and 2 can be stretched by a
              *      constant area between the up and downramp
              *  unit: seconds */
-            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI; //0.0;//50.0e-15;
+            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -226,7 +226,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -54,7 +54,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -173,7 +173,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_
 /** The profile of the test Lasers 0 and 2 can be stretched by a
  *      constant area between the up and downramp
  *  unit: seconds */
-BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = /*13.34e-15;*/6.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI; //13.34e-15;//25.0e-15;
+BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = /*13.34e-15;*/6.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -181,13 +181,13 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = /*13.34e-15;*/6.0 
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 }
 
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
 
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
 BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
@@ -227,7 +227,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
 /** The profile of the test Lasers 0 and 2 can be stretched by a
  *      constant area between the up and downramp
  *  unit: seconds */
-BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI; //0.0;//50.0e-15;
+BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -235,7 +235,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -54,7 +54,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -164,7 +164,7 @@ namespace picongpu
             /** The profile of the test Lasers 0 and 2 can be stretched by a
              *      BOOST_CONSTEXPR_OR_CONSTant area between the up and downramp
              *  unit: seconds */
-            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15; //7.0*WAVE_LENGTH_SI/::picongpu::SI::SPEED_OF_LIGHT_SI;//13.34e-15;//25.0e-15;
+            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -172,13 +172,13 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
         }
 
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146; //25.6415;//SI::aux_calulation::PULSE_TIME_SI/SI::PULSE_LENGTH_SI;
+        BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
 
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
         BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
@@ -218,7 +218,7 @@ namespace picongpu
         /** The profile of the test Lasers 0 and 2 can be stretched by a
          *      BOOST_CONSTEXPR_OR_CONSTant area between the up and downramp
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI; //0.0;//50.0e-15;
+        BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
         /** Pulse length: sigma of std. gauss for intensity (E^2)
          *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -226,7 +226,7 @@ namespace picongpu
          *  Info:             FWHM_of_Intensity = FWHM_Illumination
          *                      = what a experimentalist calls "pulse duration"
          *  unit: seconds (1 sigma) */
-        BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0; //5.0e-15; //25.0e-15 / 1.17741;
+        BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
         /** beam waist: distance from the axis where the pulse intensity (E^2)
          *              decreases to its 1/e^2-th part,


### PR DESCRIPTION
Remove confusing comments from `laserConfig.param`. (Reported a user on the mailing list.)