### PR TITLE
[WIP] Release 0.2.1: Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 Change Log / Release Log for PIConGPU
 ================================================================
 
+0.2.1
+-----
+**Date:** 2016-11-28
+
+QED synchrotron photon & fix potential deadlock in checkpoints
+
+This releases fixes a potential deadlock encountered during checkpoints and
+initialization. Furthermore, we forgot to highlight that the 0.2.0 release
+also included a QED synchrotron emission scheme (based on the review in
+A. Gonoskov et al., PRE 92, 2015).
+
+### Changes to "0.2.0"
+
+**Bug Fixes:**
+ - potential event system deadlock init/checkpoints #1659
+
+Thank you to René Widera for spotting & fixing and Heiko Burau for the QED
+synchrotron photon emission implementation!
+
+
 0.2.0 "Beta"
 ------------
 **Date:** 2016-11-24

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ electrons and ions in the plasma based on
 [Maxwell's equations](http://en.wikipedia.org/wiki/Maxwell%27s_equations).
 
 PIConGPU implements various numerical schemes to solve the PIC cycle.
-Its features include:
+Its features for the electro-magnetic PIC algorithm include:
 - a central or Yee-lattice for fields
 - particle pushers that solve the equation of motion for charged and neutral
   particles, e.g., the *Boris-* and the *Vay-Pusher*
@@ -26,12 +26,18 @@ Its features include:
 - macro-particle form factors ranging from NGP (0th order), CIC (1st),
   TSC (2nd), PSQ (3rd) to P4S (4th)
 
-Besides the electro-magnetic PIC algorithm, we developed a wide range of tools
-and diagnostics, e.g.:
+and the electro-magnetic PIC algorithm is further self-consistently coupled to:
+- classical radiation reaction (DOI: 10.1016/j.cpc.2016.04.002)
+- QED synchrotron radiation (photon emission) (DOI: 10.1103/PhysRevE.92.023305)
+- advanced field ionization methods
+  (DOI: DOI:10.1103/PhysRevA.59.569, LV Keldysh)
+
+Besides the electro-magnetic PIC algorithm and extensions to it, we developed
+a wide range of tools and diagnostics, e.g.:
 - online, far-field radiation diagnostics for coherent and incoherent radiation
   emitted by charged particles
-- full restart and output capabilities, including
-  [parallel HDF5](http://hdfgroup.org/) (via
+- full restart and output capabilities via [openPMD](http://openPMD.org),
+  including [parallel HDF5](http://hdfgroup.org/) (via
   [libSplash](https://github.com/ComputationalRadiationPhysics/libSplash)) and
   [ADIOS](https://www.olcf.ornl.gov/center-projects/adios/), allowing for
   extreme I/O scalability and massively parallel online-analysis

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,3 +1,4 @@
+```
 @inproceedings{Bussmann:2013:RSR:2503210.2504564,
  author = {Bussmann, M. and Burau, H. and Cowan, T. E. and Debus, A. and Huebl, A. and Juckeland, G. and Kluge, T. and Nagel, W. E. and Pausch, R. and Schmitt, F. and Schramm, U. and Schuchart, J. and Widera, R.},
  title = {Radiative Signatures of the Relativistic Kelvin-Helmholtz Instability},
@@ -15,3 +16,4 @@
  publisher = {ACM},
  address = {New York, NY, USA},
 }
+```


### PR DESCRIPTION
Prepares the changelog for the 0.2.1 release.

- **README: Document PIC extensions**: Highlight extensions we already added that are not in the
standard PIC cycle.
- **REFERENCE: Add Format for Markdown**: Avoids scrumbling the text when opening the file directly
on a markdown viewer (online).
- **Release 0.2.1: Changelog**
  - #1659

@ComputationalRadiationPhysics/picongpu-maintainers please have a look and comment inline. If everything is ok, please approve.