### PR TITLE
FieldTmp: MidCurrentDensityComponent

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -106,6 +106,19 @@ struct CreateChargeDensityOperation
     typedef FieldTmpOperation< ParticleChargeDensity, T_Species > type;
 };
 
+/* MidCurrentDensityComponent */
+template<typename T_Species, typename T_Direction = bmpl::int_<0> >
+struct CreateMidCurrentDensityComponentOperation
+{
+    typedef typename GetShape<T_Species>::type shapeType;
+    typedef ComputeGridValuePerFrame<
+        shapeType,
+        particleToGrid::derivedAttributes::MidCurrentDensityComponent<T_Direction::value>
+    > ParticleMidCurrentDensityComponent;
+
+    typedef FieldTmpOperation< ParticleMidCurrentDensityComponent, T_Species > type;
+};
+
 /* ParticleCounter */
 template<typename T_Species>
 struct CreateCounterOperation

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -42,7 +42,7 @@ namespace derivedAttributes
         {
            /* L, M, T, I, theta, N, J
             *
-            * ChargeDensity is in Coulomb / cubic meter: Q / m^3 = I * t / m^3
+            * ChargeDensity is in Coulomb / cubic meter: Q / m^3 = A * s / m^3
             *   -> L^-3 * T * I
             */
            std::vector<float_64> unitDimension( 7, 0.0 );

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -23,6 +23,7 @@
 #include "particles/particleToGrid/derivedAttributes/Density.def"
 #include "particles/particleToGrid/derivedAttributes/Counter.def"
 #include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
 #include "particles/particleToGrid/derivedAttributes/EnergyDensity.def"
 #include "particles/particleToGrid/derivedAttributes/Energy.def"
 #include "particles/particleToGrid/derivedAttributes/MomentumComponent.def"

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -23,6 +23,7 @@
 #include "particles/particleToGrid/derivedAttributes/Density.hpp"
 #include "particles/particleToGrid/derivedAttributes/Counter.hpp"
 #include "particles/particleToGrid/derivedAttributes/ChargeDensity.hpp"
+#include "particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp"
 #include "particles/particleToGrid/derivedAttributes/EnergyDensity.hpp"
 #include "particles/particleToGrid/derivedAttributes/Energy.hpp"
 #include "particles/particleToGrid/derivedAttributes/MomentumComponent.hpp"

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -50,7 +50,7 @@ namespace derivedAttributes
         {
            /* L, M, T, I, theta, N, J
             *
-            * MidCurrentDensity is in Ampere / square meters: I / m^2
+            * MidCurrentDensity is in Ampere / square meters: A / m^2
             *   charge density: Coulomb / m^3
             *   velocity:       m / s
             *   current density = charge density * velocity

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "static_assert.hpp"
+#include "traits/SIBaseUnits.hpp"
+#include <vector>
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    /** Calculate the on-charge current density in a selected direction.
+     *
+     * \tparam size_t with perpendicular direction x=0, y=1, z=2
+     */
+    template <size_t T_direction>
+    struct MidCurrentDensityComponent
+    {
+        PMACC_CASSERT_MSG( Valid_directions_are_0_to_2_for_X_to_Z__in_fileOutput_param, ((T_direction)>=0) );
+        PMACC_CASSERT_MSG( Valid_directions_are_0_to_2_for_X_to_Z__in_fileOutput_param, ((T_direction)<3) );
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * MidCurrentDensity is in Ampere / square meters: I / m^2
+            *   charge density: Coulomb / m^3
+            *   velocity:       m / s
+            *   current density = charge density * velocity
+            *   -> L^-2 * I
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+           unitDimension.at(SIBaseUnits::length) = -2.0;
+           unitDimension.at(SIBaseUnits::electricCurrent) =  1.0;
+
+           return unitDimension;
+        }
+
+        HINLINE std::string
+        getName() const
+        {
+            const std::string name_lookup[] = {"x", "y", "z"};
+
+            return "midCurrentDensity/" + name_lookup[T_direction];
+        }
+
+        /** Calculate a new attribute per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    template< size_t T_direction>
+    HDINLINE float1_64
+    MidCurrentDensityComponent<T_direction>::getUnit() const
+    {
+        const float_64 UNIT_AREA = UNIT_LENGTH * UNIT_LENGTH;
+        return UNIT_CHARGE / ( UNIT_TIME * UNIT_AREA );
+    }
+
+    template< size_t T_direction>
+    template< class T_Particle >
+    DINLINE float_X
+    MidCurrentDensityComponent<T_direction>::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float_X weighting = particle[weighting_];
+        const float_X charge = attribute::getCharge( weighting, particle );
+        const float3_X mom = particle[momentum_];
+        const float_X momCom = mom[T_direction];
+        const float_X mass = attribute::getMass( weighting, particle );
+
+        /* calculate new attribute */
+        Gamma<float_X> calcGamma;
+        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
+
+        /* calculate new attribute */
+        const float_X particleCurrentDensity =
+            charge / CELL_VOLUME *   /* rho */
+            momCom / gamma / mass;   /* v_component */
+
+        /* return attribute */
+        return particleCurrentDensity;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
@@ -58,8 +58,8 @@ namespace derivedAttributes
 
         /* calculate new attribute */
         const float_X particleCurrentDensity =
-            charge / CELL_VOLUME *   /* rho */
-            momCom / gamma / mass;   /* v_component */
+            charge / CELL_VOLUME *     /* rho */
+            momCom / ( gamma * mass ); /* v_component */
 
         /* return attribute */
         return particleCurrentDensity;

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -40,6 +40,8 @@ namespace picongpu
      * you can choose any of these particle to grid projections:
      *   - CreateDensityOperation: particle position + shape on the grid
      *   - CreateChargeDensityOperation: density * charge
+     *   - CreateMidCurrentDensityComponentOperation:
+     *                                   density * charge * velocity_component
      *   - CreateCounterOperation: counts point like particles per cell (debug)
      *   - CreateEnergyDensityOperation: particle energy density with respect
      *                                   to shape


### PR DESCRIPTION
Calculate a "middle" current density (which is not necessarily the average of the closest current density positions) at the position of the charge. Performed component-wise.

Can be used as an alternative way to verify charge conservation.

To use this, add

``` diff
diff --git a/src/picongpu/include/simulation_defines/param/fileOutput.param b/src/picongpu/include/simulation_defines/param/fileOutput.param
index abbea6b..12938b9 100644
--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -59,6 +59,23 @@ namespace picongpu
             CreateChargeDensityOperation<bmpl::_1>
             >::type ChargeDensity_Seq;

+    /* MidCurrentDensityComponent section define "component" as
+     * 0=X (default), 1=Y or 2=Z
+     */
+    typedef bmpl::transform<
+            VectorAllSpecies,
+            CreateMidCurrentDensityComponentOperation<bmpl::_1, bmpl::int_<0> >
+            >::type MidCurrentDensityX_Seq;
+
+    typedef bmpl::transform<
+            VectorAllSpecies,
+            CreateMidCurrentDensityComponentOperation<bmpl::_1, bmpl::int_<1> >
+            >::type MidCurrentDensityY_Seq;
+    typedef bmpl::transform<
+            VectorAllSpecies,
+            CreateMidCurrentDensityComponentOperation<bmpl::_1, bmpl::int_<2> >
+            >::type MidCurrentDensityZ_Seq;
+
     /* ParticleCounter section */
     typedef bmpl::transform<
             VectorAllSpecies,
@@ -86,9 +103,13 @@ namespace picongpu
      */
     typedef MakeSeq<
         ChargeDensity_Seq,
+        MidCurrentDensityX_Seq,
+        MidCurrentDensityY_Seq,
+        MidCurrentDensityZ_Seq/*
+    careful, we now easily reach the boost:::mpl vector/list limit of default 10 entries
         Counter_Seq,
         EnergyDensity_Seq,
-        MomentumComponent_Seq
+        MomentumComponent_Seq*/
     >::type FieldTmpSolvers;

@@ -96,7 +117,7 @@ namespace picongpu

     /** Possible native fields: FieldE, FieldB, FieldJ
      */
-    typedef MakeSeq<FieldE, FieldB>::type NativeFileOutputFields;
+    typedef MakeSeq<FieldE, FieldB, FieldJ>::type NativeFileOutputFields;

     typedef MakeSeq<
         NativeFileOutputFields,
```

to your `fieldOutput.param`.

@abukva with <3 from your desk neighbor. 
