### PR TITLE
Fix constructor for HDBuffer

### DIFF
--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
@@ -52,7 +52,7 @@ namespace PMacc {
                const GridLayout<T_dim> size,
                bool sizeOnDevice)
    {
-        hostBuffer   = new HostBufferType(dynamic_cast<HostDeviceBuffer&>(otherHostBuffer), size, offsetHost);
+        hostBuffer   = new HostBufferType(otherHostBuffer, size, offsetHost);
         deviceBuffer = new DeviceBufferType(otherDeviceBuffer, size, offsetDevice, sizeOnDevice);
    }
 


### PR DESCRIPTION
A HostBuffer can never be casted to a HostDeviceBuffer so that CTor would fail to compile when it is used. Removed the cast.