### PR TITLE
extent function `twistVectorFieldAxes<>()`

### DIFF
--- a/src/libPMacc/include/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
@@ -36,12 +36,18 @@ namespace tools
 namespace result_of
 {
 
-template<typename Axes, typename TCursor>
+/** result for TwistVectorFieldAxes
+ *
+ * \tparam T_NavigatorPerm permutation vector for navigator
+ * \tparam T_AccessorPerm permutation vector for the accessor
+ * \tparam T_Cursor cursor to permute
+ */
+template<typename T_NavigatorPerm, typename T_AccessorPerm, typename T_Cursor>
 struct TwistVectorFieldAxes
 {
-    typedef Cursor<TwistAxesAccessor<TCursor, Axes>,
-                   PMacc::cursor::CT::TwistAxesNavigator<Axes>,
-                   TCursor> type;
+    typedef Cursor<TwistAxesAccessor<T_Cursor, T_AccessorPerm>,
+                   PMacc::cursor::CT::TwistAxesNavigator<T_NavigatorPerm>,
+                   T_Cursor> type;
 };
 
 } // result_of
@@ -55,18 +61,59 @@ struct TwistVectorFieldAxes
  *
  * e.g.: new_cur = twistVectorFieldAxes<math::CT::Int<1,2,0> >(cur); // x -> y, y -> z, z -> x
  *
- * \tparam Axes compile-time vector (PMacc::math::CT::Int) that describes the mapping.
- * x-axis -> Axes::at<0>, y-axis -> Axes::at<1>, ...
+ * \tparam T_Permutation compile-time vector (PMacc::math::CT::Int) that describes the mapping.
+ * x-axis -> T_Permutation::at<0>, y-axis -> T_Permutation::at<1>, ...
  *
  */
-template<typename Axes, typename TCursor>
+template<typename T_Permutation, typename T_Cursor>
 HDINLINE
-typename result_of::TwistVectorFieldAxes<Axes, TCursor>::type
-twistVectorFieldAxes(const TCursor& cursor)
+typename result_of::TwistVectorFieldAxes<T_Permutation, T_Permutation, T_Cursor>::type
+twistVectorFieldAxes(const T_Cursor& cursor)
 {
-    return typename result_of::TwistVectorFieldAxes<Axes, TCursor>::type
-        (TwistAxesAccessor<TCursor, Axes>(),
-        PMacc::cursor::CT::TwistAxesNavigator<Axes>(),
+    return typename result_of::TwistVectorFieldAxes<T_Permutation, T_Permutation, T_Cursor>::type
+        (TwistAxesAccessor<T_Cursor, T_Permutation>(),
+        PMacc::cursor::CT::TwistAxesNavigator<T_Permutation>(),
+        cursor);
+}
+
+/** permute navigation and access of a cursor
+ *
+ * use same permutation for accessor and navigator
+ *
+ * \tparam T_Permutation permutation vector
+ * \tparam T_Cursor permutation vector
+ * \param cursor cursor to permute
+ * \param permutation cursor to permute
+ */
+template<typename T_Cursor, typename T_Permutation>
+HDINLINE
+typename result_of::TwistVectorFieldAxes<T_Permutation, T_Permutation, T_Cursor>::type
+twistVectorFieldAxes(const T_Cursor& cursor, const T_Permutation& /*permutation*/)
+{
+    return typename result_of::TwistVectorFieldAxes<T_Permutation, T_Permutation, T_Cursor>::type
+        (TwistAxesAccessor<T_Cursor, T_Permutation>(),
+        PMacc::cursor::CT::TwistAxesNavigator<T_Permutation>(),
+        cursor);
+}
+
+/** permute navigation and access of a cursor
+ *
+ * different dimensions for the accessor and navigator permutation vector are allowed
+ *
+ * \param cursor cursor to permute
+ * \param navigatorPermutation compile time permutation vector for the navigator
+ * \param accessorPermutation compile time permutation vector for the accessor
+ */
+template<typename T_Cursor, typename T_NavigatorPerm, typename T_AccessorPerm>
+HDINLINE
+typename result_of::TwistVectorFieldAxes<T_NavigatorPerm, T_AccessorPerm, T_Cursor>::type
+twistVectorFieldAxes(const T_Cursor& cursor,
+                       const T_NavigatorPerm& /*navigatorPermutation*/,
+                       const T_AccessorPerm& /*accessorPermutation*/)
+{
+    return typename result_of::TwistVectorFieldAxes<T_NavigatorPerm, T_AccessorPerm, T_Cursor>::type
+        (TwistAxesAccessor<T_Cursor, T_AccessorPerm>(),
+        PMacc::cursor::CT::TwistAxesNavigator<T_NavigatorPerm>(),
         cursor);
 }
 


### PR DESCRIPTION
Allow different permutation for navigation in space and the accessor to the vector field component.
- add two new function signatures
  - permutate navigator and accessor with the same permutation vector
  - permute navigator and accessor different
- update documentation
- change template parameter nameing

This pull request is needed for the directional splitting changes
- [x] please not merge before the release 0.2.0 is finsihed
