### PR TITLE
Hypnos (HZDR): Default -t File Path Update

### DIFF
--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -55,4 +55,4 @@ export PATH=$PATH:$PICSRC/src/tools/bin
 #   - PBS/Torque (qsub)
 #   - "k20" queue
 export TBG_SUBMIT="qsub"
-export TBG_TPLFILE="submit/hypnos/k20_profile.tpl"
+export TBG_TPLFILE="submit/hypnos-hzdr/k20_profile.tpl"


### PR DESCRIPTION
The `TBG_TPLFILE` environment suggestion to use the K20 queue was outdated (all other clusters are correct; see #1137).

This updates it so one can submit a file to K20 via:
```bash
tbg -s -t -c submit/<userInput.cfg> /bigdata/hplsim/...
```