### PR TITLE
ADIOS 1.10.0+: New Allocation Call

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1034,7 +1034,7 @@ private:
         size_t writeBuffer_in_MiB=1+threadParams->adiosGroupSize / 1024 / 1024;
         /* value `1.1` is the secure factor if we miss to count some small buffers*/
         size_t buffer_mem=static_cast<size_t>(1.1 * static_cast<float_64>(writeBuffer_in_MiB));
-        ADIOS_CMD(adios_allocate_buffer(ADIOS_BUFFER_ALLOC_NOW,buffer_mem));
+        adios_set_max_buffer_size(buffer_mem);
         threadParams->adiosBufferInitialized = true;
 
         /* open adios file. all variables need to be defined at this point */


### PR DESCRIPTION
In the lastest version of ADIOS, which we depend on as a minimum, the old `int adios_allocate` call was replaced with a more sophisticated method which can further be controlled in its maximum size of buffers via `void adios_set_max_buffer_size(uint MB)`.

This patch uses the new method and removes a warning caused by the old API.

We can actually get rid of the "estimate how much we will write" now if we want and can choose a value that suits us in terms of host RAM, but that's for an other refactoring time (and will also need checks if it really does not affect write performance).

1.10.0: Manual (4.1.2)
  http://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.10.0.pdf
1.9.0:  Manual (4.1.2)
  http://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.9.0.pdf