### PR TITLE
fix particle out of mem error/warning

### DIFF
--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -99,7 +99,7 @@ public:
             else
             {
                 printf( "%s: mallocMC out of memory (try %i of %i)\n",
-                        (numTries + 1) == maxTries ? "WARNING" : "ERROR",
+                        (numTries + 1) == maxTries ? "ERROR" : "WARNING",
                         numTries + 1,
                         maxTries );
             }


### PR DESCRIPTION
fix inverted warning and error message

This bug effects the latest release **but there is no need for a back port**. Only the error message was wrong.