### PR TITLE
Fix documentation in HasFlag.hpp

### DIFF
--- a/src/libPMacc/include/traits/HasFlag.hpp
+++ b/src/libPMacc/include/traits/HasFlag.hpp
@@ -34,7 +34,7 @@ namespace traits
  * @tparam T_Key a class which is used as identifier
  *
  * This struct must define
- * ::type (boost::bool_<>)
+ * ::type (boost::mpl::bool_<>)
  */
 template<typename T_Object, typename T_Key>
 struct HasFlag;


### PR DESCRIPTION
The specialization of HasFlag has to define a boost::mpl::bool_<>.
(Not a boost::bool_<>)