### PR TITLE
libSplash 1.6.0: Dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,7 +91,7 @@ Some of our examples will also need **libSplash**.
       [PNGWRITER\_ROOT](#additional-required-environment-variables-for-optional-libraries)
       to `$HOME/lib/pngwriter`
 
-- **libSplash** >= 1.5.0 (requires *HDF5*, *boost program-options*)
+- **libSplash** >= 1.6.0 (requires *HDF5*, *boost program-options*)
     - *Debian/Ubuntu dependencies:* `sudo apt-get install libhdf5-openmpi-dev libboost-program-options-dev`
     - *Arch Linux dependencies:* `sudo pacman --sync hdf5-openmpi boost`
     - *or compile hdf5 yourself:*  follow instructions one paragraph below 

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -93,7 +93,7 @@ touch "$thisDir"runGuard
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=sm_35"
             . /etc/profile
-            module load gcc/4.6.4 boost/1.57.0 cmake/3.1.0 cuda/6.0 openmpi/1.6.5 libSplash/1.5.0 adios/1.10.0 pngwriter/0.5.6 rivlib/1.0.0
+            module load gcc/4.6.4 boost/1.57.0 cmake/3.1.0 cuda/6.0 openmpi/1.6.5 libSplash/1.6.0 adios/1.10.0 pngwriter/0.5.6 rivlib/1.0.0
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/compile -l -q -j $cnf_numParallel \

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -419,7 +419,7 @@ include_directories(${PMACC_ROOT_DIR}/include)
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.5.0 COMPONENTS PARALLEL)
+find_package(Splash 1.6.0 COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -16,7 +16,7 @@ then
 
         # Plugins (optional)
         module load pngwriter/0.5.6
-        module load hdf5-parallel/1.8.14 libsplash/1.5.0
+        module load hdf5-parallel/1.8.14 libsplash/1.6.0
 
         # either use libSplash or ADIOS for file I/O
         #module load libmxml/2.8 adios/1.10.0

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -84,7 +84,7 @@ set(LIBS ${LIBS} ${Boost_LIBRARIES})
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.5.0 REQUIRED COMPONENTS PARALLEL)
+find_package(Splash 1.6.0 REQUIRED COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -92,7 +92,7 @@ endif(MPI_CXX_FOUND)
 # find libSplash installation
 # prefer static libraries over shared ones (but do not force them)
 set(Splash_USE_STATIC_LIBS ON)
-find_package(Splash 1.5.0 REQUIRED COMPONENTS PARALLEL)
+find_package(Splash 1.6.0 REQUIRED COMPONENTS PARALLEL)
 
 if(Splash_FOUND)
     include_directories(SYSTEM ${Splash_INCLUDE_DIRS})


### PR DESCRIPTION
Update to libSplash 1.6.0, since 1.5.0 did miss features.

**Tests:**
- [x] `png2gas`: builds
- [x] `splash2txt`: builds, runs (besides #1544)
- [x] @PrometheusPi @Flamefire the [`SerialDataCollector` API](https://github.com/ComputationalRadiationPhysics/libSplash/pull/242) changed slightly in regards of file names, can you check if the [radiation plugin](https://github.com/ComputationalRadiationPhysics/picongpu/blob/b00083f268846f69f501cbeb6aafa9a13c783929/src/picongpu/include/plugins/radiation/Radiation.hpp#L659-L668) works with it?
