### PR TITLE
rename typedef's inside `ParticleBuffer`

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -54,10 +54,10 @@ public:
 
     /* Type of frame in particles buffer
      */
-    typedef typename BufferType::ParticleType FrameType;
+    typedef typename BufferType::FrameType FrameType;
     /* Type of border frame in a particle buffer
      */
-    typedef typename BufferType::ParticleTypeBorder FrameTypeBorder;
+    typedef typename BufferType::FrameTypeBorder FrameTypeBorder;
 
     /* Type of the particle box which particle buffer create
      */

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -67,71 +67,101 @@ public:
 
     /** create static array
      */
-    template<uint32_t T_size>
+    template< uint32_t T_size >
     struct OperatorCreatePairStaticArray
     {
 
         template<typename X>
         struct apply
         {
-            typedef
-            bmpl::pair<X,
-            StaticArray< typename traits::Resolve<X>::type::type, bmpl::integral_c<uint32_t, T_size> >
+            typedef bmpl::pair<
+                X,
+                StaticArray<
+                    typename traits::Resolve<X>::type::type,
+                    bmpl::integral_c<uint32_t, T_size>
+                >
             > type;
         };
     };
 
-    typedef ExchangeMemoryIndex<vint_t, DIM - 1 > PopPushType;
+    /** type of the border frame management object
+     *
+     * contains:
+     *   - superCell position of the border frames inside a given range
+     *   - start position inside the exchange stack for frames
+     *   - number of frames corresponding to the superCell position
+     */
+    typedef ExchangeMemoryIndex<
+        vint_t,
+        DIM - 1
+    > BorderFrameIndex;
 
     typedef SuperCellSize_ SuperCellSize;
 
-    typedef
-    typename MakeSeq<
-    typename T_ParticleDescription::ValueTypeSeq,
-    localCellIdx,
-    multiMask
-    >::type full_particleList;
+    typedef typename MakeSeq<
+        typename T_ParticleDescription::ValueTypeSeq,
+        localCellIdx,
+        multiMask
+    >::type ParticleAttributeList;
+
+    typedef typename MakeSeq<
+        typename T_ParticleDescription::ValueTypeSeq,
+        localCellIdx
+    >::type ParticleAttributeListBorder;
 
     typedef
-    typename MakeSeq<
-    typename T_ParticleDescription::ValueTypeSeq,
-    localCellIdx
-    >::type border_particleList;
+    typename ReplaceValueTypeSeq<
+        T_ParticleDescription,
+        ParticleAttributeList
+    >::type FrameDescriptionWithManagementAttributes;
 
-    typedef
-    typename ReplaceValueTypeSeq<T_ParticleDescription, full_particleList>::type
-    ParticleDescriptionWithExtendedAttributes;
-
+    /** double linked list pointer */
     typedef
     typename MakeSeq<
         PreviousFramePtr<>,
         NextFramePtr<>
-    >::type PtrExtension;
+    >::type LinkedListPointer;
 
     /* extent particle description with pointer to a frame*/
-    typedef
-    typename ReplaceFrameExtensionSeq<ParticleDescriptionWithExtendedAttributes, PtrExtension>::type
-    ParticleDescriptionDefault;
+    typedef typename ReplaceFrameExtensionSeq<
+        FrameDescriptionWithManagementAttributes,
+        LinkedListPointer
+    >::type FrameDescription;
 
+    /** frame definition
+     *
+     * a group of particles is stored as frame
+     */
     typedef Frame<
-    OperatorCreatePairStaticArray<PMacc::math::CT::volume<SuperCellSize>::type::value >, ParticleDescriptionDefault> ParticleType;
+        OperatorCreatePairStaticArray<
+            PMacc::math::CT::volume< SuperCellSize >::type::value
+        >,
+        FrameDescription
+    > FrameType;
 
-    typedef
-    typename ReplaceValueTypeSeq<T_ParticleDescription, border_particleList>::type
-    ParticleDescriptionBorder;
+    typedef typename ReplaceValueTypeSeq<
+        T_ParticleDescription,
+        ParticleAttributeListBorder
+    >::type FrameDescriptionBorder;
 
-    typedef Frame<OperatorCreatePairStaticArray<1u >, ParticleDescriptionBorder> ParticleTypeBorder;
+    /** frame which is used to communicate particles to neighbors
+     *
+     * - each frame contains only one particle
+     * - local administration attributes of a particle are removed
+     */
+    typedef Frame<
+        OperatorCreatePairStaticArray< 1u >,
+        FrameDescriptionBorder
+    > FrameTypeBorder;
 
-
-    typedef ParticleType FrameType;
     typedef SuperCell<FrameType> SuperCellType;
 
 private:
 
-    /*this is only for internel calculations*/
+    /* this enum is used only for internal calculations */
     enum
     {
-        SizeOfOneBorderElement = (sizeof (ParticleTypeBorder) + sizeof (PopPushType))
+        SizeOfOneBorderElement = (sizeof (FrameTypeBorder) + sizeof (BorderFrameIndex))
     };
 
 public:
@@ -147,10 +177,9 @@ public:
     superCellSize(superCellSize), gridSize(layout), framesExchanges(NULL)
     {
 
-        exchangeMemoryIndexer = new GridBuffer<PopPushType, DIM1 > (DataSpace<DIM1 > (0));
-        framesExchanges = new GridBuffer< ParticleType, DIM1, ParticleTypeBorder > (DataSpace<DIM1 > (0));
+        exchangeMemoryIndexer = new GridBuffer<BorderFrameIndex, DIM1 > (DataSpace<DIM1 > (0));
+        framesExchanges = new GridBuffer< FrameType, DIM1, FrameTypeBorder > (DataSpace<DIM1 > (0));
 
-        //std::cout << "size: " << sizeof (ParticleType) << " " << sizeof (ParticleTypeBorder) << std::endl;
         DataSpace<DIM> superCellsCount = gridSize / superCellSize;
 
         superCells = new GridBuffer<SuperCellType, DIM > (superCellsCount);
@@ -191,11 +220,11 @@ public:
     void addExchange(Mask receive, size_t usedMemory, uint32_t communicationTag)
     {
 
-        size_t numBorderFrames = usedMemory / SizeOfOneBorderElement;
+        size_t numFrameTypeBorders = usedMemory / SizeOfOneBorderElement;
 
-        framesExchanges->addExchangeBuffer(receive, DataSpace<DIM1 > (numBorderFrames), communicationTag, true, false);
+        framesExchanges->addExchangeBuffer(receive, DataSpace<DIM1 > (numFrameTypeBorders), communicationTag, true, false);
 
-        exchangeMemoryIndexer->addExchangeBuffer(receive, DataSpace<DIM1 > (numBorderFrames), communicationTag | (1u << (20 - 5)), true, false);
+        exchangeMemoryIndexer->addExchangeBuffer(receive, DataSpace<DIM1 > (numFrameTypeBorders), communicationTag | (1u << (20 - 5)), true, false);
     }
 
     /**
@@ -203,10 +232,10 @@ public:
      *
      * @return device frames ParticlesBox
      */
-    ParticlesBox<ParticleType, DIM> getDeviceParticleBox()
+    ParticlesBox<FrameType, DIM> getDeviceParticleBox()
     {
 
-        return ParticlesBox<ParticleType, DIM > (
+        return ParticlesBox<FrameType, DIM > (
                                                  superCells->getDeviceBuffer().getDataBox());
     }
 
@@ -215,10 +244,10 @@ public:
      *
      * @return host frames ParticlesBox
      */
-    ParticlesBox<ParticleType, DIM> getHostParticleBox(int64_t memoryOffset)
+    ParticlesBox<FrameType, DIM> getHostParticleBox(int64_t memoryOffset)
     {
 
-        return ParticlesBox<ParticleType, DIM > (
+        return ParticlesBox<FrameType, DIM > (
                                                  superCells->getHostBuffer().getDataBox(),
                                                  memoryOffset
                                                 );
@@ -248,17 +277,17 @@ public:
         return framesExchanges->hasReceiveExchange(ex);
     }
 
-    StackExchangeBuffer<ParticleTypeBorder, PopPushType, DIM - 1 > getSendExchangeStack(uint32_t ex)
+    StackExchangeBuffer<FrameTypeBorder, BorderFrameIndex, DIM - 1 > getSendExchangeStack(uint32_t ex)
     {
 
-        return StackExchangeBuffer<ParticleTypeBorder, PopPushType, DIM - 1 >
+        return StackExchangeBuffer<FrameTypeBorder, BorderFrameIndex, DIM - 1 >
             (framesExchanges->getSendExchange(ex), exchangeMemoryIndexer->getSendExchange(ex));
     }
 
-    StackExchangeBuffer<ParticleTypeBorder, PopPushType, DIM - 1 > getReceiveExchangeStack(uint32_t ex)
+    StackExchangeBuffer<FrameTypeBorder, BorderFrameIndex, DIM - 1 > getReceiveExchangeStack(uint32_t ex)
     {
 
-        return StackExchangeBuffer<ParticleTypeBorder, PopPushType, DIM - 1 >
+        return StackExchangeBuffer<FrameTypeBorder, BorderFrameIndex, DIM - 1 >
             (framesExchanges->getReceiveExchange(ex), exchangeMemoryIndexer->getReceiveExchange(ex));
     }
 
@@ -335,11 +364,11 @@ public:
 
 
 private:
-    GridBuffer<PopPushType, DIM1> *exchangeMemoryIndexer;
+    GridBuffer<BorderFrameIndex, DIM1> *exchangeMemoryIndexer;
 
     GridBuffer<SuperCellType, DIM> *superCells;
     /*GridBuffer for hold borderFrames, we need a own buffer to create first exchanges without core memory*/
-    GridBuffer< ParticleType, DIM1, ParticleTypeBorder> *framesExchanges;
+    GridBuffer< FrameType, DIM1, FrameTypeBorder> *framesExchanges;
 
     DataSpace<DIM> superCellSize;
     DataSpace<DIM> gridSize;


### PR DESCRIPTION
close #1573  FrameType renaming
- rename
  - `ParticleTypeBorder` -> `FrameTypeBorder`
  - `ParticleDescriptionBorder` -> `FrameDescriptionBorder`
  - `ParticleType` -> `FrameType`
  - `ParticleDescriptionDefault` -> `FrameDescription`
  - `PtrExtension` -> `LinkedListPointer`
  - `ParticleDescriptionWithExtendedAttributes` -> `FrameDescriptionWithManagementAttributes`
  - `border_particleList` -> `ParticleAttributeListBorder`
  - `full_particleList` -> `ParticleAttributeList`
  - `PopPushType` -> `BorderFrameIndex`
- add documentation to all typedef's
- update usage of the new types
