### PR TITLE
CMake: Find non-default zlib

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -254,6 +254,15 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 
 ################################################################################
+# Find zlib
+################################################################################
+
+find_package(ZLIB REQUIRED)
+include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
+set(LIBS ${LIBS} ${ZLIB_LIBRARIES})
+
+
+################################################################################
 # Find Boost
 ################################################################################
 
@@ -511,7 +520,7 @@ cuda_add_executable(picongpu
     ${SRCFILES}
 )
 
-target_link_libraries(picongpu  ${LIBS} ${CUDA_CUDART_LIBRARY} z m)
+target_link_libraries(picongpu ${LIBS} ${CUDA_CUDART_LIBRARY} m)
 
 ################################################################################
 # Install PIConGPU


### PR DESCRIPTION
Installing PIConGPU on a minimal distribution in user mode often includes compiling zlib yourself in a non-default directory. This changes the way we look for zlib to find it properly (first found on an AWS instance with CentOS 6.8 installed).

### Notes

zlib is ~~not used by PIConGPU directly but~~ *used inside the 2D live visualization plugin (same backend as png) and might* come~~s~~ in with a lot of dependencies that do not declare it properly (which only affects linking), *too*.
`m` is a similar candidate but is usually shipped with the compiler stdlib and also has no find module in CMake afaik.