### PR TITLE
improve error message

### DIFF
--- a/src/libPMacc/include/traits/GetNComponents.hpp
+++ b/src/libPMacc/include/traits/GetNComponents.hpp
@@ -35,7 +35,11 @@ namespace traits
  * \return \p ::value as public with number of components (uint32_t)
  */
 template<typename T_Type, bool T_IsFundamental = boost::is_fundamental<T_Type>::value>
-struct GetNComponents;
+struct GetNComponents
+{
+    PMACC_CASSERT_MSG_TYPE( __GetNComponents_is_not_defined_for_this_type, T_Type, false ); 
+    static constexpr uint32_t value = 0;
+};
 
 /** return value=1 for al fundamental c++ types
  */


### PR DESCRIPTION
- improve error message for `GetNComponents` if not specialized for a given type

If the trait is not defined for a type the compiler fire a error message `incomplete type is not allow`. There is no information what does this mean. With this pull request the developer get useful information why the code is not compiling.