### PR TITLE
Fix ADIOS Restart

### DIFF
--- a/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -26,6 +26,7 @@
 #include "pmacc_types.hpp"
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
+#include "traits/PICToOpenPMD.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
 #include "traits/Resolve.hpp"
@@ -82,8 +83,9 @@ struct LoadParticleAttributesFromADIOS
 
         for (uint32_t n = 0; n < components; ++n)
         {
+            OpenPMDName<T_Identifier> openPMDName;
             std::stringstream datasetName;
-            datasetName << particlePath << T_Identifier::getName();
+            datasetName << particlePath << openPMDName();
             if (components > 1)
                 datasetName << "/" << name_lookup[n];
 


### PR DESCRIPTION
Follow-up to #1520 fixing the restart with ADIOS and openPMD.

While reading the particle attributes again, renaming (`positionOffset` in openPMD is `globalCellIdx` in PIConGPU) needs to take place (as in [HDF5](https://github.com/ComputationalRadiationPhysics/picongpu/pull/1428/files#diff-e85d4780b8b95f839a9a35695b6ad496)).

@psychocoderHPC @PrometheusPi 