### PR TITLE
Add GetStateBuffer to RNGProvider for checkpointing

### DIFF
--- a/src/libPMacc/include/random/RNGProvider.hpp
+++ b/src/libPMacc/include/random/RNGProvider.hpp
@@ -26,7 +26,7 @@
 #include "random/methods/Xor.hpp"
 #include "random/Random.hpp"
 #include "random/RNGHandle.hpp"
-#include "memory/buffers/GridBuffer.hpp"
+#include "memory/buffers/HostDeviceBuffer.hpp"
 #include "dataManagement/ISimulationData.hpp"
 
 namespace PMacc
@@ -50,13 +50,9 @@ namespace random
 
     private:
         typedef typename RNGMethod::StateType RNGState;
-        typedef GridBuffer< RNGState, dim > Buffer;
-
-        const Space m_size;
-        Buffer* buffer;
-        const std::string m_uniqueId;
 
     public:
+        typedef HostDeviceBuffer< RNGState, dim > Buffer;
         typedef typename Buffer::DataBoxType DataBoxType;
         typedef RNGHandle<RNGProvider> Handle;
 
@@ -113,11 +109,20 @@ namespace random
         SimulationDataId getUniqueId();
         void synchronize();
 
+        /**
+         * Return a reference to the buffer containing the states
+         * Note: This buffer might be empty
+         */
+        Buffer& getStateBuffer();
     private:
         /**
          * Gets the device data box
          */
         DataBoxType getDeviceDataBox();
+
+        const Space m_size;
+        Buffer* buffer;
+        const std::string m_uniqueId;
     };
 
 }  // namespace random

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -91,6 +91,13 @@ namespace random
     }
 
     template<uint32_t T_dim, class T_RNGMethod>
+    RNGProvider<T_dim, T_RNGMethod>::Buffer&
+    RNGProvider<T_dim, T_RNGMethod>::getStateBuffer()
+    {
+        return *buffer;
+    }
+
+    template<uint32_t T_dim, class T_RNGMethod>
     RNGProvider<T_dim, T_RNGMethod>::DataBoxType
     RNGProvider<T_dim, T_RNGMethod>::getDeviceDataBox()
     {
@@ -103,7 +110,7 @@ namespace random
     {
         /* generate a unique name (for this type!) to use as a default ID */
         return std::string("RNGProvider")
-                + boost::lexical_cast<std::string>(dim+0) /* +0 to create a rvalue of the class const(expr) */
+                + char('0' + dim) /* valid for 0..9 */
                 + RNGMethod::getName();
     }
 


### PR DESCRIPTION
This adds `getStateBuffer` for write access to the internal buffer. This can be used for checkpointing.
In preparation for work by @psychocoderHPC to make it not store any state, there is a added comment that the buffer might be empty.

This required some moving of members to avoid multiple `private`, `public` keywords and also uses only a `HostDeviceBuffer` instead of a `GridBuffer`