### PR TITLE
expression validation/assertion

### DIFF
--- a/src/libPMacc/include/assert.hpp
+++ b/src/libPMacc/include/assert.hpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "debug/abortWithError.hpp"
+
+#ifdef NDEBUG
+    // debug mode is disabled
+
+    /* `(void)0` force a semicolon after the macro function */
+#   define PMACC_ASSERT( expr ) ( (void) 0 )
+
+    /* `(void)0` force a semicolon after the macro function */
+#   define PMACC_ASSERT_MSG( expr, msg ) ( (void) 0 )
+
+#else
+
+    // debug mode is enabled
+
+    /** assert check
+     *
+     * if `NDEBUG` is not defined: macro expands to (void)0
+     *
+     * @param expr expression to be evaluated
+     */
+#   define PMACC_ASSERT( expr )                                                \
+    ( !!(expr) ) ? ( (void) 0 ) : PMacc::abortWithError( #expr, __FILE__, __LINE__ )
+
+    /** assert check with message
+     *
+     * if `NDEBUG` is not defined: macro expands to (void)0
+     *
+     * @param expr expression to be evaluated
+     * @param msg output message (of type `std::string`) which is printed if the
+     *            expression is evaluated to false
+     */
+#   define PMACC_ASSERT_MSG( expr, msg )                                       \
+    ( !!(expr) ) ? ( (void) 0 ) : PMacc::abortWithError( #expr, __FILE__, __LINE__, msg )
+
+#endif

--- a/src/libPMacc/include/debug/abortWithError.hpp
+++ b/src/libPMacc/include/debug/abortWithError.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <sstream>
+
+namespace PMacc
+{
+    /** abort program with an exception
+     *
+     * This function always throws a `runtime_error`.
+     *
+     * @param exp evaluated expression
+     * @param filename name of the broken file
+     * @param lineNumber line in file
+     * @param msg user defined error message
+     */
+    void abortWithError(
+        const std::string exp,
+        const std::string filename,
+        const uint32_t lineNumber,
+        const std::string msg = std::string()
+    )
+    {
+        std::stringstream line;
+        line << lineNumber;
+
+        throw std::runtime_error(
+            "expression (" +
+            exp +
+            ") failed in file (" +
+            filename + ":" + line.str() + ") : " +
+            msg
+        );
+    }
+}

--- a/src/libPMacc/include/verify.hpp
+++ b/src/libPMacc/include/verify.hpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "debug/abortWithError.hpp"
+
+/** verify expression
+ *
+ * Same behavior as PMACC_ASSERT but the expression is always evaluated.
+ *
+ * @param expr expression to be evaluated
+ */
+#define PMACC_VERIFY( expr )                                                   \
+    ( !!(expr) ) ? ( (void) 0 ) : PMacc::abortWithError( #expr, __FILE__, __LINE__ )
+
+/** verify expression with message
+ *
+ * Same behavior as PMACC_ASSERT_MSG but the expression is always evaluated.
+ *
+ * @param expr expression to be evaluated
+ * @param msg output message (of type `std::string`) which is printed if the
+ *            expression is evaluated to false
+ */
+#define PMACC_VERIFY_MSG( expr, msg )                                          \
+    ( !!(expr) ) ? ( (void) 0 ) : PMacc::abortWithError( #expr, __FILE__, __LINE__, msg )


### PR DESCRIPTION
Many assertion checks inside PMacc and PIConGPU were performed with `assert`. 
If PIConGPU/PMACC is compiled in release mode these checks were disabled.
In the most cases this checks are essential checks to validate the user input parameters and should always be evaluated.
This pull request adds PMacc specific asserts and verification macros to choose if a expression needs to be evaluated only in debug mode or also inside the release binary.
- add function `abortWithError()` to create an exception with useful information
- add macro function
  - PMACC_ASSERT
  - PMACC_ASSERT_MSG
  - PMACC_VERIFY
  - PMACC_VERIFY_MSG

**Why we are not using`BOOST_ASSERT, BOOST_VERIFY?`**

The boost assert and verify functions ended up with `std::abort()`. This needs signal handling to implement something like #654.
After we added signal handling in PMacc we can easily switch to the boost macros without changing our asserts in the code.

TODO:
- [x] test new macros
