### PR TITLE
add compile time power function

### DIFF
--- a/src/picongpu/include/plugins/radiation/utilities.hpp
+++ b/src/picongpu/include/plugins/radiation/utilities.hpp
@@ -70,9 +70,51 @@ namespace util
         }
     };
 
-}
+    /** compile time power function
+      *
+      * @tparam T - base type
+      * @tparam Exp - Exponent
+      * @return pow(x,Exp)=x^Exp
+      */
+    template< typename T, unsigned int Exp >
+    struct Pow
+    {
+        HDINLINE T operator()( const T x ) const
+        {
+            Pow< T, Exp - 1 > pow;
+            return x * pow( x );
+        }
+    };
 
+    /** compile time power function
+      *
+      * specilization Exp = 1
+      * @tparam T - base type
+      * @return pow(x,1)=x
+      */
+    template< typename T >
+    struct Pow< T, 1 >
+    {
+        HDINLINE T operator()( const T x ) const
+        {
+            return x;
+        }
+    };
 
+    /** compile time power function
+      *
+      * specilization Exp = 0
+      * (just as saveguard)
+      * @tparam T - base type
+      * @return pow(x,0)=1
+      */
+    template< typename T >
+    struct Pow< T, 0 >
+    {
+        HDINLINE T operator()( const T x ) const
+        {
+            return 1;
+        }
+    };
 
-
-
+} // namespace util


### PR DESCRIPTION
This pull request adds a compile time power function for unsigned integer exponents.

Thus, for methods like the radiation plugin where a power function needs to be called N_omega * N_particles * N_directions per time step the more expensive `pow()` is avoided.

Usage:
```c++
/* 12^3 */
Pow<float_x, 3> pow3;
float_X results = pow3(12.0);
```