### PR TITLE
add EmZ current deposition solver

### DIFF
--- a/src/picongpu/include/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/src/picongpu/include/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -1,0 +1,325 @@
+/**
+ * Copyright 2013-2016 Axel Huebl, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cuSTL/cursor/Cursor.hpp"
+#include "basicOperations.hpp"
+#include <cuSTL/cursor/tools/twistVectorFieldAxes.hpp>
+
+#include "fields/currentDeposition/EmZ/EmZ.def"
+#include "fields/currentDeposition/Esirkepov/Line.hpp"
+
+namespace picongpu
+{
+namespace currentSolver
+{
+namespace emz
+{
+    using namespace PMacc;
+
+    template<
+        typename ParticleAssign
+    >
+    struct BaseMethods
+    {
+        /** evaluate particle shape
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1,2} means {x,y,z}
+         *          different to Esirkepov paper, here we use C style
+         * @{
+         */
+
+        /** evaluate shape for the first particle S0 (see paper) */
+        DINLINE float_X
+        S0(
+            const Line< floatD_X >& line,
+            const float_X gridPoint,
+            const uint32_t d
+        ) const
+        {
+            return ParticleAssign( )( gridPoint - line.m_pos0[d] );
+        }
+
+        /** evaluate shape for the second particle */
+        DINLINE float_X
+        S1(
+            const Line< floatD_X >& line,
+            const float_X gridPoint,
+            const uint32_t d
+        ) const
+        {
+            return ParticleAssign( )( gridPoint - line.m_pos1[d] );
+        }
+        /*! @} */
+
+        /** calculate DS (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1,2} means {x,y,z}]
+         *          different to Esirkepov paper, here we use C style
+         */
+        DINLINE float_X
+        DS(
+            const Line<floatD_X>& line,
+            const float_X gridPoint,
+            const uint32_t d
+        ) const
+        {
+            return ParticleAssign( )( gridPoint - line.m_pos1[d] ) - ParticleAssign( )( gridPoint - line.m_pos0[d] );
+        }
+    };
+
+    template<
+        typename ParticleAssign,
+        int T_begin,
+        int T_end
+    >
+    struct DepositCurrent<
+        ParticleAssign,
+        T_begin,
+        T_end,
+        DIM3
+    > : public BaseMethods< ParticleAssign >
+    {
+        template< typename T_Cursor >
+        DINLINE void
+        operator()(
+            const T_Cursor& cursorJ,
+            const Line< float3_X >& line,
+            const float_X chargeDensity,
+            const float_X
+        ) const
+        {
+            /**
+             * \brief the following three calls separate the 3D current deposition
+             * into three independent 1D calls, each for one direction and current component.
+             * Therefore the coordinate system has to be rotated so that the z-direction
+             * is always specific.
+             */
+            using namespace cursor::tools;
+            cptCurrent1D(
+                twistVectorFieldAxes< PMacc::math::CT::Int < 1, 2, 0 > >( cursorJ ),
+                rotateOrigin< 1, 2, 0 >( line ),
+                cellSize.x( ) * chargeDensity / DELTA_T
+            );
+            cptCurrent1D(
+                twistVectorFieldAxes< PMacc::math::CT::Int < 2, 0, 1 > >( cursorJ ),
+                rotateOrigin< 2, 0, 1 >( line ),
+                cellSize.y( ) * chargeDensity / DELTA_T
+            );
+            cptCurrent1D(
+                cursorJ,
+                line,
+                cellSize.z( ) * chargeDensity / DELTA_T
+            );
+        }
+
+        /** deposites current in z-direction
+         *
+         * \param cursorJ cursor pointing at the current density field of the particle's cell
+         * \param line trajectory of the virtual particle
+         * \param currentSurfaceDensity surface density
+         */
+        template<
+            typename CursorJ,
+            typename T_Line
+        >
+        DINLINE void
+        cptCurrent1D(
+            CursorJ cursorJ,
+            const T_Line& line,
+            const float_X currentSurfaceDensity
+        ) const
+        {
+            if( line.m_pos0[2] == line.m_pos1[2] )
+                return;
+            /* pick every cell in the xy-plane that is overlapped by particle's
+             * form factor and deposit the current for the cells above and beneath
+             * that cell and for the cell itself.
+             */
+            for( int i = T_begin ; i < T_end ; ++i )
+            {
+                const float_X s0i = S0( line, i, 0 );
+                const float_X dsi = S1( line, i, 0 ) - s0i;
+                for( int j = T_begin ; j < T_end ; ++j )
+                {
+                    const float_X s0j = S0( line, j, 1 );
+                    const float_X dsj = S1( line, j, 1 ) - s0j;
+
+                    float_X tmp =
+                        -currentSurfaceDensity * (
+                            s0i * s0j +
+                            float_X( 0.5 ) * ( dsi * s0j + s0i * dsj ) +
+                            ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsj * dsi
+                        );
+
+                    float_X accumulated_J = float_X( 0.0 );
+                    for( int k = T_begin ; k < T_end - 1 ; ++k )
+                    {
+                        /* This is the implementation of the FORTRAN W(i,j,k,3)/ C style W(i,j,k,2) version from
+                         * Esirkepov paper. All coordinates are rotated before thus we can
+                         * always use C style W(i,j,k,2).
+                         */
+                        const float_X W = DS( line, k, 2 ) * tmp;
+                        accumulated_J += W;
+                        atomicAddWrapper(
+                            &( (*cursorJ( i, j, k ) ).z( ) ),
+                            accumulated_J
+                        );
+                    }
+                }
+            }
+        }
+    };
+
+    template<
+        typename ParticleAssign,
+        int T_begin,
+        int T_end
+    >
+    struct DepositCurrent<
+        ParticleAssign,
+        T_begin,
+        T_end,
+        DIM2
+    > : public BaseMethods< ParticleAssign >
+    {
+        template< typename T_Cursor >
+        DINLINE void
+        operator()(
+            const T_Cursor& cursorJ,
+            const Line< float2_X >& line,
+            const float_X chargeDensity,
+            const float_X velocityZ
+        ) const
+        {
+            using namespace cursor::tools;
+            cptCurrent1D(
+                cursorJ,
+                line,
+                cellSize.x( ) * chargeDensity / DELTA_T
+            );
+            cptCurrent1D(
+                twistVectorFieldAxes< PMacc::math::CT::Int < 1, 0 > >( cursorJ ),
+                rotateOrigin < 1, 0 > ( line ),
+                cellSize.y( ) * chargeDensity / DELTA_T
+            );
+            cptCurrentZ(
+                cursorJ,
+                line,
+                velocityZ * chargeDensity
+            );
+        }
+
+        /** deposites current in x-direction
+         *
+         * \param cursorJ cursor pointing at the current density field of the particle's cell
+         * \param line trajectory of the virtual particle
+         * \param currentSurfaceDensity surface density
+         */
+        template<
+            typename CursorJ,
+            typename T_Line
+        >
+        DINLINE void
+        cptCurrent1D(
+            CursorJ cursorJ,
+            const T_Line& line,
+            const float_X currentSurfaceDensity
+        ) const
+        {
+            if( line.m_pos0[0] == line.m_pos1[0] )
+                return;
+
+            for( int j = T_begin; j < T_end; ++j )
+            {
+                const float_X s0j = S0( line, j, 1 );
+                const float_X dsj = S1( line, j, 1 ) - s0j;
+
+                float_X tmp = -currentSurfaceDensity *
+                    (
+                        s0j +
+                        float_X( 0.5 ) * dsj
+                    );
+
+                float_X accumulated_J = float_X( 0.0 );
+                for( int i = T_begin; i < T_end - 1; ++i )
+                {
+                    /* This is the implementation of the FORTRAN W(i,j,k,1)/ C style W(i,j,k,0) version from
+                     * Esirkepov paper. All coordinates are rotated before thus we can
+                     * always use C style W(i,j,k,0).
+                     */
+                    const float_X W = DS( line, i, 0 ) * tmp;
+                    accumulated_J += W;
+                    atomicAddWrapper(
+                        &( ( *cursorJ( i, j ) ).x( ) ),
+                        accumulated_J
+                    );
+                }
+            }
+        }
+
+        /** deposites current in z-direction
+         *
+         * \param cursorJ cursor pointing at the current density field of the particle's cell
+         * \param line trajectory of the virtual particle
+         * \param currentSurfaceDensityZ surface density in z direction
+         */
+        template<
+            typename CursorJ,
+            typename T_Line
+        >
+        DINLINE void
+        cptCurrentZ(
+            CursorJ cursorJ,
+            const T_Line& line,
+            const float_X currentSurfaceDensityZ
+        ) const
+        {
+            if( currentSurfaceDensityZ == float_X( 0.0 ) )
+                return;
+
+            for( int j = T_begin; j < T_end; ++j )
+            {
+                const float_X s0j = S0( line, j, 1 );
+                const float_X dsj = S1( line, j, 1 ) - s0j;
+                for( int i = T_begin; i < T_end; ++i )
+                {
+                    const float_X s0i = S0( line, i, 0 );
+                    const float_X dsi = S1( line, i, 0 ) - s0i;
+                    float_X W = s0i * S0( line, j, 1 ) +
+                        float_X( 0.5 ) * ( dsi * s0j + s0i * dsj ) +
+                        ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsi * dsj;
+
+                    const float_X j_z = W * currentSurfaceDensityZ;
+                    atomicAddWrapper(
+                        &( ( *cursorJ( i, j ) ).z( ) ),
+                        j_z
+                    );
+                }
+            }
+        }
+    };
+
+} // namespace emz
+} // namespace currentSolver
+} // namespace picongpu

--- a/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.def
+++ b/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.def
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2013-2016 Axel Huebl, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace currentSolver
+{
+
+namespace emz
+{
+    template<
+        typename ParticleAssign,
+        int T_begin,
+        int T_end,
+        uint32_t T_dim = simDim
+    >
+    struct DepositCurrent;
+} //namespace emz
+
+/** EmZ (Esirkepov meets ZigZag) current deposition
+ *
+ * Deposit the particle current with a mixed algorithm based on Esirkepov and
+ * the ZigZag way splitting.
+ * EmZ support arbitrary symmetric shapes and 2D/3D cartesian grids.
+ *
+ * \tparam T_ParticleShape the particle shape for the species, \see picongpu::particles::shapes
+ *
+ */
+template< typename ParticleShape >
+struct EmZ;
+
+} //namespace currentSolver
+
+namespace traits
+{
+
+/*Get margin of a solver
+ * class must define a LowerMargin and UpperMargin
+ */
+template< typename ParticleShape >
+struct GetMargin<
+    picongpu::currentSolver::EmZ<
+        ParticleShape
+    >
+>
+{
+private:
+    typedef picongpu::currentSolver::EmZ< ParticleShape > Solver;
+public:
+    typedef typename Solver::LowerMargin LowerMargin;
+    typedef typename Solver::UpperMargin UpperMargin;
+};
+
+} //namespace traits
+
+} //namespace picongpu

--- a/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.hpp
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cuSTL/cursor/Cursor.hpp"
+
+#include "fields/currentDeposition/EmZ/EmZ.def"
+#include "fields/currentDeposition/RelayPoint.hpp"
+#include "fields/currentDeposition/EmZ/DepositCurrent.hpp"
+#include "fields/currentDeposition/Esirkepov/Line.hpp"
+
+namespace picongpu
+{
+namespace currentSolver
+{
+
+template<
+    typename T_ParticleShape
+>
+struct EmZ
+{
+    typedef typename T_ParticleShape::ChargeAssignmentOnSupport ParticleAssign;
+    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
+
+    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
+    typedef typename PMacc::math::CT::make_Int<simDim, currentLowerMargin>::type LowerMargin;
+    typedef typename PMacc::math::CT::make_Int<simDim, currentUpperMargin>::type UpperMargin;
+
+
+    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin + 1;
+    BOOST_STATIC_CONSTEXPR int end = begin + supp;
+
+
+    /** deposit the current of a particle
+     *
+     * @tparam DataBoxJ any PMacc DataBox
+     *
+     * @param dataBoxJ box shifted to the cell of particle
+     * @param posEnd position of the particle after it is pushed
+     * @param velocity velocity of the particle
+     * @param charge charge of the particle
+     * @param deltaTime time of one time step
+     */
+    template<
+        typename DataBoxJ
+    >
+    DINLINE void
+    operator()(
+        DataBoxJ dataBoxJ,
+        const floatD_X posEnd,
+        const float3_X velocity,
+        const float_X charge,
+        const float_X /* deltaTime */
+    )
+    {
+        floatD_X deltaPos;
+        for ( uint32_t d = 0; d < simDim; ++d )
+            deltaPos[d] = ( velocity[d] * DELTA_T ) / cellSize[d];
+
+        /*note: all positions are normalized to the grid*/
+        const floatD_X posStart( posEnd - deltaPos );
+
+        DataSpace<simDim> I[2];
+        floatD_X relayPoint;
+
+        /* calculate the relay point for the trajectory splitting */
+        for ( uint32_t d = 0; d < simDim; ++d )
+        {
+            BOOST_CONSTEXPR_OR_CONST bool isSupportEven = ( supp % 2 == 0 );
+            relayPoint[d] = RelayPoint< isSupportEven >()(
+                I[0][d],
+                I[1][d],
+                posStart[d],
+                posEnd[d]
+            );
+        }
+
+        Line< floatD_X > line;
+        const float_X chargeDensity = charge / CELL_VOLUME;
+
+        /* Esirkepov implementation for the current deposition */
+        emz::DepositCurrent<
+            ParticleAssign,
+            begin,
+            end
+        > deposit;
+
+        /* calculate positions for the second virtual particle */
+        for (uint32_t d = 0; d < simDim; ++d)
+        {
+            line.m_pos0[d] = calc_InCellPos(
+                posStart[d],
+                I[0][d]
+            );
+            line.m_pos1[d] = calc_InCellPos(
+                relayPoint[d],
+                I[0][d]
+            );
+        }
+
+        const bool twoParticlesNeeded = I[0] != I[1];
+
+        deposit(
+            dataBoxJ.shift( I[0] ).toCursor(),
+            line,
+            chargeDensity,
+            velocity.z() * ( twoParticlesNeeded ? float_X(0.5) : float_X(1.0) )
+        );
+
+        /* detect if there is a second virtual particle */
+        if( twoParticlesNeeded )
+        {
+            /* calculate positions for the second virtual particle */
+            for (uint32_t d = 0; d < simDim; ++d)
+            {
+                /* switched start and end point */
+                line.m_pos1[d] = calc_InCellPos(
+                    posEnd[d],
+                    I[1][d]
+                );
+                line.m_pos0[d] = calc_InCellPos(
+                    relayPoint[d],
+                    I[1][d]
+                );
+            }
+            deposit(
+                dataBoxJ.shift( I[1] ).toCursor(),
+                line,
+                chargeDensity,
+                velocity.z() * float_X(0.5)
+            );
+        }
+    }
+
+    static PMacc::traits::StringProperty
+    getStringProperties()
+    {
+        PMacc::traits::StringProperty propList( "name", "EmZ" );
+        return propList;
+    }
+
+
+    /** get normalized in cell particle position
+     *
+     * @param x position of the particle
+     * @param i shift of grid (only integral positions are allowed)
+     * @return in cell position
+     */
+    DINLINE float_X
+    calc_InCellPos(
+        const float_X x,
+        const float_X i
+    ) const
+    {
+        return x - i;
+    }
+};
+
+} //namespace currentSolver
+
+} //namespace picongpu

--- a/src/picongpu/include/fields/currentDeposition/RelayPoint.hpp
+++ b/src/picongpu/include/fields/currentDeposition/RelayPoint.hpp
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+namespace picongpu
+{
+namespace currentSolver
+{
+    template< bool isEven >
+    struct RelayPoint
+    {
+       /** calculate virtual point were we split our particle trajectory
+        *
+        * The relay point calculation differs from the ZigZag paper version in the point
+        * that the trajectory of a particle which does not leave the cell is not split.
+        * The relay point for a particle which does not leave the cell is set to the
+        * current position `x_2`
+        *
+        * If `i_1 == i_2` than the trajectory is not split.
+        *
+        * This function assumes that the shape in later steps is always evaluated
+        * at grid integral points.
+        *
+        * @param i_1[out] offset to shift the coordinate system for the first
+        *                 particle at position x_1
+        * @param i_2[out] offset to shift the coordinate system for the second
+        *                 particle at position x_2
+        * @param x_1 begin position of the particle trajectory
+        * @param x_2 end position of the particle trajectory
+        * @return relay point for particle trajectory
+        */
+        DINLINE float_X
+        operator( )(
+            int& i_1,
+            int& i_2,
+            const float_X x_1,
+            const float_X x_2
+        ) const
+        {
+            using namespace PMacc;
+            i_1 = math::floor( x_1 );
+            i_2 = math::floor( x_2 );
+
+            return i_1 == i_2 ? x_2 : ::max( i_1, i_2 );
+        }
+    };
+
+    template<>
+    struct RelayPoint< false >
+    {
+       /** calculate virtual point were we split our particle trajectory
+        *
+        * @see RelayPoint< >::operator( ) description
+        */
+        DINLINE float_X
+        operator( )(
+            int& i_1,
+            int& i_2,
+            const float_X x_1,
+            const float_X x_2
+        ) const
+        {
+            i_1 = math::float2int_rd( x_1 + float_X( 0.5 ) );
+            i_2 = math::float2int_rd( x_2 + float_X( 0.5 ) );
+
+            return i_1 == i_2 ? x_2 : float_X( i_1 + i_2 )/float_X( 2.0 );
+        }
+    };
+
+} // namespace currentSolver
+} // namespace picongpu

--- a/src/picongpu/include/fields/currentDeposition/Solver.def
+++ b/src/picongpu/include/fields/currentDeposition/Solver.def
@@ -21,6 +21,7 @@
 
 #include "fields/currentDeposition/Esirkepov/Esirkepov.def"
 #include "fields/currentDeposition/ZigZag/ZigZag.def"
+#include "fields/currentDeposition/EmZ/EmZ.def"
 
 #if(SIMDIM==DIM3)
 #include "fields/currentDeposition/VillaBune/CurrentVillaBune.def"

--- a/src/picongpu/include/fields/currentDeposition/Solver.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Solver.hpp
@@ -22,6 +22,7 @@
 #include "fields/currentDeposition/Esirkepov/Esirkepov.hpp"
 #include "fields/currentDeposition/Esirkepov/EsirkepovNative.hpp"
 #include "fields/currentDeposition/ZigZag/ZigZag.hpp"
+#include "fields/currentDeposition/EmZ/EmZ.hpp"
 
 #if(SIMDIM==DIM3)
 #include "fields/currentDeposition/VillaBune/CurrentVillaBune.hpp"


### PR DESCRIPTION
EmZ (Esirkepov meets ZigZag) used the trajectory splitting method from ZigZag
to get a configuration where the number of supporting points is fixed at compile time.
The current of the virtual particles is deposited with the Esirkepov schema.

More information coming  soon.

Tests with KHI electrons/positrons 2d and 3d with all shapes:
- [x] charge conservation Esirkepov vs. pull request
- [x] heating Esirkepov vs. pull request
- [x] speed Esirkepov vs. pull request
- [x] check KHI with Z drift for particles
- [x] rebase to  #1588
