### PR TITLE
add `Line<>` default constructor

### DIFF
--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Line.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Line.hpp
@@ -39,6 +39,10 @@ struct Line
     type m_pos0;
     type m_pos1;
 
+    DINLINE Line()
+    {
+    }
+
     DINLINE Line(const type& pos0, const type & pos1) : m_pos0(pos0), m_pos1(pos1)
     {
     }


### PR DESCRIPTION
define a default constructor for `Line<>`

This change is needed for #1582
