### PR TITLE
deselect `particleId`

### DIFF
--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -32,6 +32,7 @@
 #include "nvidia/rng/distributions/Uniform_float.hpp"
 #include "mpi/SeedPerRank.hpp"
 #include "traits/GetUniqueTypeId.hpp"
+#include "particles/operations/Deselect.hpp"
 
 namespace picongpu
 {
@@ -73,7 +74,7 @@ namespace ionization
              */
             PMACC_AUTO(targetElectronClone, partOp::deselect<bmpl::vector2<multiMask, momentum> >(childElectron));
 
-            partOp::assign(targetElectronClone, parentIon);
+            partOp::assign(targetElectronClone, partOp::deselect<particleId>(parentIon));
 
             float_X massIon = attribute::getMass(weighting,parentIon);
             const float_X massElectron = attribute::getMass(weighting,childElectron);

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -23,6 +23,7 @@
 
 #include "simulation_defines.hpp"
 #include "nvidia/atomic.hpp"
+#include "particles/operations/Deselect.hpp"
 
 namespace picongpu
 {
@@ -31,17 +32,18 @@ namespace particles
 namespace manipulators
 {
 
-struct Assign
+struct Derive
 {
 
-    HINLINE Assign(const uint32_t)
+    HINLINE Derive(const uint32_t)
     {
     }
 
     template<typename T_DestParticle, typename T_SrcParticle>
     HDINLINE void operator()(T_DestParticle& destPar, const T_SrcParticle& srcPar)
     {
-        PMacc::particles::operations::assign(destPar, srcPar);
+        namespace parOp = PMacc::particles::operations;
+        parOp::assign(destPar, parOp::deselect<particleId>(srcPar));
     }
 
 };

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -324,15 +324,16 @@ public:
     template<typename Electron, typename Photon>
     DINLINE void operator()(Electron& electron, Photon& photon) const
     {
+        namespace parOp = PMacc::particles::operations;
         PMACC_AUTO(destPhoton,
-            PMacc::particles::operations::deselect<
+            parOp::deselect<
                 boost::mpl::vector<
                     multiMask,
                     momentum
                 >
             >(photon)
         );
-        PMacc::particles::operations::assign( destPhoton, electron );
+        parOp::assign( destPhoton, parOp::deselect<particleId>(electron) );
 
         photon[multiMask_] = 1;
         photon[momentum_] = this->photon_mom;


### PR DESCRIPTION
deselect the particle id before a particle is created from another particle

This pull request is needed to support particle ids together with ionization and synchrotron radiation.