### PR TITLE
openPMD: ADIOS

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -91,7 +91,8 @@ namespace po = boost::program_options;
 struct ThreadParams
 {
     uint32_t currentStep;                   /** current simulation step */
-    std::string fullFilename;
+    std::string adiosFilename;              /* e.g., simData */
+    std::string fullFilename;               /* e.g., simData_1000.bp */
 
     /** current dump is a checkpoint */
     bool isCheckpoint;

--- a/src/picongpu/include/plugins/adios/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/adios/WriteMeta.hpp
@@ -1,0 +1,272 @@
+/**
+ * Copyright 2013-2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "simulation_defines.hpp"
+
+#include "plugins/adios/ADIOSWriter.def"
+#include "Environment.hpp"
+
+#include "fields/FieldManipulator.hpp"
+#include "fields/currentInterpolation/CurrentInterpolation.hpp"
+
+#include "traits/SIBaseUnits.hpp"
+#include "traits/PICToAdios.hpp"
+
+#include <string>
+#include <sstream>
+#include <list>
+
+
+namespace picongpu
+{
+namespace adios
+{
+using namespace PMacc;
+
+    struct WriteMeta
+    {
+        void operator()(ThreadParams *threadParams)
+        {
+            log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) write meta attributes.");
+
+            traits::PICToAdios<uint32_t> adiosUInt32Type;
+            traits::PICToAdios<float_X> adiosFloatXType;
+            traits::PICToAdios<float_64> adiosDoubleType;
+
+            /* openPMD attributes */
+            /*   required */
+            const std::string openPMDversion( "1.0.0" );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "openPMD", "/", adios_string, 1, (void*)openPMDversion.c_str()));
+
+            const uint32_t openPMDextension = 1; // ED-PIC ID
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "openPMDextension", "/", adiosUInt32Type.type, 1, (void*)&openPMDextension));
+
+            const std::string basePath( ADIOS_PATH_ROOT"%T/" );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "basePath", "/", adios_string, 1, (void*)basePath.c_str()));
+
+            const std::string meshesPath( ADIOS_PATH_FIELDS );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "meshesPath", "/", adios_string, 1, (void*)meshesPath.c_str()));
+
+            const std::string particlesPath( ADIOS_PATH_PARTICLES );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "particlesPath", "/", adios_string, 1, (void*)particlesPath.c_str()));
+
+            const std::string iterationEncoding( "fileBased" );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "iterationEncoding", "/", adios_string, 1, (void*)iterationEncoding.c_str()));
+
+            const std::string iterationFormat( threadParams->adiosFilename + std::string("_%T.h5") );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "iterationFormat", "/", adios_string, 1, (void*)iterationFormat.c_str()));
+
+            /*   recommended */
+            const std::string author = Environment<>::get().SimulationDescription().getAuthor();
+            if( author.length() > 0 )
+            {
+                ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                    "author", "/", adios_string, 1, (void*)author.c_str()));
+            }
+
+            const std::string software( "PIConGPU" );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "software", "/", adios_string, 1, (void*)software.c_str()));
+
+            std::stringstream softwareVersion;
+            softwareVersion << PICONGPU_VERSION_MAJOR << "."
+                            << PICONGPU_VERSION_MINOR << "."
+                            << PICONGPU_VERSION_PATCH;
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "softwareVersion", "/", adios_string, 1, (void*)softwareVersion.str().c_str()));
+
+            const std::string date = helper::getDateString( "%F %T %z" );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "date", "/", adios_string, 1, (void*)date.c_str()));
+
+            /*   ED-PIC */
+            const std::string fullMeshesPath( threadParams->adiosBasePath +
+                std::string(ADIOS_PATH_FIELDS) );
+
+            GetStringProperties<fieldSolver::FieldSolver> fieldSolverProps;
+            const std::string fieldSolver( fieldSolverProps["name"].value );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "fieldSolver", fullMeshesPath.c_str(), adios_string, 1, (void*)fieldSolver.c_str()));
+
+            /* order as in axisLabels:
+             *    3D: z-lower, z-upper, y-lower, y-upper, x-lower, x-upper
+             *    2D: y-lower, y-upper, x-lower, x-upper
+             */
+            GetStringProperties<FieldManipulator> fieldBoundaryProp;
+            std::list<std::string> listFieldBoundary;
+            std::list<std::string> listFieldBoundaryParam;
+            for( uint32_t i = NumberOfExchanges<simDim>::value - 1; i > 0; --i )
+            {
+                if( FRONT % i == 0 )
+                {
+                    listFieldBoundary.push_back(
+                        fieldBoundaryProp[ExchangeTypeNames()[i]]["name"].value
+                    );
+                    listFieldBoundaryParam.push_back(
+                        fieldBoundaryProp[ExchangeTypeNames()[i]]["param"].value
+                    );
+                }
+            }
+            helper::GetADIOSArrayOfString getADIOSArrayOfString;
+            PMACC_AUTO(arrFieldBoundary, getADIOSArrayOfString( listFieldBoundary ));
+            PMACC_AUTO(arrFieldBoundaryParam, getADIOSArrayOfString( listFieldBoundaryParam ));
+
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "fieldBoundary", fullMeshesPath.c_str(), adios_string_array,
+                listFieldBoundary.size(), &( arrFieldBoundary.starts.at( 0 ) )));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "fieldBoundaryParameters", fullMeshesPath.c_str(), adios_string_array,
+                listFieldBoundaryParam.size(), &( arrFieldBoundaryParam.starts.at( 0 ) )));
+
+            if( bmpl::size<VectorAllSpecies>::type::value > 0 )
+            {
+                // assume all boundaries are like the first species for openPMD 1.0.0
+                GetStringProperties<bmpl::at_c<VectorAllSpecies, 0>::type> particleBoundaryProp;
+                std::list<std::string> listParticleBoundary;
+                std::list<std::string> listParticleBoundaryParam;
+                for( uint32_t i = NumberOfExchanges<simDim>::value - 1; i > 0; --i )
+                {
+                    if( FRONT % i == 0 )
+                    {
+                        listParticleBoundary.push_back(
+                            particleBoundaryProp[ExchangeTypeNames()[i]]["name"].value
+                        );
+                        listParticleBoundaryParam.push_back(
+                            particleBoundaryProp[ExchangeTypeNames()[i]]["param"].value
+                        );
+                    }
+                }
+                PMACC_AUTO(arrParticleBoundary, getADIOSArrayOfString( listParticleBoundary ));
+                PMACC_AUTO(arrParticleBoundaryParam, getADIOSArrayOfString( listParticleBoundaryParam ));
+
+                ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                    "particleBoundary", fullMeshesPath.c_str(), adios_string_array,
+                    listParticleBoundary.size(), &( arrParticleBoundary.starts.at( 0 ) )));
+                ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                    "particleBoundaryParameters", fullMeshesPath.c_str(), adios_string_array,
+                    listParticleBoundaryParam.size(), &( arrParticleBoundaryParam.starts.at( 0 ) )));
+            }
+
+            GetStringProperties<fieldSolver::CurrentInterpolation> currentSmoothingProp;
+            const std::string currentSmoothing( currentSmoothingProp["name"].value );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "currentSmoothing", fullMeshesPath.c_str(), adios_string, 1, (void*)currentSmoothing.c_str()));
+
+            if( currentSmoothingProp.find( "param" ) != currentSmoothingProp.end() )
+            {
+                const std::string currentSmoothingParam( currentSmoothingProp["param"].value );
+                ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                    "currentSmoothingParameters", fullMeshesPath.c_str(), adios_string,
+                    1, (void*)currentSmoothingParam.c_str()));
+            }
+
+            const std::string chargeCorrection( "none" );
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                "chargeCorrection", fullMeshesPath.c_str(), adios_string, 1, (void*)chargeCorrection.c_str()));
+
+            /* write current iteration */
+            log<picLog::INPUT_OUTPUT > ("ADIOS: meta: iteration");
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "iteration", threadParams->adiosBasePath.c_str(),
+                      adiosUInt32Type.type, 1, (void*)&threadParams->currentStep ));
+
+            /* write number of slides */
+            log<picLog::INPUT_OUTPUT > ("ADIOS: meta: sim_slides");
+            uint32_t slides = MovingWindow::getInstance().getSlideCounter(threadParams->currentStep);
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "sim_slides", threadParams->adiosBasePath.c_str(),
+                      adiosUInt32Type.type, 1, (void*)&slides ));
+
+            /* openPMD: required time attributes */
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "dt", threadParams->adiosBasePath.c_str(),
+                      adiosFloatXType.type, 1, (void*)&DELTA_T ));
+            const float_X time = float_X( threadParams->currentStep ) * DELTA_T;
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "time", threadParams->adiosBasePath.c_str(),
+                      adiosFloatXType.type, 1, (void*)&time ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "timeUnitSI", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_TIME ));
+
+            /* write normed grid parameters */
+            log<picLog::INPUT_OUTPUT > ("ADIOS: meta: grid");
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "cell_width", threadParams->adiosBasePath.c_str(),
+                      adiosFloatXType.type, 1, (void*)&cellSize[0] ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "cell_height", threadParams->adiosBasePath.c_str(),
+                      adiosFloatXType.type, 1, (void*)&cellSize[1] ));
+            if( simDim == DIM3 )
+            {
+               ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                         "cell_depth", threadParams->adiosBasePath.c_str(),
+                         adiosFloatXType.type, 1, (void*)&cellSize[2] ));
+            }
+
+            /* write base units */
+            log<picLog::INPUT_OUTPUT > ("ADIOS: meta: units");
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_energy", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_ENERGY ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_length", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_LENGTH ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_speed", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_SPEED ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_time", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_TIME ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_mass", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_MASS ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_charge", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_CHARGE ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_efield", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_EFIELD ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "unit_bfield", threadParams->adiosBasePath.c_str(),
+                      adiosDoubleType.type, 1, (void*)&UNIT_BFIELD ));
+
+            /* write physical constants */
+            log<picLog::INPUT_OUTPUT > ("ADIOS: meta: mue0/eps0");
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "mue0", threadParams->adiosBasePath.c_str(),
+                      adiosFloatXType.type, 1, (void*)&MUE0 ));
+            ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                      "eps0", threadParams->adiosBasePath.c_str(),
+                      adiosFloatXType.type, 1, (void*)&EPS0 ));
+
+            log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) wite meta attributes.");
+        }
+    };
+} // namespace adios
+} // namespace picongpu


### PR DESCRIPTION
Implements the openPMD standard including the ED-PIC extension for our ADIOS plugin.

After first visual tests, this works with the latest ADIOS 1.9.0+ release but some string endings are broken if the latest `master` (~ https://github.com/ornladios/ADIOS/commit/b1038dea0145e46474b610163a184c000c371566) of ADIOS is not used (fixed bug).

What is not implemented is the refactoring of `particlePatches` (former `particles_info`) for openPMD (optional and recommended). This can be done in a follow-up PR and also after the next release. For now this does still work and one can generate the particle patch information in post-processing (I have done this successfully on Titan during the last year).

Also, I could not test the [openPMD-validator](https://github.com/openPMD/openPMD-validator) scripts since `bp2h5` eats some attributes during convert and the ADIOS `numpy` wrapper is not yet fully object oriented/h5py like https://github.com/ornladios/ADIOS/issues/56 which makes maintaining [such checker scripts](https://github.com/openPMD/openPMD-validator/blob/1.0.0/checkOpenPMD_h5.py) still too cumbersome.

Depends on:
- [x] #1518
- [x] #1519