### PR TITLE
Fix Event System Deadlock on MPI_Barrier

### DIFF
--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -144,6 +144,9 @@ public:
             CUDA_CHECK(cudaDeviceSynchronize());
             CUDA_CHECK(cudaGetLastError());
 
+            /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+            __getTransactionEvent().waitForFinished();
+
             GridController<DIM> &gc = Environment<DIM>::get().GridController();
             /* can be spared for better scalings, but allows to spare the
              * time for checkpointing if some ranks died */
@@ -162,6 +165,9 @@ public:
              * point guarantees that a checkpoint is usable */
             CUDA_CHECK(cudaDeviceSynchronize());
             CUDA_CHECK(cudaGetLastError());
+
+            /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+            __getTransactionEvent().waitForFinished();
 
             /* \todo in an ideal world with MPI-3, this would be an
              * MPI_Ibarrier call and this function would return a MPI_Request

--- a/src/picongpu/include/initialization/InitialiserController.hpp
+++ b/src/picongpu/include/initialization/InitialiserController.hpp
@@ -88,6 +88,9 @@ public:
         CUDA_CHECK(cudaGetLastError());
 
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
+
+        /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+        __getTransactionEvent().waitForFinished();
         /* can be spared for better scalings, but guarantees the user
          * that the restart was successful */
         MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1104,6 +1104,8 @@ private:
         log<picLog::INPUT_OUTPUT > ("ADIOS: closing file: %1%") % threadParams->fullFilename;
         ADIOS_CMD(adios_close(threadParams->adiosFileHandle));
 
+        /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+        __getTransactionEvent().waitForFinished();
         /*\todo: copied from adios example, we might not need this ? */
         MPI_CHECK(MPI_Barrier(threadParams->adiosComm));
 


### PR DESCRIPTION
Deadlock can be triggered if a mpi rank with unfinished PMacc tasks enters a MPI_Barrier.

- wait for all events before enter `MPI_Barrier`