### PR TITLE
fix tbg evaluation error

### DIFF
--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -69,7 +69,7 @@ function run_cfg_and_get_solved_variables
     #append template file variable definitions and solve them
     while read -r data_set
     do
-        eval "$data_set"
+        eval "$data_set" &> /dev/null
     done < <(echo "$tooltpl_file_data" | grep "^[[:blank:]]*[[:alpha:]][[:alnum:]_]*=.*")
 
     #read and evaluate extra options from parameter -o


### PR DESCRIPTION
ignore errors during the cfg and tpl file evaluation

example:
```
# tpl file

x=$(basename !TBG_VARIABLE)
```
This example crashed before this pull request do to the fact that *all* variable definitions (`something=...`) were evaluated and then replaced.

The pull request ignored errors during the evaluation. (IMO not critical)

CC-ing: @PrometheusPi 