### PR TITLE
ADIOS: 1.10.0 Update

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,7 +164,7 @@ Some of our examples will also need **libSplash**.
       - `make install`
     - set the environment variable
       [ADIOS\_ROOT](#additional-required-environment-variables-for-optional-libraries)
-      to `export ADIOS_ROOT=$HOME/lib/adios-1.9.0`, the
+      to `export ADIOS_ROOT=$HOME/lib/adios-1.10.0`, the
       [PATH](#additional-required-environment-variables-for-optional-libraries)
       to `export PATH=$PATH:$ADIOS_ROOT/bin` and the
       [LD\_LIBRARY\_PATH](#additional-required-environment-variables-for-optional-libraries)

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -93,7 +93,7 @@ touch "$thisDir"runGuard
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=sm_35"
             . /etc/profile
-            module load gcc/4.6.4 boost/1.56.0 cmake/3.1.0 cuda/6.0 openmpi/1.6.5 libSplash/1.4.0 adios/1.9.0 pngwriter/0.5.6 rivlib/1.0.0
+            module load gcc/4.6.4 boost/1.56.0 cmake/3.1.0 cuda/6.0 openmpi/1.6.5 libSplash/1.4.0 adios/1.10.0 pngwriter/0.5.6 rivlib/1.0.0
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/compile -l -q -j $cnf_numParallel \

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -368,7 +368,7 @@ endif(PIC_ENABLE_INSITU_VOLVIS)
 
 # find adios installation
 #   set(ADIOS_USE_STATIC_LIBS ON) # force static linking
-find_package(ADIOS 1.9.0)
+find_package(ADIOS 1.10.0)
 
 if(ADIOS_FOUND)
     add_definitions(-DENABLE_ADIOS=1)

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
@@ -80,11 +80,7 @@ struct ParticleAttribute
             int64_t adiosAttributeVarId = *(params->adiosParticleAttrVarIds.begin());
             params->adiosParticleAttrVarIds.pop_front();
 
-            /** We skip this part due to a bug in ADIOS 1.8.0 where
-             *  read with *compressed* data sets fail on zero-size data sets.
-             *  Note: adios_write commands are not collective (for most methods, except the PHDF5 transport) */
-            if (elements > 0)
-                ADIOS_CMD(adios_write_byid(params->adiosFileHandle, adiosAttributeVarId, tmpBfr));
+            ADIOS_CMD(adios_write_byid(params->adiosFileHandle, adiosAttributeVarId, tmpBfr));
         }
 
         __deleteArray(tmpBfr);

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -19,7 +19,7 @@ then
         module load hdf5-parallel/1.8.14 libsplash/1.4.0
 
         # either use libSplash or ADIOS for file I/O
-        #module load libmxml/2.8 adios/1.9.0
+        #module load libmxml/2.8 adios/1.10.0
 
         # Debug Tools
         #module load valgrind/3.8.1

--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -54,10 +54,9 @@ module load scorep/2.0
 
 # plugins (optional) ################################################
 module load cray-hdf5-parallel/1.8.14
-#module load adios/1.9.0 mxml/2.9 dataspaces/1.4.0
+#module load adios/1.10.0 dataspaces/1.4.0
 export HDF5_ROOT=$HDF5_DIR
 #export ADIOS_ROOT=$ADIOS_DIR
-#export MXML_ROOT=$MXML_DIR
 #export DATASPACES_ROOT=$DATASPACES_DIR
 
 # download libSplash and compile it yourself from

--- a/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
+++ b/src/picongpu/submit/titan-ornl/pythonOnRhea.profile.example
@@ -16,10 +16,9 @@ module load python_scipy
 export IPYTHONDIR=$PROJWORK/$proj/ipython
 
 # ADIOS
-export ADIOS_ROOT=$PROJWORK/$proj/lib/adios-1.9.0-rhea
+export ADIOS_ROOT=$PROJWORK/$proj/lib/adios-1.10.0-rhea
 export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
 export PATH=$ADIOS_ROOT/bin:$PATH
-module load mxml
 
 # GNU Parallel
 export GNUP_ROOT=/lustre/atlas2/aph101/proj-shared/lib/gnu-parallel
@@ -33,9 +32,9 @@ source $PROJWORK/$proj/python-venv/rhea/bin/activate
 #
 # first install adios
 #   LDFLAGS="-fPIC -pthread" CFLAGS="-fPIC -g -O2" CXXFLAGS="-fPIC -g -O2" \
-#     ./configure --prefix=$PROJWORK/$proj/lib/adios-1.9.0-rhea \
+#     ./configure --prefix=$PROJWORK/$proj/lib/adios-1.10.0-rhea \
 #     --with-zlib --with-mpi --enable-static --enable-shared \
-#     --with-mxml=$MXML_DIR --without-dataspaces
+#     --without-dataspaces
 #   make -j
 #   make install
 #

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -109,7 +109,7 @@ endif(Splash_FOUND)
 
 # find adios installation
 #   set(ADIOS_USE_STATIC_LIBS ON) # force static linking
-find_package(ADIOS 1.6.0)
+find_package(ADIOS 1.10.0)
 
 if(ADIOS_FOUND)
     add_definitions(-DENABLE_ADIOS=1)


### PR DESCRIPTION
- we used ADIOS post-1.9.0 `master` already and can now use the latest stable release 1.10.0
- pre ADIOS 1.9.0 we had to avoid zero-writes in GPUs without
particles since ADIOS transforms did otherwise crash.
This has been fixed since ADIOS 1.9.0 on our report and
additionally a test has been added upstream in
[`tests/suite/programs/zerolength.c`](https://github.com/ornladios/ADIOS/blob/v1.9.0/tests/suite/programs/zerolength.c)