### PR TITLE
`getUnitDimensions`: Use only `HINLINE`

### DIFF
--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -74,7 +74,7 @@ namespace picongpu
          * (length L, mass M, time T, electric current I,
          *  thermodynamic temperature theta, amount of substance N,
          *  luminous intensity J) */
-        HDINLINE static std::vector<float_64> getUnitDimension();
+        HINLINE static std::vector<float_64> getUnitDimension();
 
         static std::string getName();
 

--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -209,7 +209,7 @@ FieldB::getUnit( )
     return UnitValueType( UNIT_BFIELD, UNIT_BFIELD, UNIT_BFIELD );
 }
 
-HDINLINE
+HINLINE
 std::vector<float_64>
 FieldB::getUnitDimension( )
 {

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -74,7 +74,7 @@ namespace picongpu
          * (length L, mass M, time T, electric current I,
          *  thermodynamic temperature theta, amount of substance N,
          *  luminous intensity J) */
-        HDINLINE static std::vector<float_64> getUnitDimension();
+        HINLINE static std::vector<float_64> getUnitDimension();
 
         static std::string getName();
 

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -221,7 +221,7 @@ FieldE::getUnit( )
     return UnitValueType( UNIT_EFIELD, UNIT_EFIELD, UNIT_EFIELD );
 }
 
-HDINLINE
+HINLINE
 std::vector<float_64>
 FieldE::getUnitDimension( )
 {

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -98,7 +98,7 @@ public:
      * (length L, mass M, time T, electric current I,
      *  thermodynamic temperature theta, amount of substance N,
      *  luminous intensity J) */
-    HDINLINE static std::vector<float_64> getUnitDimension();
+    HINLINE static std::vector<float_64> getUnitDimension();
 
     static std::string getName();
 

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -243,7 +243,7 @@ FieldJ::getUnit( )
     return UnitValueType( UNIT_CURRENT, UNIT_CURRENT, UNIT_CURRENT );
 }
 
-HDINLINE
+HINLINE
 std::vector<float_64>
 FieldJ::getUnitDimension( )
 {

--- a/src/picongpu/include/fields/FieldTmp.hpp
+++ b/src/picongpu/include/fields/FieldTmp.hpp
@@ -80,7 +80,7 @@ namespace picongpu
          *  thermodynamic temperature theta, amount of substance N,
          *  luminous intensity J) */
         template<class FrameSolver >
-        HDINLINE static std::vector<float_64> getUnitDimension();
+        HINLINE static std::vector<float_64> getUnitDimension();
 
         static std::string getName();
 

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -284,7 +284,7 @@ namespace picongpu
     }
 
     template<class FrameSolver >
-    HDINLINE std::vector<float_64>
+    HINLINE std::vector<float_64>
     FieldTmp::getUnitDimension( )
     {
         return FrameSolver().getUnitDimension();

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -63,7 +63,7 @@ public:
      * (length L, mass M, time T, electric current I,
      *  thermodynamic temperature theta, amount of substance N,
      *  luminous intensity J) */
-    HDINLINE std::vector<float_64> getUnitDimension() const;
+    HINLINE std::vector<float_64> getUnitDimension() const;
 
     /** return name of the this solver
      * @return name of solver

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -46,7 +46,7 @@ ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::getUnit() const
 }
 
 template<class T_ParticleShape, class T_DerivedAttribute>
-HDINLINE std::vector<float_64>
+HINLINE std::vector<float_64>
 ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::getUnitDimension() const
 {
     return T_DerivedAttribute().getUnitDimension();

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -37,7 +37,7 @@ namespace derivedAttributes
         HDINLINE float1_64
         getUnit() const;
 
-        HDINLINE std::vector<float_64>
+        HINLINE std::vector<float_64>
         getUnitDimension() const
         {
            /* L, M, T, I, theta, N, J

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
@@ -36,7 +36,7 @@ namespace derivedAttributes
         HDINLINE float1_64
         getUnit() const;
 
-        HDINLINE std::vector<float_64>
+        HINLINE std::vector<float_64>
         getUnitDimension() const
         {
            /* L, M, T, I, theta, N, J

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
@@ -37,7 +37,7 @@ namespace derivedAttributes
         HDINLINE float1_64
         getUnit() const;
 
-        HDINLINE std::vector<float_64>
+        HINLINE std::vector<float_64>
         getUnitDimension() const
         {
            /* L, M, T, I, theta, N, J

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
@@ -37,7 +37,7 @@ namespace derivedAttributes
         HDINLINE float1_64
         getUnit() const;
 
-        HDINLINE std::vector<float_64>
+        HINLINE std::vector<float_64>
         getUnitDimension() const
         {
            /* L, M, T, I, theta, N, J

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -37,7 +37,7 @@ namespace derivedAttributes
         HDINLINE float1_64
         getUnit() const;
 
-        HDINLINE std::vector<float_64>
+        HINLINE std::vector<float_64>
         getUnitDimension() const
         {
            /* L, M, T, I, theta, N, J

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -37,7 +37,7 @@ namespace derivedAttributes
         HDINLINE float1_64
         getUnit() const;
 
-        HDINLINE std::vector<float_64>
+        HINLINE std::vector<float_64>
         getUnitDimension() const
         {
            /* L, M, T, I, theta, N, J


### PR DESCRIPTION
The `getUnitDimenions` interfaces create a `std::vector` which is only usable on host side (and only needed there for now).

Caused a warning in an other (upcoming) implementation.