### PR TITLE
add radiation form factor for spherical Gaussian charge distribution

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -80,17 +80,20 @@ namespace radiationNyquist
   // 0 = off (faster but macroparticles are treated as highly charged, point-like particle)
 #define __COHERENTINCOHERENTWEIGHTING__ 1
 
-
-
   /* Choose different form factors in order to consider different  particle shapes for radiation
-   * radFormFactor_CIC_3D
-   * radFormFactor_CIC_1Dy
+   *  - radFormFactor_CIC_3D ... CIC charge distribution
+   *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
+   *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+   *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
+   *  - radFormFactor_incoherent ... only incoherent radiation
    */
   namespace radFormFactor_CIC_3D { }
   namespace radFormFactor_CIC_1Dy { }
+  namespace radFormFactor_Gauss_spherical { }
+  namespace radFormFactor_Gauss_cell { }
   namespace radFormFactor_incoherent { }
 
-  namespace radFormFactor = radFormFactor_CIC_3D;
+  namespace radFormFactor = radFormFactor_Gauss_spherical;
 
 
 ///////////////////////////////////////////////////////////
@@ -148,6 +151,3 @@ namespace radWindowFunction = radWindowFunctionNone;
 
 
 }//namespace picongpu
-
-
-

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -84,17 +84,20 @@ namespace radiationNyquist
   // 0 = off (faster but macroparticles are treated as highly charged, point-like particle)
 #define __COHERENTINCOHERENTWEIGHTING__ 0
 
-
-
   /* Choose different form factors in order to consider different  particle shapes for radiation
-   * radFormFactor_CIC_3D
-   * radFormFactor_CIC_1Dy
+   *  - radFormFactor_CIC_3D ... CIC charge distribution
+   *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
+   *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+   *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
+   *  - radFormFactor_incoherent ... only incoherent radiation
    */
   namespace radFormFactor_CIC_3D { }
   namespace radFormFactor_CIC_1Dy { }
+  namespace radFormFactor_Gauss_spherical { }
+  namespace radFormFactor_Gauss_cell { }
   namespace radFormFactor_incoherent { }
 
-  namespace radFormFactor = radFormFactor_CIC_3D;
+  namespace radFormFactor = radFormFactor_Gauss_spherical;
 
 
 ///////////////////////////////////////////////////////////

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
@@ -81,17 +81,20 @@ namespace radiationNyquist
   // 0 = off (faster but macroparticles are treated as highly charged, point-like particle)
 #define __COHERENTINCOHERENTWEIGHTING__ 1
 
-
-
   /* Choose different form factors in order to consider different  particle shapes for radiation
-   * radFormFactor_CIC_3D
-   * radFormFactor_CIC_1Dy
+   *  - radFormFactor_CIC_3D ... CIC charge distribution
+   *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
+   *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+   *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
+   *  - radFormFactor_incoherent ... only incoherent radiation
    */
   namespace radFormFactor_CIC_3D { }
   namespace radFormFactor_CIC_1Dy { }
+  namespace radFormFactor_Gauss_spherical { }
+  namespace radFormFactor_Gauss_cell { }
   namespace radFormFactor_incoherent { }
 
-  namespace radFormFactor = radFormFactor_CIC_3D;
+  namespace radFormFactor = radFormFactor_Gauss_spherical;
 
 
 ///////////////////////////////////////////////////////////

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -81,17 +81,20 @@ namespace picongpu
     // 0 = off (faster but macroparticles are treated as highly charged, point-like particle)
     #define __COHERENTINCOHERENTWEIGHTING__ 0
 
-
-
     /* Choose different form factors in order to consider different  particle shapes for radiation
-     * radFormFactor_CIC_3D
-     * radFormFactor_CIC_1Dy
+     *  - radFormFactor_CIC_3D ... CIC charge distribution
+     *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
+     *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+     *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
+     *  - radFormFactor_incoherent ... only incoherent radiation
      */
     namespace radFormFactor_CIC_3D { }
     namespace radFormFactor_CIC_1Dy { }
+    namespace radFormFactor_Gauss_spherical { }
+    namespace radFormFactor_Gauss_cell { }
     namespace radFormFactor_incoherent { }
 
-    namespace radFormFactor = radFormFactor_CIC_3D;
+    namespace radFormFactor = radFormFactor_Gauss_spherical;
 
 
     ///////////////////////////////////////////////////////////


### PR DESCRIPTION
This pull request adds a radiation form factor for a spherical-symmetric charge distribution to avoid ringing from the CIC based shapes. 