### PR TITLE
add user defined 2D integration length

### DIFF
--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -48,11 +48,13 @@ namespace picongpu
 #elif(SIMDIM==DIM2)
     namespace SI
     {
+        /** take `CELL_DEPTH_SI` as integration length for 2D that this value can changed by the user */
+        BOOST_CONSTEXPR_OR_CONST float_64 integration_length = CELL_DEPTH_SI;
         /** density normed to dimension of the simulation
          *
          * http://www.tf.uni-kiel.de/matwis/amat/mw1_ge/kap_6/basics/m6_2_1.html
          */
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI*UNIT_LENGTH;
+        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED = SI::GAS_DENSITY_SI*integration_length;
     } //namespace SI
     namespace particles
     {


### PR DESCRIPTION
**Only 2D simulations are influenced**

- change 2D particle density to area density calculation
- use `CELL_DEPTH_SI` instead of `UNIT_LENGTH`

In the current dev the weighting of each particle is changed when we changed delta time even if we keep the cell size. This results in not comparable simulations.
This change give the advantage that we can compare Yee and Directional Splitting in the case we have the same grid size but different delta time's.

It is now also possible to compare to 2D Yee simulations with different cell size but equal global size in real space.


- [ ] please do ~~not~~ merge before the release branch 0.2.0 is compled

CC-ing: @PrometheusPi (he helped me)