### PR TITLE
`speciesAttributes`: Add In-Code References

### DIFF
--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 Rene Widera, Marco Garten, Alexander Grund
+ * Copyright 2014-2016 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -18,8 +18,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "simulation_defines.hpp"
@@ -31,6 +29,19 @@
 #include "identifier/value_identifier.hpp"
 #include "particles/IdProvider.def"
 
+
+/** \file speciesAttributes.param
+ *
+ * This file defines available attributes that can be stored with each particle
+ * of a particle species.
+ * Each attribute defined here needs to implement furthermore the traits
+ *   - Unit
+ *   - UnitDimension
+ *   - WeightingPower
+ *   - MacroWeighted
+ * in \see speciesAttributes.unitless . For further information about these
+ * traits see therein.
+ */
 namespace picongpu
 {
 

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -19,8 +19,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include <vector>
@@ -30,9 +28,32 @@
 #include "particles/traits/MacroWeighted.hpp"
 #include "particles/traits/WeightingPower.hpp"
 
+
+/** \file speciesAttributes.unitless
+ *
+ * This file describes the particle attributes defined in
+ * \see speciesAttributes.param of a particle species.
+ * Each particle attribute needs to implement the following traits
+ *   - `Unit`
+ *      - conversion between PIConGPU units and SI
+ *      - \see traits/Unit.hpp
+ *      - \see https://git.io/vriio
+ *   - `UnitDimension`
+ *      - powers of the seven SI base units
+ *      - \see traits/UnitDimension.hpp
+ *      - \see https://git.io/vriio
+ *   - `MacroWeighted`
+ *      - attribute is weighted to a macro-particle?
+ *      - \see particles/traits/MacroWeighted.hpp
+ *      - \see https://git.io/vwlWa
+ *   - `WeightingPower`
+ *      - attribute is different for macro and real particles?
+ *        describe how it scales with the weighting
+ *      - \see particles/traits/WeightingPower.hpp
+ *      - \see https://git.io/vwlWa
+ */
 namespace picongpu
 {
-
 namespace traits
 {
 


### PR DESCRIPTION
Adds more in-code references and online documents to the files `speciesAttributes.param/unitless`. Explains the traits that need to be implemented for each species' particle attributes.

Related to #1480