### PR TITLE
fix RNG initialization location

### DIFF
--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -342,17 +342,17 @@ public:
         /* add CUDA streams to the StreamController for concurrent execution */
         Environment<>::get().StreamController().addStreams(6);
 
-        // create factory for the random number generator
-        this->rngFactory = new RNGFactory(Environment<simDim>::get().SubGrid().getLocalDomain().size);
-        // init factory
-        PMacc::GridController<simDim>& gridCon = PMacc::Environment<simDim>::get().GridController();
-        this->rngFactory->init(gridCon.getScalarPosition());
-
-        // Initialize synchrotron functions, if there are synchrotron photon species
+        // Initialize random number generator and synchrotron functions, if there are synchrotron photon species
         typedef typename PMacc::particles::traits::FilterByFlag<VectorAllSpecies,
                                                                 synchrotronPhotons<> >::type AllSynchrotronPhotonsSpecies;
         if(!bmpl::empty<AllSynchrotronPhotonsSpecies>::value)
         {
+            // create factory for the random number generator
+            this->rngFactory = new RNGFactory(Environment<simDim>::get().SubGrid().getLocalDomain().size);
+            // init factory
+            PMacc::GridController<simDim>& gridCon = PMacc::Environment<simDim>::get().GridController();
+            this->rngFactory->init(gridCon.getScalarPosition());
+
             this->synchrotronFunctions.init();
         }
     }


### PR DESCRIPTION
The random number generator is now initialized only if there exist any photon species.