### PR TITLE
Fix Sliding Window: Offset for dt * c = dy != Slide

### DIFF
--- a/src/picongpu/include/simulationControl/MovingWindow.hpp
+++ b/src/picongpu/include/simulationControl/MovingWindow.hpp
@@ -91,12 +91,12 @@ private:
             );
 
             /* Is the time step when the virtual particle **passed** the GPU next to the last
-             * in the current step
+             * in the current to the next step
              */
-            const uint32_t firstSlideStep = math::floor(
+            const uint32_t firstSlideStep = math::ceil(
                 float_64(subGrid.getGlobalDomain().size[moveDirection] - virtualParticleInitialStartCell) *
                 cellSizeInMoveDirection / deltaWayPerStep
-            );
+            ) - 1;
 
             /* way which the virtual particle must move before the window begins
              * to move the first time [in pic length] */
@@ -104,11 +104,11 @@ private:
                 float_64(globalWindowSizeInMoveDirection - virtualParticleInitialStartCell) *
                 cellSizeInMoveDirection;
             /* Is the time step when the virtual particle **passed** the moving window
-             * in the current step
+             * in the current to the next step
              */
-            const uint32_t firstMoveStep = math::floor(
+            const uint32_t firstMoveStep = math::ceil(
                 wayToFirstMove / deltaWayPerStep
-            );
+            ) - 1;
 
             if (firstMoveStep <= currentStep)
             {


### PR DESCRIPTION
- fix that window begin to move one time step too late
- fix sliding for the case delta time is equal delta cell in y

`firstSlideStep` and `firstMoveStep` (in the old implementation) were the steps where the virtual particle has already passed the border and not the time step before it will pass the border. This pull request fix it.

@axel This bug effects the realease candidate. I only see wrong slides with directional splitting. Never the less we should add this fix to the current release branch

[update:] This bug can also happen if the result of the division to calculate `firstSlideStep` and `firstMoveStep` has no fraction.

Test:

- [x] Directional splitting with moving window
- [ ] Yee Solver with moving window

### Offline result

@ax3l: this pull request solves a inconsistency with exact bounds of `t == floor(t)` between the first[Move/Slide]Step calculation and the `virtualParticlePassesGPUBorder` check 20 lines below.