### PR TITLE
2D3V Unit Normalization: Use dZ

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gridConfig.param
@@ -30,15 +30,29 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 0.64e-16;
+
         /** equals X
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.16e-6;
-        /** equals Y - the propagation direction
+        /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.40e-7;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -31,6 +31,7 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 1.79e-16;
+
         /** equals X
          *  unit: meter */
 #define fieldSolverDirSplitting 1
@@ -54,12 +55,25 @@ namespace picongpu
 #endif
 #undef fieldSolverDirSplitting
 
-        /** equals Y - the propagation direction
+        /** equals Y
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)

--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -30,15 +30,29 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 1.39e-16;
+
         /** equals X
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.1772e-6;
-        /** equals Y - the propagation direction
+        /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.4430e-7;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
@@ -30,15 +30,29 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 0.8e-16;
+
         /** equals X
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 2.0 * SPEED_OF_LIGHT_SI * DELTA_T_SI;
-        /** equals Y - the propagation direction
+        /** equals Y
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)

--- a/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
@@ -30,13 +30,6 @@ namespace picongpu
     /** Unit of length */
     BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
-#if(SIMDIM==DIM3)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation*/
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI;
-    } //namespace SI
-
     namespace particles
     {
         /** Number of electrons per particle (= macro particle weighting)
@@ -44,23 +37,6 @@ namespace picongpu
         BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
 
     }
-
-#elif(SIMDIM==DIM2)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation
-         *
-         * http://www.tf.uni-kiel.de/matwis/amat/mw1_ge/kap_6/basics/m6_2_1.html
-         */
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI*UNIT_LENGTH;
-    } //namespace SI
-    namespace particles
-    {
-        /** Number of electrons per particle (= macro particle weighting)
-         *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
-    }
-#endif
 
 
     /** Unit of mass */

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
@@ -30,15 +30,29 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 1.66789e-17;
+
         /** equals X
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.16e-6;
-        /** equals Y - the propagation direction
+        /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.20e-7;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
@@ -30,13 +30,6 @@ namespace picongpu
     /** Unit of length */
     BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
-#if(SIMDIM==DIM3)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation*/
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI;
-    } //namespace SI
-
     namespace particles
     {
         /** Number of electrons per particle (= macro particle weighting)
@@ -44,24 +37,6 @@ namespace picongpu
         BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
 
     }
-
-#elif(SIMDIM==DIM2)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation
-         *
-         * http://www.tf.uni-kiel.de/matwis/amat/mw1_ge/kap_6/basics/m6_2_1.html
-         */
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI*UNIT_LENGTH;
-    } //namespace SI
-    namespace particles
-    {
-        /** Number of electrons per particle (= macro particle weighting)
-         *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
-    }
-#endif
-
 
     /** Unit of mass */
     BOOST_CONSTEXPR_OR_CONST float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);

--- a/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
@@ -30,13 +30,6 @@ namespace picongpu
     /** Unit of length */
     BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
-#if(SIMDIM==DIM3)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation*/
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI;
-    } //namespace SI
-
     namespace particles
     {
         /** Number of electrons per particle (= macro particle weighting)
@@ -44,24 +37,6 @@ namespace picongpu
         BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
 
     }
-
-#elif(SIMDIM==DIM2)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation
-         *
-         * http://www.tf.uni-kiel.de/matwis/amat/mw1_ge/kap_6/basics/m6_2_1.html
-         */
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI*UNIT_LENGTH;
-    } //namespace SI
-    namespace particles
-    {
-        /** Number of electrons per particle (= macro particle weighting)
-         *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
-    }
-#endif
-
 
     /** Unit of mass */
     BOOST_CONSTEXPR_OR_CONST float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);

--- a/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
@@ -30,15 +30,29 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 2.5e-15;
+
         /** equals X
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 1.341e-6;
-        /** equals Y - the propagation direction
+        /** equals Y
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
     } //namespace SI
 
         //! Defines the size of the absorbing zone (in cells)

--- a/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
@@ -30,15 +30,29 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 3.0e-17;
+
         /** equals X
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 1.8e-8;
-        /** equals Y - the propagation direction
+        /** equals Y
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 1.8e-8;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = 1.8e-8;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
     } //namespace SI
 
         //! Defines the size of the absorbing zone (in cells)

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -212,19 +212,11 @@ __global__ void kernelPaintFields(
     typename EBox::ValueType field_e = fieldE(cell);
     typename JBox::ValueType field_j = fieldJ(cell);
 
-#if(SIMDIM==DIM3)
     field_j = float3_X(
                        field_j.x() * CELL_HEIGHT * CELL_DEPTH,
                        field_j.y() * CELL_WIDTH * CELL_DEPTH,
                        field_j.z() * CELL_WIDTH * CELL_HEIGHT
                        );
-#elif (SIMDIM==DIM2)
-    field_j = float3_X(
-                       field_j.x() * CELL_HEIGHT,
-                       field_j.y() * CELL_WIDTH,
-                       field_j.z() * CELL_WIDTH * CELL_HEIGHT
-                       );
-#endif
 
     // reset picture to black
     //   color range for each RGB channel: [0.0, 1.0]

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -30,15 +30,30 @@ namespace picongpu
         /** Duration of one timestep
          *  unit: seconds */
         BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 0.8e-16;
+
         /** equals X
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.1772e-6;
-        /** equals Y - the propagation direction
+        /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.4430e-7;
         /** equals Z
          *  unit: meter */
         BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
+
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)

--- a/src/picongpu/include/simulation_defines/unitless/gasConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gasConfig.unitless
@@ -27,13 +27,8 @@
 namespace picongpu
 
 {
-#if(SIMDIM==DIM3)
-    BOOST_CONSTEXPR_OR_CONST float_X GAS_DENSITY = float_X(SI::GAS_DENSITY_NORMED*UNIT_LENGTH*UNIT_LENGTH*UNIT_LENGTH);
-#elif(SIMDIM==DIM2)
-    BOOST_CONSTEXPR_OR_CONST float_X GAS_DENSITY = float_X(SI::GAS_DENSITY_NORMED*UNIT_LENGTH*UNIT_LENGTH);
-#endif
-
-
-} //namespace picongpu
+    BOOST_CONSTEXPR_OR_CONST float_X GAS_DENSITY =
+        float_X( SI::GAS_DENSITY_SI * UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH );
+} // namespace picongpu
 
 #include "particles/gasProfiles/profiles.hpp"

--- a/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
@@ -27,24 +27,29 @@
 
 namespace picongpu
 {
-    //normed grid parameter
-    BOOST_CONSTEXPR_OR_CONST float_X DELTA_T = float_X(SI::DELTA_T_SI / UNIT_TIME);
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_WIDTH = float_X (SI::CELL_WIDTH_SI / UNIT_LENGTH); //normalized to UNIT_LENGTH
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_HEIGHT = float_X (SI::CELL_HEIGHT_SI / UNIT_LENGTH); //normalized to UNIT_LENGTH
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_DEPTH = float_X(SI::CELL_DEPTH_SI / UNIT_LENGTH); // normalized to UNIT_LENGTH
-    CONST_VECTOR(float_X,simDim,cellSize,CELL_WIDTH,CELL_HEIGHT,CELL_DEPTH);
+    // normed grid parameter
+    BOOST_CONSTEXPR_OR_CONST float_X DELTA_T = float_X( SI::DELTA_T_SI / UNIT_TIME );
+    BOOST_CONSTEXPR_OR_CONST float_X CELL_WIDTH = float_X( SI::CELL_WIDTH_SI / UNIT_LENGTH );
+    BOOST_CONSTEXPR_OR_CONST float_X CELL_HEIGHT = float_X( SI::CELL_HEIGHT_SI / UNIT_LENGTH );
+    BOOST_CONSTEXPR_OR_CONST float_X CELL_DEPTH = float_X( SI::CELL_DEPTH_SI / UNIT_LENGTH );
+    CONST_VECTOR( float_X, simDim, cellSize, CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH );
 
-#if (SIMDIM==DIM3)
+    // always a 3D cell, even in 1D3V or 2D3V
     BOOST_CONSTEXPR_OR_CONST float_X CELL_VOLUME = CELL_WIDTH * CELL_HEIGHT * CELL_DEPTH;
-    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM = 1.0 / ( CELL_WIDTH  * CELL_WIDTH  )
-                                + 1.0 / ( CELL_HEIGHT * CELL_HEIGHT )
-                                + 1.0 / ( CELL_DEPTH  * CELL_DEPTH  );
+
+    // only used for CFL checks
+#if (SIMDIM==DIM3)
+    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM =
+        1.0 / ( CELL_WIDTH  * CELL_WIDTH  ) +
+        1.0 / ( CELL_HEIGHT * CELL_HEIGHT ) +
+        1.0 / ( CELL_DEPTH  * CELL_DEPTH  );
 #elif(SIMDIM==DIM2)
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_VOLUME = CELL_WIDTH * CELL_HEIGHT;
-    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM = 1.0 / ( CELL_WIDTH  * CELL_WIDTH  )
-                                + 1.0 / ( CELL_HEIGHT * CELL_HEIGHT );
+    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM =
+        1.0 / ( CELL_WIDTH  * CELL_WIDTH  ) +
+        1.0 / ( CELL_HEIGHT * CELL_HEIGHT );
 #else
-    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM = 1.0 / ( CELL_WIDTH  * CELL_WIDTH  );
+    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM =
+        1.0 / ( CELL_WIDTH  * CELL_WIDTH );
 #endif
 
 }

--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -30,38 +30,14 @@ namespace picongpu
     /** Unit of length */
     BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
-#if(SIMDIM==DIM3)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation*/
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI;
-    } //namespace SI
-
     namespace particles
     {
         /** Number of particles per makro particle (= macro particle weighting)
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = float_64(SI::GAS_DENSITY_NORMED*SI::CELL_WIDTH_SI*SI::CELL_HEIGHT_SI *SI::CELL_DEPTH_SI )
-                                    / float_64(particles::TYPICAL_PARTICLES_PER_CELL);
+        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE =
+            float_64( SI::GAS_DENSITY_SI * SI::CELL_WIDTH_SI * SI::CELL_HEIGHT_SI * SI::CELL_DEPTH_SI ) /
+            float_64( particles::TYPICAL_PARTICLES_PER_CELL );
     }
-
-#elif(SIMDIM==DIM2)
-    namespace SI
-    {
-        /** density normed to dimension of the simulation
-         *
-         * http://www.tf.uni-kiel.de/matwis/amat/mw1_ge/kap_6/basics/m6_2_1.html
-         */
-        BOOST_CONSTEXPR_OR_CONST float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI*UNIT_LENGTH;
-    } //namespace SI
-    namespace particles
-    {
-        /** Number of particles per makro particle (= macro particle weighting)
-         *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = float_64(SI::GAS_DENSITY_NORMED*SI::CELL_WIDTH_SI*SI::CELL_HEIGHT_SI )
-                                    / float_64(particles::TYPICAL_PARTICLES_PER_CELL);
-    }
-#endif
 
 
     /** Unit of mass */


### PR DESCRIPTION
This changes the way we normalize 2D3V simulations by the following, common way: evaluate dZ (choose something in the same order such as dX and dY).

A 2D3V simulation in a cartesian PIC simulation such as ours only changes the degrees of freedom in motion for (macro) particles and all (field) information in z travels instantaneous, making the 2D3V simulation behave like the interaction of infinite "wire particles" in fields with perfect symmetry in Z.

Quantities such as `CELL_VOLUME` are now _always 3D_.

This replaces #1569, should fix #1575 and #240.
- [x] needs _intense_ RT testing
