### PR TITLE
PIC Methods: Add (openPMD) String Properties

### DIFF
--- a/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
@@ -121,6 +121,12 @@ struct AssignedTrilinearInterpolation
         }
         return result_y;
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "uniform" );
+        return propList;
+    }
 };
 
 } // picongpu

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
@@ -87,6 +87,12 @@ struct FieldToParticleInterpolation
         return result;
     }
 
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        GetStringProperties<InterpolationMethod> propList;
+        return propList;
+    }
+
 };
 
 namespace traits

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -162,6 +162,12 @@ public:
         dc.releaseData(FieldE::getName());
         dc.releaseData(FieldB::getName());
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "DS" );
+        return propList;
+    }
 };
 
 } // dirSplitting

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
@@ -23,12 +23,33 @@
 #pragma once
 
 #include "LeheSolver.def"
+#include "simulation_defines.hpp"
 
 namespace picongpu
 {
-    namespace leheSolver
+namespace leheSolver
+{
+
+} // namespace leheSolver
+} // namespace picongpu
+
+namespace PMacc
+{
+namespace traits
+{
+    template< >
+    struct StringProperties< picongpu::leheSolver::LeheSolver >
     {
-
-    } // leheSolver
-
-} // picongpu
+        static StringProperty get()
+        {
+            PMACC_AUTO(
+                propList,
+                ::picongpu::leheSolver::LeheSolver::getStringProperties()
+            );
+            // overwrite the name of the yee solver (inherit all other properties)
+            propList["name"].value = "Lehe";
+            return propList;
+        }
+    };
+} // namespace traits
+} // namespace PMacc

--- a/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.hpp
@@ -72,8 +72,14 @@ namespace picongpu
             {
 
             }
+
+            static PMacc::traits::StringProperty getStringProperties()
+            {
+                PMacc::traits::StringProperty propList( "name", "none" );
+                return propList;
+            }
         };
 
     } // namespace noSolver
 
-} // picongpu
+} // namespace picongpu

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
@@ -131,6 +131,12 @@ public:
         EventTask eRfieldB = fieldB->asyncCommunication(__getTransactionEvent());
         __setTransactionEvent(eRfieldB);
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "Yee" );
+        return propList;
+    }
 };
 
 } // yeeSolver

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -195,6 +195,12 @@ struct Esirkepov<T_ParticleShape, DIM3>
     {
         return ParticleAssign()(gridPoint - line.m_pos1[d]) - ParticleAssign()(gridPoint - line.m_pos0[d]);
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "Esirkepov" );
+        return propList;
+    }
 };
 
 } //namespace currentSolver

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -222,6 +222,12 @@ struct Esirkepov<T_ParticleShape, DIM2>
     {
         return ParticleAssign()(gridPoint - line.m_pos1[d]) - ParticleAssign()(gridPoint - line.m_pos0[d]);
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "Esirkepov" );
+        return propList;
+    }
 };
 
 } //namespace currentSolver

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -153,6 +153,13 @@ struct EsirkepovNative
     {
         return ParticleAssign()(gridPoint - line.m_pos1[d - 1]) - ParticleAssign()(gridPoint - line.m_pos0[d - 1]);
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "Esirkepov" );
+        propList["param"] = "native implementation";
+        return propList;
+    }
 };
 
 } //namespace currentSolver

--- a/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -63,6 +63,12 @@ struct VillaBune
         addCurrentSplitX(oldPos, pos, charge, boxJ_par, deltaTime);
     }
 
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "VillaBune" );
+        return propList;
+    }
+
 private:
     //Splits the [oldPos,newPos] beam into two beams at the x-boundary of the cell
     //if necessary

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -308,6 +308,12 @@ struct ZigZag
         }
     }
 
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "ZigZag" );
+        return propList;
+    }
+
 private:
 
     /** calculate virtual point were we split our particle trajectory

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -71,6 +71,13 @@ struct Binomial
         const float_X deltaT = DELTA_T;
         fieldE(self) -= filteredJ * (float_X(1.0) / EPS0) * deltaT;
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "Binomial" );
+        propList["param"] = "period=1;numPasses=1;compensator=false";
+        return propList;
+    }
 };
 
 } /* namespace currentInterpolation */

--- a/src/picongpu/include/fields/currentInterpolation/None/None.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.hpp
@@ -50,6 +50,11 @@ struct None
         fieldE(self) -= fieldJ(self) * (float_X(1.0) / EPS0) * deltaT;
     }
 
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "none" );
+        return propList;
+    }
 };
 
 } /* namespace currentInterpolation */

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -169,6 +169,11 @@ struct NoneDS
         fieldB(self) += jAvgB * constB;
     }
 
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "none" );
+        return propList;
+    }
 };
 
 } /* namespace currentInterpolation */

--- a/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
@@ -189,6 +189,13 @@ namespace picongpu
 
                 pos += dr;
             }
+
+            static PMacc::traits::StringProperty getStringProperties()
+            {
+                PMacc::traits::StringProperty propList( "name", "other" );
+                propList["param"] = "semi analytical, Axel Huebl (2011)";
+                return propList;
+            }
         };
     } //namespace
 }

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -80,6 +80,12 @@ struct Push
         }
 
     }
+
+    static PMacc::traits::StringProperty getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "Boris" );
+        return propList;
+    }
 };
 } //namespace particlePusherBoris
 } //namepsace  picongpu

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -59,6 +59,13 @@ namespace picongpu
                     pos[d] += (vel[d] * DELTA_T) / cellSize[d];
                 }
             }
+
+            static PMacc::traits::StringProperty getStringProperties()
+            {
+                PMacc::traits::StringProperty propList( "name", "other" );
+                propList["param"] = "free streaming";
+                return propList;
+            }
         };
     } //namespace
 }

--- a/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
@@ -58,6 +58,13 @@ namespace picongpu
                     pos[d] += (vel[d] * DELTA_T) / cellSize[d];
                 }
             }
+
+            static PMacc::traits::StringProperty getStringProperties()
+            {
+                PMacc::traits::StringProperty propList( "name", "other" );
+                propList["param"] = "free streaming photon pusher";
+                return propList;
+            }
         };
     } //namespace
 }

--- a/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -188,6 +188,14 @@ struct Push
     WeightingType weighting;   /* weighting of the macro particle */
   };
 
+  static PMacc::traits::StringProperty getStringProperties()
+  {
+      PMacc::traits::StringProperty propList( "name", "other" );
+      propList["param"] = "reduced Landau-Lifshitz pusher via RK4 and "
+                          "classical radiation reaction, Marija Vranic (2015)";
+      return propList;
+  }
+
 };
 } //namespace particlePusherReducedLandauLifshitz
 } //namespace picongpu

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -26,6 +26,7 @@
 #include "algorithms/PromoteType.hpp"
 #include "algorithms/ForEach.hpp"
 #include "algorithms/math.hpp"
+#include "traits/GetStringProperties.hpp"
 #include "traits/GetMargin.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/NumberOfExchanges.hpp"


### PR DESCRIPTION
Add ([openPMD](https://github.com/openPMD/openPMD-standard) compatible) string properties to all essential PIC solvers so we can query them easily in plugins, bindings and I/O.

Ideally, all new parts of the PIC algorithm should now try to implement names properties (see #1507) the same way as we implement margins, etc. to make the code base self-describing.