### PR TITLE
fix boost 1.62  boost greatest common divisor usage 

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -38,7 +38,7 @@
 #include <boost/preprocessor/arithmetic/inc.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
-#include <boost/math/common_factor.hpp>
+#include <boost/math/common_factor_rt.hpp>
 
 #include "eventSystem/tasks/TaskKernel.hpp"
 #include "eventSystem/events/kernelEvents.hpp"
@@ -101,12 +101,11 @@ math::Size_t<DIM3> getBestCudaBlockDim(const math::Size_t<dim> gridDim)
 
     /* The greatest common divisor of each component of the volume size
      * and a certain power of two value yield the best suitable block size */
-    const boost::math::gcd_evaluator<size_t> gcd; /* greatest common divisor */
     const math::Size_t<DIM3> maxThreads =
         MaxCudaBlockDim<dim>::type::toRT(); /* max threads per axis */
     for(int i = 0; i < dim; i++)
     {
-        result[i] = gcd(gridDim[i], maxThreads[i]);
+        result[i] = boost::math::gcd(gridDim[i], maxThreads[i]);
     }
 
     return result;

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -30,7 +30,7 @@
 #include "math/vector/Size_t.hpp"
 #include "pmacc_types.hpp"
 
-#include <boost/math/common_factor.hpp>
+#include <boost/math/common_factor_rt.hpp>
 #include <boost/mpl/placeholders.hpp>
 
 #include <cassert>
@@ -60,12 +60,11 @@ struct DeviceMemAssigner
 
         /* The greatest common divisor of each component of the volume size
          * and a certain power of two value gives the best suitable block size */
-        boost::math::gcd_evaluator<size_t> gcd; // greatest common divisor
         math::Size_t<3> blockDim(math::Size_t<3>::create(1));
-        int maxValues[] = {16, 16, 4}; // maximum values for each dimension
+        size_t maxValues[] = {16, 16, 4}; // maximum values for each dimension
         for(int i = 0; i < dim; i++)
         {
-            blockDim[i] = gcd(buffer->size()[i], maxValues[dim-1]);
+            blockDim[i] = boost::math::gcd(buffer->size()[i], maxValues[dim-1]);
         }
         /* the maximum number of threads per block for devices with
          * compute capability > 2.0 is 1024 */


### PR DESCRIPTION
close  #1598

- fix boost 1.62.0 compile error
  -> reason:  `gcd_evaluator` is moved out of the namespace `boost::math`
- use `boost::math::gcd()` function

The definition of `gcd_evaluator` is not longer located in the namespace `boost::math`.
There is a definition in `boost::integer` but IMO the more clean solution is to use the function `boost::math::gcd()`.
`boost::math::gcd()` select at compile time the best method to calculate the greatest common divisor.