### PR TITLE
Add MRG32k3a RNG generator

### DIFF
--- a/src/libPMacc/include/random/methods/MRG32k3a.hpp
+++ b/src/libPMacc/include/random/methods/MRG32k3a.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 Alexander Grund
+ * Copyright 2016 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/methods/MRG32k3a.hpp
+++ b/src/libPMacc/include/random/methods/MRG32k3a.hpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015-2016 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include <curand_kernel.h>
+
+namespace PMacc
+{
+namespace random
+{
+namespace methods
+{
+
+    /** Uses the CUDA MRG32k3a RNG */
+    class MRG32k3a
+    {
+    public:
+        typedef curandStateMRG32k3a StateType;
+
+        DINLINE void
+        init(StateType& state, uint32_t seed, uint32_t subsequence = 0, uint32_t offset = 0) const
+        {
+            curand_init(seed, subsequence, offset, &state);
+        }
+
+        DINLINE uint32_t
+        get32Bits(StateType& state) const
+        {
+            return curand(&state);
+        }
+
+        static std::string
+        getName()
+        {
+            return "MRG32k3a";
+        }
+    };
+
+}  // namespace methods
+}  // namespace random
+}  // namespace PMacc

--- a/src/libPMacc/include/random/methods/MRG32k3aMin.hpp
+++ b/src/libPMacc/include/random/methods/MRG32k3aMin.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 Alexander Grund
+ * Copyright 2016 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/methods/MRG32k3aMin.hpp
+++ b/src/libPMacc/include/random/methods/MRG32k3aMin.hpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015-2016 Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include <curand_kernel.h>
+
+namespace PMacc
+{
+namespace random
+{
+namespace methods
+{
+
+    /** Uses the CUDA MRG32k3a RNG but does not store state members required for normal distribution*/
+    class MRG32k3aMin
+    {
+    public:
+        struct StateType
+        {
+            double s1[3];
+            double s2[3];
+        };
+
+        DINLINE void
+        init(StateType& state, uint32_t seed, uint32_t subsequence = 0, uint32_t offset = 0) const
+        {
+            curandStateMRG32k3a tmpState;
+            curand_init(seed, subsequence, offset, &tmpState);
+            AssignState(state, tmpState);
+        }
+
+        DINLINE uint32_t
+        get32Bits(StateType& state) const
+        {
+            // We can do this cast if: 1) Only state data is used and
+            //                         2) Data is aligned and positioned the same way
+            CheckStateCompatibility();
+            return curand(reinterpret_cast<curandStateMRG32k3a*>(&state));
+        }
+
+        static std::string
+        getName()
+        {
+            return "MRG32k3aMin";
+        }
+    private:
+        static HDINLINE void CheckStateCompatibility()
+        {
+            // Sizes must match
+            PMACC_STATIC_ASSERT_MSG(
+                    sizeof(StateType::s1) == sizeof(curandStateMRG32k3a::s1),
+                    Unexpected_sizes);
+            PMACC_STATIC_ASSERT_MSG(
+                    sizeof(StateType::s2) == sizeof(curandStateMRG32k3a::s2),
+                    Unexpected_sizes);
+            // Offsets must match
+            PMACC_STATIC_ASSERT_MSG(
+                    offsetof(StateType, s1) == offsetof(curandStateMRG32k3a, s1) &&
+                    offsetof(StateType, s2) == offsetof(curandStateMRG32k3a, s2),
+                    Incompatible_structs);
+        }
+        static HDINLINE void
+        AssignState(StateType& dest, const curandStateMRG32k3a& src)
+        {
+            // Check if we can do this cast
+            CheckStateCompatibility();
+            dest = reinterpret_cast<const StateType&>(src);
+        }
+    };
+
+}  // namespace methods
+}  // namespace random
+}  // namespace PMacc


### PR DESCRIPTION
This adds another random number generator that can be used to compare those against each other.

Note that this are the only 2 implemented in CUDA that can be used easily. The others require multiple threads calling them in sync with the same state which is very hard in the current design of picongpu/PMacc.

Also added the corresponding Min state generator that cannot directly be used for normal distributions but uses less memory and is much faster (~20% in my local test)
Update: Just tested this on the K20: I see speedups of about 300% when using the Min state. Talking numbers:

- Gridsize=256x256
- Samples per Cell=100.000
- Time CUDA state: 24.4s
- Time Min state: 8.1s