### PR TITLE
fix abs2 calculation in pusher extension radiation

### DIFF
--- a/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
@@ -50,7 +50,7 @@ struct PushExtension
             // Radiation marks only a particle if it has a high velocity
             // marked particle means that momentumPrev1 is not 0.0 in one direction
 
-            const float_X abs2_mom = math::abs2(mom);
+            const float_X abs2_mom = PMacc::algorithms::math::abs2(mom);
             if (((abs2_mom)>((parameters::RadiationGamma * parameters::RadiationGamma - float_X(1.0)) * mass * mass * c2)))
             {
                 radFlag = true;


### PR DESCRIPTION
This pull request solves a **~~error~~ compile time failure** when the gamma filter of the radiation plugin is ~~called~~ used. 

Error message:
```
.../src/picongpu/include/plugins/radiation/particles/PushExtension.hpp(53): error: "math" is ambiguous
```

This bug has been introduced with [`e92f735`](https://github.com/ComputationalRadiationPhysics/picongpu/commit/e92f7357a40d1e5371e48cccac5407618fcfaf90) - pull request #1472. 

@ax3l This bug effect the latest release (candidate) - please backport it. 