### PR TITLE
switch to c++11 only

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ Requirements
 
 ### Mandatory
 
-- **gcc** 4.8 to 5.X (depends on your current [CUDA version](https://gist.github.com/ax3l/9489132))
+- **gcc** 4.9 to 5.X (depends on your current [CUDA version](https://gist.github.com/ax3l/9489132))
   - *Debian/Ubuntu:*
     - `sudo apt-get install gcc-4.9 g++-4.9 build-essential`
     - `sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9`
@@ -27,10 +27,7 @@ Requirements
     - `sudo pacman --sync base-devel`
     - the installed version of **gcc** might be too new. [Compile an older gcc](https://gist.github.com/slizzered/a9dc4e13cb1c7fffec53)
 
-- C++98 build: [CUDA 5.5-7.0](https://developer.nvidia.com/cuda-downloads)
-  - *Arch Linux:* `sudo pacman --sync cuda`
-- C++11 build: [CUDA 7.5+](https://developer.nvidia.com/cuda-downloads)
-  - note: we recommend using **gcc 4.9**
+- [CUDA 7.5+](https://developer.nvidia.com/cuda-downloads)
   - *Arch Linux:* `sudo pacman --sync cuda`
 
 - at least one **CUDA** capable **GPU**
@@ -89,7 +86,7 @@ Some of our examples will also need **libSplash**.
 - **libSplash** >= 1.6.0 (requires *HDF5*, *boost program-options*)
     - *Debian/Ubuntu dependencies:* `sudo apt-get install libhdf5-openmpi-dev libboost-program-options-dev`
     - *Arch Linux dependencies:* `sudo pacman --sync hdf5-openmpi boost`
-    - *or compile hdf5 yourself:*  follow instructions one paragraph below 
+    - *or compile hdf5 yourself:*  follow instructions one paragraph below
     - example:
       - `mkdir -p ~/src ~/build ~/lib`
       - `git clone https://github.com/ComputationalRadiationPhysics/libSplash.git ~/src/splash/`
@@ -182,7 +179,7 @@ Some of our examples will also need **libSplash**.
         Of course the paths may and will vary for your setup.
 
 - for **VampirTrace** support
-    - download 5.14.4 or higher, e.g. from 
+    - download 5.14.4 or higher, e.g. from
     [http://www.tu-dresden.de](http://www.tu-dresden.de/die_tu_dresden/zentrale_einrichtungen/zih/forschung/projekte/vampirtrace)
     - example:
       - `mkdir -p ~/src ~/build ~/lib`
@@ -203,9 +200,9 @@ Install
 
 ### Mandatory environment variables
 
-- `CUDA_ROOT`: cuda installation directory, 
+- `CUDA_ROOT`: cuda installation directory,
     e.g. `export CUDA_ROOT=<CUDA_INSTALL>`
-- `MPI_ROOT`: mpi installation directory, 
+- `MPI_ROOT`: mpi installation directory,
     e.g. `export MPI_ROOT=<MPI_INSTALL>`
 - extend your `$PATH` with helper tools for PIConGPU, see point,
     [Checkout and Build PIConGPU](#checkout-and-build-picongpu) *step 2.2*
@@ -214,9 +211,9 @@ Install
 ### Additional required environment variables (for optional libraries)
 
 #### for splash and HDF5
-- `SPLASH_ROOT`: libsplash installation directory, 
+- `SPLASH_ROOT`: libsplash installation directory,
     e.g. `export SPLASH_ROOT=$HOME/lib/splash`
-- `HDF5_ROOT`: hdf5 installation directory, 
+- `HDF5_ROOT`: hdf5 installation directory,
     e.g. `export HDF5_ROOT=$HOME/lib/hdf5`
 - `LD_LIBRARY_PATH`: add path to $HOME/lib/hdf5/lib,
     e.g. `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/hdf5/lib`

--- a/src/libPMacc/CMakeLists.txt
+++ b/src/libPMacc/CMakeLists.txt
@@ -26,21 +26,9 @@
 cmake_minimum_required(VERSION 3.3.0)
 project(PMaccTest)
 
-
-################################################################################
-# C++11 Enabler
-################################################################################
-
-# By using this if-else one can assume that:
-# CMAKE_CXX_STANDARD==11 <=> CUDA_NVCC_FLAGS contain "-std=c++11"
-if("${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11")
-    set(CMAKE_CXX_STANDARD 11)
-elseif("${CMAKE_CXX_STANDARD}" STREQUAL "11")
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -std=c++11)
-else()
-    # Note: Add support for C++14 once CUDA supports it (maybe 8.0?)
-    set(CMAKE_CXX_STANDARD 98)
-endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
 
 ################################################################################
 # PMacc
@@ -69,7 +57,7 @@ add_definitions(-DBOOST_TEST_DYN_LINK)
 enable_testing()
 
 # Test cases
-# Each *UT.cu file is an independent executable with one or more test cases 
+# Each *UT.cu file is an independent executable with one or more test cases
 file(GLOB_RECURSE TESTS test/*UT.cu)
 foreach(dim 2 3)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTEST_DIM=${dim}")

--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -71,12 +71,13 @@ endif()
 ################################################################################
 # CUDA
 ################################################################################
-find_package(CUDA 5.0 REQUIRED)
+find_package(CUDA 7.5 REQUIRED)
 
-if(CUDA_VERSION VERSION_LESS 5.5)
-    message(STATUS "CUDA Toolkit < 5.5 detected. We strongly recommend to still "
-                   "use CUDA 5.5+ drivers (319.82 or higher)!")
-endif(CUDA_VERSION VERSION_LESS 5.5)
+# work-around since the above flag does not necessarily put -std=c++11 in
+# the CMAKE_CXX_FLAGS, which is unfurtunately hiding the switch from FindCUDA
+if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "-std=c\\+\\+11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
 
 set(CUDA_ARCH sm_20 CACHE STRING "Set GPU architecture")
 string(COMPARE EQUAL ${CUDA_ARCH} "sm_10" IS_CUDA_ARCH_UNSUPPORTED)

--- a/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/src/libPMacc/examples/gameOfLife2D/CMakeLists.txt
@@ -56,12 +56,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 # Find CUDA
 ################################################################################
 
-find_package(CUDA 5.0 REQUIRED)
-
-if(CUDA_VERSION VERSION_LESS 5.5)
-    message(STATUS "CUDA Toolkit < 5.5 detected. We strongly recommend to still "
-                   "use CUDA 5.5+ drivers (319.82 or higher)!")
-endif(CUDA_VERSION VERSION_LESS 5.5)
+find_package(CUDA 7.5 REQUIRED)
 
 set(CUDA_ARCH sm_20 CACHE STRING "Set GPU architecture")
 string(COMPARE EQUAL ${CUDA_ARCH} "sm_10" IS_CUDA_ARCH_UNSUPPORTED)
@@ -73,6 +68,16 @@ if(IS_CUDA_ARCH_UNSUPPORTED)
     message(FATAL_ERROR "Unsupported CUDA architecture ${CUDA_ARCH} specified. "
                        "SM 2.0 or higher is required.")
 endif(IS_CUDA_ARCH_UNSUPPORTED)
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
+
+# work-around since the above flag does not necessarily put -std=c++11 in
+# the CMAKE_CXX_FLAGS, which is unfurtunately hiding the switch from FindCUDA
+if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "-std=c\\+\\+11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
 
 set(CUDA_FTZ "--ftz=false" CACHE STRING "Set flush to zero for GPU")
 

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -56,7 +56,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 # Find CUDA
 ################################################################################
 
-find_package(CUDA 5.5 REQUIRED)
+find_package(CUDA 7.5 REQUIRED)
 
 set(CUDA_ARCH sm_20 CACHE STRING "Set GPU architecture")
 string(COMPARE EQUAL ${CUDA_ARCH} "sm_10" IS_CUDA_ARCH_UNSUPPORTED)
@@ -66,18 +66,13 @@ string(COMPARE EQUAL ${CUDA_ARCH} "sm_13" IS_CUDA_ARCH_UNSUPPORTED)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
 
-if(CUDA_VERSION VERSION_LESS 7.5)
-    set(CMAKE_CXX_STANDARD 98)
-else()
-    set(CMAKE_CXX_STANDARD 11)
-    # work-around since the above flag does not necessarily put -std=c++11 in
-    # the CMAKE_CXX_FLAGS, which is unfurtunately hiding the switch from FindCUDA
-    if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "-std=c\\+\\+11")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
+# work-around since the above flag does not necessarily put -std=c++11 in
+# the CMAKE_CXX_FLAGS, which is unfurtunately hiding the switch from FindCUDA
+if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "-std=c\\+\\+11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
-message(STATUS "Compiling as C++${CMAKE_CXX_STANDARD}...")
 
 if(IS_CUDA_ARCH_UNSUPPORTED)
     message(FATAL_ERROR "Unsupported CUDA architecture ${CUDA_ARCH} specified. "
@@ -106,16 +101,6 @@ if(CUDA_KEEP_FILES)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" --keep --keep-dir "${PROJECT_BINARY_DIR}/nvcc_tmp")
 endif(CUDA_KEEP_FILES)
 
-# savety check for now in case someone plays with CMAKE_CXX_STANDARD
-if( (CUDA_VERSION VERSION_GREATER 7.0) AND
-    (CMAKE_CXX_STANDARD EQUAL 98) )
-    # Kind of invalid usage of floats in constant expressions
-    # which causes problems in nvcc 7.5 and up:
-    # https://github.com/ComputationalRadiationPhysics/picongpu/issues/1290
-    message(FATAL_ERROR "Please compile as C++11 with
-                        `-DCMAKE_CXX_STANDARD=11`
-                        when compiling with nvcc 7.5")
-endif()
 
 ################################################################################
 # VampirTrace
@@ -249,21 +234,12 @@ else()
     add_definitions(-DBOOST_RESULT_OF_USE_TR1)
 endif()
 
-# work-arounds and known issues
-if( (Boost_VERSION EQUAL 106000) AND
-    (CMAKE_CXX_STANDARD EQUAL 98) )
-    # Boost Bug https://svn.boost.org/trac/boost/ticket/11852
-    message(FATAL_ERROR "Boost 1.60.0: Please upgrade boost or use a C++11 "
-                        "enabled CUDA version (7.5+)")
-endif()
-
 
 # Boost >= 1.60.0 and CUDA != 7.5 failed when used with C++11
 # seen with boost 1.60.0 - 1.62.0 (atm latest) and CUDA 7.0, 8.0 (atm latest)
 # CUDA 7.5 works without a workaround
 if( (Boost_VERSION GREATER 105999) AND
-    (NOT CUDA_VERSION VERSION_EQUAL 7.5) AND
-    (NOT CMAKE_CXX_STANDARD EQUAL 98) )
+    (NOT CUDA_VERSION VERSION_EQUAL 7.5) )
     # Boost Bug https://svn.boost.org/trac/boost/ticket/11897
     message(STATUS "Boost: Disable template aliases")
     add_definitions(-DBOOST_NO_CXX11_TEMPLATE_ALIASES)
@@ -454,35 +430,30 @@ endif(PNGwriter_FOUND)
 
 find_package(ISAAC 0.1.0 CONFIG QUIET)
 if(ISAAC_FOUND)
-    if ( CMAKE_CXX_STANDARD EQUAL 98 )
-        message(STATUS "ISAAC found, but needed C++11 not enabled")
-    else( CMAKE_CXX_STANDARD EQUAL 98 )
-        SET(ISAAC_STEREO "No" CACHE STRING "Using stereoscopy")
-        SET_PROPERTY(CACHE ISAAC_STEREO PROPERTY STRINGS No SideBySide Anaglyph)
+    SET(ISAAC_STEREO "No" CACHE STRING "Using stereoscopy")
+    SET_PROPERTY(CACHE ISAAC_STEREO PROPERTY STRINGS No SideBySide Anaglyph)
 
-        if(${ISAAC_STEREO} STREQUAL "No")
-            add_definitions(-DISAAC_STEREO=0)
-        endif()
-        if(${ISAAC_STEREO} STREQUAL "SideBySide")
-            add_definitions(-DISAAC_STEREO=1)
-        endif()
-        if(${ISAAC_STEREO} STREQUAL "Anaglyph")
-            add_definitions(-DISAAC_STEREO=2)
-        endif()
+    if(${ISAAC_STEREO} STREQUAL "No")
+        add_definitions(-DISAAC_STEREO=0)
+    endif()
+    if(${ISAAC_STEREO} STREQUAL "SideBySide")
+        add_definitions(-DISAAC_STEREO=1)
+    endif()
+    if(${ISAAC_STEREO} STREQUAL "Anaglyph")
+        add_definitions(-DISAAC_STEREO=2)
+    endif()
 
-        include_directories(SYSTEM ${ISAAC_INCLUDE_DIRS})
-        set(LIBS ${LIBS} ${ISAAC_LIBRARIES})
+    include_directories(SYSTEM ${ISAAC_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${ISAAC_LIBRARIES})
 
-        set(ISAAC_MAX_FUNCTORS "3" CACHE STRING "Max length of the isaac functor chain" )
-        set(ISAAC_DEFAULT_WEIGHT "7" CACHE STRING "Default weight of an isaac source" )
-        add_definitions(${ISAAC_DEFINITIONS})
-        add_definitions(-DISAAC_MAX_FUNCTORS=${ISAAC_MAX_FUNCTORS})
-        add_definitions(-DISAAC_FUNCTOR_POW_ENABLED=0)
-        add_definitions(-DISAAC_DEFAULT_WEIGHT=${ISAAC_DEFAULT_WEIGHT})
+    set(ISAAC_MAX_FUNCTORS "3" CACHE STRING "Max length of the isaac functor chain" )
+    set(ISAAC_DEFAULT_WEIGHT "7" CACHE STRING "Default weight of an isaac source" )
+    add_definitions(${ISAAC_DEFINITIONS})
+    add_definitions(-DISAAC_MAX_FUNCTORS=${ISAAC_MAX_FUNCTORS})
+    add_definitions(-DISAAC_FUNCTOR_POW_ENABLED=0)
+    add_definitions(-DISAAC_DEFAULT_WEIGHT=${ISAAC_DEFAULT_WEIGHT})
 
-        add_definitions(-DENABLE_ISAAC=1)
-        
-    endif( CMAKE_CXX_STANDARD EQUAL 98 )
+    add_definitions(-DENABLE_ISAAC=1)
 else(ISAAC_FOUND)
     message(STATUS "Could NOT find ISAAC - set ISAAC_DIR or check your CMAKE_PREFIX_PATH" )
 endif(ISAAC_FOUND)


### PR DESCRIPTION
It's time to say goodbye C++98. :facepunch: 

- enable C++11 compile
- require cuda >=7.5
- remove c++98 workarounds
- change documentation
  - change minimal cuda version to 7.5
  - change minimal g++ to 4.9
