### PR TITLE
Fix #1625: HDF5 openPMD positionOffset

### DIFF
--- a/src/libPMacc/include/particles/Identifier.hpp
+++ b/src/libPMacc/include/particles/Identifier.hpp
@@ -47,10 +47,4 @@ value_identifier(lcellId_t,localCellIdx,0);
  */
 value_identifier(uint8_t,multiMask,0);
 
-/** Alias for the global cell index of a particle. Only used for particles in
- *  linearized memory. For particles in the linked list structure
- *  the global cell index is implicitly given by superCellIdx+localCellIdx
- */
-alias(globalCellIdx);
-
 } //namespace PMacc

--- a/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
+++ b/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
@@ -42,20 +42,29 @@ namespace kernel
 /** Copy particles from big frame to PMacc frame structure
  *  (Opposite to ConcatListOfFrames)
  *
- * - convert globalCellIdx to localCellIdx
+ * - convert a user-defined domainCellIdx to localCellIdx
  * - processed particles per block <= number of cells per superCell
  *
  * @param counter box with three integer [srcParticleOffset, numLoadedParticles, numUsedFrames]
  * @param destBox particle box were all particles are copied to (destination)
  * @param srcFrame frame with particles (is used as source)
  * @param maxParticles number of particles in srcFrame
- * @param localDomainCellOffset offset in cells to global origin (@see wiki PIConGPU domain definitions)
+ * @param localDomainCellOffset offset in cells to user-defined domain (@see wiki PIConGPU domain definitions)
+ * @param domainCellIdxIdentifier the identifier for the particle domain cellIdx
+ *                                that is calculated back to the local domain
+ *                                with respect to localDomainCellOffset
  * @param cellDesc picongpu cellDescription
  */
-template<class T_CounterBox, class T_DestBox, class T_SrcFrame, class T_Space, class T_CellDescription>
-__global__ void splitIntoListOfFrames(T_CounterBox counter, T_DestBox destBox, T_SrcFrame srcFrame,
-                                        const int maxParticles,
-                                        T_Space localDomainCellOffset, T_CellDescription cellDesc)
+template<class T_CounterBox, class T_DestBox, class T_SrcFrame, class T_Space, class T_Identifier, class T_CellDescription>
+__global__ void splitIntoListOfFrames(
+    T_CounterBox counter,
+    T_DestBox destBox,
+    T_SrcFrame srcFrame,
+    const int maxParticles,
+    const T_Space localDomainCellOffset,
+    const T_Identifier domainCellIdxIdentifier,
+    const T_CellDescription cellDesc
+)
 {
     using namespace PMacc::particles::operations;
 
@@ -95,12 +104,13 @@ __global__ void splitIntoListOfFrames(T_CounterBox counter, T_DestBox destBox, T
 
     if (hasValidParticle)
     {
-        const DataSpace<NumDims> globalCellIdx = srcFrame[srcParticleIdx][globalCellIdx_]
+        // cell index on this GPU
+        const DataSpace<NumDims> gpuCellIdx = srcFrame[srcParticleIdx][domainCellIdxIdentifier]
                                                  - localDomainCellOffset;
-        superCellIdx = globalCellIdx / SuperCellSize::toRT();
+        superCellIdx = gpuCellIdx / SuperCellSize::toRT();
         myLinearSuperCellId = DataSpaceOperations<NumDims>::map(numSuperCells, superCellIdx);
         linearSuperCellIds[linearThreadIdx] = myLinearSuperCellId;
-        DataSpace<NumDims> localCellIdx(globalCellIdx - superCellIdx * SuperCellSize::toRT());
+        DataSpace<NumDims> localCellIdx(gpuCellIdx - superCellIdx * SuperCellSize::toRT());
         lCellIdx = DataSpaceOperations<NumDims>::template map<SuperCellSize>(localCellIdx);
     }
     __syncthreads();
@@ -148,24 +158,34 @@ __global__ void splitIntoListOfFrames(T_CounterBox counter, T_DestBox destBox, T
 /** Copy particles from big frame to PMacc frame structure
  *  (Opposite to ConcatListOfFrames)
  *
- * - convert globalCellIdx to localCellIdx
+ * - convert a user-defined domainCellIdx to localCellIdx
  * - processed particles per block <= number of cells per superCell
  *
  * @param destSpecies particle species instance whose deviceBuffer is written
  * @param srcFrame device frame with particles (is used as source)
  * @param numParticles number of particles in srcFrame
  * @param chunkSize number of particles to process in one kernel call
- * @param cellsInSuperCell number of cells per super cell
- * @param localDomainCellOffset offset in cells to global origin (@see wiki PIConGPU domain definitions)
+ * @param localDomainCellOffset offset in cells to user-defined domain (@see wiki PIConGPU domain definitions)
+ * @param domainCellIdxIdentifier the identifier for the particle domain cellIdx
+ *                                that is calculated back to the local domain
+ *                                with respect to localDomainCellOffset
  * @param cellDesc picongpu cellDescription
  * @param logLvl Log level used for information logging
  */
-template<class T_LogLvl, class T_DestSpecies, class T_SrcFrame, class T_Space, class T_CellDescription>
-HINLINE void splitIntoListOfFrames(T_DestSpecies& destSpecies, T_SrcFrame srcFrame,
-                                      uint32_t numParticles, uint32_t chunkSize, uint32_t cellsInSuperCell,
-                                      const T_Space& localDomainCellOffset, const T_CellDescription& cellDesc,
-                                      const T_LogLvl& logLvl = T_LogLvl())
+template<class T_LogLvl, class T_DestSpecies, class T_SrcFrame, class T_Space, class T_Identifier, class T_CellDescription>
+HINLINE void splitIntoListOfFrames(
+    T_DestSpecies& destSpecies,
+    T_SrcFrame srcFrame,
+    uint32_t numParticles,
+    const uint32_t chunkSize,
+    const T_Space& localDomainCellOffset,
+    const T_Identifier domainCellIdxIdentifier,
+    const T_CellDescription& cellDesc,
+    const T_LogLvl& logLvl = T_LogLvl()
+)
 {
+    const uint32_t cellsInSuperCell = PMacc::math::CT::volume<typename T_CellDescription::SuperCellSize>::type::value;
+
     /* counter is used to apply for work, count used frames and count loaded particles
      * [0] -> offset for loading particles
      * [1] -> number of loaded particles
@@ -189,7 +209,8 @@ HINLINE void splitIntoListOfFrames(T_DestSpecies& destSpecies, T_SrcFrame srcFra
             (counterBuffer.getDeviceBuffer().getDataBox(),
              destSpecies.getDeviceParticlesBox(), srcFrame,
              (int) numParticles,
-             localDomainCellOffset, /*relative to data domain (not to physical domain)*/
+             localDomainCellOffset,
+             domainCellIdxIdentifier,
              cellDesc
              );
         destSpecies.fillAllGaps();

--- a/src/picongpu/include/fields/background/cellwiseOperation.hpp
+++ b/src/picongpu/include/fields/background/cellwiseOperation.hpp
@@ -38,7 +38,7 @@ namespace cellwiseOperation
 
     /** Kernel that calls T_OpFunctor and T_ValFunctor on each cell of a field
      *
-     *  Pseudo code: opFunctor( cell, valFunctor( globalCellIdx, currentStep ) );
+     *  Pseudo code: opFunctor( cell, valFunctor( totalCellIdx, currentStep ) );
      *
      * \tparam T_OpFunctor like assign, add, subtract, ...
      * \tparam T_ValFunctor like "f(x,t)", "0.0", "readFromOtherField", ...

--- a/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
@@ -39,7 +39,6 @@
 #include <boost/type_traits.hpp>
 
 #include "plugins/output/WriteSpeciesCommon.hpp"
-#include "plugins/kernel/CopySpecies.kernel"
 #include "mappings/kernel/AreaMapping.hpp"
 #include "math/Vector.hpp"
 
@@ -79,10 +78,10 @@ public:
     typedef bmpl::vector<multiMask,localCellIdx> TypesToDelete;
     typedef typename RemoveFromSeq<ParticleAttributeList, TypesToDelete>::type ParticleCleanedAttributeList;
 
-    /* add globalCellIdx for adios particle*/
+    /* add totalCellIdx for adios particle*/
     typedef typename MakeSeq<
             ParticleCleanedAttributeList,
-            globalCellIdx<globalCellIdx_pic>
+            totalCellIdx
     >::type ParticleNewAttributeList;
 
     typedef

--- a/src/picongpu/include/plugins/adios/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/WriteSpecies.hpp
@@ -75,10 +75,10 @@ public:
     typedef bmpl::vector<multiMask,localCellIdx> TypesToDelete;
     typedef typename RemoveFromSeq<ParticleAttributeList, TypesToDelete>::type ParticleCleanedAttributeList;
 
-    /* add globalCellIdx for adios particle*/
+    /* add totalCellIdx for adios particle*/
     typedef typename MakeSeq<
-    ParticleCleanedAttributeList,
-    globalCellIdx<globalCellIdx_pic>
+        ParticleCleanedAttributeList,
+        totalCellIdx
     >::type ParticleNewAttributeList;
 
     typedef
@@ -139,6 +139,7 @@ public:
                                 speciesTmp->getHostParticlesBox(mallocMCBuffer.getOffset()),
                                 filter,
                                 particleOffset, /*relative to data domain (not to physical domain)*/
+                                totalCellIdx_,
                                 mapper
                                 );
             dc.releaseData(MallocMCBuffer::getName());

--- a/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
@@ -70,10 +70,10 @@ public:
     typedef bmpl::vector2<multiMask, localCellIdx> TypesToDelete;
     typedef typename RemoveFromSeq<ParticleAttributeList, TypesToDelete>::type ParticleCleanedAttributeList;
 
-    /* add globalCellIdx for adios particle*/
+    /* add totalCellIdx for adios particle*/
     typedef typename MakeSeq<
-    ParticleCleanedAttributeList,
-    globalCellIdx<globalCellIdx_pic>
+        ParticleCleanedAttributeList,
+        totalCellIdx
     >::type ParticleNewAttributeList;
 
     typedef
@@ -166,9 +166,16 @@ public:
 
         if (totalNumParticles != 0)
         {
-            const uint32_t cellsInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
-            PMacc::particles::operations::splitIntoListOfFrames(*speciesTmp, deviceFrame, totalNumParticles,
-                    restartChunkSize, cellsInSuperCell, localDomain.offset, *(params->cellDescription), picLog::INPUT_OUTPUT());
+            PMacc::particles::operations::splitIntoListOfFrames(
+                *speciesTmp,
+                deviceFrame,
+                totalNumParticles,
+                restartChunkSize,
+                localDomain.offset,
+                totalCellIdx_,
+                *(params->cellDescription),
+                picLog::INPUT_OUTPUT()
+            );
 
             /*free host memory*/
             ForEach<typename AdiosFrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -390,11 +390,12 @@ private:
     static void *writeHDF5(void *p_args)
     {
         ThreadParams *threadParams = (ThreadParams*) (p_args);
-        const PMacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
-        /* y direction can be negative for first gpu*/
-        DataSpace<simDim> particleOffset(localDomain.offset);
-        particleOffset.y() -= threadParams->window.globalDimensions.offset.y();
+        const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
+        DataSpace<simDim> domainOffset(
+            subGrid.getGlobalDomain().offset +
+            subGrid.getLocalDomain().offset
+        );
 
         /* write all fields */
         log<picLog::INPUT_OUTPUT > ("HDF5: (begin) writing fields.");
@@ -415,12 +416,12 @@ private:
         if (threadParams->isCheckpoint)
         {
             ForEach<FileCheckpointParticles, WriteSpecies<bmpl::_1> > writeSpecies;
-            writeSpecies(threadParams, particleOffset);
+            writeSpecies(threadParams, domainOffset);
         }
         else
         {
             ForEach<FileOutputParticles, WriteSpecies<bmpl::_1> > writeSpecies;
-            writeSpecies(threadParams, particleOffset);
+            writeSpecies(threadParams, domainOffset);
         }
         log<picLog::INPUT_OUTPUT > ("HDF5: ( end ) writing particle species.");
 

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -40,17 +40,31 @@ using namespace PMacc;
  * @tparam T_SrcBox type of the data box of source memory
  * @tparam T_Filter type of filer with particle selection rules
  * @tparam T_Space type of coordinate description
+ * @tparam T_Identifier type of identifier for the particle cellIdx
  * @tparam T_Mapping type of the mapper to map cuda idx to supercells
  *
  * @param counter pointer to a device counter to reserve memory in destFrame
  * @param destFrame frame were we store particles in host memory (no Databox<...>)
  * @param srcBox ParticlesBox with frames
  * @param filer filer with rules to select particles
- * @param particleOffset can be negative for the first GPU: localDomain.offset - globalWindow.offset
- * @param mapper apper to map cuda idx to supercells
+ * @param domainOffset offset to a user-defined domain. Can, e.g. be used to
+ *                     calculate a totalCellIdx relative to
+ *                     globalDomain.offset + localDomain.offset
+ * @param domainCellIdxIdentifier the identifier for the particle cellIdx
+ *                                that is calculated with respect to
+ *                                domainOffset
+ * @param mapper map cuda idx to supercells
  */
-template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Mapping>
-__global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox, T_Filter filter, T_Space particleOffset, T_Mapping mapper)
+template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Identifier, class T_Mapping>
+__global__ void copySpecies(
+    int* counter,
+    T_DestFrame destFrame,
+    T_SrcBox srcBox,
+    T_Filter filter,
+    const T_Space domainOffset,
+    const T_Identifier domainCellIdxIdentifier,
+    const T_Mapping mapper
+)
 {
     using namespace PMacc::particles::operations;
 
@@ -94,11 +108,11 @@ __global__ void copySpecies(int* counter, T_DestFrame destFrame, T_SrcBox srcBox
         if (storageOffset != -1)
         {
             PMACC_AUTO(parDest, destFrame[globalOffset + storageOffset]);
-            PMACC_AUTO(parDestNoGlobalIdx, deselect<globalCellIdx<> >(parDest));
-            assign(parDestNoGlobalIdx, parSrc);
-            /*calculate global cell index*/
+            PMACC_AUTO(parDestNoDomainIdx, deselect<T_Identifier>(parDest));
+            assign(parDestNoDomainIdx, parSrc);
+            /* calculate cell index for user-defined domain */
             DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));
-            parDest[globalCellIdx_] = particleOffset + superCellPosition + localCell;
+            parDest[domainCellIdxIdentifier] = domainOffset + superCellPosition + localCell;
         }
         __syncthreads();
         if (threadIdx.x == 0)

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -75,10 +75,14 @@ value_identifier(bool, radiationFlag, false);
  */
 value_identifier(float_X,boundElectrons,float_X(0.0));
 
-/** specialization global position inside a domain (relative to origin of the
- * moving window) and is loaded after all other param files)
+/** Total cell index of a particle.
+ *
+ *  The total cell index is a
+ *  N-dimensional DataSpace given by a GPU's
+ *    globalDomain.offset + localDomain.offset
+ *  added to the N-dimensional cell index the particle belongs to on that GPU.
  */
-value_identifier(DataSpace<simDim>,globalCellIdx_pic,DataSpace<simDim>());
+value_identifier(DataSpace<simDim>, totalCellIdx, DataSpace<simDim>());
 
 /*! alias for particle shape @see species.param */
 alias(shape);

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -334,8 +334,8 @@ struct WeightingPower<particleId>
     }
 };
 
-template<typename T_Type>
-struct Unit<globalCellIdx<T_Type> >
+template<>
+struct Unit<totalCellIdx>
 {
     /* unitless index and not scaled by a factor: by convention 1.0 */
     static std::vector<double> get()
@@ -344,20 +344,20 @@ struct Unit<globalCellIdx<T_Type> >
         return unit;
     }
 };
-template<typename T_Type>
-struct UnitDimension<globalCellIdx<T_Type> >
+template<>
+struct UnitDimension<totalCellIdx>
 {
     static std::vector<float_64> get()
     {
-        /* globalCellIdx is a cell index and therefore unitless
+        /* totalCellIdx is a cell index and therefore unitless
          */
         std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
 
         return unitDimension;
     }
 };
-template<typename T_Type>
-struct MacroWeighted<globalCellIdx<T_Type> >
+template<>
+struct MacroWeighted<totalCellIdx>
 {
     // the cell idx is identical and can not be scaled by weightings
     static bool get()
@@ -365,8 +365,8 @@ struct MacroWeighted<globalCellIdx<T_Type> >
         return false;
     }
 };
-template<typename T_Type>
-struct WeightingPower<globalCellIdx<T_Type> >
+template<>
+struct WeightingPower<totalCellIdx>
 {
     // idx * weighting^0 == idx: same for real and macro particle
     static float_64 get()

--- a/src/picongpu/include/traits/PICToOpenPMD.hpp
+++ b/src/picongpu/include/traits/PICToOpenPMD.hpp
@@ -36,7 +36,7 @@ namespace traits
     /** Reinterpret attributes for openPMD
      *
      * Currently, this conversion tables are used to translate the PIConGPU
-     * globalCellIdx (unitless cell index) to the openPMD positionOffset (length)
+     * totalCellIdx (unitless cell index) to the openPMD positionOffset (length)
      */
     template<typename T_Identifier>
     struct OpenPMDName;

--- a/src/picongpu/include/traits/PICToOpenPMD.tpp
+++ b/src/picongpu/include/traits/PICToOpenPMD.tpp
@@ -35,11 +35,11 @@ namespace traits
         }
     };
 
-    /** Translate the globalCellIdx (unitless index) into the openPMD
+    /** Translate the totalCellIdx (unitless index) into the openPMD
      *  positionOffset (3D position vector, length)
      */
-    template<typename T_Type>
-    struct OpenPMDName<globalCellIdx<T_Type> >
+    template<>
+    struct OpenPMDName<totalCellIdx>
     {
         std::string operator()() const
         {
@@ -58,12 +58,12 @@ namespace traits
         }
     };
 
-    /** the globalCellIdx can be converted into a positionOffset
+    /** the totalCellIdx can be converted into a positionOffset
      *  until the beginning of the cell by multiplying with the component-wise
      *  cell size in SI
      */
-    template<typename T_Type>
-    struct OpenPMDUnit<globalCellIdx<T_Type> >
+    template<>
+    struct OpenPMDUnit<totalCellIdx>
     {
         std::vector<double> operator()() const
         {
@@ -91,8 +91,8 @@ namespace traits
     /** the openPMD positionOffset is an actual (vector) with a lengths that
      *  is added to the position (vector) attribute
      */
-    template<typename T_Type>
-    struct OpenPMDUnitDimension<globalCellIdx<T_Type> >
+    template<>
+    struct OpenPMDUnitDimension<totalCellIdx>
     {
         std::vector<float_64> operator()() const
         {


### PR DESCRIPTION
This fixes #1625 by creating the correct `positionOffset` in HDF5 writes+restarts which is a *total cellIdx*.

The methods to create and convert the localCellIdx to a cellIdx respectively to certain domain have been abstracted. The PMacc user can now choose to create an arbitrary new cell idx, e.g., a `globalCellIdx` with respect to the global domain as before or a `totalCellIdx` with respect to an absolute start. For PIConGPU, we nowadays always speak in positions with respect to the total domain for all inputs and outputs which is more useful then a globalCellIdx which is rather arbitrarily choosen to be t*c but might not be that physically useful, especially with respect to tracking. This also reduces a lot of code offset calc complexity.

The ADIOS plugin has not yet been updates, simply because it lacks particle patches still anyway and temporarily redefining the `particle_info` object is not a great idea. For ADIOS, just be aware we are still dumping a `globalCellIdx` in the openPMD `positionOffset` when doing moving window simulations #1628.

RT tested with LWFA example on 1x4x1 GPUs including restarts after 5 different checkpoints along several slides. Reading and projecting particles above fields now also works with our new yt project reader.