### PR TITLE
Trait: GetSpeciesFlagName

### DIFF
--- a/src/picongpu/include/particles/traits/GetSpeciesFlagName.hpp
+++ b/src/picongpu/include/particles/traits/GetSpeciesFlagName.hpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "simulation_defines.hpp"
+
+#include "traits/HasFlag.hpp"
+#include "traits/GetFlagType.hpp"
+#include "traits/Resolve.hpp"
+
+#include <string>
+
+
+namespace picongpu
+{
+namespace traits
+{
+    /** Get the GetStringProperties "name" attribute of a Species' Flag
+     *
+     * Returns the "name" attribute of a species string attribute list as
+     * std::string and if not present, returns "none".
+     */
+    template<
+        typename T_Species,
+        typename T_Flag,
+        bool T_hasFlag = HasFlag<
+            typename T_Species::FrameType,
+            T_Flag
+        >::type::value
+    >
+    struct
+    GetSpeciesFlagName
+    {
+        typedef typename PMacc::traits::Resolve<
+            typename GetFlagType<
+                typename T_Species::FrameType,
+                T_Flag
+            >::type
+        >::type SpeciesFlag;
+
+        std::string operator()() const
+        {
+            GetStringProperties< SpeciesFlag > stringProps;
+            return stringProps["name"].value;
+        }
+    };
+
+    template<
+        typename T_Species,
+        typename T_Flag
+    >
+    struct
+    GetSpeciesFlagName<T_Species, T_Flag, false>
+    {
+        std::string operator()() const
+        {
+            return "none";
+        }
+    };
+} // namespace traits
+} // namespace picongpu

--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -48,6 +48,7 @@
 #include "plugins/hdf5/writer/ParticleAttribute.hpp"
 #include "compileTime/conversion/RemoveFromSeq.hpp"
 #include "particles/ParticleDescription.hpp"
+#include "particles/traits/GetSpeciesFlagName.hpp"
 
 #include <string>
 
@@ -63,44 +64,6 @@ TYPE_ARRAY(UInt64_5, H5T_INTEL_U64, uint64_t, 5);
 
 using namespace splash;
 
-
-template<
-    typename T_Species,
-    typename T_Flag,
-    bool T_hasFlag = HasFlag<
-        typename T_Species::FrameType,
-        T_Flag
-    >::type::value
->
-struct
-GetSpeciesFlagName
-{
-    typedef typename PMacc::traits::Resolve<
-        typename GetFlagType<
-            typename T_Species::FrameType,
-            T_Flag
-        >::type
-    >::type SpeciesFlag;
-
-    std::string operator()() const
-    {
-        GetStringProperties< SpeciesFlag > stringProps;
-        return stringProps["name"].value;
-    }
-};
-
-template<
-    typename T_Species,
-    typename T_Flag
->
-struct
-GetSpeciesFlagName<T_Species, T_Flag, false>
-{
-    std::string operator()() const
-    {
-        return "none";
-    }
-};
 
 /** Write copy particle to host memory and dump to HDF5 file
  *
@@ -308,7 +271,7 @@ public:
                             "particleShape",
                             &particleShape );
 
-        GetSpeciesFlagName<T_Species, current<> > currentDepositionName;
+        traits::GetSpeciesFlagName<T_Species, current<> > currentDepositionName;
         const std::string currentDeposition( currentDepositionName() );
         ColTypeString ctCurrentDeposition( currentDeposition.length() );
         params->dataCollector->writeAttribute( params->currentStep,
@@ -317,7 +280,7 @@ public:
                             "currentDeposition",
                             currentDeposition.c_str() );
 
-        GetSpeciesFlagName<T_Species, particlePusher<> > particlePushName;
+        traits::GetSpeciesFlagName<T_Species, particlePusher<> > particlePushName;
         const std::string particlePush( particlePushName() );
         ColTypeString ctParticlePush( particlePush.length() );
         params->dataCollector->writeAttribute( params->currentStep,
@@ -326,7 +289,7 @@ public:
                             "particlePush",
                             particlePush.c_str() );
 
-        GetSpeciesFlagName<T_Species, interpolation<> > particleInterpolationName;
+        traits::GetSpeciesFlagName<T_Species, interpolation<> > particleInterpolationName;
         const std::string particleInterpolation( particleInterpolationName() );
         ColTypeString ctParticleInterpolation( particleInterpolation.length() );
         params->dataCollector->writeAttribute( params->currentStep,


### PR DESCRIPTION
Refactors the `GetSpeciesFlagName` trait so it can be used throughout the whole code (and in the upcoming openPMD ADIOS PR).