### PR TITLE
Cuda event fix to avoid deadlock

### DIFF
--- a/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
@@ -107,7 +107,14 @@ public:
     bool isFinished() const
     {
         assert(isValid);
-        return cudaEventQuery(event) == cudaSuccess;
+        cudaError_t rc = cudaEventQuery(event);
+
+        if(rc == cudaSuccess)
+            return true;
+        else if(rc == cudaErrorNotReady)
+            return false;
+        else
+            PMACC_PRINT_CUDA_ERROR_AND_THROW(rc, "Event query failed");
     }
 
 


### PR DESCRIPTION
- [x] Rebase on #1484 

There is a potential deadlock, when the eventsystem waits for the completion of an event (e.g. after a kernel) but the kernel errors (e.g. invalid memory access, timeout, ...) As in this case `cudaEventQuery` will always return an errorcode the eventsystem will never receive a `cudaSuccess`/`CudaEvent::isFinished` and loops forever. 