### PR TITLE
fix wrong comment random->quiet

### DIFF
--- a/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -43,7 +44,7 @@ namespace particles
            typedef mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type numParticlesPerDimension;
         };
 
-        /* definition of random particle start*/
+        /* definition of quiet particle start*/
         typedef QuietImpl<QuietParam> Quiet;
 
     } //namespace startPosition

--- a/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz,
+ *                     Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -62,7 +63,7 @@ struct QuietParameter
     typedef mCT::shrinkTo<mCT::Int<1, TYPICAL_PARTICLES_PER_CELL, 1>, simDim>::type numParticlesPerDimension;
 };
 
-/* definition of random particle start*/
+/* definition of quiet particle start*/
 typedef QuietImpl<QuietParameter> Quiet;
 
 

--- a/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -92,7 +93,7 @@ namespace startPosition
        typedef mCT::shrinkTo<mCT::Int<TYPICAL_PARTICLES_PER_CELL/2, TYPICAL_PARTICLES_PER_CELL/2, 1>, simDim>::type numParticlesPerDimension;
     };
 
-    /* definition of random particle start*/
+    /* definition of quiet particle start*/
     typedef QuietImpl<QuietParam> Quiet;
 
 } //namespace startPosition

--- a/src/picongpu/include/simulation_defines/param/particleConfig.param
+++ b/src/picongpu/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,6 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera, Benjamin Worpitz
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -114,7 +115,7 @@ namespace startPosition
        typedef mCT::shrinkTo<mCT::Int<1, TYPICAL_PARTICLES_PER_CELL, 1>, simDim>::type numParticlesPerDimension;
     };
 
-    /* definition of random particle start*/
+    /* definition of quiet particle start*/
     typedef QuietImpl<QuietParam> Quiet;
 
 


### PR DESCRIPTION
This pull request fixes a wrong comment in `particleConfig.param` where the quiet start implementation was described as random start. 