### PR TITLE
fix tbg variable substitution

### DIFF
--- a/src/picongpu/submit/davinci-rice/picongpu.tpl
+++ b/src/picongpu/submit/davinci-rice/picongpu.tpl
@@ -1,32 +1,25 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
 
 # PIConGPU batch script for DAVinCI (non-PRO) PBS batch system
-
-## calculation are done by tbg ##
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 #PBS -q TBG_queue
 #PBS -l walltime=TBG_wallTime
@@ -46,6 +39,15 @@ TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 #PBS -o TBG_outDir/stdout
 #PBS -e TBG_outDir/stderr
 
+
+## calculation are done by tbg ##
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}"
+
+## end tbg calculation
 
 echo 'Running program...'
 echo TBG_jobName

--- a/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
@@ -18,9 +18,25 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Tesla C2070 queue on kepler018 & kepler019
+
+# PIConGPU batch script for hypnos PBS batch system
+
+#PBS -q !TBG_queue
+#PBS -l walltime=!TBG_wallTime
+# Sets batch job's name
+#PBS -N !TBG_jobName
+#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
+#PBS -d !TBG_dstPath
+#PBS -n
+
+#PBS -o stdout
+#PBS -e stderr
+
 
 ## calculation are done by tbg ##
+# Tesla C2070 queue on kepler018 & kepler019
 TBG_queue="k20f"
 
 # settings that can be controlled by environment variables before submit
@@ -37,21 +53,6 @@ TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 # use ceil to caculate nodes
 TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-
-# PIConGPU batch script for hypnos PBS batch system
-
-#PBS -q !TBG_queue
-#PBS -l walltime=!TBG_wallTime
-# Sets batch job's name
-#PBS -N !TBG_jobName
-#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-#PBS -m !TBG_mailSettings -M !TBG_mailAddress
-#PBS -d !TBG_dstPath
-#PBS -n
-
-#PBS -o stdout
-#PBS -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
@@ -19,6 +19,24 @@
 #
 
 
+# PIConGPU batch script for hypnos PBS batch system
+
+#PBS -q !TBG_queue
+#PBS -l walltime=!TBG_wallTime
+# Sets batch job's name
+#PBS -N !TBG_jobName
+#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
+#PBS -d !TBG_dstPath
+#PBS -n
+
+#PBS -W depend=afterany:!TBG_waitJob
+
+#PBS -o stdout
+#PBS -e stderr
+
+
 ## calculation are done by tbg ##
 TBG_queue="k20"
 
@@ -39,23 +57,6 @@ TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 # use ceil to caculate nodes
 TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-
-# PIConGPU batch script for hypnos PBS batch system
-
-#PBS -q !TBG_queue
-#PBS -l walltime=!TBG_wallTime
-# Sets batch job's name
-#PBS -N !TBG_jobName
-#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-#PBS -m !TBG_mailSettings -M !TBG_mailAddress
-#PBS -d !TBG_dstPath
-#PBS -n
-
-#PBS -W depend=afterany:!TBG_waitJob
-
-#PBS -o stdout
-#PBS -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
@@ -19,6 +19,22 @@
 #
 
 
+# PIConGPU batch script for hypnos PBS batch system
+
+#PBS -q !TBG_queue
+#PBS -l walltime=!TBG_wallTime
+# Sets batch job's name
+#PBS -N !TBG_jobName
+#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
+#PBS -d !TBG_dstPath
+#PBS -n
+
+#PBS -o stdout
+#PBS -e stderr
+
+
 ## calculation are done by tbg ##
 TBG_queue="k20"
 
@@ -36,21 +52,6 @@ TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 # use ceil to caculate nodes
 TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-
-# PIConGPU batch script for hypnos PBS batch system
-
-#PBS -q !TBG_queue
-#PBS -l walltime=!TBG_wallTime
-# Sets batch job's name
-#PBS -N !TBG_jobName
-#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-#PBS -m !TBG_mailSettings -M !TBG_mailAddress
-#PBS -d !TBG_dstPath
-#PBS -n
-
-#PBS -o stdout
-#PBS -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
@@ -19,6 +19,22 @@
 #
 
 
+# PIConGPU batch script for hypnos PBS batch system
+
+#PBS -q !TBG_queue
+#PBS -l walltime=!TBG_wallTime
+# Sets batch job's name
+#PBS -N !TBG_jobName
+#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
+#PBS -d !TBG_dstPath
+#PBS -n
+
+#PBS -o stdout
+#PBS -e stderr
+
+
 ## calculation are done by tbg ##
 TBG_queue="k20"
 
@@ -36,21 +52,6 @@ TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 # use ceil to caculate nodes
 TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-
-# PIConGPU batch script for hypnos PBS batch system
-
-#PBS -q !TBG_queue
-#PBS -l walltime=!TBG_wallTime
-# Sets batch job's name
-#PBS -N !TBG_jobName
-#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-#PBS -m !TBG_mailSettings -M !TBG_mailAddress
-#PBS -d !TBG_dstPath
-#PBS -n
-
-#PBS -o stdout
-#PBS -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
@@ -19,6 +19,24 @@
 #
 
 
+# PIConGPU batch script for hypnos PBS batch system
+
+#PBS -q !TBG_queue
+#PBS -l walltime=!TBG_wallTime
+# Sets batch job's name
+#PBS -N !TBG_jobName
+#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
+#PBS -d !TBG_dstPath
+#PBS -n
+
+#PBS -W depend=afterany:!TBG_waitJob
+
+#PBS -o stdout
+#PBS -e stderr
+
+
 ## calculation are done by tbg ##
 TBG_queue="k20"
 
@@ -36,23 +54,6 @@ TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 # use ceil to caculate nodes
 TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-
-# PIConGPU batch script for hypnos PBS batch system
-
-#PBS -q !TBG_queue
-#PBS -l walltime=!TBG_wallTime
-# Sets batch job's name
-#PBS -N !TBG_jobName
-#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-#PBS -m !TBG_mailSettings -M !TBG_mailAddress
-#PBS -d !TBG_dstPath
-#PBS -n
-
-#PBS -W depend=afterany:!TBG_waitJob
-
-#PBS -o stdout
-#PBS -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
@@ -19,6 +19,22 @@
 #
 
 
+# PIConGPU batch script for hypnos PBS batch system
+
+#PBS -q !TBG_queue
+#PBS -l walltime=!TBG_wallTime
+# Sets batch job's name
+#PBS -N !TBG_jobName
+#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
+# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+#PBS -m !TBG_mailSettings -M !TBG_mailAddress
+#PBS -d !TBG_dstPath
+#PBS -n
+
+#PBS -o stdout
+#PBS -e stderr
+
+
 ## calculation are done by tbg ##
 TBG_queue="k80"
 
@@ -36,21 +52,6 @@ TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 # use ceil to caculate nodes
 TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-
-# PIConGPU batch script for hypnos PBS batch system
-
-#PBS -q !TBG_queue
-#PBS -l walltime=!TBG_wallTime
-# Sets batch job's name
-#PBS -N !TBG_jobName
-#PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-#PBS -m !TBG_mailSettings -M !TBG_mailAddress
-#PBS -d !TBG_dstPath
-#PBS -n
-
-#PBS -o stdout
-#PBS -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/joker-tud/fermi.tpl
+++ b/src/picongpu/submit/joker-tud/fermi.tpl
@@ -1,43 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpu_arch="fermi"
-TBG_queue="workq"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-    
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for joker PBS PRO batch system
 
@@ -55,6 +35,25 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -o !TBG_dstPath/stdout
 #PBS -e !TBG_dstPath/stderr
 
+
+## calculation are done by tbg ##
+TBG_gpu_arch="fermi"
+TBG_queue="workq"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
 
 echo 'Running program...'
 echo !TBG_jobName

--- a/src/picongpu/submit/joker-tud/fermi_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/fermi_vampir.tpl
@@ -1,43 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpu_arch="fermi"
-TBG_queue="workq"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-    
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for joker PBS PRO batch system
 
@@ -56,6 +36,25 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -e !TBG_dstPath/stderr
 
 
+## calculation are done by tbg ##
+TBG_gpu_arch="fermi"
+TBG_queue="workq"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
+
 echo 'Running program...'
 echo !TBG_jobName
 
@@ -72,7 +71,7 @@ module load gcc/4.6.2 openmpi/1.6.2-gnu
 module load vampirtrace/gpu-gnu-cuda5.0
 
 unset MODULES_NO_OUTPUT
-    
+
 export VT_MPI_IGNORE_FILTER=yes
 export VT_PFORM_GDIR=traces
 export VT_FILE_PREFIX=trace
@@ -95,5 +94,5 @@ $MPI_ROOT/bin/mpirun !TBG_dstPath/picongpu/bin/cuda_memtest.sh
 
 if [ $? -eq 0 ] ; then
    $MPI_ROOT/bin/mpirun -x VT_MPI_IGNORE_FILTER -x VT_PFORM_GDIR -x VT_FILE_PREFIX -x VT_BUFFER_SIZE -x VT_MAX_FLUSHES -x VT_GNU_DEMANGLE -x VT_PTHREAD_REUSE -x VT_FILTER_SPEC -x VT_UNIFY -x VT_GPUTRACE -x VT_VERBOSE -x VT_CUPTI_METRICS -x VT_CUDATRACE_BUFFER_SIZE --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
-fi           
+fi
 

--- a/src/picongpu/submit/joker-tud/tesla.tpl
+++ b/src/picongpu/submit/joker-tud/tesla.tpl
@@ -1,43 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpu_arch="tesla"
-TBG_queue="workq"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-    
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for joker PBS PRO batch system
 
@@ -55,6 +35,25 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -o !TBG_dstPath/stdout
 #PBS -e !TBG_dstPath/stderr
 
+
+## calculation are done by tbg ##
+TBG_gpu_arch="tesla"
+TBG_queue="workq"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
 
 echo 'Running program...'
 echo !TBG_jobName

--- a/src/picongpu/submit/joker-tud/tesla_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/tesla_vampir.tpl
@@ -1,43 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpu_arch="tesla"
-TBG_queue="workq"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-    
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for joker PBS PRO batch system
 
@@ -56,6 +36,25 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -e !TBG_dstPath/stderr
 
 
+## calculation are done by tbg ##
+TBG_gpu_arch="tesla"
+TBG_queue="workq"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
+
 echo 'Running program...'
 echo !TBG_jobName
 
@@ -71,7 +70,7 @@ module load gcc/4.6.2 openmpi/1.6.2-gnu
 module load vampirtrace/gpu-gnu-cuda5.0
 
 unset MODULES_NO_OUTPUT
-    
+
 export VT_MPI_IGNORE_FILTER=yes
 export VT_PFORM_GDIR=traces
 export VT_FILE_PREFIX=trace

--- a/src/picongpu/submit/judge-fzj/m2050.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050.tpl
@@ -1,45 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpuType="m2050"
-TBG_queue="largemem"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-    
-# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for judge moab batch system
 
@@ -56,9 +34,30 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
-#MSUB -e stderr    
-    
-    
+#MSUB -e stderr
+
+
+## calculation are done by tbg ##
+TBG_gpuType="m2050"
+TBG_queue="largemem"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+#number of cores per parallel node / default is 2 cores per gpu on k20 queue
+
+# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
+
 echo 'Running program...'
 echo !TBG_jobName
 
@@ -86,4 +85,4 @@ mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_
 
 if [ $? -eq 0 ] ; then
    mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
-fi 
+fi

--- a/src/picongpu/submit/judge-fzj/m2050_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050_profile.tpl
@@ -1,45 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpuType="m2050"
-TBG_queue="largemem"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-    
-# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for judge moab batch system
 
@@ -56,8 +34,29 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
-#MSUB -e stderr    
-    
+#MSUB -e stderr
+
+
+## calculation are done by tbg ##
+TBG_gpuType="m2050"
+TBG_queue="largemem"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+#number of cores per parallel node / default is 2 cores per gpu on k20 queue
+
+# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
     
 echo 'Running program...'
 echo !TBG_jobName
@@ -78,4 +77,4 @@ mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_
 
 if [ $? -eq 0 ] ; then
    mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
-fi 
+fi

--- a/src/picongpu/submit/judge-fzj/m2070.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070.tpl
@@ -1,45 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch, Wen Fu
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpuType="m2070"
-TBG_queue="largemem"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-    
-# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for judge moab batch system
 
@@ -56,9 +34,30 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
-#MSUB -e stderr    
-    
-    
+#MSUB -e stderr
+
+
+## calculation are done by tbg ##
+TBG_gpuType="m2070"
+TBG_queue="largemem"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+#number of cores per parallel node / default is 2 cores per gpu on k20 queue
+
+# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
+
 echo 'Running program...'
 echo !TBG_jobName
 
@@ -86,4 +85,4 @@ mpiexec -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_m
 
 if [ $? -eq 0 ] ; then
    mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
-fi 
+fi

--- a/src/picongpu/submit/judge-fzj/m2070_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070_profile.tpl
@@ -1,45 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
-
-## calculation are done by tbg ##
-TBG_gpuType="m2070"
-TBG_queue="largemem"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-    
-# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
 
 # PIConGPU batch script for judge moab batch system
 
@@ -56,8 +34,29 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #MSUB -d !TBG_dstPath
 
 #MSUB -o stdout
-#MSUB -e stderr    
-    
+#MSUB -e stderr
+
+
+## calculation are done by tbg ##
+TBG_gpuType="m2070"
+TBG_queue="largemem"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+#number of cores per parallel node / default is 2 cores per gpu on k20 queue
+
+# 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
     
 echo 'Running program...'
 echo !TBG_jobName
@@ -78,4 +77,4 @@ mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/cuda_
 
 if [ $? -eq 0 ] ; then
    mpiexec  -np !TBG_tasks --mca mpi_leave_pinned 0 !TBG_dstPath/picongpu/bin/picongpu !TBG_author !TBG_programParams | tee output
-fi 
+fi

--- a/src/picongpu/submit/keeneland-gt/parallel.tpl
+++ b/src/picongpu/submit/keeneland-gt/parallel.tpl
@@ -1,45 +1,26 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera, Robert Dietric
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
-# 
- 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
 
 
-## calculation are done by tbg ##
-TBG_queue="parallel"
+# PIConGPU batch script for keenland PBS PRO batch system
 
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-    
-# 3 gpus per node if we need more than 3 gpus else same count as TBG_tasks   
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`
-
-# use one core per gpu    
-TBG_coresPerNode=$TBG_gpusPerNode
-    
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
-## end calculations ##
-
-# PIConGPU batch script for keenland PBS PRO batch system  
-    
 #PBS -q !TBG_queue
 #PBS -l walltime=!TBG_wallTime
 # Sets batch job's name
@@ -52,6 +33,24 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 #PBS -o stdout
 #PBS -e stderr
 
+
+## calculation are done by tbg ##
+TBG_queue="parallel"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+
+# 3 gpus per node if we need more than 3 gpus else same count as TBG_tasks
+TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`
+
+# use one core per gpu
+TBG_coresPerNode=$TBG_gpusPerNode
+
+# use ceil to caculate nodes
+TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+## end calculations ##
 
 echo 'Running program...'
 echo !TBG_jobName

--- a/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
@@ -18,6 +18,31 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+
+# PIConGPU batch script for LBL lawrencium's SLURM batch system
+#   https://sites.google.com/a/lbl.gov/high-performance-computing-services-group/lbnl-supercluster/lawrencium
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-cpu=!TBG_memPerCPU
+#SBATCH --constraint=!TBG_feature
+#SBATCH --qos=!TBG_qos
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+#SBATCH --account=!TBG_account
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
 ## calculations will be performed by tbg ##
 
 TBG_queue="mako_manycore"
@@ -46,29 +71,6 @@ TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 TBG_memPerCPU="$(( 24000 / TBG_gpusPerNode ))M"
 
 ## end calculations ##
-
-# PIConGPU batch script for LBL lawrencium's SLURM batch system
-#   https://sites.google.com/a/lbl.gov/high-performance-computing-services-group/lbnl-supercluster/lawrencium
-
-#SBATCH --partition=!TBG_queue
-#SBATCH --time=!TBG_wallTime
-# Sets batch job's name
-#SBATCH --job-name=!TBG_jobName
-#SBATCH --nodes=!TBG_nodes
-#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
-#SBATCH --cpus-per-task=!TBG_coresPerGPU
-#SBATCH --mem-per-cpu=!TBG_memPerCPU
-#SBATCH --constraint=!TBG_feature
-#SBATCH --qos=!TBG_qos
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-#SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
-#SBATCH --account=!TBG_account
-
-#SBATCH -o stdout
-#SBATCH -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
@@ -18,6 +18,31 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+
+# PIConGPU batch script for LBL lawrencium's SLURM batch system
+#   https://sites.google.com/a/lbl.gov/high-performance-computing-services-group/lbnl-supercluster/lawrencium
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-cpu=7750M
+#SBATCH --constraint=!TBG_feature
+#SBATCH --qos=!TBG_qos
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+#SBATCH --account=!TBG_account
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
 ## calculations will be performed by tbg ##
 
 TBG_queue="lr_manycore"
@@ -44,29 +69,6 @@ TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 
 ## end calculations ##
-
-# PIConGPU batch script for LBL lawrencium's SLURM batch system
-#   https://sites.google.com/a/lbl.gov/high-performance-computing-services-group/lbnl-supercluster/lawrencium
-
-#SBATCH --partition=!TBG_queue
-#SBATCH --time=!TBG_wallTime
-# Sets batch job's name
-#SBATCH --job-name=!TBG_jobName
-#SBATCH --nodes=!TBG_nodes
-#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
-#SBATCH --cpus-per-task=!TBG_coresPerGPU
-#SBATCH --mem-per-cpu=7750M
-#SBATCH --constraint=!TBG_feature
-#SBATCH --qos=!TBG_qos
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-#SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
-#SBATCH --account=!TBG_account
-
-#SBATCH -o stdout
-#SBATCH -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
@@ -18,6 +18,27 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+
+# PIConGPU batch script for pizdaint SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --ntasks-per-core=1
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
 ## calculations will be performed by tbg ##
 TBG_queue="normal"
 
@@ -40,25 +61,6 @@ TBG_mpiTasksPerNode=1
 TBG_nodes=!TBG_tasks
 
 ## end calculations ##
-
-# PIConGPU batch script for pizdaint SLURM batch system
-
-#SBATCH --partition=!TBG_queue
-#SBATCH --time=!TBG_wallTime
-# Sets batch job's name
-#SBATCH --job-name=!TBG_jobName
-#SBATCH --nodes=!TBG_nodes
-#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
-#SBATCH --cpus-per-task=!TBG_coresPerGPU
-#SBATCH --ntasks-per-core=1
-#SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-#SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAddress
-
-#SBATCH -o stdout
-#SBATCH -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
@@ -18,6 +18,27 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+
+# PIConGPU batch script for pizdaint SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --ntasks-per-core=1
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
 ## calculations will be performed by tbg ##
 TBG_queue="total"
 
@@ -40,25 +61,6 @@ TBG_mpiTasksPerNode=1
 TBG_nodes=!TBG_tasks
 
 ## end calculations ##
-
-# PIConGPU batch script for pizdaint SLURM batch system
-
-#SBATCH --partition=!TBG_queue
-#SBATCH --time=!TBG_wallTime
-# Sets batch job's name
-#SBATCH --job-name=!TBG_jobName
-#SBATCH --nodes=!TBG_nodes
-#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
-#SBATCH --cpus-per-task=!TBG_coresPerGPU
-#SBATCH --ntasks-per-core=1
-#SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-#SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAddress
-
-#SBATCH -o stdout
-#SBATCH -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/taurus-tud/k20x_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k20x_profile.tpl
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
+#
+# This file is part of PIConGPU.
+#
 # PIConGPU is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # PIConGPU is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
@@ -17,6 +17,29 @@
 # along with PIConGPU.
 # If not, see <http://www.gnu.org/licenses/>.
 #
+
+
+# PIConGPU batch script for taurus' SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-cpu=3000
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
 
 ## calculations will be performed by tbg ##
 TBG_queue="gpu1"
@@ -40,27 +63,6 @@ TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 
 ## end calculations ##
-
-# PIConGPU batch script for taurus' SLURM batch system
-
-#SBATCH --partition=!TBG_queue
-#SBATCH --time=!TBG_wallTime
-# Sets batch job's name
-#SBATCH --job-name=!TBG_jobName
-#SBATCH --nodes=!TBG_nodes
-#SBATCH --ntasks=!TBG_tasks
-#SBATCH --mincpus=!TBG_mpiTasksPerNode
-#SBATCH --cpus-per-task=!TBG_coresPerGPU
-#SBATCH --mem-per-cpu=3000
-#SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-#SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
-
-#SBATCH -o stdout
-#SBATCH -e stderr
 
 echo 'Running program...'
 

--- a/src/picongpu/submit/taurus-tud/k80_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k80_profile.tpl
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Richard Pausch
-# 
-# This file is part of PIConGPU. 
-# 
+#
+# This file is part of PIConGPU.
+#
 # PIConGPU is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # PIConGPU is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
@@ -17,6 +17,29 @@
 # along with PIConGPU.
 # If not, see <http://www.gnu.org/licenses/>.
 #
+
+
+# PIConGPU batch script for taurus' SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-cpu=2583
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
 
 ## calculations will be performed by tbg ##
 TBG_queue="gpu2"
@@ -40,28 +63,7 @@ TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 
 ## end calculations ##
-
-# PIConGPU batch script for taurus' SLURM batch system
-
-#SBATCH --partition=!TBG_queue
-#SBATCH --time=!TBG_wallTime
-# Sets batch job's name
-#SBATCH --job-name=!TBG_jobName
-#SBATCH --nodes=!TBG_nodes
-#SBATCH --ntasks=!TBG_tasks
-#SBATCH --mincpus=!TBG_mpiTasksPerNode
-#SBATCH --cpus-per-task=!TBG_coresPerGPU
-#SBATCH --mem-per-cpu=2583
-#SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-#SBATCH --mail-type=!TBG_mailSettings
-#SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
-
-#SBATCH -o stdout
-#SBATCH -e stderr
-
+    
 echo 'Running program...'
 
 cd !TBG_dstPath

--- a/src/picongpu/submit/titan-ornl/batch_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_profile.tpl
@@ -1,35 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2013-2016 Axel Huebl, Rene Widera
-# 
-# This file is part of PIConGPU. 
-# 
-# PIConGPU is free software: you can redistribute it and/or modify 
-# it under the terms of the GNU General Public License as published by 
-# the Free Software Foundation, either version 3 of the License, or 
-# (at your option) any later version. 
-# 
-# PIConGPU is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# 
-# You should have received a copy of the GNU General Public License 
-# along with PIConGPU.  
-# If not, see <http://www.gnu.org/licenses/>. 
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
 #
 
-## calculations will be performed by tbg ##
-TBG_queue="batch"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-TBG_nameProject=${proj:-""}
-
-# use ceil to caculate nodes
-TBG_nodes=!TBG_tasks
-## end calculations ##
 
 # PIConGPU batch script for titan aka jaguar PBS batch system
 
@@ -48,6 +36,20 @@ TBG_nodes=!TBG_tasks
 
 #PBS -l gres=atlas1%atlas2
 
+
+## calculations will be performed by tbg ##
+TBG_queue="batch"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+TBG_nameProject=${proj:-""}
+
+# use ceil to caculate nodes
+TBG_nodes=!TBG_tasks
+## end calculations ##
+    
 echo 'Running program...'
 echo !TBG_jobName
 

--- a/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
@@ -18,18 +18,6 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-## calculations will be performed by tbg ##
-TBG_queue="batch"
-
-# settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-TBG_nameProject=${proj:-""}
-
-# use ceil to caculate nodes
-TBG_nodes=!TBG_tasks
-## end calculations ##
 
 # PIConGPU batch script for titan aka jaguar PBS batch system
 
@@ -48,6 +36,20 @@ TBG_nodes=!TBG_tasks
 
 #PBS -l gres=atlas1%atlas2
 
+
+## calculations will be performed by tbg ##
+TBG_queue="batch"
+
+# settings that can be controlled by environment variables before submit
+TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+TBG_nameProject=${proj:-""}
+
+# use ceil to caculate nodes
+TBG_nodes=!TBG_tasks
+## end calculations ##
+    
 echo 'Running program...'
 echo !TBG_jobName
 

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -367,10 +367,8 @@ cd "$job_outDir"
 
 solved_variables=`run_cfg_and_get_solved_variables "$TBG_cfgFile" tooltpl_file_data tooltpl_overwrite`
 
-
-#delete alle variable definitions with TBG at begin
-tooltpl_file_data_cleaned=`echo "$tooltpl_file_data" |  grep -v "^[[:alpha:]][[:alnum:]_]*=.*"`
-batch_file=`tooltpl_replace tooltpl_file_data_cleaned solved_variables`
+#replace tbg variables in the original template file
+batch_file=`tooltpl_replace tooltpl_file_data solved_variables`
 
 if [ ! -z "$tooltpl_file" ] ; then
     # preserve file attributes/permissions


### PR DESCRIPTION
close #695

- delete command that removed variable definitions `someThing=...` from the template file
- `*.tpl` files: move batch system commands above (the now still existing) bash commands

**Reason for `*.tpl` change:**
Batch system commands must be defined before any bash command. Before this pull request `tbg` deleted all variable definitions in the template file and therefore fulfilled the batch system restriction. 

Removing variable assignments (and due to that defined variables in `.start`) with `tbg` results in side effects and limited functionality for the template file (since those runtime variables will be missing in the `.start` script).

**Old `*.tpl` files are not compatible to this pull request**
