### PR TITLE
Add transverse Laguerre-modes to standard Gauss laser.

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Anton Helm, Richard Pausch, Axel Huebl
+ * Copyright 2013-2017 Anton Helm, Richard Pausch, Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -73,6 +73,10 @@ constexpr float_64 PULSE_INIT = 20.0;
 
 /* laser phase shift (no shift: 0.0) */
 constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+/* Use only the 0th Laguerremode for a standard Gaussian */
+constexpr uint32_t MODENUMBER = 0;
+PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
 
 enum PolarisationType
 {

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -73,6 +73,10 @@ namespace picongpu
 
         /* laser phase shift (no shift: 0.0) */
         constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+        /* Use only the 0th Laguerremode for a standard Gaussian */
+        constexpr uint32_t MODENUMBER = 0;
+        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
 
         enum PolarisationType
         {

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -73,6 +73,10 @@ constexpr float_64 PULSE_INIT = 20.0;
 
 /* laser phase shift (no shift: 0.0) */
 constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+/* Use only the 0th Laguerremode for a standard Gaussian */
+constexpr uint32_t MODENUMBER = 0;
+PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
 
 enum PolarisationType
 {

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -43,6 +43,13 @@ namespace picongpu
 
             float3_X elong(float3_X::create(0.0));
 
+            // This check is done here on HOST, since std::numeric_limits<float_X>::epsilon() does not compile on laserTransversal(), which is on DEVICE.
+            float_X etrans_norm = float_X(0.0);
+            for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
+                etrans_norm += LAGUERREMODES[m];
+            PMACC_VERIFY_MSG( algorithms::math::abs(etrans_norm) > std::numeric_limits<float_X>::epsilon(), "Sum of LAGUERREMODES can not be 0." );
+
+
             // a symmetric pulse will be initialized at position z=0 for
             // a time of PULSE_INIT * PULSE_LENGTH = INIT_TIME.
             // we shift the complete pulse for the half of this time to start with
@@ -128,6 +135,7 @@ namespace picongpu
             float_X etrans = float_X(0.0);
             float_X etrans_norm = float_X(0.0);
             PMACC_CASSERT_MSG(MODENUMBER_must_be_smaller_than_number_of_entries_in_LAGUERREMODES_vector, MODENUMBER<LAGUERREMODES_t::dim);
+            PMACC_VERIFY_MSG( MODENUMBER<LAGUERREMODES_t::dim, "MODENUMBER must be smaller than number of entries in LAGUERREMODES vector." );
             for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
                 etrans_norm += LAGUERREMODES[m];
 

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
- *                     Richard Pausch
+ *                     Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -81,6 +81,32 @@ namespace picongpu
         }
 
         /**
+         *  Simple iteration algorithm to implement Laguerre polynomials for GPUs.
+         *  @param n order of the Laguerre polynomial
+         *  @param x coordinate at which the polynomial is evaluated
+         *  @return
+         */
+        HDINLINE float_X simpleLaguerre( const uint32_t n, const float_X x )
+        {
+            //Result for special case n == 0
+            if (n == 0) return float_X(1.0);
+            uint32_t currentN = 1;
+            float_X laguerreNMinus1 = float_X(1.0);
+            float_X laguerreN = float_X(1.0) - x;
+            float_X laguerreNPlus1 = float_X(0.0);
+            while (currentN < n)
+            {
+                //Core statement of the algorithm
+                laguerreNPlus1 = ( ( float_X(2.0) * float_X(currentN) + float_X(1.0) - x) * laguerreN - float_X(currentN) * laguerreNMinus1 ) / float_X(currentN + 1);
+                //Advance by one order
+                laguerreNMinus1 = laguerreN;
+                laguerreN = laguerreNPlus1;
+                currentN++;
+            }
+            return laguerreN;
+        }
+
+        /**
          *
          * @param elong
          * @param phase
@@ -98,6 +124,12 @@ namespace picongpu
             // the radius of curvature of the beam's  wavefronts
             const float_X R_y = -FOCUS_POS * ( float_X(1.0) + ( y_R / FOCUS_POS )*( y_R / FOCUS_POS ) );
 
+            // initialize temporary variables
+            float_X etrans = float_X(0.0);
+            float_X etrans_norm = float_X(0.0);
+            PMACC_CASSERT_MSG(MODENUMBER_must_be_smaller_than_number_of_entries_in_LAGUERREMODES_vector, MODENUMBER<LAGUERREMODES_t::dim);
+            for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
+                etrans_norm += LAGUERREMODES[m];
 
             //beam waist in the near field: w_y(y=0) == W0
             const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
@@ -106,22 +138,38 @@ namespace picongpu
 
             if( Polarisation == LINEAR_X || Polarisation == LINEAR_Z )
             {
-                elong *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
+                for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
+                {
+                    etrans += LAGUERREMODES[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
+                        * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
+                }
+                elong *= etrans / etrans_norm;
             }
             else if( Polarisation == CIRCULAR )
             {
-                elong.x() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
+                for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
+                {
+                    etrans += LAGUERREMODES[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
+                        * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
+                }
+                elong.x() *= etrans / etrans_norm;
                 phase += float_X( PI / 2.0 );
-                elong.z() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
+                etrans = float_X(0.0);
+                for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
+                {
+                    etrans += LAGUERREMODES[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
+                        * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
+                }
+                elong.z() *= etrans / etrans_norm;
                 phase -= float_X( PI / 2.0 );
             }
 

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+ * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -73,6 +73,13 @@ namespace picongpu
 
         /* laser phase shift (no shift: 0.0) */
         constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+        /* Use only the 0th Laguerremode for a standard Gaussian */
+        constexpr uint32_t MODENUMBER = 0;
+        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+        /* This is just an example for a more complicated set of Laguerre modes. */
+        //constexpr uint32_t MODENUMBER = 12;
+        //PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321, -0.0160788);
 
         enum PolarisationType
         {


### PR DESCRIPTION
Hello y'all,

This pull request implements basic support of rotationally symmetric Gauss-Laguerre laser modes within the standard Gauss laser.

Literature on this can be found at numerous places, but you can start here:
[F. Pampaloni et al. (2004), Gaussian, Hermite-Gaussian, and Laguerre-Gaussian beams: A primer](https://arxiv.org/pdf/physics/0410021)
[Wikipedia on Gaussian laser beams](https://en.wikipedia.org/wiki/Gaussian_beam)

Although this implementation has passed basic testing, it is still work in progress. Especially, the implementation of evaluating Laguerre-Polynomials is very simple, but apparently good enough in performance for this purpose. Nevertheless a better library implementation for GPUs would be welcome. So far, I did not stumble across anything related to CUDA. On the host side we can definitely use the appropriate boost-library.

Anyway, please don't hold your fire, but start the bombardment immediately! :bomb: :scream: What needs be done? :smiley: 

Cheers! :cyclone: :zap: :coffee: 
