### PR TITLE
Fix #1506 ADIOS Field Floats

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -121,6 +121,8 @@ struct ThreadParams
     GridLayout<simDim> gridLayout;
     MappingDesc *cellDescription;
 
+    float_X *fieldBfr;                              /* temp. buffer for fields */
+
     Window window;                                  /* window describing the volume to be dumped */
 
     DataSpace<simDim> localWindowToDomainOffset;    /** offset from local moving window to local domain */

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -121,8 +121,6 @@ struct ThreadParams
     GridLayout<simDim> gridLayout;
     MappingDesc *cellDescription;
 
-    float *fieldBfr;                                /* temp. buffer for fields */
-
     Window window;                                  /* window describing the volume to be dumped */
 
     DataSpace<simDim> localWindowToDomainOffset;    /** offset from local moving window to local domain */


### PR DESCRIPTION
Fixes #1506 by allocating and deallocating each field according to the component that is in that moment written.

- [x] needs rebase after #1520 is merged
- [x] ~~segfaults...~~
- [x] ~~needs check: did adios allocate all left-over CPU mem? if yes, will this way swap now?~~
- [x] RT tested