### PR TITLE
Release 0.2.1: QED synchrotron photon & fix potential deadlock in checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 Change Log / Release Log for PIConGPU
 ================================================================
 
+0.2.1
+-----
+**Date:** 2016-11-28
+
+QED synchrotron photon & fix potential deadlock in checkpoints
+
+This releases fixes a potential deadlock encountered during checkpoints and
+initialization. Furthermore, we forgot to highlight that the 0.2.0 release
+also included a QED synchrotron emission scheme (based on the review in
+A. Gonoskov et al., PRE 92, 2015).
+
+### Changes to "0.2.0"
+
+**Bug Fixes:**
+ - potential event system deadlock init/checkpoints #1659
+
+Thank you to René Widera for spotting & fixing and Heiko Burau for the QED
+synchrotron photon emission implementation!
+
+
 0.2.0 "Beta"
 ------------
 **Date:** 2016-11-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log / Release Log for PIConGPU
 
 0.2.1
 -----
-**Date:** 2016-11-28
+**Date:** 2016-11-29
 
 QED synchrotron photon & fix potential deadlock in checkpoints
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ electrons and ions in the plasma based on
 [Maxwell's equations](http://en.wikipedia.org/wiki/Maxwell%27s_equations).
 
 PIConGPU implements various numerical schemes to solve the PIC cycle.
-Its features include:
+Its features for the electro-magnetic PIC algorithm include:
 - a central or Yee-lattice for fields
 - particle pushers that solve the equation of motion for charged and neutral
   particles, e.g., the *Boris-* and the *Vay-Pusher*
@@ -26,12 +26,18 @@ Its features include:
 - macro-particle form factors ranging from NGP (0th order), CIC (1st),
   TSC (2nd), PSQ (3rd) to P4S (4th)
 
-Besides the electro-magnetic PIC algorithm, we developed a wide range of tools
-and diagnostics, e.g.:
+and the electro-magnetic PIC algorithm is further self-consistently coupled to:
+- classical radiation reaction (DOI: 10.1016/j.cpc.2016.04.002)
+- QED synchrotron radiation (photon emission) (DOI: 10.1103/PhysRevE.92.023305)
+- advanced field ionization methods
+  (DOI: DOI:10.1103/PhysRevA.59.569, LV Keldysh)
+
+Besides the electro-magnetic PIC algorithm and extensions to it, we developed
+a wide range of tools and diagnostics, e.g.:
 - online, far-field radiation diagnostics for coherent and incoherent radiation
   emitted by charged particles
-- full restart and output capabilities, including
-  [parallel HDF5](http://hdfgroup.org/) (via
+- full restart and output capabilities via [openPMD](http://openPMD.org),
+  including [parallel HDF5](http://hdfgroup.org/) (via
   [libSplash](https://github.com/ComputationalRadiationPhysics/libSplash)) and
   [ADIOS](https://www.olcf.ornl.gov/center-projects/adios/), allowing for
   extreme I/O scalability and massively parallel online-analysis

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,3 +1,4 @@
+```
 @inproceedings{Bussmann:2013:RSR:2503210.2504564,
  author = {Bussmann, M. and Burau, H. and Cowan, T. E. and Debus, A. and Huebl, A. and Juckeland, G. and Kluge, T. and Nagel, W. E. and Pausch, R. and Schmitt, F. and Schramm, U. and Schuchart, J. and Widera, R.},
  title = {Radiative Signatures of the Relativistic Kelvin-Helmholtz Instability},
@@ -15,3 +16,4 @@
  publisher = {ACM},
  address = {New York, NY, USA},
 }
+```

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -144,6 +144,9 @@ public:
             CUDA_CHECK(cudaDeviceSynchronize());
             CUDA_CHECK(cudaGetLastError());
 
+            /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+            __getTransactionEvent().waitForFinished();
+
             GridController<DIM> &gc = Environment<DIM>::get().GridController();
             /* can be spared for better scalings, but allows to spare the
              * time for checkpointing if some ranks died */
@@ -162,6 +165,9 @@ public:
              * point guarantees that a checkpoint is usable */
             CUDA_CHECK(cudaDeviceSynchronize());
             CUDA_CHECK(cudaGetLastError());
+
+            /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+            __getTransactionEvent().waitForFinished();
 
             /* \todo in an ideal world with MPI-3, this would be an
              * MPI_Ibarrier call and this function would return a MPI_Request

--- a/src/picongpu/include/initialization/InitialiserController.hpp
+++ b/src/picongpu/include/initialization/InitialiserController.hpp
@@ -88,6 +88,9 @@ public:
         CUDA_CHECK(cudaGetLastError());
 
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
+
+        /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+        __getTransactionEvent().waitForFinished();
         /* can be spared for better scalings, but guarantees the user
          * that the restart was successful */
         MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1104,6 +1104,8 @@ private:
         log<picLog::INPUT_OUTPUT > ("ADIOS: closing file: %1%") % threadParams->fullFilename;
         ADIOS_CMD(adios_close(threadParams->adiosFileHandle));
 
+        /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+        __getTransactionEvent().waitForFinished();
         /*\todo: copied from adios example, we might not need this ? */
         MPI_CHECK(MPI_Barrier(threadParams->adiosComm));
 


### PR DESCRIPTION
This releases fixes a potential deadlock encountered during checkpoints and initialization. Furthermore, we forgot to highlight that the 0.2.0 release also included a QED synchrotron emission scheme (based on the review in [A. Gonoskov et al., PRE 92, 2015](http://dx.doi.org/10.1103/PhysRevE.92.023305)).

Thank you to @psychocoderHPC  for spotting & fixing and @Heikman for the QED synchrotron photon emission implementation!