### PR TITLE
splash2txt: unitSI openPMD

### DIFF
--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -312,7 +312,7 @@ void ToolsSplashParallel::convertToText()
         {
             try
             {
-                dc.readAttribute(m_options.step, iter->c_str(), "sim_unit",
+                dc.readAttribute(m_options.step, iter->c_str(), "unitSI",
                         &(excontainer.unit), NULL);
             } catch (const DCException&)
             {


### PR DESCRIPTION
Update `splash2txt` to understand the new `unitSI` in openPMD instead of the old `sim_unit`.