### PR TITLE
Specialize HasFlag and GetFlagType for Particle

### DIFF
--- a/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
@@ -24,10 +24,9 @@
 
 #include "pmacc_types.hpp"
 #include "particles/boostExtension/InheritLinearly.hpp"
-#include <boost/utility/result_of.hpp>
-#include <boost/type_traits.hpp>
-#include <boost/mpl/if.hpp>
 #include "traits/HasIdentifier.hpp"
+#include "traits/HasFlag.hpp"
+#include "traits/GetFlagType.hpp"
 #include "compileTime/GetKeyFromAlias.hpp"
 #include "compileTime/conversion/ResolveAliases.hpp"
 #include "compileTime/conversion/RemoveFromSeq.hpp"
@@ -40,6 +39,9 @@
 #include "particles/operations/Deselect.hpp"
 #include "particles/operations/SetAttributeToDefault.hpp"
 #include "compileTime/errorHandlerPolicies/ReturnValue.hpp"
+#include <boost/utility/result_of.hpp>
+#include <boost/type_traits.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/mpl/remove_if.hpp>
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/mpl/contains.hpp>
@@ -152,13 +154,13 @@ namespace traits
 {
 
 template<
-typename T_Key,
-typename T_FrameType,
-typename T_ValueTypeSeq
+    typename T_Key,
+    typename T_FrameType,
+    typename T_ValueTypeSeq
 >
 struct HasIdentifier<
-PMacc::Particle< T_FrameType, T_ValueTypeSeq >,
-T_Key
+    PMacc::Particle< T_FrameType, T_ValueTypeSeq >,
+    T_Key
 >
 {
 private:
@@ -176,6 +178,29 @@ public:
 
     typedef bmpl::contains<ValueTypeSeq, SolvedAliasName> type;
 };
+
+template<
+    typename T_Key,
+    typename T_FrameType,
+    typename T_ValueTypeSeq
+>
+struct HasFlag<
+    PMacc::Particle<T_FrameType, T_ValueTypeSeq>,
+    T_Key
+>: public HasFlag<T_FrameType, T_Key>
+{};
+
+template<
+    typename T_Key,
+    typename T_FrameType,
+    typename T_ValueTypeSeq
+>
+struct GetFlagType<
+    PMacc::Particle<T_FrameType, T_ValueTypeSeq>,
+    T_Key
+>: public GetFlagType<T_FrameType, T_Key>
+{};
+
 } //namespace traits
 
 namespace particles


### PR DESCRIPTION
Currently you can call the `HasIdentifier` trait also for the Particle type which is very useful in some occasions. This adds the counterparts `HasFlag` and `GetFlagType` so they can be used there as well.

Minor fixes not worth mentioning:
- Move boost includes to other boost includes
- Make the `HasIdentifier` look the same as the new traits (much shorter)
