### PR TITLE
C++11 constexpr: Remove Boost Macros

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/fieldBackground.param
+++ b/examples/Bunch/include/simulation_defines/param/fieldBackground.param
@@ -37,7 +37,7 @@ namespace picongpu
     public:
 
         /* Add this additional field for pushing particles */
-        BOOST_STATIC_CONSTEXPR bool InfluenceParticlePusher = PARAM_INCLUDE_FIELDBACKGROUND;
+        static constexpr bool InfluenceParticlePusher = PARAM_INCLUDE_FIELDBACKGROUND;
 
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
@@ -83,10 +83,10 @@ namespace picongpu
                     const uint32_t currentStep ) const
         {
             /* unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
                 * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
                 * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
 
@@ -94,7 +94,7 @@ namespace picongpu
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /* unit: none */
-            BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 1.0;
+            constexpr float_64 _A0  = 1.0;
 
             /* unit: Volt /meter
              *\todo #738 implement math::vector, native type operations
@@ -120,7 +120,7 @@ namespace picongpu
     {
     public:
         /* Add this additional field for pushing particles */
-        BOOST_STATIC_CONSTEXPR bool InfluenceParticlePusher = PARAM_INCLUDE_FIELDBACKGROUND;
+        static constexpr bool InfluenceParticlePusher = PARAM_INCLUDE_FIELDBACKGROUND;
 
         /* TWTS B-fields need to be initialized on host,
          * so they can look up global grid dimensions.
@@ -165,10 +165,10 @@ namespace picongpu
                     const uint32_t currentStep ) const
         {
             /* unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
                 * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI
                 * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
 
@@ -176,7 +176,7 @@ namespace picongpu
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 1.0;
+            constexpr float_64 _A0  = 1.0;
 
             /** unit: Volt /meter */
             const float3_64 invUnitField = float3_64( 1.0 / m_unitField[0],
@@ -200,7 +200,7 @@ namespace picongpu
     {
     public:
         /* Add this additional field? */
-        BOOST_STATIC_CONSTEXPR bool activated = false;
+        static constexpr bool activated = false;
 
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);

--- a/examples/Bunch/include/simulation_defines/param/gasConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gasConfig.param
@@ -36,7 +36,7 @@ namespace SI
      *
      * He (2e- / Atom ) with 1.e15 He / m^3
      *                      = 2.e15 e- / m^3 */
-    BOOST_CONSTEXPR_OR_CONST float_64 GAS_DENSITY_SI = 1.e25;
+    constexpr float_64 GAS_DENSITY_SI = 1.e25;
 
 }
 

--- a/examples/Bunch/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gridConfig.param
@@ -29,17 +29,17 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 0.64e-16;
+        constexpr float_64 DELTA_T_SI = 0.64e-16;
 
         /** equals X
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.16e-6;
+        constexpr float_64 CELL_WIDTH_SI = 0.16e-6;
         /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.40e-7;
+        constexpr float_64 CELL_HEIGHT_SI = 0.40e-7;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
         /** Note on units in reduced dimensions
          *
@@ -69,7 +69,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -81,7 +81,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.90;
 
 }
 

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -31,22 +31,22 @@ namespace laserGaussianBeam
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 1.5;
+constexpr float_64 _A0  = 1.5;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+//constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -54,7 +54,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
+constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -62,17 +62,17 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
  * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
  *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 /** the distance to the laser focus in y-direction
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+constexpr float_64 FOCUS_POS_SI = 4.62e-5;
 }
 /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 20.0;
+constexpr float_64 PULSE_INIT = 20.0;
 
 /* laser phase shift (no shift: 0.0) */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
 {
@@ -80,7 +80,7 @@ enum PolarisationType
     LINEAR_Z = 2u,
     CIRCULAR = 4u,
 };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = CIRCULAR;
+constexpr PolarisationType Polarisation = CIRCULAR;
 }
 
 namespace laserPulseFrontTilt
@@ -89,13 +89,13 @@ namespace laserPulseFrontTilt
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
     *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -103,7 +103,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
     *  Info:             FWHM_of_Intensity = FWHM_Illumination
     *                      = what a experimentalist calls "pulse duration"
     *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
+constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -111,23 +111,23 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
  * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
  *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
 /** the distance to the laser focus in y-direction
     *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+constexpr float_64 FOCUS_POS_SI = 4.62e-5;
 
 /** the tilt angle between laser propagation in y-direction and laser axis in
     *  x-direction (0 degree == no tilt)
     *  unit: degree */
-BOOST_CONSTEXPR_OR_CONST float_64 TILT_X_SI = 0;
+constexpr float_64 TILT_X_SI = 0;
 }
 /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
 *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 20.0;
+constexpr float_64 PULSE_INIT = 20.0;
 
 /* laser phase shift (no shift: 0.0) */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
 {
@@ -135,7 +135,7 @@ LINEAR_X = 1u,
 LINEAR_Z = 2u,
 CIRCULAR = 4u
 };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+constexpr PolarisationType Polarisation = LINEAR_X;
 }
 
 namespace laserPlaneWave
@@ -144,27 +144,27 @@ namespace laserPlaneWave
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 _A0 = 1.0;
+constexpr float_64 _A0 = 1.0;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+//constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** The profile of the test Lasers 0 and 2 can be stretched by a
  *      constant area between the up and downramp
  *  unit: seconds */
-BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 50.0*WAVE_LENGTH_SI/::picongpu::SI::SPEED_OF_LIGHT_SI;
+constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 50.0*WAVE_LENGTH_SI/::picongpu::SI::SPEED_OF_LIGHT_SI;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -172,16 +172,16 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 50.0*WAVE_LENGTH_S
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
+constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 }
 
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
+constexpr float_64 RAMP_INIT = 20.6146;
 
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
   {
@@ -189,7 +189,7 @@ enum PolarisationType
     LINEAR_Z = 2u,
     CIRCULAR = 4u,
   };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+constexpr PolarisationType Polarisation = LINEAR_X;
 }
 
 namespace laserWavepacket
@@ -198,27 +198,27 @@ namespace laserWavepacket
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-//BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+//constexpr float_64 _A0  = 3.9;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** The profile of the test Lasers 0 and 2 can be stretched by a
  *      constant area between the up and downramp
  *  unit: seconds */
-BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -226,7 +226,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
+constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -236,16 +236,16 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 2.65e-15;
  * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
  *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;
-BOOST_CONSTEXPR_OR_CONST float_64 W0_Z_SI = W0_X_SI;
+constexpr float_64 W0_X_SI = 4.246e-6;
+constexpr float_64 W0_Z_SI = W0_X_SI;
 }
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
 and half at the end of the plateau
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.0;
+constexpr float_64 RAMP_INIT = 20.0;
 
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
 {
@@ -253,7 +253,7 @@ enum PolarisationType
     LINEAR_Z = 2u,
     CIRCULAR = 4u,
 };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+constexpr PolarisationType Polarisation = LINEAR_X;
 }
 
 
@@ -263,22 +263,22 @@ namespace laserPolynom
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-//BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+//constexpr float_64 _A0  = 3.9;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 
 /** Pulse length:
@@ -287,18 +287,18 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
  *  Fall time = 0.5 * PULSE_LENGTH_SI
  *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
  *  unit: seconds  */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 4.0e-15;
+constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
  *              at the focus position of the laser
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0x_SI = 4.246e-6; // waist in x-direction
-BOOST_CONSTEXPR_OR_CONST float_64 W0z_SI = W0x_SI; // waist in z-direction
+constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
+constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
 }
 
 /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 }
 
 namespace laserNone
@@ -306,12 +306,12 @@ namespace laserNone
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.0;
+constexpr float_64 WAVE_LENGTH_SI = 0.0;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 0.0;
+constexpr float_64 AMPLITUDE_SI = 0.0;
 
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 0.0;
+constexpr float_64 PULSE_LENGTH_SI = 0.0;
 }
 }
 

--- a/examples/Bunch/include/simulation_defines/param/memory.param
+++ b/examples/Bunch/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
+constexpr size_t reservedGpuMemorySize = 350 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;
@@ -45,12 +45,12 @@ typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
 
-BOOST_CONSTEXPR_OR_CONST uint32_t GUARD_SIZE = 1;
+constexpr uint32_t GUARD_SIZE = 1;
 
 //! how many bytes for buffer is reserved to communication in one direction
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_X = 4 * 256 * 1024; //4 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
+constexpr uint32_t BYTES_EXCHANGE_X = 4 * 256 * 1024; //4 MiB
+constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
+constexpr uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
+constexpr uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
+constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
 }//namespace picongpu

--- a/examples/Bunch/include/simulation_defines/param/particleConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/particleConfig.param
@@ -35,9 +35,9 @@ namespace particles
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
      *  unit: none */
-    BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 10.0;
+    constexpr float_X MIN_WEIGHTING = 10.0;
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 6;
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 6;
 
 namespace manipulators
 {
@@ -49,7 +49,7 @@ namespace manipulators
          *  Examples:
          *    - No drift is equal to 1.0
          *  unit: none */
-        BOOST_STATIC_CONSTEXPR float_64 gamma = 5.0;
+        static constexpr float_64 gamma = 5.0;
         const DriftParamNegative_direction_t direction;
     };
     /* definition of SetDrift start*/
@@ -65,7 +65,7 @@ namespace startPosition
     {
         /** Count of particles per cell at initial state
          *  unit: none */
-        BOOST_STATIC_CONSTEXPR uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
     };
     /* definition of random particle start*/
     typedef RandomImpl<RandomParameter> Random;

--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -38,29 +38,29 @@ namespace rad_linear_frequencies
 {
 namespace SI
 {
-BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 0.0;
-BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 5.8869e17;
+constexpr float_64 omega_min = 0.0;
+constexpr float_64 omega_max = 5.8869e17;
 }
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 1024; // number of frequencies
+constexpr unsigned int N_omega = 1024; // number of frequencies
 }
 
 namespace rad_log_frequencies
 {
 namespace SI
 {
-BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 1.0e14;
-BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 1.0e17;
+constexpr float_64 omega_min = 1.0e14;
+constexpr float_64 omega_max = 1.0e17;
 }
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
 namespace rad_frequencies_from_list
 {
 //const char listLocation[] = "/scratch/s5960712/list001.freq";
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
@@ -69,7 +69,7 @@ namespace radiation_frequencies = rad_linear_frequencies;
 
 namespace radiationNyquist
 {
-  BOOST_CONSTEXPR_OR_CONST float_32 NyquistFactor = 0.5;
+  constexpr float_32 NyquistFactor = 0.5;
 }
 
 ///////////////////////////////////////////////////
@@ -119,9 +119,9 @@ namespace parameters
 //diable (0) / enable (1)
 #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-BOOST_CONSTEXPR_OR_CONST float_32 RadiationGamma = 5.;
+constexpr float_32 RadiationGamma = 5.;
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_observer = 128; // number of looking directions
+constexpr unsigned int N_observer = 128; // number of looking directions
 
 
 

--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -53,12 +53,12 @@ namespace picongpu
       const int my_theta_id = observation_id_extern;
 
       /* set up: */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 gamma_times_thetaMax = 1.5; /* max normalized angle */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 gamma = 5.0;                /* relativistic gamma */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
+      constexpr picongpu::float_64 gamma_times_thetaMax = 1.5; /* max normalized angle */
+      constexpr picongpu::float_64 gamma = 5.0;                /* relativistic gamma */
+      constexpr picongpu::float_64 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
 
       /* stepwith of theta for from [-thetaMax : +thetaMax] */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 delta_theta =  2.0 * thetaMax / (parameters::N_observer);
+      constexpr picongpu::float_64 delta_theta =  2.0 * thetaMax / (parameters::N_observer);
 
       /* compute angle theta for index */
       const picongpu::float_64 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI);

--- a/examples/Bunch/include/simulation_defines/param/visualization.param
+++ b/examples/Bunch/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
 /*scale image before write to file, only scale if value is not 1.0
  */
-BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+constexpr float_64 scale_image = 1.0;
 
 /*if true image is scaled if cellsize is not quadratic, else no scale*/
-BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = true;
+constexpr bool scale_to_cellsize = true;
 
-BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = true;
+constexpr bool white_box_per_GPU = true;
 
 namespace visPreview
 {
@@ -52,10 +52,10 @@ namespace visPreview
 #define EM_FIELD_SCALE_CHANNEL3 1
 
 // multiply highest undisturbed particle density with factor
-BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 0.25;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity = 1.0;
+constexpr float_X preParticleDens_opacity = 0.25;
+constexpr float_X preChannel1_opacity = 1.0;
+constexpr float_X preChannel2_opacity = 1.0;
+constexpr float_X preChannel3_opacity = 1.0;
 
 // specify color scales for each channel
 namespace preParticleDensCol = colorScales::red;

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/dimension.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/dimension.param
@@ -28,5 +28,5 @@
 
 namespace picongpu
 {
-    BOOST_CONSTEXPR_OR_CONST uint32_t simDim = SIMDIM;
+    constexpr uint32_t simDim = SIMDIM;
 } // namespace picongpu

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gasConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gasConfig.param
@@ -33,7 +33,7 @@ namespace picongpu
          *
          * He (2e- / Atom ) with 1.e15 He / m^3
          *                      = 2.e15 e- / m^3 */
-        BOOST_CONSTEXPR_OR_CONST float_64 GAS_DENSITY_SI = 1.e25;
+        constexpr float_64 GAS_DENSITY_SI = 1.e25;
 
     }
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -30,7 +30,7 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 1.79e-16;
+        constexpr float_64 DELTA_T_SI = 1.79e-16;
 
         /** equals X
          *  unit: meter */
@@ -45,22 +45,22 @@ namespace picongpu
          *             dX == dY
          *             dX == dZ
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = DELTA_T_SI*SPEED_OF_LIGHT_SI;
+        constexpr float_64 CELL_WIDTH_SI = DELTA_T_SI*SPEED_OF_LIGHT_SI;
 #else
         /* cell size for Yee solver (must fulfill CFL)
          * WARNING: if you change the field solver in `componentsConfig` you
          * have to change the CELL_SIZE in this code path
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 9.34635e-8;
+        constexpr float_64 CELL_WIDTH_SI = 9.34635e-8;
 #endif
 #undef fieldSolverDirSplitting
 
         /** equals Y
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
         /** Note on units in reduced dimensions
          *
@@ -90,7 +90,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -102,7 +102,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.90;
 
 }
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 400 *1024*1024;
+constexpr size_t reservedGpuMemorySize = 400 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;
@@ -45,12 +45,12 @@ typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
 
-BOOST_CONSTEXPR_OR_CONST uint32_t GUARD_SIZE = 1;
+constexpr uint32_t GUARD_SIZE = 1;
 
 //! how many bytes for buffer is reserved to communication in one direction
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_X = 8 * 256 * 1024; //8 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Y = 12 * 512 * 1024; //12 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Z = 8 * 256 * 1024; //8 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_CORNER = 16 * 1024; //16 kiB;
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EDGES = 64 * 1024; //64 kiB;
+constexpr uint32_t BYTES_EXCHANGE_X = 8 * 256 * 1024; //8 MiB
+constexpr uint32_t BYTES_EXCHANGE_Y = 12 * 512 * 1024; //12 MiB
+constexpr uint32_t BYTES_EXCHANGE_Z = 8 * 256 * 1024; //8 MiB
+constexpr uint32_t BYTES_CORNER = 16 * 1024; //16 kiB;
+constexpr uint32_t BYTES_EDGES = 64 * 1024; //64 kiB;
 }//namespace picongpu

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
@@ -68,7 +68,7 @@ namespace manipulators
          *  Examples:
          *    - No drift is equal to 1.0
          *  unit: none */
-        BOOST_STATIC_CONSTEXPR float_64 gamma = 1.021;
+        static constexpr float_64 gamma = 1.021;
         const DriftParamPositive_direction_t direction;
     };
     /* definition of SetDrift start*/
@@ -81,7 +81,7 @@ namespace manipulators
          *  Examples:
          *    - No drift is equal to 1.0
          *  unit: none */
-        BOOST_STATIC_CONSTEXPR float_64 gamma = 1.021;
+        static constexpr float_64 gamma = 1.021;
         const DriftParamNegative_direction_t direction;
     };
     /* definition of SetDrift start*/
@@ -92,7 +92,7 @@ namespace manipulators
         /*Initial temperature
          *  unit: keV
          */
-        BOOST_STATIC_CONSTEXPR float_64 temperature = 0.0005;
+        static constexpr float_64 temperature = 0.0005;
     };
     /* definition of SetDrift start*/
     typedef TemperatureImpl<TemperatureParam,nvidia::functors::Add> AddTemperature;
@@ -101,13 +101,13 @@ namespace manipulators
     struct IfRelativeGlobalPositionParamLowQuarter
     {
         /* lowerBound is included in the range*/
-        BOOST_STATIC_CONSTEXPR float_X lowerBound = 0.0;
+        static constexpr float_X lowerBound = 0.0;
         /* upperBound is excluded in the range*/
-        BOOST_STATIC_CONSTEXPR float_X upperBound = 0.25;
+        static constexpr float_X upperBound = 0.25;
         /* dimension for the filter
          * x = 0; y= 1; z = 2
          */
-        BOOST_STATIC_CONSTEXPR uint32_t dimension = 1;
+        static constexpr uint32_t dimension = 1;
     };
     /* definition of SetDrift start*/
     typedef IfRelativeGlobalPositionImpl<IfRelativeGlobalPositionParamLowQuarter,AssignXDriftPositive> AssignXDriftPrositiveToLowerQuarterYPosition;
@@ -115,13 +115,13 @@ namespace manipulators
     struct IfRelativeGlobalPositionParamMiddleHalf
     {
         /* lowerBound is included in the range*/
-        BOOST_STATIC_CONSTEXPR float_X lowerBound = 0.25;
+        static constexpr float_X lowerBound = 0.25;
         /* upperBound is excluded in the range*/
-        BOOST_STATIC_CONSTEXPR float_X upperBound = 0.75;
+        static constexpr float_X upperBound = 0.75;
         /* dimension for the filter
          * x = 0; y= 1; z = 2
          */
-        BOOST_STATIC_CONSTEXPR uint32_t dimension = 1;
+        static constexpr uint32_t dimension = 1;
     };
     /* definition of SetDrift start*/
     typedef IfRelativeGlobalPositionImpl<IfRelativeGlobalPositionParamMiddleHalf,AssignXDriftNegative> AssignXDriftNegativeToMiddleHalfYPosition;
@@ -129,13 +129,13 @@ namespace manipulators
     struct IfRelativeGlobalPositionParamUpperQuarter
     {
         /* lowerBound is included in the range*/
-        BOOST_STATIC_CONSTEXPR float_X lowerBound = 0.75;
+        static constexpr float_X lowerBound = 0.75;
         /* upperBound is excluded in the range*/
-        BOOST_STATIC_CONSTEXPR float_X upperBound = 1.0;
+        static constexpr float_X upperBound = 1.0;
         /* dimension for the filter
          * x = 0; y= 1; z = 2
          */
-        BOOST_STATIC_CONSTEXPR uint32_t dimension = 1;
+        static constexpr uint32_t dimension = 1;
     };
     /* definition of SetDrift start*/
     typedef IfRelativeGlobalPositionImpl<IfRelativeGlobalPositionParamUpperQuarter,AssignXDriftPositive> AssignXDriftPrositiveToUpperQuarterYPosition;

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -38,33 +38,33 @@ namespace rad_linear_frequencies
 {
 namespace SI
 {
-BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 0.0;
-BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 1.06e16;
+constexpr float_64 omega_min = 0.0;
+constexpr float_64 omega_max = 1.06e16;
 }
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 1024; // number of frequencies
+constexpr unsigned int N_omega = 1024; // number of frequencies
 }
 
 namespace rad_log_frequencies
 {
 namespace SI
 {
-//BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 1.0e14;
-//BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 1.0e17;
+//constexpr float_64 omega_min = 1.0e14;
+//constexpr float_64 omega_max = 1.0e17;
   // plasma omega = sqrt( (Teilchendichte * (1.6e-19)^2) / (8.854e-12 * 9.11e-31) )
   //              = 2.52e14 Hz
-BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 0.1*2.52e14;
-BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 200*2.52e14;
+constexpr float_64 omega_min = 0.1*2.52e14;
+constexpr float_64 omega_max = 200*2.52e14;
 }
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 1024; // number of frequencies
+constexpr unsigned int N_omega = 1024; // number of frequencies
 }
 
 
 namespace rad_frequencies_from_list
 {
 //const char listLocation[] = "/scratch/s5960712/list001.freq";
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
@@ -73,7 +73,7 @@ namespace radiation_frequencies = rad_log_frequencies;
 
 namespace radiationNyquist
 {
-  BOOST_CONSTEXPR_OR_CONST float_32 NyquistFactor = 0.5;
+  constexpr float_32 NyquistFactor = 0.5;
 }
 
 ///////////////////////////////////////////////////
@@ -125,9 +125,9 @@ namespace parameters
 //diable (0) / enable (1)
 #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-BOOST_CONSTEXPR_OR_CONST float_32 RadiationGamma = 5.;
+constexpr float_32 RadiationGamma = 5.;
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_observer = 256; // number of looking directions
+constexpr unsigned int N_observer = 256; // number of looking directions
 
 
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
@@ -48,17 +48,17 @@ namespace picongpu
        */
         
       /* generate two indices from single block index */
-      BOOST_CONSTEXPR_OR_CONST int N_angle_split = 16; /* index split distance */
+      constexpr int N_angle_split = 16; /* index split distance */
       /* get column index for computing angle theta: */
       const int my_index_theta = observation_id_extern / N_angle_split;
       /* get row index for computing angle phi: */
       const int my_index_phi = observation_id_extern % N_angle_split;
 
       /*  range for BOTH angles */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 angle_range= picongpu::PI/2.0;
+      constexpr picongpu::float_64 angle_range= picongpu::PI/2.0;
 
       /* angle stepwidth for BOTH angles */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 delta_angle =  1.0 * angle_range / (N_angle_split-1);
+      constexpr picongpu::float_64 delta_angle =  1.0 * angle_range / (N_angle_split-1);
 
       /* compute both angles */
       const picongpu::float_64 theta(  my_index_theta * delta_angle  + 0.5*picongpu::PI );

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/visualization.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
     /*scale image before write to file, only scale if value is not 1.0
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+    constexpr float_64 scale_image = 1.0;
 
     /*if true image is scaled if cellsize is not quadratic, else no scale*/
-    BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = false;
+    constexpr bool scale_to_cellsize = false;
 
-    BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = false;
+    constexpr bool white_box_per_GPU = false;
 
     namespace visPreview
     {
@@ -52,10 +52,10 @@ namespace picongpu
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
         // multiply highest undisturbed particle density with factor
-        BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 0.25;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity     = 1.0;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity     = 1.0;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity     = 1.0;
+        constexpr float_X preParticleDens_opacity = 0.25;
+        constexpr float_X preChannel1_opacity     = 1.0;
+        constexpr float_X preChannel2_opacity     = 1.0;
+        constexpr float_X preChannel3_opacity     = 1.0;
 
         // specify color scales for each channel
         namespace preParticleDensCol = colorScales::red;

--- a/examples/LaserWakefield/include/simulation_defines/param/dimension.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/dimension.param
@@ -28,5 +28,5 @@
 
 namespace picongpu
 {
-    BOOST_CONSTEXPR_OR_CONST uint32_t simDim = SIMDIM;
+    constexpr uint32_t simDim = SIMDIM;
 } // namespace picongpu

--- a/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
@@ -36,7 +36,7 @@ namespace SI
  *
  * He (2e- / Atom ) with 1.e15 He / m^3
  *                      = 2.e15 e- / m^3 */
-BOOST_CONSTEXPR_OR_CONST float_64 GAS_DENSITY_SI = 1.e25;
+constexpr float_64 GAS_DENSITY_SI = 1.e25;
 
 }
 
@@ -48,8 +48,8 @@ namespace gasProfiles
 
 PMACC_STRUCT(GaussianParameter,
     /** Gas Formula:
-     *   BOOST_CONSTEXPR_OR_CONST float_X exponent = abs((y - gasCenter_SI) / gasSigma_SI);
-     *   BOOST_CONSTEXPR_OR_CONST float_X density = exp(gasFactor * pow(exponent, gasPower));
+     *   constexpr float_X exponent = abs((y - gasCenter_SI) / gasSigma_SI);
+     *   constexpr float_X density = exp(gasFactor * pow(exponent, gasPower));
      *
      *   takes `gasCenterLeft_SI      for y < gasCenterLeft_SI`,
      *         `gasCenterRight_SI     for y > gasCenterRight_SI`,

--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -29,17 +29,17 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 1.39e-16;
+        constexpr float_64 DELTA_T_SI = 1.39e-16;
 
         /** equals X
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.1772e-6;
+        constexpr float_64 CELL_WIDTH_SI = 0.1772e-6;
         /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.4430e-7;
+        constexpr float_64 CELL_HEIGHT_SI = 0.4430e-7;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
         /** Note on units in reduced dimensions
          *
@@ -69,7 +69,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -81,7 +81,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.90;
 
 }
 

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -31,22 +31,22 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 8.0;
+            constexpr float_64 _A0  = 8.0;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
             /** unit: Volt /meter */
-            //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -54,7 +54,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 5.0e-15;
+            constexpr float_64 PULSE_LENGTH_SI = 5.0e-15;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -62,17 +62,17 @@ namespace picongpu
              * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
              *                             [   1.17741    ]
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+            constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
             /** the distance to the laser focus in y-direction
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+            constexpr float_64 FOCUS_POS_SI = 4.62e-5;
         }
         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 15.0;
+        constexpr float_64 PULSE_INIT = 15.0;
 
         /* laser phase shift (no shift: 0.0) */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {
@@ -80,7 +80,7 @@ namespace picongpu
             LINEAR_Z = 2u,
             CIRCULAR = 4u,
         };
-        BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = CIRCULAR;
+        constexpr PolarisationType Polarisation = CIRCULAR;
     }
 
     namespace laserPulseFrontTilt
@@ -89,13 +89,13 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -103,7 +103,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
+            constexpr float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -111,23 +111,23 @@ namespace picongpu
              * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
              *                             [   1.17741    ]
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+            constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
             /** the distance to the laser focus in y-direction
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+            constexpr float_64 FOCUS_POS_SI = 4.62e-5;
 
             /** the tilt angle between laser propagation in y-direction and laser axis in
              *  x-direction (0 degree == no tilt)
              *  unit: degree */
-            BOOST_CONSTEXPR_OR_CONST float_64 TILT_X_SI = 0;
+            constexpr float_64 TILT_X_SI = 0;
         }
         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 20.0;
+        constexpr float_64 PULSE_INIT = 20.0;
 
         /* laser phase shift (no shift: 0.0) */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {
@@ -135,7 +135,7 @@ namespace picongpu
             LINEAR_Z = 2u,
             CIRCULAR = 4u
         };
-        BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+        constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
     namespace laserPlaneWave
@@ -144,27 +144,27 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            BOOST_CONSTEXPR_OR_CONST float_64 _A0 = 1.5;
+            constexpr float_64 _A0 = 1.5;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
             /** unit: Volt /meter */
-            //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** The profile of the test Lasers 0 and 2 can be stretched by a
              *      constant area between the up and downramp
              *  unit: seconds */
-            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -172,16 +172,16 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
+            constexpr float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
 
         }
 
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
+        constexpr float_64 RAMP_INIT = 20.6146;
 
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {
@@ -189,7 +189,7 @@ namespace picongpu
             LINEAR_Z = 2u,
             CIRCULAR = 4u,
         };
-        BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+        constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
     namespace laserWavepacket
@@ -198,27 +198,27 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            //BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+            //constexpr float_64 _A0  = 3.9;
 
             /** unit: Volt /meter */
-            //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** The profile of the test Lasers 0 and 2 can be stretched by a
              *      constant area between the up and downramp
              *  unit: seconds */
-            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -226,7 +226,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
+            constexpr float_64 PULSE_LENGTH_SI = 6.25e-15 / 2.354820045;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -236,17 +236,17 @@ namespace picongpu
              *                             [   1.17741    ]
              *              if both values are equal, the laser has a circular shape in x-z
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_Z_SI = W0_X_SI;
+            constexpr float_64 W0_X_SI = 4.246e-6;
+            constexpr float_64 W0_Z_SI = W0_X_SI;
 
         }
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
         and half at the end of the plateau
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.0;
+        constexpr float_64 RAMP_INIT = 20.0;
 
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {
@@ -254,7 +254,7 @@ namespace picongpu
             LINEAR_Z = 2u,
             CIRCULAR = 4u,
         };
-        BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+        constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
 
@@ -264,22 +264,22 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            //BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+            //constexpr float_64 _A0  = 3.9;
 
             /** unit: Volt /meter */
-            //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 
             /** Pulse length:
@@ -288,18 +288,18 @@ namespace picongpu
              *  Fall time = 0.5 * PULSE_LENGTH_SI
              *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
              *  unit: seconds  */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 4.0e-15;
+            constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
              *              at the focus position of the laser
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0x_SI = 4.246e-6; // waist in x-direction
-            BOOST_CONSTEXPR_OR_CONST float_64 W0z_SI = W0x_SI;   // waist in z-direction
+            constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
+            constexpr float_64 W0z_SI = W0x_SI;   // waist in z-direction
         }
 
         /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
     }
 
     namespace laserNone
@@ -307,12 +307,12 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.0;
+            constexpr float_64 WAVE_LENGTH_SI = 0.0;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 0.0;
+            constexpr float_64 AMPLITUDE_SI = 0.0;
 
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 0.0;
+            constexpr float_64 PULSE_LENGTH_SI = 0.0;
         }
     }
 

--- a/examples/LaserWakefield/include/simulation_defines/param/memory.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
+constexpr size_t reservedGpuMemorySize = 350 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;
@@ -45,12 +45,12 @@ typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
 
-BOOST_CONSTEXPR_OR_CONST uint32_t GUARD_SIZE = 1;
+constexpr uint32_t GUARD_SIZE = 1;
 
 //! how many bytes for buffer is reserved to communication in one direction
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_X = 4 * 256 * 1024; //4 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
+constexpr uint32_t BYTES_EXCHANGE_X = 4 * 256 * 1024; //4 MiB
+constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
+constexpr uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
+constexpr uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
+constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
 }//namespace picongpu

--- a/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
@@ -40,9 +40,9 @@ namespace particles
 /** a particle with a weighting below MIN_WEIGHTING will not
  *      be created / will be deleted
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 10.0;
+constexpr float_X MIN_WEIGHTING = 10.0;
 
-BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 2;
+constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 2;
 
 namespace startPosition
 {
@@ -51,7 +51,7 @@ struct RandomParameter
 {
     /** Count of particles per cell at initial state
      *  unit: none */
-    BOOST_STATIC_CONSTEXPR uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+    static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
 };
 /* definition of random particle start*/
 typedef RandomImpl<RandomParameter> Random;

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -131,8 +131,8 @@ value_identifier(float_X, ChargeRatioIons, -1.0);
  */
 struct Hydrogen
 {
-    BOOST_STATIC_CONSTEXPR float_X numberOfProtons  = 1.0;
-    BOOST_STATIC_CONSTEXPR float_X numberOfNeutrons = 0.0;
+    static constexpr float_X numberOfProtons  = 1.0;
+    static constexpr float_X numberOfNeutrons = 0.0;
 };
 
 /*! Ionization Model Configuration ----------------------------------------

--- a/examples/LaserWakefield/include/simulation_defines/param/visualization.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
 /*scale image before write to file, only scale if value is not 1.0
  */
-BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+constexpr float_64 scale_image = 1.0;
 
 /*if true image is scaled if cellsize is not quadratic, else no scale*/
-BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = true;
+constexpr bool scale_to_cellsize = true;
 
-BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = false;
+constexpr bool white_box_per_GPU = false;
 
 namespace visPreview
 {
@@ -52,10 +52,10 @@ namespace visPreview
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
 // multiply highest undisturbed particle density with factor
-BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 0.25;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity = 1.0;
+constexpr float_X preParticleDens_opacity = 0.25;
+constexpr float_X preChannel1_opacity = 1.0;
+constexpr float_X preChannel2_opacity = 1.0;
+constexpr float_X preChannel3_opacity = 1.0;
 
 // specify color scales for each channel
 namespace preParticleDensCol = colorScales::grayInv;

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/backgroundFields.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/backgroundFields.param
@@ -25,25 +25,25 @@
 namespace picongpu
 {
     // Init Beta = v/c for the Electron
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_X = 0.5; //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_Y = 0.0; //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_Z = 0.0; //unit: none
+    constexpr float_64 BETA0_X = 0.5; //unit: none
+    constexpr float_64 BETA0_Y = 0.0; //unit: none
+    constexpr float_64 BETA0_Z = 0.0; //unit: none
 
     // position of the single particle within the cell
-    BOOST_CONSTEXPR_OR_CONST float_64 LOCAL_POS_X = 0.0; //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 LOCAL_POS_Y = 0.5; //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 LOCAL_POS_Z = 0.5; //unit: none
+    constexpr float_64 LOCAL_POS_X = 0.0; //unit: none
+    constexpr float_64 LOCAL_POS_Y = 0.5; //unit: none
+    constexpr float_64 LOCAL_POS_Z = 0.5; //unit: none
 
     namespace SI
     {
         // Constant Background Fields
-        BOOST_CONSTEXPR_OR_CONST float_64 E_X_SI = 0.0; //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_64 E_Y_SI = 0.0; //-1.0e13; //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_64 E_Z_SI = 0.0; //unit: Volt /meter
+        constexpr float_64 E_X_SI = 0.0; //unit: Volt /meter
+        constexpr float_64 E_Y_SI = 0.0; //-1.0e13; //unit: Volt /meter
+        constexpr float_64 E_Z_SI = 0.0; //unit: Volt /meter
 
-        BOOST_CONSTEXPR_OR_CONST float_64 B_X_SI = 0.0; //unit: Tesla = Vs/m^2
-        BOOST_CONSTEXPR_OR_CONST float_64 B_Y_SI = 0.0; //unit: Tesla = Vs/m^2
-        BOOST_CONSTEXPR_OR_CONST float_64 B_Z_SI = 0.0; //unit: Tesla = Vs/m^2
+        constexpr float_64 B_X_SI = 0.0; //unit: Tesla = Vs/m^2
+        constexpr float_64 B_Y_SI = 0.0; //unit: Tesla = Vs/m^2
+        constexpr float_64 B_Z_SI = 0.0; //unit: Tesla = Vs/m^2
     }
 
 }

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
@@ -29,17 +29,17 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 0.8e-16;
+        constexpr float_64 DELTA_T_SI = 0.8e-16;
 
         /** equals X
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 2.0 * SPEED_OF_LIGHT_SI * DELTA_T_SI;
+        constexpr float_64 CELL_WIDTH_SI = 2.0 * SPEED_OF_LIGHT_SI * DELTA_T_SI;
         /** equals Y
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
         /** Note on units in reduced dimensions
          *
@@ -69,7 +69,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -81,7 +81,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.90;
 
 }
 

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/particleConfig.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/particleConfig.param
@@ -36,9 +36,9 @@ namespace particles
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
      *  unit: none */
-    BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 1.0;
+    constexpr float_X MIN_WEIGHTING = 1.0;
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 1;
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 1;
 
 } //namespace particles
 

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/visualization.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
 /*scale image before write to file, only scale if value is not 1.0
  */
-BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+constexpr float_64 scale_image = 1.0;
 
 /*if true image is scaled if cellsize is not quadratic, else no scale*/
-BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = true;
+constexpr bool scale_to_cellsize = true;
 
-BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = false;
+constexpr bool white_box_per_GPU = false;
 
 namespace visPreview
 {
@@ -52,10 +52,10 @@ namespace visPreview
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
 // multiply highest undisturbed particle density with factor
-BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity = 1.0;
+constexpr float_X preParticleDens_opacity = 1.0;
+constexpr float_X preChannel1_opacity = 1.0;
+constexpr float_X preChannel2_opacity = 1.0;
+constexpr float_X preChannel3_opacity = 1.0;
 
 // specify color scales for each channel
 namespace preParticleDensCol = colorScales::red;

--- a/examples/SingleParticleCurrent/include/simulation_defines/unitless/backgroundFields.unitless
+++ b/examples/SingleParticleCurrent/include/simulation_defines/unitless/backgroundFields.unitless
@@ -26,13 +26,13 @@
 namespace picongpu
 {
     // Constant Background Fields
-    BOOST_CONSTEXPR_OR_CONST float_X E_X = float_X( SI::E_X_SI / UNIT_EFIELD); //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_X E_Y = float_X( SI::E_Y_SI / UNIT_EFIELD); //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_X E_Z = float_X( SI::E_Z_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_X = float_X( SI::E_X_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_Y = float_X( SI::E_Y_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_Z = float_X( SI::E_Z_SI / UNIT_EFIELD); //unit: Volt /meter
 
-    BOOST_CONSTEXPR_OR_CONST float_X B_X = float_X( SI::B_X_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_X B_Y = float_X( SI::B_Y_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_X B_Z = float_X( SI::B_Z_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_X = float_X( SI::B_X_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_Y = float_X( SI::B_Y_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_Z = float_X( SI::B_Z_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
 }
 
 

--- a/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleCurrent/include/simulation_defines/unitless/physicalConstants.unitless
@@ -24,58 +24,58 @@
 namespace picongpu
 {
     /** Unit of Speed */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
+    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
     /** Unit of time */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_TIME = SI::DELTA_T_SI;
+    constexpr float_64 UNIT_TIME = SI::DELTA_T_SI;
     /** Unit of length */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
+    constexpr float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
     namespace particles
     {
         /** Number of electrons per particle (= macro particle weighting)
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
+        constexpr float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
 
     }
 
 
     /** Unit of mass */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of charge */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_CHARGE = -1.0 * SI::ELECTRON_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_CHARGE = -1.0 * SI::ELECTRON_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of energy */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
+    constexpr float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
     /** Unit of EField: V/m */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
+    constexpr float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
     //** Unit of BField: Tesla [T] = Vs/m^2 */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
+    constexpr float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
 
 
 
 
-    BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+    constexpr float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
     //! reduced Planck constant
-    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+    constexpr float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
 
     //! Charge of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
+    constexpr float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
+    constexpr float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
 
     //! magnetic constant must be double 3.92907e-39
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
+    constexpr float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
 
     //! electric constant must be double 2.54513e+38
-    BOOST_CONSTEXPR_OR_CONST float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    constexpr float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     // = 1/c^2
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    constexpr float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     /* Atomic unit of electric field in PIC Efield units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+    constexpr float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
 
     /* Atomic unit of time in PIC units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
+    constexpr float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/dimension.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/dimension.param
@@ -28,5 +28,5 @@
 
 namespace picongpu
 {
-    BOOST_CONSTEXPR_OR_CONST uint32_t simDim = SIMDIM;
+    constexpr uint32_t simDim = SIMDIM;
 } // namespace picongpu

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
@@ -29,17 +29,17 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 1.66789e-17;
+        constexpr float_64 DELTA_T_SI = 1.66789e-17;
 
         /** equals X
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.16e-6;
+        constexpr float_64 CELL_WIDTH_SI = 0.16e-6;
         /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.20e-7;
+        constexpr float_64 CELL_HEIGHT_SI = 0.20e-7;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
         /** Note on units in reduced dimensions
          *
@@ -69,7 +69,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -81,7 +81,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.95;
+    constexpr float_64 slide_point = 0.95;
 
 }
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/laserConfig.param
@@ -31,22 +31,22 @@ namespace laserGaussianBeam
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-//BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 1.5;
+//constexpr float_64 _A0  = 1.5;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -54,7 +54,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -62,17 +62,17 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
  * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
  *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 /** the distance to the laser focus in y-direction
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+constexpr float_64 FOCUS_POS_SI = 4.62e-5;
 }
 /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 20.0;
+constexpr float_64 PULSE_INIT = 20.0;
 
 /* laser phase shift (no shift: 0.0) */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
 {
@@ -80,7 +80,7 @@ enum PolarisationType
     LINEAR_Z = 2u,
     CIRCULAR = 4u,
 };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = CIRCULAR;
+constexpr PolarisationType Polarisation = CIRCULAR;
 }
 
 namespace laserPulseFrontTilt
@@ -89,22 +89,22 @@ namespace laserPulseFrontTilt
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-//BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 1.5;
+//constexpr float_64 _A0  = 1.5;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
     *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -112,7 +112,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
     *  Info:             FWHM_of_Intensity = FWHM_Illumination
     *                      = what a experimentalist calls "pulse duration"
     *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -120,23 +120,23 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
  * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
  *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
 /** the distance to the laser focus in y-direction
     *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+constexpr float_64 FOCUS_POS_SI = 4.62e-5;
 
 /** the tilt angle between laser propagation in y-direction and laser axis in
     *  x-direction (0 degree == no tilt)
     *  unit: degree */
-BOOST_CONSTEXPR_OR_CONST float_64 TILT_X_SI = 0;
+constexpr float_64 TILT_X_SI = 0;
 }
 /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
 *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 20.0;
+constexpr float_64 PULSE_INIT = 20.0;
 
 /* laser phase shift (no shift: 0.0) */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
 {
@@ -144,7 +144,7 @@ enum PolarisationType
     LINEAR_Z = 2u,
     CIRCULAR = 4u
 };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+constexpr PolarisationType Polarisation = LINEAR_X;
 }
 
 namespace laserPlaneWave
@@ -153,27 +153,27 @@ namespace laserPlaneWave
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 _A0 = 1.0;
+constexpr float_64 _A0 = 1.0;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+//constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** The profile of the test Lasers 0 and 2 can be stretched by a
  *      constant area between the up and downramp
  *  unit: seconds */
-BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = /*13.34e-15;*/6.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = /*13.34e-15;*/6.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -181,16 +181,16 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = /*13.34e-15;*/6.0 
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 }
 
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
+constexpr float_64 RAMP_INIT = 20.6146;
 
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
   {
@@ -198,7 +198,7 @@ enum PolarisationType
     LINEAR_Z = 2u,
     CIRCULAR = 4u,
   };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+constexpr PolarisationType Polarisation = LINEAR_X;
 }
 
 namespace laserWavepacket
@@ -207,27 +207,27 @@ namespace laserWavepacket
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-//BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+//constexpr float_64 _A0  = 3.9;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 /** The profile of the test Lasers 0 and 2 can be stretched by a
  *      constant area between the up and downramp
  *  unit: seconds */
-BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
 /** Pulse length: sigma of std. gauss for intensity (E^2)
  *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -235,7 +235,7 @@ BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_
  *  Info:             FWHM_of_Intensity = FWHM_Illumination
  *                      = what a experimentalist calls "pulse duration"
  *  unit: seconds (1 sigma) */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
@@ -245,16 +245,16 @@ BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
  * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
  *                             [   1.17741    ]
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;
-BOOST_CONSTEXPR_OR_CONST float_64 W0_Z_SI = W0_X_SI;
+constexpr float_64 W0_X_SI = 4.246e-6;
+constexpr float_64 W0_Z_SI = W0_X_SI;
 }
 /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
     and half at the end of the plateau
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.0;
+constexpr float_64 RAMP_INIT = 20.0;
 
 /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
 enum PolarisationType
 {
@@ -262,7 +262,7 @@ enum PolarisationType
     LINEAR_Z = 2u,
     CIRCULAR = 4u,
 };
-BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+constexpr PolarisationType Polarisation = LINEAR_X;
 }
 
 
@@ -272,22 +272,22 @@ namespace laserPolynom
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
 /** UNITCONV */
-BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
 /** unit: W / m^2 */
 // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
 /** unit: none */
-//BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+//constexpr float_64 _A0  = 3.9;
 
 /** unit: Volt /meter */
-//BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 
 /** Pulse length:
@@ -296,18 +296,18 @@ BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
  *  Fall time = 0.5 * PULSE_LENGTH_SI
  *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
  *  unit: seconds  */
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 4.0e-15;
+constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
 
 /** beam waist: distance from the axis where the pulse intensity (E^2)
  *              decreases to its 1/e^2-th part,
  *              at the focus position of the laser
  *  unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 W0x_SI = 4.246e-6; // waist in x-direction
-BOOST_CONSTEXPR_OR_CONST float_64 W0z_SI = W0x_SI; // waist in z-direction
+constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
+constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
 }
 
 /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
-BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 }
 
 namespace laserNone
@@ -315,12 +315,12 @@ namespace laserNone
 namespace SI
 {
 /** unit: meter */
-BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.0;
+constexpr float_64 WAVE_LENGTH_SI = 0.0;
 
 /** unit: Volt /meter */
-BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 0.0;
+constexpr float_64 AMPLITUDE_SI = 0.0;
 
-BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 0.0;
+constexpr float_64 PULSE_LENGTH_SI = 0.0;
 }
 }
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/particleConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/particleConfig.param
@@ -36,9 +36,9 @@ namespace particles
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
      *  unit: none */
-    BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 1.0;
+    constexpr float_X MIN_WEIGHTING = 1.0;
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 1;
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 1;
 
 } //namespace particles
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
@@ -38,29 +38,29 @@ namespace rad_linear_frequencies
 {
 namespace SI
 {
-BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 0.0;
-BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 5.8869e17;
+constexpr float_64 omega_min = 0.0;
+constexpr float_64 omega_max = 5.8869e17;
 }
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 namespace rad_log_frequencies
 {
 namespace SI
 {
-BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 1.0e14;
-BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 1.0e17;
+constexpr float_64 omega_min = 1.0e14;
+constexpr float_64 omega_max = 1.0e17;
 }
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
 namespace rad_frequencies_from_list
 {
-//BOOST_CONSTEXPR_OR_CONST char listLocation[] = "/scratch/s5960712/list001.freq";
-BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+//constexpr char listLocation[] = "/scratch/s5960712/list001.freq";
+constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
@@ -69,7 +69,7 @@ namespace radiation_frequencies = rad_linear_frequencies;
 
 namespace radiationNyquist
 {
-  BOOST_CONSTEXPR_OR_CONST float_32 NyquistFactor = 0.5;
+  constexpr float_32 NyquistFactor = 0.5;
 }
 
 
@@ -120,9 +120,9 @@ namespace parameters
 //diable (0) / enable (1)
 #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-BOOST_CONSTEXPR_OR_CONST float_32 RadiationGamma = 5.;
+constexpr float_32 RadiationGamma = 5.;
 
-BOOST_CONSTEXPR_OR_CONST unsigned int N_observer = 128; // number of looking directions
+constexpr unsigned int N_observer = 128; // number of looking directions
 
 
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationObserver.param
@@ -54,12 +54,12 @@ namespace picongpu
       const int my_theta_id = observation_id_extern;
 
       /* set up: */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 gamma_times_thetaMax = 1.5; /* max normalized angle */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 gamma = 5.0;                /* relativistic gamma */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
+      constexpr picongpu::float_64 gamma_times_thetaMax = 1.5; /* max normalized angle */
+      constexpr picongpu::float_64 gamma = 5.0;                /* relativistic gamma */
+      constexpr picongpu::float_64 thetaMax = gamma_times_thetaMax / gamma; /* max angle */
 
       /* stepwith of theta for from [-thetaMax : +thetaMax] */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 delta_theta =  2.0 * thetaMax / (parameters::N_observer);
+      constexpr picongpu::float_64 delta_theta =  2.0 * thetaMax / (parameters::N_observer);
 
       /* compute angle theta for index */
       const picongpu::float_64 theta(my_theta_id * delta_theta - thetaMax + picongpu::PI);

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/testExtension.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/testExtension.param
@@ -25,20 +25,20 @@
 namespace picongpu
 {
     // Init Beta = v/c for the Electron
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_X = 0.0; //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_Y = -0.9797958971; /* gamma=5 */ //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_Z = 0.0; //unit: none
+    constexpr float_64 BETA0_X = 0.0; //unit: none
+    constexpr float_64 BETA0_Y = -0.9797958971; /* gamma=5 */ //unit: none
+    constexpr float_64 BETA0_Z = 0.0; //unit: none
 
     // Constant Background Fields
-    BOOST_CONSTEXPR_OR_CONST float_64 E_X_SI = 0.0; //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_64 E_Y_SI = 0.0; //-1.0e13; //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_64 E_Z_SI = 0.0; //unit: Volt /meter
+    constexpr float_64 E_X_SI = 0.0; //unit: Volt /meter
+    constexpr float_64 E_Y_SI = 0.0; //-1.0e13; //unit: Volt /meter
+    constexpr float_64 E_Z_SI = 0.0; //unit: Volt /meter
 
-    BOOST_CONSTEXPR_OR_CONST float_64 B_X_SI = 0.0; //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_64 B_Y_SI = 0.0; //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_64 B_Z_SI = 0.0; //unit: Tesla = Vs/m^2
+    constexpr float_64 B_X_SI = 0.0; //unit: Tesla = Vs/m^2
+    constexpr float_64 B_Y_SI = 0.0; //unit: Tesla = Vs/m^2
+    constexpr float_64 B_Z_SI = 0.0; //unit: Tesla = Vs/m^2
 
     // Offset of particle in cells
-    BOOST_CONSTEXPR_OR_CONST unsigned int OneParticleOffset = 1000;
+    constexpr unsigned int OneParticleOffset = 1000;
 }
 

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/visualization.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
 /*scale image before write to file, only scale if value is not 1.0
  */
-BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+constexpr float_64 scale_image = 1.0;
 
 /*if true image is scaled if cellsize is not quadratic, else no scale*/
-BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = true;
+constexpr bool scale_to_cellsize = true;
 
-BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = false;
+constexpr bool white_box_per_GPU = false;
 
 namespace visPreview
 {
@@ -52,10 +52,10 @@ namespace visPreview
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
 // multiply highest undisturbed particle density with factor
-BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity = 1.0;
+constexpr float_X preParticleDens_opacity = 1.0;
+constexpr float_X preChannel1_opacity = 1.0;
+constexpr float_X preChannel2_opacity = 1.0;
+constexpr float_X preChannel3_opacity = 1.0;
 
 // specify color scales for each channel
 namespace preParticleDensCol = colorScales::red;

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/physicalConstants.unitless
@@ -24,57 +24,57 @@
 namespace picongpu
 {
     /** Unit of Speed */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
+    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
     /** Unit of time */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_TIME = SI::DELTA_T_SI;
+    constexpr float_64 UNIT_TIME = SI::DELTA_T_SI;
     /** Unit of length */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
+    constexpr float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
     namespace particles
     {
         /** Number of electrons per particle (= macro particle weighting)
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
+        constexpr float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
 
     }
 
     /** Unit of mass */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of charge */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_CHARGE = -1.0 * SI::ELECTRON_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_CHARGE = -1.0 * SI::ELECTRON_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of energy */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
+    constexpr float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
     /** Unit of EField: V/m */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
+    constexpr float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
     //** Unit of BField: Tesla [T] = Vs/m^2 */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
+    constexpr float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
 
 
 
 
-    BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+    constexpr float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
     //! reduced Planck constant
-    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+    constexpr float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
 
     //! Charge of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
+    constexpr float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
+    constexpr float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
 
     //! magnetic constant must be double 3.92907e-39
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
+    constexpr float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
 
     //! electric constant must be double 2.54513e+38
-    BOOST_CONSTEXPR_OR_CONST float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    constexpr float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     // = 1/c^2
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    constexpr float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     /* Atomic unit of electric field in PIC Efield units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+    constexpr float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
 
     /* Atomic unit of time in PIC units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
+    constexpr float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/testExtension.unitless
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/unitless/testExtension.unitless
@@ -25,13 +25,13 @@
 namespace picongpu
 {
     // Constant Background Fields
-    BOOST_CONSTEXPR_OR_CONST float_X E_X = float_X( E_X_SI / UNIT_EFIELD); //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_X E_Y = float_X( E_Y_SI / UNIT_EFIELD); //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_X E_Z = float_X( E_Z_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_X = float_X( E_X_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_Y = float_X( E_Y_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_Z = float_X( E_Z_SI / UNIT_EFIELD); //unit: Volt /meter
 
-    BOOST_CONSTEXPR_OR_CONST float_X B_X = float_X( B_X_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_X B_Y = float_X( B_Y_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_X B_Z = float_X( B_Z_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_X = float_X( B_X_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_Y = float_X( B_Y_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_Z = float_X( B_Z_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
 }
 
 

--- a/examples/SingleParticleTest/include/simulation_defines/param/backgroundFields.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/backgroundFields.param
@@ -25,23 +25,23 @@
 namespace picongpu
 {
     // Init Beta = v/c for the Electron
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_X = 0.0; //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_Y = 0.5; //unit: none
-    BOOST_CONSTEXPR_OR_CONST float_64 BETA0_Z = 0.0; //unit: none
+    constexpr float_64 BETA0_X = 0.0; //unit: none
+    constexpr float_64 BETA0_Y = 0.5; //unit: none
+    constexpr float_64 BETA0_Z = 0.0; //unit: none
 
     namespace SI
     {
         // Constant Background Fields
-        BOOST_CONSTEXPR_OR_CONST float_64 E_X_SI = 0.0; //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_64 E_Y_SI = 0.0; //-1.0e13; //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_64 E_Z_SI = 0.0; //unit: Volt /meter
+        constexpr float_64 E_X_SI = 0.0; //unit: Volt /meter
+        constexpr float_64 E_Y_SI = 0.0; //-1.0e13; //unit: Volt /meter
+        constexpr float_64 E_Z_SI = 0.0; //unit: Volt /meter
 
-        BOOST_CONSTEXPR_OR_CONST float_64 B_X_SI = 0.0; //unit: Tesla = Vs/m^2
-        BOOST_CONSTEXPR_OR_CONST float_64 B_Y_SI = 0.0; //unit: Tesla = Vs/m^2
-        BOOST_CONSTEXPR_OR_CONST float_64 B_Z_SI = 50.0; //unit: Tesla = Vs/m^2
+        constexpr float_64 B_X_SI = 0.0; //unit: Tesla = Vs/m^2
+        constexpr float_64 B_Y_SI = 0.0; //unit: Tesla = Vs/m^2
+        constexpr float_64 B_Z_SI = 50.0; //unit: Tesla = Vs/m^2
     }
 
     // Y Offset of particle in cells
-    BOOST_CONSTEXPR_OR_CONST unsigned int OneParticleOffset = 100;
+    constexpr unsigned int OneParticleOffset = 100;
 }
 

--- a/examples/SingleParticleTest/include/simulation_defines/param/dimension.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/dimension.param
@@ -28,5 +28,5 @@
 
 namespace picongpu
 {
-    BOOST_CONSTEXPR_OR_CONST uint32_t simDim = SIMDIM;
+    constexpr uint32_t simDim = SIMDIM;
 } // namespace picongpu

--- a/examples/SingleParticleTest/include/simulation_defines/param/particleConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/particleConfig.param
@@ -36,9 +36,9 @@ namespace particles
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
      *  unit: none */
-    BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 1.0;
+    constexpr float_X MIN_WEIGHTING = 1.0;
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 1;
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 1;
 
 } //namespace particles
 

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -127,8 +127,8 @@ typedef Particles<
  */
 //struct Hydrogen
 //{
-//    BOOST_STATIC_CONSTEXPR float_X numberOfProtons  = 1.0;
-//    BOOST_STATIC_CONSTEXPR float_X numberOfNeutrons = 0.0;
+//    static constexpr float_X numberOfProtons  = 1.0;
+//    static constexpr float_X numberOfNeutrons = 0.0;
 //};
 
 /*! Ionization Model Configuration ----------------------------------------

--- a/examples/SingleParticleTest/include/simulation_defines/param/visualization.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
 /*scale image before write to file, only scale if value is not 1.0
  */
-BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+constexpr float_64 scale_image = 1.0;
 
 /*if true image is scaled if cellsize is not quadratic, else no scale*/
-BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = true;
+constexpr bool scale_to_cellsize = true;
 
-BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = false;
+constexpr bool white_box_per_GPU = false;
 
 namespace visPreview
 {
@@ -52,10 +52,10 @@ namespace visPreview
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
 // multiply highest undisturbed particle density with factor
-BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity = 1.0;
-BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity = 1.0;
+constexpr float_X preParticleDens_opacity = 1.0;
+constexpr float_X preChannel1_opacity = 1.0;
+constexpr float_X preChannel2_opacity = 1.0;
+constexpr float_X preChannel3_opacity = 1.0;
 
 // specify color scales for each channel
 namespace preParticleDensCol = colorScales::red;

--- a/examples/SingleParticleTest/include/simulation_defines/unitless/backgroundFields.unitless
+++ b/examples/SingleParticleTest/include/simulation_defines/unitless/backgroundFields.unitless
@@ -26,13 +26,13 @@
 namespace picongpu
 {
     // Constant Background Fields
-    BOOST_CONSTEXPR_OR_CONST float_X E_X = float_X( SI::E_X_SI / UNIT_EFIELD); //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_X E_Y = float_X( SI::E_Y_SI / UNIT_EFIELD); //unit: Volt /meter
-    BOOST_CONSTEXPR_OR_CONST float_X E_Z = float_X( SI::E_Z_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_X = float_X( SI::E_X_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_Y = float_X( SI::E_Y_SI / UNIT_EFIELD); //unit: Volt /meter
+    constexpr float_X E_Z = float_X( SI::E_Z_SI / UNIT_EFIELD); //unit: Volt /meter
 
-    BOOST_CONSTEXPR_OR_CONST float_X B_X = float_X( SI::B_X_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_X B_Y = float_X( SI::B_Y_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
-    BOOST_CONSTEXPR_OR_CONST float_X B_Z = float_X( SI::B_Z_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_X = float_X( SI::B_X_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_Y = float_X( SI::B_Y_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
+    constexpr float_X B_Z = float_X( SI::B_Z_SI / UNIT_BFIELD); //unit: Tesla = Vs/m^2
 }
 
 

--- a/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/examples/SingleParticleTest/include/simulation_defines/unitless/physicalConstants.unitless
@@ -24,57 +24,57 @@
 namespace picongpu
 {
     /** Unit of Speed */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
+    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
     /** Unit of time */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_TIME = SI::DELTA_T_SI;
+    constexpr float_64 UNIT_TIME = SI::DELTA_T_SI;
     /** Unit of length */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
+    constexpr float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
     namespace particles
     {
         /** Number of electrons per particle (= macro particle weighting)
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
+        constexpr float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE = 1;
 
     }
 
     /** Unit of mass */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_MASS = SI::ELECTRON_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of charge */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_CHARGE = -1.0 * SI::ELECTRON_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_CHARGE = -1.0 * SI::ELECTRON_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of energy */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
+    constexpr float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
     /** Unit of EField: V/m */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
+    constexpr float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
     //** Unit of BField: Tesla [T] = Vs/m^2 */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
+    constexpr float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
 
 
 
 
-    BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+    constexpr float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
     //! reduced Planck constant
-    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+    constexpr float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
 
     //! Charge of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
+    constexpr float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
+    constexpr float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
 
     //! magnetic constant must be double 3.92907e-39
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
+    constexpr float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
 
     //! electric constant must be double 2.54513e+38
-    BOOST_CONSTEXPR_OR_CONST float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    constexpr float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     // = 1/c^2
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    constexpr float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     /* Atomic unit of electric field in PIC Efield units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+    constexpr float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
 
     /* Atomic unit of time in PIC units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
+    constexpr float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu

--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -193,10 +193,10 @@ public:
 
 private:
     // number of timesteps which collect the data
-    BOOST_STATIC_CONSTEXPR uint32_t collectTimesteps = 512;
+    static constexpr uint32_t collectTimesteps = 512;
     // first timestep which collects data
     //   you may like to let the plasma develope/thermalize a little bit
-    BOOST_STATIC_CONSTEXPR uint32_t firstTimestep = 1024;
+    static constexpr uint32_t firstTimestep = 1024;
 
     container::HostBuffer<float, 2 >* eField_zt[2];
 

--- a/examples/ThermalTest/include/simulation_defines/param/gasConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gasConfig.param
@@ -33,7 +33,7 @@ namespace picongpu
          *
          * He (2e- / Atom ) with 1.e15 He / m^3
          *                      = 2.e15 e- / m^3 */
-        BOOST_CONSTEXPR_OR_CONST float_64 GAS_DENSITY_SI = 1.571e24;
+        constexpr float_64 GAS_DENSITY_SI = 1.571e24;
 
     }
 

--- a/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
@@ -29,17 +29,17 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 2.5e-15;
+        constexpr float_64 DELTA_T_SI = 2.5e-15;
 
         /** equals X
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 1.341e-6;
+        constexpr float_64 CELL_WIDTH_SI = 1.341e-6;
         /** equals Y
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
         /** Note on units in reduced dimensions
          *
@@ -69,7 +69,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -81,7 +81,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.90;
 
 }
 

--- a/examples/ThermalTest/include/simulation_defines/param/memory.param
+++ b/examples/ThermalTest/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
+constexpr size_t reservedGpuMemorySize = 350 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;
@@ -45,12 +45,12 @@ typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
 
-BOOST_CONSTEXPR_OR_CONST uint32_t GUARD_SIZE = 1;
+constexpr uint32_t GUARD_SIZE = 1;
 
 //! how many bytes for buffer is reserved to communication in one direction
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_X = 40 * 1024 * 1024; //4 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Y = 40 * 1024 * 1024; //6 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Z = 40 * 1024 * 1024; //4 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_CORNER = 800 * 1024; //8 kiB;
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EDGES = 3200 * 1024; //32 kiB;
+constexpr uint32_t BYTES_EXCHANGE_X = 40 * 1024 * 1024; //4 MiB
+constexpr uint32_t BYTES_EXCHANGE_Y = 40 * 1024 * 1024; //6 MiB
+constexpr uint32_t BYTES_EXCHANGE_Z = 40 * 1024 * 1024; //4 MiB
+constexpr uint32_t BYTES_CORNER = 800 * 1024; //8 kiB;
+constexpr uint32_t BYTES_EDGES = 3200 * 1024; //32 kiB;
 }//namespace picongpu

--- a/examples/ThermalTest/include/simulation_defines/param/particleConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/particleConfig.param
@@ -39,9 +39,9 @@ namespace particles
 /** a particle with a weighting below MIN_WEIGHTING will not
  *      be created / will be deleted
  *  unit: none */
-BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 10.0;
+constexpr float_X MIN_WEIGHTING = 10.0;
 
-BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 16;
+constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 16;
 
 namespace manipulators
 {
@@ -50,7 +50,7 @@ struct TemperatureParam
     /*Initial temperature
      *  unit: keV
      */
-    BOOST_STATIC_CONSTEXPR float_64 temperature = 51.16;
+    static constexpr float_64 temperature = 51.16;
 };
 /* definition of SetDrift start*/
 typedef TemperatureImpl<TemperatureParam,nvidia::functors::Add> AddTemperature;
@@ -63,7 +63,7 @@ struct RandomParameter
 {
     /** Count of particles per cell at initial state
      *  unit: none */
-    BOOST_STATIC_CONSTEXPR uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+    static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
 };
 /* definition of random particle start*/
 typedef RandomImpl<RandomParameter> Random;

--- a/examples/WeibelTransverse/include/simulation_defines/param/gasConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gasConfig.param
@@ -33,7 +33,7 @@ namespace picongpu
          *
          * He (2e- / Atom ) with 1.e15 He / m^3
          *                      = 2.e15 e- / m^3 */
-        BOOST_CONSTEXPR_OR_CONST float_64 GAS_DENSITY_SI = 1.e25;
+        constexpr float_64 GAS_DENSITY_SI = 1.e25;
 
     }
 

--- a/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
@@ -29,17 +29,17 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 3.0e-17;
+        constexpr float_64 DELTA_T_SI = 3.0e-17;
 
         /** equals X
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 1.8e-8;
+        constexpr float_64 CELL_WIDTH_SI = 1.8e-8;
         /** equals Y
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 1.8e-8;
+        constexpr float_64 CELL_HEIGHT_SI = 1.8e-8;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = 1.8e-8;
+        constexpr float_64 CELL_DEPTH_SI = 1.8e-8;
 
         /** Note on units in reduced dimensions
          *
@@ -69,7 +69,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -81,7 +81,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.90;
 
 }
 

--- a/examples/WeibelTransverse/include/simulation_defines/param/memory.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
  *   - reduces
  *   - ...
  */
-BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 400 *1024*1024;
+constexpr size_t reservedGpuMemorySize = 400 *1024*1024;
 
 /* short namespace*/
 namespace mCT=PMacc::math::CT;
@@ -44,12 +44,12 @@ typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 
 /** define the object for mapping superCells to cells*/
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
-BOOST_CONSTEXPR_OR_CONST uint32_t GUARD_SIZE = 1;
+constexpr uint32_t GUARD_SIZE = 1;
 
 //! how many bytes for buffer is reserved to communication in one direction
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_X = 8 * 256 * 1024; //8 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Y = 12 * 512 * 1024; //12 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Z = 256 * 256 * 1024; //256 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_CORNER = 2 * 256 * 1024; //2 MiB
-BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EDGES = 8 * 256 * 1024; //8 MiB
+constexpr uint32_t BYTES_EXCHANGE_X = 8 * 256 * 1024; //8 MiB
+constexpr uint32_t BYTES_EXCHANGE_Y = 12 * 512 * 1024; //12 MiB
+constexpr uint32_t BYTES_EXCHANGE_Z = 256 * 256 * 1024; //256 MiB
+constexpr uint32_t BYTES_CORNER = 2 * 256 * 1024; //2 MiB
+constexpr uint32_t BYTES_EDGES = 8 * 256 * 1024; //8 MiB
 }//namespace picongpu

--- a/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
@@ -37,9 +37,9 @@ namespace particles
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
      *  unit: none */
-    BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 10.0;
+    constexpr float_X MIN_WEIGHTING = 10.0;
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 4;
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 4;
 
 namespace manipulators
 {
@@ -51,7 +51,7 @@ namespace manipulators
          *  Examples:
          *    - No drift is equal to 1.0
          *  unit: none */
-        BOOST_STATIC_CONSTEXPR float_64 gamma = 1.021;
+        static constexpr float_64 gamma = 1.021;
         const DriftParamElectrons_direction_t direction;
     };
     /* definition of SetDrift start*/
@@ -64,7 +64,7 @@ namespace manipulators
          *  Examples:
          *    - No drift is equal to 1.0
          *  unit: none */
-        BOOST_STATIC_CONSTEXPR float_64 gamma = 1.021;
+        static constexpr float_64 gamma = 1.021;
         const DriftParamIons_direction_t direction;
     };
     /* definition of SetDrift start*/
@@ -75,7 +75,7 @@ namespace manipulators
         /*Initial temperature
          *  unit: keV
          */
-        BOOST_STATIC_CONSTEXPR float_64 temperature = 0.005;
+        static constexpr float_64 temperature = 0.005;
     };
     /* definition of SetDrift start*/
     typedef TemperatureImpl<TemperatureParam,nvidia::functors::Add> AddTemperature;

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -120,8 +120,8 @@ value_identifier(float_X, ChargeRatioIons, -1.0);
  */
 struct Hydrogen
 {
-    BOOST_STATIC_CONSTEXPR float_X numberOfProtons  = 1.0;
-    BOOST_STATIC_CONSTEXPR float_X numberOfNeutrons = 0.0;
+    static constexpr float_X numberOfProtons  = 1.0;
+    static constexpr float_X numberOfNeutrons = 0.0;
 };
 
 /*! Ionization Model Configuration ----------------------------------------

--- a/examples/WeibelTransverse/include/simulation_defines/param/visualization.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
     /*scale image before write to file, only scale if value is not 1.0
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+    constexpr float_64 scale_image = 1.0;
 
     /*if true image is scaled if cellsize is not quadratic, else no scale*/
-    BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = false;
+    constexpr bool scale_to_cellsize = false;
 
-    BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = false;
+    constexpr bool white_box_per_GPU = false;
 
     namespace visPreview
     {
@@ -52,10 +52,10 @@ namespace picongpu
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
         // multiply highest undisturbed particle density with factor
-        BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 0.25;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity = 1.0;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity = 1.0;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity = 1.0;
+        constexpr float_X preParticleDens_opacity = 0.25;
+        constexpr float_X preChannel1_opacity = 1.0;
+        constexpr float_X preChannel2_opacity = 1.0;
+        constexpr float_X preChannel3_opacity = 1.0;
 
         // specify color scales for each channel
         namespace preParticleDensCol = colorScales::red;

--- a/src/libPMacc/include/compileTime/AllCombinations.hpp
+++ b/src/libPMacc/include/compileTime/AllCombinations.hpp
@@ -67,7 +67,7 @@ struct AllCombinations<T_MplSeq, T_TmpResult, false >
     typedef T_MplSeq MplSeq;
     typedef T_TmpResult TmpResult;
 
-    BOOST_STATIC_CONSTEXPR uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
+    static constexpr uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
     typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1 > > ::type LastElement;
     typedef bmpl::empty<LastElement> IsLastElementEmpty;
     typedef typename MakeSeq<LastElement>::type LastElementAsSequence;
@@ -156,7 +156,7 @@ struct AllCombinations
      * a sequence because all next algorithms can only work with sequences */
     typedef typename MakeSeq<T_MplSeq>::type MplSeq;
 
-    BOOST_STATIC_CONSTEXPR uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
+    static constexpr uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
     typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1 > > ::type LastElement;
     typedef bmpl::empty<LastElement> IsLastElementEmpty;
     typedef typename MakeSeq<LastElement>::type LastElementAsSequence;

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -53,7 +53,7 @@ struct SphericMapper;
 template<typename BlockSize>
 struct SphericMapper<1, BlockSize>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
 
     dim3 cudaGridDim(const math::Size_t<1>& size) const
     {
@@ -78,7 +78,7 @@ struct SphericMapper<1, BlockSize>
 template<typename BlockSize>
 struct SphericMapper<2, BlockSize>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 2;
+    static constexpr int dim = 2;
 
     dim3 cudaGridDim(const math::Size_t<2>& size) const
     {
@@ -105,7 +105,7 @@ struct SphericMapper<2, BlockSize>
 template<typename BlockSize>
 struct SphericMapper<3, BlockSize>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 3;
+    static constexpr int dim = 3;
 
     dim3 cudaGridDim(const math::Size_t<3>& size) const
     {
@@ -134,7 +134,7 @@ struct SphericMapper<3, BlockSize>
 template<>
 struct SphericMapper<1, mpl::void_>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
 
     dim3 cudaGridDim(const math::Size_t<1>& size, const math::Size_t<3>& blockDim) const
     {
@@ -159,7 +159,7 @@ struct SphericMapper<1, mpl::void_>
 template<>
 struct SphericMapper<2, mpl::void_>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 2;
+    static constexpr int dim = 2;
 
     dim3 cudaGridDim(const math::Size_t<2>& size, const math::Size_t<3>& blockDim) const
     {
@@ -186,7 +186,7 @@ struct SphericMapper<2, mpl::void_>
 template<>
 struct SphericMapper<3, mpl::void_>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 3;
+    static constexpr int dim = 3;
 
     dim3 cudaGridDim(const math::Size_t<3>& size, const math::Size_t<3>& blockDim) const
     {

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -72,7 +72,7 @@ class CartBuffer : public
 {
 public:
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
     typedef cursor::BufferCursor<Type, T_dim> Cursor;
     typedef typename Allocator::tag memoryTag;
     typedef math::Size_t<T_dim> SizeType;

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -35,7 +35,7 @@ template<typename Type, int T_dim>
 struct DeviceMemAllocator
 {
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
     typedef cursor::BufferCursor<type, dim> Cursor;
     typedef allocator::tag::device tag;
 
@@ -50,7 +50,7 @@ template<typename Type>
 struct DeviceMemAllocator<Type, 1>
 {
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
     typedef cursor::BufferCursor<type, 1> Cursor;
     typedef allocator::tag::device tag;
 

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
@@ -35,7 +35,7 @@ template<typename Type, int T_dim>
 struct DeviceMemEvenPitch
 {
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
     typedef cursor::BufferCursor<type, dim> Cursor;
     typedef allocator::tag::device tag;
 
@@ -48,7 +48,7 @@ template<typename Type>
 struct DeviceMemEvenPitch<Type, 1>
 {
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
     typedef cursor::BufferCursor<type, 1> Cursor;
     typedef allocator::tag::device tag;
 

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -36,7 +36,7 @@ template<typename Type, int T_dim>
 struct HostMemAllocator
 {
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
     typedef cursor::BufferCursor<type, T_dim> Cursor;
     typedef allocator::tag::host tag;
 
@@ -51,7 +51,7 @@ template<typename Type>
 struct HostMemAllocator<Type, 1>
 {
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
     typedef cursor::BufferCursor<type, 1> Cursor;
     typedef allocator::tag::host tag;
 

--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -39,7 +39,7 @@ struct SharedMemAllocator<Type, Size, 1, uid>
 {
     typedef Type type;
     typedef math::CT::UInt32<> Pitch;
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
     typedef cursor::CT::BufferCursor<type, math::CT::UInt32<> > Cursor;
 
     __device__ static Cursor allocate()
@@ -54,7 +54,7 @@ struct SharedMemAllocator<Type, Size, 2, uid>
 {
     typedef Type type;
     typedef math::CT::UInt32<sizeof(Type) * Size::x::value> Pitch;
-    BOOST_STATIC_CONSTEXPR int dim = 2;
+    static constexpr int dim = 2;
     typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
     __device__ static Cursor allocate()
@@ -70,7 +70,7 @@ struct SharedMemAllocator<Type, Size, 3, uid>
     typedef Type type;
     typedef math::CT::UInt32<sizeof(Type) * Size::x::value,
                              sizeof(Type) * Size::x::value * Size::y::value> Pitch;
-    BOOST_STATIC_CONSTEXPR int dim = 3;
+    static constexpr int dim = 3;
     typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
     __device__ static Cursor allocate()

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -46,7 +46,7 @@ namespace bmpl = boost::mpl;
 template<typename T_Dim = bmpl::_1, typename T_CartBuffer = bmpl::_2>
 struct DeviceMemAssigner
 {
-    BOOST_STATIC_CONSTEXPR int dim = T_Dim::value;
+    static constexpr int dim = T_Dim::value;
     typedef T_CartBuffer CartBuffer;
 
     template<typename Type>

--- a/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -38,7 +38,7 @@ namespace bmpl = boost::mpl;
 template<typename T_Dim = bmpl::_1, typename T_CartBuffer = bmpl::_2>
 struct HostMemAssigner
 {
-    BOOST_STATIC_CONSTEXPR int dim = T_Dim::value;
+    static constexpr int dim = T_Dim::value;
     typedef T_CartBuffer CartBuffer;
 
     template<typename Type>

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -47,7 +47,7 @@ public:
     typedef _Size Size;
     typedef typename Allocator::Pitch Pitch;
     typedef cursor::CT::BufferCursor<Type, Pitch> Cursor;
-    BOOST_STATIC_CONSTEXPR int dim = Size::dim;
+    static constexpr int dim = Size::dim;
     typedef zone::CT::SphericZone<_Size, typename math::CT::make_Int<dim, 0>::type> Zone;
 private:
     Type* dataPointer;

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -37,7 +37,7 @@ namespace copier
 template<int T_dim>
 struct D2DCopier
 {
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
 
     PMACC_NO_NVCC_HDWARNING /* Handled via CUDA_ARCH */
     template<typename Type>

--- a/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
@@ -34,7 +34,7 @@ namespace copier
 template<int T_dim>
 struct H2HCopier
 {
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
 
     PMACC_NO_NVCC_HDWARNING /* Should never be called from device functions */
     template<typename Type>

--- a/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
@@ -67,7 +67,7 @@ namespace traits
 template<typename Type, int T_dim>
 struct dim<BufferCursor<Type, T_dim> >
 {
-    BOOST_STATIC_CONSTEXPR int value = PMacc::cursor::traits::dim<
+    static constexpr int value = PMacc::cursor::traits::dim<
         Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*> >::value;
 };
 

--- a/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
@@ -166,7 +166,7 @@ namespace traits
 template<typename _Accessor, typename _Navigator, typename _Marker>
 struct dim< PMacc::cursor::Cursor<_Accessor, _Navigator, _Marker> >
 {
-    BOOST_STATIC_CONSTEXPR int value = PMacc::cursor::traits::dim<typename Cursor<_Accessor, _Navigator, _Marker>::Navigator >::value;
+    static constexpr int value = PMacc::cursor::traits::dim<typename Cursor<_Accessor, _Navigator, _Marker>::Navigator >::value;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
@@ -37,7 +37,7 @@ template<typename Cursor>
 class SafeCursor : public Cursor
 {
 public:
-    BOOST_STATIC_CONSTEXPR int dim = PMacc::cursor::traits::dim<Cursor>::value;
+    static constexpr int dim = PMacc::cursor::traits::dim<Cursor>::value;
 private:
     /* \todo: Use a zone instead of lowerExtent and UpperExtent */
     const math::Int<dim> lowerExtent;
@@ -145,7 +145,7 @@ namespace traits
 template<typename Cursor>
 struct dim<SafeCursor<Cursor> >
 {
-    BOOST_STATIC_CONSTEXPR int value = SafeCursor<Cursor>::dim;
+    static constexpr int value = SafeCursor<Cursor>::dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -40,7 +40,7 @@ class SafeCursor : public Cursor
 {
 private:
     typedef SafeCursor<Cursor, LowerExtent, UpperExtent> This;
-    BOOST_STATIC_CONSTEXPR int dim = PMacc::cursor::traits::dim<Cursor>::value;
+    static constexpr int dim = PMacc::cursor::traits::dim<Cursor>::value;
     math::Int<dim> offset;
 public:
     HDINLINE SafeCursor(const Cursor& cursor)

--- a/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -38,7 +38,7 @@ class BufferNavigator
 {
 public:
     typedef tag::BufferNavigator tag;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
 private:
     math::Size_t<dim-1> pitch;
 public:
@@ -65,7 +65,7 @@ class BufferNavigator<1>
 {
 public:
     typedef tag::BufferNavigator tag;
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
 
 public:
     HDINLINE
@@ -87,7 +87,7 @@ namespace traits
 template<int T_dim>
 struct dim<BufferNavigator<T_dim> >
 {
-    BOOST_STATIC_CONSTEXPR int value = T_dim;
+    static constexpr int value = T_dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -36,7 +36,7 @@ class CartNavigator
 {
 public:
     typedef tag::CartNavigator tag;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
 private:
     math::Int<dim> factor;
 public:
@@ -64,7 +64,7 @@ namespace traits
 template<int T_dim>
 struct dim<CartNavigator<T_dim> >
 {
-    BOOST_STATIC_CONSTEXPR int value = T_dim;
+    static constexpr int value = T_dim;
 };
 
 } // traits

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
@@ -34,7 +34,7 @@ template<int T_dim>
 class MapTo1DNavigator
 {
 public:
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
 private:
     math::Size_t<dim> shape;
     int pos;

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -35,7 +35,7 @@ template<int T_dim>
 struct MultiIndexNavigator
 {
     typedef tag::MultiIndexNavigator tag;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
 
     template<typename MultiIndex>
     HDINLINE
@@ -51,7 +51,7 @@ namespace traits
 template<int T_dim>
 struct dim<MultiIndexNavigator<T_dim> >
 {
-    BOOST_STATIC_CONSTEXPR int value = T_dim;
+    static constexpr int value = T_dim;
 };
 
 }

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
@@ -38,7 +38,7 @@ struct BufferNavigator;
 template<typename Pitch>
 struct BufferNavigator<Pitch, 1>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
 
     template<typename Data>
     HDINLINE
@@ -53,7 +53,7 @@ struct BufferNavigator<Pitch, 1>
 template<typename Pitch>
 struct BufferNavigator<Pitch, 2>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 2;
+    static constexpr int dim = 2;
 
     template<typename Data>
     HDINLINE
@@ -69,7 +69,7 @@ struct BufferNavigator<Pitch, 2>
 template<typename Pitch>
 struct BufferNavigator<Pitch, 3>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 3;
+    static constexpr int dim = 3;
 
     template<typename Data>
     HDINLINE

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
@@ -37,7 +37,7 @@ struct TwistAxesNavigator;
 template<typename Axes>
 struct TwistAxesNavigator<Axes, 2>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 2;
+    static constexpr int dim = 2;
 
     template<typename TCursor>
     HDINLINE
@@ -53,7 +53,7 @@ struct TwistAxesNavigator<Axes, 2>
 template<typename Axes>
 struct TwistAxesNavigator<Axes, 3>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 3;
+    static constexpr int dim = 3;
 
     template<typename TCursor>
     HDINLINE

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
@@ -37,7 +37,7 @@ struct TwistedAxesNavigator;
 template<typename Axes>
 struct TwistedAxesNavigator<Axes, 2>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 2;
+    static constexpr int dim = 2;
 
     template<typename TCursor>
     HDINLINE
@@ -53,7 +53,7 @@ struct TwistedAxesNavigator<Axes, 2>
 template<typename Axes>
 struct TwistedAxesNavigator<Axes, 3>
 {
-    BOOST_STATIC_CONSTEXPR int dim = 3;
+    static constexpr int dim = 3;
 
     template<typename TCursor>
     HDINLINE

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -47,7 +47,7 @@ template<int T_dim>
 struct SphericZone
 {
     typedef tag::SphericZone tag;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
     math::Size_t<dim> size;
     math::Int<dim> offset;
 

--- a/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
@@ -38,7 +38,7 @@ template<int T_dim>
 struct ToricZone
 {
     typedef tag::ToricZone tag;
-    BOOST_STATIC_CONSTEXPR int dim = T_dim;
+    static constexpr int dim = T_dim;
     math::Size_t<dim> offset;
     math::Size_t<dim> size;
     uint32_t thickness;

--- a/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
@@ -46,7 +46,7 @@ struct SphericZone
 {
     typedef _Size Size;
     typedef _Offset Offset;
-    BOOST_STATIC_CONSTEXPR int dim = Size::dim;
+    static constexpr int dim = Size::dim;
 };
 
 } // CT

--- a/src/libPMacc/include/cudaSpecs.hpp
+++ b/src/libPMacc/include/cudaSpecs.hpp
@@ -37,7 +37,7 @@ namespace cudaSpecs
  */
 
 /** maximum number of threads per block */
-BOOST_CONSTEXPR_OR_CONST uint32_t maxNumThreadsPerBlock = 1024;
+constexpr uint32_t maxNumThreadsPerBlock = 1024;
 
 /** maximum number of threads per axis of a block */
 typedef math::CT::Size_t<1024, 1024, 64> MaxNumThreadsPerBlockDim;

--- a/src/libPMacc/include/debug/VerboseLog.hpp
+++ b/src/libPMacc/include/debug/VerboseLog.hpp
@@ -55,13 +55,13 @@ namespace verboseLog_detail
 template<typename X, typename Y>
 struct IsSameClassType
 {
-    BOOST_STATIC_CONSTEXPR bool result = false;
+    static constexpr bool result = false;
 };
 
 template<typename X>
 struct IsSameClassType<X, X>
 {
-    BOOST_STATIC_CONSTEXPR bool result = true;
+    static constexpr bool result = true;
 };
 
 } //namespace verboseLog_detail
@@ -70,7 +70,7 @@ template<uint64_t lvl_, class membership_>
 struct LogLvl
 {
     typedef membership_ Parent;
-    BOOST_STATIC_CONSTEXPR uint64_t lvl = lvl_;
+    static constexpr uint64_t lvl = lvl_;
 
     /* This operation is only allowed for LogLvl with the same Parent type.
      * Create a LogLvl that contains two levels. At least one lvl has to be true
@@ -91,7 +91,7 @@ class VerboseLog
 {
 private:
     typedef typename LogLevel::Parent LogParent;
-    BOOST_STATIC_CONSTEXPR uint64_t logLvl = LogLevel::lvl;
+    static constexpr uint64_t logLvl = LogLevel::lvl;
 public:
 
     VerboseLog(const char* msg) : fmt(msg)

--- a/src/libPMacc/include/debug/VerboseLogMakros.hpp
+++ b/src/libPMacc/include/debug/VerboseLogMakros.hpp
@@ -40,7 +40,7 @@
  * @param default_lvl must be a integer which represent a defined log lvl
  */
 #define __DEFINE_VERBOSE_CLASS_DEFAULT_LVL(default_lvl) \
-    BOOST_STATIC_CONSTEXPR uint64_t log_level = default_lvl;      \
+    static constexpr uint64_t log_level = default_lvl;      \
     }
 
 /** helper for define log lvl inside of DEFINE_VERBOSE_CLASS

--- a/src/libPMacc/include/dimensions/DataSpace.hpp
+++ b/src/libPMacc/include/dimensions/DataSpace.hpp
@@ -42,7 +42,7 @@ namespace PMacc
     {
     public:
 
-        BOOST_STATIC_CONSTEXPR int Dim=DIM;
+        static constexpr int Dim=DIM;
         typedef math::Vector<int,DIM> BaseType;
 
         /**

--- a/src/libPMacc/include/dimensions/DataSpace.tpp
+++ b/src/libPMacc/include/dimensions/DataSpace.tpp
@@ -47,7 +47,7 @@ struct GetComponentsType<DataSpace<DIM>, false >
 template<unsigned DIM>
 struct GetNComponents<DataSpace<DIM>,false >
 {
-    BOOST_STATIC_CONSTEXPR uint32_t value=DIM;
+    static constexpr uint32_t value=DIM;
 };
 
 }// namespace traits

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -114,7 +114,7 @@ class TaskSetValueBase : public StreamTask
 {
 public:
     typedef T_ValueType ValueType;
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+    static constexpr uint32_t dim = T_dim;
 
     TaskSetValueBase(DeviceBuffer<ValueType, dim>& dst, const ValueType& value) :
     StreamTask(),
@@ -158,7 +158,7 @@ class TaskSetValue<T_ValueType, T_dim, true> : public TaskSetValueBase<T_ValueTy
 {
 public:
     typedef T_ValueType ValueType;
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+    static constexpr uint32_t dim = T_dim;
 
     TaskSetValue(DeviceBuffer<ValueType, dim>& dst, const ValueType& value) :
     TaskSetValueBase<ValueType, dim>(dst, value)
@@ -199,7 +199,7 @@ class TaskSetValue<T_ValueType, T_dim, false> : public TaskSetValueBase<T_ValueT
 {
 public:
     typedef T_ValueType ValueType;
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+    static constexpr uint32_t dim = T_dim;
 
     TaskSetValue(DeviceBuffer<ValueType, dim>& dst, const ValueType& value) :
     TaskSetValueBase<ValueType, dim>(dst, value), valuePointer_host(NULL)

--- a/src/libPMacc/include/lambda/CT/Expression.hpp
+++ b/src/libPMacc/include/lambda/CT/Expression.hpp
@@ -37,19 +37,19 @@ struct Expression;
 template<typename Child0, int _terminalTypeIdx>
 struct Expression<lambda::Expression<exprTypes::terminal, mpl::vector<Child0> >, _terminalTypeIdx>
 {
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = _terminalTypeIdx + 1;
+    static constexpr int nextTerminalTypeIdx = _terminalTypeIdx + 1;
 };
 
 template<int I, int _terminalTypeIdx>
 struct Expression<lambda::Expression<exprTypes::terminal, mpl::vector<placeholder<I> > >, _terminalTypeIdx>
 {
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = _terminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = _terminalTypeIdx;
 };
 
 template<int I, int _terminalTypeIdx>
 struct Expression<lambda::Expression<exprTypes::terminal, mpl::vector<mpl::int_<I> > >, _terminalTypeIdx>
 {
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = _terminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = _terminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -57,7 +57,7 @@ struct Expression<lambda::Expression<exprTypes::assign, mpl::vector<_Child0, _Ch
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -65,7 +65,7 @@ struct Expression<lambda::Expression<exprTypes::plus, mpl::vector<_Child0, _Chil
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -73,7 +73,7 @@ struct Expression<lambda::Expression<exprTypes::minus, mpl::vector<_Child0, _Chi
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -81,7 +81,7 @@ struct Expression<lambda::Expression<exprTypes::multiply, mpl::vector<_Child0, _
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -89,7 +89,7 @@ struct Expression<lambda::Expression<exprTypes::divide, mpl::vector<_Child0, _Ch
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -97,7 +97,7 @@ struct Expression<lambda::Expression<exprTypes::comma, mpl::vector<_Child0, _Chi
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -105,7 +105,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, int _terminalTypeIdx>
@@ -114,7 +114,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
     typedef CT::Expression<_Child2, Child1::nextTerminalTypeIdx> Child2;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child2::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child2::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, typename _Child3, int _terminalTypeIdx>
@@ -124,7 +124,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
     typedef CT::Expression<_Child2, Child1::nextTerminalTypeIdx> Child2;
     typedef CT::Expression<_Child3, Child2::nextTerminalTypeIdx> Child3;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child3::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child3::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, typename _Child3, typename _Child4, int _terminalTypeIdx>
@@ -135,7 +135,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child2, Child1::nextTerminalTypeIdx> Child2;
     typedef CT::Expression<_Child3, Child2::nextTerminalTypeIdx> Child3;
     typedef CT::Expression<_Child4, Child3::nextTerminalTypeIdx> Child4;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child4::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child4::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, typename _Child2, typename _Child3, typename _Child4, typename _Child5, int _terminalTypeIdx>
@@ -147,7 +147,7 @@ struct Expression<lambda::Expression<exprTypes::call, mpl::vector<_Child0, _Chil
     typedef CT::Expression<_Child3, Child2::nextTerminalTypeIdx> Child3;
     typedef CT::Expression<_Child4, Child3::nextTerminalTypeIdx> Child4;
     typedef CT::Expression<_Child5, Child4::nextTerminalTypeIdx> Child5;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child5::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child5::nextTerminalTypeIdx;
 };
 
 template<typename _Child0, typename _Child1, int _terminalTypeIdx>
@@ -155,7 +155,7 @@ struct Expression<lambda::Expression<exprTypes::subscript, mpl::vector<_Child0, 
 {
     typedef CT::Expression<_Child0, _terminalTypeIdx> Child0;
     typedef CT::Expression<_Child1, Child0::nextTerminalTypeIdx> Child1;
-    BOOST_STATIC_CONSTEXPR int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
+    static constexpr int nextTerminalTypeIdx = Child1::nextTerminalTypeIdx;
 };
 
 } // CT

--- a/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
+++ b/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
@@ -31,14 +31,14 @@
 namespace PMacc
 {
 
-template<class BlockArea_, int MaxThreads_ =  math::CT::volume<typename BlockArea_::SuperCellSize>::type::value >
+template<class BlockArea_, int MaxThreads_ = math::CT::volume<typename BlockArea_::SuperCellSize>::type::value >
 class ThreadCollective
 {
 private:
     typedef typename BlockArea_::SuperCellSize SuperCellSize;
     typedef typename BlockArea_::FullSuperCellSize FullSuperCellSize;
     typedef typename BlockArea_::OffsetOrigin OffsetOrigin;
-    BOOST_STATIC_CONSTEXPR int maxThreads=MaxThreads_;
+    static constexpr int maxThreads = MaxThreads_;
 
     enum
     {

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -65,9 +65,9 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
     template<typename T_Type, int T_Dim>                                       \
     struct ConstArrayStorage                                                   \
     {                                                                          \
-        BOOST_STATIC_CONSTEXPR bool isConst = true;                                      \
+        static constexpr bool isConst = true;                                  \
         typedef T_Type type;                                                   \
-        BOOST_STATIC_CONSTEXPR int dim=T_Dim;                                            \
+        static constexpr int dim = T_Dim;                                      \
                                                                                \
         HDINLINE const type& operator[](const int idx) const                   \
         {                                                                      \

--- a/src/libPMacc/include/math/MapTuple.hpp
+++ b/src/libPMacc/include/math/MapTuple.hpp
@@ -110,7 +110,7 @@ Map_, typename mpl::deref<typename mpl::begin<Map_>::type>::type::first>::type, 
 {
 public:
     typedef Map_ Map;
-    BOOST_STATIC_CONSTEXPR int dim = mpl::size<Map>::type::value;
+    static constexpr int dim = mpl::size<Map>::type::value;
 private:
    
     typedef MapTuple<typename mpl::erase_key<

--- a/src/libPMacc/include/math/Tuple.hpp
+++ b/src/libPMacc/include/math/Tuple.hpp
@@ -71,7 +71,7 @@ class Tuple<TypeList, false>
     : public Tuple<typename mpl::pop_front<TypeList>::type>
 {
 public:
-    BOOST_STATIC_CONSTEXPR int dim = mpl::size<TypeList>::type::value;
+    static constexpr int dim = mpl::size<TypeList>::type::value;
     typedef TypeList TypeList_;
 private:
     typedef Tuple<typename mpl::pop_front<TypeList>::type> base;

--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -45,8 +45,8 @@ namespace detail
 template<typename T_Type, int T_Dim>
 struct Vector_components
 {
-    BOOST_STATIC_CONSTEXPR bool isConst = false;
-    BOOST_STATIC_CONSTEXPR int dim = T_Dim;
+    static constexpr bool isConst = false;
+    static constexpr int dim = T_Dim;
     typedef T_Type type;
 
     /*align full vector*/
@@ -116,7 +116,7 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
 {
     typedef T_Storage<T_Type, T_dim> Storage;
     typedef typename Storage::type type;
-    BOOST_STATIC_CONSTEXPR int dim = Storage::dim;
+    static constexpr int dim = Storage::dim;
     typedef tag::Vector tag;
     typedef T_Accessor Accessor;
     typedef T_Navigator Navigator;
@@ -495,7 +495,7 @@ template<typename Type>
 struct Vector<Type, 0 >
 {
     typedef Type type;
-    BOOST_STATIC_CONSTEXPR int dim = 0;
+    static constexpr int dim = 0;
 
     template<typename OtherType >
     HDINLINE operator Vector<OtherType, 0 > () const

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -47,7 +47,7 @@ struct GetComponentsType<PMacc::math::Vector<T_DataType, T_Dim>, false >
 template<typename T_DataType, int T_Dim>
 struct GetNComponents<PMacc::math::Vector<T_DataType, T_Dim>,false >
 {
-    BOOST_STATIC_CONSTEXPR uint32_t value = (uint32_t) PMacc::math::Vector<T_DataType, T_Dim>::dim;
+    static constexpr uint32_t value = (uint32_t) PMacc::math::Vector<T_DataType, T_Dim>::dim;
 };
 
 template<typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, template<typename, int> class T_Storage>

--- a/src/libPMacc/include/math/vector/compile-time/Float.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Float.hpp
@@ -43,7 +43,7 @@ struct Float
     typedef Y y;
     typedef Z z;
 
-    BOOST_STATIC_CONSTEXPR int dim = 3;
+    static constexpr int dim = 3;
 };
 
 template<>
@@ -54,7 +54,7 @@ struct Float<X>
 {
     typedef X x;
 
-    BOOST_STATIC_CONSTEXPR int dim = 1;
+    static constexpr int dim = 1;
 };
 
 template<typename X, typename Y>
@@ -63,7 +63,7 @@ struct Float<X, Y>
     typedef X x;
     typedef Y y;
 
-    BOOST_STATIC_CONSTEXPR int dim = 2u;
+    static constexpr int dim = 2u;
 };
 
 } // CT

--- a/src/libPMacc/include/math/vector/compile-time/Vector.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Vector.hpp
@@ -135,7 +135,7 @@ struct Vector
         typedef typename mpl::at_c<mplVector, element>::type type;
     };
 
-    BOOST_STATIC_CONSTEXPR int dim = mpl::size<mplVector >::type::value;
+    static constexpr int dim = mpl::size<mplVector >::type::value;
 
     typedef typename detail::TypeSelector<x>::type type;
     typedef Vector<x, y, z> This;

--- a/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
@@ -36,7 +36,7 @@ class DataBoxDim1Access : protected T_Base
 public:
 
     typedef T_Base Base;
-    BOOST_STATIC_CONSTEXPR uint32_t Dim= Base::Dim;
+    static constexpr uint32_t Dim = Base::Dim;
 
 
     typedef typename Base::ValueType ValueType;

--- a/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
@@ -48,7 +48,7 @@ public:
 
     typedef typename UnaryFunctor::result ValueType;
     typedef ValueType RefValueType;
-    BOOST_STATIC_CONSTEXPR uint32_t Dim = Base::Dim;
+    static constexpr uint32_t Dim = Base::Dim;
 
     HDINLINE DataBoxUnaryTransform(const Base& base) : Base(base)
     {

--- a/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
@@ -42,8 +42,8 @@ template<typename Type_, uint32_t communicationTag_ = 0, bool sizeOnDevice_ = fa
         struct TypeDescriptionElement
 {
     typedef Type_ Type;
-    BOOST_STATIC_CONSTEXPR uint32_t communicationTag = communicationTag_;
-    BOOST_STATIC_CONSTEXPR bool sizeOnDevice = sizeOnDevice_;
+    static constexpr uint32_t communicationTag = communicationTag_;
+    static constexpr bool sizeOnDevice = sizeOnDevice_;
 
 
 };
@@ -62,7 +62,7 @@ template<typename Type_, uint32_t communicationTag_ = 0, bool sizeOnDevice_ = fa
  *  struct Mem
  *  {
  *    enum Names{VALUE1,VALUE2};
- *    BOOST_STATIC_CONSTEXPR uint32_t Count=2;
+ *    static constexpr uint32_t Count=2;
  *  };
  * @tparam BORDERTYPE optional type for border data in the buffers. TYPE is used by default.
  */

--- a/src/libPMacc/include/particles/IdProvider.hpp
+++ b/src/libPMacc/include/particles/IdProvider.hpp
@@ -133,7 +133,7 @@ namespace PMacc {
         }
 
         // Number of bits in the ids
-        BOOST_STATIC_CONSTEXPR int32_t numBitsOfType = sizeof(curState.maxNumProc) * CHAR_BIT;
+        static constexpr int32_t numBitsOfType = sizeof(curState.maxNumProc) * CHAR_BIT;
 
         // Get current id
         uint64_t nextId = curState.nextId;

--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -51,7 +51,7 @@ public:
     typedef SuperCell<FrameType> SuperCellType;
     typedef DataBox<PitchedBox<SuperCell<FrameType>, DIM> > BaseType;
 
-    BOOST_STATIC_CONSTEXPR uint32_t Dim = DIM;
+    static constexpr uint32_t Dim = DIM;
 
     /** default constructor
      *

--- a/src/libPMacc/include/particles/memory/dataTypes/StaticArray.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/StaticArray.hpp
@@ -35,7 +35,7 @@ template<typename T_Type, typename T_size>
 class StaticArray
 {
 public:
-    BOOST_STATIC_CONSTEXPR uint32_t size = T_size::value;
+    static constexpr uint32_t size = T_size::value;
     typedef T_Type Type;
 private:
     Type data[size];

--- a/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
+++ b/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
@@ -72,8 +72,8 @@ __global__ void splitIntoListOfFrames(
     typedef typename T_DestBox::FrameType DestFrameType;
     typedef typename T_DestBox::FramePtr DestFramePtr;
     typedef typename T_CellDescription::SuperCellSize SuperCellSize;
-    BOOST_CONSTEXPR_OR_CONST unsigned NumDims = T_DestBox::Dim;
-    BOOST_CONSTEXPR_OR_CONST uint32_t particlesPerFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+    constexpr unsigned NumDims = T_DestBox::Dim;
+    constexpr uint32_t particlesPerFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
     __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<DestFramePtr>::type destFramePtr[particlesPerFrame];
     __shared__ int linearSuperCellIds[particlesPerFrame];

--- a/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
@@ -39,7 +39,7 @@ template<unsigned T_dim, class Base = NullFrame>
 class PositionFilter : public Base
 {
 public:
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+    static constexpr uint32_t dim = T_dim;
 protected:
     DataSpace<dim> offset;
     DataSpace<dim> max;

--- a/src/libPMacc/include/pmacc_types.hpp
+++ b/src/libPMacc/include/pmacc_types.hpp
@@ -33,7 +33,7 @@
 #include <boost/mpl/placeholders.hpp>
 #include <boost/filesystem.hpp>
 
-// Allows use of C++11/C++98 compatibility macros like BOOST_CONSTEXPR
+// compatibility macros (compiler or C++ standard version specific)
 #include <boost/config.hpp>
 
 #include <builtin_types.h>

--- a/src/libPMacc/include/preprocessor/struct.hpp
+++ b/src/libPMacc/include/preprocessor/struct.hpp
@@ -46,7 +46,7 @@
  *     e.g. (0,(_,myName,_))
  */
 
-/** create BOOST_STATIC_CONSTEXPR member vector that needs no memory inside of the struct
+/** create static constexpr member vector that needs no memory inside of the struct
  *
  *   @param type type of an element (types containing a comma are not allowed (e.g. `Vector<type,dim>`)
  *               use `typedef Vector<type,dim> NewType;` to avoid this behavior
@@ -56,7 +56,7 @@
  *   @code{.cpp}
  *     PMACC_C_VECTOR(float2_64, center_SI, 1.134e-5, 1.134e-5);
  *     // is the compile time equivalent of
- *     BOOST_STATIC_CONSTEXPR float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);
+ *     static constexpr float2_64 center_SI = float2_64(1.134e-5, 1.134e-5);
  *   @endcode
  */
 #define PMACC_C_VECTOR(type,name,...) (0,(typename PMacc::traits::GetValueType<type>::type, \
@@ -65,7 +65,7 @@
                                           __VA_ARGS__))
 
 
-/** create BOOST_STATIC_CONSTEXPR member vector that needs no memory inside of the struct
+/** create static constexpr member vector that needs no memory inside of the struct
  *
  *   @param type type of an element
  *   @param dim number of vector components
@@ -75,12 +75,12 @@
  *   @code{.cpp}
  *     PMACC_C_VECTOR_DIM(float_64, simDim, center_SI, 1.134e-5, 1.134e-5, 1.134e-5);
  *     // is the compile time equivalent of
- *     BOOST_STATIC_CONSTEXPR Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);
+ *     static constexpr Vector<float_64,simDim> center_SI = Vector<float_64,simDim>(1.134e-5, 1.134e-5, 1.134e-5);
  *   @endcode
  */
 #define PMACC_C_VECTOR_DIM(type,dim,name,...) (0,(type,name,dim,__VA_ARGS__))
 
-/** create BOOST_STATIC_CONSTEXPR member
+/** create static constexpr member
  *
  *   @param type type of the member
  *   @param name member variable name
@@ -89,7 +89,7 @@
  *   @code{.cpp}
  *     PMACC_C_VALUE(float_64, power_SI, 2.0);
  *     // is the compile time equivalent of
- *     BOOST_STATIC_CONSTEXPR float_64 power_SI = float_64(2.0);
+ *     static constexpr float_64 power_SI = float_64(2.0);
  *   @endcode
  */
 #define PMACC_C_VALUE(type,name,value) (1,(type,name,value))
@@ -145,7 +145,7 @@
          )                                                                     \
         )
 
-/** create BOOST_STATIC_CONSTEXPR character string
+/** create static constexpr character string
  *
  *   @param name member variable name
  *   @param char_string character string
@@ -153,7 +153,7 @@
  *   @code{.cpp}
  *     PMACC_C_STRING(filename, "fooFile.txt");
  *     // is the compile time equivalent of
- *     BOOST_STATIC_CONSTEXPR char* filename = (char*)"fooFile.tyt";
+ *     static constexpr char* filename = (char*)"fooFile.txt";
  *   @endcode
  */
 #define PMACC_C_STRING(name,initValue) (3,(_,name,initValue))
@@ -223,7 +223,7 @@
 #define PMACC_PP_CREATE_VALUE_VARIABLE_WITH_PAREN(elem)                        \
     PMACC_PP_SELECT_TYPEID( 5,PMACC_PP_X_CREATE_VALUE_VARIABLE_WITH_PAREN, elem )
 
-#define PMACC_PP_X_CREATE_C_VALUE_VARIABLE(data,type,name,...) BOOST_STATIC_CONSTEXPR type name = __VA_ARGS__;
+#define PMACC_PP_X_CREATE_C_VALUE_VARIABLE(data,type,name,...) static constexpr type name = __VA_ARGS__;
 #define PMACC_PP_CREATE_C_VALUE_VARIABLE(elem)                                 \
     PMACC_PP_SELECT_TYPEID( 1,PMACC_PP_X_CREATE_C_VALUE_VARIABLE,elem )
 

--- a/src/libPMacc/include/random/RNGHandle.hpp
+++ b/src/libPMacc/include/random/RNGHandle.hpp
@@ -38,7 +38,7 @@ namespace random
     struct RNGHandle
     {
         typedef T_RNGProvider RNGProvider;
-        BOOST_STATIC_CONSTEXPR uint32_t rngDim = RNGProvider::dim;
+        static constexpr uint32_t rngDim = RNGProvider::dim;
         typedef typename RNGProvider::DataBoxType RNGBox;
         typedef typename RNGProvider::RNGMethod RNGMethod;
         typedef typename RNGMethod::StateType RNGState;

--- a/src/libPMacc/include/random/RNGProvider.hpp
+++ b/src/libPMacc/include/random/RNGProvider.hpp
@@ -44,7 +44,7 @@ namespace random
     class RNGProvider: ISimulationData
     {
     public:
-        BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+        static constexpr uint32_t dim = T_dim;
         typedef T_RNGMethod RNGMethod;
         typedef DataSpace<dim> Space;
 

--- a/src/libPMacc/include/traits/GetNComponents.hpp
+++ b/src/libPMacc/include/traits/GetNComponents.hpp
@@ -42,7 +42,7 @@ struct GetNComponents;
 template<typename T_Type>
 struct GetNComponents<T_Type, true>
 {
-    BOOST_STATIC_CONSTEXPR uint32_t value=1;
+    static constexpr uint32_t value=1;
 };
 
 } //namespace traits

--- a/src/libPMacc/include/traits/IsSameType.hpp
+++ b/src/libPMacc/include/traits/IsSameType.hpp
@@ -35,13 +35,13 @@ namespace PMacc
     template< typename T1, typename T2 >
     struct IsSameType
     {
-        BOOST_STATIC_CONSTEXPR bool result = false;
+        static constexpr bool result = false;
     };
 
     template< typename T1 >
     struct IsSameType< T1, T1 >
     {
-        BOOST_STATIC_CONSTEXPR bool result = true;
+        static constexpr bool result = true;
     };
 
 } // namespace PMacc

--- a/src/libPMacc/include/traits/Limits.tpp
+++ b/src/libPMacc/include/traits/Limits.tpp
@@ -37,19 +37,19 @@ namespace limits
 template<>
 struct Max<int>
 {
-    BOOST_STATIC_CONSTEXPR int value=INT_MAX;
+    static constexpr int value=INT_MAX;
 };
 
 template<>
 struct Max<uint32_t>
 {
-    BOOST_STATIC_CONSTEXPR uint32_t value=static_cast<uint32_t>(-1);
+    static constexpr uint32_t value=static_cast<uint32_t>(-1);
 };
 
 template<>
 struct Max<uint64_t>
 {
-    BOOST_STATIC_CONSTEXPR uint64_t value=static_cast<uint64_t>(-1);
+    static constexpr uint64_t value=static_cast<uint64_t>(-1);
 };
 
 } //namespace limits

--- a/src/libPMacc/include/traits/NumberOfExchanges.hpp
+++ b/src/libPMacc/include/traits/NumberOfExchanges.hpp
@@ -41,19 +41,19 @@ struct NumberOfExchanges;
 template<>
 struct NumberOfExchanges<DIM1>
 {
-    BOOST_STATIC_CONSTEXPR uint32_t value = LEFT + RIGHT;
+    static constexpr uint32_t value = LEFT + RIGHT;
 };
 
 template<>
 struct NumberOfExchanges<DIM2>
 {
-    BOOST_STATIC_CONSTEXPR uint32_t value = TOP + BOTTOM;
+    static constexpr uint32_t value = TOP + BOTTOM;
 };
 
 template<>
 struct NumberOfExchanges<DIM3>
 {
-    BOOST_STATIC_CONSTEXPR uint32_t value = BACK + FRONT;
+    static constexpr uint32_t value = BACK + FRONT;
 };
 
 } //namespace traits

--- a/src/libPMacc/test/particles/IdProvider.hpp
+++ b/src/libPMacc/test/particles/IdProvider.hpp
@@ -88,11 +88,11 @@ struct IdProviderTest
 {
     void operator()()
     {
-        BOOST_CONSTEXPR_OR_CONST uint32_t numBlocks = 4;
-        BOOST_CONSTEXPR_OR_CONST uint32_t numThreadsPerBlock = 64;
-        BOOST_CONSTEXPR_OR_CONST uint32_t numThreads = numBlocks * numThreadsPerBlock;
-        BOOST_CONSTEXPR_OR_CONST uint32_t numIdsPerThread = 2;
-        BOOST_CONSTEXPR_OR_CONST uint32_t numIds = numThreads * numIdsPerThread;
+        constexpr uint32_t numBlocks = 4;
+        constexpr uint32_t numThreadsPerBlock = 64;
+        constexpr uint32_t numThreads = numBlocks * numThreadsPerBlock;
+        constexpr uint32_t numIdsPerThread = 2;
+        constexpr uint32_t numIds = numThreads * numIdsPerThread;
 
         typedef PMacc::IdProvider<T_dim> IdProvider;
         IdProvider::init();

--- a/src/picongpu/include/algorithms/DifferenceToLower.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToLower.hpp
@@ -39,7 +39,7 @@ using namespace PMacc;
 template<uint32_t T_Dim>
 struct DifferenceToLower
 {
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_Dim;
+    static constexpr uint32_t dim = T_Dim;
 
 
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type OffsetOrigin;
@@ -53,7 +53,7 @@ struct DifferenceToLower
     template<uint32_t T_direction, bool T_isLesserThanDim = (T_direction < dim)>
     struct GetDifference
     {
-        BOOST_STATIC_CONSTEXPR uint32_t direction = T_direction;
+        static constexpr uint32_t direction = T_direction;
 
         /** get difference to lower value
          * @return difference divided by cell size of the given direction

--- a/src/picongpu/include/algorithms/DifferenceToUpper.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToUpper.hpp
@@ -38,7 +38,7 @@ namespace picongpu
 template<uint32_t T_Dim>
 struct DifferenceToUpper
 {
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_Dim;
+    static constexpr uint32_t dim = T_Dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type OffsetOrigin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type OffsetEnd;
@@ -51,7 +51,7 @@ struct DifferenceToUpper
     template<uint32_t T_direction, bool T_isLesserThanDim = (T_direction < dim)>
     struct GetDifference
     {
-        BOOST_STATIC_CONSTEXPR uint32_t direction = T_direction;
+        static constexpr uint32_t direction = T_direction;
 
         /** get difference to lower value
          * @return difference divided by cell size of the given direction

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
@@ -44,16 +44,16 @@ template<class T_Shape, class InterpolationMethod>
 struct FieldToParticleInterpolation
 {
     typedef typename T_Shape::ChargeAssignmentOnSupport AssignmentFunction;
-    BOOST_STATIC_CONSTEXPR int supp = AssignmentFunction::support;
+    static constexpr int supp = AssignmentFunction::support;
 
-    BOOST_STATIC_CONSTEXPR int lowerMargin = supp / 2 ;
-    BOOST_STATIC_CONSTEXPR int upperMargin = (supp + 1) / 2;
+    static constexpr int lowerMargin = supp / 2 ;
+    static constexpr int upperMargin = (supp + 1) / 2;
     typedef typename PMacc::math::CT::make_Int<simDim,lowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim,upperMargin>::type UpperMargin;
 
     /*(supp + 1) % 2 is 1 for even supports else 0*/
-    BOOST_STATIC_CONSTEXPR int begin = -supp / 2 + (supp + 1) % 2;
-    BOOST_STATIC_CONSTEXPR int end = begin+supp-1;
+    static constexpr int begin = -supp / 2 + (supp + 1) % 2;
+    static constexpr int end = begin+supp-1;
 
     template<class Cursor, class VecVector>
     HDINLINE typename Cursor::ValueType operator()(Cursor field,

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
@@ -44,10 +44,10 @@ template<class T_Shape, class InterpolationMethod>
 struct FieldToParticleInterpolationNative
 {
     typedef typename T_Shape::ChargeAssignment AssignmentFunction;
-    BOOST_STATIC_CONSTEXPR int supp = AssignmentFunction::support;
+    static constexpr int supp = AssignmentFunction::support;
 
-    BOOST_STATIC_CONSTEXPR int lowerMargin = supp / 2;
-    BOOST_STATIC_CONSTEXPR int upperMargin = (supp + 1) / 2;
+    static constexpr int lowerMargin = supp / 2;
+    static constexpr int upperMargin = (supp + 1) / 2;
     typedef typename PMacc::math::CT::make_Int<simDim,lowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim,upperMargin>::type UpperMargin;
 

--- a/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
+++ b/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
@@ -38,7 +38,7 @@ namespace picongpu
 template<uint32_t T_Dim>
 struct LinearInterpolateWithUpper
 {
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_Dim;
+    static constexpr uint32_t dim = T_Dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type OffsetOrigin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type OffsetEnd;
@@ -51,7 +51,7 @@ struct LinearInterpolateWithUpper
     template<uint32_t T_direction, bool T_isLesserThanDim = (T_direction < dim)>
     struct GetInterpolatedValue
     {
-        BOOST_STATIC_CONSTEXPR uint32_t direction = T_direction;
+        static constexpr uint32_t direction = T_direction;
 
         /** get interpolated value
          * @return interpolated value

--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -54,7 +54,7 @@ namespace picongpu
     public:
         typedef float3_X ValueType;
         typedef promoteType<float_64, ValueType>::type UnitValueType;
-        BOOST_STATIC_CONSTEXPR int numComponents = ValueType::dim;
+        static constexpr int numComponents = ValueType::dim;
 
         typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
 

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -53,7 +53,7 @@ namespace picongpu
     public:
         typedef float3_X ValueType;
         typedef promoteType<float_64, ValueType>::type UnitValueType;
-        BOOST_STATIC_CONSTEXPR int numComponents = ValueType::dim;
+        static constexpr int numComponents = ValueType::dim;
 
         typedef MappingDesc::SuperCellSize SuperCellSize;
 

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -62,7 +62,7 @@ public:
 
     typedef float3_X ValueType;
     typedef promoteType<float_64, ValueType>::type UnitValueType;
-    BOOST_STATIC_CONSTEXPR int numComponents = ValueType::dim;
+    static constexpr int numComponents = ValueType::dim;
 
     typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
 

--- a/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.hpp
@@ -38,16 +38,16 @@ template<
 struct EmZ
 {
     typedef typename T_ParticleShape::ChargeAssignmentOnSupport ParticleAssign;
-    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
+    static constexpr int supp = ParticleAssign::support;
 
-    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
-    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
+    static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef typename PMacc::math::CT::make_Int<simDim, currentLowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim, currentUpperMargin>::type UpperMargin;
 
 
-    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin + 1;
-    BOOST_STATIC_CONSTEXPR int end = begin + supp;
+    static constexpr int begin = -currentLowerMargin + 1;
+    static constexpr int end = begin + supp;
 
 
     /** deposit the current of a particle
@@ -85,7 +85,7 @@ struct EmZ
         /* calculate the relay point for the trajectory splitting */
         for ( uint32_t d = 0; d < simDim; ++d )
         {
-            BOOST_CONSTEXPR_OR_CONST bool isSupportEven = ( supp % 2 == 0 );
+            constexpr bool isSupportEven = ( supp % 2 == 0 );
             relayPoint[d] = RelayPoint< isSupportEven >()(
                 I[0][d],
                 I[1][d],

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -39,10 +39,10 @@ template<typename T_ParticleShape>
 struct Esirkepov<T_ParticleShape, DIM3>
 {
     typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
-    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
+    static constexpr int supp = ParticleAssign::support;
 
-    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
-    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
+    static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef PMacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
     typedef PMacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
 
@@ -54,8 +54,8 @@ struct Esirkepov<T_ParticleShape, DIM3>
      * For the case were previous position is greater than current position we correct
      * begin and end on runtime and add +1 to begin and end.
      */
-    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin;
-    BOOST_STATIC_CONSTEXPR int end = begin + supp + 1;
+    static constexpr int begin = -currentLowerMargin;
+    static constexpr int end = begin + supp + 1;
 
     float_X charge;
 

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -47,10 +47,10 @@ template<typename T_ParticleShape>
 struct Esirkepov<T_ParticleShape, DIM2>
 {
     typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
-    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
+    static constexpr int supp = ParticleAssign::support;
 
-    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
-    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
+    static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef typename PMacc::math::CT::make_Int<DIM2, currentLowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<DIM2, currentUpperMargin>::type UpperMargin;
 
@@ -62,8 +62,8 @@ struct Esirkepov<T_ParticleShape, DIM2>
      * For the case were previous position is greater than current position we correct
      * begin and end on runtime and add +1 to begin and end.
      */
-    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin;
-    BOOST_STATIC_CONSTEXPR int end = begin + supp + 1;
+    static constexpr int begin = -currentLowerMargin;
+    static constexpr int end = begin + supp + 1;
 
     float_X charge;
 

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -48,17 +48,17 @@ template<typename T_ParticleShape>
 struct EsirkepovNative
 {
     typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
-    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
+    static constexpr int supp = ParticleAssign::support;
 
-    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1;
-    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
+    static constexpr int currentLowerMargin = supp / 2 + 1;
+    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef PMacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
     typedef PMacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
 
 
     /* iterate over all grid points */
-    BOOST_STATIC_CONSTEXPR int begin = -currentLowerMargin;
-    BOOST_STATIC_CONSTEXPR int end = currentUpperMargin + 1;
+    static constexpr int begin = -currentLowerMargin;
+    static constexpr int end = currentUpperMargin + 1;
 
     float_X charge;
 

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -142,10 +142,10 @@ struct ZigZag
      */
     typedef T_ParticleShape ParticleShape;
     typedef typename ParticleShape::ChargeAssignmentOnSupport ParticleAssign;
-    BOOST_STATIC_CONSTEXPR int supp = ParticleAssign::support;
+    static constexpr int supp = ParticleAssign::support;
 
-    BOOST_STATIC_CONSTEXPR int currentLowerMargin = supp / 2 + 1;
-    BOOST_STATIC_CONSTEXPR int currentUpperMargin = (supp + 1) / 2 + 1;
+    static constexpr int currentLowerMargin = supp / 2 + 1;
+    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
     typedef typename PMacc::math::CT::make_Int<simDim, currentLowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim, currentUpperMargin>::type UpperMargin;
 
@@ -154,15 +154,15 @@ struct ZigZag
      * @see ShiftCoordinateSystem
      * grid points were we calculate the current [begin;end)
      */
-    BOOST_STATIC_CONSTEXPR int begin = -supp / 2 + (supp + 1) % 2;
-    BOOST_STATIC_CONSTEXPR int end = begin + supp;
+    static constexpr int begin = -supp / 2 + (supp + 1) % 2;
+    static constexpr int end = begin + supp;
 
     /* same as begin and end but for the direction where we calculate j
      * supp_dir = support of the cloud shape
      */
-    BOOST_STATIC_CONSTEXPR int supp_dir = supp - 1;
-    BOOST_STATIC_CONSTEXPR int dir_begin = -supp_dir / 2 + (supp_dir + 1) % 2;
-    BOOST_STATIC_CONSTEXPR int dir_end = dir_begin + supp_dir;
+    static constexpr int supp_dir = supp - 1;
+    static constexpr int dir_begin = -supp_dir / 2 + (supp_dir + 1) % 2;
+    static constexpr int dir_end = dir_begin + supp_dir;
 
     /** functor to calculate current for one direction
      *

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -34,7 +34,7 @@ using namespace PMacc;
 template<uint32_t T_dim>
 struct Binomial
 {
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+    static constexpr uint32_t dim = T_dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type UpperMargin;

--- a/src/picongpu/include/fields/currentInterpolation/None/None.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.hpp
@@ -34,7 +34,7 @@ using namespace PMacc;
 template<uint32_t T_dim>
 struct None
 {
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_dim;
+    static constexpr uint32_t dim = T_dim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type UpperMargin;

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -42,7 +42,7 @@ namespace detail
     template<uint32_t T_simDim, uint32_t T_plane>
     struct LinearInterpolateComponentPlaneUpper
     {
-        BOOST_STATIC_CONSTEXPR uint32_t dim = T_simDim;
+        static constexpr uint32_t dim = T_simDim;
 
         /* UpperMargin is actually 0 in direction of T_plane */
         typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
@@ -81,8 +81,8 @@ namespace detail
     template<uint32_t T_simDim, uint32_t T_direction, bool isShiftAble=(T_direction<T_simDim) >
     struct ShiftMeIfYouCan
     {
-        BOOST_STATIC_CONSTEXPR uint32_t dim = T_simDim;
-        BOOST_STATIC_CONSTEXPR uint32_t dir = T_direction;
+        static constexpr uint32_t dim = T_simDim;
+        static constexpr uint32_t dir = T_direction;
 
         template<class T_DataBox >
         HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
@@ -131,7 +131,7 @@ namespace detail
 template<uint32_t T_simDim>
 struct NoneDS
 {
-    BOOST_STATIC_CONSTEXPR uint32_t dim = T_simDim;
+    static constexpr uint32_t dim = T_simDim;
 
     typedef typename PMacc::math::CT::make_Int<dim, 0>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<dim, 1>::type UpperMargin;

--- a/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
@@ -39,7 +39,7 @@ class TaskFieldReceiveAndInsert : public MPITask
 public:
 
 
-    BOOST_STATIC_CONSTEXPR uint32_t Dim = picongpu::simDim;
+    static constexpr uint32_t Dim = picongpu::simDim;
 
     TaskFieldReceiveAndInsert(Field &buffer) :
     m_buffer(buffer),

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK.def
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK.def
@@ -61,7 +61,7 @@ namespace ionization
     {
         /* Boolean value that results in an additional polarization factor in
          * the ionization rate for linear polarization */
-        BOOST_STATIC_CONSTEXPR bool linPol = true;
+        static constexpr bool linPol = true;
         typedef particles::ionization::AlgorithmADK<linPol> IonizationAlgorithm;
         typedef ADK_Impl<IonizationAlgorithm, T_DestSpecies> type;
     };
@@ -87,7 +87,7 @@ namespace ionization
     {
         /* Boolean value that results in an additional polarization factor in
          * the ionization rate for linear polarization */
-        BOOST_STATIC_CONSTEXPR bool linPol = false;
+        static constexpr bool linPol = false;
         typedef particles::ionization::AlgorithmADK<linPol> IonizationAlgorithm;
         typedef ADK_Impl<IonizationAlgorithm, T_DestSpecies> type;
     };

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -58,8 +58,8 @@ struct CreateParticlesFromParticleImpl : private T_Functor
 
 
     typedef T_Functor Functor;
-    BOOST_STATIC_CONSTEXPR uint32_t particlePerParticle = T_Count::value;
-    BOOST_STATIC_CONSTEXPR int cellsInSuperCell = (int)PMacc::math::CT::volume<SuperCellSize>::type::value;
+    static constexpr uint32_t particlePerParticle = T_Count::value;
+    static constexpr int cellsInSuperCell = (int)PMacc::math::CT::volume<SuperCellSize>::type::value;
 
     HINLINE CreateParticlesFromParticleImpl(uint32_t currentStep) : Functor(currentStep)
     {

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -41,10 +41,10 @@ class ComputeGridValuePerFrame
 public:
 
     typedef typename T_ParticleShape::ChargeAssignment AssignmentFunction;
-    BOOST_STATIC_CONSTEXPR int supp = AssignmentFunction::support;
+    static constexpr int supp = AssignmentFunction::support;
 
-    BOOST_STATIC_CONSTEXPR int lowerMargin = supp / 2;
-    BOOST_STATIC_CONSTEXPR int upperMargin = (supp + 1) / 2;
+    static constexpr int lowerMargin = supp / 2;
+    static constexpr int upperMargin = (supp + 1) / 2;
     typedef typename PMacc::math::CT::make_Int<simDim, lowerMargin>::type LowerMargin;
     typedef typename PMacc::math::CT::make_Int<simDim, upperMargin>::type UpperMargin;
 

--- a/src/picongpu/include/particles/shapes/CIC.hpp
+++ b/src/picongpu/include/particles/shapes/CIC.hpp
@@ -37,7 +37,7 @@ struct CIC
      * width of the support of this form_factor. This is the area where the function
      * is non-zero.
      */
-    BOOST_STATIC_CONSTEXPR int support = 2;
+    static constexpr int support = 2;
 };
 
 }//namespace shared_CIC

--- a/src/picongpu/include/particles/shapes/Counter.hpp
+++ b/src/picongpu/include/particles/shapes/Counter.hpp
@@ -39,7 +39,7 @@ namespace shapes
              * width of the support of this form_factor. This is the area where the function
              * is non-zero.
              */
-            BOOST_STATIC_CONSTEXPR int support = 0;
+            static constexpr int support = 0;
         };
 
     } // namespace shared_Counter

--- a/src/picongpu/include/particles/shapes/NGP.hpp
+++ b/src/picongpu/include/particles/shapes/NGP.hpp
@@ -39,7 +39,7 @@ namespace shapes
              * width of the support of this form_factor. This is the area where the function
              * is non-zero.
              */
-            BOOST_STATIC_CONSTEXPR int support = 1;
+            static constexpr int support = 1;
         };
 
     } // namespace shared_NGP

--- a/src/picongpu/include/particles/shapes/P4S.hpp
+++ b/src/picongpu/include/particles/shapes/P4S.hpp
@@ -34,7 +34,7 @@ namespace shared_P4S
 
 struct P4S
 {
-    BOOST_STATIC_CONSTEXPR int support = 5;
+    static constexpr int support = 5;
 
     HDINLINE static float_X ff_1st_radius(const float_X x)
     {

--- a/src/picongpu/include/particles/shapes/PCS.hpp
+++ b/src/picongpu/include/particles/shapes/PCS.hpp
@@ -33,7 +33,7 @@ namespace shared_PCS
 {
 struct PCS
 {
-    BOOST_STATIC_CONSTEXPR int support = 4;
+    static constexpr int support = 4;
 
 
 

--- a/src/picongpu/include/particles/shapes/TSC.hpp
+++ b/src/picongpu/include/particles/shapes/TSC.hpp
@@ -39,7 +39,7 @@ struct TSC
      * width of the support of this form_factor. This is the area where the function
      * is non-zero.
      */
-    BOOST_STATIC_CONSTEXPR int support = 3;
+    static constexpr int support = 3;
 
 
     HDINLINE static float_X ff_1st_radius(const float_X x)

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
@@ -74,8 +74,8 @@ namespace picongpu
             bmpl::int_<0>,
             bmpl::max<bmpl::_1, bmpl::_2>
             >::type SuperCellsLongestEdge;
-        BOOST_STATIC_CONSTEXPR uint32_t maxShared = 32*1024; /* 32 KB */
-        BOOST_STATIC_CONSTEXPR uint32_t num_pbins = maxShared/(sizeof(float_PS)*SuperCellsLongestEdge::value);
+        static constexpr uint32_t maxShared = 32*1024; /* 32 KB */
+        static constexpr uint32_t num_pbins = maxShared/(sizeof(float_PS)*SuperCellsLongestEdge::value);
 
         container::DeviceBuffer<float_PS, 2>* dBuffer;
 

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -550,7 +550,7 @@ private:
    *  Return:
    *  std::string - name
    *
-   * This method avoids initializing BOOST_STATIC_CONSTEXPR string arrays.
+   * This method avoids initializing static constexpr string arrays.
    */
   static const std::string dataLabels(int index)
   {

--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -32,7 +32,7 @@ class Amplitude
 {
 public:
   /* number of scalar components in Amplitude = 3 (3D) * 2 (complex) = 6 */
-  BOOST_STATIC_CONSTEXPR uint32_t numComponents = uint32_t(3) * uint32_t(sizeof(complex_64) / sizeof(typename complex_64::type));
+  static constexpr uint32_t numComponents = uint32_t(3) * uint32_t(sizeof(complex_64) / sizeof(typename complex_64::type));
 
   /** constructor
    *

--- a/src/picongpu/include/simulation_defines/param/dimension.param
+++ b/src/picongpu/include/simulation_defines/param/dimension.param
@@ -24,5 +24,5 @@
 
 namespace picongpu
 {
-    BOOST_CONSTEXPR_OR_CONST uint32_t simDim = SIMDIM;
+    constexpr uint32_t simDim = SIMDIM;
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/fieldBackground.param
+++ b/src/picongpu/include/simulation_defines/param/fieldBackground.param
@@ -29,7 +29,7 @@ namespace picongpu
     {
     public:
         /* Add this additional field for pushing particles */
-        BOOST_STATIC_CONSTEXPR bool InfluenceParticlePusher = false;
+        static constexpr bool InfluenceParticlePusher = false;
 
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
@@ -46,7 +46,7 @@ namespace picongpu
                     const uint32_t currentStep ) const
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */
-            BOOST_CONSTEXPR_OR_CONST float_64 period_SI(20.0e-6);
+            constexpr float_64 period_SI(20.0e-6);
             /* calculate cells -> SI -> m to microns*/
             const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI * 1.0e6;
             /* note: you can also transform the time step to seconds by
@@ -62,7 +62,7 @@ namespace picongpu
     {
     public:
         /* Add this additional field for pushing particles */
-        BOOST_STATIC_CONSTEXPR bool InfluenceParticlePusher = false;
+        static constexpr bool InfluenceParticlePusher = false;
 
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
@@ -79,7 +79,7 @@ namespace picongpu
                     const uint32_t currentStep ) const
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */
-            BOOST_CONSTEXPR_OR_CONST float_64 period_SI(20.0e-6);
+            constexpr float_64 period_SI(20.0e-6);
             /* calculate cells -> SI -> m to microns*/
             const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI * 1.0e6;
             /* note: you can also transform the time step to seconds by
@@ -95,7 +95,7 @@ namespace picongpu
     {
     public:
         /* Add this additional field? */
-        BOOST_STATIC_CONSTEXPR bool activated = false;
+        static constexpr bool activated = false;
 
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
@@ -112,7 +112,7 @@ namespace picongpu
                     const uint32_t currentStep ) const
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */
-            BOOST_CONSTEXPR_OR_CONST float_64 period_SI(20.0e-6);
+            constexpr float_64 period_SI(20.0e-6);
             /* calculate cells -> SI -> m to microns*/
             const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI * 1.0e6;
             /* note: you can also transform the time step to seconds by

--- a/src/picongpu/include/simulation_defines/param/gasConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gasConfig.param
@@ -35,7 +35,7 @@ namespace SI
  *
  * He (2e- / Atom ) with 1.e15 He / m^3
  *                      = 2.e15 e- / m^3 */
-    BOOST_CONSTEXPR_OR_CONST float_64 GAS_DENSITY_SI = 1.e25;
+    constexpr float_64 GAS_DENSITY_SI = 1.e25;
 
 }
 

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -29,17 +29,17 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 DELTA_T_SI = 0.8e-16;
+        constexpr float_64 DELTA_T_SI = 0.8e-16;
 
         /** equals X
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_WIDTH_SI = 0.1772e-6;
+        constexpr float_64 CELL_WIDTH_SI = 0.1772e-6;
         /** equals Y - the laser & moving window propagation direction
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_HEIGHT_SI = 0.4430e-7;
+        constexpr float_64 CELL_HEIGHT_SI = 0.4430e-7;
         /** equals Z
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
         /** Note on units in reduced dimensions
          *
@@ -70,7 +70,7 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t ABSORBER_FADE_IN_STEPS = 16;
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
 
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
@@ -82,7 +82,7 @@ namespace picongpu
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.90;
 
 }
 

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -31,22 +31,22 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            //BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 1.5;
+            //constexpr float_64 _A0  = 1.5;
 
             /** unit: Volt /meter */
-            //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -54,7 +54,7 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+            constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -62,17 +62,17 @@ namespace picongpu
              * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
              *                             [   1.17741    ]
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+            constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
             /** the distance to the laser focus in y-direction
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+            constexpr float_64 FOCUS_POS_SI = 4.62e-5;
         }
         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 20.0;
+        constexpr float_64 PULSE_INIT = 20.0;
 
         /* laser phase shift (no shift: 0.0) */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {
@@ -80,7 +80,7 @@ namespace picongpu
             LINEAR_Z = 2u,
             CIRCULAR = 4u,
         };
-        BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = CIRCULAR;
+        constexpr PolarisationType Polarisation = CIRCULAR;
     }
 
     namespace laserPulseFrontTilt
@@ -89,13 +89,13 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
                 *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -103,7 +103,7 @@ namespace picongpu
                 *  Info:             FWHM_of_Intensity = FWHM_Illumination
                 *                      = what a experimentalist calls "pulse duration"
                 *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+            constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
@@ -111,23 +111,23 @@ namespace picongpu
              * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
              *                             [   1.17741    ]
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0_SI = 5.0e-6 / 1.17741;
+            constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
             /** the distance to the laser focus in y-direction
                 *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 FOCUS_POS_SI = 4.62e-5;
+            constexpr float_64 FOCUS_POS_SI = 4.62e-5;
 
             /** the tilt angle between laser propagation in y-direction and laser axis in
                 *  x-direction (0 degree == no tilt)
                 *  unit: degree */
-            BOOST_CONSTEXPR_OR_CONST float_64 TILT_X_SI = 0;
+            constexpr float_64 TILT_X_SI = 0;
         }
         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
         *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 PULSE_INIT = 20.0;
+        constexpr float_64 PULSE_INIT = 20.0;
 
         /* laser phase shift (no shift: 0.0) */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {
@@ -135,7 +135,7 @@ namespace picongpu
             LINEAR_Z = 2u,
             CIRCULAR = 4u
         };
-        BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+        constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
     namespace laserPlaneWave
@@ -144,27 +144,27 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            BOOST_CONSTEXPR_OR_CONST float_64 _A0 = 1.5;
+            constexpr float_64 _A0 = 1.5;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
             /** unit: Volt /meter */
-            //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** The profile of the test Lasers 0 and 2 can be stretched by a
-             *      BOOST_CONSTEXPR_OR_CONSTant area between the up and downramp
+             *      constexprant area between the up and downramp
              *  unit: seconds */
-            BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
              *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -172,16 +172,16 @@ namespace picongpu
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
              *  unit: seconds (1 sigma) */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+            constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
         }
 
         /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.6146;
+        constexpr float_64 RAMP_INIT = 20.6146;
 
         /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
         enum PolarisationType
         {
@@ -189,7 +189,7 @@ namespace picongpu
             LINEAR_Z = 2u,
             CIRCULAR = 4u,
         };
-        BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+        constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
     namespace laserWavepacket
@@ -198,27 +198,27 @@ namespace picongpu
     namespace SI
     {
         /** unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+        constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
         /** UNITCONV */
-        BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+        constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
         /** unit: W / m^2 */
         // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
         /** unit: none */
-        //BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+        //constexpr float_64 _A0  = 3.9;
 
         /** unit: Volt /meter */
-        //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+        //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
         /** unit: Volt /meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+        constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
         /** The profile of the test Lasers 0 and 2 can be stretched by a
-         *      BOOST_CONSTEXPR_OR_CONSTant area between the up and downramp
+         *      constexprant area between the up and downramp
          *  unit: seconds */
-        BOOST_CONSTEXPR_OR_CONST float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+        constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
         /** Pulse length: sigma of std. gauss for intensity (E^2)
          *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
@@ -226,7 +226,7 @@ namespace picongpu
          *  Info:             FWHM_of_Intensity = FWHM_Illumination
          *                      = what a experimentalist calls "pulse duration"
          *  unit: seconds (1 sigma) */
-        BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+        constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
         /** beam waist: distance from the axis where the pulse intensity (E^2)
          *              decreases to its 1/e^2-th part,
@@ -236,17 +236,17 @@ namespace picongpu
          * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
          *                             [   1.17741    ]
          *  unit: meter */
-        BOOST_CONSTEXPR_OR_CONST float_64 W0_X_SI = 4.246e-6;
-        BOOST_CONSTEXPR_OR_CONST float_64 W0_Z_SI = W0_X_SI;
+        constexpr float_64 W0_X_SI = 4.246e-6;
+        constexpr float_64 W0_Z_SI = W0_X_SI;
 
     }
     /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
     and half at the end of the plateau
      *  unit: none */
-    BOOST_CONSTEXPR_OR_CONST float_64 RAMP_INIT = 20.0;
+    constexpr float_64 RAMP_INIT = 20.0;
 
     /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-    BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+    constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 
     enum PolarisationType
     {
@@ -254,7 +254,7 @@ namespace picongpu
         LINEAR_Z = 2u,
         CIRCULAR = 4u,
     };
-    BOOST_CONSTEXPR_OR_CONST PolarisationType Polarisation = LINEAR_X;
+    constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
 
@@ -264,22 +264,22 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.8e-6;
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
             /** UNITCONV */
-            BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
             // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
             /** unit: none */
-            //BOOST_CONSTEXPR_OR_CONST float_64 _A0  = 3.9;
+            //constexpr float_64 _A0  = 3.9;
 
             /** unit: Volt /meter */
-            //BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 1.738e13;
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
 
             /** Pulse length:
@@ -288,18 +288,18 @@ namespace picongpu
              *  Fall time = 0.5 * PULSE_LENGTH_SI
              *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
              *  unit: seconds  */
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 4.0e-15;
+            constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
 
             /** beam waist: distance from the axis where the pulse intensity (E^2)
              *              decreases to its 1/e^2-th part,
              *              at the focus position of the laser
              *  unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 W0x_SI = 4.246e-6; // waist in x-direction
-            BOOST_CONSTEXPR_OR_CONST float_64 W0z_SI = W0x_SI; // waist in z-direction
+            constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
+            constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
         }
 
         /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
     }
 
     namespace laserNone
@@ -307,12 +307,12 @@ namespace picongpu
         namespace SI
         {
             /** unit: meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 WAVE_LENGTH_SI = 0.0;
+            constexpr float_64 WAVE_LENGTH_SI = 0.0;
 
             /** unit: Volt /meter */
-            BOOST_CONSTEXPR_OR_CONST float_64 AMPLITUDE_SI = 0.0;
+            constexpr float_64 AMPLITUDE_SI = 0.0;
 
-            BOOST_CONSTEXPR_OR_CONST float_64 PULSE_LENGTH_SI = 0.0;
+            constexpr float_64 PULSE_LENGTH_SI = 0.0;
         }
     }
 

--- a/src/picongpu/include/simulation_defines/param/memory.param
+++ b/src/picongpu/include/simulation_defines/param/memory.param
@@ -32,7 +32,7 @@ namespace picongpu
      *   - reduces
      *   - ...
      */
-    BOOST_CONSTEXPR_OR_CONST size_t reservedGpuMemorySize = 350 *1024*1024;
+    constexpr size_t reservedGpuMemorySize = 350 *1024*1024;
 
     /* short namespace*/
     namespace mCT=PMacc::math::CT;
@@ -45,12 +45,12 @@ namespace picongpu
     /** define mapper which is used for kernel call mappings */
     typedef MappingDescription<simDim, SuperCellSize > MappingDesc;
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t GUARD_SIZE = 1;
+    constexpr uint32_t GUARD_SIZE = 1;
 
     //! how many bytes for buffer is reserved to communication in one direction
-    BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_X = 4 * 256 * 1024; //4 MiB
-    BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
-    BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
-    BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
-    BOOST_CONSTEXPR_OR_CONST uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
+    constexpr uint32_t BYTES_EXCHANGE_X = 4 * 256 * 1024; //4 MiB
+    constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
+    constexpr uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
+    constexpr uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
+    constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/particleConfig.param
+++ b/src/picongpu/include/simulation_defines/param/particleConfig.param
@@ -37,9 +37,9 @@ namespace particles
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
      *  unit: none */
-    BOOST_CONSTEXPR_OR_CONST float_X MIN_WEIGHTING = 10.0;
+    constexpr float_X MIN_WEIGHTING = 10.0;
 
-    BOOST_CONSTEXPR_OR_CONST uint32_t TYPICAL_PARTICLES_PER_CELL = 2;
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 2;
 
 namespace manipulators
 {
@@ -47,7 +47,7 @@ namespace manipulators
     CONST_VECTOR(float_X,3,DriftParam_direction,1.0,0.0,0.0);
     struct DriftParam
     {
-        BOOST_STATIC_CONSTEXPR float_64 gamma = 1.0;
+        static constexpr float_64 gamma = 1.0;
         const DriftParam_direction_t direction;
     };
     /* definition of SetDrift start*/
@@ -58,7 +58,7 @@ namespace manipulators
         /*Initial temperature
          *  unit: keV
          */
-        BOOST_STATIC_CONSTEXPR float_64 temperature = 0.0;
+        static constexpr float_64 temperature = 0.0;
     };
     /* definition of SetDrift start*/
     typedef TemperatureImpl<TemperatureParam,nvidia::functors::Add> AddTemperature;
@@ -67,13 +67,13 @@ namespace manipulators
     struct IfRelativeGlobalPositionParam
     {
         /* lowerBound is included in the range*/
-        BOOST_STATIC_CONSTEXPR float_X lowerBound = 0.0;
+        static constexpr float_X lowerBound = 0.0;
         /* upperBound is excluded in the range*/
-        BOOST_STATIC_CONSTEXPR float_X upperBound = 0.5;
+        static constexpr float_X upperBound = 0.5;
         /* dimension for the filter
          * x = 0; y= 1; z = 2
          */
-        BOOST_STATIC_CONSTEXPR uint32_t dimension = 0;
+        static constexpr uint32_t dimension = 0;
     };
     /* definition of SetDrift start*/
     typedef IfRelativeGlobalPositionImpl<IfRelativeGlobalPositionParam,AssignXDrift> AssignXDriftToLowerHalfXPosition;
@@ -103,7 +103,7 @@ namespace startPosition
     {
         /** Count of particles per cell at initial state
          *  unit: none */
-        BOOST_STATIC_CONSTEXPR uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
     };
     /* definition of random particle start*/
     typedef RandomImpl<RandomParameter> Random;

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -25,44 +25,44 @@
 
 namespace picongpu
 {
-    BOOST_CONSTEXPR_OR_CONST float_64 PI = 3.141592653589793238462643383279502884197169399;
+    constexpr float_64 PI = 3.141592653589793238462643383279502884197169399;
 
     namespace SI
     {
         /** unit: m / s */
-        BOOST_CONSTEXPR_OR_CONST float_64 SPEED_OF_LIGHT_SI = 2.99792458e8;
+        constexpr float_64 SPEED_OF_LIGHT_SI = 2.99792458e8;
 
         /** unit: N / A^2 */
-        BOOST_CONSTEXPR_OR_CONST float_64 MUE0_SI = PI * 4.e-7;
+        constexpr float_64 MUE0_SI = PI * 4.e-7;
         /** unit: C / (V m) */
-        BOOST_CONSTEXPR_OR_CONST float_64 EPS0_SI = 1.0 / MUE0_SI / SPEED_OF_LIGHT_SI
+        constexpr float_64 EPS0_SI = 1.0 / MUE0_SI / SPEED_OF_LIGHT_SI
             / SPEED_OF_LIGHT_SI;
 
         /** reduced Planck constant
          * unit: J * s
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 HBAR_SI = 1.054571800e-34;
+        constexpr float_64 HBAR_SI = 1.054571800e-34;
 
         // Electron properties
         /** unit: kg */
-        BOOST_CONSTEXPR_OR_CONST float_64 ELECTRON_MASS_SI = 9.109382e-31;
+        constexpr float_64 ELECTRON_MASS_SI = 9.109382e-31;
         /** unit: C */
-        BOOST_CONSTEXPR_OR_CONST float_64 ELECTRON_CHARGE_SI = -1.602176e-19;
+        constexpr float_64 ELECTRON_CHARGE_SI = -1.602176e-19;
 
         /* atomic unit for energy:
          * 1 Rydberg = 27.21 eV --> converted to Joule
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 ATOMIC_UNIT_ENERGY = 4.36e-18;
+        constexpr float_64 ATOMIC_UNIT_ENERGY = 4.36e-18;
 
         /* atomic unit for electric field in V/m:
          * field strength between electron and core in ground state hydrogen
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 ATOMIC_UNIT_EFIELD = 5.14e11;
+        constexpr float_64 ATOMIC_UNIT_EFIELD = 5.14e11;
 
         /* atomic unit for time in s:
          * 150 attoseconds (classical electron orbit time in hydrogen)  / 2 PI
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 ATOMIC_UNIT_TIME = 2.4189e-17;
+        constexpr float_64 ATOMIC_UNIT_TIME = 2.4189e-17;
     }
 
     // converts
@@ -77,24 +77,24 @@ namespace picongpu
     //
     // example:
     //   // some particle physicist beloved input:
-    //   BOOST_CONSTEXPR_OR_CONST float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
+    //   constexpr float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
     //
     //   // first convert to SI (because SI stays our standard Unit System!)
-    //   BOOST_CONSTEXPR_OR_CONST float_64 An_Arbitrary_Energy_Input_SI = An_Arbitrary_Energy_Input_keV * UNITCONV_keV_to_Joule // unit: Joule
+    //   constexpr float_64 An_Arbitrary_Energy_Input_SI = An_Arbitrary_Energy_Input_keV * UNITCONV_keV_to_Joule // unit: Joule
     //
     //   // now the "real" convert to our internal unitless system
-    //   BOOST_CONSTEXPR_OR_CONST float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI / UNIT_ENERGY) // unit: none
+    //   constexpr float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI / UNIT_ENERGY) // unit: none
     //
     // As a convention, we DO NOT use the short track:
-    //   BOOST_CONSTEXPR_OR_CONST float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
-    //   BOOST_CONSTEXPR_OR_CONST float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI * UNITCONV_keV_to_Joule / UNIT_ENERGY) // unit: none
+    //   constexpr float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
+    //   constexpr float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI * UNITCONV_keV_to_Joule / UNIT_ENERGY) // unit: none
     //
-    BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_keV_to_Joule = 1.60217646e-16;
-    BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_Joule_to_keV = (1.0 / UNITCONV_keV_to_Joule);
+    constexpr float_64 UNITCONV_keV_to_Joule = 1.60217646e-16;
+    constexpr float_64 UNITCONV_Joule_to_keV = (1.0 / UNITCONV_keV_to_Joule);
 
     /* 1 atomic unit of energy is equal to 1 Hartree or 2 Rydberg
      * which is twice the ground state binding energy of atomic hydrogen */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_AU_to_eV = 27.21139;
-    BOOST_CONSTEXPR_OR_CONST float_64 UNITCONV_eV_to_AU = (1.0 / UNITCONV_AU_to_eV);
+    constexpr float_64 UNITCONV_AU_to_eV = 27.21139;
+    constexpr float_64 UNITCONV_eV_to_AU = (1.0 / UNITCONV_AU_to_eV);
 
 }

--- a/src/picongpu/include/simulation_defines/param/pusherConfig.param
+++ b/src/picongpu/include/simulation_defines/param/pusherConfig.param
@@ -49,7 +49,7 @@ namespace picongpu
             LINEAR = 1u,
             NONLINEAR = 2u
         };
-        BOOST_CONSTEXPR_OR_CONST TrajectoryInterpolationType TrajectoryInterpolation = LINEAR;
+        constexpr TrajectoryInterpolationType TrajectoryInterpolation = LINEAR;
 
     }
 

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -38,29 +38,29 @@ namespace picongpu
     {
         namespace SI
         {
-            BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 0.0;
-            BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 1.06e16;
+            constexpr float_64 omega_min = 0.0;
+            constexpr float_64 omega_max = 1.06e16;
         }
 
-        BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+        constexpr unsigned int N_omega = 2048; // number of frequencies
     }
 
     namespace rad_log_frequencies
     {
         namespace SI
         {
-            BOOST_CONSTEXPR_OR_CONST float_64 omega_min = 1.0e14;
-            BOOST_CONSTEXPR_OR_CONST float_64 omega_max = 1.0e17;
+            constexpr float_64 omega_min = 1.0e14;
+            constexpr float_64 omega_max = 1.0e17;
         }
 
-        BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+        constexpr unsigned int N_omega = 2048; // number of frequencies
     }
 
 
     namespace rad_frequencies_from_list
     {
-        //BOOST_CONSTEXPR_OR_CONST char listLocation[] = "/scratch/s5960712/list001.freq";
-        BOOST_CONSTEXPR_OR_CONST unsigned int N_omega = 2048; // number of frequencies
+        //constexpr char listLocation[] = "/scratch/s5960712/list001.freq";
+        constexpr unsigned int N_omega = 2048; // number of frequencies
     }
 
 
@@ -69,7 +69,7 @@ namespace picongpu
 
     namespace radiationNyquist
     {
-        BOOST_CONSTEXPR_OR_CONST float_32 NyquistFactor = 0.5;
+        constexpr float_32 NyquistFactor = 0.5;
     }
 
 
@@ -120,9 +120,9 @@ namespace picongpu
         //diable (0) / enable (1)
         #define RAD_ACTIVATE_GAMMA_FILTER 0
 
-        BOOST_CONSTEXPR_OR_CONST float_32 RadiationGamma = 5.;
+        constexpr float_32 RadiationGamma = 5.;
 
-        BOOST_CONSTEXPR_OR_CONST unsigned int N_observer = 256; // number of looking directions
+        constexpr unsigned int N_observer = 256; // number of looking directions
 
 
 

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -66,7 +66,7 @@ namespace picongpu
        */
 
       /* generate two indices from single block index */
-      BOOST_CONSTEXPR_OR_CONST int N_angle_split = 16; /* index split distance */
+      constexpr int N_angle_split = 16; /* index split distance */
       /* get column index for computing angle theta: */
       const int my_index_theta = observation_id_extern / N_angle_split;
       /* get row index for computing angle phi: */
@@ -80,12 +80,12 @@ namespace picongpu
       const picongpu::float_64 angle_theta_end   = + picongpu::PI/8.0
                                              + 0.5*picongpu::PI; /* [rad] */
       /* angles range for phi */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 angle_phi_start = - picongpu::PI/8.0; /* [rad] */
-      BOOST_CONSTEXPR_OR_CONST picongpu::float_64 angle_phi_end   = + picongpu::PI/8.0; /* [rad] */
+      constexpr picongpu::float_64 angle_phi_start = - picongpu::PI/8.0; /* [rad] */
+      constexpr picongpu::float_64 angle_phi_end   = + picongpu::PI/8.0; /* [rad] */
 
 
       /* compute step with between two angles for range [angle_??_start : angle_??_end] */
-      BOOST_CONSTEXPR_OR_CONST int N_theta           = parameters::N_observer / N_angle_split;
+      constexpr int N_theta           = parameters::N_observer / N_angle_split;
       const picongpu::float_64 delta_angle_theta =  (angle_theta_start -
                        angle_theta_end) / (N_theta-1.0);
       const picongpu::float_64 delta_angle_phi   =  (angle_phi_start -

--- a/src/picongpu/include/simulation_defines/param/speciesConstants.param
+++ b/src/picongpu/include/simulation_defines/param/speciesConstants.param
@@ -27,14 +27,14 @@ namespace picongpu
     /** Threshold used for calculations that want to separate between
      *  high-precision formulas for relativistic and non-relativistic
      *  use-cases, e.g. energy-binning algorithms. */
-    BOOST_CONSTEXPR_OR_CONST float_X GAMMA_THRESH = float_X(1.005);
+    constexpr float_X GAMMA_THRESH = float_X(1.005);
 
     /** This limit is used to decide between a pure 1-sqrt(1-x) calculation
      *  and a 5th order Taylor approximation of 1-sqrt(1-x) to avoid halving
      *  of significant digits due to the sqrt() evaluation at x = 1/gamma^2 near 0.0.
      *  With 0.18 the relative error between Taylor approximation and real value
      *  will be below 0.001% = 1e-5 * for x=1/gamma^2 < 0.18 */
-    BOOST_CONSTEXPR_OR_CONST float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
+    constexpr float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
 
     namespace SI
     {
@@ -42,12 +42,12 @@ namespace picongpu
          *
          * unit: kg
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 BASE_MASS_SI = ELECTRON_MASS_SI;
+        constexpr float_64 BASE_MASS_SI = ELECTRON_MASS_SI;
 
         /** base particle charge
          *
          * unit: C
          */
-        BOOST_CONSTEXPR_OR_CONST float_64 BASE_CHARGE_SI = ELECTRON_CHARGE_SI;
+        constexpr float_64 BASE_CHARGE_SI = ELECTRON_CHARGE_SI;
     }
 }

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -147,8 +147,8 @@ value_identifier(float_X, ChargeRatioIons, -1.0);
  */
 struct Hydrogen
 {
-    BOOST_STATIC_CONSTEXPR float_X numberOfProtons  = 1.0;
-    BOOST_STATIC_CONSTEXPR float_X numberOfNeutrons = 0.0;
+    static constexpr float_X numberOfProtons  = 1.0;
+    static constexpr float_X numberOfNeutrons = 0.0;
 };
 
 /*! Ionization Model Configuration ----------------------------------------

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -33,24 +33,24 @@ namespace synchrotronPhotons
 #endif
 
 /** enable (disable) QED (classical) photon emission spectrum */
-BOOST_CONSTEXPR_OR_CONST bool enableQEDTerm = false;
+constexpr bool enableQEDTerm = false;
 
 /** Above this value (to the power of three, see comments on mapping) the synchrotron functions are nearly zero. */
-BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_CUTOFF = 5.0;
+constexpr float_64 SYNC_FUNCS_CUTOFF = 5.0;
 
 /** stepwidth for the numerical integration of the bessel function for the first synchrotron function */
-BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_BESSEL_INTEGRAL_STEPWIDTH = 1.0e-3;
+constexpr float_64 SYNC_FUNCS_BESSEL_INTEGRAL_STEPWIDTH = 1.0e-3;
 
 /** Number of sampling points of the lookup table */
-BOOST_CONSTEXPR_OR_CONST uint32_t SYNC_FUNCS_NUM_SAMPLES = 8192;
+constexpr uint32_t SYNC_FUNCS_NUM_SAMPLES = 8192;
 
 /** Photons of oszillation periods greater than a timestep are not created since the grid already accounts for them.
  * This cutoff ratio is defined as: photon-oszillation-period / timestep */
-BOOST_CONSTEXPR_OR_CONST float_64 SOFT_PHOTONS_CUTOFF_RATIO = 1.0;
+constexpr float_64 SOFT_PHOTONS_CUTOFF_RATIO = 1.0;
 
 /** if the emission probability per timestep is higher than this value and the log level is set to
  *  "CRITICAL" a warning will be raised. */
-BOOST_CONSTEXPR_OR_CONST float_64 SINGLE_EMISSION_PROB_LIMIT = 0.4;
+constexpr float_64 SINGLE_EMISSION_PROB_LIMIT = 0.4;
 
 } // namespace synchrotronPhotons
 } // namespace particles

--- a/src/picongpu/include/simulation_defines/param/visualization.param
+++ b/src/picongpu/include/simulation_defines/param/visualization.param
@@ -28,12 +28,12 @@ namespace picongpu
 {
     /*scale image before write to file, only scale if value is not 1.0
      */
-    BOOST_CONSTEXPR_OR_CONST float_64 scale_image = 1.0;
+    constexpr float_64 scale_image = 1.0;
 
     /*if true image is scaled if cellsize is not quadratic, else no scale*/
-    BOOST_CONSTEXPR_OR_CONST bool scale_to_cellsize = true;
+    constexpr bool scale_to_cellsize = true;
 
-    BOOST_CONSTEXPR_OR_CONST bool white_box_per_GPU = false;
+    constexpr bool white_box_per_GPU = false;
 
     namespace visPreview
     {
@@ -52,10 +52,10 @@ namespace picongpu
         #define EM_FIELD_SCALE_CHANNEL3 -1
 
         // multiply highest undisturbed particle density with factor
-        BOOST_CONSTEXPR_OR_CONST float_X preParticleDens_opacity = 0.25;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel1_opacity = 1.0;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel2_opacity = 1.0;
-        BOOST_CONSTEXPR_OR_CONST float_X preChannel3_opacity = 1.0;
+        constexpr float_X preParticleDens_opacity = 0.25;
+        constexpr float_X preChannel1_opacity = 1.0;
+        constexpr float_X preChannel2_opacity = 1.0;
+        constexpr float_X preChannel3_opacity = 1.0;
 
         // specify color scales for each channel
         namespace preParticleDensCol = colorScales::red;

--- a/src/picongpu/include/simulation_defines/unitless/gasConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gasConfig.unitless
@@ -27,7 +27,7 @@
 namespace picongpu
 
 {
-    BOOST_CONSTEXPR_OR_CONST float_X GAS_DENSITY =
+    constexpr float_X GAS_DENSITY =
         float_X( SI::GAS_DENSITY_SI * UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH );
 } // namespace picongpu
 

--- a/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
@@ -28,27 +28,27 @@
 namespace picongpu
 {
     // normed grid parameter
-    BOOST_CONSTEXPR_OR_CONST float_X DELTA_T = float_X( SI::DELTA_T_SI / UNIT_TIME );
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_WIDTH = float_X( SI::CELL_WIDTH_SI / UNIT_LENGTH );
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_HEIGHT = float_X( SI::CELL_HEIGHT_SI / UNIT_LENGTH );
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_DEPTH = float_X( SI::CELL_DEPTH_SI / UNIT_LENGTH );
+    constexpr float_X DELTA_T = float_X( SI::DELTA_T_SI / UNIT_TIME );
+    constexpr float_X CELL_WIDTH = float_X( SI::CELL_WIDTH_SI / UNIT_LENGTH );
+    constexpr float_X CELL_HEIGHT = float_X( SI::CELL_HEIGHT_SI / UNIT_LENGTH );
+    constexpr float_X CELL_DEPTH = float_X( SI::CELL_DEPTH_SI / UNIT_LENGTH );
     CONST_VECTOR( float_X, DIM3, cellSize, CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH );
 
     // always a 3D cell, even in 1D3V or 2D3V
-    BOOST_CONSTEXPR_OR_CONST float_X CELL_VOLUME = CELL_WIDTH * CELL_HEIGHT * CELL_DEPTH;
+    constexpr float_X CELL_VOLUME = CELL_WIDTH * CELL_HEIGHT * CELL_DEPTH;
 
     // only used for CFL checks
 #if (SIMDIM==DIM3)
-    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM =
+    constexpr float_X INV_CELL2_SUM =
         1.0 / ( CELL_WIDTH  * CELL_WIDTH  ) +
         1.0 / ( CELL_HEIGHT * CELL_HEIGHT ) +
         1.0 / ( CELL_DEPTH  * CELL_DEPTH  );
 #elif(SIMDIM==DIM2)
-    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM =
+    constexpr float_X INV_CELL2_SUM =
         1.0 / ( CELL_WIDTH  * CELL_WIDTH  ) +
         1.0 / ( CELL_HEIGHT * CELL_HEIGHT );
 #else
-    BOOST_CONSTEXPR_OR_CONST float_X INV_CELL2_SUM =
+    constexpr float_X INV_CELL2_SUM =
         1.0 / ( CELL_WIDTH  * CELL_WIDTH );
 #endif
 

--- a/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
@@ -29,66 +29,66 @@ namespace picongpu
     namespace laserPulseFrontTilt
     {
         //normed laser parameter
-        BOOST_CONSTEXPR_OR_CONST float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
-        BOOST_CONSTEXPR_OR_CONST float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_X W0 = float_X(SI::W0_SI / UNIT_LENGTH); // unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X FOCUS_POS = float_X(SI::FOCUS_POS_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X INIT_TIME = float_X ((PULSE_INIT*SI::PULSE_LENGTH_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
-        BOOST_CONSTEXPR_OR_CONST float_X TILT_X = float_X (( SI::TILT_X_SI * PI ) / 180); // unit: raidiant (in dimensions of pi)
+        constexpr float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
+        constexpr float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
+        constexpr float_X W0 = float_X(SI::W0_SI / UNIT_LENGTH); // unit: meter
+        constexpr float_X FOCUS_POS = float_X(SI::FOCUS_POS_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X INIT_TIME = float_X ((PULSE_INIT*SI::PULSE_LENGTH_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
+        constexpr float_X TILT_X = float_X (( SI::TILT_X_SI * PI ) / 180); // unit: raidiant (in dimensions of pi)
     }
 
     namespace laserGaussianBeam
     {
         //normed laser parameter
-        BOOST_CONSTEXPR_OR_CONST float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
-        BOOST_CONSTEXPR_OR_CONST float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_X W0 = float_X(SI::W0_SI / UNIT_LENGTH); // unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X FOCUS_POS = float_X(SI::FOCUS_POS_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X INIT_TIME = float_X ((PULSE_INIT*SI::PULSE_LENGTH_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
+        constexpr float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
+        constexpr float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
+        constexpr float_X W0 = float_X(SI::W0_SI / UNIT_LENGTH); // unit: meter
+        constexpr float_X FOCUS_POS = float_X(SI::FOCUS_POS_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X INIT_TIME = float_X ((PULSE_INIT*SI::PULSE_LENGTH_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
     }
 
     namespace laserPlaneWave
     {
         //normed laser parameter
-        BOOST_CONSTEXPR_OR_CONST float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_NOFOCUS_CONSTANT = float_X (SI::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); //unit: seconds
-        BOOST_CONSTEXPR_OR_CONST float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_X INIT_TIME = float_X ((RAMP_INIT*SI::PULSE_LENGTH_SI + SI::LASER_NOFOCUS_CONSTANT_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
+        constexpr float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
+        constexpr float_X LASER_NOFOCUS_CONSTANT = float_X (SI::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); //unit: seconds
+        constexpr float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
+        constexpr float_X INIT_TIME = float_X ((RAMP_INIT*SI::PULSE_LENGTH_SI + SI::LASER_NOFOCUS_CONSTANT_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
     }
 
     namespace laserWavepacket
     {
         //normed laser parameter
-        BOOST_CONSTEXPR_OR_CONST float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
-        BOOST_CONSTEXPR_OR_CONST float_X LASER_NOFOCUS_CONSTANT = float_X (SI::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); //unit: seconds
-        BOOST_CONSTEXPR_OR_CONST float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_X W0_X = float_X(SI::W0_X_SI / UNIT_LENGTH); // unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X W0_Z = float_X(SI::W0_Z_SI / UNIT_LENGTH); // unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X INIT_TIME = float_X ((RAMP_INIT*SI::PULSE_LENGTH_SI + SI::LASER_NOFOCUS_CONSTANT_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
+        constexpr float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
+        constexpr float_X LASER_NOFOCUS_CONSTANT = float_X (SI::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); //unit: seconds
+        constexpr float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
+        constexpr float_X W0_X = float_X(SI::W0_X_SI / UNIT_LENGTH); // unit: meter
+        constexpr float_X W0_Z = float_X(SI::W0_Z_SI / UNIT_LENGTH); // unit: meter
+        constexpr float_X INIT_TIME = float_X ((RAMP_INIT*SI::PULSE_LENGTH_SI + SI::LASER_NOFOCUS_CONSTANT_SI) / UNIT_TIME); // unit: seconds (full inizialisation length)
     }
 
     namespace laserPolynom
     {
         //normed laser parameter
-        BOOST_CONSTEXPR_OR_CONST float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds
-        BOOST_CONSTEXPR_OR_CONST float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_X W0x = float_X(SI::W0x_SI / UNIT_LENGTH); // unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X W0z = float_X(SI::W0z_SI / UNIT_LENGTH); // unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X INIT_TIME = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); // unit: seconds (full inizialisation length)
+        constexpr float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds
+        constexpr float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
+        constexpr float_X W0x = float_X(SI::W0x_SI / UNIT_LENGTH); // unit: meter
+        constexpr float_X W0z = float_X(SI::W0z_SI / UNIT_LENGTH); // unit: meter
+        constexpr float_X INIT_TIME = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); // unit: seconds (full inizialisation length)
     }
 
     namespace laserNone
     {
         //normed laser parameter
-        BOOST_CONSTEXPR_OR_CONST float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
-        BOOST_CONSTEXPR_OR_CONST float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
-        BOOST_CONSTEXPR_OR_CONST float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
-        BOOST_CONSTEXPR_OR_CONST float_X INIT_TIME = 0.0; //no inizialisation of laser
+        constexpr float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
+        constexpr float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
+        constexpr float_X INIT_TIME = 0.0; //no inizialisation of laser
     }
 
 }

--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -24,59 +24,59 @@
 namespace picongpu
 {
     /** Unit of Speed */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
+    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
     /** Unit of time */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_TIME = SI::DELTA_T_SI;
+    constexpr float_64 UNIT_TIME = SI::DELTA_T_SI;
     /** Unit of length */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
+    constexpr float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
 
     namespace particles
     {
         /** Number of particles per makro particle (= macro particle weighting)
          *  unit: none */
-        BOOST_CONSTEXPR_OR_CONST float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE =
+        constexpr float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE =
             float_64( SI::GAS_DENSITY_SI * SI::CELL_WIDTH_SI * SI::CELL_HEIGHT_SI * SI::CELL_DEPTH_SI ) /
             float_64( particles::TYPICAL_PARTICLES_PER_CELL );
     }
 
 
     /** Unit of mass */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_MASS = SI::BASE_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_MASS = SI::BASE_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of charge */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_CHARGE = -1.0 * SI::BASE_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_CHARGE = -1.0 * SI::BASE_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
     /** Unit of energy */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
+    constexpr float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
     /** Unit of EField: V/m */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
+    constexpr float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
     //** Unit of BField: Tesla [T] = Vs/m^2 */
-    BOOST_CONSTEXPR_OR_CONST float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
+    constexpr float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
 
 
 
 
-    BOOST_CONSTEXPR_OR_CONST float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+    constexpr float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 
     //! reduced Planck constant
-    BOOST_CONSTEXPR_OR_CONST float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
+    constexpr float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
 
     //! Charge of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
+    constexpr float_X ELECTRON_CHARGE = (float_X) (SI::ELECTRON_CHARGE_SI / UNIT_CHARGE);
     //! Mass of electron
-    BOOST_CONSTEXPR_OR_CONST float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
+    constexpr float_X ELECTRON_MASS = (float_X) (SI::ELECTRON_MASS_SI / UNIT_MASS);
 
-    //! magnetic BOOST_CONSTEXPR_OR_CONSTant must be double 3.92907e-39
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
+    //! magnetic constexprant must be double 3.92907e-39
+    constexpr float_X MUE0 = (float_X) (SI::MUE0_SI / UNIT_LENGTH / UNIT_MASS * UNIT_CHARGE * UNIT_CHARGE);
 
-    //! electric BOOST_CONSTEXPR_OR_CONSTant must be double 2.54513e+38
-    BOOST_CONSTEXPR_OR_CONST float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    //! electric constexprant must be double 2.54513e+38
+    constexpr float_X EPS0 = (float_X) (1. / MUE0 / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     // = 1/c^2
-    BOOST_CONSTEXPR_OR_CONST float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
+    constexpr float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
     /* Atomic unit of electric field in PIC Efield units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
+    constexpr float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
 
     /* Atomic unit of time in PIC units */
-    BOOST_CONSTEXPR_OR_CONST float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
+    constexpr float_X ATOMIC_UNIT_TIME = float_X(SI::ATOMIC_UNIT_TIME / UNIT_TIME);
 
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -34,33 +34,33 @@ namespace picongpu
 {
   namespace rad_linear_frequencies
   {
-    BOOST_CONSTEXPR_OR_CONST float_X omega_min = SI::omega_min*UNIT_TIME;
-    BOOST_CONSTEXPR_OR_CONST float_X omega_max = SI::omega_max*UNIT_TIME;
-    BOOST_CONSTEXPR_OR_CONST float_X delta_omega = (float_X) ((omega_max - omega_min) / (float_X) (N_omega - 1)); // difference beween two omega
+    constexpr float_X omega_min = SI::omega_min*UNIT_TIME;
+    constexpr float_X omega_max = SI::omega_max*UNIT_TIME;
+    constexpr float_X delta_omega = (float_X) ((omega_max - omega_min) / (float_X) (N_omega - 1)); // difference beween two omega
 
-    BOOST_CONSTEXPR_OR_CONST unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
-    BOOST_CONSTEXPR_OR_CONST unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
+    constexpr unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+    constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
   }
 
   namespace rad_log_frequencies
   {
-    BOOST_CONSTEXPR_OR_CONST float_X omega_min = (SI::omega_min*UNIT_TIME);
-    BOOST_CONSTEXPR_OR_CONST float_X omega_max = (SI::omega_max*UNIT_TIME);
+    constexpr float_X omega_min = (SI::omega_min*UNIT_TIME);
+    constexpr float_X omega_max = (SI::omega_max*UNIT_TIME);
 
-    BOOST_CONSTEXPR_OR_CONST unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
-    BOOST_CONSTEXPR_OR_CONST unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
+    constexpr unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+    constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
   }
 
   namespace rad_frequencies_from_list
   {
-    BOOST_CONSTEXPR_OR_CONST unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
-    BOOST_CONSTEXPR_OR_CONST unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
+    constexpr unsigned int blocksize_omega = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+    constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
   }
 
 namespace parameters
 {
 
-    BOOST_CONSTEXPR_OR_CONST unsigned int gridsize_theta = N_observer; // size of grid /dim: y); radiation
+    constexpr unsigned int gridsize_theta = N_observer; // size of grid /dim: y); radiation
 
 }
 

--- a/src/picongpu/include/simulation_defines/unitless/speciesConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesConstants.unitless
@@ -25,8 +25,8 @@ namespace picongpu
 {
 
     //! Charge of base particle
-    BOOST_CONSTEXPR_OR_CONST float_X BASE_CHARGE = (float_X) (SI::BASE_CHARGE_SI / UNIT_CHARGE);
+    constexpr float_X BASE_CHARGE = (float_X) (SI::BASE_CHARGE_SI / UNIT_CHARGE);
     //! Mass of base particle
-    BOOST_CONSTEXPR_OR_CONST float_X BASE_MASS = (float_X) (SI::BASE_MASS_SI / UNIT_MASS);
+    constexpr float_X BASE_MASS = (float_X) (SI::BASE_MASS_SI / UNIT_MASS);
 
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
@@ -28,14 +28,14 @@ namespace synchrotronPhotons
 {
 
 /** Sample point stepping */
-BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_STEP_WIDTH =
+constexpr float_64 SYNC_FUNCS_STEP_WIDTH =
     SYNC_FUNCS_CUTOFF / static_cast<float_64>(SYNC_FUNCS_NUM_SAMPLES - 1u);
 
 /** In the definition of the first synchrotron function the bessel function is integrated
  * up to infinity but in fact it is sufficient to integrate up to this constant. */
-BOOST_CONSTEXPR_OR_CONST float_64 SYNC_FUNCS_F1_INTEGRAL_BOUND = 50.0;
+constexpr float_64 SYNC_FUNCS_F1_INTEGRAL_BOUND = 50.0;
 
-BOOST_CONSTEXPR_OR_CONST float_X SOFT_PHOTONS_CUTOFF_MOM = static_cast<float_X>(
+constexpr float_X SOFT_PHOTONS_CUTOFF_MOM = static_cast<float_X>(
     HBAR * 2.0 * M_PI / SOFT_PHOTONS_CUTOFF_RATIO / DELTA_T / SPEED_OF_LIGHT);
 
 } // namespace synchrotronPhotons

--- a/src/picongpu/include/traits/SIBaseUnits.hpp
+++ b/src/picongpu/include/traits/SIBaseUnits.hpp
@@ -28,7 +28,7 @@ namespace traits
     /* openPMD uses the powers of the 7 SI base measures to describe
      * the unit of a record
      * \see http://git.io/vROmP */
-    BOOST_CONSTEXPR_OR_CONST uint32_t NUnitDimension = 7;
+    constexpr uint32_t NUnitDimension = 7;
 
     // pre-C++11 "scoped enumerator" work-around
     namespace SIBaseUnits {


### PR DESCRIPTION
Remove all boost macros to use C++11 `constexpr` directly.

Changed via
```bash
# examples src
find examples -type f -print0 | xargs -0 sed -i 's/BOOST_STATIC_CONSTEXPR/static constexpr/g'
find examples -type f -print0 | xargs -0 sed -i 's/BOOST_CONSTEXPR_OR_CONST/constexpr/g'
```

 & minor manual typos and style issues fixed on the way.

Committed via
```bash
GIT_AUTHOR_NAME="Tools" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git [...]
```