### PR TITLE
Rhea (ORNL): Update Post-Processing Env

### DIFF
--- a/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
+++ b/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
@@ -21,6 +21,11 @@ export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
 export PATH=$ADIOS_ROOT/bin:$PATH
 module load mxml
 
+# GNU Parallel
+export GNUP_ROOT=/lustre/atlas2/aph101/proj-shared/lib/gnu-parallel
+export PATH=$GNUP_ROOT/bin:$PATH
+export MANPATH=$GNUP_ROOT/share/man:$MANPATH
+
 # load python virtual env
 source $PROJWORK/$proj/python-venv/rhea/bin/activate
 
@@ -32,6 +37,11 @@ source $PROJWORK/$proj/python-venv/rhea/bin/activate
 #     --with-zlib --with-mpi --enable-static --enable-shared \
 #     --with-mxml=$MXML_DIR --without-dataspaces
 #   make -j
+#   make install
+#
+# if needed for post-processing, install gnu parallel (as xargs+ssh alternative)
+#   ./configure --prefix=$PROJWORK/$proj/lib/gnu-parallel
+#   make
 #   make install
 #
 # now run for setting up the python virtual environment


### PR DESCRIPTION
Adds [GNU Parallel](http://www.gnu.org/software/parallel) as an xargs + array job alternative to the Rhea post-processing environment example.

Example job script:
```bash
#!/usr/bin/env bash
#PBS -N h5ExSlice
#PBS -S /bin/bash
#PBS -q batch
#PBS -A aph101
#PBS -l walltime=48:00:00
#PBS -l nodes=10
#PBS -l gres=atlas2
#PBS -d /lustre/atlas2/myProj/proj-shared/runs/myRun/simOutput
# -m bea -M mail@example.com
#PBS -o h5_slice/h5_slice.gnup.Qsub.out
#PBS -e h5_slice/h5_slice.gnup.Qsub.err

source $PROJWORK/aph101/pythonOnRhea.profile
source $(which env_parallel.bash)

# old job scripts
rm h5_slice/h5_slice.gnup.Qsub.out.{out,err}

# all files to process
f=$(ls simData_*.bp)

# parallel processes per node
ppn=2 #16
# node list of this job
nodes=($(cat $PBS_NODEFILE | sort -u))
num_n=${#nodes[@]}

# nodes to use in GNU Parallel syntax #threads/server1,#threads/server2
nodes_gnup=$(printf ",$ppn/%s" "${nodes[@]}")
nodes_gnup=${nodes_gnup:1}

# simple concat
nodes_gnupS=$(printf ",%s" "${nodes[@]}")
nodes_gnupS=${nodes_gnupS:1}

#echo "nodes ($num_n): ${nodes[@]}"
#echo "gnup: $nodes_gnup"
#echo "gnupS: $nodes_gnupS"

# 2D field slices at center position
#   time: ~ 40'
echo "2D slices..."
date
mkdir -p h5_slice

# simply use all CPUs of each node:
#    --sshloginfile $PBS_NODEFILE
# explicitly per node:
#   --sshlogin $nodes_gnup
# or maximum -j <N> per node:
echo "${f[@]}" | env_parallel -u -j $ppn --sshlogin $nodes_gnupS --sshdelay 2 \
    'cd /lustre/atlas2/myProj/proj-shared/runs/myRun/simOutput; ' \
    'echo "$(hostname) ($(which python)): {}" &&  ./h5_slice.py ./{}'

date
```

More examples: [NASA](http://www.nas.nasa.gov/hecc/support/kb/Using-GNU-Parallel-to-Package-Multiple-Jobs-in-a-Single-PBS-Job_303.html)