### PR TITLE
dynamic EventPool for cuda events

### DIFF
--- a/src/libPMacc/include/Environment.hpp
+++ b/src/libPMacc/include/Environment.hpp
@@ -35,7 +35,7 @@
 #include "nvidia/memory/MemoryInfo.hpp"
 #include "simulationControl/SimulationDescription.hpp"
 #include "mappings/simulation/Filesystem.hpp"
-
+#include "eventSystem/events/EventPool.hpp"
 #include "Environment.def"
 
 #include <cuda_runtime.h>
@@ -80,6 +80,11 @@ public:
     PMacc::EnvironmentController& EnvironmentController()
     {
         return EnvironmentController::getInstance();
+    }
+
+    PMacc::EventPool& EventPool()
+    {
+        return EventPool::getInstance();
     }
 
     PMacc::Factory& Factory()
@@ -279,3 +284,4 @@ private:
 
 #include "eventSystem/EventSystem.tpp"
 #include "particles/tasks/ParticleFactory.tpp"
+#include "eventSystem/events/CudaEvent.hpp"

--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -33,7 +33,6 @@ namespace PMacc
 {
     // forward declaration
     class EventTask;
-    class EventPool;
 
     /**
      * Manages the event system by executing and waiting for tasks.
@@ -73,7 +72,6 @@ namespace PMacc
 
         void addPassiveTask(ITask *task);
 
-        EventPool& getEventPool();
 
         std::size_t getCount();
 
@@ -101,7 +99,6 @@ namespace PMacc
 
         TaskMap tasks;
         TaskMap passiveTasks;
-        EventPool *eventPool;
     };
 
 } //namespace PMacc

--- a/src/libPMacc/include/eventSystem/Manager.tpp
+++ b/src/libPMacc/include/eventSystem/Manager.tpp
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include "eventSystem/events/EventPool.hpp"
 #include "eventSystem/streams/StreamController.hpp"
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/Manager.hpp"
@@ -41,8 +40,6 @@ inline Manager::~Manager( )
 {
     CUDA_CHECK( cudaGetLastError( ) );
     waitForAllTasks( );
-    CUDA_CHECK( cudaGetLastError( ) );
-    delete eventPool;
     CUDA_CHECK( cudaGetLastError( ) );
 }
 
@@ -194,22 +191,12 @@ inline void Manager::addPassiveTask( ITask *task )
 
 inline Manager::Manager( )
 {
-    /**
-     * The \see Environment ensures that the \see StreamController is
-     * already created before calling this
-     */
-    eventPool = new EventPool( );
-    eventPool->addEvents( 300 );
 }
 
 inline Manager::Manager( const Manager& )
 {
 }
 
-inline EventPool& Manager::getEventPool( )
-{
-    return *eventPool;
-}
 
 inline std::size_t Manager::getCount( )
 {

--- a/src/libPMacc/include/eventSystem/events/CudaEvent.def
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.def
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include <cuda_runtime.h>
+
+namespace PMacc
+{
+
+/** Wrapper for cudaEvent_t
+ *
+ * This class follows the RAII rules
+ */
+class CudaEvent
+{
+private:
+
+    /** native cuda event */
+    cudaEvent_t event;
+    /** native cuda stream where the event is recorded
+     *
+     *  only valid if isRecorded is true
+     */
+    cudaStream_t stream;
+    /** state if event is recorded */
+    bool isRecorded;
+    /** state if a recorded event is finished
+     *
+     * avoid cuda driver calls after `isFinished()` returns the first time true
+     */
+    bool finished;
+
+    /** number of CudaEventHandle's to the instance */
+    uint32_t refCounter;
+
+
+public:
+
+    /** Constructor
+     *
+     * if called before the cuda device is initialized the behavior is undefined
+     */
+    CudaEvent( );
+
+    /** Destructor */
+    ~CudaEvent( );
+
+    /** register a existing handle to a event instance */
+    void registerHandle( );
+
+    /** free a registered handle */
+    void releaseHandle( );
+
+    /** get native cudaEvent_t object
+     *
+     * @return native cuda event
+     */
+    cudaEvent_t operator*( ) const
+    {
+        return event;
+    }
+
+    /** get stream in which this event is recorded
+     *
+     * @return native cuda stream
+     */
+    cudaStream_t getStream( ) const
+    {
+        assert( isRecorded );
+        return stream;
+    }
+
+    /** check whether the event is finished
+     *
+     * @return true if event is finished else false
+     */
+    bool isFinished( );
+
+    /** record event in a device stream
+     *
+     * @param stream native cuda stream
+     */
+    void recordEvent( cudaStream_t stream );
+
+};
+}

--- a/src/libPMacc/include/eventSystem/events/CudaEventHandle.hpp
+++ b/src/libPMacc/include/eventSystem/events/CudaEventHandle.hpp
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2014-2016 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include <cuda_runtime.h>
+#include "eventSystem/events/CudaEvent.def"
+
+namespace PMacc
+{
+
+/** handle to CudaEvent */
+class CudaEventHandle
+{
+private:
+
+    /** pointer to the CudaEvent */
+    CudaEvent* event;
+
+public:
+
+    /** create invalid handle  */
+    CudaEventHandle( ) : event( NULL )
+    {
+
+    }
+
+    /** create a handle to a valid CudaEvent
+     *
+     * @param evPointer pointer to a CudaEvent
+     */
+    CudaEventHandle( CudaEvent* const evPointer ) : event( evPointer )
+    {
+        event->registerHandle();
+    }
+
+    CudaEventHandle( const CudaEventHandle& other ) : event( NULL )
+    {
+        /* register and release handle is done by the assign operator */
+        *this = other;
+    }
+
+    /** assign an event handle
+     *
+     * undefined behavior if the other event handle is equal to this instance
+     *
+     * @param other event handle
+     * @return this handle
+     */
+    CudaEventHandle&
+    operator=( const CudaEventHandle& other )
+    {
+        /* check if an old event is overwritten */
+        if( event )
+            event->releaseHandle( );
+        event = other.event;
+        /* check that new event pointer is not NULL */
+        if( event )
+            event->registerHandle( );
+        return *this;
+    }
+
+    /** Destructor */
+    ~CudaEventHandle( )
+    {
+        if( event )
+            event->releaseHandle( );
+        event = NULL;
+    }
+
+    /**
+     * get native cuda event
+     *
+     * @return native cuda event
+     */
+    cudaEvent_t operator*( ) const
+    {
+        assert( event );
+        return **event;
+    }
+
+    /** check whether the event is finished
+     *
+     * @return true if event is finished else false
+     */
+    bool isFinished( )
+    {
+        assert( event );
+        return event->isFinished( );
+    }
+
+
+    /** get stream in which this event is recorded
+     *
+     * @return native cuda stream
+     */
+    cudaStream_t getStream( ) const
+    {
+        assert( event );
+        return event->getStream( );
+    }
+
+    /** record event in a device stream
+     *
+     * @param stream native cuda stream
+     */
+    void recordEvent( cudaStream_t stream )
+    {
+        assert( event );
+        event->recordEvent( stream );
+    }
+};
+}

--- a/src/libPMacc/include/eventSystem/events/EventPool.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventPool.hpp
@@ -23,79 +23,120 @@
 
 #pragma once
 
-#include "eventSystem/events/CudaEvent.hpp"
+#include "eventSystem/events/CudaEvent.def"
+#include "eventSystem/events/CudaEventHandle.hpp"
 #include "debug/VerboseLog.hpp"
 #include "pmacc_types.hpp"
 
 #include <vector>
+#include <list>
+#include <stdexcept>
 
 namespace PMacc
 {
 
-    /**
-     * Manages a pool of cudaEvent_t objects and gives access to them.
-     */
+    /** Manages a pool of cudaEvent_t objects and gives access to them. */
     class EventPool
     {
     public:
 
-        /**
-         * Constructor.
-         * adds a single cuda event to the pool
+        /** Returns a free cuda event
+         *
+         * @return free cuda event
          */
-        EventPool()
+        CudaEventHandle pop( )
         {
-            addEvents(1);
-            currentEventIndex = 0;
-        }
-
-        /**
-         * Destructor.
-         * destroys all cuda events in the pool
-         */
-        virtual ~EventPool()
-        {
-            for (size_t i = 0; i < events.size(); i++)
+            if( freeEvents.size( ) != 0 )
             {
-                log(ggLog::CUDA_RT()+ggLog::MEMORY(),"Sync and Delete Event: %1%") % i;
-                CudaEvent::destroy(events[i]);
+                CudaEventHandle result = freeEvents.front( );
+                freeEvents.pop_front( );
+                return result;
             }
+            createEvents( );
+            return pop( );
         }
 
-        /**
-         * Returns the next cuda event in the event pool.
-         * @return the next cuda event
+
+        /** add CudaEvent to the pool
+         *
+         * the pool takes the ownership of the pointer
+         *
+         * @param ev pointer to CudaEvent
          */
-        CudaEvent getNextEvent()
+        void push( CudaEvent* const ev )
         {
-            CudaEvent result = events[currentEventIndex];
-            currentEventIndex = (currentEventIndex + 1) % events.size();
-            return result;
+            /* Guard that no event is added during the pool is closed (shutdown phase).
+             * This method is also called during the evaluation of the destructor.
+             */
+            if( !isClosed )
+                freeEvents.push_back( CudaEventHandle(ev) );
         }
 
-        /**
-         * Adds count new cuda events to the pool.
+        /** create and add cuda events to the pool
+         *
          * @param count number of cuda events to add
          */
-        void addEvents(size_t count)
+        void createEvents( size_t count = 1u )
         {
-            for (size_t i = 0; i < count; i++)
+            for( size_t i = 0u; i < count; i++ )
             {
-                events.push_back(CudaEvent::create());
+                CudaEvent* nativeEvent = new CudaEvent( );
+                events.push_back( nativeEvent );
+                push( nativeEvent );
             }
         }
 
-        /**
-         * Returns the number of cuda events in the pool.
+        /** Returns the number of cuda events in the pool.
+         *
          * @return number of cuda events
          */
-        size_t getEventsCount()
+        size_t getEventsCount( )
         {
-            return events.size();
+            return events.size( );
         }
 
     private:
-        std::vector<CudaEvent> events;
-        size_t currentEventIndex;
+        friend class Environment< DIM1 >;
+        friend class Environment< DIM2 >;
+        friend class Environment< DIM3 >;
+
+        static EventPool& getInstance( )
+        {
+            static EventPool instance;
+            return instance;
+        }
+
+        /** Constructor */
+        EventPool( ) : isClosed( false )
+        {
+        }
+
+        /** Destructor
+         *
+         * destroys all cuda events in the pool
+         */
+        ~EventPool()
+        {
+            log( ggLog::CUDA_RT( )+ggLog::MEMORY( ), "shutdown EventPool with %1% events" ) % getEventsCount( );
+            isClosed = true;
+            freeEvents.clear( );
+            for( std::vector<CudaEvent*>::const_iterator iter = events.begin(); iter != events.end(); ++iter )
+            {
+                delete *iter;
+            }
+            events.clear( );
+        }
+
+        //! hold all CudaEvents
+        std::vector<CudaEvent*> events;
+
+        //! hold currently free CudaEventHandle's
+        std::list<CudaEventHandle> freeEvents;
+
+        /**! state if the pool is closed
+         *
+         * if true no events can be added to the pool
+         */
+        bool isClosed;
     };
 }

--- a/src/libPMacc/include/eventSystem/streams/EventStream.hpp
+++ b/src/libPMacc/include/eventSystem/streams/EventStream.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "eventSystem/events/CudaEvent.hpp"
+#include "eventSystem/events/CudaEventHandle.hpp"
 #include "pmacc_types.hpp"
 
 #include <cuda_runtime.h>
@@ -67,7 +67,7 @@ public:
         return stream;
     }
 
-    void waitOn(const CudaEvent& ev)
+    void waitOn(const CudaEventHandle& ev)
     {
         if (this->stream != ev.getStream())
         {

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "eventSystem/tasks/ITask.hpp"
-#include "eventSystem/events/CudaEvent.hpp"
+#include "eventSystem/events/CudaEventHandle.hpp"
 
 namespace PMacc
 {
@@ -56,14 +56,14 @@ namespace PMacc
          *
          * @return the task's cuda event
          */
-        CudaEvent getCudaEvent() const;
+        CudaEventHandle getCudaEventHandle() const;
 
         /**
          * Sets the
          *
          * @param cudaEvent
          */
-        void setCudaEvent(const CudaEvent& cudaEvent);
+        void setCudaEventHandle(const CudaEventHandle& cudaEvent);
 
         /**
          * Returns if this task is finished.
@@ -103,8 +103,8 @@ namespace PMacc
 
 
         EventStream *stream;
-        CudaEvent cudaEvent;
-        bool hasCudaEvent;
+        CudaEventHandle cudaEvent;
+        bool hasCudaEventHandle;
         bool alwaysFinished;
     };
 

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
@@ -26,6 +26,7 @@
 //#include "eventSystem/EventSystem.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
 #include "eventSystem/streams/EventStream.hpp"
+#include "Environment.hpp"
 
 namespace PMacc
 {
@@ -33,21 +34,21 @@ namespace PMacc
 inline StreamTask::StreamTask( ) :
 ITask( ),
 stream( NULL ),
-hasCudaEvent( false ),
+hasCudaEventHandle( false ),
 alwaysFinished( false )
 {
     this->setTaskType( ITask::TASK_CUDA );
 }
 
-inline CudaEvent StreamTask::getCudaEvent( ) const
+inline CudaEventHandle StreamTask::getCudaEventHandle( ) const
 {
-    assert( hasCudaEvent );
+    assert( hasCudaEventHandle );
     return cudaEvent;
 }
 
-inline void StreamTask::setCudaEvent(const CudaEvent& cudaEvent )
+inline void StreamTask::setCudaEventHandle(const CudaEventHandle& cudaEvent )
 {
-    this->hasCudaEvent = true;
+    this->hasCudaEventHandle = true;
     this->cudaEvent = cudaEvent;
 }
 
@@ -55,7 +56,7 @@ inline bool StreamTask::isFinished( )
 {
     if ( alwaysFinished )
         return true;
-    if ( hasCudaEvent )
+    if ( hasCudaEventHandle )
     {
         if ( cudaEvent.isFinished( ) )
         {
@@ -89,9 +90,9 @@ inline cudaStream_t StreamTask::getCudaStream( )
 
 inline void StreamTask::activate( )
 {
-    cudaEvent = Environment<>::get().Manager().getEventPool( ).getNextEvent( );
+    cudaEvent = Environment<>::get().EventPool( ).pop( );
     cudaEvent.recordEvent(this->stream->getCudaStream());
-    hasCudaEvent = true;
+    hasCudaEventHandle = true;
 }
 
 } //namespace PMacc

--- a/src/libPMacc/include/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -74,21 +74,20 @@ namespace PMacc
 
         void event(id_t eventId, EventType, IEventData*)
         {
-            if (task1 == eventId)
+            if(task1 == eventId)
             {
                 task1 = 0;
 
                 ITask* task = Environment<>::get().Manager().getITaskIfNotFinished(task2);
-                if (task != NULL)
+                if(task != NULL)
                 {
                     ITask::TaskType type = task->getTaskType();
                     if (type == ITask::TASK_CUDA )
                     {
                         this->stream = static_cast<StreamTask*>(task)->getEventStream();
                         this->setTaskType(ITask::TASK_CUDA);
-                        this->cudaEvent=static_cast<StreamTask*>(task)->getCudaEvent();
-                        this->hasCudaEvent=true;
-
+                        this->cudaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
+                        this->hasCudaEventHandle = true;
                     }
                 }
             }
@@ -97,16 +96,15 @@ namespace PMacc
                 task2 = 0;
 
                 ITask* task = Environment<>::get().Manager().getITaskIfNotFinished(task1);
-                if (task != NULL)
+                if(task != NULL)
                 {
                     ITask::TaskType type = task->getTaskType();
                     if (type == ITask::TASK_CUDA )
                     {
                         this->stream = static_cast<StreamTask*>(task)->getEventStream();
                         this->setTaskType(ITask::TASK_CUDA);
-                        this->cudaEvent=static_cast<StreamTask*>(task)->getCudaEvent();
-                        this->hasCudaEvent=true;
-
+                        this->cudaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
+                        this->hasCudaEventHandle = true;
                     }
                 }
             }
@@ -134,23 +132,23 @@ namespace PMacc
         {
             s1->addObserver(this);
             s2->addObserver(this);
-            if (s1->getTaskType() == ITask::TASK_CUDA && s2->getTaskType() == ITask::TASK_CUDA)
+            if(s1->getTaskType() == ITask::TASK_CUDA && s2->getTaskType() == ITask::TASK_CUDA)
             {
                 this->setTaskType(ITask::TASK_CUDA);
                 this->setEventStream(static_cast<StreamTask*> (s2)->getEventStream());
                 if(static_cast<StreamTask*> (s1)->getEventStream() != static_cast<StreamTask*> (s2)->getEventStream())
-                    this->getEventStream()->waitOn(static_cast<StreamTask*> (s1)->getCudaEvent());
+                    this->getEventStream()->waitOn(static_cast<StreamTask*> (s1)->getCudaEventHandle());
                 this->activate();
             }
-            else if (s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_CUDA)
+            else if(s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_CUDA)
             {
                 this->setTaskType(ITask::TASK_MPI);
             }
-            else if (s2->getTaskType() == ITask::TASK_MPI && s1->getTaskType() == ITask::TASK_CUDA)
+            else if(s2->getTaskType() == ITask::TASK_MPI && s1->getTaskType() == ITask::TASK_CUDA)
             {
                 this->setTaskType(ITask::TASK_MPI);
             }
-            else if (s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_MPI)
+            else if(s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_MPI)
             {
                 this->setTaskType(ITask::TASK_MPI);
             }


### PR DESCRIPTION
close #1189

- remove `EventPool` from task manager
- add `EventPool` as singleton to `Environment<>`
- `StreamTask`
  - rename `getCudaEvent()` to `getCudaEventHandle()`
  - rename `setCudaEvent()` to `setCudaEventHandle()`
- `TaskLogicalAnd`: rename attribute `hasCudaEvent` to `hasCudaEventHandle`
- `EventStream`: `waitOn()` is using the new `CudaEventHandle`
- full refactor `EventPool`: dynamic number of used cuda events
- rename `CudaEvent` to `CudaEventHandle`
- add `CudaEvent` (wrapper for a native cuda event)

The bug in #1189 is closed with a new feature of the event pool. The event pool now allocates as much cuda events as needed.

- [x]  runtime test