### PR TITLE
Dependency: Boost 1.57.0+

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,7 +56,7 @@ Requirements
   - *Debian/Ubuntu:* `sudo apt-get install zlib1g-dev`
   - *Arch Linux:* `sudo pacman --sync zlib`
 
-- **boost** 1.56.0+ ("program options", "regex" , "filesystem", "system", "thread", "math" and nearly all header-only libs)
+- **boost** 1.57.0+ ("program options", "regex" , "filesystem", "system", "thread", "math" and nearly all header-only libs)
   - download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.gz/download),
       e.g. version 1.57.0
   - *Debian/Ubuntu:* `sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-math-dev`
@@ -64,7 +64,6 @@ Requirements
   - *From source:*
     - `./bootstrap.sh --with-libraries=filesystem,program_options,regex,system,thread,math --prefix=$HOME/lib/boost`
     - `./b2 -j4 && ./b2 install`
-  - C++11 warning: use boost 1.57.0+
 
 - **git** 1.7.9.5 or [higher](https://help.github.com/articles/https-cloning-errors)
   - *Debian/Ubuntu:* `sudo apt-get install git`

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -93,7 +93,7 @@ touch "$thisDir"runGuard
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=sm_35"
             . /etc/profile
-            module load gcc/4.6.4 boost/1.56.0 cmake/3.1.0 cuda/6.0 openmpi/1.6.5 libSplash/1.5.0 adios/1.10.0 pngwriter/0.5.6 rivlib/1.0.0
+            module load gcc/4.6.4 boost/1.57.0 cmake/3.1.0 cuda/6.0 openmpi/1.6.5 libSplash/1.5.0 adios/1.10.0 pngwriter/0.5.6 rivlib/1.0.0
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/compile -l -q -j $cnf_numParallel \

--- a/src/libPMacc/CMakeLists.txt
+++ b/src/libPMacc/CMakeLists.txt
@@ -53,7 +53,7 @@ add_definitions(${PMacc_DEFINITIONS})
 ###############################################################################
 # Boost.Test
 ###############################################################################
-find_package(Boost 1.56.0 COMPONENTS unit_test_framework  REQUIRED)
+find_package(Boost 1.57.0 COMPONENTS unit_test_framework  REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 

--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -195,7 +195,7 @@ endif(PNGwriter_FOUND)
 ###############################################################################
 # Boost LIB
 ###############################################################################
-find_package(Boost 1.56.0 MODULE REQUIRED COMPONENTS program_options regex system)
+find_package(Boost 1.57.0 MODULE REQUIRED COMPONENTS program_options regex system)
 set(PMacc_INCLUDE_DIRS ${PMacc_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 set(PMacc_LIBRARIES ${PMacc_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -224,7 +224,7 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.56.0 REQUIRED COMPONENTS program_options regex filesystem
+find_package(Boost 1.57.0 REQUIRED COMPONENTS program_options regex filesystem
                                               system thread math_tr1)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -10,7 +10,7 @@ then
         # Core Dependencies
         module load gcc/4.8.2
         module load cmake/3.3.0
-        module load boost/1.56.0
+        module load boost/1.60.0
         module load cuda/6.5
         module load openmpi/1.8.4.kepler
 

--- a/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
+++ b/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
@@ -7,7 +7,7 @@ then
         module load gcc/4.4.7
         module load cuda/5.5
         # not yet available, build boost as in `INSTALL.md`
-        #module load boost/1.56.0-gcc
+        #module load boost/1.57.0-gcc
         module load openmpi/1.6.5-gcc
 
         # Core tools

--- a/src/picongpu/submit/taurus-tud/picongpu.profile.example
+++ b/src/picongpu/submit/taurus-tud/picongpu.profile.example
@@ -4,17 +4,17 @@ module purge
 #
 module load oscar-modules
 module load cmake/3.3.1 git
-module load cuda/7.0.28 # gcc <=4.9, intel 15.0
+module load cuda/7.5.18 # gcc <=4.9, intel 15.0
 module load bullxmpi
 module load gnuplot/4.6.1
 
 # Compilers ###################################################################
 ### GCC
-module load gcc/4.9.1 boost/1.56.0-gnu4.9.1
+module load gcc/5.1.0 boost/1.58.0-gnu5.1
 ### ICC
 #module load intel/2015.3.187 boost/1.59.0-intel2015.3.187
 ### PGI
-#export BOOST_ROOT=$HOME/lib/boost_1_56_pgi_14_9
+#export BOOST_ROOT=$HOME/lib/boost_1_57_pgi_14_9
 #export BOOST_INC=$BOOST_ROOT/include
 #export BOOST_LIB=$BOOST_ROOT/lib
 # must be set in `which <pgiDir>/bin/localrc`:
@@ -23,7 +23,7 @@ module load gcc/4.9.1 boost/1.56.0-gnu4.9.1
 
 # Other Software ##############################################################
 #
-module load hdf5/1.8.14
+module load hdf5/1.8.15-gcc-5.1.0
 module load zlib/1.2.8
 
 # Environment #################################################################


### PR DESCRIPTION
- ~~Does not need a merge before 0.2.0 release branch is opened!~~

For compatibility between C++98/11 build versions of boost and our build, we increase the dependency to boost 1.57.0+

Refs:
- https://svn.boost.org/trac/boost/ticket/6124
- https://svn.boost.org/trac/boost/ticket/6779
- https://svn.boost.org/trac/boost/ticket/10038

> # 6124, #6779, and #10038 are all the same problem.
> 
> The private library interface has been changed to use a plain-old C++03 enum.
> This is the fix suggested by Andy in 6779.
> The fix was too late for 1.57 beta 1, but should be in the final 1.57 release.
