### PR TITLE
Improve PMacc testsystem

### DIFF
--- a/src/libPMacc/CMakeLists.txt
+++ b/src/libPMacc/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Erik Zenker
+# Copyright 2015-2016 Erik Zenker, Alexander Grund
 #
 # This file is part of libPMacc.
 #
@@ -28,6 +28,21 @@ project(PMaccTest)
 
 
 ################################################################################
+# C++11 Enabler
+################################################################################
+
+# By using this if-else one can assume that:
+# CMAKE_CXX_STANDARD==11 <=> CUDA_NVCC_FLAGS contain "-std=c++11"
+if("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11")
+    set(CMAKE_CXX_STANDARD 11)
+elseif("${CMAKE_CXX_STANDARD}" STREQUAL "11")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -std=c++11)
+else()
+    # Note: Add support for C++14 once CUDA supports it (maybe 8.0?)
+    set(CMAKE_CXX_STANDARD 98)
+endif()
+
+################################################################################
 # PMacc
 ################################################################################
 find_package(PMacc REQUIRED CONFIG PATHS ${CMAKE_CURRENT_SOURCE_DIR})
@@ -47,13 +62,24 @@ set(LIBS ${LIBS} ${Boost_LIBRARIES})
 # Targets
 ###############################################################################
 
-# Test cases
-file(GLOB_RECURSE TESTS test/*UT.cu)
-cuda_add_executable(check EXCLUDE_FROM_ALL ${TESTS})
-target_link_libraries(check ${LIBS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test)
+add_definitions(-DBOOST_TEST_DYN_LINK)
 
 # CTest
 enable_testing()
-add_test(PMacc_test_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target check)
-add_test(PMacc_test_run  mpiexec -n 1 ./check --log_level=test_suite)
-set_tests_properties(PMacc_test_run PROPERTIES DEPENDS PMacc_test_build)
+
+# Test cases
+# Each *UT.cu file is an independent executable with one or more test cases 
+file(GLOB_RECURSE TESTS test/*UT.cu)
+foreach(dim 2 3)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTEST_DIM=${dim}")
+    foreach(testCaseFilepath ${TESTS})
+        get_filename_component(testCaseFilename ${testCaseFilepath} NAME)
+        string(REPLACE "UT.cu" "" testCase ${testCaseFilename})
+        set(testExe "${PROJECT_NAME}-${testCase}-${dim}D")
+        cuda_add_executable(${testExe} ${testCaseFilepath} ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)
+        target_link_libraries(${testExe} ${LIBS})
+        add_test(NAME "${testCase}-${dim}D" COMMAND mpiexec -n 1 ./${testExe})
+    endforeach()
+    string(REPLACE "-DTEST_DIM=${dim}" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endforeach()

--- a/src/libPMacc/test/PMaccFixture.hpp
+++ b/src/libPMacc/test/PMaccFixture.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 Erik Zenker
+ * Copyright 2016-2016 Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -20,8 +20,22 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MODULE "PMacc Unit Tests"
-#include <boost/test/unit_test.hpp>
+#pragma once
 
+#include <Environment.hpp>
+#include <dimensions/DataSpace.hpp>
 
+/** Fixture that initializes libPMacc for a given dimensionality */
+template<unsigned T_dim>
+struct PMaccFixture
+{
+    PMaccFixture()
+    {
+        const PMacc::DataSpace<T_dim> devices = PMacc::DataSpace<T_dim>::create(1);
+        const PMacc::DataSpace<T_dim> periodic = PMacc::DataSpace<T_dim>::create(1);
+        PMacc::Environment<T_dim>::get().initDevices(devices, periodic);
+    }
+};
+
+typedef PMaccFixture<2> PMaccFixture2D;
+typedef PMaccFixture<3> PMaccFixture3D;

--- a/src/libPMacc/test/main.cpp
+++ b/src/libPMacc/test/main.cpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015-2016 Erik Zenker, Alexander Grund
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE "PMacc Unit Tests"
+#define BOOST_TEST_NO_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <mpi.h>
+
+int main(int argc, char* argv[], char* envp[])
+{
+    MPI_Init(&argc, &argv);
+    int result = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
+    MPI_Finalize();
+    return result;
+}

--- a/src/libPMacc/test/memory/HostBufferIntern/copyFrom.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/copyFrom.hpp
@@ -31,7 +31,8 @@
 struct CopyFromTest {
 
     template<typename T_Dim>
-    void operator()(T_Dim){
+    void exec(T_Dim)
+    {
 
         typedef uint8_t Data;
         typedef size_t Extents;
@@ -64,6 +65,12 @@ struct CopyFromTest {
 
     }
 
+    PMACC_NO_NVCC_HDWARNING
+    template<typename T_Dim>
+    HDINLINE void operator()(T_Dim dim)
+    {
+        exec(dim);
+    }
 };
 
 BOOST_AUTO_TEST_CASE( copyFrom ){

--- a/src/libPMacc/test/memory/HostBufferIntern/reset.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/reset.hpp
@@ -30,14 +30,16 @@
 struct ResetTest {
 
     template<typename T_Dim>
-    void operator()(T_Dim){
+    void exec(T_Dim)
+    {
 
         typedef uint8_t Data;
         typedef size_t Extents;
 
         std::vector<size_t> nElementsPerDim = getElementsPerDim<T_Dim>();
         
-        for(unsigned i = 0; i < nElementsPerDim.size(); ++i){
+        for(unsigned i = 0; i < nElementsPerDim.size(); ++i)
+        {
             ::PMacc::DataSpace<T_Dim::value> const dataSpace = ::PMacc::DataSpace<T_Dim::value>::create(nElementsPerDim[i]);
             ::PMacc::HostBufferIntern<Data, T_Dim::value> hostBufferIntern(dataSpace);
 
@@ -51,6 +53,12 @@ struct ResetTest {
 
     }
 
+    PMACC_NO_NVCC_HDWARNING
+    template<typename T_Dim>
+    HDINLINE void operator()(T_Dim dim)
+    {
+        exec(dim);
+    }
 };
 
 BOOST_AUTO_TEST_CASE( reset ){

--- a/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
@@ -31,7 +31,7 @@ struct setValueTest
 {
 
     template<typename T_Dim>
-    void operator()(T_Dim)
+    void exec(T_Dim)
     {
 
         typedef uint8_t Data;
@@ -47,7 +47,7 @@ struct setValueTest
             const Data value = 255;
             hostBufferIntern.setValue(value);
 
-	    PMACC_AUTO( ptr, hostBufferIntern.getPointer( ) );
+            PMACC_AUTO( ptr, hostBufferIntern.getPointer( ) );
             for(size_t j = 0; j < static_cast<size_t>(dataSpace.productOfComponents()); ++j)
             {
                 BOOST_CHECK_EQUAL( ptr[j], value );
@@ -57,6 +57,12 @@ struct setValueTest
         
     }
 
+    PMACC_NO_NVCC_HDWARNING
+    template<typename T_Dim>
+    HDINLINE void operator()(T_Dim dim)
+    {
+        exec(dim);
+    }
 };
 
 BOOST_AUTO_TEST_CASE( setValue )

--- a/src/libPMacc/test/memory/memoryUT.cu
+++ b/src/libPMacc/test/memory/memoryUT.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 Erik Zenker
+ * Copyright 2015-2016 Erik Zenker, Alexander Grund
  *
  * This file is part of libPMacc.
  *
@@ -20,6 +20,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "PMaccFixture.hpp"
+
 // STL
 #include <stdint.h> /* uint8_t */
 #include <iostream> /* cout, endl */
@@ -29,7 +31,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/for_each.hpp>
-#include <boost/mpl/integral_c.hpp>
+#include <boost/mpl/int.hpp>
 
 // MPI
 #include <mpi.h> /* MPI_Init, MPI_Finalize */
@@ -48,35 +50,6 @@
 /*******************************************************************************
  * Configuration
  ******************************************************************************/
-
-/**
- * A fixture is an object that is constructed before some
- * statment and destructed after some statement. Thus, the
- * fixture defines pre and postconditions of this statement.
- *
- * This fixture defines the initialization and termination
- * of MPI and the initialization of the environment
- * singleton.
- */
-struct Fixture {
-    Fixture(){
-        int argc = 0;
-        char **argv = NULL;
-
-        MPI_Init( &argc, &argv );
-
-        PMacc::DataSpace<DIM3> const devices(1,1,1);
-        PMacc::DataSpace<DIM3> const periodic(1,1,1);
-        PMacc::Environment<DIM3>::get().initDevices(devices, periodic);
-
-
-    }
-
-    ~Fixture(){
-        MPI_Finalize( );
-    }
-
-};
 
 
 /**
@@ -110,16 +83,17 @@ std::vector<size_t> getElementsPerDim(){
  * each dimension setup automatically. For this
  * purpose boost::mpl::for_each is used.
  */
-typedef ::boost::mpl::list<boost::mpl::integral_c<int, DIM1>,
-                           boost::mpl::integral_c<int, DIM2>,
-                           boost::mpl::integral_c<int, DIM3> > Dims;
-
-BOOST_GLOBAL_FIXTURE( Fixture );
+typedef ::boost::mpl::list<boost::mpl::int_<DIM1>,
+                           boost::mpl::int_<DIM2>,
+                           boost::mpl::int_<DIM3> > Dims;
 
 
 /*******************************************************************************
  * Test Suites
  ******************************************************************************/
+typedef PMaccFixture<TEST_DIM> MyPMaccFixture;
+BOOST_GLOBAL_FIXTURE(MyPMaccFixture);
+
 BOOST_AUTO_TEST_SUITE( memory )
 
   BOOST_AUTO_TEST_SUITE( HostBufferIntern )


### PR DESCRIPTION
This fixes some issues with the PMacc test system, so it can be used for more tests.

Core:

- Fix cuda warnings (lots of output)
- One exectuable per testcase and dividing into 2D and 3D tests (singletons make it impossible to test this in one program)
- Move some common code into extra files (MPI-init and PMacc init)

Note: This triggers a CMake bug, that may prevent parallel `make` builds due to wrong dependencies between the test object files. See http://stackoverflow.com/questions/39913202/adding-multiple-cuda-executables-leaks-dependencies