### PR TITLE
fix illegal memory access

### DIFF
--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -275,7 +275,7 @@ kernelPaintParticles3D(ParBox pb,
     typedef typename ParBox::FramePtr FramePtr;
     typedef typename MappingDesc::SuperCellSize Block;
     __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-    __shared__ bool isValid;
+    __shared__ int isValid;
 
     bool isImageThread = false;
 
@@ -289,7 +289,7 @@ kernelPaintParticles3D(ParBox pb,
 
 
     if (localId == 0)
-        isValid = false;
+        isValid = 0;
     __syncthreads();
 
     //\todo: guard size should not be set to (fixed) 1 here
@@ -301,12 +301,12 @@ kernelPaintParticles3D(ParBox pb,
     if (globalCell == slice)
 #endif
     {
-        nvidia::atomicAllExch((int*) &isValid,1); /*WAW Error in cuda-memcheck racecheck*/
+        nvidia::atomicAllExch(&isValid,1); /*WAW Error in cuda-memcheck racecheck*/
         isImageThread = true;
     }
     __syncthreads();
 
-    if (!isValid)
+    if (isValid==0)
         return;
 
     /*index in image*/


### PR DESCRIPTION
remove shared memory `bool` with `int` variable to allow save atomic operations

The issue with the old implementation is that there is no atomicExch operation for `bool` and if we use a reinterpret cast to `int` we overwrite more than 1byte and create an memory overflow.