### PR TITLE
ADIOS: Add String Helper

### DIFF
--- a/src/picongpu/include/plugins/common/stringHelpers.hpp
+++ b/src/picongpu/include/plugins/common/stringHelpers.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 #include <list>
 #include <algorithm>
+#include <numeric>
 #include <iostream>
 
 namespace picongpu
@@ -74,6 +75,37 @@ namespace helper
         Result operator()(
             std::list<std::string> listOfStrings,
             char padding = '\0'
+        );
+    };
+
+    /** Create array of c-strings suitable for ADIOS
+     *
+     * Convert a std::list of strings to a format that is suitable to
+     * be written into ADIOS (`char *strings[]`).
+     */
+    class GetADIOSArrayOfString
+    {
+    private:
+        // accumulate the size of a string + \0 to an initial value
+        struct StrSize
+        {
+            size_t operator()( size_t init, std::string s )
+            {
+                return init +     // previous length
+                       s.size() + // this strings length
+                       1;         // this strings null terminator
+           }
+        };
+    public:
+        // resulting type containing all attributes for a ADIOS write call
+        struct Result
+        {
+            std::vector<char> buffers;
+            std::vector<char*> starts;
+        };
+
+        Result operator()(
+            std::list<std::string> listOfStrings
         );
     };
 

--- a/src/picongpu/stringHelpers.cpp
+++ b/src/picongpu/stringHelpers.cpp
@@ -97,5 +97,53 @@ namespace helper
             return result;
     }
 
+    GetADIOSArrayOfString::Result
+    GetADIOSArrayOfString::operator()(
+        std::list<std::string> listOfStrings
+    )
+    {
+            Result result;
+
+            // sum of all strings + their null terminators
+            StrSize strSize;
+            const size_t sumLen = std::accumulate(
+                listOfStrings.begin(),
+                listOfStrings.end(),
+                0u,
+                strSize
+            );
+
+            // allocate & prepare buffer, starts
+            result.buffers.assign( sumLen, '\0' );
+            result.starts.assign( listOfStrings.size(), NULL );
+
+            // concat all strings, \0 terminated
+            size_t startIdx = 0;
+            std::list<std::string>::iterator listIt = listOfStrings.begin();
+            for(
+                size_t i = 0;
+                i < listOfStrings.size();
+                ++i, ++listIt
+            )
+            {
+                std::vector<char>::iterator startIt =
+                    result.buffers.begin() + startIdx;
+
+                // copy byte wise onto padding
+                std::copy(
+                    listIt->begin(),
+                    listIt->end(),
+                    startIt
+                );
+
+                // start pointer
+                result.starts.at(i) = &(*startIt);
+
+                startIdx += listIt->size() + 1;
+            }
+
+            // return
+            return result;
+    }
 } // namespace helper
 } // namespace picongpu


### PR DESCRIPTION
Add string helper classes to concat an array of strings for the ADIOS library.

This is the same as #1323 has been for libSplash (HDF5)

@psychocoderHPC @PrometheusPi 