### PR TITLE
Pusher: Inherit Attributes

### DIFF
--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -155,7 +155,7 @@ template<typename T_ParticleDescription>
 void Particles<T_ParticleDescription>::update(uint32_t )
 {
     typedef typename GetFlagType<FrameType,particlePusher<> >::type PusherAlias;
-    typedef typename PMacc::traits::Resolve<PusherAlias>::type::type ParticlePush;
+    typedef typename PMacc::traits::Resolve<PusherAlias>::type ParticlePush;
 
     typedef typename PMacc::traits::Resolve<
         typename GetFlagType<FrameType,interpolation<> >::type

--- a/src/picongpu/include/particles/traits/GetPusher.hpp
+++ b/src/picongpu/include/particles/traits/GetPusher.hpp
@@ -34,7 +34,7 @@ struct GetPusher
 {
     typedef typename PMacc::traits::Resolve<
         typename GetFlagType<typename T_Species::FrameType, particlePusher<> >::type
-      >::type::type type;
+      >::type type;
 };
 
 }// namespace traits

--- a/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
@@ -45,35 +45,35 @@ namespace pusher
 
 #if(SIMDIM==DIM3)
 
-struct Axel
+struct Axel :
+public particlePusherAxel::Push<Velocity, Gamma<> >
 {
-    typedef particlePusherAxel::Push<Velocity, Gamma<> > type;
 };
 #endif
 
-struct Boris
+struct Boris :
+public particlePusherBoris::Push<Velocity, Gamma<> >
 {
-    typedef particlePusherBoris::Push<Velocity, Gamma<> > type;
 };
 
-struct Vay
+struct Vay :
+public particlePusherVay::Push<Velocity, Gamma<> >
 {
-    typedef particlePusherVay::Push<Velocity, Gamma<> > type;
 };
 
-struct Free
+struct Free :
+public particlePusherFree::Push<Velocity, Gamma<> >
 {
-    typedef particlePusherFree::Push<Velocity, Gamma<> > type;
 };
 
-struct Photon
+struct Photon :
+public particlePusherPhoton::Push<Velocity, Gamma<> >
 {
-    typedef particlePusherPhoton::Push<Velocity, Gamma<> > type;
 };
 
-struct ReducedLandauLifshitz
+struct ReducedLandauLifshitz :
+public particlePusherReducedLandauLifshitz::Push<Velocity, Gamma<> >
 {
-    typedef particlePusherReducedLandauLifshitz::Push<Velocity, Gamma<> > type;
 };
 
 } //namespace pusher


### PR DESCRIPTION
Refactores the access and selection of pushers (in unitless) so our `GetPusher<>` traits can access the implemented method directly.

This avoids `SomeTrait<...>::type::type` accesses which are bad style.

(`pusherConfig.unitless` is not used in examples since it only contains defines)