### PR TITLE
Plugin: Fix ChargeConservation Checkpointing

### DIFF
--- a/src/picongpu/include/plugins/ChargeConservation.tpp
+++ b/src/picongpu/include/plugins/ChargeConservation.tpp
@@ -45,7 +45,8 @@ namespace picongpu
 
 ChargeConservation::ChargeConservation()
     : name("ChargeConservation: Print the maximum charge deviation between particles and div E to textfile 'chargeConservation.dat'"),
-      prefix("chargeConservation"), filename("chargeConservation.dat")
+      prefix("chargeConservation"), filename("chargeConservation.dat"),
+      cellDescription(NULL)
 {
     Environment<>::get().PluginConnector().registerPlugin(this);
 }
@@ -81,7 +82,11 @@ void ChargeConservation::pluginLoad()
 
 void ChargeConservation::restart(uint32_t restartStep, const std::string restartDirectory)
 {
-    if(!this->allGPU_reduce->root() || this->notifyPeriod == 0u) return;
+    if(this->notifyPeriod == 0u)
+        return;
+
+    if(!this->allGPU_reduce->root())
+        return;
 
     restoreTxtFile( this->output_file,
                     this->filename,
@@ -91,7 +96,11 @@ void ChargeConservation::restart(uint32_t restartStep, const std::string restart
 
 void ChargeConservation::checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
 {
-    if(!this->allGPU_reduce->root() || this->notifyPeriod == 0u) return;
+    if(this->notifyPeriod == 0u)
+        return;
+
+    if(!this->allGPU_reduce->root())
+        return;
 
     checkpointTxtFile( this->output_file,
                        this->filename,


### PR DESCRIPTION
Fix a segfault in the charge conservation (checker) plugin which is triggered when the plugin is disabled (default) and checkpoints are written.

ccing @Heikman 