### PR TITLE
remove namespace workaround

### DIFF
--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -43,7 +43,6 @@ namespace templates
 /** Traveling-wave Thomson scattering laser pulse */
 namespace twts
 {
-    namespace pmMath = PMacc::algorithms::math;
 
     HINLINE
     BField::BField( const float_64 focus_y_SI,
@@ -105,8 +104,8 @@ namespace twts
          *
          * RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field vectors.
          */
-        const float_64 By_rot = -pmMath::sin(+phi)*By_By+pmMath::cos(+phi)*Bz_By;
-        const float_64 Bz_rot = -pmMath::cos(+phi)*By_Bz-pmMath::sin(+phi)*Bz_Bz;
+        const float_64 By_rot = -math::sin(+phi)*By_By+math::cos(+phi)*Bz_By;
+        const float_64 Bz_rot = -math::cos(+phi)*By_Bz-math::sin(+phi)*Bz_Bz;
 
         /* Finally, the B-field normalized to the peak amplitude. */
         return float3_X( float_X(0.0),
@@ -138,8 +137,8 @@ namespace twts
          *
          * RotationMatrix[-(PI/2+phi)].(By,Bz) for rotating back the field-vectors.
          */
-        const float_64 By_rot = +pmMath::cos(+phi)*Bz_By;
-        const float_64 Bz_rot = -pmMath::sin(+phi)*Bz_Bz;
+        const float_64 By_rot = +math::cos(+phi)*Bz_By;
+        const float_64 Bz_rot = -math::sin(+phi)*Bz_Bz;
 
         /* Finally, the B-field normalized to the peak amplitude. */
         return float3_X( float_X( calcTWTSBx(pos[0], time) ),
@@ -201,8 +200,8 @@ namespace twts
          *
          * RotationMatrix[-(PI / 2+phi)].(By,Bx) for rotating back the field vectors.
          */
-        const float_64 By_rot = -pmMath::sin(phi)*By_By+pmMath::cos(phi)*Bx_By;
-        const float_64 Bx_rot = -pmMath::cos(phi)*By_Bx-pmMath::sin(phi)*Bx_Bx;
+        const float_64 By_rot = -math::sin(phi)*By_By+math::cos(phi)*Bx_By;
+        const float_64 Bx_rot = -math::cos(phi)*By_Bx-math::sin(phi)*Bx_Bx;
 
         /* Finally, the B-field normalized to the peak amplitude. */
         return float3_X( float_X(Bx_rot),
@@ -259,8 +258,8 @@ namespace twts
          * RotationMatrix[-(PI / 2+phi)].(By,Bx)
          * for rotating back the field-vectors.
          */
-        const float_64 By_rot = +pmMath::cos(phi)*Bx_By;
-        const float_64 Bx_rot = -pmMath::sin(phi)*Bx_Bx;
+        const float_64 By_rot = +math::cos(phi)*Bx_By;
+        const float_64 Bx_rot = -math::sin(phi)*Bx_Bx;
 
         /* Finally, the B-field normalized to the peak amplitude. */
         return float3_X( float_X( Bx_rot ),
@@ -313,9 +312,9 @@ namespace twts
          * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
          * z-axis of the coordinate system in this function.
          */
-        const float_T phiReal = float_T( pmMath::abs(phi) );
-        const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
-                                                beta0*pmMath::sin(phiReal));
+        const float_T phiReal = float_T( math::abs(phi) );
+        const float_T alphaTilt = math::atan2(float_T(1.0)-beta0*math::cos(phiReal),
+                                                beta0*math::sin(phiReal));
         /* Definition of the laser pulse front tilt angle for the laser field below.
          *
          * For beta0=1.0, this is equivalent to our standard definition. Question: Why is the
@@ -354,17 +353,17 @@ namespace twts
         const float_T t = float_T(time / UNIT_TIME);
 
         /* Shortcuts for speeding up the field calculation. */
-        const float_T sinPhi = pmMath::sin(phiT);
-        const float_T cosPhi = pmMath::cos(phiT);
-        const float_T cosPhi2 = pmMath::cos(phiT / 2.0);
-        const float_T tanPhi2 = pmMath::tan(phiT / 2.0);
+        const float_T sinPhi = math::sin(phiT);
+        const float_T cosPhi = math::cos(phiT);
+        const float_T cosPhi2 = math::cos(phiT / 2.0);
+        const float_T tanPhi2 = math::tan(phiT / 2.0);
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
          * thus help with formal code verification through manual code inspection.
          */
         const complex_T helpVar1 = rho0 + complex_T(0,1)*y*cosPhi + complex_T(0,1)*z*sinPhi;
         const complex_T helpVar2 = cspeed*om0*tauG*tauG + complex_T(0,2)
-                                    *(-z - y*pmMath::tan(float_T(PI / 2)-phiT))*tanPhi2*tanPhi2;
+                                    *(-z - y*math::tan(float_T(PI / 2)-phiT))*tanPhi2*tanPhi2;
         const complex_T helpVar3 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
 
         const complex_T helpVar4 = float_T(-1.0)*(
@@ -382,11 +381,11 @@ namespace twts
             - float_T(4.0)*cspeed*om0*t*wy*wy*z*rho0*tanPhi2*tanPhi2
             - complex_T(0,4)*cspeed*y*y*z*rho0*tanPhi2*tanPhi2
             + float_T(4.0)*om0*wy*wy*z*z*rho0*tanPhi2*tanPhi2
-            - complex_T(0,2)*cspeed*k*wy*wy*x*x*y*pmMath::tan(float_T(PI / 2)-phiT)*tanPhi2*tanPhi2
-            - float_T(4.0)*cspeed*om0*t*wy*wy*y*rho0*pmMath::tan(float_T(PI / 2)-phiT)
+            - complex_T(0,2)*cspeed*k*wy*wy*x*x*y*math::tan(float_T(PI / 2)-phiT)*tanPhi2*tanPhi2
+            - float_T(4.0)*cspeed*om0*t*wy*wy*y*rho0*math::tan(float_T(PI / 2)-phiT)
                 *tanPhi2*tanPhi2
-            - complex_T(0,4)*cspeed*y*y*y*rho0*pmMath::tan(float_T(PI / 2)-phiT)*tanPhi2*tanPhi2
-            + float_T(4.0)*om0*wy*wy*y*z*rho0*pmMath::tan(float_T(PI / 2)-phiT)*tanPhi2*tanPhi2
+            - complex_T(0,4)*cspeed*y*y*y*rho0*math::tan(float_T(PI / 2)-phiT)*tanPhi2*tanPhi2
+            + float_T(4.0)*om0*wy*wy*y*z*rho0*math::tan(float_T(PI / 2)-phiT)*tanPhi2*tanPhi2
             + float_T(2.0)*z*sinPhi*(
                 + om0*(
                     + cspeed*cspeed*(
@@ -421,7 +420,7 @@ namespace twts
                     + cspeed*om0*t*wy*wy
                     + complex_T(0,1)*cspeed*y*y
                     - om0*wy*wy*z
-                    )*pmMath::tan(float_T(PI / 2)-phiT)
+                    )*math::tan(float_T(PI / 2)-phiT)
                 )*tanPhi2*tanPhi2
             )
         /* The "round-trip" conversion in the line below fixes a gross accuracy bug
@@ -430,19 +429,19 @@ namespace twts
         ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2) );
 
         const complex_T helpVar5 = complex_T(0,-1)*cspeed*om0*tauG*tauG
-                                + (-z - y*pmMath::tan(float_T(PI / 2)-phiT))
+                                + (-z - y*math::tan(float_T(PI / 2)-phiT))
                                     *tanPhi2*tanPhi2*float_T(2.0);
         const complex_T helpVar6 = (cspeed*(cspeed*om0*tauG*tauG + complex_T(0,2)
-                                *(-z - y*pmMath::tan(float_T(PI / 2)-phiT))*tanPhi2*tanPhi2))
+                                *(-z - y*math::tan(float_T(PI / 2)-phiT))*tanPhi2*tanPhi2))
                                     / (om0*rho0);
-        const complex_T result = (pmMath::exp(helpVar4)*tauG / cosPhi2 / cosPhi2
+        const complex_T result = (math::exp(helpVar4)*tauG / cosPhi2 / cosPhi2
             *(rho0 + complex_T(0,1)*y*cosPhi + complex_T(0,1)*z*sinPhi)
             *(
                   complex_T(0,2)*cspeed*t + cspeed*om0*tauG*tauG - complex_T(0,4)*z
                 + cspeed*(complex_T(0,2)*t + om0*tauG*tauG)*cosPhi
                 + complex_T(0,2)*y*tanPhi2
-            )*pmMath::pow(helpVar3,float_T(-1.5))
-        ) / (float_T(2.0)*helpVar5*pmMath::sqrt(helpVar6));
+            )*math::pow(helpVar3,float_T(-1.5))
+        ) / (float_T(2.0)*helpVar5*math::sqrt(helpVar6));
 
         return result.get_real() / UNIT_SPEED;
     }
@@ -469,9 +468,9 @@ namespace twts
          * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
          * z-axis of the coordinate system in this function.
          */
-        const float_T phiReal = float_T( pmMath::abs(phi) );
-        const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
-                                                beta0*pmMath::sin(phiReal));
+        const float_T phiReal = float_T( math::abs(phi) );
+        const float_T alphaTilt = math::atan2(float_T(1.0)-beta0*math::cos(phiReal),
+                                                beta0*math::sin(phiReal));
 
         /* Definition of the laser pulse front tilt angle for the laser field below.
          *
@@ -511,16 +510,16 @@ namespace twts
         const float_T t = float_T(time / UNIT_TIME);
 
         /* Shortcuts for speeding up the field calculation. */
-        const float_T sinPhi = pmMath::sin(phiT);
-        const float_T cosPhi = pmMath::cos(phiT);
-        const float_T sinPhi2 = pmMath::sin(phiT / float_T(2.0));
-        const float_T cosPhi2 = pmMath::cos(phiT / float_T(2.0));
-        const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
+        const float_T sinPhi = math::sin(phiT);
+        const float_T cosPhi = math::cos(phiT);
+        const float_T sinPhi2 = math::sin(phiT / float_T(2.0));
+        const float_T cosPhi2 = math::cos(phiT / float_T(2.0));
+        const float_T tanPhi2 = math::tan(phiT / float_T(2.0));
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
          * thus help with formal code verification through manual code inspection.
          */
-        const complex_T helpVar1 = -(cspeed*z) - cspeed*y*pmMath::tan(float_T(PI / 2)-phiT)
+        const complex_T helpVar1 = -(cspeed*z) - cspeed*y*math::tan(float_T(PI / 2)-phiT)
                                     + complex_T(0,1)*cspeed*rho0 / sinPhi;
         const complex_T helpVar2 = complex_T(0,1)*rho0 - y*cosPhi - z*sinPhi;
         const complex_T helpVar3 = helpVar2*cspeed;
@@ -553,10 +552,10 @@ namespace twts
         const complex_T helpVar7 = cspeed*om0*tauG*tauG
                                     - complex_T(0,1)*y*cosPhi / cosPhi2 / cosPhi2*tanPhi2
                                     - complex_T(0,2)*z*tanPhi2*tanPhi2;
-        const complex_T result = ( complex_T(0,2)*pmMath::exp(helpVar6)*tauG*tanPhi2
+        const complex_T result = ( complex_T(0,2)*math::exp(helpVar6)*tauG*tanPhi2
                                     *(cspeed*t - z + y*tanPhi2)
-                                    *pmMath::sqrt( (om0*rho0) / helpVar3 )
-                                  ) / pmMath::pow(helpVar7,float_T(1.5));
+                                    *math::sqrt( (om0*rho0) / helpVar3 )
+                                  ) / math::pow(helpVar7,float_T(1.5));
 
         return result.get_real() / UNIT_SPEED;
     }
@@ -598,9 +597,9 @@ namespace twts
          * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
          * z-axis of the coordinate system in this function.
          */
-        const float_T phiReal = float_T( pmMath::abs(phi) );
-        const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
-                                                beta0*pmMath::sin(phiReal));
+        const float_T phiReal = float_T( math::abs(phi) );
+        const float_T alphaTilt = math::atan2(float_T(1.0)-beta0*math::cos(phiReal),
+                                                beta0*math::sin(phiReal));
         /* Definition of the laser pulse front tilt angle for the laser field below.
          *
          * For beta0=1.0, this is equivalent to our standard definition. Question: Why is the
@@ -639,11 +638,11 @@ namespace twts
         const float_T t = float_T(time / UNIT_TIME);
 
         /* Shortcuts for speeding up the field calculation. */
-        const float_T sinPhi = pmMath::sin(phiT);
-        const float_T cosPhi = pmMath::cos(phiT);
-        const float_T sinPhi2 = pmMath::sin(phiT / float_T(2.0));
-        const float_T cosPhi2 = pmMath::cos(phiT / float_T(2.0));
-        const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
+        const float_T sinPhi = math::sin(phiT);
+        const float_T cosPhi = math::cos(phiT);
+        const float_T sinPhi2 = math::sin(phiT / float_T(2.0));
+        const float_T cosPhi2 = math::cos(phiT / float_T(2.0));
+        const float_T tanPhi2 = math::tan(phiT / float_T(2.0));
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
          * thus help with formal code verification through manual code inspection.
@@ -713,15 +712,15 @@ namespace twts
         const complex_T helpVar4 = (
             cspeed*om0*(
                 cspeed*om0*tauG*tauG
-                - complex_T(0,8)*y*pmMath::tan( float_T(PI) / float_T(2.0) - phiT )
+                - complex_T(0,8)*y*math::tan( float_T(PI) / float_T(2.0) - phiT )
                     / sinPhi / sinPhi * sinPhi2*sinPhi2*sinPhi2*sinPhi2
                 - complex_T(0,2)*z*tanPhi2*tanPhi2
             )
         ) / rho0;
 
         const complex_T result = float_T(-1.0)*(
-            cspeed*pmMath::exp(helpVar3)*k*tauG*x*pmMath::pow( helpVar2, float_T(-1.5) )
-            / pmMath::sqrt(helpVar4)
+            cspeed*math::exp(helpVar3)*k*tauG*x*math::pow( helpVar2, float_T(-1.5) )
+            / math::sqrt(helpVar4)
         );
 
         return result.get_real() / UNIT_SPEED;

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -43,7 +43,6 @@ namespace templates
 /* Traveling-wave Thomson scattering laser pulse */
 namespace twts
 {
-    namespace pmMath = PMacc::algorithms::math;
 
     HINLINE
     EField::EField( const float_64 focus_y_SI,
@@ -110,8 +109,8 @@ namespace twts
          *
          * RotationMatrix[-(PI/2+phi)].(Ey,Ez) for rotating back the field-vectors.
          */
-        const float_64 Ey_rot = -pmMath::sin(+phi)*Ey_Ey;
-        const float_64 Ez_rot = -pmMath::cos(+phi)*Ey_Ez;
+        const float_64 Ey_rot = -math::sin(+phi)*Ey_Ey;
+        const float_64 Ez_rot = -math::cos(+phi)*Ey_Ez;
 
         /* Finally, the E-field normalized to the peak amplitude. */
         return float3_X( float_X(0.0),
@@ -164,8 +163,8 @@ namespace twts
          *
          * RotationMatrix[-(PI / 2+phi)].(Ey,Ex) for rotating back the field-vectors.
          */
-        const float_64 Ey_rot = -pmMath::sin(+phi)*Ey_Ey;
-        const float_64 Ex_rot = -pmMath::cos(+phi)*Ey_Ex;
+        const float_64 Ey_rot = -math::sin(+phi)*Ey_Ey;
+        const float_64 Ex_rot = -math::cos(+phi)*Ey_Ex;
 
         /* Finally, the E-field normalized to the peak amplitude. */
         return float3_X( float_X(Ex_rot),
@@ -219,9 +218,9 @@ namespace twts
          * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
          * z-axis of the coordinate system in this function.
          */
-        const float_T phiReal = float_T( pmMath::abs(phi) );
-        const float_T alphaTilt = pmMath::atan2(float_T(1.0)-beta0*pmMath::cos(phiReal),
-                                                beta0*pmMath::sin(phiReal));
+        const float_T phiReal = float_T( math::abs(phi) );
+        const float_T alphaTilt = math::atan2(float_T(1.0)-beta0*math::cos(phiReal),
+                                                beta0*math::sin(phiReal));
         /* Definition of the laser pulse front tilt angle for the laser field below.
          *
          * For beta0 = 1.0, this is equivalent to our standard definition. Question: Why is the
@@ -256,11 +255,11 @@ namespace twts
         const float_T t = float_T(time / UNIT_TIME);
 
         /* Calculating shortcuts for speeding up field calculation */
-        const float_T sinPhi = pmMath::sin(phiT);
-        const float_T cosPhi = pmMath::cos(phiT);
-        const float_T sinPhi2 = pmMath::sin(phiT / float_T(2.0));
-        const float_T cosPhi2 = pmMath::cos(phiT / float_T(2.0));
-        const float_T tanPhi2 = pmMath::tan(phiT / float_T(2.0));
+        const float_T sinPhi = math::sin(phiT);
+        const float_T cosPhi = math::cos(phiT);
+        const float_T sinPhi2 = math::sin(phiT / float_T(2.0));
+        const float_T cosPhi2 = math::cos(phiT / float_T(2.0));
+        const float_T tanPhi2 = math::tan(phiT / float_T(2.0));
 
         /* The "helpVar" variables decrease the nesting level of the evaluated expressions and
          * thus help with formal code verification through manual code inspection.
@@ -287,7 +286,7 @@ namespace twts
                         - complex_T(0,2)*cspeed*om0*t*wy*wy*rho0
                         + float_T(2.0)*cspeed*y*y*rho0
                         + complex_T(0,2)*om0*wy*wy*z*rho0
-                    )*pmMath::tan(float_T(PI / 2.0)-phiT)/sinPhi
+                    )*math::tan(float_T(PI / 2.0)-phiT)/sinPhi
                 )*sinPhi2*sinPhi2*sinPhi2*sinPhi2
             - complex_T(0,2)*cspeed*cspeed*om0*t*t*wy*wy*z*sinPhi
             - float_T(2.0)*cspeed*cspeed*om0*om0*t*tauG*tauG*wy*wy*z*sinPhi
@@ -329,11 +328,11 @@ namespace twts
         ) * complex_T( float_64(1.0) / complex_64(float_T(2.0)*cspeed*wy*wy*helpVar1*helpVar2) );
 
         const complex_T helpVar5 = cspeed*om0*tauG*tauG
-            - complex_T(0,8)*y*pmMath::tan( float_T(PI / 2)-phiT )
+            - complex_T(0,8)*y*math::tan( float_T(PI / 2)-phiT )
                                 / sinPhi / sinPhi*sinPhi2*sinPhi2*sinPhi2*sinPhi2
             - complex_T(0,2)*z*tanPhi2*tanPhi2;
-        const complex_T result = (pmMath::exp(helpVar4)*tauG
-            *pmMath::sqrt((cspeed*om0*rho0) / helpVar3)) / pmMath::sqrt(helpVar5);
+        const complex_T result = (math::exp(helpVar4)*tauG
+            *math::sqrt((cspeed*om0*rho0) / helpVar3)) / math::sqrt(helpVar5);
         return result.get_real();
     }
 

--- a/src/picongpu/include/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
@@ -34,8 +34,7 @@ namespace twts
 /* Auxiliary functions for calculating the TWTS field */
 namespace detail
 {
-    namespace pmMath = PMacc::algorithms::math;
-    
+
     template <unsigned T_dim>
     class GetInitialTimeDelay
     {
@@ -63,7 +62,7 @@ namespace detail
                                       const float_X phi,
                                       const float_X beta_0 ) const;
     };
-    
+
     template<>
     HDINLINE float_64
     GetInitialTimeDelay<DIM3>::operator()( const bool auto_tdelay,
@@ -75,7 +74,7 @@ namespace detail
                                            const float_X beta_0 ) const
     {
         if ( auto_tdelay ) {
-            
+
             /* angle between the laser pulse front and the y-axis. Good approximation for
              * beta0\simeq 1. For exact relation look in TWTS core routines for Ex, By or Bz. */
             const float_64 eta = (PI / 2) - (phi / 2);
@@ -83,25 +82,25 @@ namespace detail
              * projection we calculate the y-distance walkoff of the TWTS-pulse.
              * The abs()-function is for correct offset for -phi<-90Deg and +phi>+90Deg. */
             const float_64 y1 = float_64(halfSimSize[2]
-                                *picongpu::SI::CELL_DEPTH_SI)*pmMath::abs(pmMath::cos(eta));
+                                *picongpu::SI::CELL_DEPTH_SI)*math::abs(math::cos(eta));
             /* Fudge parameter to make sure, that TWTS pulse starts to impact simulation volume
              * at low intensity values. */
             const float_64 m = 3.;
             /* Approximate cross section of laser pulse through y-axis,
              * scaled with "fudge factor" m. */
             const float_64 y2 = m*(pulselength_SI*picongpu::SI::SPEED_OF_LIGHT_SI)
-                                / pmMath::cos(eta);
+                                / math::cos(eta);
             /* y-position of laser coordinate system origin within simulation. */
             const float_64 y3 = focus_y_SI;
             /* Programmatically obtained time-delay */
             const float_64 tdelay = (y1+y2+y3) / (picongpu::SI::SPEED_OF_LIGHT_SI*beta_0);
-            
+
             return tdelay;
         }
         else
             return tdelay_user_SI;
     }
-    
+
     template <>
     HDINLINE float_64
     GetInitialTimeDelay<DIM2>::operator()( const bool auto_tdelay,
@@ -113,7 +112,7 @@ namespace detail
                                            const float_X beta_0 ) const
     {
         if ( auto_tdelay ) {
-            
+
             /* angle between the laser pulse front and the y-axis. Good approximation for
              * beta0\simeq 1. For exact relation look in TWTS core routines for Ex, By or Bz. */
             const float_64 eta = (PI / 2) - (phi / 2);
@@ -121,19 +120,19 @@ namespace detail
              * projection we calculate the y-distance walkoff of the TWTS-pulse.
              * The abs()-function is for correct offset for -phi<-90Deg and +phi>+90Deg. */
             const float_64 y1 = float_64(halfSimSize[0]
-                                *picongpu::SI::CELL_WIDTH_SI)*pmMath::abs(pmMath::cos(eta));
+                                *picongpu::SI::CELL_WIDTH_SI)*math::abs(math::cos(eta));
             /* Fudge parameter to make sure, that TWTS pulse starts to impact simulation volume
              * at low intensity values. */
             const float_64 m = 3.;
             /* Approximate cross section of laser pulse through y-axis,
              * scaled with "fudge factor" m. */
             const float_64 y2 = m*(pulselength_SI*picongpu::SI::SPEED_OF_LIGHT_SI)
-                                / pmMath::cos(eta);
+                                / math::cos(eta);
             /* y-position of laser coordinate system origin within simulation. */
             const float_64 y3 = focus_y_SI;
             /* Programmatically obtained time-delay */
             const float_64 tdelay = (y1+y2+y3) / (picongpu::SI::SPEED_OF_LIGHT_SI*beta_0);
-            
+
             return tdelay;
         }
         else
@@ -154,7 +153,7 @@ namespace detail
                                             halfSimSize, pulselength_SI,
                                             focus_y_SI, phi, beta_0);
     }
-    
+
 } /* namespace detail */
 } /* namespace twts */
 } /* namespace templates */

--- a/src/picongpu/include/fields/background/templates/TWTS/RotateField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/RotateField.tpp
@@ -34,11 +34,10 @@ namespace twts
 /** Auxiliary functions for calculating the TWTS field */
 namespace detail
 {
-    namespace pmMath = PMacc::algorithms::math;
-    
+
     template <typename T_Type, typename T_AngleType>
     struct RotateField;
-    
+
     template <typename T_Type, typename T_AngleType>
     struct RotateField<PMacc::math::Vector<T_Type,3>, T_AngleType >
     {
@@ -57,14 +56,14 @@ namespace detail
              *  system in paper is oriented the other way round.) */
             return result(
                 fieldPosVector.x(),
-               -pmMath::sin(AngleType(phi))*fieldPosVector.y()
-                    -pmMath::cos(AngleType(phi))*fieldPosVector.z() ,
-               +pmMath::cos(AngleType(phi))*fieldPosVector.y()
-                    -pmMath::sin(AngleType(phi))*fieldPosVector.z() );
+               -math::sin(AngleType(phi))*fieldPosVector.y()
+                    -math::cos(AngleType(phi))*fieldPosVector.z() ,
+               +math::cos(AngleType(phi))*fieldPosVector.y()
+                    -math::sin(AngleType(phi))*fieldPosVector.z() );
         }
-                        
+
     };
-    
+
     template <typename T_Type, typename T_AngleType>
     struct RotateField<PMacc::math::Vector<T_Type,2>, T_AngleType >
     {
@@ -81,7 +80,7 @@ namespace detail
              *  phi to determine the required amount of pulse front tilt.
              *  RotationMatrix[PI/2+phi].(y,z) (180Deg-flip at phi=90Deg since coordinate
              *  system in paper is oriented the other way round.) */
-            
+
             /*  Rotate 90 degree around y-axis, so that TWTS laser propagates within
              *  the 2D (x,y)-plane. Corresponding position vector for the Ez-components
              *  in 2D simulations.
@@ -102,13 +101,13 @@ namespace detail
              * Note: The x-axis of rotation is fine in 2D, because that component now contains
              *       the (non-existing) simulation z-coordinate. */
              return result(
-                -pmMath::sin(AngleType(phi))*fieldPosVector.y()
-                    -pmMath::cos(AngleType(phi))*fieldPosVector.x() ,
-                +pmMath::cos(AngleType(phi))*fieldPosVector.y()
-                    -pmMath::sin(AngleType(phi))*fieldPosVector.x() );
+                -math::sin(AngleType(phi))*fieldPosVector.y()
+                    -math::cos(AngleType(phi))*fieldPosVector.x() ,
+                +math::cos(AngleType(phi))*fieldPosVector.y()
+                    -math::sin(AngleType(phi))*fieldPosVector.x() );
         }
     };
-    
+
     template <typename T_Type, typename T_AngleType>
     HDINLINE typename RotateField<T_Type,T_AngleType>::result
     rotateField( const T_Type& fieldPosVector,
@@ -116,7 +115,7 @@ namespace detail
     {
         return RotateField<T_Type,T_AngleType>()(fieldPosVector,phi);
     }
-    
+
 } /* namespace detail */
 } /* namespace twts */
 } /* namespace templates */

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -48,7 +48,7 @@ HDINLINE float_X MapToLookupTable::operator()(const float_X x) const
      *
      * This is the inverse mapping of the mapping in @see:`SynchrotronFunctions::init()`
      */
-    const float_X x_m = PMacc::algorithms::math::pow(x, float_X(1.0/3.0));
+    const float_X x_m = math::pow(x, float_X(1.0/3.0));
 
     const float_X cutOff = static_cast<float_X>(SYNC_FUNCS_CUTOFF);
 

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -207,7 +207,6 @@ private:
     void pluginLoad()
     {
         namespace pm = PMacc::math;
-        namespace pam = PMacc::algorithms::math;
 
         if(this->notifyPeriod == 0)
             return;
@@ -263,11 +262,11 @@ private:
         /* calculate rotated calorimeter frame from posYaw_deg and posPitch_deg */
         const float_64 posYaw_rad = this->posYaw_deg * float_64(M_PI / 180.0);
         const float_64 posPitch_rad = this->posPitch_deg * float_64(M_PI / 180.0);
-        this->calorimeterFrameVecY = float3_X(pam::sin(posYaw_rad) * pam::cos(posPitch_rad),
-                                              pam::cos(posYaw_rad) * pam::cos(posPitch_rad),
-                                              pam::sin(posPitch_rad));
+        this->calorimeterFrameVecY = float3_X(math::sin(posYaw_rad) * math::cos(posPitch_rad),
+                                              math::cos(posYaw_rad) * math::cos(posPitch_rad),
+                                              math::sin(posPitch_rad));
         /* If the y-axis is pointing exactly up- or downwards we need to define the x-axis manually */
-        if(pam::abs(this->calorimeterFrameVecY.z()) == float_X(1.0))
+        if(math::abs(this->calorimeterFrameVecY.z()) == float_X(1.0))
         {
             this->calorimeterFrameVecX = float3_X(1.0, 0.0, 0.0);
         }
@@ -275,11 +274,11 @@ private:
         {
             /* choose `calorimeterFrameVecX` so that the roll is zero. */
             const float3_X vecUp(0.0, 0.0, -1.0);
-            this->calorimeterFrameVecX = pam::cross(vecUp, this->calorimeterFrameVecY);
+            this->calorimeterFrameVecX = math::cross(vecUp, this->calorimeterFrameVecY);
             /* normalize vector */
-            this->calorimeterFrameVecX /= pam::abs(this->calorimeterFrameVecX);
+            this->calorimeterFrameVecX /= math::abs(this->calorimeterFrameVecX);
         }
-        this->calorimeterFrameVecZ = pam::cross(this->calorimeterFrameVecX, this->calorimeterFrameVecY);
+        this->calorimeterFrameVecZ = math::cross(this->calorimeterFrameVecX, this->calorimeterFrameVecY);
 
         /* create calorimeter functor instance */
         this->calorimeterFunctor = MyCalorimeterFunctorPtr(new MyCalorimeterFunctor(
@@ -288,8 +287,8 @@ private:
             this->numBinsYaw,
             this->numBinsPitch,
             this->numBinsEnergy,
-            this->logScale ? pam::log10(this->minEnergy) : this->minEnergy,
-            this->logScale ? pam::log10(this->maxEnergy) : this->maxEnergy,
+            this->logScale ? math::log10(this->minEnergy) : this->minEnergy,
+            this->logScale ? math::log10(this->maxEnergy) : this->maxEnergy,
             this->logScale,
             this->calorimeterFrameVecX,
             this->calorimeterFrameVecY,

--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -44,9 +44,9 @@ public:
       picongpu::float_X cosValue;
       picongpu::float_X sinValue;
       picongpu::math::sincos(phase, sinValue, cosValue);
-      amp_x=PMacc::algorithms::math::euler(vec.x(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
-      amp_y=PMacc::algorithms::math::euler(vec.y(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
-      amp_z=PMacc::algorithms::math::euler(vec.z(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
+      amp_x=picongpu::math::euler(vec.x(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
+      amp_y=picongpu::math::euler(vec.y(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
+      amp_z=picongpu::math::euler(vec.z(), picongpu::precisionCast<picongpu::float_64>(sinValue), picongpu::precisionCast<picongpu::float_64>(cosValue) );
   }
 
 
@@ -113,7 +113,7 @@ public:
       const picongpu::float_64 factor = 1.0 /
         (16. * util::cube(M_PI) * picongpu::EPS0 * picongpu::SPEED_OF_LIGHT);
 
-      return factor * (PMacc::algorithms::math::abs2(amp_x) + PMacc::algorithms::math::abs2(amp_y) + PMacc::algorithms::math::abs2(amp_z));
+      return factor * (picongpu::math::abs2(amp_x) + picongpu::math::abs2(amp_y) + picongpu::math::abs2(amp_z));
   }
 
 

--- a/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
@@ -50,7 +50,7 @@ struct PushExtension
             // Radiation marks only a particle if it has a high velocity
             // marked particle means that momentumPrev1 is not 0.0 in one direction
 
-            const float_X abs2_mom = PMacc::algorithms::math::abs2(mom);
+            const float_X abs2_mom = math::abs2(mom);
             if (((abs2_mom)>((parameters::RadiationGamma * parameters::RadiationGamma - float_X(1.0)) * mass * mass * c2)))
             {
                 radFlag = true;


### PR DESCRIPTION
- delete explicit call to `PMacc::algorithms::math`
- use short cut `math::*`

The explicit definition of the namespace is a workaround for #1338 and solved with #1472.
This pull request is a cleanup.