### PR TITLE
Device Selection: Guard Valid Range

### DIFF
--- a/src/libPMacc/include/Environment.hpp
+++ b/src/libPMacc/include/Environment.hpp
@@ -180,7 +180,7 @@ private:
         {
             throw std::runtime_error("no CUDA capable devices detected");
         }
-        else if (num_gpus < deviceNumber) //check if device can be selected by deviceNumber
+        else if (deviceNumber >= num_gpus) //check if device can be selected by deviceNumber
         {
             std::cerr << "no CUDA device " << deviceNumber << ", only " << num_gpus << " devices found" << std::endl;
             throw std::runtime_error("CUDA capable devices can't be selected");


### PR DESCRIPTION
device number outside valid range can be selected

The bug can be triggered if `CUDA_VISIBLE_DEVICES` is set to the number of GPUs in the node or if more MPI ranks as gpus per node are started.
The result is a run time crash. This bug is **not** critical and need no back port.