### PR TITLE
Data Alignment for Kernel Parameters: 16 Byte

### DIFF
--- a/src/libPMacc/include/ppFunctions.hpp
+++ b/src/libPMacc/include/ppFunctions.hpp
@@ -52,3 +52,22 @@
  * @return false if no arguments are given, else true
  */
 #define PMACC_HAS_ARGS(...)  ((sizeof((int[]){0, ##__VA_ARGS__}))==sizeof(int)?false:true)
+
+/** round up to next higher pow 2 value
+ *
+ * - if value is pow2, value is returned
+ * - maximal pow 2 value is 128
+ * - negative values are not supported
+ *
+ * @param value integral number between [1,Inf]
+ * @return next higher pow 2 value
+ */
+#define PMACC_ROUND_UP_NEXT_POW2(value) \
+        ((value)==1?1:                  \
+        ((value)<=2?2:                  \
+        ((value)<=4?4:                  \
+        ((value)<=8?8:                  \
+        ((value)<=16?16:                \
+        ((value)<=32?32:                \
+        ((value)<=64?64:128             \
+        )))))))


### PR DESCRIPTION
close #1563 and close #1553

~~- add type to get a architecture depending useful alignment~~
- change `__optimal_align__` based on discussion #1563
- add pre processor macro `PMACC_ROUND_UP_NEXT_POW2`

Tests:
- [x] remove warning #1553 
- [x] KHI heating test
- [x] KHI speedtest (result: no speed decrease) 

CC-ing: @Flamefire 