### PR TITLE
openPMD base units: scoped enum

### DIFF
--- a/src/picongpu/include/traits/SIBaseUnits.hpp
+++ b/src/picongpu/include/traits/SIBaseUnits.hpp
@@ -30,9 +30,7 @@ namespace traits
      * \see http://git.io/vROmP */
     BOOST_CONSTEXPR_OR_CONST uint32_t NUnitDimension = 7;
 
-    // pre-C++11 "scoped enumerator" work-around
-    namespace SIBaseUnits {
-    enum SIBaseUnits_t
+    enum class SIBaseUnits
     {
         length = 0,                   // L
         mass = 1,                     // M
@@ -42,7 +40,6 @@ namespace traits
         amountOfSubstance = 5,        // N
         luminousIntensity = 6,        // J
     };
-    }
 
 } // namespace traits
 } // namespace picongpu


### PR DESCRIPTION
Use a *scoped enum* for openPMD `SIBaseUnits`. This is a C++11 feature making its declaration less verbose.