### PR TITLE
avoid local memory usage of `Particle<>`

### DIFF
--- a/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
@@ -71,16 +71,15 @@ struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
     typedef Particle<FrameType, ValueTypeSeq> ThisType;
     typedef typename FrameType::MethodsList MethodsList;
 
-    /* IMPORTANT: store first value with big size to avoid
-     * that pointer is copied byte by byte because data are not aligned
-     *
-     * in this case sizeof(uint32_t)<=sizeof(pointer)
-     */
-    /** pointer to parent frame where this particle is from*/
-    PMACC_ALIGN(frame, FrameType* const);
-
     /** index of particle inside the Frame*/
     PMACC_ALIGN(idx, const uint32_t);
+
+    /** pointer to parent frame where this particle is from
+     *
+     * ATTENTION: The pointer must be the last member to avoid local memory usage
+     *            https://github.com/ComputationalRadiationPhysics/picongpu/pull/762
+     */
+    PMACC_ALIGN(frame, FrameType* const);
 
     /** create particle
      *


### PR DESCRIPTION
- store pointer as last element inside the struct
- remove old (invalid) comment
```
/* IMPORTANT: store first value with big size to avoid		
 *
 * that pointer is copied byte by byte because data are not aligned		     	
 * in this case sizeof(uint32_t)<=sizeof(pointer)		
 */
```


This changes based on the pull request #762.

- The local mem problem effects **not** CUDA 7.5.
- Local mem problem for CUDA 6.5 & 7.0 is solved with this pull request.
- CUDA <= 6.0 was not tested.

Tests:

- [x] KHI electron/ion compare speed  dev/pullrequest
- [x] KHI electrons/positrons

CC-ing: @Flamefire 