### PR TITLE
Add pow compile time using c++11

### DIFF
--- a/src/picongpu/include/plugins/radiation/utilities.hpp
+++ b/src/picongpu/include/plugins/radiation/utilities.hpp
@@ -70,9 +70,40 @@ namespace util
         }
     };
 
-}
 
 
+namespace details
+{
+  /** power function - with extra const parameter for efficient code
+    *
+    * T_type requires cast from int and multiplication
+    * @tparam T_Type - base type
+    * @param x - base value
+    * @param exp - exponent
+    * @param results (=1) - do not change - workaround to produce efficient code
+    * @return std::pow(x, exp)
+    */
+  template< typename T_Type >
+  HDINLINE constexpr T_Type pow( T_Type const x , uint32_t const exp, const T_Type result = T_Type( 1 ) )
+  {
+    return exp == 0 ? result : (
+        exp == 1 ? x * result : util::details::pow( x, exp - 1, result * x )
+    );
+  }
+} // namespace details
 
+  /** power function
+    *
+    * T_type requires cast from int and multiplication
+    * @tparam T_Type - base type
+    * @param x - base value
+    * @param exp - exponent
+    * @return std::pow(x, exp)
+    */
+  template< typename T_Type >
+  HDINLINE constexpr T_Type pow( T_Type const x , uint32_t const exp )
+  {
+    return util::details::pow( x, exp );
+  }
 
-
+} // namespace util


### PR DESCRIPTION
This is an alternative to #1644. Instead of template meta programming C++11 `constexpr` is used.

 - [x] verify that this pow is not slower on GPUs than version #1644 
 - [x] retest more efficient method (verify against old results) 