### PR TITLE
Add missing const for getter in GridLayout

### DIFF
--- a/src/libPMacc/include/dimensions/GridLayout.hpp
+++ b/src/libPMacc/include/dimensions/GridLayout.hpp
@@ -66,7 +66,7 @@ namespace PMacc
             return dataSpace + guard + guard;
         }
 
-        HDINLINE DataSpace<DIM> getDataSpaceWithoutGuarding()
+        HDINLINE DataSpace<DIM> getDataSpaceWithoutGuarding() const
         {
             return dataSpace;
         }


### PR DESCRIPTION
Allows usage of  `const GridLayout&` parameters