### PR TITLE
Kernels: Refactor Functions to Functors

### DIFF
--- a/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
@@ -34,67 +34,69 @@
 namespace picongpu
 {
 
-template< class ParBox>
-__global__ void kernelAddOneParticle(ParBox pb,
-                                     DataSpace<simDim> superCell, DataSpace<simDim> parLocalCell)
+struct kernelAddOneParticle
 {
-    typedef typename ParBox::FramePtr FramePtr;
-
-    FramePtr frame;
-
-    int linearIdx = DataSpaceOperations<simDim>::template map<MappingDesc::SuperCellSize > (parLocalCell);
-
-    float_X parWeighting = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
-
-    frame = pb.getEmptyFrame();
-    pb.setAsLastFrame(frame, superCell);
-
-
-
-
-    // many particle loop:
-    for (unsigned i = 0; i < 1; ++i)
+    template< class ParBox >
+    DINLINE void operator()(ParBox pb, DataSpace<simDim> superCell, DataSpace<simDim> parLocalCell) const
     {
+        typedef typename ParBox::FramePtr FramePtr;
 
-        PMACC_AUTO(par, frame[i]);
+        FramePtr frame;
 
-        /** we now initialize all attributes of the new particle to their default values
-         *   some attributes, such as the position, localCellIdx, weighting or the
-         *   multiMask (\see AttrToIgnore) of the particle will be set individually
-         *   in the following lines since they are already known at this point.
-         */
+        int linearIdx = DataSpaceOperations<simDim>::template map<MappingDesc::SuperCellSize > (parLocalCell);
+
+        float_X parWeighting = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+
+        frame = pb.getEmptyFrame();
+        pb.setAsLastFrame(frame, superCell);
+
+
+
+
+        // many particle loop:
+        for (unsigned i = 0; i < 1; ++i)
         {
-            typedef typename ParBox::FrameType FrameType;
-            typedef typename FrameType::ValueTypeSeq ParticleAttrList;
-            typedef bmpl::vector4<position<>, multiMask, localCellIdx, weighting> AttrToIgnore;
-            typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
 
-            algorithms::forEach::ForEach<ParticleCleanedAttrList,
-                SetAttributeToDefault<bmpl::_1> > setToDefault;
-            setToDefault(forward(par));
+            PMACC_AUTO(par, frame[i]);
+
+            /** we now initialize all attributes of the new particle to their default values
+             *   some attributes, such as the position, localCellIdx, weighting or the
+             *   multiMask (\see AttrToIgnore) of the particle will be set individually
+             *   in the following lines since they are already known at this point.
+             */
+            {
+                typedef typename ParBox::FrameType FrameType;
+                typedef typename FrameType::ValueTypeSeq ParticleAttrList;
+                typedef bmpl::vector4<position<>, multiMask, localCellIdx, weighting> AttrToIgnore;
+                typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
+
+                algorithms::forEach::ForEach<ParticleCleanedAttrList,
+                    SetAttributeToDefault<bmpl::_1> > setToDefault;
+                setToDefault(forward(par));
+            }
+            floatD_X pos = float3_X(LOCAL_POS_X, LOCAL_POS_Y, LOCAL_POS_Z).shrink<simDim>();
+
+            const float_X GAMMA0 = (float_X) (1.0 / sqrt(1.0 - (BETA0_X * BETA0_X + BETA0_Y * BETA0_Y + BETA0_Z * BETA0_Z)));
+            float3_X mom = float3_X(
+                                    GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_X) * SPEED_OF_LIGHT,
+                                    GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Y) * SPEED_OF_LIGHT,
+                                    GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Z) * SPEED_OF_LIGHT
+                                    );
+
+            par[position_] = pos;
+            par[momentum_] = mom;
+            par[multiMask_] = 1;
+            par[localCellIdx_] = linearIdx;
+            par[weighting_] = parWeighting;
+
+    #if(ENABLE_RADIATION == 1)
+    #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+            par[radiationFlag_] = true;
+    #endif
+    #endif
         }
-        floatD_X pos = float3_X(LOCAL_POS_X, LOCAL_POS_Y, LOCAL_POS_Z).shrink<simDim>();
-
-        const float_X GAMMA0 = (float_X) (1.0 / sqrt(1.0 - (BETA0_X * BETA0_X + BETA0_Y * BETA0_Y + BETA0_Z * BETA0_Z)));
-        float3_X mom = float3_X(
-                                GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_X) * SPEED_OF_LIGHT,
-                                GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Y) * SPEED_OF_LIGHT,
-                                GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Z) * SPEED_OF_LIGHT
-                                );
-
-        par[position_] = pos;
-        par[momentum_] = mom;
-        par[multiMask_] = 1;
-        par[localCellIdx_] = linearIdx;
-        par[weighting_] = parWeighting;
-
-#if(ENABLE_RADIATION == 1)
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
-        par[radiationFlag_] = true;
-#endif
-#endif
     }
-}
+};
 
 template<class ParticlesClass>
 class ParticlesInitOneParticle
@@ -128,7 +130,7 @@ public:
         std::cout << "localSuperCell: " << localSuperCell << std::endl;
         std::cout << "cellInSuperCell: " << cellInSuperCell << std::endl;
 
-        __cudaKernel(kernelAddOneParticle)
+        PMACC_TYPEKERNEL(kernelAddOneParticle)
             (1, 1)
             (parClass.getDeviceParticlesBox(),
              localSuperCell, cellInSuperCell);

--- a/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
@@ -130,7 +130,7 @@ public:
         std::cout << "localSuperCell: " << localSuperCell << std::endl;
         std::cout << "cellInSuperCell: " << cellInSuperCell << std::endl;
 
-        PMACC_TYPEKERNEL(kernelAddOneParticle)
+        PMACC_KERNEL(kernelAddOneParticle{})
             (1, 1)
             (parClass.getDeviceParticlesBox(),
              localSuperCell, cellInSuperCell);

--- a/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
@@ -131,7 +131,7 @@ public:
         localSuperCell = localSuperCell + cellDescription.getGuardingSuperCells();
 
 
-        PMACC_TYPEKERNEL(kernelAddOneParticle)
+        PMACC_KERNEL(kernelAddOneParticle{})
             (1, 1)
             (parClass.getDeviceParticlesBox(),
              localSuperCell, cellInSuperCell);

--- a/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
@@ -34,68 +34,70 @@
 namespace picongpu
 {
 
-template< class ParBox>
-__global__ void kernelAddOneParticle(ParBox pb,
-                                     DataSpace<simDim> superCell, DataSpace<simDim> parLocalCell)
+struct kernelAddOneParticle
 {
-    typedef typename ParBox::FramePtr FramePtr;
-
-    FramePtr frame;
-
-    int linearIdx = DataSpaceOperations<simDim>::template map<MappingDesc::SuperCellSize > (parLocalCell);
-
-    float_X parWeighting = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
-
-    frame = pb.getEmptyFrame();
-    pb.setAsLastFrame(frame, superCell);
-
-
-
-
-    // many particle loop:
-    for (unsigned i = 0; i < 1; ++i)
+    template< class ParBox>
+    DINLINE void operator()(ParBox pb, DataSpace<simDim> superCell, DataSpace<simDim> parLocalCell) const
     {
-        PMACC_AUTO(par, frame[i]);
+        typedef typename ParBox::FramePtr FramePtr;
 
-        /** we now initialize all attributes of the new particle to their default values
-         *   some attributes, such as the position, localCellIdx, weighting or the
-         *   multiMask (\see AttrToIgnore) of the particle will be set individually
-         *   in the following lines since they are already known at this point.
-         */
+        FramePtr frame;
+
+        int linearIdx = DataSpaceOperations<simDim>::template map<MappingDesc::SuperCellSize > (parLocalCell);
+
+        float_X parWeighting = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+
+        frame = pb.getEmptyFrame();
+        pb.setAsLastFrame(frame, superCell);
+
+
+
+
+        // many particle loop:
+        for (unsigned i = 0; i < 1; ++i)
         {
-            typedef typename ParBox::FrameType FrameType;
-            typedef typename FrameType::ValueTypeSeq ParticleAttrList;
-            typedef bmpl::vector4<position<>, multiMask, localCellIdx, weighting> AttrToIgnore;
-            typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
+            PMACC_AUTO(par, frame[i]);
 
-            algorithms::forEach::ForEach<ParticleCleanedAttrList,
-                SetAttributeToDefault<bmpl::_1> > setToDefault;
-            setToDefault(forward(par));
+            /** we now initialize all attributes of the new particle to their default values
+             *   some attributes, such as the position, localCellIdx, weighting or the
+             *   multiMask (\see AttrToIgnore) of the particle will be set individually
+             *   in the following lines since they are already known at this point.
+             */
+            {
+                typedef typename ParBox::FrameType FrameType;
+                typedef typename FrameType::ValueTypeSeq ParticleAttrList;
+                typedef bmpl::vector4<position<>, multiMask, localCellIdx, weighting> AttrToIgnore;
+                typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
+
+                algorithms::forEach::ForEach<ParticleCleanedAttrList,
+                    SetAttributeToDefault<bmpl::_1> > setToDefault;
+                setToDefault(forward(par));
+            }
+
+            floatD_X pos(floatD_X::create(0.5));
+
+            const float_X GAMMA0 = (float_X) (1.0 / sqrt(1.0 - (BETA0_X * BETA0_X + BETA0_Y * BETA0_Y + BETA0_Z * BETA0_Z)));
+            float3_X mom = float3_X(
+                                         GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_X) * SPEED_OF_LIGHT,
+                                         GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Y) * SPEED_OF_LIGHT,
+                                         GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Z) * SPEED_OF_LIGHT
+                                    );
+
+
+            par[position_] = pos;
+            par[momentum_] = mom;
+            par[multiMask_] = 1;
+            par[localCellIdx_] = linearIdx;
+            par[weighting_] = parWeighting;
+
+    #if(ENABLE_RADIATION == 1)
+    #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+            par[radiationFlag_] = true;
+    #endif
+    #endif
         }
-
-        floatD_X pos(floatD_X::create(0.5));
-
-        const float_X GAMMA0 = (float_X) (1.0 / sqrt(1.0 - (BETA0_X * BETA0_X + BETA0_Y * BETA0_Y + BETA0_Z * BETA0_Z)));
-        float3_X mom = float3_X(
-                                     GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_X) * SPEED_OF_LIGHT,
-                                     GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Y) * SPEED_OF_LIGHT,
-                                     GAMMA0 * attribute::getMass(parWeighting,par) * float_X(BETA0_Z) * SPEED_OF_LIGHT
-                                );
-
-
-        par[position_] = pos;
-        par[momentum_] = mom;
-        par[multiMask_] = 1;
-        par[localCellIdx_] = linearIdx;
-        par[weighting_] = parWeighting;
-
-#if(ENABLE_RADIATION == 1)
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
-        par[radiationFlag_] = true;
-#endif
-#endif
     }
-}
+};
 
 template<class ParticlesClass>
 class ParticlesInitOneParticle
@@ -125,7 +127,7 @@ public:
         localSuperCell = localSuperCell + cellDescription.getGuardingSuperCells();
 
 
-        __cudaKernel(kernelAddOneParticle)
+        PMACC_TYPEKERNEL(kernelAddOneParticle)
             (1, 1)
             (parClass.getDeviceParticlesBox(),
              localSuperCell, cellInSuperCell);

--- a/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
@@ -127,7 +127,7 @@ public:
         localSuperCell = localSuperCell + cellDescription.getGuardingSuperCells();
 
 
-        PMACC_TYPEKERNEL(kernelAddOneParticle)
+        PMACC_KERNEL(kernelAddOneParticle{})
             (1, 1)
             (parClass.getDeviceParticlesBox(),
              localSuperCell, cellInSuperCell);

--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -38,73 +38,79 @@ namespace gol
     {
         using namespace PMacc;
 
-        template<class BoxReadOnly, class BoxWriteOnly, class Mapping>
-        __global__ void evolution(BoxReadOnly buffRead,
-                                  BoxWriteOnly buffWrite,
-                                  uint32_t rule,
-                                  Mapping mapper)
+        struct evolution
         {
-            typedef typename BoxReadOnly::ValueType Type;
-            typedef SuperCellDescription<
-                    typename Mapping::SuperCellSize,
-                    math::CT::Int< 1, 1 >,
-                    math::CT::Int< 1, 1 >
-                    > BlockArea;
-            PMACC_AUTO(cache, CachedBox::create < 0, Type > (BlockArea()));
-
-            const Space block(mapper.getSuperCellIndex(Space(blockIdx)));
-            const Space blockCell = block * Mapping::SuperCellSize::toRT();
-            const Space threadIndex(threadIdx);
-            PMACC_AUTO(buffRead_shifted, buffRead.shift(blockCell));
-
-            ThreadCollective<BlockArea> collective(threadIndex);
-
-            nvidia::functors::Assign assign;
-            collective(
-                      assign,
-                      cache,
-                      buffRead_shifted
-                      );
-            __syncthreads();
-
-            Type neighbors = 0;
-            for (uint32_t i = 1; i < 9; ++i)
+            template<class BoxReadOnly, class BoxWriteOnly, class Mapping>
+            DINLINE void operator()(BoxReadOnly buffRead,
+                                      BoxWriteOnly buffWrite,
+                                      uint32_t rule,
+                                      Mapping mapper) const
             {
-                Space offset(Mask::getRelativeDirections<DIM2 > (i));
-                neighbors += cache(threadIndex + offset);
+                typedef typename BoxReadOnly::ValueType Type;
+                typedef SuperCellDescription<
+                        typename Mapping::SuperCellSize,
+                        math::CT::Int< 1, 1 >,
+                        math::CT::Int< 1, 1 >
+                        > BlockArea;
+                PMACC_AUTO(cache, CachedBox::create < 0, Type > (BlockArea()));
+
+                const Space block(mapper.getSuperCellIndex(Space(blockIdx)));
+                const Space blockCell = block * Mapping::SuperCellSize::toRT();
+                const Space threadIndex(threadIdx);
+                PMACC_AUTO(buffRead_shifted, buffRead.shift(blockCell));
+
+                ThreadCollective<BlockArea> collective(threadIndex);
+
+                nvidia::functors::Assign assign;
+                collective(
+                          assign,
+                          cache,
+                          buffRead_shifted
+                          );
+                __syncthreads();
+
+                Type neighbors = 0;
+                for (uint32_t i = 1; i < 9; ++i)
+                {
+                    Space offset(Mask::getRelativeDirections<DIM2 > (i));
+                    neighbors += cache(threadIndex + offset);
+                }
+
+                Type isLife = cache(threadIndex);
+                isLife = (bool)(((!isLife)*(1 << (neighbors + 9))) & rule) +
+                        (bool)(((isLife)*(1 << (neighbors))) & rule);
+
+                buffWrite(blockCell + threadIndex) = isLife;
             }
-
-            Type isLife = cache(threadIndex);
-            isLife = (bool)(((!isLife)*(1 << (neighbors + 9))) & rule) +
-                    (bool)(((isLife)*(1 << (neighbors))) & rule);
-
-            buffWrite(blockCell + threadIndex) = isLife;
-        }
-
-        template<class BoxWriteOnly, class Mapping>
-        __global__ void randomInit(BoxWriteOnly buffWrite,
-                                   uint32_t seed,
-                                   float fraction,
-                                   Mapping mapper)
+        };
+        
+        struct randomInit
         {
-            /* get position in grid in units of SuperCells from blockID */
-            const Space block(mapper.getSuperCellIndex(Space(blockIdx)));
-            /* convert position in unit of cells */
-            const Space blockCell = block * Mapping::SuperCellSize::toRT();
-            /* convert CUDA dim3 to DataSpace<DIM3> */
-            const Space threadIndex(threadIdx);
-            const uint32_t cellIdx = DataSpaceOperations<DIM2>::map(
-                    mapper.getGridSuperCells() * Mapping::SuperCellSize::toRT(),
-                    blockCell + threadIndex);
+            template<class BoxWriteOnly, class Mapping>
+            DINLINE void operator()(BoxWriteOnly buffWrite,
+                                       uint32_t seed,
+                                       float fraction,
+                                       Mapping mapper) const
+            {
+                /* get position in grid in units of SuperCells from blockID */
+                const Space block(mapper.getSuperCellIndex(Space(blockIdx)));
+                /* convert position in unit of cells */
+                const Space blockCell = block * Mapping::SuperCellSize::toRT();
+                /* convert CUDA dim3 to DataSpace<DIM3> */
+                const Space threadIndex(threadIdx);
+                const uint32_t cellIdx = DataSpaceOperations<DIM2>::map(
+                        mapper.getGridSuperCells() * Mapping::SuperCellSize::toRT(),
+                        blockCell + threadIndex);
 
-            /* get uniform random number from seed  */
-            PMACC_AUTO(rng, nvidia::rng::create(
-                                nvidia::rng::methods::Xor(seed, cellIdx),
-                                nvidia::rng::distributions::Uniform_float()));
+                /* get uniform random number from seed  */
+                PMACC_AUTO(rng, nvidia::rng::create(
+                                    nvidia::rng::methods::Xor(seed, cellIdx),
+                                    nvidia::rng::distributions::Uniform_float()));
 
-            /* write 1(white) if uniform random number 0<rng<1 is smaller than 'fraction' */
-            buffWrite(blockCell + threadIndex) = (rng() <= fraction);
-        }
+                /* write 1(white) if uniform random number 0<rng<1 is smaller than 'fraction' */
+                buffWrite(blockCell + threadIndex) = (rng() <= fraction);
+            }
+        };
     }
 
     template<class MappingDesc>
@@ -130,8 +136,8 @@ namespace gol
             GridController<DIM2>& gc = Environment<DIM2>::get().GridController();
             uint32_t seed = gc.getGlobalSize() + gc.getGlobalRank();
 
-            __cudaKernel(kernel::randomInit)
-                    (mapper.getGridDim(), MappingDesc::SuperCellSize::toRT().toDim3())
+            PMACC_TYPEKERNEL(kernel::randomInit)
+                    (mapper.getGridDim(), MappingDesc::SuperCellSize::toRT())
                     (
                      writeBox,
                      seed,
@@ -143,8 +149,8 @@ namespace gol
         void run(const DBox& readBox, const DBox & writeBox)
         {
             AreaMapping < Area, MappingDesc > mapper(mapping);
-            __cudaKernel(kernel::evolution)
-                    (mapper.getGridDim(), MappingDesc::SuperCellSize::toRT().toDim3())
+            PMACC_TYPEKERNEL(kernel::evolution)
+                    (mapper.getGridDim(), MappingDesc::SuperCellSize::toRT())
                     (readBox,
                      writeBox,
                      rule,

--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -83,7 +83,7 @@ namespace gol
                 buffWrite(blockCell + threadIndex) = isLife;
             }
         };
-        
+
         struct randomInit
         {
             template<class BoxWriteOnly, class Mapping>
@@ -136,7 +136,7 @@ namespace gol
             GridController<DIM2>& gc = Environment<DIM2>::get().GridController();
             uint32_t seed = gc.getGlobalSize() + gc.getGlobalRank();
 
-            PMACC_TYPEKERNEL(kernel::randomInit)
+            PMACC_KERNEL(kernel::randomInit{})
                     (mapper.getGridDim(), MappingDesc::SuperCellSize::toRT())
                     (
                      writeBox,
@@ -149,7 +149,7 @@ namespace gol
         void run(const DBox& readBox, const DBox & writeBox)
         {
             AreaMapping < Area, MappingDesc > mapper(mapping);
-            PMACC_TYPEKERNEL(kernel::evolution)
+            PMACC_KERNEL(kernel::evolution{})
                     (mapper.getGridDim(), MappingDesc::SuperCellSize::toRT())
                     (readBox,
                      writeBox,

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
@@ -63,10 +63,10 @@ namespace kernel
         /* ... */                                                                                           \
         BOOST_PP_REPEAT(N, SHIFT_CURSOR_ZONE, _)                                                            \
                                                                                                             \
-        dim3 blockDim(BlockDim::toRT().toDim3());                                                           \
+        auto blockDim = BlockDim::toRT();                                                                   \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace PMacc;                                                                              \
-        __cudaKernel(detail::kernelForeach)(mapper.cudaGridDim(p_zone.size), blockDim)                       \
+        PMACC_TYPEKERNEL(detail::kernelForeach)(mapper.cudaGridDim(p_zone.size), blockDim)                  \
                   /* c0_shifted, c1_shifted, ... */                                                         \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                   \
     }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
@@ -66,7 +66,7 @@ namespace kernel
         auto blockDim = BlockDim::toRT();                                                                   \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace PMacc;                                                                              \
-        PMACC_TYPEKERNEL(detail::kernelForeach)(mapper.cudaGridDim(p_zone.size), blockDim)                  \
+        PMACC_KERNEL(detail::kernelForeach{})(mapper.cudaGridDim(p_zone.size), blockDim)                    \
                   /* c0_shifted, c1_shifted, ... */                                                         \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                   \
     }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -94,7 +94,7 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), KERNEL_FOREA
         auto blockDim = ThreadBlock::toRT();                                                                \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace PMacc;                                                                              \
-        PMACC_TYPEKERNEL(detail::kernelForeachBlock)(mapper.cudaGridDim(p_zone.size), blockDim)             \
+        PMACC_KERNEL(detail::kernelForeachBlock{})(mapper.cudaGridDim(p_zone.size), blockDim)               \
                     /* c0_shifted, c1_shifted, ... */                                                       \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                   \
     }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -42,15 +42,17 @@ namespace detail
 /*                        typename C0, ..., typename CN     */ \
 template<typename Mapper, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor> \
 /*                                          C0 c0, ..., CN cN   */ \
-__global__ void kernelForeach(Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) \
+DINLINE void operator()(Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) const \
 { \
     math::Int<Mapper::dim> cellIndex(mapper(blockIdx, threadIdx)); \
 /*          forward(c0[cellIndex]), ..., forward(cN[cellIndex])     */ \
     functor(BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _)); \
 }
 
+struct kernelForeach
+{
 BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), KERNEL_FOREACH, _)
-
+};
 #undef KERNEL_FOREACH
 #undef SHIFTACCESS_CURSOR
 

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -55,9 +55,14 @@ struct SphericMapper<1, BlockSize>
 {
     static constexpr int dim = 1;
 
-    dim3 cudaGridDim(const math::Size_t<1>& size) const
+    typename math::Size_t<3>::BaseType 
+    cudaGridDim(const math::Size_t<1>& size) const
     {
-        return dim3(size.x() / BlockSize::x::value, 1, 1);
+        return math::Size_t<3>(
+            size.x() / BlockSize::x::value, 
+            1u, 
+            1u
+        );
     }
 
     HDINLINE
@@ -80,10 +85,14 @@ struct SphericMapper<2, BlockSize>
 {
     static constexpr int dim = 2;
 
-    dim3 cudaGridDim(const math::Size_t<2>& size) const
+    typename math::Size_t<3>::BaseType  
+    cudaGridDim(const math::Size_t<2>& size) const
     {
-        return dim3(size.x() / BlockSize::x::value,
-                    size.y() / BlockSize::y::value, 1);
+        return math::Size_t<3>(
+            size.x() / BlockSize::x::value,
+            size.y() / BlockSize::y::value, 
+            1u
+         );
     }
 
     HDINLINE
@@ -107,11 +116,14 @@ struct SphericMapper<3, BlockSize>
 {
     static constexpr int dim = 3;
 
-    dim3 cudaGridDim(const math::Size_t<3>& size) const
+    typename math::Size_t<3>::BaseType  
+    cudaGridDim(const math::Size_t<3>& size) const
     {
-        return dim3(size.x() / BlockSize::x::value,
-                    size.y() / BlockSize::y::value,
-                    size.z() / BlockSize::z::value);
+        return math::Size_t<3>(
+            size.x() / BlockSize::x::value,
+            size.y() / BlockSize::y::value,
+            size.z() / BlockSize::z::value
+        );
     }
 
     HDINLINE
@@ -136,9 +148,14 @@ struct SphericMapper<1, mpl::void_>
 {
     static constexpr int dim = 1;
 
-    dim3 cudaGridDim(const math::Size_t<1>& size, const math::Size_t<3>& blockDim) const
+    typename math::Size_t<3>::BaseType
+    cudaGridDim(const math::Size_t<1>& size, const math::Size_t<3>& blockDim) const
     {
-        return dim3(size.x() / blockDim.x(), 1, 1);
+        return math::Size_t<3>(
+            size.x() / blockDim.x(), 
+            1u, 
+            1u
+        );
     }
 
     DINLINE
@@ -161,10 +178,14 @@ struct SphericMapper<2, mpl::void_>
 {
     static constexpr int dim = 2;
 
-    dim3 cudaGridDim(const math::Size_t<2>& size, const math::Size_t<3>& blockDim) const
+    typename math::Size_t<3>::BaseType
+    cudaGridDim(const math::Size_t<2>& size, const math::Size_t<3>& blockDim) const
     {
-        return dim3(size.x() / blockDim.x(),
-                    size.y() / blockDim.y(), 1);
+        return math::Size_t<3>(
+            size.x() / blockDim.x(),
+            size.y() / blockDim.y(), 
+            1
+        );
     }
 
     DINLINE
@@ -188,11 +209,14 @@ struct SphericMapper<3, mpl::void_>
 {
     static constexpr int dim = 3;
 
-    dim3 cudaGridDim(const math::Size_t<3>& size, const math::Size_t<3>& blockDim) const
+    typename math::Size_t<3>::BaseType  
+    cudaGridDim(const math::Size_t<3>& size, const math::Size_t<3>& blockDim) const
     {
-        return dim3(size.x() / blockDim.x(),
-                    size.y() / blockDim.y(),
-                    size.z() / blockDim.z());
+        return math::Size_t<3>(
+            size.x() / blockDim.x(),
+            size.y() / blockDim.y(),
+            size.z() / blockDim.z()
+        );
     }
 
     DINLINE

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -135,10 +135,14 @@ math::Size_t<DIM3> getBestCudaBlockDim(const math::Size_t<dim> gridDim)
         PMACC_VERIFY(this->_blockDim.y() <= cudaSpecs::MaxNumThreadsPerBlockDim::y::value);                         \
         PMACC_VERIFY(this->_blockDim.z() <= cudaSpecs::MaxNumThreadsPerBlockDim::z::value);                         \
                                                                                                                     \
-        dim3 blockDim(this->_blockDim.x(), this->_blockDim.y(), this->_blockDim.z());                               \
+        typename math::Size_t<3>::BaseType blockDim(                                                                \
+            this->_blockDim.x(),                                                                                    \
+            this->_blockDim.y(),                                                                                    \
+            this->_blockDim.z()                                                                                     \
+        );                                                                                                          \
         kernel::detail::SphericMapper<Zone::dim> mapper;                                                            \
         using namespace PMacc;                                                                                      \
-        __cudaKernel(kernel::detail::kernelForeach)(mapper.cudaGridDim(p_zone.size, this->_blockDim), blockDim)      \
+        PMACC_TYPEKERNEL(kernel::detail::kernelForeach)(mapper.cudaGridDim(p_zone.size, this->_blockDim), blockDim) \
                 /*   c0_shifted, ..., cN_shifted    */                                                              \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                           \
     }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -142,7 +142,7 @@ math::Size_t<DIM3> getBestCudaBlockDim(const math::Size_t<dim> gridDim)
         );                                                                                                          \
         kernel::detail::SphericMapper<Zone::dim> mapper;                                                            \
         using namespace PMacc;                                                                                      \
-        PMACC_TYPEKERNEL(kernel::detail::kernelForeach)(mapper.cudaGridDim(p_zone.size, this->_blockDim), blockDim) \
+        PMACC_KERNEL(kernel::detail::kernelForeach{})(mapper.cudaGridDim(p_zone.size, this->_blockDim), blockDim)   \
                 /*   c0_shifted, ..., cN_shifted    */                                                              \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), lambda::make_Functor(functor));                           \
     }

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -279,12 +279,5 @@ namespace exec
  */
 #define PMACC_KERNEL( ... ) PMacc::exec::kernel( __VA_ARGS__, __FILE__,  static_cast< size_t >( __LINE__ ) )
 
-/** create a kernel object out of a functor type name
- *
- * this macro add the current filename and line number to the kernel object
- *
- * @param ... type of the kernel functor
- */
-#define PMACC_TYPEKERNEL( ... ) PMacc::exec::kernel( __VA_ARGS__{}, __FILE__,  static_cast< size_t >( __LINE__ ) )
 
 #include "eventSystem/events/kernelEvents.tpp"

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -49,13 +49,15 @@
 
 namespace PMacc
 {
+namespace exec
+{
     /** configured kernel object
-     * 
+     *
      * this objects contains the functor and the starting parameter
-     * 
+     *
      * @tparam T_Kernel pmacc Kernel object
-     * @tparam T_VectorGrid type which defines the grid extents (type must be cast able to CUDA dim3)
-     * @tparam T_VectorBlock type which defines the block extents (type must be cast able to CUDA dim3)
+     * @tparam T_VectorGrid type which defines the grid extents (type must be castable to CUDA dim3)
+     * @tparam T_VectorBlock type which defines the block extents (type must be castable to CUDA dim3)
      */
     template<
         typename T_Kernel,
@@ -63,10 +65,10 @@ namespace PMacc
         typename T_VectorBlock
     >
     struct KernelStarter;
-    
+
     /** wrapper for the user kernel functor
-     * 
-     * contains debug information like filename and lien of the kernel call
+     *
+     * contains debug information like filename and line of the kernel call
      */
     template< typename T_KernelFunctor >
     struct Kernel
@@ -79,11 +81,11 @@ namespace PMacc
         size_t const m_line;
 
         /**
-         * 
+         *
          * @param gridExtent grid extent configuration for the kernel
-         * @param blockExtent block extent configuration for the kernel 
+         * @param blockExtent block extent configuration for the kernel
          * @param sharedMemByte dynamic shared memory used by the kernel (in byte )
-         * @return 
+         * @return
          */
         HINLINE Kernel(
             T_KernelFunctor const & kernelFunctor,
@@ -98,15 +100,15 @@ namespace PMacc
         }
 
         /** configured kernel object
-         * 
+         *
          * this objects contains the functor and the starting parameter
-         * 
-         * @tparam T_VectorGrid type which defines the grid extents (type must be cast able to CUDA dim3)
-         * @tparam T_VectorBlock type which defines the block extents (type must be cast able to CUDA dim3)
-         * 
+         *
+         * @tparam T_VectorGrid type which defines the grid extents (type must be castable to CUDA dim3)
+         * @tparam T_VectorBlock type which defines the block extents (type must be castable to CUDA dim3)
+         *
          * @param gridExtent grid extent configuration for the kernel
-         * @param blockExtent block extent configuration for the kernel 
-         * @param sharedMemByte dynamic shared memory used by the kernel (in byte )
+         * @param blockExtent block extent configuration for the kernel
+         * @param sharedMemByte dynamic shared memory used by the kernel (in byte)
          */
         template<
             typename T_VectorGrid,
@@ -119,7 +121,7 @@ namespace PMacc
             T_VectorBlock const & blockExtent,
             size_t const sharedMemByte = 0
         ) const
-        -> KernelStarter< 
+        -> KernelStarter<
             Kernel,
             T_VectorGrid,
             T_VectorBlock
@@ -127,7 +129,7 @@ namespace PMacc
     };
 
 
-    template< 
+    template<
         typename T_Kernel,
         typename T_VectorGrid,
         typename T_VectorBlock
@@ -140,11 +142,11 @@ namespace PMacc
         T_VectorGrid const m_gridExtent;
         /** block extents for the kernel */
         T_VectorBlock const m_blockExtent;
-        /** dynamic shared memory consumed by the kernel (in byte)*/
+        /** dynamic shared memory consumed by the kernel (in byte) */
         size_t const m_sharedMemByte;
 
         /** kernel starter object
-         * 
+         *
          * @param kernel pmacc Kernel
          */
         HINLINE KernelStarter(
@@ -162,10 +164,10 @@ namespace PMacc
         }
 
         /** execute the kernel functor
-         * 
+         *
          * @tparam T_Args types of the arguments
          * @param args arguments for the kernel functor
-         * 
+         *
          * @{
          */
         template<
@@ -180,8 +182,8 @@ namespace PMacc
 
             std::string const kernelName = typeid( m_kernel.m_kernelFunctor ).name();
             std::string const kernelInfo = kernelName +
-                std::string( " [" ) + m_kernel.m_file + std::string( ":" ) + 
-                std::to_string( m_kernel.m_line ) + std::string( " ]" ); 
+                std::string( " [" ) + m_kernel.m_file + std::string( ":" ) +
+                std::to_string( m_kernel.m_line ) + std::string( " ]" );
 
             CUDA_CHECK_KERNEL_MSG(
                 cudaDeviceSynchronize( ),
@@ -197,21 +199,21 @@ namespace PMacc
                     T_VectorGrid
                 >::value
             > gridExtent( m_gridExtent );
-            
+
             DataSpace<
                 traits::GetNComponents<
                     T_VectorBlock
                 >::value
             > blockExtent( m_blockExtent );
-            
+
             nvidia::gpuEntryFunction<<<
                 gridExtent,
                 blockExtent,
                 m_sharedMemByte,
                 taskKernel->getCudaStream()
-            >>>( 
-                m_kernel.m_kernelFunctor, 
-                args ... 
+            >>>(
+                m_kernel.m_kernelFunctor,
+                args ...
             );
             CUDA_CHECK_KERNEL_MSG(
                 cudaGetLastError( ),
@@ -227,7 +229,7 @@ namespace PMacc
                 std::string(  "Crash after kernel activation" ) + kernelInfo
             );
         }
-        
+
         template<
             typename ... T_Args
         >
@@ -235,18 +237,18 @@ namespace PMacc
         void
         operator()(
             T_Args const &... args
-        ) 
+        )
         {
             return static_cast< const KernelStarter >(*this)( args ... );
         }
-        
+
         /** @} */
 
     };
 
 
     /** creates a kernel object
-     * 
+     *
      * @tparam T_KernelFunctor type of the kernel functor
      * @param kernelFunctor instance of the functor
      * @param file file name (for debug)
@@ -257,32 +259,32 @@ namespace PMacc
         T_KernelFunctor const & kernelFunctor,
         std::string const & file = std::string(),
         size_t const line = 0
-    ) -> PMacc::Kernel< T_KernelFunctor >
+    ) -> Kernel< T_KernelFunctor >
     {
-        return PMacc::Kernel< T_KernelFunctor >(
+        return Kernel< T_KernelFunctor >(
             kernelFunctor,
             file,
             line
         );
     }
- 
+} // namespace exec
 } // namespace PMacc
 
 
 /** create a kernel object out of a functor instance
- * 
+ *
  * this macro add the current filename and line number to the kernel object
- * 
+ *
  * @param ... instance of kernel functor
  */
-#define PMACC_KERNEL( ... ) PMacc::kernel( __VA_ARGS__, __FILE__,  static_cast< size_t >( __LINE__ ) )
+#define PMACC_KERNEL( ... ) PMacc::exec::kernel( __VA_ARGS__, __FILE__,  static_cast< size_t >( __LINE__ ) )
 
 /** create a kernel object out of a functor type name
- * 
+ *
  * this macro add the current filename and line number to the kernel object
- * 
- * @param ... type of the kernel functor 
- */ 
-#define PMACC_TYPEKERNEL( ... ) PMacc::kernel( __VA_ARGS__{}, __FILE__,  static_cast< size_t >( __LINE__ ) )
+ *
+ * @param ... type of the kernel functor
+ */
+#define PMACC_TYPEKERNEL( ... ) PMacc::exec::kernel( __VA_ARGS__{}, __FILE__,  static_cast< size_t >( __LINE__ ) )
 
 #include "eventSystem/events/kernelEvents.tpp"

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.tpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.tpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include "pmacc_types.hpp"
+#include "eventSystem/events/kernelEvents.hpp"
+
+
+namespace PMacc
+{
+    template< typename T_KernelFunctor >
+    template<
+        typename T_VectorGrid,
+        typename T_VectorBlock
+    >
+    HINLINE
+    auto
+    Kernel< T_KernelFunctor >::operator()(
+        T_VectorGrid const & gridExtent,
+        T_VectorBlock const & blockExtent,
+        size_t const sharedMemByte
+    ) const
+    -> KernelStarter<
+        Kernel,
+        T_VectorGrid,
+        T_VectorBlock
+    >
+    {
+        return KernelStarter<
+            Kernel,
+            T_VectorGrid,
+            T_VectorBlock
+        >(
+            *this,
+            gridExtent,
+            blockExtent,
+            sharedMemByte
+        );
+    }
+} // namespace PMacc

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.tpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.tpp
@@ -29,6 +29,8 @@
 
 namespace PMacc
 {
+namespace exec
+{
     template< typename T_KernelFunctor >
     template<
         typename T_VectorGrid,
@@ -58,4 +60,5 @@ namespace PMacc
             sharedMemByte
         );
     }
+} // namespace exec
 } // namespace PMacc

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -28,14 +28,18 @@
 #include "eventSystem/tasks/StreamTask.hpp"
 #include "eventSystem/events/kernelEvents.hpp"
 #include "dimensions/DataSpace.hpp"
+#include "nvidia/gpuEntryFunction.hpp"
 
 #include <cuda_runtime_api.h>
 #include <cuda.h>
 
-__global__ void kernelSetValueOnDeviceMemory(size_t* pointer, const size_t size)
+struct kernelSetValueOnDeviceMemory
 {
-    *pointer = size;
-}
+    DINLINE void operator()(size_t* pointer, const size_t size) const
+    {
+        *pointer = size;
+    }
+};
 
 namespace PMacc
 {
@@ -83,9 +87,17 @@ private:
 
     void setSize()
     {
-        kernelSetValueOnDeviceMemory
-            << < 1, 1, 0, this->getCudaStream() >> >
-            (destination->getCurrentSizeOnDevicePointer(), size);
+         auto sizePtr = destination->getCurrentSizeOnDevicePointer();
+         nvidia::gpuEntryFunction<<<
+            1,
+            1,
+            0,
+            this->getCudaStream()
+        >>>( 
+            kernelSetValueOnDeviceMemory{},
+            sizePtr, 
+            size
+        );
 
         activate();
     }

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -29,6 +29,7 @@
 #include "memory/boxes/DataBox.hpp"
 #include "eventSystem/EventSystem.hpp"
 #include "eventSystem/tasks/StreamTask.hpp"
+#include "nvidia/gpuEntryFunction.hpp"
 
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits.hpp>
@@ -82,20 +83,22 @@ getValue(T_Type& value)
 
 }
 
-template <class DataBox, typename T_ValueType, typename Space>
-__global__ void kernelSetValue(DataBox data, const T_ValueType value, const Space size)
+struct kernelSetValue
 {
-    const Space threadIndex(threadIdx);
-    const Space blockIndex(blockIdx);
-    const Space gridSize(blockDim);
+    template <class DataBox, typename T_ValueType, typename Space>
+    DINLINE void operator()(DataBox data, const T_ValueType value, const Space size) const
+    {
+        const Space threadIndex(threadIdx);
+        const Space blockIndex(blockIdx);
+        const Space gridSize(blockDim);
 
-    Space idx(gridSize * blockIndex + threadIndex);
+        Space idx(gridSize * blockIndex + threadIndex);
 
-    if (idx.x() >= size.x())
-        return;
-    data(idx) = taskSetValueHelper::getValue(value);
-}
-
+        if (idx.x() >= size.x())
+            return;
+        data(idx) = taskSetValueHelper::getValue(value);
+    }
+};
 
 template <class TYPE, unsigned DIM>
 class DeviceBuffer;
@@ -177,13 +180,23 @@ public:
 
         if(area_size.productOfComponents() != 0)
         {
-            dim3 gridSize = area_size;
+            auto gridSize = area_size;
 
             /* line wise thread blocks*/
-            gridSize.x = ceil(double(gridSize.x) / 256.);
+            gridSize.x() = ceil(double(gridSize.x()) / 256.);
 
-            kernelSetValue<<<gridSize, 256, 0, this->getCudaStream()>>>
-                (this->destination->getDataBox(), this->value, area_size);
+            auto destBox = this->destination->getDataBox();
+            nvidia::gpuEntryFunction<<<
+                gridSize,
+                256,
+                0,
+                this->getCudaStream()
+            >>>( 
+                kernelSetValue{},
+                destBox, 
+                this->value, 
+                area_size 
+            );
         }
         this->activate();
     }
@@ -221,10 +234,10 @@ public:
         const DataSpace<dim> area_size(this->destination->getCurrentDataSpace(current_size));
         if(area_size.productOfComponents() != 0)
         {
-            dim3 gridSize = area_size;
+            auto gridSize = area_size;
 
             /* line wise thread blocks*/
-            gridSize.x = ceil(double(gridSize.x) / 256.);
+            gridSize.x()= ceil(double(gridSize.x()) / 256.);
 
             ValueType* devicePtr = this->destination->getPointer();
 
@@ -234,8 +247,19 @@ public:
             CUDA_CHECK(cudaMemcpyAsync(
                                        devicePtr, valuePointer_host, sizeof (ValueType),
                                        cudaMemcpyHostToDevice, this->getCudaStream()));
-            kernelSetValue<<<gridSize, 256, 0, this->getCudaStream()>>>
-                (this->destination->getDataBox(), devicePtr, area_size);
+
+            auto destBox = this->destination->getDataBox();
+            nvidia::gpuEntryFunction<<<
+                gridSize,
+                256,
+                0,
+                this->getCudaStream()
+            >>>( 
+                kernelSetValue{},
+                destBox, 
+                devicePtr, 
+                area_size 
+            );
         }
 
         this->activate();

--- a/src/libPMacc/include/nvidia/gpuEntryFunction.hpp
+++ b/src/libPMacc/include/nvidia/gpuEntryFunction.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Felix Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include "pmacc_types.hpp"
+
+#pragma once
+
+namespace PMacc
+{
+namespace nvidia
+{
+    /**
+     * 
+     * @tparam T_KernelFunctor type of the functor for device execution
+     * @param kernel functor for device execution
+     * @param args arguments for the functor
+     */
+    template<
+        typename T_KernelFunctor,
+        typename ... T_Args
+    >
+    PMACC_GLOBAL_KEYWORD void gpuEntryFunction(
+        T_KernelFunctor const kernel,
+        T_Args ... args
+    )
+    {
+        kernel( args ... );
+    }
+} //namespace nvidia
+} //namespace PMacc

--- a/src/libPMacc/include/nvidia/reduce/Reduce.hpp
+++ b/src/libPMacc/include/nvidia/reduce/Reduce.hpp
@@ -33,206 +33,216 @@
 
 namespace PMacc
 {
-    namespace nvidia
+namespace nvidia
+{
+namespace reduce
+{
+
+namespace kernel
+{
+    template< typename Type >
+    struct reduce
     {
-        namespace reduce
+        template<typename Src, typename Dest, class Functor, class Functor2>
+        DINLINE void operator()(
+            Src src, const uint32_t src_count,
+            Dest dest,
+            Functor func, Functor2 func2
+        ) const
         {
+            const uint32_t localId = threadIdx.x;
+            const uint32_t tid = blockIdx.x * blockDim.x + localId;
+            const uint32_t globalThreadCount = gridDim.x * blockDim.x;
 
-            namespace kernel
+            /* cuda can not handle extern shared memory were the type is
+             * defined by a template
+             * - therefore we use type int for the definition (dirty but OK) */
+            extern __shared__ int s_mem_extern[];
+            /* create a pointer with the right type*/
+            Type* s_mem=(Type*)s_mem_extern;
+
+
+            
+            bool isActive = (tid < src_count);
+
+            if(isActive)
             {
-
-                template<typename Type, typename Src, typename Dest, class Functor, class Functor2>
-                __global__ void reduce(
-                                       Src src, const uint32_t src_count,
-                                       Dest dest,
-                                       Functor func, Functor2 func2)
+                /*fill shared mem*/
+                Type r_value = src[tid];
+                /*reduce not read global memory to shared*/
+                uint32_t i = tid + globalThreadCount;
+                while (i < src_count)
                 {
-                    const uint32_t localId = threadIdx.x;
-                    const uint32_t tid = blockIdx.x * blockDim.x + localId;
-                    const uint32_t globalThreadCount = gridDim.x * blockDim.x;
-
-                    /* cuda can not handle extern shared memory were the type is
-                     * defined by a template
-                     * - therefore we use type int for the definition (dirty but OK) */
-                    extern __shared__ int s_mem_extern[];
-                    /* create a pointer with the right type*/
-                    Type* s_mem=(Type*)s_mem_extern;
-
-                    if (tid >= src_count)
-                        return; /*end not needed threads*/
-
-                    /*fill shared mem*/
-                    Type r_value = src[tid];
-                    /*reduce not read global memory to shared*/
-                    uint32_t i = tid + globalThreadCount;
-                    while (i < src_count)
-                    {
-                        func(r_value, src[i]);
-                        i += globalThreadCount;
-                    }
-                    s_mem[localId] = r_value;
-                    __syncthreads();
-                    /*now reduce shared memory*/
-                    uint32_t chunk_count = blockDim.x;
-
-                    while (chunk_count != 1)
-                    {
-                        /* Half number of chunks (rounded down) */
-                        uint32_t active_threads = chunk_count / 2;
-                        if (localId >= active_threads)
-                            return; /*end not needed threads*/
-
-                        /* New chunks is half number of chunks rounded up for uneven counts
-                         * --> local_tid=0 will reduce the single element for an odd number of values at the end */
-                        chunk_count = (chunk_count + 1) / 2;
-                        func(s_mem[localId], s_mem[localId + chunk_count]);
-
-                        __syncthreads();
-                    }
-
-                    func2(dest[blockIdx.x], s_mem[0]);
+                    func(r_value, src[i]);
+                    i += globalThreadCount;
                 }
+                s_mem[localId] = r_value;
             }
 
-            class Reduce
+            __syncthreads();
+            /*now reduce shared memory*/
+            uint32_t chunk_count = blockDim.x;
+
+            while (chunk_count != 1)
             {
-            public:
+                /* Half number of chunks (rounded down) */
+                uint32_t active_threads = chunk_count / 2;
 
-                /* Constructor
-                 * Don't create a instance before you have set you cuda device!
-                 * @param byte how many bytes in global gpu memory can reserved for the reduce algorithm
-                 * @param sharedMemByte limit the usage of shared memory per block on gpu
-                 */
-                HINLINE Reduce(const uint32_t byte, const uint32_t sharedMemByte = 4 * 1024) :
-                byte(byte), sharedMemByte(sharedMemByte), reduceBuffer(NULL)
-                {
+                /* New chunks is half number of chunks rounded up for uneven counts
+                 * --> local_tid=0 will reduce the single element for an odd number of values at the end */
+                chunk_count = (chunk_count + 1) / 2;
+                
+                isActive = (tid < src_count) && !(localId != 0 && localId >= active_threads);
+                if(isActive)
+                    func(s_mem[localId], s_mem[localId + chunk_count]);
 
-                    reduceBuffer = new GridBuffer<char, DIM1 > (DataSpace<DIM1 > (byte));
-                }
-
-                /* Reduce elements in global gpu memory
-                 *
-                 * @param func binary functor for reduce which takes two arguments, first argument is the source and get the new reduced value.
-                 * Functor must specialize the function getMPI_Op.
-                 * @param src a class or a pointer where the reduce algorithm can access the value by operator [] (one dimension access)
-                 * @param n number of elements to reduce
-                 *
-                 * @return reduced value
-                 */
-                template<class Functor, typename Src>
-                HINLINE typename traits::GetValueType<Src>::ValueType operator()(Functor func, Src src, uint32_t n)
-                {
-                   /* - the result of a functor can be a reference or a const value
-                    * - it is not allowed to create const or reference memory
-                    *   thus we remove `references` and `const` qualifiers */
-                   typedef typename boost::remove_const<
-                               typename boost::remove_reference<
-                                   typename traits::GetValueType<Src>::ValueType
-                               >::type
-                           >::type Type;
-
-                    uint32_t blockcount = optimalThreadsPerBlock(n, sizeof (Type));
-
-                    uint32_t n_buffer = byte / sizeof (Type);
-
-                    uint32_t threads = n_buffer * blockcount * 2; /* x2 is used thus we can use all byte in Buffer, after we calculate threads/2 */
-
-
-
-                    if (threads > n) threads = n;
-                    Type* dest = (Type*) reduceBuffer->getDeviceBuffer().getBasePointer();
-
-                    uint32_t blocks = threads / 2 / blockcount;
-                    if (blocks == 0) blocks = 1;
-                    __cudaKernel((kernel::reduce < Type >))(blocks, blockcount, blockcount * sizeof (Type))(src, n, dest, func,
-                                                                                                            PMacc::nvidia::functors::Assign());
-                    n = blocks;
-                    blockcount = optimalThreadsPerBlock(n, sizeof (Type));
-                    blocks = n / 2 / blockcount;
-                    if (blocks == 0 && n > 1) blocks = 1;
-
-
-                    while (blocks != 0)
-                    {
-                        if (blocks > 1)
-                        {
-                            uint32_t blockOffset = ceil((double) blocks / blockcount);
-                            uint32_t useBlocks = blocks - blockOffset;
-                            uint32_t problemSize = n - (blockOffset * blockcount);
-                            Type* srcPtr = dest + (blockOffset * blockcount);
-
-                            __cudaKernel((kernel::reduce < Type >))(useBlocks, blockcount, blockcount * sizeof (Type))(srcPtr, problemSize, dest, func, func);
-                            blocks = blockOffset*blockcount;
-                        }
-                        else
-                        {
-
-                            __cudaKernel((kernel::reduce < Type >))(blocks, blockcount, blockcount * sizeof (Type))(dest, n, dest, func,
-                                                                                                                    PMacc::nvidia::functors::Assign());
-                        }
-
-                        n = blocks;
-                        blockcount = optimalThreadsPerBlock(n, sizeof (Type));
-                        blocks = n / 2 / blockcount;
-                        if (blocks == 0 && n > 1) blocks = 1;
-                    }
-
-                    reduceBuffer->deviceToHost();
-                    __getTransactionEvent().waitForFinished();
-                    return *((Type*) (reduceBuffer->getHostBuffer().getBasePointer()));
-
-                }
-
-                virtual ~Reduce()
-                {
-                    __delete(reduceBuffer);
-                }
-
-            private:
-
-                /* calculate number of threads per block
-                 * @param threads maximal number of threads per block
-                 * @return number of threads per block
-                 */
-                HINLINE uint32_t getThreadsPerBlock(uint32_t threads)
-                {
-                    /// \todo this list is not complete
-                    ///        extend it and maybe check for sm_version
-                    ///        and add possible threads accordingly.
-                    ///        maybe this function should be exported
-                    ///        to a more general nvidia class, too.
-                    if (threads >= 512) return 512;
-                    if (threads >= 256) return 256;
-                    if (threads >= 128) return 128;
-                    if (threads >= 64) return 64;
-                    if (threads >= 32) return 32;
-                    if (threads >= 16) return 16;
-                    if (threads >= 8) return 8;
-                    if (threads >= 4) return 4;
-                    if (threads >= 2) return 2;
-
-                    return 1;
-                }
-
-                /*calculate optimal number of threads per block with respect to shared memory limitations
-                 * @param n number of elements to reduce
-                 * @param sizePerElement size in bytes per elements
-                 * @return optimal count of threads per block to solve the problem
-                 */
-                HINLINE uint32_t optimalThreadsPerBlock(uint32_t n, uint32_t sizePerElement)
-                {
-                    uint32_t const sharedBorder = sharedMemByte / sizePerElement;
-                    return getThreadsPerBlock(std::min(sharedBorder, n));
-                }
-
-                /*global gpu buffer for reduce steps*/
-                GridBuffer<char, DIM1 > *reduceBuffer;
-                /*buffer size limit in bytes on gpu*/
-                uint32_t byte;
-                /*shared memory limit in byte for one block*/
-                uint32_t sharedMemByte;
-
-            };
+                __syncthreads();
+            }
+            if( localId == 0 )
+                func2(dest[blockIdx.x], s_mem[0]);
         }
-    }
+    };
+}
+
+    class Reduce
+    {
+    public:
+
+        /* Constructor
+         * Don't create a instance before you have set you cuda device!
+         * @param byte how many bytes in global gpu memory can reserved for the reduce algorithm
+         * @param sharedMemByte limit the usage of shared memory per block on gpu
+         */
+        HINLINE Reduce(const uint32_t byte, const uint32_t sharedMemByte = 4 * 1024) :
+        byte(byte), sharedMemByte(sharedMemByte), reduceBuffer(NULL)
+        {
+
+            reduceBuffer = new GridBuffer<char, DIM1 > (DataSpace<DIM1 > (byte));
+        }
+
+        /* Reduce elements in global gpu memory
+         *
+         * @param func binary functor for reduce which takes two arguments, first argument is the source and get the new reduced value.
+         * Functor must specialize the function getMPI_Op.
+         * @param src a class or a pointer where the reduce algorithm can access the value by operator [] (one dimension access)
+         * @param n number of elements to reduce
+         *
+         * @return reduced value
+         */
+        template<class Functor, typename Src>
+        HINLINE typename traits::GetValueType<Src>::ValueType operator()(Functor func, Src src, uint32_t n)
+        {
+           /* - the result of a functor can be a reference or a const value
+            * - it is not allowed to create const or reference memory
+            *   thus we remove `references` and `const` qualifiers */
+           typedef typename boost::remove_const<
+                       typename boost::remove_reference<
+                           typename traits::GetValueType<Src>::ValueType
+                       >::type
+                   >::type Type;
+
+            uint32_t blockcount = optimalThreadsPerBlock(n, sizeof (Type));
+
+            uint32_t n_buffer = byte / sizeof (Type);
+
+            uint32_t threads = n_buffer * blockcount * 2; /* x2 is used thus we can use all byte in Buffer, after we calculate threads/2 */
+
+
+
+            if (threads > n) threads = n;
+            Type* dest = (Type*) reduceBuffer->getDeviceBuffer().getBasePointer();
+
+            uint32_t blocks = threads / 2 / blockcount;
+            if (blocks == 0) blocks = 1;
+            PMACC_TYPEKERNEL(kernel::reduce < Type >)(blocks, blockcount, blockcount * sizeof (Type))(src, n, dest, func,
+                                                                                                    PMacc::nvidia::functors::Assign());
+            n = blocks;
+            blockcount = optimalThreadsPerBlock(n, sizeof (Type));
+            blocks = n / 2 / blockcount;
+            if (blocks == 0 && n > 1) blocks = 1;
+
+
+            while (blocks != 0)
+            {
+                if (blocks > 1)
+                {
+                    uint32_t blockOffset = ceil((double) blocks / blockcount);
+                    uint32_t useBlocks = blocks - blockOffset;
+                    uint32_t problemSize = n - (blockOffset * blockcount);
+                    Type* srcPtr = dest + (blockOffset * blockcount);
+
+                    PMACC_TYPEKERNEL(kernel::reduce < Type >)(useBlocks, blockcount, blockcount * sizeof (Type))(srcPtr, problemSize, dest, func, func);
+                    blocks = blockOffset*blockcount;
+                }
+                else
+                {
+
+                    PMACC_TYPEKERNEL(kernel::reduce < Type >)(blocks, blockcount, blockcount * sizeof (Type))(dest, n, dest, func,
+                                                                                                            PMacc::nvidia::functors::Assign());
+                }
+
+                n = blocks;
+                blockcount = optimalThreadsPerBlock(n, sizeof (Type));
+                blocks = n / 2 / blockcount;
+                if (blocks == 0 && n > 1) blocks = 1;
+            }
+
+            reduceBuffer->deviceToHost();
+            __getTransactionEvent().waitForFinished();
+            return *((Type*) (reduceBuffer->getHostBuffer().getBasePointer()));
+
+        }
+
+        virtual ~Reduce()
+        {
+            __delete(reduceBuffer);
+        }
+
+    private:
+
+        /* calculate number of threads per block
+         * @param threads maximal number of threads per block
+         * @return number of threads per block
+         */
+        HINLINE uint32_t getThreadsPerBlock(uint32_t threads)
+        {
+            /// \todo this list is not complete
+            ///        extend it and maybe check for sm_version
+            ///        and add possible threads accordingly.
+            ///        maybe this function should be exported
+            ///        to a more general nvidia class, too.
+            if (threads >= 512) return 512;
+            if (threads >= 256) return 256;
+            if (threads >= 128) return 128;
+            if (threads >= 64) return 64;
+            if (threads >= 32) return 32;
+            if (threads >= 16) return 16;
+            if (threads >= 8) return 8;
+            if (threads >= 4) return 4;
+            if (threads >= 2) return 2;
+
+            return 1;
+        }
+
+        /*calculate optimal number of threads per block with respect to shared memory limitations
+         * @param n number of elements to reduce
+         * @param sizePerElement size in bytes per elements
+         * @return optimal count of threads per block to solve the problem
+         */
+        HINLINE uint32_t optimalThreadsPerBlock(uint32_t n, uint32_t sizePerElement)
+        {
+            uint32_t const sharedBorder = sharedMemByte / sizePerElement;
+            return getThreadsPerBlock(std::min(sharedBorder, n));
+        }
+
+        /*global gpu buffer for reduce steps*/
+        GridBuffer<char, DIM1 > *reduceBuffer;
+        /*buffer size limit in bytes on gpu*/
+        uint32_t byte;
+        /*shared memory limit in byte for one block*/
+        uint32_t sharedMemByte;
+
+    };
+}
+}
 }

--- a/src/libPMacc/include/nvidia/reduce/Reduce.hpp
+++ b/src/libPMacc/include/nvidia/reduce/Reduce.hpp
@@ -62,7 +62,7 @@ namespace kernel
             Type* s_mem=(Type*)s_mem_extern;
 
 
-            
+
             bool isActive = (tid < src_count);
 
             if(isActive)
@@ -91,7 +91,7 @@ namespace kernel
                 /* New chunks is half number of chunks rounded up for uneven counts
                  * --> local_tid=0 will reduce the single element for an odd number of values at the end */
                 chunk_count = (chunk_count + 1) / 2;
-                
+
                 isActive = (tid < src_count) && !(localId != 0 && localId >= active_threads);
                 if(isActive)
                     func(s_mem[localId], s_mem[localId + chunk_count]);
@@ -154,7 +154,7 @@ namespace kernel
 
             uint32_t blocks = threads / 2 / blockcount;
             if (blocks == 0) blocks = 1;
-            PMACC_TYPEKERNEL(kernel::reduce < Type >)(blocks, blockcount, blockcount * sizeof (Type))(src, n, dest, func,
+            PMACC_KERNEL(kernel::reduce < Type >{})(blocks, blockcount, blockcount * sizeof (Type))(src, n, dest, func,
                                                                                                     PMacc::nvidia::functors::Assign());
             n = blocks;
             blockcount = optimalThreadsPerBlock(n, sizeof (Type));
@@ -171,13 +171,13 @@ namespace kernel
                     uint32_t problemSize = n - (blockOffset * blockcount);
                     Type* srcPtr = dest + (blockOffset * blockcount);
 
-                    PMACC_TYPEKERNEL(kernel::reduce < Type >)(useBlocks, blockcount, blockcount * sizeof (Type))(srcPtr, problemSize, dest, func, func);
+                    PMACC_KERNEL(kernel::reduce < Type >{})(useBlocks, blockcount, blockcount * sizeof (Type))(srcPtr, problemSize, dest, func, func);
                     blocks = blockOffset*blockcount;
                 }
                 else
                 {
 
-                    PMACC_TYPEKERNEL(kernel::reduce < Type >)(blocks, blockcount, blockcount * sizeof (Type))(dest, n, dest, func,
+                    PMACC_KERNEL(kernel::reduce < Type >{})(blocks, blockcount, blockcount * sizeof (Type))(dest, n, dest, func,
                                                                                                             PMacc::nvidia::functors::Assign());
                 }
 

--- a/src/libPMacc/include/particles/IdProvider.hpp
+++ b/src/libPMacc/include/particles/IdProvider.hpp
@@ -36,22 +36,31 @@ namespace PMacc {
 
         __device__ uint64_cu nextId;
 
-        __global__ void setNextId(uint64_cu id)
+        struct setNextId
         {
-            nextId = id;
-        }
+            DINLINE void operator()(uint64_cu id) const
+            {
+                nextId = id;
+            }
+        };
 
-        template<class T_Box>
-        __global__ void getNextId(T_Box boxOut)
+        struct getNextId
         {
-            boxOut(0) = nextId;
-        }
+            template<class T_Box>
+            DINLINE void operator()(T_Box boxOut) const
+            {
+                boxOut(0) = nextId;
+            }
+        };
 
-        template<class T_Box, class T_GetNewId>
-        __global__ void getNewId(T_Box boxOut, T_GetNewId getNewId)
+        struct getNewId
         {
-            boxOut(0) = getNewId();
-        }
+            template<class T_Box, class T_GetNewId>
+            DINLINE void operator()(T_Box boxOut, T_GetNewId getNewId) const
+            {
+                boxOut(0) = getNewId();
+            }
+        };
 
     }  // namespace idDetail
 
@@ -93,7 +102,7 @@ namespace PMacc {
     IdProvider<T_dim>::State IdProvider<T_dim>::getState()
     {
         HostDeviceBuffer<uint64_cu, 1> nextIdBuf(DataSpace<1>(1));
-        __cudaKernel(idDetail::getNextId)(1, 1)(nextIdBuf.getDeviceBuffer().getDataBox());
+        PMACC_TYPEKERNEL(idDetail::getNextId)(1, 1)(nextIdBuf.getDeviceBuffer().getDataBox());
         nextIdBuf.deviceToHost();
         State state;
         state.nextId = static_cast<uint64_t>(nextIdBuf.getHostBuffer().getDataBox()(0));
@@ -165,14 +174,14 @@ namespace PMacc {
     template<unsigned T_dim>
     void IdProvider<T_dim>::setNextId(uint64_t nextId)
     {
-        __cudaKernel(idDetail::setNextId)(1, 1)(nextId);
+        PMACC_TYPEKERNEL(idDetail::setNextId)(1, 1)(nextId);
     }
 
     template<unsigned T_dim>
     uint64_t IdProvider<T_dim>::getNewIdHost()
     {
         HostDeviceBuffer<uint64_cu, 1> newIdBuf(DataSpace<1>(1));
-        __cudaKernel(idDetail::getNewId)(1, 1)(newIdBuf.getDeviceBuffer().getDataBox(), GetNewId());
+        PMACC_TYPEKERNEL(idDetail::getNewId)(1, 1)(newIdBuf.getDeviceBuffer().getDataBox(), GetNewId());
         newIdBuf.deviceToHost();
         return static_cast<uint64_t>(newIdBuf.getHostBuffer().getDataBox()(0));
     }

--- a/src/libPMacc/include/particles/IdProvider.hpp
+++ b/src/libPMacc/include/particles/IdProvider.hpp
@@ -102,7 +102,7 @@ namespace PMacc {
     IdProvider<T_dim>::State IdProvider<T_dim>::getState()
     {
         HostDeviceBuffer<uint64_cu, 1> nextIdBuf(DataSpace<1>(1));
-        PMACC_TYPEKERNEL(idDetail::getNextId)(1, 1)(nextIdBuf.getDeviceBuffer().getDataBox());
+        PMACC_KERNEL(idDetail::getNextId{})(1, 1)(nextIdBuf.getDeviceBuffer().getDataBox());
         nextIdBuf.deviceToHost();
         State state;
         state.nextId = static_cast<uint64_t>(nextIdBuf.getHostBuffer().getDataBox()(0));
@@ -174,14 +174,14 @@ namespace PMacc {
     template<unsigned T_dim>
     void IdProvider<T_dim>::setNextId(uint64_t nextId)
     {
-        PMACC_TYPEKERNEL(idDetail::setNextId)(1, 1)(nextId);
+        PMACC_KERNEL(idDetail::setNextId{})(1, 1)(nextId);
     }
 
     template<unsigned T_dim>
     uint64_t IdProvider<T_dim>::getNewIdHost()
     {
         HostDeviceBuffer<uint64_cu, 1> newIdBuf(DataSpace<1>(1));
-        PMACC_TYPEKERNEL(idDetail::getNewId)(1, 1)(newIdBuf.getDeviceBuffer().getDataBox(), GetNewId());
+        PMACC_KERNEL(idDetail::getNewId{})(1, 1)(newIdBuf.getDeviceBuffer().getDataBox(), GetNewId());
         newIdBuf.deviceToHost();
         return static_cast<uint64_t>(newIdBuf.getHostBuffer().getDataBox()(0));
     }

--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -99,14 +99,14 @@ protected:
         __startTransaction(__getTransactionEvent());
         do
         {
-            __cudaKernel(kernelShiftParticles)
-                (mapper.getGridDim(), TileSize)
+            PMACC_TYPEKERNEL(kernelShiftParticles)
+                (mapper.getGridDim(), (int)TileSize)
                 (pBox, mapper);
-            __cudaKernel(kernelFillGaps)
-                (mapper.getGridDim(), TileSize)
+            PMACC_TYPEKERNEL(kernelFillGaps)
+                (mapper.getGridDim(), (int)TileSize)
                 (pBox, mapper);
-            __cudaKernel(kernelFillGapsLastFrame)
-                (mapper.getGridDim(), TileSize)
+            PMACC_TYPEKERNEL(kernelFillGapsLastFrame)
+                (mapper.getGridDim(), (int)TileSize)
                 (pBox, mapper);
         }
         while (mapper.next());
@@ -123,12 +123,12 @@ protected:
     {
         AreaMapping<AREA, MappingDesc> mapper(this->cellDescription);
 
-        __cudaKernel(kernelFillGaps)
-            (mapper.getGridDim(), TileSize)
+        PMACC_TYPEKERNEL(kernelFillGaps)
+            (mapper.getGridDim(), (int)TileSize)
             (particlesBuffer->getDeviceParticleBox(), mapper);
 
-        __cudaKernel(kernelFillGapsLastFrame)
-            (mapper.getGridDim(), TileSize)
+        PMACC_TYPEKERNEL(kernelFillGapsLastFrame)
+            (mapper.getGridDim(), (int)TileSize)
             (particlesBuffer->getDeviceParticleBox(), mapper);
     }
 

--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -99,13 +99,13 @@ protected:
         __startTransaction(__getTransactionEvent());
         do
         {
-            PMACC_TYPEKERNEL(kernelShiftParticles)
+            PMACC_KERNEL(kernelShiftParticles{})
                 (mapper.getGridDim(), (int)TileSize)
                 (pBox, mapper);
-            PMACC_TYPEKERNEL(kernelFillGaps)
+            PMACC_KERNEL(kernelFillGaps{})
                 (mapper.getGridDim(), (int)TileSize)
                 (pBox, mapper);
-            PMACC_TYPEKERNEL(kernelFillGapsLastFrame)
+            PMACC_KERNEL(kernelFillGapsLastFrame{})
                 (mapper.getGridDim(), (int)TileSize)
                 (pBox, mapper);
         }
@@ -123,11 +123,11 @@ protected:
     {
         AreaMapping<AREA, MappingDesc> mapper(this->cellDescription);
 
-        PMACC_TYPEKERNEL(kernelFillGaps)
+        PMACC_KERNEL(kernelFillGaps{})
             (mapper.getGridDim(), (int)TileSize)
             (particlesBuffer->getDeviceParticleBox(), mapper);
 
-        PMACC_TYPEKERNEL(kernelFillGapsLastFrame)
+        PMACC_KERNEL(kernelFillGapsLastFrame{})
             (mapper.getGridDim(), (int)TileSize)
             (particlesBuffer->getDeviceParticleBox(), mapper);
     }

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -48,554 +48,574 @@ getPreviousFrameAndRemoveLastFrame( const typename T_ParticleBox::FramePtr& fram
     return result;
 }
 
-/*! This kernel move particles to the next supercell
- * This kernel can only run with a double checker board
- */
-template<class T_ParBox, class Mapping>
-__global__ void kernelShiftParticles( T_ParBox pb, Mapping mapper )
+struct kernelShiftParticles
 {
-    typedef T_ParBox ParBox;
-    typedef typename ParBox::FrameType FrameType;
-    typedef typename ParBox::FramePtr FramePtr;
-    typedef typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type FramePtrShared;
-
-    const uint32_t dim = Mapping::Dim;
-    const uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
-    /* number exchanges in 2D=9 and in 3D=27 */
-    const uint32_t numExchanges = traits::NumberOfExchanges<dim>::value;
-
-    /* define memory for two times Exchanges
-     * index range [0,numExchanges-1] are being referred to as `low frames`
-     * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
+    /*! This kernel move particles to the next supercell
+     * This kernel can only run with a double checker board
      */
-    __shared__ FramePtrShared destFrames[numExchanges * 2];
-    __shared__ int destFramesCounter[numExchanges]; //count particles per frame
-
-    /* lastFrameSize is only valid for threads with `linearThreadIdx` < numExchanges */
-    uint32_t lastFrameSize = 0;
-
-    __shared__ FramePtrShared frame;
-    __shared__ bool mustShift;
-
-    DataSpace<dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<dim> (blockIdx) );
-    const uint32_t linearThreadIdx = threadIdx.x;
-
-    if ( linearThreadIdx == 0 )
+    template<class T_ParBox, class Mapping>
+    DINLINE void operator()( T_ParBox pb, Mapping mapper ) const
     {
-        mustShift = pb.getSuperCell( superCellIdx ).mustShift( );
-        if ( mustShift )
-        {
-            pb.getSuperCell( superCellIdx ).setMustShift( false );
-            frame = pb.getFirstFrame( superCellIdx );
-        }
-    }
+        typedef T_ParBox ParBox;
+        typedef typename ParBox::FrameType FrameType;
+        typedef typename ParBox::FramePtr FramePtr;
+        typedef typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type FramePtrShared;
 
-    __syncthreads( );
-    if ( !mustShift || !frame.isValid( ) ) return;
+        const uint32_t dim = Mapping::Dim;
+        const uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
+        /* number exchanges in 2D=9 and in 3D=27 */
+        const uint32_t numExchanges = traits::NumberOfExchanges<dim>::value;
 
-    const DataSpace<dim> relative = superCellIdx + Mask::getRelativeDirections<dim> (linearThreadIdx + 1);
-
-    /* if a partially filled last frame exists for the neighboring supercell,
-     * each master thread (one master per direction) will load it
-     */
-    if ( linearThreadIdx < numExchanges )
-    {
-        destFramesCounter[linearThreadIdx] = 0;
-        destFrames[linearThreadIdx] = FramePtr();
-        destFrames[linearThreadIdx + numExchanges] = FramePtr();
-        /* load last frame of neighboring supercell */
-        FramePtrShared tmpFrame(pb.getLastFrame( relative ));
-
-        if ( tmpFrame.isValid() )
-        {
-            lastFrameSize = pb.getSuperCell( relative ).getSizeLastFrame( );
-            // do not use the neighbor's last frame if it is full
-            if ( lastFrameSize < frameSize )
-            {
-                destFrames[linearThreadIdx] = tmpFrame;
-                destFramesCounter[linearThreadIdx] = lastFrameSize;
-            }
-        }
-    }
-    __syncthreads( );
-
-    /* iterate over the frame list of the current supercell */
-    while ( frame.isValid() )
-    {
-        lcellId_t destParticleIdx = INV_LOC_IDX;
-
-        /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
-         * -2 is no particle
-         * -1 is particle but it is not shifted (stays in supercell)
-         * >=0 particle moves in a certain direction
-         *     (@see ExchangeType in types.h)
+        /* define memory for two times Exchanges
+         * index range [0,numExchanges-1] are being referred to as `low frames`
+         * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
          */
-        int direction = frame[linearThreadIdx][multiMask_] - 2;
-        if ( direction >= 0 )
-        {
-            destParticleIdx = atomicAdd( &(destFramesCounter[direction]), 1 );
-        }
-        __syncthreads( );
+        __shared__ FramePtrShared destFrames[numExchanges * 2];
+        __shared__ int destFramesCounter[numExchanges]; //count particles per frame
 
-        /* If the master thread (responsible for a certain direction) did not
-         * obtain a `low frame` from the neighboring super cell before the loop,
-         * it will create one now.
-         *
-         * In case not all particles that are shifted to the neighboring
-         * supercell fit into the `low frame`, a second frame is created to
-         * contain further particles, the `high frame` (default: invalid).
-         */
-        if ( linearThreadIdx < numExchanges )
-        {
-            if ( destFramesCounter[linearThreadIdx] > 0 )
-            {
-                lastFrameSize = destFramesCounter[linearThreadIdx];
-                /* if we had no `low frame` we load a new empty one */
-                if ( !destFrames[linearThreadIdx].isValid() )
-                {
-                    FramePtrShared tmpFrame(pb.getEmptyFrame( ));
-                    destFrames[linearThreadIdx] = tmpFrame;
-                    pb.setAsLastFrame( tmpFrame, relative );
-                }
-                /* check if a `high frame` is needed */
-                if ( destFramesCounter[linearThreadIdx] > frameSize )
-                {
-                        lastFrameSize = destFramesCounter[linearThreadIdx] - frameSize;
-                        FramePtrShared tmpFrame(pb.getEmptyFrame( ));
-                        destFrames[linearThreadIdx + numExchanges] = tmpFrame;
-                        pb.setAsLastFrame( tmpFrame, relative );
-                }
-            }
-        }
-        __syncthreads( );
+        /* lastFrameSize is only valid for threads with `linearThreadIdx` < numExchanges */
+        uint32_t lastFrameSize = 0;
 
-        /* All threads with a valid index in the neighbor's frame, valid index
-         * range is [0, frameSize * 2-1], will copy their particle to the new
-         * frame.
-         *
-         * The default value for indexes (in the destination frame) is
-         * above this range (INV_LOC_IDX) for all particles that are not shifted.
-         */
-        if ( destParticleIdx < frameSize * 2 )
-        {
-            if ( destParticleIdx >= frameSize )
-            {
-                /* use `high frame` */
-                direction += numExchanges;
-                destParticleIdx -= frameSize;
-            }
-            PMACC_AUTO( dstParticle, destFrames[direction][destParticleIdx] );
-            PMACC_AUTO( srcParticle, frame[linearThreadIdx] );
-            dstParticle[multiMask_] = 1;
-            srcParticle[multiMask_] = 0;
-            PMACC_AUTO( dstFilteredParticle,
-                        particles::operations::deselect<multiMask>(dstParticle) );
-            particles::operations::assign( dstFilteredParticle, srcParticle );
-        }
-        __syncthreads( );
+        __shared__ FramePtrShared frame;
+        __shared__ bool mustShift;
 
-        /* if the `low frame` is now full, each master thread removes it and
-         * uses the `high frame` (is invalid, if still empty) as the next
-         * `low frame` for the following iteration of the loop
-         */
-        if ( linearThreadIdx < numExchanges )
-        {
-            if ( destFramesCounter[linearThreadIdx] >= frameSize )
-            {
-                destFramesCounter[linearThreadIdx] -= frameSize;
-                destFrames[linearThreadIdx] = destFrames[linearThreadIdx + numExchanges];
-                destFrames[linearThreadIdx + numExchanges] = FramePtr();
-            }
-            if ( linearThreadIdx == 0 )
-            {
-                frame = pb.getNextFrame( frame );
-            }
-        }
-        __syncthreads( );
-    }
-
-    /* each master thread updates the number of particles in the last frame
-     * of the neighbors supercell
-     */
-    if ( linearThreadIdx < numExchanges )
-    {
-        pb.getSuperCell( relative ).setSizeLastFrame( lastFrameSize );
-    }
-}
-
-template<class ParBox, class Mapping>
-__global__ void kernelFillGapsLastFrame( ParBox pb, Mapping mapper )
-{
-    using namespace particles::operations;
-
-    enum
-    {
-        TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
-        Dim = Mapping::Dim
-    };
-
-    typedef typename ParBox::FramePtr FramePtr;
-
-    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
-
-    __shared__ int gapIndices_sh[TileSize];
-    __shared__ int counterGaps;
-    __shared__ int counterParticles;
-
-    __shared__ int srcGap;
-
-
-    if ( threadIdx.x == 0 )
-    {
-        lastFrame = pb.getLastFrame( DataSpace<Dim > (superCellIdx) );
-        counterGaps = 0;
-        counterParticles = 0;
-        srcGap = 0;
-    }
-    __syncthreads( );
-
-
-    if ( lastFrame.isValid( ) )
-    {
-        //count particles in last frame
-        const bool isParticle = lastFrame[threadIdx.x][multiMask_];
-        if ( isParticle == true ) //\todo: bits zählen
-        {
-            nvidia::atomicAllInc( &counterParticles );
-        }
-        __syncthreads( );
-
-        if ( threadIdx.x < counterParticles && isParticle == false )
-        {
-            const int localGapIdx = nvidia::atomicAllInc( &counterGaps );
-            gapIndices_sh[localGapIdx] = threadIdx.x;
-        }
-        __syncthreads( );
-        if ( threadIdx.x >= counterParticles && isParticle )
-        {
-            //any particle search a gap
-            const int srcGapIdx = nvidia::atomicAllInc( &srcGap );
-            const int gapIdx = gapIndices_sh[srcGapIdx];
-            PMACC_AUTO( parDestFull, lastFrame[gapIdx] );
-            /*enable particle*/
-            parDestFull[multiMask_] = 1;
-            /* we not update multiMask because copy from mem to mem is to slow
-             * we have enabled particle explicit */
-            PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
-            PMACC_AUTO( parSrc, (lastFrame[threadIdx.x]) );
-            assign( parDest, parSrc );
-            parSrc[multiMask_] = 0; //delete old partice
-        }
-    }
-    if ( threadIdx.x == 0 )
-        pb.getSuperCell( superCellIdx ).setSizeLastFrame( counterParticles );
-
-}
-
-template<class ParBox, class Mapping>
-__global__ void kernelFillGaps( ParBox pb, Mapping mapper )
-{
-    using namespace particles::operations;
-
-    enum
-    {
-        TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
-        Dim = Mapping::Dim
-    };
-
-    typedef typename ParBox::FramePtr FramePtr;
-
-    DataSpace<Dim> superCellIdx( mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) ) );
-
-    //data copied from right (last) to left (first)
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type firstFrame;
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
-
-    __shared__ int particleIndices_sh[TileSize];
-    __shared__ int counterGaps;
-    __shared__ int counterParticles;
-
-
-    if ( threadIdx.x == 0 )
-    {
-        firstFrame = pb.getFirstFrame( DataSpace<Dim > (superCellIdx) );
-        lastFrame = pb.getLastFrame( DataSpace<Dim > (superCellIdx) );
-    }
-    __syncthreads( );
-
-    while ( firstFrame.isValid( ) && firstFrame != lastFrame )
-    {
-
-        if ( threadIdx.x == 0 )
-        {
-            //\todo: check if we need control thread or can write to shared with all threads
-            counterGaps = 0;
-            counterParticles = 0;
-        }
-        int localGapIdx = INV_LOC_IDX; //later we cann call localGapIdx < X because X<INV_LOC_IDX
-
-        __syncthreads( );
-
-        // find gaps
-        if ( firstFrame[threadIdx.x][multiMask_] == 0 )
-        {
-            localGapIdx = nvidia::atomicAllInc( &counterGaps );
-        }
-        __syncthreads( );
-
-        if ( counterGaps == 0 )
-        {
-            if ( threadIdx.x == 0 )
-            {
-                firstFrame = pb.getNextFrame( firstFrame );
-            }
-            __syncthreads( ); //wait control thread search new frame
-            continue; //check next frame
-        }
-
-        // search particles for gaps
-        if ( lastFrame[threadIdx.x][multiMask_] == 1 )
-        {
-            int localParticleIdx = nvidia::atomicAllInc( &counterParticles );
-            particleIndices_sh[localParticleIdx] = threadIdx.x;
-        }
-        __syncthreads( );
-        if ( localGapIdx < counterParticles )
-        {
-            const int parIdx = particleIndices_sh[localGapIdx];
-            PMACC_AUTO( parDestFull, (firstFrame[threadIdx.x]) );
-            /*enable particle*/
-            parDestFull[multiMask_] = 1;
-            /* we not update multiMask because copy from mem to mem is to slow
-             * we have enabled particle explicit */
-            PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
-            PMACC_AUTO( parSrc, (lastFrame[parIdx]) );
-            assign( parDest, parSrc );
-            parSrc[multiMask_] = 0;
-        }
-        __syncthreads( );
-        if ( threadIdx.x == 0 )
-        {
-            if ( counterGaps < counterParticles )
-            {
-                //any gap in the first frame is filled
-                firstFrame = pb.getNextFrame( firstFrame );
-            }
-            else if ( counterGaps > counterParticles )
-            {
-                //we need more particles
-                lastFrame = getPreviousFrameAndRemoveLastFrame( lastFrame, pb, superCellIdx );
-            }
-            else if ( counterGaps == counterParticles )
-            {
-                lastFrame = getPreviousFrameAndRemoveLastFrame( lastFrame, pb, superCellIdx );
-                if ( lastFrame.isValid( ) && lastFrame != firstFrame )
-                {
-                    firstFrame = pb.getNextFrame( firstFrame );
-                }
-            }
-        }
-        __syncthreads( );
-    }
-}
-
-template< class T_ParticleBox, class Mapping>
-__global__ void kernelDeleteParticles( T_ParticleBox pb,
-                                       Mapping mapper )
-{
-    using namespace particles::operations;
-
-    typedef T_ParticleBox ParticleBox;
-    typedef typename ParticleBox::FrameType FrameType;
-    typedef typename ParticleBox::FramePtr FramePtr;
-
-    enum
-    {
-        Dim = Mapping::Dim
-    };
-
-    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
-    const int linearThreadIdx = threadIdx.x;
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-
-    if ( linearThreadIdx == 0 )
-    {
-        frame = pb.getLastFrame( superCellIdx );
-    }
-
-    __syncthreads( );
-
-    while ( frame.isValid( ) )
-    {
-
-        PMACC_AUTO( particle, (frame[linearThreadIdx]) );
-        particle[multiMask_] = 0; //delete particle
-
-        __syncthreads( );
+        DataSpace<dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<dim> (blockIdx) );
+        const uint32_t linearThreadIdx = threadIdx.x;
 
         if ( linearThreadIdx == 0 )
         {
-            //always remove the last frame
-            frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
+            mustShift = pb.getSuperCell( superCellIdx ).mustShift( );
+            if ( mustShift )
+            {
+                pb.getSuperCell( superCellIdx ).setMustShift( false );
+                frame = pb.getFirstFrame( superCellIdx );
+            }
         }
+
         __syncthreads( );
-    }
+        if ( !mustShift || !frame.isValid( ) ) return;
 
-    if ( linearThreadIdx == 0 )
-        pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
+        const DataSpace<dim> relative = superCellIdx + Mask::getRelativeDirections<dim> (linearThreadIdx + 1);
 
-}
-
-template< class ParBox, class BORDER, class Mapping>
-__global__ void kernelBashParticles( ParBox pb,
-                                     ExchangePushDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
-                                     Mapping mapper )
-{
-    using namespace particles::operations;
-
-    enum
-    {
-        TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
-        Dim = Mapping::Dim
-    };
-    typedef typename ParBox::FramePtr FramePtr;
-
-    DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
-
-    __shared__ int numBashedParticles;
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-    __shared__ bool hasMemory;
-    __shared__ TileDataBox<BORDER> tmpBorder;
-
-    if ( threadIdx.x == 0 )
-    {
-        hasMemory = true;
-        frame = pb.getLastFrame( superCellIdx );
-    }
-    //\todo: eventuell ist es schneller, parallelen und seriellen Code zu trennen
-    __syncthreads( );
-    while ( frame.isValid( ) && hasMemory )
-    {
-        lcellId_t bashIdx = INV_LOC_IDX;
-        if ( threadIdx.x == 0 )
-            numBashedParticles = 0;
-        __syncthreads( );
-
-        if ( frame[threadIdx.x][multiMask_] == 1 )
+        /* if a partially filled last frame exists for the neighboring supercell,
+         * each master thread (one master per direction) will load it
+         */
+        if ( linearThreadIdx < numExchanges )
         {
-            bashIdx = nvidia::atomicAllInc( &numBashedParticles );
+            destFramesCounter[linearThreadIdx] = 0;
+            destFrames[linearThreadIdx] = FramePtr();
+            destFrames[linearThreadIdx + numExchanges] = FramePtr();
+            /* load last frame of neighboring supercell */
+            FramePtrShared tmpFrame(pb.getLastFrame( relative ));
+
+            if ( tmpFrame.isValid() )
+            {
+                lastFrameSize = pb.getSuperCell( relative ).getSizeLastFrame( );
+                // do not use the neighbor's last frame if it is full
+                if ( lastFrameSize < frameSize )
+                {
+                    destFrames[linearThreadIdx] = tmpFrame;
+                    destFramesCounter[linearThreadIdx] = lastFrameSize;
+                }
+            }
         }
         __syncthreads( );
 
-        if ( numBashedParticles > 0 )
+        /* iterate over the frame list of the current supercell */
+        while ( frame.isValid() )
+        {
+            lcellId_t destParticleIdx = INV_LOC_IDX;
+
+            /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
+             * -2 is no particle
+             * -1 is particle but it is not shifted (stays in supercell)
+             * >=0 particle moves in a certain direction
+             *     (@see ExchangeType in types.h)
+             */
+            int direction = frame[linearThreadIdx][multiMask_] - 2;
+            if ( direction >= 0 )
+            {
+                destParticleIdx = atomicAdd( &(destFramesCounter[direction]), 1 );
+            }
+            __syncthreads( );
+
+            /* If the master thread (responsible for a certain direction) did not
+             * obtain a `low frame` from the neighboring super cell before the loop,
+             * it will create one now.
+             *
+             * In case not all particles that are shifted to the neighboring
+             * supercell fit into the `low frame`, a second frame is created to
+             * contain further particles, the `high frame` (default: invalid).
+             */
+            if ( linearThreadIdx < numExchanges )
+            {
+                if ( destFramesCounter[linearThreadIdx] > 0 )
+                {
+                    lastFrameSize = destFramesCounter[linearThreadIdx];
+                    /* if we had no `low frame` we load a new empty one */
+                    if ( !destFrames[linearThreadIdx].isValid() )
+                    {
+                        FramePtrShared tmpFrame(pb.getEmptyFrame( ));
+                        destFrames[linearThreadIdx] = tmpFrame;
+                        pb.setAsLastFrame( tmpFrame, relative );
+                    }
+                    /* check if a `high frame` is needed */
+                    if ( destFramesCounter[linearThreadIdx] > frameSize )
+                    {
+                            lastFrameSize = destFramesCounter[linearThreadIdx] - frameSize;
+                            FramePtrShared tmpFrame(pb.getEmptyFrame( ));
+                            destFrames[linearThreadIdx + numExchanges] = tmpFrame;
+                            pb.setAsLastFrame( tmpFrame, relative );
+                    }
+                }
+            }
+            __syncthreads( );
+
+            /* All threads with a valid index in the neighbor's frame, valid index
+             * range is [0, frameSize * 2-1], will copy their particle to the new
+             * frame.
+             *
+             * The default value for indexes (in the destination frame) is
+             * above this range (INV_LOC_IDX) for all particles that are not shifted.
+             */
+            if ( destParticleIdx < frameSize * 2 )
+            {
+                if ( destParticleIdx >= frameSize )
+                {
+                    /* use `high frame` */
+                    direction += numExchanges;
+                    destParticleIdx -= frameSize;
+                }
+                PMACC_AUTO( dstParticle, destFrames[direction][destParticleIdx] );
+                PMACC_AUTO( srcParticle, frame[linearThreadIdx] );
+                dstParticle[multiMask_] = 1;
+                srcParticle[multiMask_] = 0;
+                PMACC_AUTO( dstFilteredParticle,
+                            particles::operations::deselect<multiMask>(dstParticle) );
+                particles::operations::assign( dstFilteredParticle, srcParticle );
+            }
+            __syncthreads( );
+
+            /* if the `low frame` is now full, each master thread removes it and
+             * uses the `high frame` (is invalid, if still empty) as the next
+             * `low frame` for the following iteration of the loop
+             */
+            if ( linearThreadIdx < numExchanges )
+            {
+                if ( destFramesCounter[linearThreadIdx] >= frameSize )
+                {
+                    destFramesCounter[linearThreadIdx] -= frameSize;
+                    destFrames[linearThreadIdx] = destFrames[linearThreadIdx + numExchanges];
+                    destFrames[linearThreadIdx + numExchanges] = FramePtr();
+                }
+                if ( linearThreadIdx == 0 )
+                {
+                    frame = pb.getNextFrame( frame );
+                }
+            }
+            __syncthreads( );
+        }
+
+        /* each master thread updates the number of particles in the last frame
+         * of the neighbors supercell
+         */
+        if ( linearThreadIdx < numExchanges )
+        {
+            pb.getSuperCell( relative ).setSizeLastFrame( lastFrameSize );
+        }
+    }
+};
+
+struct kernelFillGapsLastFrame
+{
+    template<class ParBox, class Mapping>
+    DINLINE void operator()( ParBox pb, Mapping mapper ) const
+    {
+        using namespace particles::operations;
+
+        enum
+        {
+            TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
+            Dim = Mapping::Dim
+        };
+
+        typedef typename ParBox::FramePtr FramePtr;
+
+        DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
+
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
+
+        __shared__ int gapIndices_sh[TileSize];
+        __shared__ int counterGaps;
+        __shared__ int counterParticles;
+
+        __shared__ int srcGap;
+
+
+        if ( threadIdx.x == 0 )
+        {
+            lastFrame = pb.getLastFrame( DataSpace<Dim > (superCellIdx) );
+            counterGaps = 0;
+            counterParticles = 0;
+            srcGap = 0;
+        }
+        __syncthreads( );
+
+
+        if ( lastFrame.isValid( ) )
+        {
+            //count particles in last frame
+            const bool isParticle = lastFrame[threadIdx.x][multiMask_];
+            if ( isParticle == true ) //\todo: bits zählen
+            {
+                nvidia::atomicAllInc( &counterParticles );
+            }
+            __syncthreads( );
+
+            if ( threadIdx.x < counterParticles && isParticle == false )
+            {
+                const int localGapIdx = nvidia::atomicAllInc( &counterGaps );
+                gapIndices_sh[localGapIdx] = threadIdx.x;
+            }
+            __syncthreads( );
+            if ( threadIdx.x >= counterParticles && isParticle )
+            {
+                //any particle search a gap
+                const int srcGapIdx = nvidia::atomicAllInc( &srcGap );
+                const int gapIdx = gapIndices_sh[srcGapIdx];
+                PMACC_AUTO( parDestFull, lastFrame[gapIdx] );
+                /*enable particle*/
+                parDestFull[multiMask_] = 1;
+                /* we not update multiMask because copy from mem to mem is to slow
+                 * we have enabled particle explicit */
+                PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
+                PMACC_AUTO( parSrc, (lastFrame[threadIdx.x]) );
+                assign( parDest, parSrc );
+                parSrc[multiMask_] = 0; //delete old partice
+            }
+        }
+        if ( threadIdx.x == 0 )
+            pb.getSuperCell( superCellIdx ).setSizeLastFrame( counterParticles );
+
+    }
+};
+
+struct kernelFillGaps
+{
+    template<class ParBox, class Mapping>
+    DINLINE void operator()( ParBox pb, Mapping mapper ) const
+    {
+        using namespace particles::operations;
+
+        enum
+        {
+            TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
+            Dim = Mapping::Dim
+        };
+
+        typedef typename ParBox::FramePtr FramePtr;
+
+        DataSpace<Dim> superCellIdx( mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) ) );
+
+        //data copied from right (last) to left (first)
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type firstFrame;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
+
+        __shared__ int particleIndices_sh[TileSize];
+        __shared__ int counterGaps;
+        __shared__ int counterParticles;
+
+
+        if ( threadIdx.x == 0 )
+        {
+            firstFrame = pb.getFirstFrame( DataSpace<Dim > (superCellIdx) );
+            lastFrame = pb.getLastFrame( DataSpace<Dim > (superCellIdx) );
+        }
+        __syncthreads( );
+
+        while ( firstFrame.isValid( ) && firstFrame != lastFrame )
         {
 
             if ( threadIdx.x == 0 )
             {
-                // DataSpaceOperations<DIM2>::reduce computes target position for domainTile and exchangeType
-                tmpBorder = border.pushN( numBashedParticles,
-                                          DataSpaceOperations<Dim>::reduce(
-                                                                            superCellIdx,
-                                                                            mapper.getExchangeType( ) ) );
-                if ( tmpBorder.getSize( ) < numBashedParticles )
-                    hasMemory = false;
+                //\todo: check if we need control thread or can write to shared with all threads
+                counterGaps = 0;
+                counterParticles = 0;
+            }
+            int localGapIdx = INV_LOC_IDX; //later we cann call localGapIdx < X because X<INV_LOC_IDX
+
+            __syncthreads( );
+
+            // find gaps
+            if ( firstFrame[threadIdx.x][multiMask_] == 0 )
+            {
+                localGapIdx = nvidia::atomicAllInc( &counterGaps );
             }
             __syncthreads( );
 
-            if ( bashIdx != INV_LOC_IDX && bashIdx < tmpBorder.getSize( ) )
+            if ( counterGaps == 0 )
             {
-                PMACC_AUTO( parDest, tmpBorder[bashIdx][0] );
-                PMACC_AUTO( parSrc, (frame[threadIdx.x]) );
+                if ( threadIdx.x == 0 )
+                {
+                    firstFrame = pb.getNextFrame( firstFrame );
+                }
+                __syncthreads( ); //wait control thread search new frame
+                continue; //check next frame
+            }
+
+            // search particles for gaps
+            if ( lastFrame[threadIdx.x][multiMask_] == 1 )
+            {
+                int localParticleIdx = nvidia::atomicAllInc( &counterParticles );
+                particleIndices_sh[localParticleIdx] = threadIdx.x;
+            }
+            __syncthreads( );
+            if ( localGapIdx < counterParticles )
+            {
+                const int parIdx = particleIndices_sh[localGapIdx];
+                PMACC_AUTO( parDestFull, (firstFrame[threadIdx.x]) );
+                /*enable particle*/
+                parDestFull[multiMask_] = 1;
+                /* we not update multiMask because copy from mem to mem is to slow
+                 * we have enabled particle explicit */
+                PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
+                PMACC_AUTO( parSrc, (lastFrame[parIdx]) );
                 assign( parDest, parSrc );
                 parSrc[multiMask_] = 0;
             }
             __syncthreads( );
+            if ( threadIdx.x == 0 )
+            {
+                if ( counterGaps < counterParticles )
+                {
+                    //any gap in the first frame is filled
+                    firstFrame = pb.getNextFrame( firstFrame );
+                }
+                else if ( counterGaps > counterParticles )
+                {
+                    //we need more particles
+                    lastFrame = getPreviousFrameAndRemoveLastFrame( lastFrame, pb, superCellIdx );
+                }
+                else if ( counterGaps == counterParticles )
+                {
+                    lastFrame = getPreviousFrameAndRemoveLastFrame( lastFrame, pb, superCellIdx );
+                    if ( lastFrame.isValid( ) && lastFrame != firstFrame )
+                    {
+                        firstFrame = pb.getNextFrame( firstFrame );
+                    }
+                }
+            }
+            __syncthreads( );
+        }
+    }
+};
 
-            if ( threadIdx.x == 0 && hasMemory )
+struct kernelDeleteParticles
+{
+    template< class T_ParticleBox, class Mapping>
+    DINLINE void operator()( 
+        T_ParticleBox pb,
+        Mapping mapper 
+    ) const
+    {
+        using namespace particles::operations;
+
+        typedef T_ParticleBox ParticleBox;
+        typedef typename ParticleBox::FrameType FrameType;
+        typedef typename ParticleBox::FramePtr FramePtr;
+
+        enum
+        {
+            Dim = Mapping::Dim
+        };
+
+        DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
+        const int linearThreadIdx = threadIdx.x;
+
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+
+        if ( linearThreadIdx == 0 )
+        {
+            frame = pb.getLastFrame( superCellIdx );
+        }
+
+        __syncthreads( );
+
+        while ( frame.isValid( ) )
+        {
+
+            PMACC_AUTO( particle, (frame[linearThreadIdx]) );
+            particle[multiMask_] = 0; //delete particle
+
+            __syncthreads( );
+
+            if ( linearThreadIdx == 0 )
             {
                 //always remove the last frame
                 frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
             }
+            __syncthreads( );
         }
-        else
+
+        if ( linearThreadIdx == 0 )
+            pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
+
+    }
+};
+
+struct kernelBashParticles
+{
+    template< class ParBox, class BORDER, class Mapping>
+    DINLINE void operator()( 
+        ParBox pb,
+        ExchangePushDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
+        Mapping mapper ) const
+    {
+        using namespace particles::operations;
+
+        enum
         {
-            //if we had no particles to copy than we are the last and only frame
+            TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
+            Dim = Mapping::Dim
+        };
+        typedef typename ParBox::FramePtr FramePtr;
+
+        DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
+
+        __shared__ int numBashedParticles;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        __shared__ bool hasMemory;
+        __shared__ TileDataBox<BORDER> tmpBorder;
+
+        if ( threadIdx.x == 0 )
+        {
+            hasMemory = true;
+            frame = pb.getLastFrame( superCellIdx );
+        }
+        //\todo: eventuell ist es schneller, parallelen und seriellen Code zu trennen
+        __syncthreads( );
+        while ( frame.isValid( ) && hasMemory )
+        {
+            lcellId_t bashIdx = INV_LOC_IDX;
             if ( threadIdx.x == 0 )
+                numBashedParticles = 0;
+            __syncthreads( );
+
+            if ( frame[threadIdx.x][multiMask_] == 1 )
             {
-                frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
+                bashIdx = nvidia::atomicAllInc( &numBashedParticles );
+            }
+            __syncthreads( );
+
+            if ( numBashedParticles > 0 )
+            {
+
+                if ( threadIdx.x == 0 )
+                {
+                    // DataSpaceOperations<DIM2>::reduce computes target position for domainTile and exchangeType
+                    tmpBorder = border.pushN( numBashedParticles,
+                                              DataSpaceOperations<Dim>::reduce(
+                                                                                superCellIdx,
+                                                                                mapper.getExchangeType( ) ) );
+                    if ( tmpBorder.getSize( ) < numBashedParticles )
+                        hasMemory = false;
+                }
+                __syncthreads( );
+
+                if ( bashIdx != INV_LOC_IDX && bashIdx < tmpBorder.getSize( ) )
+                {
+                    PMACC_AUTO( parDest, tmpBorder[bashIdx][0] );
+                    PMACC_AUTO( parSrc, (frame[threadIdx.x]) );
+                    assign( parDest, parSrc );
+                    parSrc[multiMask_] = 0;
+                }
+                __syncthreads( );
+
+                if ( threadIdx.x == 0 && hasMemory )
+                {
+                    //always remove the last frame
+                    frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
+                }
+            }
+            else
+            {
+                //if we had no particles to copy than we are the last and only frame
+                if ( threadIdx.x == 0 )
+                {
+                    frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
+                }
+            }
+            __syncthreads( );
+        }
+        if ( threadIdx.x == 0 )
+            pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
+
+    }
+};
+
+
+struct kernelInsertParticles
+{
+    template<class ParBox, class BORDER, class Mapping>
+    DINLINE void operator()( ParBox pb,
+                                           ExchangePopDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
+                                           Mapping mapper ) const
+    {
+
+        using namespace particles::operations;
+
+        enum
+        {
+            TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
+            Dim = Mapping::Dim
+        };
+
+        typedef typename ParBox::FramePtr FramePtr;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        __shared__ int elementCount;
+        __shared__ TileDataBox<BORDER> tmpBorder;
+
+
+        DataSpace < Mapping::Dim - 1 > superCell;
+
+        if ( threadIdx.x == 0 )
+        {
+            tmpBorder = border.get(blockIdx.x,superCell);
+            elementCount = tmpBorder.getSize( );
+            if ( elementCount > 0 )
+            {
+                frame = pb.getEmptyFrame( );
             }
         }
         __syncthreads( );
-    }
-    if ( threadIdx.x == 0 )
-        pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
-
-}
-
-template<class ParBox, class BORDER, class Mapping>
-__global__ void kernelInsertParticles( ParBox pb,
-                                       ExchangePopDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
-                                       Mapping mapper )
-{
-
-    using namespace particles::operations;
-
-    enum
-    {
-        TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
-        Dim = Mapping::Dim
-    };
-
-    typedef typename ParBox::FramePtr FramePtr;
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-    __shared__ int elementCount;
-    __shared__ TileDataBox<BORDER> tmpBorder;
-
-
-    DataSpace < Mapping::Dim - 1 > superCell;
-
-    if ( threadIdx.x == 0 )
-    {
-        tmpBorder = border.get(blockIdx.x,superCell);
-        elementCount = tmpBorder.getSize( );
-        if ( elementCount > 0 )
+        if ( threadIdx.x < elementCount )
         {
-            frame = pb.getEmptyFrame( );
+            PMACC_AUTO( parDestFull, (frame[threadIdx.x]) );
+            parDestFull[multiMask_] = 1;
+            PMACC_AUTO( parSrc, ((tmpBorder[threadIdx.x])[0]) );
+            /*we know that source has no multiMask*/
+            PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
+            assign( parDest, parSrc );
         }
+        /*if this syncronize fix the kernel crash in spezial cases,
+         * I can't tell why.
+         */
+        __syncthreads( );
+        if ( (threadIdx.x == 0) && (elementCount > 0) )
+        {
+            // compute the super cell position in target frame to insert into
+            ///\todo: offset == simulation border should be passed to this func instead of being created here
+            DataSpace<Dim> dstSuperCell = DataSpaceOperations < Dim - 1 > ::extend( superCell,
+                                                                                    mapper.getExchangeType( ),
+                                                                                    mapper.getGridSuperCells( ),
+                                                                                    DataSpace<Dim>::create( mapper.getGuardingSuperCells( ) ) );
+
+            pb.setAsLastFrame( frame, dstSuperCell );
+        }
+
+
     }
-    __syncthreads( );
-    if ( threadIdx.x < elementCount )
-    {
-        PMACC_AUTO( parDestFull, (frame[threadIdx.x]) );
-        parDestFull[multiMask_] = 1;
-        PMACC_AUTO( parSrc, ((tmpBorder[threadIdx.x])[0]) );
-        /*we know that source has no multiMask*/
-        PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
-        assign( parDest, parSrc );
-    }
-    /*if this syncronize fix the kernel crash in spezial cases,
-     * I can't tell why.
-     */
-    __syncthreads( );
-    if ( (threadIdx.x == 0) && (elementCount > 0) )
-    {
-        // compute the super cell position in target frame to insert into
-        ///\todo: offset == simulation border should be passed to this func instead of being created here
-        DataSpace<Dim> dstSuperCell = DataSpaceOperations < Dim - 1 > ::extend( superCell,
-                                                                                mapper.getExchangeType( ),
-                                                                                mapper.getGridSuperCells( ),
-                                                                                DataSpace<Dim>::create( mapper.getGuardingSuperCells( ) ) );
-
-        pb.setAsLastFrame( frame, dstSuperCell );
-    }
-
-
-}
-
+};
 
 
 } //namespace PMacc
-

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -39,10 +39,10 @@ namespace PMacc
     {
 
         ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
-        dim3 grid(mapper.getGridDim());
+        auto grid = mapper.getGridDim();
 
-        __cudaKernel(kernelDeleteParticles)
-                (grid, TileSize)
+        PMACC_TYPEKERNEL(kernelDeleteParticles)
+                (grid, (int)TileSize)
                 (particlesBuffer->getDeviceParticleBox(), mapper);
     }
 
@@ -52,10 +52,10 @@ namespace PMacc
     {
 
         AreaMapping<T_area, MappingDesc> mapper(this->cellDescription);
-        dim3 grid(mapper.getGridDim());
+        auto grid = mapper.getGridDim();
 
-        __cudaKernel(kernelDeleteParticles)
-                (grid, TileSize)
+        PMACC_TYPEKERNEL(kernelDeleteParticles)
+                (grid, (int)TileSize)
                 (particlesBuffer->getDeviceParticleBox(), mapper);
     }
 
@@ -74,10 +74,10 @@ namespace PMacc
             ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
 
             particlesBuffer->getSendExchangeStack(exchangeType).setCurrentSize(0);
-            dim3 grid(mapper.getGridDim());
+            auto grid = mapper.getGridDim();
 
-            __cudaKernel(kernelBashParticles)
-                    (grid, TileSize)
+            PMACC_TYPEKERNEL(kernelBashParticles)
+                    (grid, (int)TileSize)
                     (particlesBuffer->getDeviceParticleBox(),
                     particlesBuffer->getSendExchangeStack(exchangeType).getDeviceExchangePushDataBox(), mapper);
         }
@@ -93,8 +93,8 @@ namespace PMacc
             if (grid != 0)
             {
                 ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
-                __cudaKernel(kernelInsertParticles)
-                        (grid, TileSize)
+                PMACC_TYPEKERNEL(kernelInsertParticles)
+                        (grid, (int)TileSize)
                         (particlesBuffer->getDeviceParticleBox(),
                         particlesBuffer->getReceiveExchangeStack(exchangeType).getDeviceExchangePopDataBox(),
                         mapper);

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -41,7 +41,7 @@ namespace PMacc
         ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
         auto grid = mapper.getGridDim();
 
-        PMACC_TYPEKERNEL(kernelDeleteParticles)
+        PMACC_KERNEL(kernelDeleteParticles{})
                 (grid, (int)TileSize)
                 (particlesBuffer->getDeviceParticleBox(), mapper);
     }
@@ -54,7 +54,7 @@ namespace PMacc
         AreaMapping<T_area, MappingDesc> mapper(this->cellDescription);
         auto grid = mapper.getGridDim();
 
-        PMACC_TYPEKERNEL(kernelDeleteParticles)
+        PMACC_KERNEL(kernelDeleteParticles{})
                 (grid, (int)TileSize)
                 (particlesBuffer->getDeviceParticleBox(), mapper);
     }
@@ -76,7 +76,7 @@ namespace PMacc
             particlesBuffer->getSendExchangeStack(exchangeType).setCurrentSize(0);
             auto grid = mapper.getGridDim();
 
-            PMACC_TYPEKERNEL(kernelBashParticles)
+            PMACC_KERNEL(kernelBashParticles{})
                     (grid, (int)TileSize)
                     (particlesBuffer->getDeviceParticleBox(),
                     particlesBuffer->getSendExchangeStack(exchangeType).getDeviceExchangePushDataBox(), mapper);
@@ -93,7 +93,7 @@ namespace PMacc
             if (grid != 0)
             {
                 ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
-                PMACC_TYPEKERNEL(kernelInsertParticles)
+                PMACC_KERNEL(kernelInsertParticles{})
                         (grid, (int)TileSize)
                         (particlesBuffer->getDeviceParticleBox(),
                         particlesBuffer->getReceiveExchangeStack(exchangeType).getDeviceExchangePopDataBox(),

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -121,7 +121,7 @@ struct CountParticles
 
         AreaMapping<AREA, CellDesc> mapper(cellDescription);
 
-        PMACC_TYPEKERNEL(kernelCountParticles)
+        PMACC_KERNEL(kernelCountParticles{})
             (mapper.getGridDim(), block)
             (buffer.getDeviceParticlesBox(),
              counter.getDeviceBuffer().getBasePointer(),

--- a/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
+++ b/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
@@ -38,121 +38,123 @@ namespace operations
 {
 namespace kernel
 {
-
-/** Copy particles from big frame to PMacc frame structure
- *  (Opposite to ConcatListOfFrames)
- *
- * - convert a user-defined domainCellIdx to localCellIdx
- * - processed particles per block <= number of cells per superCell
- *
- * @param counter box with three integer [srcParticleOffset, numLoadedParticles, numUsedFrames]
- * @param destBox particle box were all particles are copied to (destination)
- * @param srcFrame frame with particles (is used as source)
- * @param maxParticles number of particles in srcFrame
- * @param localDomainCellOffset offset in cells to user-defined domain (@see wiki PIConGPU domain definitions)
- * @param domainCellIdxIdentifier the identifier for the particle domain cellIdx
- *                                that is calculated back to the local domain
- *                                with respect to localDomainCellOffset
- * @param cellDesc picongpu cellDescription
- */
-template<class T_CounterBox, class T_DestBox, class T_SrcFrame, class T_Space, class T_Identifier, class T_CellDescription>
-__global__ void splitIntoListOfFrames(
-    T_CounterBox counter,
-    T_DestBox destBox,
-    T_SrcFrame srcFrame,
-    const int maxParticles,
-    const T_Space localDomainCellOffset,
-    const T_Identifier domainCellIdxIdentifier,
-    const T_CellDescription cellDesc
-)
-{
-    using namespace PMacc::particles::operations;
-
-    typedef T_SrcFrame SrcFrameType;
-    typedef typename T_DestBox::FrameType DestFrameType;
-    typedef typename T_DestBox::FramePtr DestFramePtr;
-    typedef typename T_CellDescription::SuperCellSize SuperCellSize;
-    constexpr unsigned NumDims = T_DestBox::Dim;
-    constexpr uint32_t particlesPerFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<DestFramePtr>::type destFramePtr[particlesPerFrame];
-    __shared__ int linearSuperCellIds[particlesPerFrame];
-    __shared__ int srcParticleOffset;
-
-
-    const int linearThreadIdx = threadIdx.x;
-
-
-    const DataSpace<NumDims> numSuperCells(cellDesc.getGridSuperCells() - cellDesc.getGuardingSuperCells()*2);
-    if (linearThreadIdx == 0)
+    struct splitIntoListOfFrames
     {
-        /* apply for work for the full block
-         * counter [0] -> offset to load particles
+        /** Copy particles from big frame to PMacc frame structure
+         *  (Opposite to ConcatListOfFrames)
+         *
+         * - convert a user-defined domainCellIdx to localCellIdx
+         * - processed particles per block <= number of cells per superCell
+         *
+         * @param counter box with three integer [srcParticleOffset, numLoadedParticles, numUsedFrames]
+         * @param destBox particle box were all particles are copied to (destination)
+         * @param srcFrame frame with particles (is used as source)
+         * @param maxParticles number of particles in srcFrame
+         * @param localDomainCellOffset offset in cells to user-defined domain (@see wiki PIConGPU domain definitions)
+         * @param domainCellIdxIdentifier the identifier for the particle domain cellIdx
+         *                                that is calculated back to the local domain
+         *                                with respect to localDomainCellOffset
+         * @param cellDesc picongpu cellDescription
          */
-        srcParticleOffset = atomicAdd(&(counter[0]), particlesPerFrame);
-    }
-    destFramePtr[linearThreadIdx] = DestFramePtr();
-    linearSuperCellIds[linearThreadIdx] = -1;
-
-    __syncthreads();
-
-    const int srcParticleIdx = srcParticleOffset + linearThreadIdx;
-    const bool hasValidParticle = srcParticleIdx < maxParticles;
-    DataSpace<NumDims> superCellIdx;
-    lcellId_t lCellIdx = INV_LOC_IDX;
-    int myLinearSuperCellId = -1;
-
-    if (hasValidParticle)
-    {
-        // cell index on this GPU
-        const DataSpace<NumDims> gpuCellIdx = srcFrame[srcParticleIdx][domainCellIdxIdentifier]
-                                                 - localDomainCellOffset;
-        superCellIdx = gpuCellIdx / SuperCellSize::toRT();
-        myLinearSuperCellId = DataSpaceOperations<NumDims>::map(numSuperCells, superCellIdx);
-        linearSuperCellIds[linearThreadIdx] = myLinearSuperCellId;
-        DataSpace<NumDims> localCellIdx(gpuCellIdx - superCellIdx * SuperCellSize::toRT());
-        lCellIdx = DataSpaceOperations<NumDims>::template map<SuperCellSize>(localCellIdx);
-    }
-    __syncthreads();
-
-    int masterIdx = linearThreadIdx - 1;
-
-    if (hasValidParticle)
-    {
-        /* search master thread index */
-        while (masterIdx >= 0)
+        template<class T_CounterBox, class T_DestBox, class T_SrcFrame, class T_Space, class T_Identifier, class T_CellDescription>
+        DINLINE void operator()(
+            T_CounterBox counter,
+            T_DestBox destBox,
+            T_SrcFrame srcFrame,
+            const int maxParticles,
+            const T_Space localDomainCellOffset,
+            const T_Identifier domainCellIdxIdentifier,
+            const T_CellDescription cellDesc
+        ) const
         {
-            if (myLinearSuperCellId != linearSuperCellIds[masterIdx])
-                break;
-            --masterIdx;
-        }
-        ++masterIdx;
-        /* load empty frame if thread is the master*/
-        if (masterIdx == linearThreadIdx)
-        {
-            /* counter[2] -> number of used frames */
-            nvidia::atomicAllInc(&(counter[2]));
-            DestFramePtr tmpFrame = destBox.getEmptyFrame();
-            destFramePtr[linearThreadIdx] = tmpFrame;
-            destBox.setAsFirstFrame(tmpFrame, superCellIdx + cellDesc.getGuardingSuperCells());
-        }
-    }
-    __syncthreads();
+            using namespace PMacc::particles::operations;
 
-    if (hasValidParticle)
-    {
-        /* copy attributes and activate particle*/
-        PMACC_AUTO(parDest, destFramePtr[masterIdx][linearThreadIdx]);
-        PMACC_AUTO(parDestDeselect, deselect<bmpl::vector2<localCellIdx, multiMask> >(parDest));
-        assign(parDestDeselect, srcFrame[srcParticleIdx]);
-        parDest[localCellIdx_] = lCellIdx;
-        parDest[multiMask_] = 1;
-        /* counter[1] -> number of loaded particles
-         * this counter is evaluated on host side
-         * (check that loaded particles by this kernel == loaded particles from HDF5 file)*/
-        nvidia::atomicAllInc(&(counter[1]));
-    }
-}
+            typedef T_SrcFrame SrcFrameType;
+            typedef typename T_DestBox::FrameType DestFrameType;
+            typedef typename T_DestBox::FramePtr DestFramePtr;
+            typedef typename T_CellDescription::SuperCellSize SuperCellSize;
+            constexpr unsigned NumDims = T_DestBox::Dim;
+            constexpr uint32_t particlesPerFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+
+            __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<DestFramePtr>::type destFramePtr[particlesPerFrame];
+            __shared__ int linearSuperCellIds[particlesPerFrame];
+            __shared__ int srcParticleOffset;
+
+
+            const int linearThreadIdx = threadIdx.x;
+
+
+            const DataSpace<NumDims> numSuperCells(cellDesc.getGridSuperCells() - cellDesc.getGuardingSuperCells()*2);
+            if (linearThreadIdx == 0)
+            {
+                /* apply for work for the full block
+                 * counter [0] -> offset to load particles
+                 */
+                srcParticleOffset = atomicAdd(&(counter[0]), particlesPerFrame);
+            }
+            destFramePtr[linearThreadIdx] = DestFramePtr();
+            linearSuperCellIds[linearThreadIdx] = -1;
+
+            __syncthreads();
+
+            const int srcParticleIdx = srcParticleOffset + linearThreadIdx;
+            const bool hasValidParticle = srcParticleIdx < maxParticles;
+            DataSpace<NumDims> superCellIdx;
+            lcellId_t lCellIdx = INV_LOC_IDX;
+            int myLinearSuperCellId = -1;
+
+            if (hasValidParticle)
+            {
+                // cell index on this GPU
+                const DataSpace<NumDims> gpuCellIdx = srcFrame[srcParticleIdx][domainCellIdxIdentifier]
+                                                         - localDomainCellOffset;
+                superCellIdx = gpuCellIdx / SuperCellSize::toRT();
+                myLinearSuperCellId = DataSpaceOperations<NumDims>::map(numSuperCells, superCellIdx);
+                linearSuperCellIds[linearThreadIdx] = myLinearSuperCellId;
+                DataSpace<NumDims> localCellIdx(gpuCellIdx - superCellIdx * SuperCellSize::toRT());
+                lCellIdx = DataSpaceOperations<NumDims>::template map<SuperCellSize>(localCellIdx);
+            }
+            __syncthreads();
+
+            int masterIdx = linearThreadIdx - 1;
+
+            if (hasValidParticle)
+            {
+                /* search master thread index */
+                while (masterIdx >= 0)
+                {
+                    if (myLinearSuperCellId != linearSuperCellIds[masterIdx])
+                        break;
+                    --masterIdx;
+                }
+                ++masterIdx;
+                /* load empty frame if thread is the master*/
+                if (masterIdx == linearThreadIdx)
+                {
+                    /* counter[2] -> number of used frames */
+                    nvidia::atomicAllInc(&(counter[2]));
+                    DestFramePtr tmpFrame = destBox.getEmptyFrame();
+                    destFramePtr[linearThreadIdx] = tmpFrame;
+                    destBox.setAsFirstFrame(tmpFrame, superCellIdx + cellDesc.getGuardingSuperCells());
+                }
+            }
+            __syncthreads();
+
+            if (hasValidParticle)
+            {
+                /* copy attributes and activate particle*/
+                PMACC_AUTO(parDest, destFramePtr[masterIdx][linearThreadIdx]);
+                PMACC_AUTO(parDestDeselect, deselect<bmpl::vector2<localCellIdx, multiMask> >(parDest));
+                assign(parDestDeselect, srcFrame[srcParticleIdx]);
+                parDest[localCellIdx_] = lCellIdx;
+                parDest[multiMask_] = 1;
+                /* counter[1] -> number of loaded particles
+                 * this counter is evaluated on host side
+                 * (check that loaded particles by this kernel == loaded particles from HDF5 file)*/
+                nvidia::atomicAllInc(&(counter[1]));
+            }
+        }
+    };
 } //namespace kernel
 
 /** Copy particles from big frame to PMacc frame structure
@@ -204,7 +206,7 @@ HINLINE void splitIntoListOfFrames(
         uint32_t currentChunkSize = std::min(leftOverParticles, chunkSize);
         log(logLvl, "load particles on device chunk offset=%1%; chunk size=%2%; left particles %3%") %
             (i * chunkSize) % currentChunkSize % leftOverParticles;
-        __cudaKernel(kernel::splitIntoListOfFrames)
+        PMACC_TYPEKERNEL(kernel::splitIntoListOfFrames)
             (algorithms::math::float2int_ru(double(currentChunkSize) / double(cellsInSuperCell)), cellsInSuperCell)
             (counterBuffer.getDeviceBuffer().getDataBox(),
              destSpecies.getDeviceParticlesBox(), srcFrame,

--- a/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
+++ b/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
@@ -206,7 +206,7 @@ HINLINE void splitIntoListOfFrames(
         uint32_t currentChunkSize = std::min(leftOverParticles, chunkSize);
         log(logLvl, "load particles on device chunk offset=%1%; chunk size=%2%; left particles %3%") %
             (i * chunkSize) % currentChunkSize % leftOverParticles;
-        PMACC_TYPEKERNEL(kernel::splitIntoListOfFrames)
+        PMACC_KERNEL(kernel::splitIntoListOfFrames{})
             (algorithms::math::float2int_ru(double(currentChunkSize) / double(cellsInSuperCell)), cellsInSuperCell)
             (counterBuffer.getDeviceBuffer().getDataBox(),
              destSpecies.getDeviceParticlesBox(), srcFrame,

--- a/src/libPMacc/include/pmacc_types.hpp
+++ b/src/libPMacc/include/pmacc_types.hpp
@@ -73,6 +73,9 @@ typedef long long int int64_cu;
 #   define PMACC_CUDA_ARCH __CUDA_ARCH__
 #endif
 
+/** pmacc global identifier for CUDA kernel */
+#define PMACC_GLOBAL_KEYWORD __location__(global)
+
 /*
  * Disable nvcc warning:
  * calling a __host__ function from __host__ __device__ function.

--- a/src/libPMacc/include/pmacc_types.hpp
+++ b/src/libPMacc/include/pmacc_types.hpp
@@ -73,7 +73,7 @@ typedef long long int int64_cu;
 #   define PMACC_CUDA_ARCH __CUDA_ARCH__
 #endif
 
-/** pmacc global identifier for CUDA kernel */
+/** PMacc global identifier for CUDA kernel */
 #define PMACC_GLOBAL_KEYWORD __location__(global)
 
 /*

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -32,17 +32,21 @@ namespace random
 
     namespace kernel {
 
-        template<class T_RNGMethod, class T_RNGBox, class T_Space>
-        __global__ void
-        initRNGProvider(T_RNGBox rngBox, uint32_t seed, const T_Space size)
+        template< typename T_RNGMethod>
+        struct initRNGProvider
         {
-            const uint32_t linearTid = blockIdx.x * blockDim.x + threadIdx.x;
-            if(linearTid >= size.productOfComponents())
-                return;
+            template<class T_RNGBox, class T_Space>
+            DINLINE void
+            operator()(T_RNGBox rngBox, uint32_t seed, const T_Space size) const
+            {
+                const uint32_t linearTid = blockIdx.x * blockDim.x + threadIdx.x;
+                if(linearTid >= size.productOfComponents())
+                    return;
 
-            const T_Space cellIdx = DataSpaceOperations<T_Space::dim>::map(size, linearTid);
-            T_RNGMethod().init(rngBox(cellIdx), seed, linearTid);
-        }
+                const T_Space cellIdx = DataSpaceOperations<T_Space::dim>::map(size, linearTid);
+                T_RNGMethod().init(rngBox(cellIdx), seed, linearTid);
+            }
+        };
 
     }  // namespace kernel
 
@@ -66,7 +70,7 @@ namespace random
 
         PMACC_AUTO(bufferBox, buffer->getDeviceBuffer().getDataBox());
 
-        __cudaKernel(kernel::initRNGProvider<RNGMethod>)
+        PMACC_TYPEKERNEL(kernel::initRNGProvider<RNGMethod>)
         (gridSize, blockSize)
         (bufferBox, seed, m_size);
     }

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -70,7 +70,7 @@ namespace random
 
         PMACC_AUTO(bufferBox, buffer->getDeviceBuffer().getDataBox());
 
-        PMACC_TYPEKERNEL(kernel::initRNGProvider<RNGMethod>)
+        PMACC_KERNEL(kernel::initRNGProvider<RNGMethod>{})
         (gridSize, blockSize)
         (bufferBox, seed, m_size);
     }

--- a/src/libPMacc/test/particles/IdProvider.hpp
+++ b/src/libPMacc/test/particles/IdProvider.hpp
@@ -120,7 +120,7 @@ struct IdProviderTest
         BOOST_REQUIRE_EQUAL(IdProvider::getNewId(), state.nextId);
         // Generate the same IDs on the device
         PMacc::HostDeviceBuffer<uint64_t, 1> idBuf(numIds);
-        PMACC_TYPEKERNEL(generateIds<IdProvider>)(numBlocks, numThreadsPerBlock)
+        PMACC_KERNEL(generateIds<IdProvider>{})(numBlocks, numThreadsPerBlock)
                 (idBuf.getDeviceBuffer().getDataBox(), numThreads, numIdsPerThread);
         idBuf.deviceToHost();
         BOOST_REQUIRE_EQUAL(numIds, ids.size());

--- a/src/libPMacc/test/random/2DDistribution.cu
+++ b/src/libPMacc/test/random/2DDistribution.cu
@@ -133,7 +133,7 @@ void generateRandomNumbers(const Space2D& rngSize, uint32_t numSamples, T_Device
     Space2D gridSize(rngSize / blockSize);
 
     CUDA_CHECK(cudaEventRecord(start));
-    PMACC_TYPEKERNEL(RandomFiller)(gridSize, blockSize)(buffer.getDataBox(), buffer.getDataSpace(), rand, numSamples);
+    PMACC_KERNEL(RandomFiller{})(gridSize, blockSize)(buffer.getDataBox(), buffer.getDataSpace(), rand, numSamples);
     CUDA_CHECK(cudaEventRecord(stop));
     CUDA_CHECK(cudaEventSynchronize(stop));
     float milliseconds = 0;

--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -36,56 +36,59 @@ namespace picongpu
 {
 using namespace PMacc;
 
-template<class EBox>
-__global__ void kernelLaserE(EBox fieldE, LaserManipulator lMan)
+struct kernelLaserE
 {
-    DataSpace<simDim> cellOffset;
-    
-    cellOffset.x() = (blockIdx.x * blockDim.x) + threadIdx.x;
-    DataSpace<simDim> EFieldOffset;
-    EFieldOffset.x() = cellOffset.x() + (MappingDesc::SuperCellSize::x::value * GUARD_SIZE);
-    EFieldOffset.y() = MappingDesc::SuperCellSize::y::value*GUARD_SIZE;
-
-#if (SIMDIM==DIM3)
-    cellOffset.z() = (blockIdx.y * blockDim.y) + threadIdx.y;
-    EFieldOffset.z() = cellOffset.z() + (MappingDesc::SuperCellSize::z::value * GUARD_SIZE);
-#endif
-
-    //uint32_t zOffset
-
-    /** Calculate how many neighbors to the left we have
-     * to initialize the laser in the E-Field
-     *
-     * Example: Yee needs one neighbor to perform dB = curlE
-     *            -> initialize in y=0 plane
-     *          A second order solver could need 2 neighbors left:
-     *            -> initialize in y=0 and y=1 plane
-     *
-     * Question: Why do other codes initialize the B-Field instead?
-     * Answer:   Because our fields are defined on the lower cell side
-     *           (C-Style ftw). Therefore, our curls (for example Yee)
-     *           are shifted nabla+ <-> nabla- compared to Fortran codes
-     *           (in other words: curlLeft <-> curlRight)
-     *           for E and B.
-     *           For this reason, we have to initialize E instead of B.
-     *
-     * Problem: that's still not our case. For example our Yee does a
-     *          dE = curlLeft(B) - therefor, we should init B, too.
-     */
-    //const int max_y_neighbors = Get<fieldSolver::FieldSolver::OffsetOrigin_E, 1 >::value;
-    const int max_y_neighbors = 1;
-
-    for (int totalOffsetY = 0; totalOffsetY < max_y_neighbors; ++totalOffsetY)
+    template<class EBox>
+    DINLINE void operator()(EBox fieldE, LaserManipulator lMan) const
     {
-        /** \todo Right now, the phase could be wrong ( == is cloned)
-         *        \See LaserPhysics.hpp
+        DataSpace<simDim> cellOffset;
+
+        cellOffset.x() = (blockIdx.x * blockDim.x) + threadIdx.x;
+        DataSpace<simDim> EFieldOffset;
+        EFieldOffset.x() = cellOffset.x() + (MappingDesc::SuperCellSize::x::value * GUARD_SIZE);
+        EFieldOffset.y() = MappingDesc::SuperCellSize::y::value*GUARD_SIZE;
+
+    #if (SIMDIM==DIM3)
+        cellOffset.z() = (blockIdx.y * blockDim.y) + threadIdx.y;
+        EFieldOffset.z() = cellOffset.z() + (MappingDesc::SuperCellSize::z::value * GUARD_SIZE);
+    #endif
+
+        //uint32_t zOffset
+
+        /** Calculate how many neighbors to the left we have
+         * to initialize the laser in the E-Field
          *
-         *  \todo What about the B-Field in the second plane?
+         * Example: Yee needs one neighbor to perform dB = curlE
+         *            -> initialize in y=0 plane
+         *          A second order solver could need 2 neighbors left:
+         *            -> initialize in y=0 and y=1 plane
+         *
+         * Question: Why do other codes initialize the B-Field instead?
+         * Answer:   Because our fields are defined on the lower cell side
+         *           (C-Style ftw). Therefore, our curls (for example Yee)
+         *           are shifted nabla+ <-> nabla- compared to Fortran codes
+         *           (in other words: curlLeft <-> curlRight)
+         *           for E and B.
+         *           For this reason, we have to initialize E instead of B.
+         *
+         * Problem: that's still not our case. For example our Yee does a
+         *          dE = curlLeft(B) - therefor, we should init B, too.
          */
-        cellOffset.y()=totalOffsetY;
-        fieldE(EFieldOffset) = lMan.getManipulation(cellOffset);
+        //const int max_y_neighbors = Get<fieldSolver::FieldSolver::OffsetOrigin_E, 1 >::value;
+        const int max_y_neighbors = 1;
+
+        for (int totalOffsetY = 0; totalOffsetY < max_y_neighbors; ++totalOffsetY)
+        {
+            /** \todo Right now, the phase could be wrong ( == is cloned)
+             *        \See LaserPhysics.hpp
+             *
+             *  \todo What about the B-Field in the second plane?
+             */
+            cellOffset.y()=totalOffsetY;
+            fieldE(EFieldOffset) = lMan.getManipulation(cellOffset);
+        }
     }
-}
+};
 
 }
 

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -201,7 +201,7 @@ void FieldE::laserManipulation( uint32_t currentStep )
     gridBlocks.y()=fieldE->getGridLayout( ).getDataSpaceWithoutGuarding( ).z( ) / SuperCellSize::z::value;
     blockSize.y()=SuperCellSize::z::value;
 #endif
-    __cudaKernel( kernelLaserE )
+    PMACC_TYPEKERNEL( kernelLaserE )
         ( gridBlocks,
           blockSize )
         ( this->getDeviceDataBox( ), laser->getLaserManipulator( currentStep ) );

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -89,9 +89,9 @@ fieldB( NULL )
         GetMargin<fieldSolver::FieldSolver, FIELD_E>::UpperMargin
         >::type UpperMarginInterpolationAndSolver;
 
-    /* Calculate upper and lower margin for pusher 
-       (currently all pusher use the interpolation of the species)  
-       and find maximum margin 
+    /* Calculate upper and lower margin for pusher
+       (currently all pusher use the interpolation of the species)
+       and find maximum margin
     */
     typedef typename PMacc::particles::traits::FilterByFlag
     <
@@ -201,7 +201,7 @@ void FieldE::laserManipulation( uint32_t currentStep )
     gridBlocks.y()=fieldE->getGridLayout( ).getDataSpaceWithoutGuarding( ).z( ) / SuperCellSize::z::value;
     blockSize.y()=SuperCellSize::z::value;
 #endif
-    PMACC_TYPEKERNEL( kernelLaserE )
+    PMACC_KERNEL( kernelLaserE{} )
         ( gridBlocks,
           blockSize )
         ( this->getDeviceDataBox( ), laser->getLaserManipulator( currentStep ) );

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -47,78 +47,82 @@ using namespace PMacc;
 
 typedef FieldJ::DataBoxType J_DataBox;
 
-template<int workerMultiplier, class BlockDescription_, uint32_t AREA, class JBox, class ParBox, class Mapping, class FrameSolver>
-__global__ void kernelComputeCurrent(JBox fieldJ,
-                                     ParBox boxPar, FrameSolver frameSolver, Mapping mapper)
+template< int workerMultiplier, class BlockDescription_, uint32_t AREA >
+struct kernelComputeCurrent
 {
-    typedef typename ParBox::FrameType FrameType;
-    typedef typename ParBox::FramePtr FramePtr;
-    typedef typename Mapping::SuperCellSize SuperCellSize;
-
-    const uint32_t cellsPerSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
-
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-    const DataSpace<simDim > threadIndex(threadIdx);
-
-    /* thread id, can be greater than cellsPerSuperCell*/
-    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
-
-    const uint32_t virtualBlockId = linearThreadIdx / cellsPerSuperCell;
-    /* move linearThreadIdx for all threads to [0;cellsPerSuperCell) */
-    const int virtualLinearId = linearThreadIdx - (virtualBlockId * cellsPerSuperCell);
-
-
-    FramePtr frame;
-    lcellId_t particlesInSuperCell = 0;
-
-    frame = boxPar.getLastFrame(block);
-    if (frame.isValid() && virtualBlockId == 0)
-        particlesInSuperCell = boxPar.getSuperCell(block).getSizeLastFrame();
-
-    /* select N-th (N=virtualBlockId) frame from the end of the list*/
-    for (int i = 1; (i <= virtualBlockId) && frame.isValid(); ++i)
+    template<class JBox, class ParBox, class Mapping, class FrameSolver>
+    DINLINE void operator()(JBox fieldJ,
+                                         ParBox boxPar, FrameSolver frameSolver, Mapping mapper) const
     {
-        particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
-        frame = boxPar.getPreviousFrame(frame);
-    }
+        typedef typename ParBox::FrameType FrameType;
+        typedef typename ParBox::FramePtr FramePtr;
+        typedef typename Mapping::SuperCellSize SuperCellSize;
 
-    /* This memory is used by all virtual blocks*/
-    PMACC_AUTO(cachedJ, CachedBox::create < 0, typename JBox::ValueType > (BlockDescription_()));
+        const uint32_t cellsPerSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
-    Set<typename JBox::ValueType > set(float3_X::create(0.0));
-    ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveSet(linearThreadIdx);
-    collectiveSet(set, cachedJ);
+        const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+        const DataSpace<simDim > threadIndex(threadIdx);
 
-    __syncthreads();
+        /* thread id, can be greater than cellsPerSuperCell*/
+        const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
 
-    while (frame.isValid())
-    {
-        /* this test is only importend for the last frame
-         * if frame is not the last one particlesInSuperCell==particles count in supercell
-         */
-        if (virtualLinearId < particlesInSuperCell)
+        const uint32_t virtualBlockId = linearThreadIdx / cellsPerSuperCell;
+        /* move linearThreadIdx for all threads to [0;cellsPerSuperCell) */
+        const int virtualLinearId = linearThreadIdx - (virtualBlockId * cellsPerSuperCell);
+
+
+        FramePtr frame;
+        lcellId_t particlesInSuperCell = 0;
+
+        frame = boxPar.getLastFrame(block);
+        if (frame.isValid() && virtualBlockId == 0)
+            particlesInSuperCell = boxPar.getSuperCell(block).getSizeLastFrame();
+
+        /* select N-th (N=virtualBlockId) frame from the end of the list*/
+        for (int i = 1; (i <= virtualBlockId) && frame.isValid(); ++i)
         {
-            frameSolver(*frame,
-                        virtualLinearId,
-                        cachedJ);
-        }
-
-        particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
-        for (int i = 0; (i < workerMultiplier) && frame.isValid(); ++i)
-        {
+            particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
             frame = boxPar.getPreviousFrame(frame);
         }
+
+        /* This memory is used by all virtual blocks*/
+        PMACC_AUTO(cachedJ, CachedBox::create < 0, typename JBox::ValueType > (BlockDescription_()));
+
+        Set<typename JBox::ValueType > set(float3_X::create(0.0));
+        ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveSet(linearThreadIdx);
+        collectiveSet(set, cachedJ);
+
+        __syncthreads();
+
+        while (frame.isValid())
+        {
+            /* this test is only importend for the last frame
+             * if frame is not the last one particlesInSuperCell==particles count in supercell
+             */
+            if (virtualLinearId < particlesInSuperCell)
+            {
+                frameSolver(*frame,
+                            virtualLinearId,
+                            cachedJ);
+            }
+
+            particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
+            for (int i = 0; (i < workerMultiplier) && frame.isValid(); ++i)
+            {
+                frame = boxPar.getPreviousFrame(frame);
+            }
+        }
+
+        /* we wait that all threads finish the loop*/
+        __syncthreads();
+
+        nvidia::functors::Add add;
+        const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
+        ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveAdd(linearThreadIdx);
+        PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
+        collectiveAdd(add, fieldJBlock, cachedJ);
     }
-
-    /* we wait that all threads finish the loop*/
-    __syncthreads();
-
-    nvidia::functors::Add add;
-    const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
-    ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveAdd(linearThreadIdx);
-    PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
-    collectiveAdd(add, fieldJBlock, cachedJ);
-}
+};
 
 template<class ParticleAlgo, class Velocity, class TVec>
 struct ComputeCurrentPerFrame
@@ -158,118 +162,127 @@ private:
     const PMACC_ALIGN(m_deltaTime, float_32);
 };
 
-template<class T_CurrentInterpolation, class T_Mapping>
-__global__ void kernelAddCurrentToEMF(typename FieldE::DataBoxType fieldE,
-                                      typename FieldB::DataBoxType fieldB,
-                                      J_DataBox fieldJ,
-                                      T_CurrentInterpolation currentInterpolation,
-                                      T_Mapping mapper)
+struct kernelAddCurrentToEMF
 {
-    /* Caching of fieldJ */
-    typedef SuperCellDescription<
-                SuperCellSize,
-                typename T_CurrentInterpolation::LowerMargin,
-                typename T_CurrentInterpolation::UpperMargin
-                > BlockArea;
-
-    PMACC_AUTO(cachedJ, CachedBox::create < 0, typename J_DataBox::ValueType > (BlockArea()));
-
-    nvidia::functors::Assign assign;
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-    const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
-
-    const DataSpace<simDim > threadIndex(threadIdx);
-    PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
-
-    ThreadCollective<BlockArea> collective(threadIndex);
-    collective(
-              assign,
-              cachedJ,
-              fieldJBlock
-              );
-
-    __syncthreads();
-
-    const DataSpace<T_Mapping::Dim> cell(blockCell + threadIndex);
-
-    // Amperes Law:
-    //   Change of the dE = - j / EPS0 * dt
-    //                        j = current density (= current per area)
-    //                          = fieldJ
-    currentInterpolation( fieldE.shift(cell), fieldB.shift(cell), cachedJ.shift(threadIndex) );
-}
-
-template<class Mapping>
-__global__ void kernelBashCurrent(J_DataBox fieldJ,
-                                  J_DataBox targetJ,
-                                  DataSpace<simDim> exchangeSize,
-                                  DataSpace<simDim> direction,
-                                  Mapping mapper)
-{
-    const DataSpace<simDim> blockCell(
-                                      mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx))
-                                      * Mapping::SuperCellSize::toRT()
-                                      );
-    const DataSpace<Mapping::Dim> threadIndex(threadIdx);
-    const DataSpace<Mapping::Dim> sourceCell(blockCell + threadIndex);
-
-    /*origin in area from local GPU*/
-    DataSpace<simDim> nullSourceCell(
-                                     mapper.getSuperCellIndex(DataSpace<simDim > ())
-                                     * Mapping::SuperCellSize::toRT()
-                                     );
-    DataSpace<simDim> targetCell(sourceCell - nullSourceCell);
-
-    for (uint32_t d = 0; d < simDim; ++d)
+    template<class T_CurrentInterpolation, class T_Mapping>
+    DINLINE void operator()(typename FieldE::DataBoxType fieldE,
+                                          typename FieldB::DataBoxType fieldB,
+                                          J_DataBox fieldJ,
+                                          T_CurrentInterpolation currentInterpolation,
+                                          T_Mapping mapper) const
     {
-        if (direction[d] == -1)
-        {
-            if (threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d]) return;
-            targetCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
-        }
-        else if ((direction[d] == 1) && (threadIndex[d] >= exchangeSize[d])) return;
+        /* Caching of fieldJ */
+        typedef SuperCellDescription<
+                    SuperCellSize,
+                    typename T_CurrentInterpolation::LowerMargin,
+                    typename T_CurrentInterpolation::UpperMargin
+                    > BlockArea;
+
+        PMACC_AUTO(cachedJ, CachedBox::create < 0, typename J_DataBox::ValueType > (BlockArea()));
+
+        nvidia::functors::Assign assign;
+        const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+        const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
+
+        const DataSpace<simDim > threadIndex(threadIdx);
+        PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
+
+        ThreadCollective<BlockArea> collective(threadIndex);
+        collective(
+                  assign,
+                  cachedJ,
+                  fieldJBlock
+                  );
+
+        __syncthreads();
+
+        const DataSpace<T_Mapping::Dim> cell(blockCell + threadIndex);
+
+        // Amperes Law:
+        //   Change of the dE = - j / EPS0 * dt
+        //                        j = current density (= current per area)
+        //                          = fieldJ
+        currentInterpolation( fieldE.shift(cell), fieldB.shift(cell), cachedJ.shift(threadIndex) );
     }
+};
 
-    targetJ(targetCell) = fieldJ(sourceCell);
-}
-
-template<class Mapping>
-__global__ void kernelInsertCurrent(J_DataBox fieldJ,
-                                    J_DataBox sourceJ,
-                                    DataSpace<simDim> exchangeSize,
-                                    DataSpace<simDim> direction,
-                                    Mapping mapper)
+struct kernelBashCurrent
 {
-    const DataSpace<Mapping::Dim> threadIndex(threadIdx);
-    const DataSpace<simDim> blockCell(
-                                      mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx))
-                                      * Mapping::SuperCellSize::toRT()
-                                      );
-    DataSpace<Mapping::Dim> targetCell(blockCell + threadIndex);
-
-    /*origin in area from local GPU*/
-    DataSpace<simDim> nullSourceCell(
-                                     mapper.getSuperCellIndex(DataSpace<simDim > ())
-                                     * Mapping::SuperCellSize::toRT()
-                                     );
-    DataSpace<simDim> sourceCell(targetCell - nullSourceCell);
-
-    for (uint32_t d = 0; d < simDim; ++d)
+    template<class Mapping>
+    DINLINE void operator()(J_DataBox fieldJ,
+                                      J_DataBox targetJ,
+                                      DataSpace<simDim> exchangeSize,
+                                      DataSpace<simDim> direction,
+                                      Mapping mapper) const
     {
-        if (direction[d] == 1)
-        {
-            if (threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d]) return;
-            sourceCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
-            targetCell[d] -= SuperCellSize::toRT()[d];
-        }
-        else if (direction[d] == -1)
-        {
-            if (threadIndex[d] >= exchangeSize[d]) return;
-            targetCell[d] += SuperCellSize::toRT()[d];
-        }
-    }
+        const DataSpace<simDim> blockCell(
+                                          mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx))
+                                          * Mapping::SuperCellSize::toRT()
+                                          );
+        const DataSpace<Mapping::Dim> threadIndex(threadIdx);
+        const DataSpace<Mapping::Dim> sourceCell(blockCell + threadIndex);
 
-    fieldJ(targetCell) += sourceJ(sourceCell);
-}
+        /*origin in area from local GPU*/
+        DataSpace<simDim> nullSourceCell(
+                                         mapper.getSuperCellIndex(DataSpace<simDim > ())
+                                         * Mapping::SuperCellSize::toRT()
+                                         );
+        DataSpace<simDim> targetCell(sourceCell - nullSourceCell);
+
+        for (uint32_t d = 0; d < simDim; ++d)
+        {
+            if (direction[d] == -1)
+            {
+                if (threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d]) return;
+                targetCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
+            }
+            else if ((direction[d] == 1) && (threadIndex[d] >= exchangeSize[d])) return;
+        }
+
+        targetJ(targetCell) = fieldJ(sourceCell);
+    }
+};
+
+struct kernelInsertCurrent
+{
+    template<class Mapping>
+    DINLINE void operator()(J_DataBox fieldJ,
+                                        J_DataBox sourceJ,
+                                        DataSpace<simDim> exchangeSize,
+                                        DataSpace<simDim> direction,
+                                        Mapping mapper) const
+    {
+        const DataSpace<Mapping::Dim> threadIndex(threadIdx);
+        const DataSpace<simDim> blockCell(
+                                          mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx))
+                                          * Mapping::SuperCellSize::toRT()
+                                          );
+        DataSpace<Mapping::Dim> targetCell(blockCell + threadIndex);
+
+        /*origin in area from local GPU*/
+        DataSpace<simDim> nullSourceCell(
+                                         mapper.getSuperCellIndex(DataSpace<simDim > ())
+                                         * Mapping::SuperCellSize::toRT()
+                                         );
+        DataSpace<simDim> sourceCell(targetCell - nullSourceCell);
+
+        for (uint32_t d = 0; d < simDim; ++d)
+        {
+            if (direction[d] == 1)
+            {
+                if (threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d]) return;
+                sourceCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
+                targetCell[d] -= SuperCellSize::toRT()[d];
+            }
+            else if (direction[d] == -1)
+            {
+                if (threadIndex[d] >= exchangeSize[d]) return;
+                targetCell[d] += SuperCellSize::toRT()[d];
+            }
+        }
+
+        fieldJ(targetCell) += sourceJ(sourceCell);
+    }
+};
 
 }

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -188,7 +188,7 @@ void FieldJ::bashField( uint32_t exchangeType )
     auto grid = mapper.getGridDim( );
 
     const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > ( mapper.getExchangeType( ) );
-    PMACC_TYPEKERNEL( kernelBashCurrent )
+    PMACC_KERNEL( kernelBashCurrent{} )
         ( grid, mapper.getSuperCellSize( ) )
         ( fieldJ.getDeviceBuffer( ).getDataBox( ),
           fieldJ.getSendExchange( exchangeType ).getDeviceBuffer( ).getDataBox( ),
@@ -204,7 +204,7 @@ void FieldJ::insertField( uint32_t exchangeType )
     auto grid = mapper.getGridDim( );
 
     const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > ( mapper.getExchangeType( ) );
-    PMACC_TYPEKERNEL( kernelInsertCurrent )
+    PMACC_KERNEL( kernelInsertCurrent{} )
         ( grid, mapper.getSuperCellSize( ) )
         ( fieldJ.getDeviceBuffer( ).getDataBox( ),
           fieldJ.getReceiveExchange( exchangeType ).getDeviceBuffer( ).getDataBox( ),
@@ -302,7 +302,7 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
 
     do
     {
-        PMACC_TYPEKERNEL( kernelComputeCurrent<workerMultiplier, BlockArea, AREA> )
+        PMACC_KERNEL( kernelComputeCurrent<workerMultiplier, BlockArea, AREA>{} )
             ( mapper.getGridDim( ), blockSize )
             ( jBox,
               pBox, solver, mapper );
@@ -315,7 +315,7 @@ template<uint32_t AREA, class T_CurrentInterpolation>
 void FieldJ::addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation )
 {
     AreaMapping<AREA, MappingDesc> mapper(cellDescription);
-    PMACC_TYPEKERNEL( kernelAddCurrentToEMF )
+    PMACC_KERNEL( kernelAddCurrentToEMF{} )
         ( mapper.getGridDim(), MappingDesc::SuperCellSize::toRT( ) )
         ( this->fieldE->getDeviceDataBox( ),
           this->fieldB->getDeviceDataBox( ),

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -78,7 +78,7 @@ public:
                 if (MovingWindow::getInstance().isSlidingWindowActive() && i == BOTTOM) continue;
 
                 ExchangeMapping<GUARD, MappingDesc> mapper(cellDescription, i);
-                __cudaKernel(kernelAbsorbBorder)
+                PMACC_TYPEKERNEL(kernelAbsorbBorder)
                     (mapper.getGridDim(), mapper.getSuperCellSize())
                     (deviceBox, thickness, absorber_strength,
                      mapper);

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -78,7 +78,7 @@ public:
                 if (MovingWindow::getInstance().isSlidingWindowActive() && i == BOTTOM) continue;
 
                 ExchangeMapping<GUARD, MappingDesc> mapper(cellDescription, i);
-                PMACC_TYPEKERNEL(kernelAbsorbBorder)
+                PMACC_KERNEL(kernelAbsorbBorder{})
                     (mapper.getGridDim(), mapper.getSuperCellSize())
                     (deviceBox, thickness, absorber_strength,
                      mapper);

--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -93,22 +93,25 @@ DINLINE void absorb(BoxedMemory field, uint32_t thickness, float_X absorber_stre
     while (finish == 0);
 }
 
-template<class BoxedMemory, class Mapping>
-__global__ void kernelAbsorbBorder(BoxedMemory field, uint32_t thickness, float_X absorber_strength, Mapping mapper)
+struct kernelAbsorbBorder
 {
+    template<class BoxedMemory, class Mapping>
+    DINLINE void operator()(BoxedMemory field, uint32_t thickness, float_X absorber_strength, Mapping mapper) const
+    {
 
-    const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > (mapper.getExchangeType());
+        const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > (mapper.getExchangeType());
 
-    //this is a workaround that we get a kernelwithout lmem
-    if (direction.x() != 0)
-        absorb < 0 > (field, thickness, absorber_strength, mapper, direction);
-    else if (direction.y() != 0)
-        absorb < 1 > (field, thickness, absorber_strength, mapper, direction);
-#if (SDIMDIM==DIM3)
-    else if (direction.z() != 0)
-        absorb < 2 > (field, thickness, absorber_strength, mapper, direction);
-#endif
-}
+        //this is a workaround that we get a kernelwithout lmem
+        if (direction.x() != 0)
+            absorb < 0 > (field, thickness, absorber_strength, mapper, direction);
+        else if (direction.y() != 0)
+            absorb < 1 > (field, thickness, absorber_strength, mapper, direction);
+    #if (SDIMDIM==DIM3)
+        else if (direction.z() != 0)
+            absorb < 2 > (field, thickness, absorber_strength, mapper, direction);
+    #endif
+    }
+};
 } //namespace
 #endif    /* FIELDMANIPULATOR_KERNEL */
 

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -43,132 +43,141 @@ namespace picongpu
 {
     using namespace PMacc;
 
-
-    template<class BlockDescription_, uint32_t AREA, class TmpBox, class ParBox, class FrameSolver, class Mapping>
-    __global__ void kernelComputeSupercells( TmpBox fieldTmp, ParBox boxPar, FrameSolver frameSolver, Mapping mapper )
+    template< class BlockDescription_, uint32_t AREA >
+    struct kernelComputeSupercells
     {
-        typedef typename ParBox::FramePtr FramePtr;
-        typedef typename BlockDescription_::SuperCellSize SuperCellSize;
-        const DataSpace<simDim> block( mapper.getSuperCellIndex( DataSpace<simDim > ( blockIdx ) ) );
-
-
-        const DataSpace<simDim > threadIndex( threadIdx );
-        const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > ( threadIndex );
-
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-
-        __shared__ lcellId_t particlesInSuperCell;
-
-
-        if( linearThreadIdx == 0 )
+        template<class TmpBox, class ParBox, class FrameSolver, class Mapping>
+        DINLINE void operator()( TmpBox fieldTmp, ParBox boxPar, FrameSolver frameSolver, Mapping mapper ) const
         {
-            frame = boxPar.getLastFrame( block );
-            particlesInSuperCell = boxPar.getSuperCell( block ).getSizeLastFrame( );
-        }
-        __syncthreads( );
+            typedef typename ParBox::FramePtr FramePtr;
+            typedef typename BlockDescription_::SuperCellSize SuperCellSize;
+            const DataSpace<simDim> block( mapper.getSuperCellIndex( DataSpace<simDim > ( blockIdx ) ) );
 
-        if( !frame.isValid() )
-            return; //end kernel if we have no frames
 
-        PMACC_AUTO( cachedVal, CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) ) );
-        Set<typename TmpBox::ValueType > set( float_X( 0.0 ) );
+            const DataSpace<simDim > threadIndex( threadIdx );
+            const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > ( threadIndex );
 
-        ThreadCollective<BlockDescription_> collective( linearThreadIdx );
-        collective( set, cachedVal );
+            __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
 
-        __syncthreads( );
-        while( frame.isValid() )
-        {
-            if( linearThreadIdx < particlesInSuperCell )
-            {
-                frameSolver( *frame, linearThreadIdx, SuperCellSize::toRT(), cachedVal );
-            }
-            __syncthreads( );
+            __shared__ lcellId_t particlesInSuperCell;
+
+
             if( linearThreadIdx == 0 )
             {
-                frame = boxPar.getPreviousFrame( frame );
-                particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
+                frame = boxPar.getLastFrame( block );
+                particlesInSuperCell = boxPar.getSuperCell( block ).getSizeLastFrame( );
             }
             __syncthreads( );
+
+            if( !frame.isValid() )
+                return; //end kernel if we have no frames
+
+            PMACC_AUTO( cachedVal, CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) ) );
+            Set<typename TmpBox::ValueType > set( float_X( 0.0 ) );
+
+            ThreadCollective<BlockDescription_> collective( linearThreadIdx );
+            collective( set, cachedVal );
+
+            __syncthreads( );
+            while( frame.isValid() )
+            {
+                if( linearThreadIdx < particlesInSuperCell )
+                {
+                    frameSolver( *frame, linearThreadIdx, SuperCellSize::toRT(), cachedVal );
+                }
+                __syncthreads( );
+                if( linearThreadIdx == 0 )
+                {
+                    frame = boxPar.getPreviousFrame( frame );
+                    particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
+                }
+                __syncthreads( );
+            }
+
+            nvidia::functors::Add add;
+            const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT( );
+            PMACC_AUTO( fieldTmpBlock, fieldTmp.shift( blockCell ) );
+            collective( add, fieldTmpBlock, cachedVal );
+            __syncthreads( );
         }
+    };
 
-        nvidia::functors::Add add;
-        const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT( );
-        PMACC_AUTO( fieldTmpBlock, fieldTmp.shift( blockCell ) );
-        collective( add, fieldTmpBlock, cachedVal );
-        __syncthreads( );
-    }
-
-    template<class Box, class Mapping>
-    __global__ void kernelBashValue( Box fieldTmp,
-                                     Box targetJ,
-                                     DataSpace<simDim> exchangeSize,
-                                     DataSpace<simDim> direction,
-                                     Mapping mapper )
+    struct kernelBashValue
     {
-        const DataSpace<Mapping::Dim> threadIndex(threadIdx);
-        const DataSpace<simDim> blockCell(
-                                           mapper.getSuperCellIndex( DataSpace<simDim > ( blockIdx ) )
-                                           * Mapping::SuperCellSize::toRT( )
-                                           );
-        const DataSpace<Mapping::Dim> sourceCell( blockCell + threadIndex );
-
-        /*origin in area from local GPU*/
-        DataSpace<simDim> nullSourceCell(
-                                          mapper.getSuperCellIndex( DataSpace<simDim > ( ) )
-                                          * Mapping::SuperCellSize::toRT( )
-                                          );
-        DataSpace<simDim> targetCell( sourceCell - nullSourceCell );
-
-        for (uint32_t d = 0; d < simDim; ++d)
+        template<class Box, class Mapping>
+        DINLINE void operator()( Box fieldTmp,
+                                         Box targetJ,
+                                         DataSpace<simDim> exchangeSize,
+                                         DataSpace<simDim> direction,
+                                         Mapping mapper ) const
         {
-            if( direction[d] == -1 )
-            {
-                if( threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d] ) return;
-                targetCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
-            }
-            else if( ( direction[d] == 1 ) && ( threadIndex[d] >= exchangeSize[d] ) ) return;
-        }
-        targetJ( targetCell ) = fieldTmp( sourceCell );
-    }
+            const DataSpace<Mapping::Dim> threadIndex(threadIdx);
+            const DataSpace<simDim> blockCell(
+                                               mapper.getSuperCellIndex( DataSpace<simDim > ( blockIdx ) )
+                                               * Mapping::SuperCellSize::toRT( )
+                                               );
+            const DataSpace<Mapping::Dim> sourceCell( blockCell + threadIndex );
 
-    template<class Box, class Mapping>
-    __global__ void kernelInsertValue( Box fieldTmp,
-                                       Box sourceTmp,
-                                       DataSpace<simDim> exchangeSize,
-                                       DataSpace<simDim> direction,
-                                       Mapping mapper )
+            /*origin in area from local GPU*/
+            DataSpace<simDim> nullSourceCell(
+                                              mapper.getSuperCellIndex( DataSpace<simDim > ( ) )
+                                              * Mapping::SuperCellSize::toRT( )
+                                              );
+            DataSpace<simDim> targetCell( sourceCell - nullSourceCell );
+
+            for (uint32_t d = 0; d < simDim; ++d)
+            {
+                if( direction[d] == -1 )
+                {
+                    if( threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d] ) return;
+                    targetCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
+                }
+                else if( ( direction[d] == 1 ) && ( threadIndex[d] >= exchangeSize[d] ) ) return;
+            }
+            targetJ( targetCell ) = fieldTmp( sourceCell );
+        }
+    };
+
+    struct kernelInsertValue
     {
-        const DataSpace<Mapping::Dim> threadIndex(threadIdx);
-        const DataSpace<simDim> blockCell(
-                                           mapper.getSuperCellIndex( DataSpace<simDim > ( blockIdx ) )
-                                           * Mapping::SuperCellSize::toRT( )
-                                           );
-        DataSpace<Mapping::Dim> targetCell( blockCell + threadIndex );
-
-        /*origin in area from local GPU*/
-        DataSpace<simDim> nullSourceCell(
-                                          mapper.getSuperCellIndex( DataSpace<simDim > ( ) )
-                                          * Mapping::SuperCellSize::toRT( )
-                                          );
-        DataSpace<simDim> sourceCell( targetCell - nullSourceCell );
-
-        for (uint32_t d = 0; d < simDim; ++d)
+        template<class Box, class Mapping>
+        DINLINE void operator()( Box fieldTmp,
+                                           Box sourceTmp,
+                                           DataSpace<simDim> exchangeSize,
+                                           DataSpace<simDim> direction,
+                                           Mapping mapper ) const
         {
-            if( direction[d] == 1 )
-            {
-                if( threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d] ) return;
-                sourceCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
-                targetCell[d] -= SuperCellSize::toRT()[d];
-            }
-            else if( direction[d] == -1 )
-            {
-                if( threadIndex[d] >= exchangeSize[d] ) return;
-                targetCell[d] += SuperCellSize::toRT()[d];
-            }
-        }
+            const DataSpace<Mapping::Dim> threadIndex(threadIdx);
+            const DataSpace<simDim> blockCell(
+                                               mapper.getSuperCellIndex( DataSpace<simDim > ( blockIdx ) )
+                                               * Mapping::SuperCellSize::toRT( )
+                                               );
+            DataSpace<Mapping::Dim> targetCell( blockCell + threadIndex );
 
-        fieldTmp( targetCell ) += sourceTmp( sourceCell );
-    }
+            /*origin in area from local GPU*/
+            DataSpace<simDim> nullSourceCell(
+                                              mapper.getSuperCellIndex( DataSpace<simDim > ( ) )
+                                              * Mapping::SuperCellSize::toRT( )
+                                              );
+            DataSpace<simDim> sourceCell( targetCell - nullSourceCell );
+
+            for (uint32_t d = 0; d < simDim; ++d)
+            {
+                if( direction[d] == 1 )
+                {
+                    if( threadIndex[d] < SuperCellSize::toRT()[d] - exchangeSize[d] ) return;
+                    sourceCell[d] -= SuperCellSize::toRT()[d] - exchangeSize[d];
+                    targetCell[d] -= SuperCellSize::toRT()[d];
+                }
+                else if( direction[d] == -1 )
+                {
+                    if( threadIndex[d] >= exchangeSize[d] ) return;
+                    targetCell[d] += SuperCellSize::toRT()[d];
+                }
+            }
+
+            fieldTmp( targetCell ) += sourceTmp( sourceCell );
+        }
+    };
 
 } // namespace picongpu

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -179,7 +179,7 @@ namespace picongpu
 
         do
         {
-            __cudaKernel( ( kernelComputeSupercells<BlockArea, AREA> ) )
+            PMACC_TYPEKERNEL( kernelComputeSupercells<BlockArea, AREA> )
                 ( mapper.getGridDim( ), mapper.getSuperCellSize( ) )
                 ( tmpBox,
                   pBox, solver, mapper );
@@ -218,10 +218,10 @@ namespace picongpu
     {
         ExchangeMapping<GUARD, MappingDesc> mapper( this->cellDescription, exchangeType );
 
-        dim3 grid = mapper.getGridDim( );
+        auto grid = mapper.getGridDim( );
 
         const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > ( mapper.getExchangeType( ) );
-        __cudaKernel( kernelBashValue )
+        PMACC_TYPEKERNEL( kernelBashValue )
             ( grid, mapper.getSuperCellSize( ) )
             ( fieldTmp->getDeviceBuffer( ).getDataBox( ),
               fieldTmp->getSendExchange( exchangeType ).getDeviceBuffer( ).getDataBox( ),
@@ -234,10 +234,10 @@ namespace picongpu
     {
         ExchangeMapping<GUARD, MappingDesc> mapper( this->cellDescription, exchangeType );
 
-        dim3 grid = mapper.getGridDim( );
+        auto grid = mapper.getGridDim( );
 
         const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > ( mapper.getExchangeType( ) );
-        __cudaKernel( kernelInsertValue )
+        PMACC_TYPEKERNEL( kernelInsertValue )
             ( grid, mapper.getSuperCellSize( ) )
             ( fieldTmp->getDeviceBuffer( ).getDataBox( ),
               fieldTmp->getReceiveExchange( exchangeType ).getDeviceBuffer( ).getDataBox( ),

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -179,7 +179,7 @@ namespace picongpu
 
         do
         {
-            PMACC_TYPEKERNEL( kernelComputeSupercells<BlockArea, AREA> )
+            PMACC_KERNEL( kernelComputeSupercells<BlockArea, AREA>{} )
                 ( mapper.getGridDim( ), mapper.getSuperCellSize( ) )
                 ( tmpBox,
                   pBox, solver, mapper );
@@ -221,7 +221,7 @@ namespace picongpu
         auto grid = mapper.getGridDim( );
 
         const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > ( mapper.getExchangeType( ) );
-        PMACC_TYPEKERNEL( kernelBashValue )
+        PMACC_KERNEL( kernelBashValue{} )
             ( grid, mapper.getSuperCellSize( ) )
             ( fieldTmp->getDeviceBuffer( ).getDataBox( ),
               fieldTmp->getSendExchange( exchangeType ).getDeviceBuffer( ).getDataBox( ),
@@ -237,7 +237,7 @@ namespace picongpu
         auto grid = mapper.getGridDim( );
 
         const DataSpace<simDim> direction = Mask::getRelativeDirections<simDim > ( mapper.getExchangeType( ) );
-        PMACC_TYPEKERNEL( kernelInsertValue )
+        PMACC_KERNEL( kernelInsertValue{} )
             ( grid, mapper.getSuperCellSize( ) )
             ( fieldTmp->getDeviceBuffer( ).getDataBox( ),
               fieldTmp->getReceiveExchange( exchangeType ).getDeviceBuffer( ).getDataBox( ),

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
@@ -74,9 +74,10 @@ private:
                 typename CurlB::UpperMargin
                 > BlockArea;
 
-        __picKernelArea((kernelUpdateE<BlockArea, CurlB>), m_cellDescription, AREA)
-                (SuperCellSize::toRT().toDim3())
-                (this->fieldE->getDeviceDataBox(), this->fieldB->getDeviceDataBox());
+        AreaMapping<AREA, MappingDesc> mapper(m_cellDescription);
+        PMACC_TYPEKERNEL(kernelUpdateE<BlockArea, CurlB>)
+                (mapper.getGridDim(), SuperCellSize::toRT())
+                (this->fieldE->getDeviceDataBox(), this->fieldB->getDeviceDataBox(),mapper);
     }
 
     template<uint32_t AREA>
@@ -88,10 +89,12 @@ private:
                 typename CurlE::UpperMargin
                 > BlockArea;
 
-        __picKernelArea((kernelUpdateBHalf<BlockArea, CurlE>), m_cellDescription, AREA)
-                (SuperCellSize::toRT().toDim3())
+        AreaMapping<AREA, MappingDesc> mapper(m_cellDescription);
+        PMACC_TYPEKERNEL(kernelUpdateBHalf<BlockArea, CurlE>)
+                (mapper.getGridDim(), SuperCellSize::toRT())
                 (this->fieldB->getDeviceDataBox(),
-                this->fieldE->getDeviceDataBox());
+                this->fieldE->getDeviceDataBox(),
+                mapper);
     }
 
 public:

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
@@ -67,7 +67,7 @@ private:
         /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
         PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_gridConfig_param_file,
             (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
-        
+
         typedef SuperCellDescription<
                 SuperCellSize,
                 typename CurlB::LowerMargin,
@@ -75,7 +75,7 @@ private:
                 > BlockArea;
 
         AreaMapping<AREA, MappingDesc> mapper(m_cellDescription);
-        PMACC_TYPEKERNEL(kernelUpdateE<BlockArea, CurlB>)
+        PMACC_KERNEL(kernelUpdateE<BlockArea, CurlB>{})
                 (mapper.getGridDim(), SuperCellSize::toRT())
                 (this->fieldE->getDeviceDataBox(), this->fieldB->getDeviceDataBox(),mapper);
     }
@@ -90,7 +90,7 @@ private:
                 > BlockArea;
 
         AreaMapping<AREA, MappingDesc> mapper(m_cellDescription);
-        PMACC_TYPEKERNEL(kernelUpdateBHalf<BlockArea, CurlE>)
+        PMACC_KERNEL(kernelUpdateBHalf<BlockArea, CurlE>{})
                 (mapper.getGridDim(), SuperCellSize::toRT())
                 (this->fieldB->getDeviceDataBox(),
                 this->fieldE->getDeviceDataBox(),

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
@@ -24,65 +24,73 @@ namespace yeeSolver
 {
 using namespace PMacc;
 
-
-template<class BlockDescription_, class CurlType_, class EBox, class BBox, class Mapping>
-__global__ void kernelUpdateE(EBox fieldE, BBox fieldB, Mapping mapper)
+template< typename BlockDescription_, typename CurlType_ >
+struct kernelUpdateE
 {
+    template<class EBox, class BBox, class Mapping>
+    DINLINE void operator()(EBox fieldE, BBox fieldB, Mapping mapper) const
+    {
 
-    PMACC_AUTO(cachedB, CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_()));
+        PMACC_AUTO(cachedB, CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_()));
 
-    nvidia::functors::Assign assign;
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-    const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
+        nvidia::functors::Assign assign;
+        const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+        const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
 
-    const DataSpace<simDim > threadIndex(threadIdx);
-    PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
+        const DataSpace<simDim > threadIndex(threadIdx);
+        PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
 
-    ThreadCollective<BlockDescription_> collective(threadIndex);
-    collective(
-              assign,
-              cachedB,
-              fieldBBlock
-              );
+        ThreadCollective<BlockDescription_> collective(threadIndex);
+        collective(
+                  assign,
+                  cachedB,
+                  fieldBBlock
+                  );
 
-    __syncthreads();
+        __syncthreads();
 
-    const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
-    const float_X dt = DELTA_T;
+        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+        const float_X dt = DELTA_T;
 
-    CurlType_ curl;
-    fieldE(blockCell + threadIndex) += curl(cachedB.shift(DataSpace<simDim > (threadIdx))) * c2 * dt;
-}
+        CurlType_ curl;
+        fieldE(blockCell + threadIndex) += curl(cachedB.shift(DataSpace<simDim > (threadIdx))) * c2 * dt;
+    }
+};
 
-template<class BlockDescription_, class CurlType_, class EBox, class BBox, class Mapping>
-__global__ void kernelUpdateBHalf(BBox fieldB,
-                                  EBox fieldE,
-                                  Mapping mapper)
+template<class BlockDescription_, class CurlType_>
+struct kernelUpdateBHalf
 {
+    template<class EBox, class BBox, class Mapping>
+    DINLINE void operator()(
+        BBox fieldB,
+        EBox fieldE,
+        Mapping mapper) const
+    {
 
-    PMACC_AUTO(cachedE, CachedBox::create < 0, typename EBox::ValueType > (BlockDescription_()));
+        PMACC_AUTO(cachedE, CachedBox::create < 0, typename EBox::ValueType > (BlockDescription_()));
 
-    nvidia::functors::Assign assign;
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-    const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
-    const DataSpace<simDim > threadIndex(threadIdx);
-    PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
+        nvidia::functors::Assign assign;
+        const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+        const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
+        const DataSpace<simDim > threadIndex(threadIdx);
+        PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
 
-    ThreadCollective<BlockDescription_> collective(threadIndex);
-    collective(
-              assign,
-              cachedE,
-              fieldEBlock
-              );
+        ThreadCollective<BlockDescription_> collective(threadIndex);
+        collective(
+                  assign,
+                  cachedE,
+                  fieldEBlock
+                  );
 
 
-    __syncthreads();
+        __syncthreads();
 
-    const float_X dt = DELTA_T;
+        const float_X dt = DELTA_T;
 
-    CurlType_ curl;
-    fieldB(blockCell + threadIndex) -= curl(cachedE.shift(threadIndex)) * float_X(0.5) * dt;
-}
+        CurlType_ curl;
+        fieldB(blockCell + threadIndex) -= curl(cachedE.shift(threadIndex)) * float_X(0.5) * dt;
+    }
+};
 
 } // yeeSolver
 

--- a/src/picongpu/include/fields/background/cellwiseOperation.hpp
+++ b/src/picongpu/include/fields/background/cellwiseOperation.hpp
@@ -115,7 +115,7 @@ namespace cellwiseOperation
 
             /* start kernel */
             AreaMapping<T_Area, MappingDesc> mapper(m_cellDescription);
-            PMACC_TYPEKERNEL(kernelCellwiseOperation)
+            PMACC_KERNEL(kernelCellwiseOperation{})
                     (mapper.getGridDim(), SuperCellSize::toRT())
                     (field->getDeviceDataBox(), opFunctor, valFunctor, totalCellOffset, currentStep, mapper);
         }

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -58,194 +58,207 @@ namespace picongpu
 
 using namespace PMacc;
 
-template<class T_MyParBox, class T_OtherFrameBox, class T_ManipulateFunctor, class Mapping>
-__global__ void kernelDeriveParticles(T_MyParBox myBox, T_OtherFrameBox otherBox, T_ManipulateFunctor manipulateFunctor, Mapping mapper)
+
+struct kernelDeriveParticles
 {
-    using namespace PMacc::particles::operations;
-    typedef typename T_MyParBox::FramePtr MyFramePtr;
-    typedef typename T_OtherFrameBox::FramePtr OtherFramePtr;
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<OtherFramePtr>::type frame;
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<MyFramePtr>::type myFrame;
-
-
-    typedef typename Mapping::SuperCellSize SuperCellSize;
-
-
-    const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
-
-    if (threadIdx.x == 0)
+    template<class T_MyParBox, class T_OtherFrameBox, class T_ManipulateFunctor, class Mapping>
+    DINLINE void operator()(T_MyParBox myBox, T_OtherFrameBox otherBox, T_ManipulateFunctor manipulateFunctor, Mapping mapper) const
     {
-        frame = otherBox.getFirstFrame(block);
-        if (frame.isValid())
-        {
-            //we have everything to clone
-            myFrame = myBox.getEmptyFrame();
-        }
-    }
-    __syncthreads();
-    while (frame.isValid()) //move over all Frames
-    {
-        PMACC_AUTO(parDest, myFrame[threadIdx.x]);
-        PMACC_AUTO(parSrc, frame[threadIdx.x]);
-        assign(parDest, deselect<particleId>(parSrc));
+        using namespace PMacc::particles::operations;
+        typedef typename T_MyParBox::FramePtr MyFramePtr;
+        typedef typename T_OtherFrameBox::FramePtr OtherFramePtr;
 
-        const DataSpace<simDim> localCellIdx = block * SuperCellSize::toRT()
-            + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x)
-            - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-        manipulateFunctor(localCellIdx,
-                          parDest, parSrc,
-                          true, parSrc[multiMask_] == 1);
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<OtherFramePtr>::type frame;
 
-        __syncthreads();
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<MyFramePtr>::type myFrame;
+
+
+        typedef typename Mapping::SuperCellSize SuperCellSize;
+
+
+        const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
 
         if (threadIdx.x == 0)
         {
-            myBox.setAsLastFrame(myFrame, block);
-
-            frame = otherBox.getNextFrame(frame);
+            frame = otherBox.getFirstFrame(block);
             if (frame.isValid())
             {
+                //we have everything to clone
                 myFrame = myBox.getEmptyFrame();
             }
         }
         __syncthreads();
-    }
-}
+        while (frame.isValid()) //move over all Frames
+        {
+            PMACC_AUTO(parDest, myFrame[threadIdx.x]);
+            PMACC_AUTO(parSrc, frame[threadIdx.x]);
+            assign(parDest, deselect<particleId>(parSrc));
 
-/* kernel must called with one dimension for blockSize */
-template<typename T_ParticleFunctor,typename T_ParBox,  class Mapping>
-__global__ void kernelManipulateAllParticles(T_ParBox pb,
-                                             T_ParticleFunctor particleFunctor,
-                                             Mapping mapper)
+            const DataSpace<simDim> localCellIdx = block * SuperCellSize::toRT()
+                + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x)
+                - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+            manipulateFunctor(localCellIdx,
+                              parDest, parSrc,
+                              true, parSrc[multiMask_] == 1);
+
+            __syncthreads();
+
+            if (threadIdx.x == 0)
+            {
+                myBox.setAsLastFrame(myFrame, block);
+
+                frame = otherBox.getNextFrame(frame);
+                if (frame.isValid())
+                {
+                    myFrame = myBox.getEmptyFrame();
+                }
+            }
+            __syncthreads();
+        }
+    }
+};
+
+struct kernelManipulateAllParticles
 {
-    typedef typename T_ParBox::FramePtr FramePtr;
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-
-    typedef typename Mapping::SuperCellSize SuperCellSize;
-
-
-    const DataSpace<simDim > threadIndex(threadIdx);
-    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
-
-    const DataSpace<simDim> superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-
-    if (linearThreadIdx == 0)
+    /* kernel must called with one dimension for blockSize */
+    template<typename T_ParticleFunctor,typename T_ParBox,  class Mapping>
+    DINLINE void operator()(
+        T_ParBox pb,
+        T_ParticleFunctor particleFunctor,
+        Mapping mapper) const
     {
-        frame = pb.getLastFrame(superCellIdx);
-    }
+        typedef typename T_ParBox::FramePtr FramePtr;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
 
-    __syncthreads();
-    if (!frame.isValid())
-        return; //end kernel if we have no frames
-
-    /* BUGFIX to issue #538
-     * volatile prohibits that the compiler creates wrong code*/
-    volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
-
-    const DataSpace<simDim> idx(superCellIdx * SuperCellSize::toRT() + threadIndex);
-    const DataSpace<simDim> localCellIdx = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+        typedef typename Mapping::SuperCellSize SuperCellSize;
 
 
-    __syncthreads();
+        const DataSpace<simDim > threadIndex(threadIdx);
+        const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
 
-    while (frame.isValid())
-    {
-        PMACC_AUTO(particle, frame[linearThreadIdx]);
-        particleFunctor(localCellIdx, particle, particle, isParticle, isParticle);
+        const DataSpace<simDim> superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
 
-        __syncthreads();
         if (linearThreadIdx == 0)
         {
-            frame = pb.getPreviousFrame(frame);
+            frame = pb.getLastFrame(superCellIdx);
         }
-        isParticle = true;
+
         __syncthreads();
-    }
-}
+        if (!frame.isValid())
+            return; //end kernel if we have no frames
 
-template<class BlockDescription_, class ParBox, class BBox, class EBox, class Mapping, class FrameSolver>
-__global__ void kernelMoveAndMarkParticles(ParBox pb,
-                                           EBox fieldE,
-                                           BBox fieldB,
-                                           FrameSolver frameSolver,
-                                           Mapping mapper)
-{
-    /* definitions for domain variables, like indices of blocks and threads
-     *
-     * conversion from block to linear frames */
-    typedef typename BlockDescription_::SuperCellSize SuperCellSize;
-    typedef typename ParBox::FramePtr FramePtr;
+        /* BUGFIX to issue #538
+         * volatile prohibits that the compiler creates wrong code*/
+        volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
 
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+        const DataSpace<simDim> idx(superCellIdx * SuperCellSize::toRT() + threadIndex);
+        const DataSpace<simDim> localCellIdx = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
 
-    const DataSpace<simDim > threadIndex(threadIdx);
-    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
+        __syncthreads();
 
-
-    const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
-
-
-
-    FramePtr frame;
-
-    __shared__ int mustShift;
-    lcellId_t particlesInSuperCell;
-
-
-    if (linearThreadIdx == 0)
-    {
-        mustShift = 0;
-    }
-    frame = pb.getLastFrame(block);
-    particlesInSuperCell = pb.getSuperCell(block).getSizeLastFrame();
-
-    PMACC_AUTO(cachedB, CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_()));
-    PMACC_AUTO(cachedE, CachedBox::create < 1, typename EBox::ValueType > (BlockDescription_()));
-
-    __syncthreads();
-    if (!frame.isValid())
-        return; //end kernel if we have no frames
-
-
-    PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
-
-    nvidia::functors::Assign assign;
-    ThreadCollective<BlockDescription_> collective(linearThreadIdx);
-    collective(
-              assign,
-              cachedB,
-              fieldBBlock
-              );
-
-    PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
-    collective(
-              assign,
-              cachedE,
-              fieldEBlock
-              );
-    __syncthreads();
-
-    /*move over frames and call frame solver*/
-    while (frame.isValid())
-    {
-        if (linearThreadIdx < particlesInSuperCell)
+        while (frame.isValid())
         {
-            frameSolver(*frame, linearThreadIdx, cachedB, cachedE, mustShift);
-        }
-        frame = pb.getPreviousFrame(frame);
-        particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
+            PMACC_AUTO(particle, frame[linearThreadIdx]);
+            particleFunctor(localCellIdx, particle, particle, isParticle, isParticle);
 
+            __syncthreads();
+            if (linearThreadIdx == 0)
+            {
+                frame = pb.getPreviousFrame(frame);
+            }
+            isParticle = true;
+            __syncthreads();
+        }
     }
-    __syncthreads();
-    /*set in SuperCell the mustShift flag which is a optimization for shift particles and fillGaps*/
-    if (linearThreadIdx == 0 && mustShift == 1)
-    {
-        pb.getSuperCell(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx))).setMustShift(true);
-    }
-}
+};
+
+template< class BlockDescription_ >
+struct kernelMoveAndMarkParticles
+{
+    template<class ParBox, class BBox, class EBox, class Mapping, class FrameSolver>
+    DINLINE void operator()(
+       ParBox pb,
+       EBox fieldE,
+       BBox fieldB,
+       FrameSolver frameSolver,
+       Mapping mapper) const
+   {
+       /* definitions for domain variables, like indices of blocks and threads
+        *
+        * conversion from block to linear frames */
+       typedef typename BlockDescription_::SuperCellSize SuperCellSize;
+       typedef typename ParBox::FramePtr FramePtr;
+
+       const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+
+
+       const DataSpace<simDim > threadIndex(threadIdx);
+       const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
+
+
+       const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
+
+
+
+       FramePtr frame;
+
+       __shared__ int mustShift;
+       lcellId_t particlesInSuperCell;
+
+
+       if (linearThreadIdx == 0)
+       {
+           mustShift = 0;
+       }
+       frame = pb.getLastFrame(block);
+       particlesInSuperCell = pb.getSuperCell(block).getSizeLastFrame();
+
+       PMACC_AUTO(cachedB, CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_()));
+       PMACC_AUTO(cachedE, CachedBox::create < 1, typename EBox::ValueType > (BlockDescription_()));
+
+       __syncthreads();
+       if (!frame.isValid())
+           return; //end kernel if we have no frames
+
+
+       PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
+
+       nvidia::functors::Assign assign;
+       ThreadCollective<BlockDescription_> collective(linearThreadIdx);
+       collective(
+                 assign,
+                 cachedB,
+                 fieldBBlock
+                 );
+
+       PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
+       collective(
+                 assign,
+                 cachedE,
+                 fieldEBlock
+                 );
+       __syncthreads();
+
+       /*move over frames and call frame solver*/
+       while (frame.isValid())
+       {
+           if (linearThreadIdx < particlesInSuperCell)
+           {
+               frameSolver(*frame, linearThreadIdx, cachedB, cachedE, mustShift);
+           }
+           frame = pb.getPreviousFrame(frame);
+           particlesInSuperCell = PMacc::math::CT::volume<SuperCellSize>::type::value;
+
+       }
+       __syncthreads();
+       /*set in SuperCell the mustShift flag which is a optimization for shift particles and fillGaps*/
+       if (linearThreadIdx == 0 && mustShift == 1)
+       {
+           pb.getSuperCell(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx))).setMustShift(true);
+       }
+   }
+};
 
 template<class PushAlgo, class TVec, class T_Field2ParticleInterpolation>
 struct PushParticlePerFrame

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -176,7 +176,7 @@ void Particles<T_ParticleDescription>::update(uint32_t )
     auto block = MappingDesc::SuperCellSize::toRT();
 
     AreaMapping<CORE+BORDER,MappingDesc> mapper(this->cellDescription);
-    PMACC_TYPEKERNEL( kernelMoveAndMarkParticles<BlockArea> )
+    PMACC_KERNEL( kernelMoveAndMarkParticles<BlockArea>{} )
         (mapper.getGridDim(), block)
         ( this->getDeviceParticlesBox( ),
           this->fieldE->getDeviceDataBox( ),
@@ -204,7 +204,7 @@ void Particles<T_ParticleDescription>::initGas( T_GasFunctor& gasFunctor,
 
     auto block = MappingDesc::SuperCellSize::toRT( );
     AreaMapping<CORE+BORDER,MappingDesc> mapper(this->cellDescription);
-    PMACC_TYPEKERNEL( kernelFillGridWithParticles<Particles<T_ParticleDescription> > )
+    PMACC_KERNEL( kernelFillGridWithParticles<Particles<T_ParticleDescription> >{} )
         (mapper.getGridDim(), block)
         ( gasFunctor, positionFunctor, totalGpuCellOffset, this->particlesBuffer->getDeviceParticleBox( ), mapper );
 
@@ -221,7 +221,7 @@ void Particles<T_ParticleDescription>::deviceDeriveFrom( Particles< T_SrcParticl
 
     log<picLog::SIMULATION_STATE > ( "clone species %1%" ) % FrameType::getName( );
     AreaMapping<CORE + BORDER, MappingDesc> mapper(this->cellDescription);
-    PMACC_TYPEKERNEL( kernelDeriveParticles )
+    PMACC_KERNEL( kernelDeriveParticles{} )
         (mapper.getGridDim(), block) ( this->getDeviceParticlesBox( ), src.getDeviceParticlesBox( ), functor, mapper );
     this->fillAllGaps( );
 }
@@ -234,7 +234,7 @@ void Particles<T_ParticleDescription>::manipulateAllParticles( uint32_t currentS
     auto block = MappingDesc::SuperCellSize::toRT( );
 
     AreaMapping<CORE + BORDER, MappingDesc> mapper(this->cellDescription);
-    PMACC_TYPEKERNEL( kernelManipulateAllParticles )
+    PMACC_KERNEL( kernelManipulateAllParticles{} )
         (mapper.getGridDim(), block)
         ( this->particlesBuffer->getDeviceParticleBox( ),
           functor,

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -303,7 +303,7 @@ struct CallIonization
              * "blocks" will be calculated from "this->cellDescription" and "CORE + BORDER"
              * "threads" is calculated from the previously defined vector "block"
              */
-            PMACC_TYPEKERNEL( particles::ionization::kernelIonizeParticles )
+            PMACC_KERNEL( particles::ionization::kernelIonizeParticles{} )
                 (mapper.getGridDim(), block)
                 ( srcSpeciesPtr->getDeviceParticlesBox( ),
                   electronsPtr->getDeviceParticlesBox( ),

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -61,125 +61,130 @@ DINLINE float_X calcRealDensity(T_GasProfile& gasFunctor,
     return value;
 }
 
-template< typename T_Species, typename T_GasProfile, typename T_PositionFunctor, typename ParBox, class Mapping>
-__global__ void kernelFillGridWithParticles(T_GasProfile gasFunctor,
-                                            T_PositionFunctor positionFunctor,
-                                            DataSpace<simDim> totalGpuCellOffset,
-                                            ParBox pb,
-                                            Mapping mapper)
+template< typename T_Species >
+struct kernelFillGridWithParticles
 {
-    typedef typename ParBox::FramePtr FramePtr;
-    const DataSpace<simDim> superCells(mapper.getGridSuperCells());
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-
-
-    typedef typename Mapping::SuperCellSize SuperCellSize;
-
-    const DataSpace<simDim > threadIndex(threadIdx);
-    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
-    const DataSpace<simDim> superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-
-
-    /* do not add particle to guarding super cells */
-    for (uint32_t d = 0; d < simDim; ++d)
-        if (superCellIdx[d] == 0 || superCellIdx[d] == superCells[d] - 1) return;
-
-    /*get local cell idx*/
-    const DataSpace<simDim> idx(superCellIdx * SuperCellSize::toRT() + threadIndex);
-
-    /*delete garding cells */
-    const DataSpace<simDim> localCellIndex = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-
-    const DataSpace<simDim> totalGpuCellIdx = totalGpuCellOffset + localCellIndex;
-    const float_X realDensity = calcRealDensity<T_Species>(gasFunctor, totalGpuCellIdx);
-
-    const float_X realParticlesPerCell = realDensity * CELL_VOLUME;
-
-    __shared__ int finished;
-    if (linearThreadIdx == 0)
-        finished = 1;
-    __syncthreads();
-
-    positionFunctor.init(totalGpuCellIdx);
-    // decrease number of macro particles, if weighting would be too small
-    particles::startPosition::MacroParticleCfg makroCfg =
-        positionFunctor.mapRealToMacroParticle(realParticlesPerCell);
-    float_X macroWeighting = makroCfg.weighting;
-    uint32_t numParsPerCell = makroCfg.numParticlesPerCell;
-
-    const uint32_t totalNumParsPerCell = numParsPerCell;
-
-    if (numParsPerCell > 0)
-        nvidia::atomicAllExch(&finished, 0); //one or more cells have particles to create
-
-    __syncthreads();
-    if (finished == 1)
-        return; // if there is no particle which has to be created
-
-    if (linearThreadIdx == 0)
+    template<typename T_GasProfile, typename T_PositionFunctor, typename ParBox, class Mapping>
+    DINLINE void operator()(
+        T_GasProfile gasFunctor,
+        T_PositionFunctor positionFunctor,
+        DataSpace<simDim> totalGpuCellOffset,
+        ParBox pb,
+        Mapping mapper) const
     {
-        frame = pb.getEmptyFrame();
-        pb.setAsLastFrame(frame, superCellIdx);
-    }
+        typedef typename ParBox::FramePtr FramePtr;
+        const DataSpace<simDim> superCells(mapper.getGridSuperCells());
 
-    __syncthreads();
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
 
-    // distribute the particles within the cell
-    do
-    {
 
-        __syncthreads();
+        typedef typename Mapping::SuperCellSize SuperCellSize;
+
+        const DataSpace<simDim > threadIndex(threadIdx);
+        const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
+        const DataSpace<simDim> superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+
+
+        /* do not add particle to guarding super cells */
+        for (uint32_t d = 0; d < simDim; ++d)
+            if (superCellIdx[d] == 0 || superCellIdx[d] == superCells[d] - 1) return;
+
+        /*get local cell idx*/
+        const DataSpace<simDim> idx(superCellIdx * SuperCellSize::toRT() + threadIndex);
+
+        /*delete garding cells */
+        const DataSpace<simDim> localCellIndex = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+
+        const DataSpace<simDim> totalGpuCellIdx = totalGpuCellOffset + localCellIndex;
+        const float_X realDensity = calcRealDensity<T_Species>(gasFunctor, totalGpuCellIdx);
+
+        const float_X realParticlesPerCell = realDensity * CELL_VOLUME;
+
+        __shared__ int finished;
         if (linearThreadIdx == 0)
-            finished = 1; //clear flag
+            finished = 1;
         __syncthreads();
+
+        positionFunctor.init(totalGpuCellIdx);
+        // decrease number of macro particles, if weighting would be too small
+        particles::startPosition::MacroParticleCfg makroCfg =
+            positionFunctor.mapRealToMacroParticle(realParticlesPerCell);
+        float_X macroWeighting = makroCfg.weighting;
+        uint32_t numParsPerCell = makroCfg.numParticlesPerCell;
+
+        const uint32_t totalNumParsPerCell = numParsPerCell;
 
         if (numParsPerCell > 0)
-        {
-            floatD_X pos = positionFunctor(totalNumParsPerCell - numParsPerCell);
-            PMACC_AUTO(particle, (frame[linearThreadIdx]));
+            nvidia::atomicAllExch(&finished, 0); //one or more cells have particles to create
 
-            /** we now initialize all attributes of the new particle to their default values
-             *   some attributes, such as the position, localCellIdx, weighting or the
-             *   multiMask (\see AttrToIgnore) of the particle will be set individually
-             *   in the following lines since they are already known at this point.
-             */
-            {
-                typedef typename ParBox::FrameType FrameType;
-                typedef typename FrameType::ValueTypeSeq ParticleAttrList;
-                typedef bmpl::vector4<position<>, multiMask, localCellIdx, weighting> AttrToIgnore;
-                typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
-
-                algorithms::forEach::ForEach<ParticleCleanedAttrList,
-                    SetAttributeToDefault<bmpl::_1> > setToDefault;
-                setToDefault(forward(particle));
-            }
-            particle[position_] = pos;
-            particle[multiMask_] = 1;
-            particle[localCellIdx_] = linearThreadIdx;
-            particle[weighting_] = macroWeighting;
-
-#if(ENABLE_RADIATION == 1)
-#    if(RAD_MARK_PARTICLE>1) && (RAD_ACTIVATE_GAMMA_FILTER==0)
-            particle[radiationFlag_] = (bool)(rng() < (1.0 / (float_32) RAD_MARK_PARTICLE));
-#    endif
-#    if(RAD_ACTIVATE_GAMMA_FILTER!=0)
-            particle[radiationFlag_] = (bool)(false);
-#    endif
-#endif
-
-            numParsPerCell--;
-            if (numParsPerCell > 0)
-                atomicExch(&finished, 0); //one or more cell has particles to create
-        }
         __syncthreads();
-        if (linearThreadIdx == 0 && finished == 0)
+        if (finished == 1)
+            return; // if there is no particle which has to be created
+
+        if (linearThreadIdx == 0)
         {
             frame = pb.getEmptyFrame();
             pb.setAsLastFrame(frame, superCellIdx);
         }
+
+        __syncthreads();
+
+        // distribute the particles within the cell
+        do
+        {
+
+            __syncthreads();
+            if (linearThreadIdx == 0)
+                finished = 1; //clear flag
+            __syncthreads();
+
+            if (numParsPerCell > 0)
+            {
+                floatD_X pos = positionFunctor(totalNumParsPerCell - numParsPerCell);
+                PMACC_AUTO(particle, (frame[linearThreadIdx]));
+
+                /** we now initialize all attributes of the new particle to their default values
+                 *   some attributes, such as the position, localCellIdx, weighting or the
+                 *   multiMask (\see AttrToIgnore) of the particle will be set individually
+                 *   in the following lines since they are already known at this point.
+                 */
+                {
+                    typedef typename ParBox::FrameType FrameType;
+                    typedef typename FrameType::ValueTypeSeq ParticleAttrList;
+                    typedef bmpl::vector4<position<>, multiMask, localCellIdx, weighting> AttrToIgnore;
+                    typedef typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type ParticleCleanedAttrList;
+
+                    algorithms::forEach::ForEach<ParticleCleanedAttrList,
+                        SetAttributeToDefault<bmpl::_1> > setToDefault;
+                    setToDefault(forward(particle));
+                }
+                particle[position_] = pos;
+                particle[multiMask_] = 1;
+                particle[localCellIdx_] = linearThreadIdx;
+                particle[weighting_] = macroWeighting;
+
+    #if(ENABLE_RADIATION == 1)
+    #    if(RAD_MARK_PARTICLE>1) && (RAD_ACTIVATE_GAMMA_FILTER==0)
+                particle[radiationFlag_] = (bool)(rng() < (1.0 / (float_32) RAD_MARK_PARTICLE));
+    #    endif
+    #    if(RAD_ACTIVATE_GAMMA_FILTER!=0)
+                particle[radiationFlag_] = (bool)(false);
+    #    endif
+    #endif
+
+                numParsPerCell--;
+                if (numParsPerCell > 0)
+                    atomicExch(&finished, 0); //one or more cell has particles to create
+            }
+            __syncthreads();
+            if (linearThreadIdx == 0 && finished == 0)
+            {
+                frame = pb.getEmptyFrame();
+                pb.setAsLastFrame(frame, superCellIdx);
+            }
+        }
+        while (finished == 0);
     }
-    while (finished == 0);
-}
+};
 
 }

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -46,265 +46,269 @@ namespace ionization
 
 using namespace PMacc;
 
-/** kernelIonizeParticles
- * \brief main kernel for ionization
- *
- * - maps the frame dimensions and gathers the particle boxes
- * - contains / calls the ionization algorithm
- * - calls the electron creation functors
- *
- * \tparam ParBoxIons container of the ions
- * \tparam ParBoxElectrons container of the electrons
- * \tparam Mapping class containing methods for acquiring info from the block
- * \tparam FrameIonizer \see e.g. BSIHydrogenLike_Impl in BSIHydrogenLike_Impl.hpp
- *         instance of the ionization model functor
- */
-template<class ParBoxIons, class ParBoxElectrons, class Mapping, class FrameIonizer>
-__global__ void kernelIonizeParticles(ParBoxIons ionBox,
-                                      ParBoxElectrons electronBox,
-                                      FrameIonizer frameIonizer,
-                                      Mapping mapper)
+
+struct kernelIonizeParticles
 {
-
-    /* "particle box" : container/iterator where the particles live in
-     * and where one can get the frame in a super cell from
+    /** kernelIonizeParticles
+     * \brief main kernel for ionization
+     *
+     * - maps the frame dimensions and gathers the particle boxes
+     * - contains / calls the ionization algorithm
+     * - calls the electron creation functors
+     *
+     * \tparam ParBoxIons container of the ions
+     * \tparam ParBoxElectrons container of the electrons
+     * \tparam Mapping class containing methods for acquiring info from the block
+     * \tparam FrameIonizer \see e.g. BSIHydrogenLike_Impl in BSIHydrogenLike_Impl.hpp
+     *         instance of the ionization model functor
      */
-    typedef typename ParBoxElectrons::FrameType ELECTRONFRAME;
-    typedef typename ParBoxIons::FrameType IONFRAME;
-    typedef typename ParBoxIons::FramePtr IonFramePtr;
-    typedef typename ParBoxElectrons::FramePtr ElectronFramePtr;
-
-    /* specify field to particle interpolation scheme */
-    typedef typename PMacc::traits::Resolve<
-        typename GetFlagType<IONFRAME,interpolation<> >::type
-    >::type InterpolationScheme;
-
-    /* margins around the supercell for the interpolation of the field on the cells */
-    typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
-    typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
-
-    /* relevant area of a block */
-    typedef SuperCellDescription<
-        typename MappingDesc::SuperCellSize,
-        LowerMargin,
-        UpperMargin
-        > BlockDescription_;
-
-    /* for not mixing operations::assign up with the nvidia functor assign */
-    namespace partOp = PMacc::particles::operations;
-
-    /* definitions for domain variables, like indices of blocks and threads */
-    typedef typename BlockDescription_::SuperCellSize SuperCellSize;
-    /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-
-    /* multi-dim vector from origin of the block to a cell in units of cells */
-    const DataSpace<simDim > threadIndex(threadIdx);
-    /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
-    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
-
-    /* multi-dim offset from the origin of the local domain on GPU
-     * to the origin of the block of the in unit of cells
-     */
-    const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
-
-    /* subtract guarding cells to only have the simulation volume */
-    const DataSpace<simDim> localCellIndex = (block * SuperCellSize::toRT() + threadIndex) - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-
-    /* typedef for the functor that writes new macro electrons into electron frames during runtime */
-    typedef typename particles::ionization::WriteElectronIntoFrame WriteElectronIntoFrame;
-
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<IonFramePtr>::type ionFrame;
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ElectronFramePtr>::type electronFrame;
-    __shared__ lcellId_t maxParticlesInFrame;
-
-
-    /* find last frame in super cell
-     * define maxParticlesInFrame as the maximum frame size
-     */
-    if (linearThreadIdx == 0)
+    template<class ParBoxIons, class ParBoxElectrons, class Mapping, class FrameIonizer>
+    DINLINE void operator()(ParBoxIons ionBox,
+                                          ParBoxElectrons electronBox,
+                                          FrameIonizer frameIonizer,
+                                          Mapping mapper) const
     {
-        ionFrame = ionBox.getLastFrame(block);
-        maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
-    }
 
-    __syncthreads();
-    if (!ionFrame.isValid())
-        return; //end kernel if we have no frames
-
-    /* caching of E- and B- fields and initialization of random generator if needed */
-    frameIonizer.init(blockCell, linearThreadIdx, localCellIndex);
-
-    /* Declare counter in shared memory that will later tell the current fill level or
-     * occupation of the newly created target electron frames.
-     */
-    __shared__ int newFrameFillLvl;
-
-    /* Declare local variable oldFrameFillLvl for each thread */
-    int oldFrameFillLvl;
-
-    /* Initialize local (register) counter for each thread
-     * - describes how many new macro electrons should be created
-     */
-    unsigned int newMacroElectrons = 0;
-
-    /* Declare local electron ID
-     * - describes at which position in the new frame the new electron is to be created
-     */
-    int electronId;
-
-    /* Master initializes the frame fill level with 0 */
-    if (linearThreadIdx == 0)
-    {
-        newFrameFillLvl = 0;
-        electronFrame = NULL;
-    }
-    __syncthreads();
-
-    /* move over source species frames and call frameIonizer
-     * frames are worked on in backwards order to avoid asking if there is another frame
-     * --> performance
-     * Because all frames are completely filled except the last and apart from that last frame
-     * one wants to make sure that all threads are working and every frame is worked on.
-     */
-    while (ionFrame.isValid())
-    {
-        /* casting uint8_t multiMask to boolean */
-        const bool isParticle = ionFrame[linearThreadIdx][multiMask_];
-        __syncthreads();
-
-        /* < IONIZATION and change of charge states >
-         * if the threads contain particles, the frameIonizer can ionize them
-         * if they are non-particles their inner ionization counter remains at 0
+        /* "particle box" : container/iterator where the particles live in
+         * and where one can get the frame in a super cell from
          */
-        if (isParticle)
-            /* ionization based on ionization model - this actually increases charge states*/
-            frameIonizer(*ionFrame, linearThreadIdx, newMacroElectrons);
+        typedef typename ParBoxElectrons::FrameType ELECTRONFRAME;
+        typedef typename ParBoxIons::FrameType IONFRAME;
+        typedef typename ParBoxIons::FramePtr IonFramePtr;
+        typedef typename ParBoxElectrons::FramePtr ElectronFramePtr;
 
-        __syncthreads();
-        /* always true while-loop over all particles inside source frame until each thread breaks out individually
-         *
-         * **Attention**: Speaking of 1st and 2nd frame only may seem odd.
-         * The question might arise what happens if more electrons are created than would fit into two frames.
-         * Well, multi-ionization during a time step is accounted for. The number of new electrons is
-         * determined inside the outer loop over the valid frames while in the inner loop each thread can create only ONE
-         * new macro electron. But the loop repeats until each thread has created all the electrons needed in the time step.
+        /* specify field to particle interpolation scheme */
+        typedef typename PMacc::traits::Resolve<
+            typename GetFlagType<IONFRAME,interpolation<> >::type
+        >::type InterpolationScheme;
+
+        /* margins around the supercell for the interpolation of the field on the cells */
+        typedef typename GetMargin<InterpolationScheme>::LowerMargin LowerMargin;
+        typedef typename GetMargin<InterpolationScheme>::UpperMargin UpperMargin;
+
+        /* relevant area of a block */
+        typedef SuperCellDescription<
+            typename MappingDesc::SuperCellSize,
+            LowerMargin,
+            UpperMargin
+            > BlockDescription_;
+
+        /* for not mixing operations::assign up with the nvidia functor assign */
+        namespace partOp = PMacc::particles::operations;
+
+        /* definitions for domain variables, like indices of blocks and threads */
+        typedef typename BlockDescription_::SuperCellSize SuperCellSize;
+        /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+        const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+
+        /* multi-dim vector from origin of the block to a cell in units of cells */
+        const DataSpace<simDim > threadIndex(threadIdx);
+        /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
+        const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
+
+        /* multi-dim offset from the origin of the local domain on GPU
+         * to the origin of the block of the in unit of cells
          */
-        while (true)
-        {
-            /* < INIT >
-             * - electronId is initialized as -1 (meaning: invalid)
-             * - (local) oldFrameFillLvl set equal to (shared) newFrameFillLvl for each thread
-             * --> each thread remembers the old "counter"
-             * - then sync
-             */
-            electronId = -1;
-            oldFrameFillLvl = newFrameFillLvl;
-            __syncthreads();
-            /* < CHECK & ADD >
-             * - if a thread wants to create electrons in each cycle it can do that only once
-             * and before that it atomically adds to the shared counter and uses the current
-             * value as electronId in the new frame
-             * - then sync
-             */
-            if (newMacroElectrons > 0)
-                electronId = nvidia::atomicAllInc(&newFrameFillLvl);
+        const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
 
-            __syncthreads();
-            /* < EXIT? >
-             * - if the counter hasn't changed all threads break out of the loop */
-            if (oldFrameFillLvl == newFrameFillLvl)
-                break;
+        /* subtract guarding cells to only have the simulation volume */
+        const DataSpace<simDim> localCellIndex = (block * SuperCellSize::toRT() + threadIndex) - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
-            __syncthreads();
-            /* < FIRST NEW FRAME >
-             * - if there is no frame, yet, the master will create a new target electron frame
-             * and attach it to the back of the frame list
-             * - sync all threads again for them to know which frame to use
-             */
-            if (linearThreadIdx == 0)
-            {
-                if (!electronFrame.isValid())
-                {
-                    electronFrame = electronBox.getEmptyFrame();
-                    electronBox.setAsLastFrame(electronFrame, block);
-                }
-            }
-            __syncthreads();
-            /* < CREATE 1 >
-             * - all electrons fitting into the current frame are created there
-             * - internal ionization counter is decremented by 1
-             * - sync
-             */
-            if ((0 <= electronId) && (electronId < maxParticlesInFrame))
-            {
-                /* each thread makes the attributes of its ion accessible */
-                PMACC_AUTO(parentIon,(ionFrame[linearThreadIdx]));
-                /* each thread initializes an electron if one should be created */
-                PMACC_AUTO(targetElectronFull,(electronFrame[electronId]));
+        /* typedef for the functor that writes new macro electrons into electron frames during runtime */
+        typedef typename particles::ionization::WriteElectronIntoFrame WriteElectronIntoFrame;
 
-                /* create an electron in the new electron frame:
-                 * - see particles/ionization/ionizationMethods.hpp
-                 */
-                WriteElectronIntoFrame writeElectron;
-                writeElectron(parentIon,targetElectronFull);
 
-                newMacroElectrons -= 1;
-            }
-            __syncthreads();
-            /* < SECOND NEW FRAME >
-             * - if the shared counter is larger than the frame size a new electron frame is reserved
-             * and attached to the back of the frame list
-             * - then the shared counter is set back by one frame size
-             * - sync so that every thread knows about the new frame
-             */
-            if (linearThreadIdx == 0)
-            {
-                if (newFrameFillLvl >= maxParticlesInFrame)
-                {
-                    electronFrame = electronBox.getEmptyFrame();
-                    electronBox.setAsLastFrame(electronFrame, block);
-                    newFrameFillLvl -= maxParticlesInFrame;
-                }
-            }
-            __syncthreads();
-            /* < CREATE 2 >
-             * - if the EID is larger than the frame size
-             *      - the EID is set back by one frame size
-             *      - the thread writes an electron to the new frame
-             *      - the internal counter is decremented by 1
-             */
-            if (electronId >= maxParticlesInFrame)
-            {
-                electronId -= maxParticlesInFrame;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<IonFramePtr>::type ionFrame;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ElectronFramePtr>::type electronFrame;
+        __shared__ lcellId_t maxParticlesInFrame;
 
-                /* each thread makes the attributes of its ion accessible */
-                PMACC_AUTO(parentIon,((*ionFrame)[linearThreadIdx]));
-                /* each thread initializes an electron if one should be produced */
-                PMACC_AUTO(targetElectronFull,(electronFrame[electronId]));
 
-                /* create an electron in the new electron frame:
-                 * - see particles/ionization/ionizationMethods.hpp
-                 */
-                WriteElectronIntoFrame writeElectron;
-                writeElectron(parentIon,targetElectronFull);
-
-                newMacroElectrons -= 1;
-            }
-            __syncthreads();
-        }
-        __syncthreads();
-
+        /* find last frame in super cell
+         * define maxParticlesInFrame as the maximum frame size
+         */
         if (linearThreadIdx == 0)
         {
-            ionFrame = ionBox.getPreviousFrame(ionFrame);
+            ionFrame = ionBox.getLastFrame(block);
             maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
         }
-        __syncthreads();
-    }
-} // void kernelIonizeParticles
 
+        __syncthreads();
+        if (!ionFrame.isValid())
+            return; //end kernel if we have no frames
+
+        /* caching of E- and B- fields and initialization of random generator if needed */
+        frameIonizer.init(blockCell, linearThreadIdx, localCellIndex);
+
+        /* Declare counter in shared memory that will later tell the current fill level or
+         * occupation of the newly created target electron frames.
+         */
+        __shared__ int newFrameFillLvl;
+
+        /* Declare local variable oldFrameFillLvl for each thread */
+        int oldFrameFillLvl;
+
+        /* Initialize local (register) counter for each thread
+         * - describes how many new macro electrons should be created
+         */
+        unsigned int newMacroElectrons = 0;
+
+        /* Declare local electron ID
+         * - describes at which position in the new frame the new electron is to be created
+         */
+        int electronId;
+
+        /* Master initializes the frame fill level with 0 */
+        if (linearThreadIdx == 0)
+        {
+            newFrameFillLvl = 0;
+            electronFrame = NULL;
+        }
+        __syncthreads();
+
+        /* move over source species frames and call frameIonizer
+         * frames are worked on in backwards order to avoid asking if there is another frame
+         * --> performance
+         * Because all frames are completely filled except the last and apart from that last frame
+         * one wants to make sure that all threads are working and every frame is worked on.
+         */
+        while (ionFrame.isValid())
+        {
+            /* casting uint8_t multiMask to boolean */
+            const bool isParticle = ionFrame[linearThreadIdx][multiMask_];
+            __syncthreads();
+
+            /* < IONIZATION and change of charge states >
+             * if the threads contain particles, the frameIonizer can ionize them
+             * if they are non-particles their inner ionization counter remains at 0
+             */
+            if (isParticle)
+                /* ionization based on ionization model - this actually increases charge states*/
+                frameIonizer(*ionFrame, linearThreadIdx, newMacroElectrons);
+
+            __syncthreads();
+            /* always true while-loop over all particles inside source frame until each thread breaks out individually
+             *
+             * **Attention**: Speaking of 1st and 2nd frame only may seem odd.
+             * The question might arise what happens if more electrons are created than would fit into two frames.
+             * Well, multi-ionization during a time step is accounted for. The number of new electrons is
+             * determined inside the outer loop over the valid frames while in the inner loop each thread can create only ONE
+             * new macro electron. But the loop repeats until each thread has created all the electrons needed in the time step.
+             */
+            while (true)
+            {
+                /* < INIT >
+                 * - electronId is initialized as -1 (meaning: invalid)
+                 * - (local) oldFrameFillLvl set equal to (shared) newFrameFillLvl for each thread
+                 * --> each thread remembers the old "counter"
+                 * - then sync
+                 */
+                electronId = -1;
+                oldFrameFillLvl = newFrameFillLvl;
+                __syncthreads();
+                /* < CHECK & ADD >
+                 * - if a thread wants to create electrons in each cycle it can do that only once
+                 * and before that it atomically adds to the shared counter and uses the current
+                 * value as electronId in the new frame
+                 * - then sync
+                 */
+                if (newMacroElectrons > 0)
+                    electronId = nvidia::atomicAllInc(&newFrameFillLvl);
+
+                __syncthreads();
+                /* < EXIT? >
+                 * - if the counter hasn't changed all threads break out of the loop */
+                if (oldFrameFillLvl == newFrameFillLvl)
+                    break;
+
+                __syncthreads();
+                /* < FIRST NEW FRAME >
+                 * - if there is no frame, yet, the master will create a new target electron frame
+                 * and attach it to the back of the frame list
+                 * - sync all threads again for them to know which frame to use
+                 */
+                if (linearThreadIdx == 0)
+                {
+                    if (!electronFrame.isValid())
+                    {
+                        electronFrame = electronBox.getEmptyFrame();
+                        electronBox.setAsLastFrame(electronFrame, block);
+                    }
+                }
+                __syncthreads();
+                /* < CREATE 1 >
+                 * - all electrons fitting into the current frame are created there
+                 * - internal ionization counter is decremented by 1
+                 * - sync
+                 */
+                if ((0 <= electronId) && (electronId < maxParticlesInFrame))
+                {
+                    /* each thread makes the attributes of its ion accessible */
+                    PMACC_AUTO(parentIon,(ionFrame[linearThreadIdx]));
+                    /* each thread initializes an electron if one should be created */
+                    PMACC_AUTO(targetElectronFull,(electronFrame[electronId]));
+
+                    /* create an electron in the new electron frame:
+                     * - see particles/ionization/ionizationMethods.hpp
+                     */
+                    WriteElectronIntoFrame writeElectron;
+                    writeElectron(parentIon,targetElectronFull);
+
+                    newMacroElectrons -= 1;
+                }
+                __syncthreads();
+                /* < SECOND NEW FRAME >
+                 * - if the shared counter is larger than the frame size a new electron frame is reserved
+                 * and attached to the back of the frame list
+                 * - then the shared counter is set back by one frame size
+                 * - sync so that every thread knows about the new frame
+                 */
+                if (linearThreadIdx == 0)
+                {
+                    if (newFrameFillLvl >= maxParticlesInFrame)
+                    {
+                        electronFrame = electronBox.getEmptyFrame();
+                        electronBox.setAsLastFrame(electronFrame, block);
+                        newFrameFillLvl -= maxParticlesInFrame;
+                    }
+                }
+                __syncthreads();
+                /* < CREATE 2 >
+                 * - if the EID is larger than the frame size
+                 *      - the EID is set back by one frame size
+                 *      - the thread writes an electron to the new frame
+                 *      - the internal counter is decremented by 1
+                 */
+                if (electronId >= maxParticlesInFrame)
+                {
+                    electronId -= maxParticlesInFrame;
+
+                    /* each thread makes the attributes of its ion accessible */
+                    PMACC_AUTO(parentIon,((*ionFrame)[linearThreadIdx]));
+                    /* each thread initializes an electron if one should be produced */
+                    PMACC_AUTO(targetElectronFull,(electronFrame[electronId]));
+
+                    /* create an electron in the new electron frame:
+                     * - see particles/ionization/ionizationMethods.hpp
+                     */
+                    WriteElectronIntoFrame writeElectron;
+                    writeElectron(parentIon,targetElectronFull);
+
+                    newMacroElectrons -= 1;
+                }
+                __syncthreads();
+            }
+            __syncthreads();
+
+            if (linearThreadIdx == 0)
+            {
+                ionFrame = ionBox.getPreviousFrame(ionFrame);
+                maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
+            }
+            __syncthreads();
+        }
+    } // void kernelIonizeParticles
+};
+    
 } // namespace ionization
 } // namespace particles
 } // namespace picongpu

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -410,7 +410,7 @@ private:
         const float_X maxEnergy = maxEnergy_keV * UNITCONV_keV_to_Joule / UNIT_ENERGY;
 
         AreaMapping<AREA, MappingDesc> mapper(*cellDescription);
-        PMACC_TYPEKERNEL(kernelBinEnergyParticles)
+        PMACC_KERNEL(kernelBinEnergyParticles{})
             (mapper.getGridDim(), block, (realNumBins) * sizeof (float_X))
             (particles->getDeviceParticlesBox(),
              gBins->getDeviceBuffer().getDataBox(), numBins, minEnergy,

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -118,7 +118,7 @@ struct kernelEnergyParticles
                 {
                     /* kinetic energy for particles: E = (gamma - 1) * m * c^2
                      *                                    gamma = sqrt( 1 + (p/m/c)^2 )
-                     * _local_energyKin += (algorithms::math::sqrt(mom2 / (mass * mass * c2) 
+                     * _local_energyKin += (algorithms::math::sqrt(mom2 / (mass * mass * c2)
                      *                                             + 1.) - 1.) * mass * c2;
                      */
                     _local_energyKin += (gamma - float_X(1.0)) * mass*c2;
@@ -156,7 +156,7 @@ struct kernelEnergyParticles
         }
     }
 };
-    
+
 template<class ParticlesType>
 class EnergyParticles : public ISimulationPlugin
 {
@@ -319,7 +319,7 @@ private:
 
         AreaMapping<AREA, MappingDesc> mapper(*cellDescription);
         /* kernel call = sum all particle energies on GPU */
-        PMACC_TYPEKERNEL(kernelEnergyParticles)
+        PMACC_KERNEL(kernelEnergyParticles{})
             (mapper.getGridDim(), block)
             (particles->getDeviceParticlesBox(),
              gEnergy->getDeviceBuffer().getDataBox(),

--- a/src/picongpu/include/plugins/IntensityPlugin.hpp
+++ b/src/picongpu/include/plugins/IntensityPlugin.hpp
@@ -341,7 +341,7 @@ private:
         typedef typename MappingDesc::SuperCellSize SuperCellSize;
         auto  block = PMacc::math::CT::Vector<SuperCellSize::x,SuperCellSize::y>::toRT();
 
-        PMACC_TYPEKERNEL(kernelIntensity)
+        PMACC_KERNEL(kernelIntensity{})
             (grid, block)
             (
              fieldE->getDeviceDataBox(),

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -260,7 +260,7 @@ private:
         auto block = SuperCellSize::toRT();
 
         AreaMapping<AREA, MappingDesc> mapper(*cellDescription);
-        PMACC_TYPEKERNEL(kernelPositionsParticles)
+        PMACC_KERNEL(kernelPositionsParticles{})
             (mapper.getGridDim(), block)
             (particles->getDeviceParticlesBox(),
              gParticle->getDeviceBuffer().getBasePointer(),

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -188,7 +188,7 @@ private:
         auto block = MappingDesc::SuperCellSize::toRT();
 
         AreaMapping<CORE + BORDER, MappingDesc> mapper(*cellDescription);
-        PMACC_TYPEKERNEL(kernelSumCurrents)
+        PMACC_KERNEL(kernelSumCurrents{})
             (mapper.getGridDim(), block)
             (fieldJ->getDeviceDataBox(),
              sumcurrents->getDeviceBuffer().getBasePointer(),

--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -152,14 +152,14 @@ public:
             filter.setWindowPosition(params->localWindowToDomainOffset,
                                      params->window.localDimensions.size);
 
-            dim3 block(PMacc::math::CT::volume<SuperCellSize>::type::value);
+            auto block = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
             /* int: assume < 2e9 particles per GPU */
             GridBuffer<int, DIM1> counterBuffer(DataSpace<DIM1>(1));
             AreaMapping < CORE + BORDER, MappingDesc > mapper(*(params->cellDescription));
 
             /* this sanity check costs a little bit of time but hdf5 writing is slower */
-            __cudaKernel(copySpecies)
+            PMACC_TYPEKERNEL(copySpecies)
                 (mapper.getGridDim(), block)
                 (counterBuffer.getDeviceBuffer().getPointer(),
                  deviceFrame, speciesTmp->getDeviceParticlesBox(),

--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -159,7 +159,7 @@ public:
             AreaMapping < CORE + BORDER, MappingDesc > mapper(*(params->cellDescription));
 
             /* this sanity check costs a little bit of time but hdf5 writing is slower */
-            PMACC_TYPEKERNEL(copySpecies)
+            PMACC_KERNEL(copySpecies{})
                 (mapper.getGridDim(), block)
                 (counterBuffer.getDeviceBuffer().getPointer(),
                  deviceFrame, speciesTmp->getDeviceParticlesBox(),

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -34,96 +34,99 @@ namespace picongpu
 
 using namespace PMacc;
 
-/** copy particle of a species to a host frame
- *
- * @tparam T_DestFrame type of destination frame
- * @tparam T_SrcBox type of the data box of source memory
- * @tparam T_Filter type of filer with particle selection rules
- * @tparam T_Space type of coordinate description
- * @tparam T_Identifier type of identifier for the particle cellIdx
- * @tparam T_Mapping type of the mapper to map cuda idx to supercells
- *
- * @param counter pointer to a device counter to reserve memory in destFrame
- * @param destFrame frame were we store particles in host memory (no Databox<...>)
- * @param srcBox ParticlesBox with frames
- * @param filer filer with rules to select particles
- * @param domainOffset offset to a user-defined domain. Can, e.g. be used to
- *                     calculate a totalCellIdx relative to
- *                     globalDomain.offset + localDomain.offset
- * @param domainCellIdxIdentifier the identifier for the particle cellIdx
- *                                that is calculated with respect to
- *                                domainOffset
- * @param mapper map cuda idx to supercells
- */
-template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Identifier, class T_Mapping>
-__global__ void copySpecies(
-    int* counter,
-    T_DestFrame destFrame,
-    T_SrcBox srcBox,
-    T_Filter filter,
-    const T_Space domainOffset,
-    const T_Identifier domainCellIdxIdentifier,
-    const T_Mapping mapper
-)
+
+struct copySpecies
 {
-    using namespace PMacc::particles::operations;
-
-    typedef T_DestFrame DestFrameType;
-    typedef typename T_SrcBox::FrameType SrcFrameType;
-    typedef typename T_SrcBox::FramePtr SrcFramePtr;
-
-    typedef T_Mapping Mapping;
-    typedef typename Mapping::SuperCellSize Block;
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SrcFramePtr>::type srcFramePtr;
-    __shared__ int localCounter;
-    __shared__ int globalOffset;
-
-    int storageOffset;
-
-
-    const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
-    const DataSpace<Mapping::Dim> superCellPosition((block - mapper.getGuardingSuperCells()) * mapper.getSuperCellSize());
-    filter.setSuperCellPosition(superCellPosition);
-    if (threadIdx.x == 0)
+    /** copy particle of a species to a host frame
+     *
+     * @tparam T_DestFrame type of destination frame
+     * @tparam T_SrcBox type of the data box of source memory
+     * @tparam T_Filter type of filer with particle selection rules
+     * @tparam T_Space type of coordinate description
+     * @tparam T_Identifier type of identifier for the particle cellIdx
+     * @tparam T_Mapping type of the mapper to map cuda idx to supercells
+     *
+     * @param counter pointer to a device counter to reserve memory in destFrame
+     * @param destFrame frame were we store particles in host memory (no Databox<...>)
+     * @param srcBox ParticlesBox with frames
+     * @param filer filer with rules to select particles
+     * @param domainOffset offset to a user-defined domain. Can, e.g. be used to
+     *                     calculate a totalCellIdx relative to
+     *                     globalDomain.offset + localDomain.offset
+     * @param domainCellIdxIdentifier the identifier for the particle cellIdx
+     *                                that is calculated with respect to
+     *                                domainOffset
+     * @param mapper map cuda idx to supercells
+     */
+    template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Identifier, class T_Mapping>
+    DINLINE void operator()(
+        int* counter,
+        T_DestFrame destFrame,
+        T_SrcBox srcBox,
+        T_Filter filter,
+        const T_Space domainOffset,
+        const T_Identifier domainCellIdxIdentifier,
+        const T_Mapping mapper
+    ) const
     {
-        localCounter = 0;
-        srcFramePtr = srcBox.getFirstFrame(block);
-    }
-    __syncthreads();
-    while (srcFramePtr.isValid()) //move over all Frames
-    {
-        PMACC_AUTO(parSrc, (srcFramePtr[threadIdx.x]));
-        storageOffset = -1;
-        /*count particle in frame*/
-        if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx.x))
-            storageOffset = nvidia::atomicAllInc(&localCounter);
-        __syncthreads();
+        using namespace PMacc::particles::operations;
+
+        typedef T_DestFrame DestFrameType;
+        typedef typename T_SrcBox::FrameType SrcFrameType;
+        typedef typename T_SrcBox::FramePtr SrcFramePtr;
+
+        typedef T_Mapping Mapping;
+        typedef typename Mapping::SuperCellSize Block;
+
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SrcFramePtr>::type srcFramePtr;
+        __shared__ int localCounter;
+        __shared__ int globalOffset;
+
+        int storageOffset;
+
+
+        const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
+        const DataSpace<Mapping::Dim> superCellPosition((block - mapper.getGuardingSuperCells()) * mapper.getSuperCellSize());
+        filter.setSuperCellPosition(superCellPosition);
         if (threadIdx.x == 0)
         {
-            /*reserve host memory for particle*/
-            globalOffset = atomicAdd(counter, localCounter);
-        }
-        __syncthreads();
-        if (storageOffset != -1)
-        {
-            PMACC_AUTO(parDest, destFrame[globalOffset + storageOffset]);
-            PMACC_AUTO(parDestNoDomainIdx, deselect<T_Identifier>(parDest));
-            assign(parDestNoDomainIdx, parSrc);
-            /* calculate cell index for user-defined domain */
-            DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));
-            parDest[domainCellIdxIdentifier] = domainOffset + superCellPosition + localCell;
-        }
-        __syncthreads();
-        if (threadIdx.x == 0)
-        {
-            /*get next frame in supercell*/
-            srcFramePtr = srcBox.getNextFrame(srcFramePtr);
             localCounter = 0;
+            srcFramePtr = srcBox.getFirstFrame(block);
         }
         __syncthreads();
+        while (srcFramePtr.isValid()) //move over all Frames
+        {
+            PMACC_AUTO(parSrc, (srcFramePtr[threadIdx.x]));
+            storageOffset = -1;
+            /*count particle in frame*/
+            if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx.x))
+                storageOffset = nvidia::atomicAllInc(&localCounter);
+            __syncthreads();
+            if (threadIdx.x == 0)
+            {
+                /*reserve host memory for particle*/
+                globalOffset = atomicAdd(counter, localCounter);
+            }
+            __syncthreads();
+            if (storageOffset != -1)
+            {
+                PMACC_AUTO(parDest, destFrame[globalOffset + storageOffset]);
+                PMACC_AUTO(parDestNoDomainIdx, deselect<T_Identifier>(parDest));
+                assign(parDestNoDomainIdx, parSrc);
+                /* calculate cell index for user-defined domain */
+                DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));
+                parDest[domainCellIdxIdentifier] = domainOffset + superCellPosition + localCell;
+            }
+            __syncthreads();
+            if (threadIdx.x == 0)
+            {
+                /*get next frame in supercell*/
+                srcFramePtr = srcBox.getNextFrame(srcFramePtr);
+                localCounter = 0;
+            }
+            __syncthreads();
+        }
     }
-}
-
+};
 } //namespace picongpu
 

--- a/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -44,58 +44,60 @@ namespace picongpu
 using namespace PMacc;
 using namespace splash;
 
-template<class ParBox, class CounterBox, class Mapping>
-__global__ void CountMakroParticle(ParBox parBox, CounterBox counterBox, Mapping mapper)
+struct CountMakroParticle
 {
-
-    typedef MappingDesc::SuperCellSize SuperCellSize;
-    typedef typename ParBox::FrameType FrameType;
-    typedef typename ParBox::FramePtr FramePtr;
-
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-    /* counterBox has no guarding supercells*/
-    const DataSpace<simDim> counterCell = block - mapper.getGuardingSuperCells();
-
-    const DataSpace<simDim > threadIndex(threadIdx);
-    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
-
-    __shared__ uint64_cu counterValue;
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-
-    if (linearThreadIdx == 0)
+    template<class ParBox, class CounterBox, class Mapping>
+    DINLINE void operator()(ParBox parBox, CounterBox counterBox, Mapping mapper) const
     {
-        counterValue = 0;
-        frame = parBox.getLastFrame(block);
-        if (!frame.isValid())
-        {
-            counterBox(counterCell) = counterValue;
-        }
-    }
-    __syncthreads();
-    if (!frame.isValid())
-        return; //end kernel if we have no frames
 
-    bool isParticle = frame[linearThreadIdx][multiMask_];
+        typedef MappingDesc::SuperCellSize SuperCellSize;
+        typedef typename ParBox::FrameType FrameType;
+        typedef typename ParBox::FramePtr FramePtr;
 
-    while (frame.isValid())
-    {
-        if (isParticle)
-        {
-            atomicAdd(&counterValue, static_cast<uint64_cu> (1LU));
-        }
-        __syncthreads();
+        const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+        /* counterBox has no guarding supercells*/
+        const DataSpace<simDim> counterCell = block - mapper.getGuardingSuperCells();
+
+        const DataSpace<simDim > threadIndex(threadIdx);
+        const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
+
+        __shared__ uint64_cu counterValue;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+
         if (linearThreadIdx == 0)
         {
-            frame = parBox.getPreviousFrame(frame);
+            counterValue = 0;
+            frame = parBox.getLastFrame(block);
+            if (!frame.isValid())
+            {
+                counterBox(counterCell) = counterValue;
+            }
         }
-        isParticle = true;
         __syncthreads();
+        if (!frame.isValid())
+            return; //end kernel if we have no frames
+
+        bool isParticle = frame[linearThreadIdx][multiMask_];
+
+        while (frame.isValid())
+        {
+            if (isParticle)
+            {
+                atomicAdd(&counterValue, static_cast<uint64_cu> (1LU));
+            }
+            __syncthreads();
+            if (linearThreadIdx == 0)
+            {
+                frame = parBox.getPreviousFrame(frame);
+            }
+            isParticle = true;
+            __syncthreads();
+        }
+
+        if (linearThreadIdx == 0)
+            counterBox(counterCell) = counterValue;
     }
-
-    if (linearThreadIdx == 0)
-        counterBox(counterCell) = counterValue;
-}
-
+};
 /** Count makro particle of a species and write down the result to a global HDF5 file.
  *
  * - count the total number of makro particle per supercell
@@ -213,8 +215,8 @@ private:
         typedef MappingDesc::SuperCellSize SuperCellSize;
         AreaMapping<AREA, MappingDesc> mapper(*cellDescription);
 
-        __cudaKernel(CountMakroParticle)
-            (mapper.getGridDim(), SuperCellSize::toRT().toDim3())
+        PMACC_TYPEKERNEL(CountMakroParticle)
+            (mapper.getGridDim(), SuperCellSize::toRT())
             (particles->getDeviceParticlesBox(),
              localResult->getDeviceBuffer().getDataBox(), mapper);
 

--- a/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -215,7 +215,7 @@ private:
         typedef MappingDesc::SuperCellSize SuperCellSize;
         AreaMapping<AREA, MappingDesc> mapper(*cellDescription);
 
-        PMACC_TYPEKERNEL(CountMakroParticle)
+        PMACC_KERNEL(CountMakroParticle{})
             (mapper.getGridDim(), SuperCellSize::toRT())
             (particles->getDeviceParticlesBox(),
              localResult->getDeviceBuffer().getDataBox(), mapper);

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -528,7 +528,7 @@ public:
         PMACC_ASSERT(cellDescription != NULL);
         AreaMapping<CORE + BORDER, MappingDesc> mapper(*cellDescription);
         //create image fields
-        PMACC_TYPEKERNEL(kernelPaintFields)
+        PMACC_KERNEL(kernelPaintFields{})
             (mapper.getGridDim(), SuperCellSize::toRT())
             (fieldE->getDeviceDataBox(),
              fieldB->getDeviceDataBox(),
@@ -569,18 +569,18 @@ public:
         //We don't know the superCellSize at compile time
         // (because of the runtime dimension selection in any analyser),
         // thus we must use a one dimension kernel and no mapper
-        PMACC_TYPEKERNEL(vis_kernels::divideAnyCell)(ceil((float_64) elements / 256), 256)(d1access, elements, max);
+        PMACC_KERNEL(vis_kernels::divideAnyCell{})(ceil((float_64) elements / 256), 256)(d1access, elements, max);
 #endif
 
         // convert channels to RGB
-        PMACC_TYPEKERNEL(vis_kernels::channelsToRGB)(ceil((float_64) elements / 256), 256)(d1access, elements);
+        PMACC_KERNEL(vis_kernels::channelsToRGB{})(ceil((float_64) elements / 256), 256)(d1access, elements);
 
         // add density color channel
         DataSpace<simDim> blockSize(MappingDesc::SuperCellSize::toRT());
         DataSpace<DIM2> blockSize2D(blockSize[m_transpose.x()], blockSize[m_transpose.y()]);
 
         //create image particles
-        PMACC_TYPEKERNEL(kernelPaintParticles3D)
+        PMACC_KERNEL(kernelPaintParticles3D{})
             (mapper.getGridDim(), SuperCellSize::toRT(), blockSize2D.productOfComponents() * sizeof (float_X))
             (particles->getDeviceParticlesBox(),
              img->getDeviceBuffer().getDataBox(),

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -515,12 +515,12 @@ public:
         this->calorimeterFunctor->setCalorimeterCursor(this->dBufLeftParsCalorimeter->origin());
 
         ExchangeMapping<GUARD, MappingDesc> mapper(*this->cellDescription, direction);
-        dim3 grid(mapper.getGridDim());
+        auto grid = mapper.getGridDim();
 
         DataConnector &dc = Environment<>::get().DataConnector();
         ParticlesType* particles = &(dc.getData<ParticlesType > (speciesName, true));
 
-        __cudaKernel(kernelParticleCalorimeter)
+        PMACC_TYPEKERNEL(kernelParticleCalorimeter)
                 (grid, mapper.getSuperCellSize())
                 (particles->getDeviceParticlesBox(), (MyCalorimeterFunctor)*this->calorimeterFunctor, mapper);
     }

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -520,7 +520,7 @@ public:
         DataConnector &dc = Environment<>::get().DataConnector();
         ParticlesType* particles = &(dc.getData<ParticlesType > (speciesName, true));
 
-        PMACC_TYPEKERNEL(kernelParticleCalorimeter)
+        PMACC_KERNEL(kernelParticleCalorimeter{})
                 (grid, mapper.getSuperCellSize())
                 (particles->getDeviceParticlesBox(), (MyCalorimeterFunctor)*this->calorimeterFunctor, mapper);
     }

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -28,49 +28,52 @@ using namespace PMacc;
 
 /** This kernel is only called for guard particles.
  */
-template<typename ParticlesBox, typename CalorimeterFunctor, typename Mapper>
-__global__ void kernelParticleCalorimeter(ParticlesBox particlesBox,
-                                       CalorimeterFunctor calorimeterFunctor,
-                                       Mapper mapper)
+struct kernelParticleCalorimeter
 {
-    /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
-    const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
-
-    /* multi-dim vector from origin of the block to a cell in units of cells */
-    const DataSpace<simDim > threadIndex(threadIdx);
-    /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
-    const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
-
-    typedef typename ParticlesBox::FramePtr ParticlesFramePtr;
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ParticlesFramePtr>::type particlesFrame;
-
-    /* find last frame in super cell
-     */
-    if (linearThreadIdx == 0)
+    template<typename ParticlesBox, typename CalorimeterFunctor, typename Mapper>
+    DINLINE void operator()(ParticlesBox particlesBox,
+                                           CalorimeterFunctor calorimeterFunctor,
+                                           Mapper mapper) const
     {
-        particlesFrame = particlesBox.getLastFrame(block);
-    }
+        /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+        const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
 
-    __syncthreads();
+        /* multi-dim vector from origin of the block to a cell in units of cells */
+        const DataSpace<simDim > threadIndex(threadIdx);
+        /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
+        const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
 
-    while(particlesFrame.isValid())
-    {
-        /* casting uint8_t multiMask to boolean */
-        const bool isParticle = particlesFrame[linearThreadIdx][multiMask_];
+        typedef typename ParticlesBox::FramePtr ParticlesFramePtr;
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ParticlesFramePtr>::type particlesFrame;
 
-        if(isParticle)
-        {
-            calorimeterFunctor(particlesFrame, linearThreadIdx);
-        }
-
-        __syncthreads();
-
+        /* find last frame in super cell
+         */
         if (linearThreadIdx == 0)
         {
-            particlesFrame = particlesBox.getPreviousFrame(particlesFrame);
+            particlesFrame = particlesBox.getLastFrame(block);
         }
+
         __syncthreads();
+
+        while(particlesFrame.isValid())
+        {
+            /* casting uint8_t multiMask to boolean */
+            const bool isParticle = particlesFrame[linearThreadIdx][multiMask_];
+
+            if(isParticle)
+            {
+                calorimeterFunctor(particlesFrame, linearThreadIdx);
+            }
+
+            __syncthreads();
+
+            if (linearThreadIdx == 0)
+            {
+                particlesFrame = particlesBox.getPreviousFrame(particlesFrame);
+            }
+            __syncthreads();
+        }
     }
-}
+};
 
 } // namespace picongpu

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -1168,7 +1168,7 @@ private:
        * percent) and definitely slower on Kepler GPUs (sm_3x, tested on K20))
        */
       const int N_observer = parameters::N_observer;
-      const dim3 gridDim_rad(N_observer);
+      const auto gridDim_rad = N_observer;
 
       /* number of threads per block = number of cells in a super cell
        *          = number of particles in a Frame
@@ -1178,7 +1178,7 @@ private:
        * Particles in a Frame can be accessed in parallel.
        */
 
-      const dim3 blockDim_rad(PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value);
+      const auto blockDim_rad = PMacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
 
       // Some funny things that make it possible for the kernel to calculate
       // the absolute position of the particles
@@ -1190,7 +1190,7 @@ private:
 
 
       // PIC-like kernel call of the radiation kernel
-      __cudaKernel(kernelRadiationParticles)
+      PMACC_TYPEKERNEL(kernelRadiationParticles)
         (gridDim_rad, blockDim_rad)
         (
          /*Pointer to particles memory on the device*/

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -1054,7 +1054,7 @@ private:
       /* check if restart file exists */
       if( !boost::filesystem::exists(filename.str()) )
       {
-          log<picLog::INPUT_OUTPUT > ("Radiation (%1%): restart file not found (%2%) - start with zero values") % 
+          log<picLog::INPUT_OUTPUT > ("Radiation (%1%): restart file not found (%2%) - start with zero values") %
                                       speciesName % filename.str();
       }
       else
@@ -1190,7 +1190,7 @@ private:
 
 
       // PIC-like kernel call of the radiation kernel
-      PMACC_TYPEKERNEL(kernelRadiationParticles)
+      PMACC_KERNEL(kernelRadiationParticles{})
         (gridDim_rad, blockDim_rad)
         (
          /*Pointer to particles memory on the device*/

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -68,427 +68,430 @@ namespace po = boost::program_options;
 /////////////////////////////////////  Radiation Kernel  //////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-/**
- * The radiation kernel calculates for all particles on the device the
- * emitted radiation for every direction and every frequency.
- * The parallelization is as follows:
- *  - There are as many Blocks of threads as there are directions for which
- *    radiation needs to be calculated. (A block of threads shares
- *    shared memory)
- *  - The number of threads per block is equal to the number of cells per
- *    super cells which is also equal to the number of particles per frame
- *
- * The procedure starts with calculating unique ids for the threads and
- * initializing the shared memory.
- * Then a loop over all super cells starts.
- * Every thread loads a particle from that super cell and calculates its
- * retarded time and its real amplitude (both is dependent of the direction).
- * For every Particle
- * exists therefor a unique space within the shared memory.
- * After that, a thread calculates for a specific frequency the emitted
- * radiation of all particles.
- * @param pb
- * @param radiation
- * @param globalOffset
- * @param currentStep
- * @param mapper
- * @param freqFkt
- * @param simBoxSize
- */
-template<class ParBox, class DBox, class Mapping>
-__global__
-/*__launch_bounds__(256, 4)*/
-void kernelRadiationParticles(ParBox pb,
-                              DBox radiation,
-                              DataSpace<simDim> globalOffset,
-                              uint32_t currentStep,
-                              Mapping mapper,
-                              radiation_frequencies::FreqFunctor freqFkt,
-                              DataSpace<simDim> simBoxSize)
+
+struct kernelRadiationParticles
 {
-
-    typedef typename MappingDesc::SuperCellSize Block;
-    typedef typename ParBox::FrameType FRAME;
-    typedef typename ParBox::FramePtr FramePtr;
-
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame; // pointer to  frame storing particles
-    __shared__ lcellId_t particlesInFrame; // number  of particles in current frame
-
-    using namespace parameters; // parameters of radiation
-
-    /// calculate radiated Amplitude
-    /* parallelized in 1 dimensions:
-     * looking direction (theta)
-     * (not anymore data handling)
-     * create shared memory for particle data to reduce global memory calls
-     * every thread in a block loads one particle and every thread runs
-     * through all particles and calculates the radiation for one direction
-     * for all frequencies
+    /**
+     * The radiation kernel calculates for all particles on the device the
+     * emitted radiation for every direction and every frequency.
+     * The parallelization is as follows:
+     *  - There are as many Blocks of threads as there are directions for which
+     *    radiation needs to be calculated. (A block of threads shares
+     *    shared memory)
+     *  - The number of threads per block is equal to the number of cells per
+     *    super cells which is also equal to the number of particles per frame
+     *
+     * The procedure starts with calculating unique ids for the threads and
+     * initializing the shared memory.
+     * Then a loop over all super cells starts.
+     * Every thread loads a particle from that super cell and calculates its
+     * retarded time and its real amplitude (both is dependent of the direction).
+     * For every Particle
+     * exists therefor a unique space within the shared memory.
+     * After that, a thread calculates for a specific frequency the emitted
+     * radiation of all particles.
+     * @param pb
+     * @param radiation
+     * @param globalOffset
+     * @param currentStep
+     * @param mapper
+     * @param freqFkt
+     * @param simBoxSize
      */
-
-    const int blockSize=PMacc::math::CT::volume<Block>::type::value;
-    // vectorial part of the integrand in the Jackson formula
-    __shared__ vector_64 real_amplitude_s[blockSize];
-
-    // retarded time
-    __shared__ picongpu::float_64 t_ret_s[blockSize];
-
-    // storage for macro particle weighting needed if
-    // the coherent and incoherent radiation of a single
-    // macro-particle needs to be considered
-#if (__COHERENTINCOHERENTWEIGHTING__==1)
-    __shared__ float_X radWeighting_s[blockSize];
-#endif
-
-    // particle counter used if not all particles are considered for
-    // radiation calculation
-    __shared__ int counter_s;
-
-    // memory for Nyquist frequency at current time step
-#if (__NYQUISTCHECK__==1)
-    __shared__ NyquistLowPass lowpass_s[blockSize];
-#endif
-
-
-    const int theta_idx = blockIdx.x; //blockIdx.x is used to determine theta
-    const uint32_t linearThreadIdx = threadIdx.x; // used for determine omega and particle id
-
-
-    // simulation time (needed for retarded time)
-    const picongpu::float_64 t((picongpu::float_64) currentStep * (picongpu::float_64) DELTA_T);
-
-    // looking direction (needed for observer) used in the thread
-    const vector_64 look = radiation_observer::observation_direction(theta_idx);
-
-    // get extent of guarding super cells (needed to ignore them)
-    const int guardingSuperCells = mapper.getGuardingSuperCells();
-
-
-    // number of super cells on GPU per dimension (still including guard cells)
-    // remove both guards from count [later one sided guard needs to be added again]
-    const DataSpace<simDim> superCellsCount(mapper.getGridSuperCells() -2 * guardingSuperCells);
-
-    // get absolute number of relevant super cells
-    const int numSuperCells = superCellsCount.productOfComponents();
-
-
-    // go over all super cells on GPU
-    // but ignore all guarding supercells
-    for (int super_cell_index = 0; super_cell_index <= numSuperCells; ++super_cell_index)
+    template<class ParBox, class DBox, class Mapping>
+    DINLINE
+    /*__launch_bounds__(256, 4)*/
+    void operator()(ParBox pb,
+                                  DBox radiation,
+                                  DataSpace<simDim> globalOffset,
+                                  uint32_t currentStep,
+                                  Mapping mapper,
+                                  radiation_frequencies::FreqFunctor freqFkt,
+                                  DataSpace<simDim> simBoxSize) const
     {
-        /* warpId != 1 synchronization is needed,
-           since a race condition can occur if "continue loop" is called,
-           all threads must wait for the selection of a new frame
-           until all threads have evaluated "isValid"
-        */
-        __syncthreads();
 
-        // select SuperCell and add one sided guard again
-        DataSpace<simDim> superCell = DataSpaceOperations<simDim>::map(superCellsCount, super_cell_index);
-        superCell += guardingSuperCells;
+        typedef typename MappingDesc::SuperCellSize Block;
+        typedef typename ParBox::FrameType FRAME;
+        typedef typename ParBox::FramePtr FramePtr;
 
-        const DataSpace<simDim> superCellOffset(globalOffset
-                                                + ((superCell - guardingSuperCells)
-                                                   * Block::toRT()));
-        // -guardingSuperCells remove guarding block
+        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame; // pointer to  frame storing particles
+        __shared__ lcellId_t particlesInFrame; // number  of particles in current frame
 
-        /*
-         * The Master process (thread 0) in every thread block is in
-         * charge of loading a frame from
-         * the current super cell and evaluate the total number of
-         * particles in this frame.
+        using namespace parameters; // parameters of radiation
+
+        /// calculate radiated Amplitude
+        /* parallelized in 1 dimensions:
+         * looking direction (theta)
+         * (not anymore data handling)
+         * create shared memory for particle data to reduce global memory calls
+         * every thread in a block loads one particle and every thread runs
+         * through all particles and calculates the radiation for one direction
+         * for all frequencies
          */
-        if (linearThreadIdx == 0)
-          {
-            // set frame pointer
-            frame = pb.getLastFrame(superCell);
 
-            // number of particles in this frame
-            particlesInFrame = pb.getSuperCell(superCell).getSizeLastFrame();
+        const int blockSize=PMacc::math::CT::volume<Block>::type::value;
+        // vectorial part of the integrand in the Jackson formula
+        __shared__ vector_64 real_amplitude_s[blockSize];
 
-            counter_s = 0;
-          }
+        // retarded time
+        __shared__ picongpu::float_64 t_ret_s[blockSize];
 
-        __syncthreads();
+        // storage for macro particle weighting needed if
+        // the coherent and incoherent radiation of a single
+        // macro-particle needs to be considered
+    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+        __shared__ float_X radWeighting_s[blockSize];
+    #endif
 
-        /* go to next supercell
-         *
-         * if "isValid" is false then there is no frame
-         * inside the superCell (anymore)
-         */
-        while (frame.isValid())
+        // particle counter used if not all particles are considered for
+        // radiation calculation
+        __shared__ int counter_s;
+
+        // memory for Nyquist frequency at current time step
+    #if (__NYQUISTCHECK__==1)
+        __shared__ NyquistLowPass lowpass_s[blockSize];
+    #endif
+
+
+        const int theta_idx = blockIdx.x; //blockIdx.x is used to determine theta
+        const uint32_t linearThreadIdx = threadIdx.x; // used for determine omega and particle id
+
+
+        // simulation time (needed for retarded time)
+        const picongpu::float_64 t((picongpu::float_64) currentStep * (picongpu::float_64) DELTA_T);
+
+        // looking direction (needed for observer) used in the thread
+        const vector_64 look = radiation_observer::observation_direction(theta_idx);
+
+        // get extent of guarding super cells (needed to ignore them)
+        const int guardingSuperCells = mapper.getGuardingSuperCells();
+
+
+        // number of super cells on GPU per dimension (still including guard cells)
+        // remove both guards from count [later one sided guard needs to be added again]
+        const DataSpace<simDim> superCellsCount(mapper.getGridSuperCells() -2 * guardingSuperCells);
+
+        // get absolute number of relevant super cells
+        const int numSuperCells = superCellsCount.productOfComponents();
+
+
+        // go over all super cells on GPU
+        // but ignore all guarding supercells
+        for (int super_cell_index = 0; super_cell_index <= numSuperCells; ++super_cell_index)
         {
-            // only threads with particles are running
-            if (linearThreadIdx < particlesInFrame)
-            {
-
-                PMACC_AUTO(par,frame[linearThreadIdx]);
-                // get old and new particle momenta
-                const vector_X particle_momentumNow = vector_X(par[momentum_]);
-                const vector_X particle_momentumOld = vector_X(par[momentumPrev1_]);
-                /* initializes "saveParticleAt" flag with -1
-                 * because "counter_s" will never be -1
-                 * therefore, if a particle is saved, a value of counter
-                 * is stored in "saveParticleAt" != -1
-                 * THIS IS ACTUALLY ONLY NEEDED IF: the radiation flag was set
-                 * LATER: can this be optimized?
-                 */
-                int saveParticleAt = -1;
-
-                /* if particle is not accelerated we skip all calculations
-                 *
-                 * this is a component-wise comparison
-                 */
-                if( particle_momentumNow != particle_momentumOld )
-                {
-                    /* If the gamma filter is activated or not all particles are used
-                     * for radiation calculation, check if particle contributes
-                     * to the radiation calculation by checking its flag.
-                     */
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
-                    if (par[radiationFlag_])
-#endif
-                    saveParticleAt = nvidia::atomicAllInc(&counter_s);
-                    /* for information:
-                    *   atomicAdd returns an int with the previous
-                    *   value of "counter_s" != -1
-                    *   therefore, if a particle is selected
-                    *   "saveParticleAs" != -1
-                    */
-
-                    // if a particle needs to be considered
-                    if (saveParticleAt != -1)
-                    {
-
-                        // calculate global position
-                        lcellId_t cellIdx = par[localCellIdx_];
-
-                        // position inside of the cell
-                        floatD_X pos = par[position_];
-
-                        // calculate global position of cell
-                        const DataSpace<simDim> globalPos(superCellOffset
-                                                          + DataSpaceOperations<simDim>::template map<Block >
-                                                          (cellIdx));
-
-                        // add global position of cell with local position of particle in cell
-                        vector_X particle_locationNow;
-                        // set z component to zero in case of simDim==DIM2
-                        particle_locationNow[2] = 0.0;
-                        // run over all components and compute gobal position
-                        for(int i=0; i<simDim; ++i)
-                          particle_locationNow[i] = ((float_X) globalPos[i] + (float_X) pos[i]) * cellSize[i];
-
-
-                        /* get macro-particle weighting
-                         *
-                         * Info:
-                         * the weighting is the number of real particles described
-                         * by a macro-particle
-                         */
-                        const float_X weighting = par[weighting_];
-
-
-                        /* only of coherent and incoherent radiation of a single macro-particle is
-                         * considered, the weighting of each macro-particle needs to be stored
-                         * in order to be considered when the actual frequency calculation is done
-                         */
-#if (__COHERENTINCOHERENTWEIGHTING__==1)
-                       radWeighting_s[saveParticleAt] = weighting;
-#endif
-
-                        // mass of macro-particle
-                        const float_X particle_mass = attribute::getMass(weighting,par);
-
-
-                        /****************************************************
-                         **** Here happens the true physical calculation ****
-                         ****************************************************/
-
-                        // set up particle using the radiation's own particle class
-                        /*!\todo please add a namespace for Particle class*/
-                        const ::Particle particle(particle_locationNow,
-                                                  particle_momentumOld,
-                                                  particle_momentumNow,
-                                                  particle_mass);
-
-                        // set up amplitude calculator
-                        typedef Calc_Amplitude< Retarded_time_1, Old_DFT > Calc_Amplitude_n_sim_1;
-
-                        // calculate amplitude
-                        const Calc_Amplitude_n_sim_1 amplitude3(particle,
-                                                                DELTA_T,
-                                                                t);
-
-
-                    // if coherent and incoherent of single macro-particle is considered
-#if (__COHERENTINCOHERENTWEIGHTING__==1)
-                        // get charge of single electron ! (weighting=1.0f)
-                        const picongpu::float_X particle_charge = frame::getCharge<FRAME>();
-
-                        // compute real amplitude of macro-particle with a charge of
-                        // a single electron
-                        real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
-                          particle_charge *
-                          picongpu::float_64(DELTA_T);
-#else
-                        // if coherent and incoherent of single macro-particle is NOT considered
-
-                        // get charge of entire macro-particle
-                        const picongpu::float_X particle_charge = attribute::getCharge(weighting,par);
-
-                        // compute real amplitude of macro-particle
-                        real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
-                          particle_charge *
-                          picongpu::float_64(DELTA_T);
-#endif
-
-                        // retarded time stored in shared memory
-                        t_ret_s[saveParticleAt] = amplitude3.get_t_ret(look);
-
-                        // if Nyquist-limiter is used, then the NyquistLowPlass object
-                        // is setup and stored in shared memory
-#if (__NYQUISTCHECK__==1)
-                        lowpass_s[saveParticleAt] = NyquistLowPass(look, particle);
-#endif
-
-
-                        /* the particle amplitude is used to include the weighting
-                         * of the window function filter without needing more memory */
-                        const radWindowFunction::radWindowFunction winFkt;
-
-                        /* start with a factor of one */
-                        float_X windowFactor = 1.0;
-
-                        for (uint32_t d = 0; d < simDim; ++d)
-                        {
-                            windowFactor *= winFkt(particle_locationNow[d],
-                            simBoxSize[d] * cellSize[d]);
-                        }
-
-                        /* apply window function factor to amplitude */
-                        real_amplitude_s[saveParticleAt] *= windowFactor;
-
-
-
-                    } // END: if a particle needs to be considered
-                } // END: check if particle is accelerated
-            } // END: only threads with particles are running
-
-
-            __syncthreads(); // wait till every thread has loaded its particle data
-
-
-
-            // run over all  valid omegas for this thread
-            for (int o = linearThreadIdx; o < radiation_frequencies::N_omega; o += blockSize)
-              {
-
-                /* storage for amplitude (complex 3D vector)
-                 * it  is initialized with zeros (  0 +  i 0 )
-                 */
-                Amplitude amplitude = Amplitude::zero();
-
-                // compute frequency "omega" using for-loop-index "o"
-                const picongpu::float_64 omega = freqFkt(o);
-
-
-                // if coherent and incoherent radiation of a single macro-particle
-                // is considered, create a form factor object
-#if (__COHERENTINCOHERENTWEIGHTING__==1)
-                const radFormFactor::radFormFactor myRadFormFactor;
-#endif
-
-                /* Particle loop: thread runs through loaded particle data
-                 *
-                 * Summation of Jackson radiation formula integrand
-                 * over all electrons for fixed, thread-specific
-                 * frequency
-                 */
-                for (int j = 0; j < counter_s; ++j)
-                  {
-
-                    // if Nyquist-limiter is on
-#if (__NYQUISTCHECK__==1)
-                    // check Nyquist-limit for each particle "j" and each frequency "omega"
-                    if (lowpass_s[j].check(omega))
-                      {
-#endif
-
-                        /****************************************************
-                         **** Here happens the true physical calculation ****
-                         ****************************************************/
-
-
-                        // if coherent/incoherent radiation of single macro-particle
-                        // is considered
-                        // the form factor influences the real amplitude
-#if (__COHERENTINCOHERENTWEIGHTING__==1)
-                        const vector_64 weighted_real_amp = real_amplitude_s[j] * precisionCast<float_64 >
-                          (myRadFormFactor(radWeighting_s[j], omega, look));
-#else
-                        // if coherent/incoherent radiation of single macro-particle
-                        // is NOT considered
-                        // no change on real amplitude is performed
-                        const vector_64 weighted_real_amp = real_amplitude_s[j];
-#endif
-
-                        // complex amplitude for j-th particle
-                        Amplitude amplitude_add(weighted_real_amp,
-                                                t_ret_s[j] * omega);
-
-                        // add this single amplitude those previously considered
-                        amplitude += amplitude_add;
-
-                        // if Nyquist limiter is on
-#if (__NYQUISTCHECK__==1)
-                      }// END: check Nyquist-limit for each particle "j" and each frequency "omega"
-#endif
-
-                  }// END: Particle loop
-
-
-                /* the radiation contribution of the following is added to global memory:
-                 *     - valid particles of last super cell
-                 *     - from this (one) time step
-                 *     - omega_id = theta_idx * radiation_frequencies::N_omega + o
-                 */
-                radiation[theta_idx * radiation_frequencies::N_omega + o] += amplitude;
-
-
-              } // end frequency loop
-
-
-            // wait till all radiation contributions for this super cell are done
+            /* warpId != 1 synchronization is needed,
+               since a race condition can occur if "continue loop" is called,
+               all threads must wait for the selection of a new frame
+               until all threads have evaluated "isValid"
+            */
             __syncthreads();
 
+            // select SuperCell and add one sided guard again
+            DataSpace<simDim> superCell = DataSpaceOperations<simDim>::map(superCellsCount, super_cell_index);
+            superCell += guardingSuperCells;
 
+            const DataSpace<simDim> superCellOffset(globalOffset
+                                                    + ((superCell - guardingSuperCells)
+                                                       * Block::toRT()));
+            // -guardingSuperCells remove guarding block
 
+            /*
+             * The Master process (thread 0) in every thread block is in
+             * charge of loading a frame from
+             * the current super cell and evaluate the total number of
+             * particles in this frame.
+             */
             if (linearThreadIdx == 0)
               {
-                /* First threads starts loading next frame of the super-cell:
-                 *
-                 * Info:
-                 *   The calculation starts with the last SuperCell (must not be full filled)
-                 *   all previous SuperCells are full with particles
-                 */
-                particlesInFrame = blockSize;
-                frame = pb.getPreviousFrame(frame);
+                // set frame pointer
+                frame = pb.getLastFrame(superCell);
+
+                // number of particles in this frame
+                particlesInFrame = pb.getSuperCell(superCell).getSizeLastFrame();
+
                 counter_s = 0;
               }
 
-            // wait till first thread has loaded new frame
             __syncthreads();
 
-            // run through while-loop(is Valid) again
+            /* go to next supercell
+             *
+             * if "isValid" is false then there is no frame
+             * inside the superCell (anymore)
+             */
+            while (frame.isValid())
+            {
+                // only threads with particles are running
+                if (linearThreadIdx < particlesInFrame)
+                {
 
-          } // end while(frame.isValid())
+                    PMACC_AUTO(par,frame[linearThreadIdx]);
+                    // get old and new particle momenta
+                    const vector_X particle_momentumNow = vector_X(par[momentum_]);
+                    const vector_X particle_momentumOld = vector_X(par[momentumPrev1_]);
+                    /* initializes "saveParticleAt" flag with -1
+                     * because "counter_s" will never be -1
+                     * therefore, if a particle is saved, a value of counter
+                     * is stored in "saveParticleAt" != -1
+                     * THIS IS ACTUALLY ONLY NEEDED IF: the radiation flag was set
+                     * LATER: can this be optimized?
+                     */
+                    int saveParticleAt = -1;
 
-      } // end loop over all super cells
+                    /* if particle is not accelerated we skip all calculations
+                     *
+                     * this is a component-wise comparison
+                     */
+                    if( particle_momentumNow != particle_momentumOld )
+                    {
+                        /* If the gamma filter is activated or not all particles are used
+                         * for radiation calculation, check if particle contributes
+                         * to the radiation calculation by checking its flag.
+                         */
+    #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+                        if (par[radiationFlag_])
+    #endif
+                        saveParticleAt = nvidia::atomicAllInc(&counter_s);
+                        /* for information:
+                        *   atomicAdd returns an int with the previous
+                        *   value of "counter_s" != -1
+                        *   therefore, if a particle is selected
+                        *   "saveParticleAs" != -1
+                        */
+
+                        // if a particle needs to be considered
+                        if (saveParticleAt != -1)
+                        {
+
+                            // calculate global position
+                            lcellId_t cellIdx = par[localCellIdx_];
+
+                            // position inside of the cell
+                            floatD_X pos = par[position_];
+
+                            // calculate global position of cell
+                            const DataSpace<simDim> globalPos(superCellOffset
+                                                              + DataSpaceOperations<simDim>::template map<Block >
+                                                              (cellIdx));
+
+                            // add global position of cell with local position of particle in cell
+                            vector_X particle_locationNow;
+                            // set z component to zero in case of simDim==DIM2
+                            particle_locationNow[2] = 0.0;
+                            // run over all components and compute gobal position
+                            for(int i=0; i<simDim; ++i)
+                              particle_locationNow[i] = ((float_X) globalPos[i] + (float_X) pos[i]) * cellSize[i];
 
 
-} // end radiation kernel
+                            /* get macro-particle weighting
+                             *
+                             * Info:
+                             * the weighting is the number of real particles described
+                             * by a macro-particle
+                             */
+                            const float_X weighting = par[weighting_];
 
+
+                            /* only of coherent and incoherent radiation of a single macro-particle is
+                             * considered, the weighting of each macro-particle needs to be stored
+                             * in order to be considered when the actual frequency calculation is done
+                             */
+    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+                           radWeighting_s[saveParticleAt] = weighting;
+    #endif
+
+                            // mass of macro-particle
+                            const float_X particle_mass = attribute::getMass(weighting,par);
+
+
+                            /****************************************************
+                             **** Here happens the true physical calculation ****
+                             ****************************************************/
+
+                            // set up particle using the radiation's own particle class
+                            /*!\todo please add a namespace for Particle class*/
+                            const ::Particle particle(particle_locationNow,
+                                                      particle_momentumOld,
+                                                      particle_momentumNow,
+                                                      particle_mass);
+
+                            // set up amplitude calculator
+                            typedef Calc_Amplitude< Retarded_time_1, Old_DFT > Calc_Amplitude_n_sim_1;
+
+                            // calculate amplitude
+                            const Calc_Amplitude_n_sim_1 amplitude3(particle,
+                                                                    DELTA_T,
+                                                                    t);
+
+
+                        // if coherent and incoherent of single macro-particle is considered
+    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+                            // get charge of single electron ! (weighting=1.0f)
+                            const picongpu::float_X particle_charge = frame::getCharge<FRAME>();
+
+                            // compute real amplitude of macro-particle with a charge of
+                            // a single electron
+                            real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
+                              particle_charge *
+                              picongpu::float_64(DELTA_T);
+    #else
+                            // if coherent and incoherent of single macro-particle is NOT considered
+
+                            // get charge of entire macro-particle
+                            const picongpu::float_X particle_charge = attribute::getCharge(weighting,par);
+
+                            // compute real amplitude of macro-particle
+                            real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
+                              particle_charge *
+                              picongpu::float_64(DELTA_T);
+    #endif
+
+                            // retarded time stored in shared memory
+                            t_ret_s[saveParticleAt] = amplitude3.get_t_ret(look);
+
+                            // if Nyquist-limiter is used, then the NyquistLowPlass object
+                            // is setup and stored in shared memory
+    #if (__NYQUISTCHECK__==1)
+                            lowpass_s[saveParticleAt] = NyquistLowPass(look, particle);
+    #endif
+
+
+                            /* the particle amplitude is used to include the weighting
+                             * of the window function filter without needing more memory */
+                            const radWindowFunction::radWindowFunction winFkt;
+
+                            /* start with a factor of one */
+                            float_X windowFactor = 1.0;
+
+                            for (uint32_t d = 0; d < simDim; ++d)
+                            {
+                                windowFactor *= winFkt(particle_locationNow[d],
+                                simBoxSize[d] * cellSize[d]);
+                            }
+
+                            /* apply window function factor to amplitude */
+                            real_amplitude_s[saveParticleAt] *= windowFactor;
+
+
+
+                        } // END: if a particle needs to be considered
+                    } // END: check if particle is accelerated
+                } // END: only threads with particles are running
+
+
+                __syncthreads(); // wait till every thread has loaded its particle data
+
+
+
+                // run over all  valid omegas for this thread
+                for (int o = linearThreadIdx; o < radiation_frequencies::N_omega; o += blockSize)
+                  {
+
+                    /* storage for amplitude (complex 3D vector)
+                     * it  is initialized with zeros (  0 +  i 0 )
+                     */
+                    Amplitude amplitude = Amplitude::zero();
+
+                    // compute frequency "omega" using for-loop-index "o"
+                    const picongpu::float_64 omega = freqFkt(o);
+
+
+                    // if coherent and incoherent radiation of a single macro-particle
+                    // is considered, create a form factor object
+    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+                    const radFormFactor::radFormFactor myRadFormFactor;
+    #endif
+
+                    /* Particle loop: thread runs through loaded particle data
+                     *
+                     * Summation of Jackson radiation formula integrand
+                     * over all electrons for fixed, thread-specific
+                     * frequency
+                     */
+                    for (int j = 0; j < counter_s; ++j)
+                      {
+
+                        // if Nyquist-limiter is on
+    #if (__NYQUISTCHECK__==1)
+                        // check Nyquist-limit for each particle "j" and each frequency "omega"
+                        if (lowpass_s[j].check(omega))
+                          {
+    #endif
+
+                            /****************************************************
+                             **** Here happens the true physical calculation ****
+                             ****************************************************/
+
+
+                            // if coherent/incoherent radiation of single macro-particle
+                            // is considered
+                            // the form factor influences the real amplitude
+    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+                            const vector_64 weighted_real_amp = real_amplitude_s[j] * precisionCast<float_64 >
+                              (myRadFormFactor(radWeighting_s[j], omega, look));
+    #else
+                            // if coherent/incoherent radiation of single macro-particle
+                            // is NOT considered
+                            // no change on real amplitude is performed
+                            const vector_64 weighted_real_amp = real_amplitude_s[j];
+    #endif
+
+                            // complex amplitude for j-th particle
+                            Amplitude amplitude_add(weighted_real_amp,
+                                                    t_ret_s[j] * omega);
+
+                            // add this single amplitude those previously considered
+                            amplitude += amplitude_add;
+
+                            // if Nyquist limiter is on
+    #if (__NYQUISTCHECK__==1)
+                          }// END: check Nyquist-limit for each particle "j" and each frequency "omega"
+    #endif
+
+                      }// END: Particle loop
+
+
+                    /* the radiation contribution of the following is added to global memory:
+                     *     - valid particles of last super cell
+                     *     - from this (one) time step
+                     *     - omega_id = theta_idx * radiation_frequencies::N_omega + o
+                     */
+                    radiation[theta_idx * radiation_frequencies::N_omega + o] += amplitude;
+
+
+                  } // end frequency loop
+
+
+                // wait till all radiation contributions for this super cell are done
+                __syncthreads();
+
+
+
+                if (linearThreadIdx == 0)
+                  {
+                    /* First threads starts loading next frame of the super-cell:
+                     *
+                     * Info:
+                     *   The calculation starts with the last SuperCell (must not be full filled)
+                     *   all previous SuperCells are full with particles
+                     */
+                    particlesInFrame = blockSize;
+                    frame = pb.getPreviousFrame(frame);
+                    counter_s = 0;
+                  }
+
+                // wait till first thread has loaded new frame
+                __syncthreads();
+
+                // run through while-loop(is Valid) again
+
+              } // end while(frame.isValid())
+
+          } // end loop over all super cells
+
+
+    } // end radiation kernel
+};
 
 }
 

--- a/src/picongpu/include/simulation_classTypes.hpp
+++ b/src/picongpu/include/simulation_classTypes.hpp
@@ -38,39 +38,3 @@ namespace picongpu
     typedef PIConGPUVerbose picLog;
 
 } //namespace picongpu
-
-/**
- * Appends kernel arguments to generated code and activates kernel task.
- *
- * @param ... parameters to pass to kernel
- */
-#define PIC_PMACC_CUDAPARAMS(...) (__VA_ARGS__,mapper);                        \
-        PMACC_ACTIVATE_KERNEL                                                  \
-    }   /*this is used if call is EventTask.waitforfinished();*/
-
-/**
- * Configures block and grid sizes and shared memory for the kernel.
- *
- * gridsize for kernel call is set by mapper
- *
- * @param block sizes of block on gpu
- * @param ... amount of shared memory for the kernel (optional)
- */
-#define PIC_PMACC_CUDAKERNELCONFIG(block,...) <<<mapper.getGridDim(),(block),  \
-    __VA_ARGS__+0,                                                             \
-    taskKernel->getCudaStream()>>> PIC_PMACC_CUDAPARAMS
-
-/**
- * Calls a CUDA kernel and creates an EventTask which represents the kernel.
- *
- * gridsize for kernel call is set by mapper
- * last argument of kernel call is add by mapper and is the mapper
- *
- * @param kernelname name of the CUDA kernel (can also used with templates etc. myKernnel<1>)
- * @param area area type for which the kernel is called
- */
-#define __picKernelArea(kernelname,description,area) {                               \
-    CUDA_CHECK_KERNEL_MSG(cudaDeviceSynchronize(),"picKernelArea crash before kernel call");       \
-    AreaMapping<area,MappingDesc> mapper(description);                               \
-    TaskKernel *taskKernel =  Environment<>::get().Factory().createTaskKernel(#kernelname);  \
-    kernelname PIC_PMACC_CUDAKERNELCONFIG


### PR DESCRIPTION
- remove macro `__cudaKernel`
- remove  macro `__picKernelArea`
- add new kernel creation methods
  - PMacc kernel wrapper: `Kernel<>`
  - helper function: `kernel()`
  - macro: `PMACC_KERNEL()`
- use new kernel starter
- indent kernel body within the functor
- remove the usage of the type `dim3` within the user code
- `Reduce.hpp` and `IdProvider.hpp`: remove early returns within a kernel

I can't avoid the white space changes, else the code become not readable and maintainable.

Why is `__picKernelArea` removed?
- this macro add an extra parameter to the kernel (this is confusing)
- the macro is hard to maintain and to read

Tests:

- [x] compiled with `compie -l examples ...`
- [x] compile PMacc tests
- [x] compile PMacc GameOfLife
- [x] runtime test KHI 2/3D positrons/electrons shape CIC/TSC/PCS/P4S

~~This is only a preview. I will split do separate commits for PMacc and PIConGPU~~



**How to refactor a CUDA kernel to a functor:**

- remove `__cudaKernel(...)` with `PMACC_KERNEL(...)`
- remove `__picKernelArea`
```C++
__picKernelArea( kernelName, cellDescription, AREA )( blockExtent )( ... );
```
to
```C++
AreaMapping< AREA, MappingDesc > mapper( cellDescription );
PMACC_KERNEL( kernelName{} )( mapper.getGridDim(), blockExtent )( ..., mapper );
```
- transform kernel function to a functor:
```C++
template< typename T_Type >
__global__ void kernelName( T_Type a ){ }
```
to
```C++
struct KernelName
{
  template< typename T_Type >
  DINLINE void operator( )( T_Type a ) const
  { };
}
```
