### PR TITLE
Restart: Allow Disable of Moving Window

### DIFF
--- a/src/libPMacc/include/communication/CommunicatorMPI.hpp
+++ b/src/libPMacc/include/communication/CommunicatorMPI.hpp
@@ -244,6 +244,10 @@ public:
 
     bool setStateAfterSlides(size_t numSlides)
     {
+        // nothing happens
+        if(numSlides == 0)
+            return false;
+
         // we can only slide in y direction right now
         if(DIM < DIM2)
             return false;

--- a/src/libPMacc/include/mappings/simulation/GridController.hpp
+++ b/src/libPMacc/include/mappings/simulation/GridController.hpp
@@ -193,6 +193,12 @@ namespace PMacc
              */
             bool setStateAfterSlides(size_t numSlides)
             {
+                // nothing to do, nothing to change
+                // note: prevents destroying static load balancing in y for
+                //       non-moving window simulations
+                if( numSlides == 0 )
+                    return false;
+
                 bool result = comm.setStateAfterSlides(numSlides);
                 updateDomainOffset(numSlides);
                 return result;

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -690,10 +690,14 @@ public:
         log<picLog::INPUT_OUTPUT > ("ADIOS: Setting slide count for moving window to %1%") % slides;
         MovingWindow::getInstance().setSlideCounter(slides, restartStep);
 
-        /* re-distribute the local offsets in y-direction */
+        /* re-distribute the local offsets in y-direction
+         * this will work for restarts with moving window still enabled
+         * and restarts that disable the moving window
+         * \warning enabling the moving window from a checkpoint that
+         *          had no moving window will not work
+         */
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
-        if( MovingWindow::getInstance().isSlidingWindowActive() )
-            gc.setStateAfterSlides(slides);
+        gc.setStateAfterSlides(slides);
 
         /* set window for restart, complete global domain */
         mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -204,9 +204,13 @@ public:
         log<picLog::INPUT_OUTPUT > ("HDF5 setting slide count for moving window to %1%") % slides;
         MovingWindow::getInstance().setSlideCounter(slides, restartStep);
 
-        /* re-distribute the local offsets in y-direction */
-        if( MovingWindow::getInstance().isSlidingWindowActive() )
-            gc.setStateAfterSlides(slides);
+        /* re-distribute the local offsets in y-direction
+         * this will work for restarts with moving window still enabled
+         * and restarts that disable the moving window
+         * \warning enabling the moving window from a checkpoint that
+         *          had no moving window will not work
+         */
+        gc.setStateAfterSlides(slides);
 
         /* set window for restart, complete global domain */
         mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -390,8 +390,7 @@ public:
          * information such as local offsets in y-direction
          */
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
-        if( MovingWindow::getInstance().isSlidingWindowActive() )
-            gc.setStateAfterSlides(0);
+        gc.setStateAfterSlides(0);
 
         /* fill all objects registed in DataConnector */
         if (initialiserController)


### PR DESCRIPTION
### Feature Description

Allows running a simulation with `-m`, writing a checkpoint and restarting that checkpoint *without* `-m`.

### Notes

This does not break restarts that keep the moving window "-m" on.

Warning: *enabling* the moving window from a checkpoint that had no moving window does still not work nor from a sim was "paused" with that method will not work. This would require remembering "how many iterations did someone stop the moving window".

First build for @Heikman during his Master's thesis and requested again by [Bifeng](https://cg.hzdr.de/Lists/picongpu-users/Message/151.html) on the user mailing list. The patch was so small and quick that I forgot to write a PR for it.