### PR TITLE
fix `localCellIdx` in `kernelCloneParticles`

### DIFF
--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -91,7 +91,7 @@ __global__ void kernelCloneParticles(T_MyParBox myBox, T_OtherFrameBox otherBox,
         PMACC_AUTO(parSrc, frame[threadIdx.x]);
         assign(parDest, parSrc);
 
-        const DataSpace<simDim> localCellIdx = block
+        const DataSpace<simDim> localCellIdx = block * SuperCellSize::toRT()
             + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x)
             - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
         manipulateFunctor(localCellIdx,


### PR DESCRIPTION
fix wrong calculation of `localCellIdx`

This bug was introduced with #959