### PR TITLE
libSplash 1.5.0+: Remove Dummy Writes

### DIFF
--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -451,22 +451,6 @@ private:
         ColTypeDouble ctDouble;
         SplashFloatXType splashFloatXType;
 
-        // stupid work-around to create a group with libSplash 1.4.0
-        GridController<simDim>& gc = Environment<simDim>::get().GridController();
-        const Dimensions numEntries( gc.getGlobalSize(), 1, 1 );
-        const Dimensions myOffset( gc.getGlobalRank(), 0, 0 );
-        const Dimensions myEntries( 1, 1, 1 );
-        const uint64_t dummy( 0 );
-
-        params->dataCollector->write(
-            params->currentStep,
-            numEntries,
-            myOffset,
-            ctUInt64, 1,
-            myEntries,
-            (recordPath + std::string("/dummy")).c_str(),
-            &dummy);
-
         /* openPMD base standard
          *   write constant record
          */


### PR DESCRIPTION
Follow-up to #1613: When writing [constant openPMD record components](https://github.com/openPMD/openPMD-standard/blob/1.0.0/STANDARD.md#constant-record-components) via attributes in an empty group libSplash supports group-creation without "dummy" data set writes.

This removes previous work-arounds that wrote one dummy data set before writing the actual attributes.

merge after #1613, both successfully tested at RT