### PR TITLE
SubGrid: Set globalDomain Offset

### DIFF
--- a/src/libPMacc/include/mappings/simulation/SubGrid.hpp
+++ b/src/libPMacc/include/mappings/simulation/SubGrid.hpp
@@ -62,13 +62,22 @@ namespace PMacc
 
         /**
          * Set offset of the local domain.
-         * (Note: this used to be called 'global offset')
          *
          * @param offset offset of local domain
          */
         void setLocalDomainOffset(const Size& offset)
         {
             localDomain = Selection<DIM>(localDomain.size, offset);
+        }
+
+        /**
+         * Set offset of the global domain.
+         *
+         * @param offset offset of global domain
+         */
+        void setGlobalDomainOffset(const Size& offset)
+        {
+            globalDomain = Selection<DIM>(globalDomain.size, offset);
         }
 
         /**

--- a/src/picongpu/include/simulationControl/MovingWindow.hpp
+++ b/src/picongpu/include/simulationControl/MovingWindow.hpp
@@ -362,7 +362,7 @@ public:
         Window window;
 
         window.localDimensions = subGrid.getLocalDomain();
-        window.globalDimensions = subGrid.getGlobalDomain();
+        window.globalDimensions = Selection<simDim>(subGrid.getGlobalDomain().size);
 
         return window;
     }


### PR DESCRIPTION
This fixes a bug that the offset in the `PMacc::Selection` [globalDomain](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-domain-definitions) returned by `Environment<simDim>::get().SubGrid().getGlobalDomain()` was always set to zero (aka "all 0").

The implementation does not change anything else, since the affected object was only used in a conversion from Domain to a Window which naturally has to remove the `globalDomain.offset` (aka "set it to zero=default") anyway.

Already RT tested in combination with the fix for #1625 with LWFA and moving window (including restarts).