### PR TITLE
ZigZag: Update input Docs (Do not Use)

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/species.param
+++ b/examples/Bunch/include/simulation_defines/param/species.param
@@ -57,11 +57,11 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS , P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS , P4S (1st to 4th order)
  */
 typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
@@ -59,11 +59,11 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
 #ifndef PARAM_CURRENTSOLVER
 #define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>

--- a/examples/LaserWakefield/include/simulation_defines/param/species.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/species.param
@@ -69,11 +69,11 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
 #ifndef PARAM_CURRENTSOLVER
 #define PARAM_CURRENTSOLVER Esirkepov

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/species.param
@@ -57,11 +57,11 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
 typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/species.param
@@ -57,11 +57,11 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
 typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
 

--- a/examples/SingleParticleTest/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/species.param
@@ -54,11 +54,11 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
 typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
 

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -59,11 +59,11 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes: ---------------------------------------------------
  * - currentSolver::currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
 typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
 


### PR DESCRIPTION
ZigZag in our implementation, and probably even in the original publications, is not charge conserving #1128.

Move it in the input files down to "development" solvers so users do not use it.