### PR TITLE
ForEach always use const references

### DIFF
--- a/src/libPMacc/include/algorithms/ForEach.hpp
+++ b/src/libPMacc/include/algorithms/ForEach.hpp
@@ -70,11 +70,14 @@ namespace PMacc
 namespace algorithms
 {
 
+/** macro creates  typeNameN & */
+#define PMACC_UNUSED_REF(_, n, typeName) typeName##n &
+
 //########################### definitions for preprocessor #####################
 /** create operator() for EmptyFunctor
  *
  * template<typename T0, ... , typename TN>
- * HDINLINE void operator()(const T0, ..., const TN ) const {}
+ * HDINLINE void operator()(const T0&, ..., const TN& ) const {}
  *
  * All operator are empty and do nothing.
  * The operator parameters are plain type-only (without a name) to support
@@ -89,8 +92,8 @@ namespace algorithms
     /*  if N != 0 we add ```>``` */                                            \
     BOOST_PP_IF(BOOST_PP_NOT_EQUAL(N,0),>,BOOST_PP_EMPTY())                    \
     HDINLINE void                                                              \
-    /*        ( const T0, ... , cont TN         ) */                           \
-    operator()( BOOST_PP_ENUM_PARAMS(N, const T)) PMACC_PP_CONST               \
+    /*        ( const T0& , ... , const TN&                ) */                \
+    operator()( BOOST_PP_ENUM(N, PMACC_UNUSED_REF, const T)) PMACC_PP_CONST    \
     {                                                                          \
     }/*end of operator()*/
 
@@ -101,7 +104,7 @@ namespace algorithms
 /** create operator() for ForEach
  *
  * template<typename T0, ... , typename TN>
- * HDINLINE void operator()(const T0 t0, ..., const TN tN) const {}
+ * HDINLINE void operator()(const T0&, ..., const TN&) const {}
  */
 #define PMACC_FOREACH_OPERATOR(Z, N, PMACC_PP_CONST)                           \
     PMACC_NO_NVCC_HDWARNING                                                    \
@@ -145,13 +148,13 @@ struct CallFunctorOfIterator
 
     /* N=PMACC_MAX_FUNCTOR_OPERATOR_PARAMS
      * template<typename T0, ... , typename TN>
-     * create operator()(const T0 t0,...,const TN tN) const {} */
+     * create operator()(const T0&, ..., const TN&) const {} */
     BOOST_PP_REPEAT_FROM_TO(0, BOOST_PP_INC(PMACC_MAX_FUNCTOR_OPERATOR_PARAMS),
                             PMACC_FOREACH_OPERATOR, const)
 
     /* N=PMACC_MAX_FUNCTOR_OPERATOR_PARAMS
      * template<typename T0, ... , typename TN>
-     * create operator()(const T0 t0,...,const TN tN) {} */
+     * create operator()(const T0&, ..., const TN&) {} */
     BOOST_PP_REPEAT_FROM_TO(0, BOOST_PP_INC(PMACC_MAX_FUNCTOR_OPERATOR_PARAMS),
                             PMACC_FOREACH_OPERATOR, BOOST_PP_EMPTY())
 };
@@ -165,7 +168,7 @@ struct CallFunctorOfIterator<itBegin, itEnd, true>
     /* N=PMACC_MAX_FUNCTOR_OPERATOR_PARAMS
      * create:
      * template<typename T0, ... , TN>
-     * void operator()(const T0 ,...,const TN) const {} */
+     * void operator()(const T0&, ..., const TN&) const {} */
     BOOST_PP_REPEAT_FROM_TO(0, BOOST_PP_INC(PMACC_MAX_FUNCTOR_OPERATOR_PARAMS),
                             PMACC_FOREACH_OPERATOR_NO_USAGE, const)
 
@@ -173,7 +176,7 @@ struct CallFunctorOfIterator<itBegin, itEnd, true>
     /* N=PMACC_MAX_FUNCTOR_OPERATOR_PARAMS
      * create:
      * template<typename T0, ... , TN>
-     * void operator()(const T0 ,...,const TN) {} */
+     * void operator()(const T0&, ..., const TN&) {} */
     BOOST_PP_REPEAT_FROM_TO(0, BOOST_PP_INC(PMACC_MAX_FUNCTOR_OPERATOR_PARAMS),
                             PMACC_FOREACH_OPERATOR_NO_USAGE, BOOST_PP_EMPTY())
 };
@@ -225,14 +228,14 @@ struct ForEach
 
     /* N=PMACC_MAX_FUNCTOR_OPERATOR_PARAMS
      * template<typename T0, ... , typename TN>
-     * create operator()(const T0 t0,...,const TN tN) const {}*/
+     * create operator()(const T0&, ..., const TN&) const {}*/
     BOOST_PP_REPEAT_FROM_TO(0, BOOST_PP_INC(PMACC_MAX_FUNCTOR_OPERATOR_PARAMS),
                             PMACC_FOREACH_OPERATOR, const)
 
 
     /* N=PMACC_MAX_FUNCTOR_OPERATOR_PARAMS
      * template<typename T0, ... , typename TN>
-     * create operator()(const T0 t0,...,const TN tN) {}*/
+     * create operator()(const T0& t0,...,const TN& tN) {}*/
     BOOST_PP_REPEAT_FROM_TO(0, BOOST_PP_INC(PMACC_MAX_FUNCTOR_OPERATOR_PARAMS),
                             PMACC_FOREACH_OPERATOR, BOOST_PP_EMPTY())
 };


### PR DESCRIPTION
- use function parameters always as const reference
- fix wrong documenation
- fix warning `host function called from host/device`

close #848

This pull request should be back ported to the current release candidate.