### PR TITLE
Specialize ADK for linear or circular laser polarization

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -139,7 +139,10 @@ struct Hydrogen
  *
  * - None : no particle is ionized
  * - BSIHydrogenLike : simple barrier suppression ionization
- * - ADK : Ammosov-Delone-Krainov tunneling ionization (H-like)
+ * - ADKLinPol : Ammosov-Delone-Krainov tunneling ionization (H-like)
+ *               -> linearly polarized lasers
+ * - ADKCircPol : Ammosov-Delone-Krainov tunneling ionization (H-like)
+ *                -> circularly polarized lasers
  *
  * Research and development: ----------------------------------------------
  * - BSIEffectiveZ : BSI taking electron shielding into account via an effective

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK.def
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK.def
@@ -29,9 +29,7 @@ namespace particles
 namespace ionization
 {
 
-    /** \struct ADK_Impl
-     *
-     * \brief Ammosov-Delone-Krainov tunneling model
+    /** Ammosov-Delone-Krainov tunneling model
      *
      * \tparam T_DestSpecies electron species to be created
      * \tparam T_SrcSpecies ion species to be ionized
@@ -39,12 +37,10 @@ namespace ionization
      *         cannot be known in list of particle species' flags
      *         \see speciesDefinition.param
      */
-    template<typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
+    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
     struct ADK_Impl;
 
-    /** \struct ADK
-     *
-     * \brief Ammosov-Delone-Krainov tunneling model
+    /** Ammosov-Delone-Krainov tunneling model - linear laser polarization
      *
      * - takes the ionization energies of the various charge states of ions
      * - calculates the ionization rates and then the ionization probabilities from them
@@ -61,9 +57,39 @@ namespace ionization
      * \see speciesDefinition.param
      */
     template<typename T_DestSpecies>
-    struct ADK
+    struct ADKLinPol
     {
-        typedef ADK_Impl<T_DestSpecies> type;
+        /* Boolean value that results in an additional polarization factor in
+         * the ionization rate for linear polarization */
+        BOOST_STATIC_CONSTEXPR bool linPol = true;
+        typedef particles::ionization::AlgorithmADK<linPol> IonizationAlgorithm;
+        typedef ADK_Impl<IonizationAlgorithm, T_DestSpecies> type;
+    };
+
+    /** Ammosov-Delone-Krainov tunneling model - circular laser polarization
+     *
+     * - takes the ionization energies of the various charge states of ions
+     * - calculates the ionization rates and then the ionization probabilities from them
+     * - ATTENTION: this approach is not very applicable for rapidly changing high intensity laser fields
+     * - this is a Monte Carlo method: if a random number is smaller
+     *   or equal than the ionization probability -> increase the charge state
+     * - see for example: Delone, N. B.; Krainov, V. P. (1998).
+     *   "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
+     *   doi:10.1070/PU1998v041n05ABEH000393
+     *
+     * wrapper class,
+     * needed because the SrcSpecies cannot be known during the
+     * first specialization of the ionization model in the particle definition
+     * \see speciesDefinition.param
+     */
+    template<typename T_DestSpecies>
+    struct ADKCircPol
+    {
+        /* Boolean value that results in an additional polarization factor in
+         * the ionization rate for linear polarization */
+        BOOST_STATIC_CONSTEXPR bool linPol = false;
+        typedef particles::ionization::AlgorithmADK<linPol> IonizationAlgorithm;
+        typedef ADK_Impl<IonizationAlgorithm, T_DestSpecies> type;
     };
 
 } // namespace ionization

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -51,7 +51,7 @@ namespace ionization
      * \tparam T_DestSpecies electron species to be created
      * \tparam T_SrcSpecies particle species that is ionized
      */
-    template<typename T_DestSpecies, typename T_SrcSpecies>
+    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies>
     struct ADK_Impl
     {
 
@@ -81,7 +81,7 @@ namespace ionization
         private:
 
             /* define ionization ALGORITHM (calculation) for ionization MODEL */
-            typedef particles::ionization::AlgorithmADK IonizationAlgorithm;
+            typedef T_IonizationAlgorithm IonizationAlgorithm;
 
             /* random number generator for Monte Carlo */
             typedef particles::ionization::RandomNrForMonteCarlo<SrcSpecies> RandomGen;

--- a/src/picongpu/include/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -43,12 +43,15 @@ namespace particles
 namespace ionization
 {
 
-    /** \struct AlgorithmADK
+    /** Calculation for the Ammosov-Delone-Krainov tunneling model
      *
-     * \brief calculation for the Ammosov-Delone-Krainov tunneling model */
+     * for either linear or circular laser polarization
+     *
+     * \tparam T_linPol boolean value that is true for lin. pol. and false for circ. pol.
+     */
+    template<bool T_linPol>
     struct AlgorithmADK
     {
-
         /** Functor implementation
          * \tparam EType type of electric field
          * \tparam BType type of magnetic field
@@ -82,10 +85,18 @@ namespace ionization
                 float_X dBase = float_X(4.0) * util::cube(protonNumber) / (eInAU * util::quad(nEff)) ;
                 float_X dFromADK = math::pow(dBase,nEff);
 
-                /* ionization rate */
-                float_X rateADK = math::sqrt(float_X(3.0) * util::cube(nEff) * eInAU / (pi * util::cube(protonNumber))) \
-                                * eInAU * util::square(dFromADK) / (float_X(8.0) * pi * protonNumber) \
+                /* ionization rate (for CIRCULAR polarization)*/
+                float_X rateADK = eInAU * util::square(dFromADK) / (float_X(8.0) * pi * protonNumber) \
                                 * math::exp(float_X(-2.0) * util::cube(protonNumber) / (float_X(3.0) * util::cube(nEff) * eInAU));
+
+                /* in case of linear polarization the rate is modified by an additional factor */
+                if(T_linPol)
+                {
+                    /* factor from averaging over one laser cycle with LINEAR polarization */
+                    const float_X polarizationFactor = math::sqrt(float_X(3.0) * util::cube(nEff) * eInAU / (pi * util::cube(protonNumber)));
+
+                    rateADK *= polarizationFactor;
+                }
 
                 /* simulation time step in atomic units */
                 const float_X timeStepAU = float_X(DELTA_T / ATOMIC_UNIT_TIME);

--- a/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
+++ b/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
@@ -37,6 +37,7 @@ namespace ionization
 
     struct AlgorithmNone;
 
+    template<bool T_polarizationType>
     struct AlgorithmADK;
 
     struct AlgorithmBSIHydrogenLike;

--- a/src/picongpu/include/particles/ionization/byField/ionizers.def
+++ b/src/picongpu/include/particles/ionization/byField/ionizers.def
@@ -25,8 +25,12 @@
  * These includes contain forward declarations of < Ionization Models >
  */
 
+/** contains definitions for:
+ *  - ADKLinPol
+ *  - ADKCircPol
+ */
 #include "particles/ionization/byField/ADK/ADK.def"
-/** contains BSI definitions for:
+/** contains definitions for:
  *  - BSIHydrogenLike
  *  - BSIEffectiveZ
  *  - BSIStarkShifted


### PR DESCRIPTION
The ADK model has been updated so that now the user is given the choice between the linear and circular polarization case, according to [Delone, Krainov 1998 Phys.-Usp. 41 469](http://iopscience.iop.org/article/10.1070/PU1998v041n05ABEH000393).