### PR TITLE
IO: Density & Charge Density

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -80,17 +80,30 @@ public:
 /** Predefined Calculations for \see fieldOutput.param
  */
 
-/* ChargeDensity */
+/* Density */
 template<typename T_Species>
 struct CreateDensityOperation
 {
     typedef typename GetShape<T_Species>::type shapeType;
     typedef ComputeGridValuePerFrame<
         shapeType,
-        particleToGrid::derivedAttributes::ChargeDensity
+        particleToGrid::derivedAttributes::Density
     > ParticleDensity;
 
     typedef FieldTmpOperation< ParticleDensity, T_Species > type;
+};
+
+/* ChargeDensity */
+template<typename T_Species>
+struct CreateChargeDensityOperation
+{
+    typedef typename GetShape<T_Species>::type shapeType;
+    typedef ComputeGridValuePerFrame<
+        shapeType,
+        particleToGrid::derivedAttributes::ChargeDensity
+    > ParticleChargeDensity;
+
+    typedef FieldTmpOperation< ParticleChargeDensity, T_Species > type;
 };
 
 /* ParticleCounter */

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -39,7 +39,8 @@ namespace picongpu
      *
      * you can choose any of these particle to grid projections:
      *   - CreateDensityOperation: particle position + shape on the grid
-     *   - CreateCounterOperation: counts point like particles per cell
+     *   - CreateChargeDensityOperation: density * charge
+     *   - CreateCounterOperation: counts point like particles per cell (debug)
      *   - CreateEnergyDensityOperation: particle energy density with respect
      *                                   to shape
      *   - CreateEnergyOperation: particle energy with respect to shape
@@ -50,11 +51,11 @@ namespace picongpu
      */
     using namespace particleToGrid;
 
-    /* Density section */
+    /* ChargeDensity section */
     typedef bmpl::transform<
             VectorAllSpecies,
-            CreateDensityOperation<bmpl::_1>
-            >::type Density_Seq;
+            CreateChargeDensityOperation<bmpl::_1>
+            >::type ChargeDensity_Seq;
 
     /* ParticleCounter section */
     typedef bmpl::transform<
@@ -82,7 +83,7 @@ namespace picongpu
      * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
      */
     typedef MakeSeq<
-        Density_Seq,
+        ChargeDensity_Seq,
         Counter_Seq,
         EnergyDensity_Seq,
         MomentumComponent_Seq


### PR DESCRIPTION
User interface, `fileOutput.param`: Refactor the previous "sloppy" `density` which always was a `charge density` and add a real `density` option in `FieldTmp` generated, particle-derived fields.

### Changes in Meaning
- `DensityOperation`: from charge density to real density
- `ChargeDensityOperation`: new, previously called `DensityOperation`

(namings in the output files have already been fixed in previous PRs such as #1259 in the current dev)