### PR TITLE
Add Bremsstrahlung

### DIFF
--- a/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "ScaledSpectrum.hpp"
+#include "PhotonEmissionAngle.hpp"
+#include "fields/FieldTmp.hpp"
+
+#include "random/methods/XorMin.hpp"
+#include "random/distributions/Uniform.hpp"
+#include "random/RNGProvider.hpp"
+
+#include "traits/Resolve.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+/** Handling of the Bremsstrahlung effect.
+ *
+ * Here the screened Bethe-Heitler cross section is used. See e.g.:
+ * Salvat, F., et al. "Monte Carlo simulation of bremsstrahlung emission by electrons."
+ * Radiation Physics and Chemistry 75.10 (2006): 1201-1219.
+ *
+ * The numerics separates the energy spectrum into two parts. In the low-energy part
+ * photon emission is neglected and a drag force is applied to the electrons. In the high-energy part
+ * photons are created in addition to the drag force.
+ *
+ * Electron deflection is treated as screened Rutherford scattering, see e.g. Jackson, chap. 13.5
+ *
+ * The photon emission angle is taken from the Lorentz-boosted dipole radiation formula,
+ * see e.g. Jackson, chap. 15.2
+ *
+ * \tparam T_ElectronSpecies
+ * \tparam T_PhotonSpecies
+ */
+template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
+struct Bremsstrahlung
+{
+    typedef T_IonSpecies IonSpecies;
+    typedef T_ElectronSpecies ElectronSpecies;
+    typedef T_PhotonSpecies PhotonSpecies;
+
+    typedef typename ElectronSpecies::FrameType FrameType;
+
+    /* specify field to particle interpolation scheme */
+    typedef typename PMacc::traits::Resolve<
+        typename GetFlagType<FrameType,interpolation<> >::type
+        >::type Field2ParticleInterpolation;
+
+    /* margins around the supercell for the interpolation of the field on the cells */
+    typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
+    typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+
+    /* relevant area of a block */
+    typedef SuperCellDescription<
+        typename MappingDesc::SuperCellSize,
+        LowerMargin,
+        UpperMargin
+        > BlockArea;
+
+    BlockArea BlockDescription;
+
+    typedef MappingDesc::SuperCellSize TVec;
+
+    typedef FieldTmp::ValueType ValueTypeIonDensity;
+
+private:
+    /* global memory ion density field device databoxes */
+    PMACC_ALIGN(ionDensityBox, FieldTmp::DataBoxType);
+    /* shared memory ion density device databoxes */
+    PMACC_ALIGN(cachedIonDensity, DataBox<SharedBox<ValueTypeIonDensity, typename BlockArea::FullSuperCellSize, 0> >);
+
+    PMACC_ALIGN(scaledSpectrumFunctor, ScaledSpectrum::LookupTableFunctor);
+    PMACC_ALIGN(stoppingPowerFunctor, ScaledSpectrum::LookupTableFunctor);
+    PMACC_ALIGN(getPhotonAngleFunctor, GetPhotonAngle::GetPhotonAngleFunctor);
+
+    PMACC_ALIGN(photonMom, float3_X);
+
+    /* random number generator */
+    typedef PMacc::random::RNGProvider<simDim, PMacc::random::methods::XorMin> RNGFactory;
+    typedef PMacc::random::distributions::Uniform<float> Distribution;
+    typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
+    RandomGen randomGen;
+
+public:
+    /* host constructor initializing member */
+    Bremsstrahlung(
+        const ScaledSpectrum::LookupTableFunctor& scaledSpectrumFunctor,
+        const ScaledSpectrum::LookupTableFunctor& stoppingPowerFunctor,
+        const GetPhotonAngle::GetPhotonAngleFunctor& getPhotonAngleFunctor,
+        const uint32_t currentStep);
+
+    /** Initialization function on device
+     *
+     * \brief Cache ion density field on device
+     *         and initialize possible prerequisites, like e.g. random number generator.
+     *
+     * This function will be called inline on the device which must happen BEFORE threads diverge
+     * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+     * initializing the ion density field in shared memory.
+     */
+    DINLINE void init(const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& localCellOffset);
+
+    /** Rotates a vector to a given polar angle and a random azimuthal angle.
+     *
+     * @param vec vector to be rotated
+     * @param theta polar angle
+     * @return rotated vector
+     */
+    DINLINE float3_X scatterByTheta(const float3_X vec, const float_X theta);
+
+    /** Return the number of target particles to be created from each source particle.
+     *
+     * Called for each frame of the source species.
+     *
+     * @param sourceFrame Frame of the source species
+     * @param localIdx Index of the source particle within frame
+     * @return number of particle to be created from each source particle
+     */
+    DINLINE unsigned int numNewParticles(FrameType& sourceFrame, int localIdx);
+
+    /** Functor implementation.
+     *
+     * Called once for each single particle creation.
+     *
+     * \tparam Electron type of electron which creates the photon
+     * \tparam Photon type of photon that is created
+     */
+    template<typename Electron, typename Photon>
+    DINLINE void operator()(Electron& electron, Photon& photon);
+};
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/Density.hpp"
+#include "algorithms/Gamma.hpp"
+#include "algorithms/math/defines/sqrt.hpp"
+#include "algorithms/math/defines/dot.hpp"
+#include "algorithms/math/defines/cross.hpp"
+#include "traits/frame/GetMass.hpp"
+#include "traits/frame/GetCharge.hpp"
+#include "particles/operations/Assign.hpp"
+#include "particles/operations/Deselect.hpp"
+#include "particles/traits/GetAtomicNumbers.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
+Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::Bremsstrahlung(
+    const ScaledSpectrum::LookupTableFunctor& scaledSpectrumFunctor,
+    const ScaledSpectrum::LookupTableFunctor& stoppingPowerFunctor,
+    const GetPhotonAngle::GetPhotonAngleFunctor& getPhotonAngleFunctor,
+    const uint32_t currentStep)
+        : scaledSpectrumFunctor(scaledSpectrumFunctor),
+          stoppingPowerFunctor(stoppingPowerFunctor),
+          getPhotonAngleFunctor(getPhotonAngleFunctor),
+          photonMom(float3_X::create(0)),
+          randomGen(RNGFactory::createRandom<Distribution>())
+{
+    DataConnector &dc = Environment<>::get().DataConnector();
+
+    /* initialize pointers on host-side tmp-field databoxes */
+    FieldTmp* fieldIonDensity = &(dc.getData<FieldTmp > (FieldTmp::getUniqueId( 0 ), true));
+    /* reset values to zero */
+    fieldIonDensity->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
+
+    /* load species without copying the particle data to the host */
+    T_IonSpecies* ionSpecies = &(dc.getData<T_IonSpecies >(T_IonSpecies::FrameType::getName(), true));
+
+    /* compute ion density */
+    typedef typename CreateEnergyDensityOperation<T_IonSpecies>::type::Solver DensitySolver;
+    fieldIonDensity->computeValue < CORE + BORDER, DensitySolver > (*ionSpecies, currentStep);
+    dc.releaseData(T_IonSpecies::FrameType::getName());
+
+    /* initialize device-side tmp-field databoxes */
+    this->ionDensityBox = fieldIonDensity->getDeviceDataBox();
+}
+
+template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
+DINLINE
+void Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::init
+    (const DataSpace<simDim>& blockCell, const int& linearThreadIdx, const DataSpace<simDim>& localCellOffset)
+{
+    /* caching of ion density field */
+    cachedIonDensity = CachedBox::create < 0, ValueTypeIonDensity > (BlockArea());
+
+    /* instance of nvidia assignment operator */
+    nvidia::functors::Assign assign;
+    /* copy fields from global to shared */
+    const auto fieldIonDensityBlock = ionDensityBox.shift(blockCell);
+    ThreadCollective<BlockArea> collective(linearThreadIdx);
+    collective(
+              assign,
+              cachedIonDensity,
+              fieldIonDensityBlock
+              );
+
+    /* wait for shared memory to be initialized */
+    __syncthreads();
+
+    /* initialize random number generator with the local cell index in the simulation */
+    this->randomGen.init(localCellOffset);
+}
+
+
+template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
+DINLINE
+float3_X Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::scatterByTheta
+    (const float3_X vec, const float_X theta)
+{
+    using namespace PMacc::algorithms;
+
+    float_X sinTheta, cosTheta;
+    math::sincos(theta, sinTheta, cosTheta);
+
+    const float_X phi = -float_X(M_PI) + float_X(2.0) * float_X(M_PI) * this->randomGen();
+    float_X sinPhi, cosPhi;
+    math::sincos(phi, sinPhi, cosPhi);
+
+    const float3_X vecUp(0.0, 0.0, 1.0);
+    float3_X vecOrtho1 = math::cross(vecUp, vec);
+    const float_X vecOrtho1Abs = math::abs(vecOrtho1);
+
+    float3_X vecOrtho1_norm;
+    if(vecOrtho1Abs == float_X(0.0))
+        vecOrtho1_norm = float3_X(1.0, 0.0, 0.0);
+    else
+        vecOrtho1_norm = vecOrtho1 / vecOrtho1Abs;
+    const float3_X vecOrtho2 = math::cross(vecOrtho1_norm, vec);
+    vecOrtho1 = vecOrtho1_norm * math::abs(vec);
+
+    return vec * cosTheta +
+           vecOrtho1 * (sinTheta * cosPhi) +
+           vecOrtho2 * (sinTheta * sinPhi);
+}
+
+template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
+DINLINE
+unsigned int Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::numNewParticles(FrameType& sourceFrame, int localIdx)
+{
+    using namespace PMacc::algorithms;
+
+    auto particle = sourceFrame[localIdx];
+
+    /* particle position, used for field-to-particle interpolation */
+    const floatD_X pos = particle[position_];
+    const int particleCellIdx = particle[localCellIdx_];
+    /* multi-dim coordinate of the local cell inside the super cell */
+    const DataSpace<TVec::dim> localCell(DataSpaceOperations<TVec::dim>::template map<TVec > (particleCellIdx));
+    /* interpolation of fieldTmp */
+    const fieldSolver::numericalCellType::traits::FieldPosition<FieldTmp, simDim> fieldTmpPos;
+    const ValueTypeIonDensity ionDensity_norm = Field2ParticleInterpolation()
+        (cachedIonDensity.shift(localCell).toCursor(), pos, fieldTmpPos());
+
+    /* TODO: obtain the ion density from the molare ion density in order to avoid the rescaling.
+     * So this should be: ionDensity = ionMolDensity / UNIT_AMOUNT_SUBSTANCE */
+    const float_X ionDensity = ionDensity_norm.x() * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+
+    const float_X weighting = particle[weighting_];
+
+    const float_X c = SPEED_OF_LIGHT;
+    float3_X mom = particle[momentum_] / weighting;
+    const float_X momAbs = math::abs(mom);
+    float3_X mom_norm = mom / momAbs;
+
+    const float_X mass = frame::getMass<FrameType>();
+    const float_X Ekin = (Gamma<>()(mom, mass) - float_X(1.0)) * mass * c*c;
+    if(Ekin < electron::MIN_ENERGY)
+        return 0;
+
+    /* electron deflection due to Rutherford scattering without modifying the electron
+       energy based on radiation emission */
+    const float_X zMin = float_X(1.0) / (float_X(M_PI)*float_X(M_PI));
+    const float_X zMax = float_X(1.0) / (electron::MIN_THETA*electron::MIN_THETA);
+    const float_X z = zMin + this->randomGen() * (zMax - zMin);
+    const float_X theta = math::rsqrt(z);
+    const float_X targetZ = GetAtomicNumbers<T_IonSpecies>::type::numberOfProtons;
+    const float_X rutherfordCoeff = float_X(2.0) * ELECTRON_CHARGE*ELECTRON_CHARGE / (float_X(4.0) * float_X(M_PI) * EPS0) * targetZ / Ekin;
+    const float_X scaledDeflectionDCS = float_X(M_PI) * (zMax - zMin) * rutherfordCoeff*rutherfordCoeff;
+    const float_X deflectionProb = ionDensity * c * DELTA_T * scaledDeflectionDCS;
+
+    if(this->randomGen() < deflectionProb)
+    {
+        mom = this->scatterByTheta(mom, theta);
+        mom_norm = mom / momAbs;
+    }
+
+    /* non-radiative Bremsstrahlung */
+    const float_X kappaCutoff = math::min(photon::SOFT_PHOTONS_CUTOFF / Ekin, float_X(1.0));
+    const float_X stoppingPower = ionDensity * c * this->stoppingPowerFunctor(Ekin, kappaCutoff);
+    const float_X newEkin = math::max(Ekin - stoppingPower * DELTA_T, float_X(0.0));
+    const float_X newEkin_norm = newEkin / (mass * c*c);
+    /* This is based on: (p / mc)^2 = (E_kin / mc^2)^2 + 2 * (E_kin / mc^2) */
+    const float_X newMomAbs = mass * c * math::sqrt(newEkin_norm*newEkin_norm + float_X(2.0) * newEkin_norm);
+    const float_X deltaMom = newMomAbs - momAbs;
+    particle[momentum_] = (mom + deltaMom * mom_norm) * weighting;
+
+    /* photon emission */
+    const float_X delta = this->randomGen();
+    const float_X kappa = math::pow(kappaCutoff, delta);
+    const float_X scalingFactor = -math::log(kappaCutoff);
+    const float_X emissionProb = photon::WEIGHTING_RATIO * scalingFactor * ionDensity * c * DELTA_T * this->scaledSpectrumFunctor(Ekin, kappa);
+
+    // raise a warning if the emission probability is too high.
+    if(picLog::log_level & picLog::CRITICAL::lvl)
+    {
+        if(emissionProb > float_X(photon::SINGLE_EMISSION_PROB_LIMIT))
+        {
+            const float_X Ekin_SI = Ekin * UNIT_ENERGY;
+            printf("[Bremsstrahlung] warning: emission probability is too high: \
+                    p = %g, at Ekin = %g keV, kappa = %g, ion density = %g m^-3\n",
+                    emissionProb,
+                    Ekin_SI * UNITCONV_Joule_to_keV,
+                    kappa,
+                    ionDensity / (UNIT_LENGTH*UNIT_LENGTH*UNIT_LENGTH));
+        }
+    }
+
+    if(this->randomGen() < emissionProb)
+    {
+        const float_X photonEnergy = kappa * Ekin;
+        this->photonMom = mom_norm * weighting / photon::WEIGHTING_RATIO * photonEnergy / c;
+        return 1;
+    }
+
+    return 0;
+}
+
+
+template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
+template<typename Electron, typename Photon>
+DINLINE
+void Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::operator()
+    (Electron& electron, Photon& photon)
+{
+    auto destPhoton =
+        PMacc::particles::operations::deselect<
+            boost::mpl::vector<
+                multiMask,
+                momentum,
+                weighting
+            >
+        >(photon);
+
+    namespace parOp = PMacc::particles::operations;
+    parOp::assign( destPhoton, parOp::deselect<particleId>(electron) );
+
+    const float3_X elMom = electron[momentum_];
+    const float_X weighting = electron[weighting_] / photon::WEIGHTING_RATIO;
+    electron[momentum_] = elMom - this->photonMom; // ultra relativistic limit in terms of energy
+
+    /* photon emission angle */
+    const float_X mass = frame::getMass<FrameType>();
+    const float_X gamma = Gamma<>()(elMom / weighting, mass);
+
+    const float_X theta = this->getPhotonAngleFunctor(this->randomGen(), gamma);
+
+    const float3_X scatteredPhotonMom = this->scatterByTheta(this->photonMom, theta);
+
+    photon[multiMask_] = 1;
+    photon[momentum_] = scatteredPhotonMom;
+    photon[weighting_] = weighting;
+}
+
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cuSTL/container/HostBuffer.hpp"
+#include "cuSTL/cursor/Cursor.hpp"
+#include "cuSTL/cursor/navigator/PlusNavigator.hpp"
+#include "cuSTL/cursor/tools/LinearInterp.hpp"
+#include "cuSTL/cursor/BufferCursor.hpp"
+#include "algorithms/math.hpp"
+#include <boost/array.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/numeric/odeint/integrate/integrate.hpp>
+#include <boost/math/tools/minima.hpp>
+#include <limits>
+#include <utility>
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+namespace detail
+{
+
+/** Functor mapping `delta` to the photon emission polar angle `theta`,
+ * where delta is a uniformly distributed random number between zero and one.
+ */
+struct GetPhotonAngleFunctor
+{
+    typedef typename ::PMacc::result_of::Functor<
+        ::PMacc::cursor::tools::LinearInterp<float_X>,
+        ::PMacc::cursor::BufferCursor<float_X, DIM2> >::type LinInterpCursor;
+
+    typedef float_X type;
+
+    LinInterpCursor linInterpCursor;
+    float_X lnMinGamma;
+    float_X lnMaxGamma;
+
+    /** constructor
+     *
+     * @param linInterpCursor lookup table for the photon emission angle.
+     */
+    HDINLINE GetPhotonAngleFunctor(LinInterpCursor linInterpCursor)
+        : linInterpCursor(linInterpCursor)
+    {
+        this->lnMinGamma = math::log(photon::MIN_GAMMA);
+        this->lnMaxGamma = math::log(photon::MAX_GAMMA);
+    }
+
+    /** Return the polar emission angle of the photon.
+     *
+     * @param delta uniformly distributed random number between zero and one.
+     * @param gamma relativistic factor of the incident electron.
+     */
+    HDINLINE float_X operator()(const float_X delta, const float_X gamma) const
+    {
+        const float_X deltaLookupPos = delta * static_cast<float_64>(photon::NUM_SAMPLES_DELTA - 1);
+
+        const float_X lnGamma = algorithms::math::log(gamma);
+        const float_X gammaLookupPos =
+            (lnGamma - this->lnMinGamma) /
+            (this->lnMaxGamma - this->lnMinGamma) *
+            static_cast<float_X>(photon::NUM_SAMPLES_GAMMA - 1);
+
+        if (picLog::log_level & picLog::CRITICAL::lvl)
+        {
+            if(gamma > photon::MAX_GAMMA)
+            {
+                printf("[Bremsstrahlung] error lookup table: gamma = %g is out of range.\n",
+                       gamma);
+            }
+        }
+
+        return this->linInterpCursor[float2_X(deltaLookupPos, gammaLookupPos)];
+    }
+};
+
+} // namespace detail
+
+/** Creates and holds the lookup table for the photon emission angle.
+ */
+struct GetPhotonAngle
+{
+    typedef detail::GetPhotonAngleFunctor GetPhotonAngleFunctor;
+
+private:
+
+    typedef boost::shared_ptr<PMacc::container::DeviceBuffer<float_X, DIM2> > MyBuf;
+    MyBuf dBufTheta;
+
+    /** probability density at polar angle theta.
+     * It's the ultrarelativistic limit of the dipole radiation formula, see e.g. Jackson, chap. 15.2
+     */
+    struct Probability
+    {
+        const float_64 gamma2;
+        Probability(const float_64 gamma) : gamma2(gamma*gamma) {}
+
+        template<typename T_State>
+        void operator()(const T_State &p, T_State &dpdtheta, const float_64 theta) const
+        {
+            const float_64 theta2 = theta*theta;
+            const float_64 denom = float_64(1.0) + gamma2 * theta2;
+
+            dpdtheta[0] = float_64(3.0) * theta * gamma2 * (float_64(1.0) + gamma2*gamma2 * theta2*theta2) /
+                          (denom*denom*denom*denom);
+        }
+    };
+
+    /** Return the absolute deviation of a delta, computed from a given theta, and a reference delta.
+     *
+     * Delta is the angular emission probability (normalized to one) integrated from zero to theta,
+     * where theta is the angle between the photon momentum and the final electron momentum.
+     */
+    struct AimForDelta
+    {
+        const float_64 targetDelta;
+        const float_64 gamma;
+
+        /** constructor
+         *
+         * @param targetDelta reference delta
+         * @param gamma relativistic factor
+         */
+        AimForDelta(const float_64 targetDelta, const float_64 gamma) :
+            targetDelta(targetDelta), gamma(gamma) {}
+
+        float_64 delta(const float_64 theta, const float_64 gamma) const
+        {
+            namespace odeint = boost::numeric::odeint;
+
+            typedef boost::array<float_64, 1> state_type;
+
+            state_type integral_result = {0.0};
+            const float_64 lowerLimit = 0.0;
+            const float_64 upperLimit = theta;
+            const float_64 stepwidth = (upperLimit - lowerLimit) / float_64(1000.0);
+            Probability integrand(gamma);
+            odeint::integrate(integrand, integral_result, lowerLimit, upperLimit, stepwidth);
+
+            return integral_result[0];
+        }
+
+        float_64 operator()(const float_64 theta) const
+        {
+            return math::abs(this->delta(theta, this->gamma) - this->targetDelta);
+        }
+    };
+
+    /** Return the maximal theta which corresponds to the maximal delta and a given gamma
+     *
+     * @param gamma relativistic factor
+     */
+    float_64 maxTheta(const float_64 gamma) const
+    {
+        AimForDelta aimForDelta(photon::MAX_DELTA, gamma);
+
+        std::pair<float_64, float_64> minimum;
+
+        minimum = boost::math::tools::brent_find_minima(
+            aimForDelta,
+            0.0,
+            M_PI,
+            std::numeric_limits<float_64>::digits);
+
+        return minimum.first;
+    }
+
+    /** computes the polar emission angle theta.
+     *
+     * @param delta uniformly distributed random number within [0, 1] or (0, 1)
+     * @param gamma relativistic factor
+     * @param maxTheta maximal theta
+     */
+    float_64 theta(const float_64 delta, const float_64 gamma, const float_64 maxTheta) const
+    {
+        AimForDelta aimForDelta(delta, gamma);
+        const float_64 minTheta = 0.0;
+        std::pair<float_64, float_64> minimum;
+
+        minimum = boost::math::tools::brent_find_minima(
+            aimForDelta,
+            minTheta,
+            maxTheta,
+            std::numeric_limits<float_64>::digits);
+
+        return minimum.first;
+    }
+
+public:
+
+    /** Generate lookup table
+     */
+    void init()
+    {
+        // there is a margin of one cell to make the linear interpolation valid for border cells.
+        this->dBufTheta = MyBuf(new PMacc::container::DeviceBuffer<float_X, DIM2>(
+            photon::NUM_SAMPLES_DELTA + 1,
+            photon::NUM_SAMPLES_GAMMA + 1));
+
+        PMacc::container::HostBuffer<float_X, DIM2> hBufTheta(this->dBufTheta->size());
+        hBufTheta.assign(float_X(0.0));
+        auto curTheta = hBufTheta.origin();
+
+        const float_64 lnMinGamma = math::log(photon::MIN_GAMMA);
+        const float_64 lnMaxGamma = math::log(photon::MAX_GAMMA);
+
+        for(uint32_t gammaIdx = 0; gammaIdx < photon::NUM_SAMPLES_GAMMA; gammaIdx++)
+        {
+            const float_64 lnGamma_norm = static_cast<float_64>(gammaIdx) /
+                                          static_cast<float_64>(photon::NUM_SAMPLES_GAMMA - 1);
+            const float_64 gamma = math::exp(lnMinGamma + (lnMaxGamma - lnMinGamma) * lnGamma_norm);
+            const float_64 maxTheta = this->maxTheta(gamma);
+
+            for(uint32_t deltaIdx = 0; deltaIdx < photon::NUM_SAMPLES_DELTA; deltaIdx++)
+            {
+                const float_64 delta = photon::MAX_DELTA * static_cast<float_64>(deltaIdx) /
+                                       static_cast<float_64>(photon::NUM_SAMPLES_DELTA - 1);
+
+                *curTheta(deltaIdx, gammaIdx) = static_cast<float_X>(this->theta(delta, gamma, maxTheta));
+            }
+        }
+
+        *this->dBufTheta = hBufTheta;
+    }
+
+    /** Return a functor mapping `delta` to the photon emission polar angle `theta`,
+     * where delta is a uniformly distributed random number within [0, 1] or (0, 1)
+     */
+    GetPhotonAngleFunctor getPhotonAngleFunctor() const
+    {
+        GetPhotonAngleFunctor::LinInterpCursor linInterpCursor =
+            PMacc::cursor::tools::LinearInterp<float_X>()(this->dBufTheta->origin());
+
+        return GetPhotonAngleFunctor(linInterpCursor);
+    }
+};
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/traits/GetAtomicNumbers.hpp"
+
+#include "cuSTL/cursor/Cursor.hpp"
+#include "cuSTL/cursor/navigator/PlusNavigator.hpp"
+#include "cuSTL/cursor/tools/LinearInterp.hpp"
+#include "cuSTL/cursor/BufferCursor.hpp"
+#include "algorithms/math.hpp"
+#include <boost/array.hpp>
+#include <boost/numeric/odeint/integrate/integrate.hpp>
+#include <boost/shared_ptr.hpp>
+#include <limits>
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+namespace detail
+{
+
+/** Functor for the scaled differential cross section (dcs) which
+ * equals to the electron energy loss times the cross section per unit energy.
+ */
+struct LookupTableFunctor
+{
+    typedef typename ::PMacc::result_of::Functor<
+        ::PMacc::cursor::tools::LinearInterp<float_X>,
+        ::PMacc::cursor::BufferCursor<float_X, DIM2> >::type LinInterpCursor;
+
+    typedef float_X type;
+
+    LinInterpCursor linInterpCursor;
+    float_X lnEMin;
+    float_X lnEMax;
+
+    /** constructor
+     *
+     * @param linInterpCursor
+     */
+    HDINLINE LookupTableFunctor(LinInterpCursor linInterpCursor);
+    /** scaled differential cross section
+     *
+     * @param Ekin kinectic energy of the incident electron
+     * @param kappa energy loss normalized to Ekin
+     */
+    HDINLINE float_X operator()(const float_X Ekin, const float_X kappa) const;
+};
+
+} // namespace detail
+
+
+/** Generates and holds the lookup tables for the scaled differential cross section
+ * and the stopping power.
+ *
+ * scaled differential cross section = electron energy loss times cross section per unit energy
+ *
+ * stopping power = energy loss per unit length
+ *
+ * The lookup tables are generated from the screened Bethe-Heitler cross section. See e.g.:
+ * Salvat, F., et al. "Monte Carlo simulation of bremsstrahlung emission by electrons."
+ * Radiation Physics and Chemistry 75.10 (2006): 1201-1219.
+ */
+struct ScaledSpectrum
+{
+public:
+    typedef detail::LookupTableFunctor LookupTableFunctor;
+private:
+
+    typedef boost::shared_ptr<PMacc::container::DeviceBuffer<float_X, DIM2> > MyBuf;
+    MyBuf dBufScaledSpectrum;
+    MyBuf dBufStoppingPower;
+
+    /** differential cross section: cross section per unit energy
+     *
+     * This is the screened Bethe-Heitler cross section. See e.g.:
+     * Salvat, F., et al. "Monte Carlo simulation of bremsstrahlung emission by electrons."
+     * Radiation Physics and Chemistry 75.10 (2006): 1201-1219.
+     *
+     * @param Ekin kinetic electron energy
+     * @param kappa energy loss normalized to Ekin
+     * @param targetZ atomic number of the target material
+     */
+    float_64 dcs(const float_64 Ekin, const float_64 kappa, const float_64 targetZ) const;
+
+    /** differential cross section times energy loss
+     */
+    struct StoppingPowerIntegrand
+    {
+        const float_64 Ekin;
+        const float_64 targetZ;
+        const ScaledSpectrum& scaledSpectrum;
+
+        StoppingPowerIntegrand(const float_64 Ekin, const ScaledSpectrum& scaledSpectrum, const float_64 targetZ) :
+            Ekin(Ekin), scaledSpectrum(scaledSpectrum), targetZ(targetZ) {}
+
+        template<typename T_State, typename T_W>
+        void operator()(const T_State &x, T_State &dxdW, T_W W) const
+        {
+            dxdW[0] = this->scaledSpectrum.dcs(this->Ekin, W / this->Ekin, this->targetZ) * W;
+        }
+    };
+
+public:
+
+    /** Generate lookup tables
+     *
+     * @param targetZ atomic number of the target material
+     */
+    void init(const float_64 targetZ);
+
+    /** Return a functor representing the scaled differential cross section
+     *
+     * scaled differential cross section = electron energy loss times cross section per unit energy
+     */
+    LookupTableFunctor getScaledSpectrumFunctor() const;
+
+    /** Return a functor representing the stopping power
+     *
+     * stopping power = energy loss per unit length
+     */
+    LookupTableFunctor getStoppingPowerFunctor() const;
+};
+
+
+/** Creates a `ScaledSpectrum` instance for a given electron species
+ * and stores it in a map<atomic number, ScaledSpectrum> object.
+ *
+ * This functor is called from MySimulation::init() to generate lookup tables.
+ */
+template<typename T_ElectronSpecies>
+struct FillScaledSpectrumMap
+{
+    typedef T_ElectronSpecies ElectronSpecies;
+
+    typedef typename PMacc::particles::traits::ResolveAliasFromSpecies<
+        ElectronSpecies,
+        bremsstrahlungIons<>
+    >::type IonSpecies;
+
+
+    template<typename T_Map>
+    void operator()(T_Map& map) const
+    {
+        const float_X targetZ = GetAtomicNumbers<IonSpecies>::type::numberOfProtons;
+
+        if(map.count(targetZ) == 0)
+        {
+            ScaledSpectrum scaledSpectrum;
+            scaledSpectrum.init(static_cast<float_64>(targetZ));
+            map[targetZ] = scaledSpectrum;
+        }
+    }
+};
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -1,0 +1,222 @@
+/**
+ * Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cuSTL/container/HostBuffer.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+namespace detail
+{
+
+
+/** constructor
+ *
+ * @param linInterpCursor
+ */
+HDINLINE LookupTableFunctor::LookupTableFunctor(LinInterpCursor linInterpCursor)
+    : linInterpCursor(linInterpCursor)
+{
+    this->lnEMin = math::log(electron::MIN_ENERGY);
+    this->lnEMax = math::log(electron::MAX_ENERGY);
+}
+
+/** scaled differential cross section
+ *
+ * @param Ekin kinectic energy of the incident electron
+ * @param kappa energy loss normalized to Ekin
+ */
+HDINLINE float_X LookupTableFunctor::operator()(const float_X Ekin, const float_X kappa) const
+{
+    const float_X lnE = math::log(Ekin);
+
+    const float_X binE = (lnE - this->lnEMin) / (this->lnEMax - this->lnEMin) * static_cast<float_X>(electron::NUM_SAMPLES_EKIN - 1);
+    // in the low-energy limit Bremsstrahlung is not taken into account
+    if(binE < float_X(0.0))
+        return float_X(0.0);
+    const float_X binKappa = kappa * static_cast<float_X>(electron::NUM_SAMPLES_KAPPA - 1);
+
+    if (picLog::log_level & picLog::CRITICAL::lvl)
+    {
+        if(Ekin < electron::MIN_ENERGY || Ekin > electron::MAX_ENERGY)
+        {
+            const float_64 Ekin_SI = Ekin * UNIT_ENERGY;
+            printf("[Bremsstrahlung] error lookup table: Ekin=%g MeV is out of range.\n",
+                   float_X(Ekin_SI * UNITCONV_Joule_to_keV * float_X(1.0e-3)));
+        }
+        if(kappa < float_X(0.0) || kappa > float_X(1.0))
+            printf("[Bremsstrahlung] error lookup table: kappa=%f is out of range.\n",
+                   kappa);
+    }
+
+    return this->linInterpCursor[float2_X(binE, binKappa)];
+}
+
+
+} // namespace detail
+
+
+
+/** differential cross section: cross section per unit energy
+ *
+ * This is the screened Bethe-Heitler cross section. See e.g.:
+ * Salvat, F., et al. "Monte Carlo simulation of bremsstrahlung emission by electrons."
+ * Radiation Physics and Chemistry 75.10 (2006): 1201-1219.
+ *
+ * @param Ekin kinetic electron energy
+ * @param kappa energy loss normalized to Ekin
+ */
+float_64 ScaledSpectrum::dcs(const float_64 Ekin, const float_64 kappa, const float_64 targetZ) const
+{
+    const float_64 bohrRadius = float_64(4.0) * M_PI * EPS0 * HBAR*HBAR / (ELECTRON_MASS * ELECTRON_CHARGE*ELECTRON_CHARGE);
+    const float_64 classicalElRadius = ELECTRON_CHARGE*ELECTRON_CHARGE / (float_64(4.0) * M_PI * EPS0 * ELECTRON_MASS * SPEED_OF_LIGHT*SPEED_OF_LIGHT);
+    const float_64 fineStructureConstant = ELECTRON_CHARGE*ELECTRON_CHARGE / (float_64(4.0) * M_PI * EPS0 * HBAR * SPEED_OF_LIGHT);
+
+    const float_64 c = SPEED_OF_LIGHT;
+    const float_64 c2 = c*c;
+    const float_64 m_e = ELECTRON_MASS;
+    const float_64 r_e = classicalElRadius;
+    const float_64 alpha = fineStructureConstant;
+
+    const float_64 W = kappa * Ekin;
+    const float_64 eps = W / (Ekin + m_e * c2);
+    const float_64 R = math::pow(targetZ, float_64(-1.0) / float_64(3.0)) * bohrRadius;
+    const float_64 gamma = Ekin / (m_e * c2) + float_64(1.0);
+    const float_64 b = R * m_e * c / HBAR / (float_64(2.0) * gamma) * eps / (float_64(1.0) - eps);
+
+    const float_64 phi_1 = float_64(4.0) * math::log(R * m_e * c / HBAR) + float_64(2.0) - float_64(2.0) * math::log(float_64(1.0) + b*b)
+        - float_64(4.0) * b * math::atan(float_64(1.0) / b);
+    const float_64 phi_2 = float_64(4.0) * math::log(R * m_e * c / HBAR) + float_64(7.0) / float_64(3.0) - float_64(2.0) * math::log(float_64(1.0) + b*b)
+        - float_64(6.0) * b * math::atan(float_64(1.0) / b)
+        - b*b * (float_64(4.0) - float_64(4.0) * b * math::atan(float_64(1.0) / b) - float_64(3.0) * math::log(float_64(1.0) + float_64(1.0) / (b*b)));
+
+    return r_e*r_e * alpha * targetZ*targetZ / W * (eps*eps * phi_1 + float_64(4.0) / float_64(3.0) * (float_64(1.0) - eps) * phi_2);
+}
+
+
+
+void ScaledSpectrum::init(const float_64 targetZ)
+{
+    namespace odeint = boost::numeric::odeint;
+
+    // there is a margin of one cell to make the linear interpolation valid for border cells.
+    this->dBufScaledSpectrum = MyBuf(
+        new PMacc::container::DeviceBuffer<float_X, DIM2>(
+            electron::NUM_SAMPLES_EKIN + 1,
+            electron::NUM_SAMPLES_KAPPA + 1));
+    this->dBufStoppingPower = MyBuf(
+        new PMacc::container::DeviceBuffer<float_X, DIM2>(
+            electron::NUM_SAMPLES_EKIN + 1,
+            electron::NUM_SAMPLES_KAPPA + 1));
+
+    PMacc::container::HostBuffer<float_X, DIM2> hBufScaledSpectrum(this->dBufScaledSpectrum->size());
+    PMacc::container::HostBuffer<float_X, DIM2> hBufStoppingPower(this->dBufStoppingPower->size());
+    hBufScaledSpectrum.assign(float_X(0.0));
+    hBufStoppingPower.assign(float_X(0.0));
+
+    auto curScaledSpectrum = hBufScaledSpectrum.origin();
+    auto curStoppingPower = hBufStoppingPower.origin();
+
+    const float_64 lnEMin = math::log(electron::MIN_ENERGY);
+    const float_64 lnEMax = math::log(electron::MAX_ENERGY);
+
+    typedef boost::array<float_64, 1> state_type;
+
+    for(uint32_t EkinIdx = 0; EkinIdx < electron::NUM_SAMPLES_EKIN; EkinIdx++)
+    {
+        for(uint32_t kappaIdx = 0; kappaIdx < electron::NUM_SAMPLES_KAPPA; kappaIdx++)
+        {
+            float_64 kappa = static_cast<float_64>(kappaIdx) /
+                             static_cast<float_64>(electron::NUM_SAMPLES_KAPPA - 1);
+            if(kappa == 0.0)
+                kappa = electron::MIN_KAPPA;
+
+            const float_64 lnE_norm = static_cast<float_64>(EkinIdx) /
+                                      static_cast<float_64>(electron::NUM_SAMPLES_EKIN - 1);
+            const float_64 Ekin = math::exp(lnEMin + (lnEMax - lnEMin) * lnE_norm);
+
+            *curScaledSpectrum(EkinIdx, kappaIdx) = Ekin * kappa * static_cast<float_X>(this->dcs(Ekin, kappa, targetZ));
+
+            state_type integral_result = {0.0};
+            const float_64 lowerLimit = electron::MIN_KAPPA * Ekin;
+            const float_64 upperLimit = kappa * Ekin;
+            const float_64 stepwidth = upperLimit / electron::NUM_STEPS_STOPPING_POWER_INTERGRAL;
+            StoppingPowerIntegrand integrand(Ekin, *this, targetZ);
+            odeint::integrate(integrand, integral_result, lowerLimit, upperLimit, stepwidth);
+            *curStoppingPower(EkinIdx, kappaIdx) = static_cast<float_X>(integral_result[0]);
+
+            // check for nans
+            if(*curScaledSpectrum(EkinIdx, kappaIdx) != *curScaledSpectrum(EkinIdx, kappaIdx))
+            {
+                const float_64 Ekin_SI = Ekin * UNIT_ENERGY;
+                const float_64 Ekin_MeV = Ekin_SI * UNITCONV_Joule_to_keV / 1.0e3;
+                std::stringstream errMsg;
+                errMsg << "[Bremsstrahlung] lookup table (scaled spectrum) has NaN-entry at Ekin = "
+                       << Ekin_MeV << " MeV, kappa = " << kappa << std::endl;
+                throw std::runtime_error(errMsg.str().c_str());
+            }
+            if(*curStoppingPower(EkinIdx, kappaIdx) != *curStoppingPower(EkinIdx, kappaIdx))
+            {
+                const float_64 Ekin_SI = Ekin * UNIT_ENERGY;
+                const float_64 Ekin_MeV = Ekin_SI * UNITCONV_Joule_to_keV / 1.0e3;
+                std::stringstream errMsg;
+                errMsg << "[Bremsstrahlung] lookup table (stopping power) has NaN-entry at Ekin = "
+                       << Ekin_MeV << " MeV, kappa = " << kappa << std::endl;
+                throw std::runtime_error(errMsg.str().c_str());
+            }
+        }
+    }
+
+    *this->dBufScaledSpectrum = hBufScaledSpectrum;
+    *this->dBufStoppingPower = hBufStoppingPower;
+}
+
+/** Return a functor representing the scaled differential cross section
+ *
+ * scaled differential cross section = electron energy loss times cross section per unit energy
+ */
+detail::LookupTableFunctor ScaledSpectrum::getScaledSpectrumFunctor() const
+{
+    LookupTableFunctor::LinInterpCursor linInterpCursor =
+        PMacc::cursor::tools::LinearInterp<float_X>()(this->dBufScaledSpectrum->origin());
+
+    return LookupTableFunctor(linInterpCursor);
+}
+
+/** Return a functor representing the stopping power
+ *
+ * stopping power = energy loss per unit length
+ */
+detail::LookupTableFunctor ScaledSpectrum::getStoppingPowerFunctor() const
+{
+    LookupTableFunctor::LinInterpCursor linInterpCursor =
+        PMacc::cursor::tools::LinearInterp<float_X>()(this->dBufStoppingPower->origin());
+
+    return LookupTableFunctor(linInterpCursor);
+}
+
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/_defaultParam.loader
+++ b/src/picongpu/include/simulation_defines/_defaultParam.loader
@@ -40,6 +40,7 @@
 #include "simulation_defines/param/gasConfig.param"
 #include "simulation_defines/param/particleConfig.param"
 #include "simulation_defines/param/synchrotronPhotons.param"
+#include "simulation_defines/param/bremsstrahlung.param"
 #include "simulation_defines/param/species.param"
 #include "simulation_defines/param/speciesDefinition.param"
 #include "simulation_defines/param/speciesInitialization.param"

--- a/src/picongpu/include/simulation_defines/_defaultUnitless.loader
+++ b/src/picongpu/include/simulation_defines/_defaultUnitless.loader
@@ -44,3 +44,4 @@
 #include "simulation_defines/unitless/fileOutput.unitless"
 #include "simulation_defines/unitless/checkpoints.unitless"
 #include "simulation_defines/unitless/synchrotronPhotons.unitless"
+#include "simulation_defines/unitless/bremsstrahlung.unitless"

--- a/src/picongpu/include/simulation_defines/param/bremsstrahlung.param
+++ b/src/picongpu/include/simulation_defines/param/bremsstrahlung.param
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+/** params related to the energy loss and deflection of the incident electron
+ */
+namespace electron
+{
+    /** Minimal kinectic electron energy in MeV for the lookup table.
+     * For electrons below this value Bremsstrahlung is not taken into account.
+     */
+    constexpr float_64 MIN_ENERGY_MeV = 0.5;
+
+    /** Maximal kinetic electron energy in MeV for the lookup table.
+     * Electrons above this value cause a out-of-bounds access at the
+     * lookup table. Bounds checking is enabled for "CRITICAL" log level.
+     */
+    constexpr float_64 MAX_ENERGY_MeV = 200.0;
+
+    /** Minimal polar deflection angle due to screening. See Jackson 13.5 for a rule of thumb to this value. */
+    constexpr float_64 MIN_THETA = 0.01;
+
+    /** number of lookup table divisions for the kappa axis.
+     * Kappa is the energy loss normalized to the initial kinetic energy.
+     * The axis is scaled linearly.
+     */
+    constexpr uint32_t NUM_SAMPLES_KAPPA = 32;
+
+    /** number of lookup table divisions for the initial kinetic energy axis.
+     * The axis is scaled logarithmically.
+     */
+    constexpr uint32_t NUM_SAMPLES_EKIN = 32;
+
+    /** Kappa is the energy loss normalized to the initial kinetic energy.
+     * This minimal value is needed by the numerics to avoid a division by zero.
+     */
+    constexpr float_64 MIN_KAPPA = 1.0e-10;
+
+} // namespace electron
+
+/** params related to the creation and the emission angle of the photon
+ */
+namespace photon
+{
+    /** Low-energy threshold in keV of the incident electron for the creation of photons.
+     * Below this value photon emission is neglected.
+     */
+    constexpr float_64 SOFT_PHOTONS_CUTOFF_keV = 5000.0;
+
+    /** number of lookup table divisions for the delta axis.
+     * Delta is the angular emission probability (normalized to one) integrated from zero to theta,
+     * where theta is the angle between the photon momentum and the final electron momentum.
+     *
+     * The axis is scaled linearly.
+     */
+    constexpr uint32_t NUM_SAMPLES_DELTA = 256;
+
+    /** number of lookup table divisions for the gamma axis.
+     * Gamma is the relativistic factor of the incident electron.
+     *
+     * The axis is scaled logarithmically.
+     */
+    constexpr uint32_t NUM_SAMPLES_GAMMA = 64;
+
+    /** Maximal value of delta for the lookup table.
+     * Delta is the angular emission probability (normalized to one) integrated from zero to theta,
+     * where theta is the angle between the photon momentum and the final electron momentum.
+     *
+     * A value close to one is reasonable. Though exactly one was actually correct,
+     * because it would map to theta = pi (maximum polar angle), the sampling then would be bad
+     * in the ultrarelativistic case. In this regime the emission primarily takes place at small thetas.
+     * So a maximum delta close to one maps to a reasonable maximum theta.
+     */
+    constexpr float_64 MAX_DELTA = 0.95;
+
+    /** minimal gamma for the lookup table. */
+    constexpr float_64 MIN_GAMMA = 1.0;
+
+    /** maximal gamma for the lookup table.
+     * Bounds checking is enabled for "CRITICAL" log level.
+     */
+    constexpr float_64 MAX_GAMMA = 250;
+
+    /** if the emission probability per timestep is higher than this value and the log level is set to
+     *  "CRITICAL" a warning will be raised.
+     */
+    constexpr float_64 SINGLE_EMISSION_PROB_LIMIT = 0.4;
+
+    constexpr float_64 WEIGHTING_RATIO = 10;
+} // namespace photon
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -99,6 +99,12 @@ alias(ionizationEnergies);
 /*! alias for synchrotronPhotons @see speciesDefinition.param */
 alias(synchrotronPhotons)
 
+/*! alias for ion species used for bremsstrahlung */
+alias(bremsstrahlungIons);
+
+/*! alias for photon species used for bremsstrahlung */
+alias(bremsstrahlungPhotons);
+
 /*! alias for particle to field interpolation @see species.param */
 alias(interpolation);
 

--- a/src/picongpu/include/simulation_defines/unitless/bremsstrahlung.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/bremsstrahlung.unitless
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+namespace electron
+{
+
+constexpr float_64 MIN_ENERGY_SI = MIN_ENERGY_MeV * 1.0e3 * UNITCONV_keV_to_Joule;
+constexpr float_X MIN_ENERGY = MIN_ENERGY_SI / UNIT_ENERGY;
+
+constexpr float_64 MAX_ENERGY_SI = MAX_ENERGY_MeV * 1.0e3 * UNITCONV_keV_to_Joule;
+constexpr float_X MAX_ENERGY = MAX_ENERGY_SI / UNIT_ENERGY;
+
+constexpr float_X NUM_STEPS_STOPPING_POWER_INTERGRAL = 1.0e3;
+
+} // namespace electron
+
+namespace photon
+{
+
+constexpr float_64 SOFT_PHOTONS_CUTOFF_SI = SOFT_PHOTONS_CUTOFF_keV * UNITCONV_keV_to_Joule;
+constexpr float_X SOFT_PHOTONS_CUTOFF = SOFT_PHOTONS_CUTOFF_SI / UNIT_ENERGY;
+
+} // namespace photon
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
Implementation of the Bremsstrahlung effect.

Here the screened Bethe-Heitler cross section is used. See e.g.:

> Salvat, F., et al. "Monte Carlo simulation of bremsstrahlung emission by electrons."
>    Radiation Physics and Chemistry 75.10 (2006): 1201-1219.

The numerics separates the energy spectrum into two parts. In the low-energy part
photon emission is neglected and a drag force is applied to the electrons. In the high-energy part
photons are created in addition to the drag force.

Electron deflection is treated as screened Rutherford scattering, see e.g. Jackson, chap. 13.5

The photon emission angle is taken from the Lorentz-boosted dipole radiation formula,
see e.g. Jackson, chap. 15.2

**Tests**

Energy loss without photons. 100MeV electrons should loose 10% of their energy during transmission through a solid copper target.

![energy_loss_drag_force](https://cloud.githubusercontent.com/assets/5159590/16234146/e1b4f678-37d0-11e6-90e6-59cfc98cbbaa.png)

With photons:
- photon threshold is 5 MeV.

![energy_loss_photon](https://cloud.githubusercontent.com/assets/5159590/16234158/ec194eca-37d0-11e6-840c-47b31ff20d40.png)

Photon spectrum:

![photon_spectrum](https://cloud.githubusercontent.com/assets/5159590/16452255/cad5c2ec-3e07-11e6-8870-93d8a9c05f6d.png)

Photon emission angle with deactivated electron deflection and energy loss:

![photon_emission_angle](https://cloud.githubusercontent.com/assets/5159590/16234184/030cb1b2-37d1-11e6-956e-f2d1ba42f18b.png)

Electron deflection on single-scattering:
- scattering probability per target transmission is 10 %.
- minimum angle is 0.01 rad. Smaller values can be attributed to multi-scattering.
- energy loss is deactivated

![rutherford_single](https://cloud.githubusercontent.com/assets/5159590/16234207/17463aa4-37d1-11e6-870a-5e679294997b.png)

Electron deflection on multi-scattering:
- electrons are scattered 20 times on average.
- energy loss is deactivated.
- mean squared theta deviation equals 20 times mean squared theta deviation from single-scattering as expected.

![rutherford_multi](https://cloud.githubusercontent.com/assets/5159590/16234223/26b09066-37d1-11e6-9a67-6390afc2c88e.png)
