### PR TITLE
fix tbg runtime errors and param `-o`

### DIFF
--- a/src/picongpu/submit/davinci-rice/picongpu.tpl
+++ b/src/picongpu/submit/davinci-rice/picongpu.tpl
@@ -43,9 +43,9 @@
 ## calculation are done by tbg ##
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}"
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}"
 
 ## end tbg calculation
 

--- a/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
@@ -37,21 +37,21 @@
 
 ## calculation are done by tbg ##
 # Tesla C2070 queue on kepler018 & kepler019
-TBG_queue="k20f"
+.TBG_queue="k20f"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+.TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
@@ -38,24 +38,24 @@
 
 
 ## calculation are done by tbg ##
-TBG_queue="k20"
+.TBG_queue="k20"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # get the ID of the last job of the submitting user waiting in the k20 queue
-TBG_waitJob=`qstat -u $(whoami) | grep $TBG_queue | tail -n 1 | awk '{print $1}'`
+.TBG_waitJob=`qstat -u $(whoami) | grep $TBG_queue | tail -n 1 | awk '{print $1}'`
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+.TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
@@ -36,21 +36,21 @@
 
 
 ## calculation are done by tbg ##
-TBG_queue="k20"
+.TBG_queue="k20"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+.TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
@@ -36,21 +36,21 @@
 
 
 ## calculation are done by tbg ##
-TBG_queue="k20"
+.TBG_queue="k20"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+.TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
@@ -38,21 +38,21 @@
 
 
 ## calculation are done by tbg ##
-TBG_queue="k20"
+.TBG_queue="k20"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+.TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
@@ -36,21 +36,21 @@
 
 
 ## calculation are done by tbg ##
-TBG_queue="k80"
+.TBG_queue="k80"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+.TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/joker-tud/fermi.tpl
+++ b/src/picongpu/submit/joker-tud/fermi.tpl
@@ -37,22 +37,22 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpu_arch="fermi"
-TBG_queue="workq"
+.TBG_gpu_arch="fermi"
+.TBG_queue="workq"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/joker-tud/fermi_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/fermi_vampir.tpl
@@ -37,22 +37,22 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpu_arch="fermi"
-TBG_queue="workq"
+.TBG_gpu_arch="fermi"
+.TBG_queue="workq"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/joker-tud/tesla.tpl
+++ b/src/picongpu/submit/joker-tud/tesla.tpl
@@ -37,22 +37,22 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpu_arch="tesla"
-TBG_queue="workq"
+.TBG_gpu_arch="tesla"
+.TBG_queue="workq"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/joker-tud/tesla_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/tesla_vampir.tpl
@@ -37,22 +37,22 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpu_arch="tesla"
-TBG_queue="workq"
+.TBG_gpu_arch="tesla"
+.TBG_queue="workq"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/judge-fzj/m2050.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050.tpl
@@ -38,24 +38,24 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpuType="m2050"
-TBG_queue="largemem"
+.TBG_gpuType="m2050"
+.TBG_queue="largemem"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/judge-fzj/m2050_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050_profile.tpl
@@ -38,26 +38,26 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpuType="m2050"
-TBG_queue="largemem"
+.TBG_gpuType="m2050"
+.TBG_queue="largemem"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-    
+
 echo 'Running program...'
 echo !TBG_jobName
 

--- a/src/picongpu/submit/judge-fzj/m2070.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070.tpl
@@ -38,24 +38,24 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpuType="m2070"
-TBG_queue="largemem"
+.TBG_gpuType="m2070"
+.TBG_queue="largemem"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/judge-fzj/m2070_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070_profile.tpl
@@ -38,26 +38,26 @@
 
 
 ## calculation are done by tbg ##
-TBG_gpuType="m2070"
-TBG_queue="largemem"
+.TBG_gpuType="m2070"
+.TBG_queue="largemem"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 
 # 2 gpus per node if we need more than 2 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
-    
+
 echo 'Running program...'
 echo !TBG_jobName
 

--- a/src/picongpu/submit/keeneland-gt/parallel.tpl
+++ b/src/picongpu/submit/keeneland-gt/parallel.tpl
@@ -35,7 +35,7 @@
 
 
 ## calculation are done by tbg ##
-TBG_queue="parallel"
+.TBG_queue="parallel"
 
 # settings that can be controlled by environment variables before submit
 TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
@@ -43,13 +43,13 @@ TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 3 gpus per node if we need more than 3 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`
 
 # use one core per gpu
-TBG_coresPerNode=$TBG_gpusPerNode
+.TBG_coresPerNode=$TBG_gpusPerNode
 
 # use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 echo 'Running program...'

--- a/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
@@ -45,30 +45,30 @@
 
 ## calculations will be performed by tbg ##
 
-TBG_queue="mako_manycore"
-TBG_account="ac_blast"
-TBG_qos="mako_normal"
-TBG_feature="mako_fermi"
+.TBG_queue="mako_manycore"
+.TBG_account="ac_blast"
+.TBG_qos="mako_normal"
+.TBG_feature="mako_fermi"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 2 gpus per node
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
 
 # number of cores to block per GPU - we use one right now
-TBG_coresPerGPU=1
+.TBG_coresPerGPU=1
 
 # We only start 1 MPI task per GPU
-TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 
 # use ceil to calculate the number of nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 
 # in MB; 24 GB per node on 12 CPUs
-TBG_memPerCPU="$(( 24000 / TBG_gpusPerNode ))M"
+.TBG_memPerCPU="$(( 24000 / TBG_gpusPerNode ))M"
 
 ## end calculations ##
 

--- a/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
@@ -45,28 +45,28 @@
 
 ## calculations will be performed by tbg ##
 
-TBG_queue="lr_manycore"
-TBG_account="ac_blast"
-TBG_qos="lr_normal"
-TBG_feature="lr_kepler"
+.TBG_queue="lr_manycore"
+.TBG_account="ac_blast"
+.TBG_qos="lr_normal"
+.TBG_feature="lr_kepler"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 1 gpu per node
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 1 ] ; then echo 1; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 1 ] ; then echo 1; else echo $TBG_tasks; fi`
 
 # number of cores to block per GPU - we got 8 cpus per gpu
 #   and we will be accounted 8 CPUs per GPU anyway
-TBG_coresPerGPU=8
+.TBG_coresPerGPU=8
 
 # We only start 1 MPI task per GPU
-TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 
 # use ceil to calculate the number of nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 
 ## end calculations ##
 

--- a/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
@@ -40,25 +40,25 @@
 
 
 ## calculations will be performed by tbg ##
-TBG_queue="normal"
+.TBG_queue="normal"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 1 gpus per node
-TBG_gpusPerNode=1
+.TBG_gpusPerNode=1
 
 # number of cores to block per GPU - we got 8 cpus per gpu
 #   and we will be accounted 8 CPUs per GPU anyway
-TBG_coresPerGPU=8
+.TBG_coresPerGPU=8
 
 # We only start 1 MPI task per GPU
-TBG_mpiTasksPerNode=1
+.TBG_mpiTasksPerNode=1
 
 # use ceil to caculate nodes
-TBG_nodes=!TBG_tasks
+.TBG_nodes=!TBG_tasks
 
 ## end calculations ##
 

--- a/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
@@ -40,25 +40,25 @@
 
 
 ## calculations will be performed by tbg ##
-TBG_queue="total"
+.TBG_queue="total"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 1 gpus per node
-TBG_gpusPerNode=1
+.TBG_gpusPerNode=1
 
 # number of cores to block per GPU - we got 8 cpus per gpu
 #   and we will be accounted 8 CPUs per GPU anyway
-TBG_coresPerGPU=8
+.TBG_coresPerGPU=8
 
 # We only start 1 MPI task per GPU
-TBG_mpiTasksPerNode=1
+.TBG_mpiTasksPerNode=1
 
 # use ceil to caculate nodes
-TBG_nodes=!TBG_tasks
+.TBG_nodes=!TBG_tasks
 
 ## end calculations ##
 

--- a/src/picongpu/submit/taurus-tud/k20x_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k20x_profile.tpl
@@ -42,25 +42,25 @@
 
 
 ## calculations will be performed by tbg ##
-TBG_queue="gpu1"
+.TBG_queue="gpu1"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 2 gpus per node
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
 
 # number of cores to block per GPU - we got 8 cpus per gpu
 #   and we will be accounted 8 CPUs per GPU anyway
-TBG_coresPerGPU=8
+.TBG_coresPerGPU=8
 
 # We only start 1 MPI task per GPU
-TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 
 ## end calculations ##
 

--- a/src/picongpu/submit/taurus-tud/k80_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k80_profile.tpl
@@ -42,28 +42,28 @@
 
 
 ## calculations will be performed by tbg ##
-TBG_queue="gpu2"
+.TBG_queue="gpu2"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 # number of cores to block per GPU - we got 6 cpus per gpu
 #   and we will be accounted 6 CPUs per GPU anyway
-TBG_coresPerGPU=6
+.TBG_coresPerGPU=6
 
 # We only start 1 MPI task per GPU
-TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 
 # use ceil to caculate nodes
-TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 
 ## end calculations ##
-    
+
 echo 'Running program...'
 
 cd !TBG_dstPath

--- a/src/picongpu/submit/titan-ornl/batch_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_profile.tpl
@@ -38,18 +38,18 @@
 
 
 ## calculations will be performed by tbg ##
-TBG_queue="batch"
+.TBG_queue="batch"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-TBG_nameProject=${proj:-""}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${proj:-""}
 
 # use ceil to caculate nodes
-TBG_nodes=!TBG_tasks
+.TBG_nodes=!TBG_tasks
 ## end calculations ##
-    
+
 echo 'Running program...'
 echo !TBG_jobName
 

--- a/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
@@ -38,18 +38,18 @@
 
 
 ## calculations will be performed by tbg ##
-TBG_queue="batch"
+.TBG_queue="batch"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
-TBG_nameProject=${proj:-""}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${proj:-""}
 
 # use ceil to caculate nodes
-TBG_nodes=!TBG_tasks
+.TBG_nodes=!TBG_tasks
 ## end calculations ##
-    
+
 echo 'Running program...'
 echo !TBG_jobName
 

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -30,7 +30,10 @@
 
 
 #######################
-# $1 name of variable with template descriptions
+## replace all `!var` variables
+#
+# $1 list with variable definitions (one variable per line)
+# $2 input data stream
 ########################
 function tooltpl_replace
 {
@@ -60,29 +63,16 @@ function tooltpl_replace
     echo "$tooltpl_replace_data"
 }
 
-function run_cfg_and_get_solved_variables
+#######################
+## recursive replace all `!var` variables
+#
+# replace recursive all `!var` variables in a data stream of variable definition
+#
+# $1 data stream with variable definitions (one variable assign per line)
+#######################
+function tooltpl_replace_recursive
 {
-    source "$1" # name and path to cfg file
-    eval tooltpl_file_data="\$$2" #data stream from tpl file
-    eval extra_op="\$$3"    #overwrite templates with extra options parameter -x
-
-    #append template file variable definitions and solve them
-    while read -r data_set
-    do
-        eval "$data_set" &> /dev/null
-    done < <(echo "$tooltpl_file_data" | grep "^[[:blank:]]*[[:alpha:]][[:alnum:]_]*=.*")
-
-    #read and evaluate extra options from parameter -o
-    for i in $extra_op
-    do
-      eval "$i"
-    done
-
-    #filter all TBG variables
-    tooltbl_env=`set | grep "^[[:alpha:]][[:alnum:]_]*=.*" | grep -v tooltpl  `
-
-    data="$tooltbl_env"
-
+    eval data="\$$1" #data stream from tpl file
     unresolved_vars=`echo "$data" | grep "\![[:alpha:]][[:alnum:]_]*" | wc -l`
     unresolved_vars_old=$(( unresolved_vars + 1))
 
@@ -106,7 +96,96 @@ function run_cfg_and_get_solved_variables
         echo "  - dependency loop with two or more variables" >&2
     fi
     echo "$data"
- }
+}
+
+#######################
+## apply extra overwrite variables
+#
+# overwrite variable definition from $1 if defined in $2
+#
+# $1 data stream where variables should be overwritten
+# $2 data stream with overwrite template parameter definitions (tbg parameter -o)
+#######################
+function apply_extra_vars
+{
+    eval tooltpl_data="\$$1"
+    eval tooltpl_extra_op="\$$2"
+    while read -r data_set
+    do
+        echo "$data_set" | grep "^[[:blank:]]*[[:alpha:]][[:alnum:]_]*=.*" &>/dev/null
+        if [ $? -eq 0 ] ; then
+            # get variable name (left side of assign)
+            tooltpl_var=`echo -e "$data_set" | cut -d"=" -f1`
+            # check if variable must be overwritten
+            tooltpl_op=`echo -e "$tooltpl_extra_op" | tr " " "\n" | grep "$tooltpl_var="`
+            if [ $? -eq 0 ] ; then
+                # overwrite variable assignment
+                echo "$tooltpl_op"
+            else
+                # data_set is a assignment but variable not contained in $2
+                echo "$data_set"
+            fi
+        else
+            # data_set is no assignment, therefore write out without changes
+            echo "$data_set"
+        fi
+    done < <(echo "$tooltpl_data")
+}
+
+#######################
+## get substituted variables
+#
+# replace recursive all `!var` variables in a list of variable definition
+#
+# $1 data path and name to submit script
+# $2 tpl file data
+# $3 data stream with overwrite template parameter definitions (tbg parameter -o)
+#######################
+function run_cfg_and_get_solved_variables
+{
+    eval tooltpl_file_data="\$$2" #data stream from tpl file
+    eval tooltpl_extra_op="\$$3"    #overwrite templates with extra options parameter -o
+
+    # merge multi line to single line
+    tooltpl_cfg_script=`sed -e :a -e '/\\\\$/N; s/\\\\\n//; ta' $1 `
+
+    # overwrite variable definition if contained in $3
+    tooltpl_cfg_script_overwritten=`apply_extra_vars tooltpl_cfg_script tooltpl_extra_op`
+
+    # execute the cfg script
+    eval "$tooltpl_cfg_script_overwritten" # name and path to cfg file
+
+    # get all variable assignments (form: `.var=value`) from the tpl file
+    tooltpl_tbg_vars=`echo "$tooltpl_file_data" | grep "^[[:blank:]]*\.[[:alpha:]][[:alnum:]_]*=.*" | \
+        sed 's/^[[:blank:]]*\.//'`
+    # overwrite all variable assignments from tpl file with overwrite variables
+    tooltpl_tbg_vars_overwritten=`apply_extra_vars tooltpl_tbg_vars tooltpl_extra_op`
+
+    # get all variable definitions from the current environment
+    tooltpl_env=`set | grep "^[[:alpha:]][[:alnum:]_]*=.*" | grep -v tooltpl`
+
+    # append tpl variable assignments to the environment variables
+    tooltpl_full_env=`echo -e "$tooltpl_env\n$tooltpl_tbg_vars_overwritten"`
+
+    # replace all !var usage
+    tooltpl_solved_environment=`tooltpl_replace_recursive tooltpl_full_env`
+
+    # evaluate all variable assignments which are contained in the tpl file
+    while read -r data_set
+    do
+        tooltpl_var=`echo "$data_set" | cut -d"=" -f1`
+        echo "$tooltpl_tbg_vars_overwritten" | grep "$tooltpl_var" &> /dev/null
+        if [ $? -eq 0 ] ; then
+            # variable is contained in the tpl file
+            # evaluate variable and print out
+            eval "$data_set"
+            echo -n "$tooltpl_var="; eval echo "\$$tooltpl_var"
+        else
+            # variable is not in the tpl file (only print out current state)
+            echo "$data_set"
+        fi
+    done < <(echo "$tooltpl_solved_environment" |  grep "^[[:blank:]]*[[:alpha:]][[:alnum:]_]*=.*")
+}
 
 #######################
 # $1 path to final file
@@ -172,6 +251,7 @@ help()
     echo "                                 tbg will use stdin, if no file is specified."
     echo "                                 Default: [templateFile] via export TBG_TPLFILE"
     echo "-o                             - Overwrite any template variable:"
+    echo "                                 spaces within the right side of assign are not allowed"
     echo "                                 e.g. -o \"VARNAME1=10 VARNAME2=5\""
     echo "                                 Overwriting is done after cfg file was executed"
     echo "-h | --help                    - Shows help (this output)."
@@ -359,16 +439,14 @@ fi
 mkdir -p "$job_outDir/tbg"
 cd "$job_outDir"
 
-#set all userdefined variables from -x parameter (e.g. TBG_A="hallo" TBG_B=123)
-#for i in $cfg_extraOpt
-#do
-#    eval "$i"
-#done
 
-solved_variables=`run_cfg_and_get_solved_variables "$TBG_cfgFile" tooltpl_file_data tooltpl_overwrite`
+# get the full replaced and evaluated variable definitions
+tooltpl_solved_variables=`run_cfg_and_get_solved_variables "$TBG_cfgFile" tooltpl_file_data tooltpl_overwrite`
 
-#replace tbg variables in the original template file
-batch_file=`tooltpl_replace tooltpl_file_data solved_variables`
+#delete all variable assignments (form: `.var=value`) from the tpl file
+tooltpl_file_data_cleaned=`echo "$tooltpl_file_data" |  grep -v "^[[:blank:]]*\.[[:alpha:]][[:alnum:]_]*=.*"`
+# create the content of the batch system file `submit.start`
+batch_file=`tooltpl_replace tooltpl_file_data_cleaned tooltpl_solved_variables`
 
 if [ ! -z "$tooltpl_file" ] ; then
     # preserve file attributes/permissions


### PR DESCRIPTION
- fix runtime errors introduced with #1609
- revert dirty evaluation from #1611
- fix tbg `-o` parameter
- add new syntax to define variables in the tpl files `.varname=value`
- update all tpl files with new syntax: `.var=value` 

Documentation
============

We define two life times for variables.
  -  **tbg-time**: this means a variable is visible during the time `tbg` creates the start file `submit.start` for the batch system. it contains several steps:
      1. substitute variables defined with `tbg -o` in the `*.cfg` file (overwrite assignments `varName=value`)
      2. evaluate the `*.cfg` file
      3. substitute variables defined with `tbg -o` in the `*.tpl` file (overwrite **only** assignments `.varName=value`)
      4. catch all variables from the current environment and substitute all `!varName` usages
      5. remove all `.varname=value` from the `*.tpl` file
      6. substitude all `!varName` in tpl file with the results of the step v.
  - **run-time**: is the time where the job is started from the batch system and the file `submit.start` is executed

variables
------------
  - each placeholder in the form `!varName` is replaced by the corresponding variable value
  - assignments of tbg variables must begin with `.` e.g. `.myTplVar=5` (syntax is only allowed within a template file) -> named **tplVar**

`*.cfg` file
--------
 - is a bash script and is executed at **tbg-time**
 - the syntax follows the restrictions of the bash
 - variables with the accessor `!varName` are not replaced
 - all assigned variables can be used for substitutions in the tpl file
 - each variable assignment in the form `varName=value` is overwritten by variables given by the `tbg` parameter `-o` before the cfg file is executed

`*.tpl` file
--------
 - is used to create `submit.start`
 - variable assignments with **tplVar** are executed/evaluated at **tbg-time**
 - **tplVar**, environment variables and variables from the cfg file can be used with the accessor `!varName`
 - **tplVar** are overwritten by variables given with `-o` to `tbg`
 - **tplVar** are removed from the `submit.start`

`submit.start`
----------------
 - is created by `tbg` out of the `*.tpl` file and the substituted variables
 - it is not allowed to have any bash code before the batch script commands, e.g. `#PBS ...`
 - all variable definitions and assignments are evaluated at **run-time** (note: **tplVar** are removed at **tbg-time**)
