### PR TITLE
add TSC and PCS rad form factor shapes

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -82,12 +82,16 @@ namespace radiationNyquist
 
   /* Choose different form factors in order to consider different  particle shapes for radiation
    *  - radFormFactor_CIC_3D ... CIC charge distribution
+   *  - radFormFactor_TSC_3D ... TSC charge distribution
+   *  - radFormFactor_PCS_3D ... PCS charge distribution
    *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
    *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
    *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
    *  - radFormFactor_incoherent ... only incoherent radiation
    */
   namespace radFormFactor_CIC_3D { }
+  namespace radFormFactor_TSC_3D { }
+  namespace radFormFactor_PCS_3D { }
   namespace radFormFactor_CIC_1Dy { }
   namespace radFormFactor_Gauss_spherical { }
   namespace radFormFactor_Gauss_cell { }

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -86,12 +86,16 @@ namespace radiationNyquist
 
   /* Choose different form factors in order to consider different  particle shapes for radiation
    *  - radFormFactor_CIC_3D ... CIC charge distribution
+   *  - radFormFactor_TSC_3D ... TSC charge distribution
+   *  - radFormFactor_PCS_3D ... PCS charge distribution
    *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
    *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
    *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
    *  - radFormFactor_incoherent ... only incoherent radiation
    */
   namespace radFormFactor_CIC_3D { }
+  namespace radFormFactor_TSC_3D { }
+  namespace radFormFactor_PCS_3D { }
   namespace radFormFactor_CIC_1Dy { }
   namespace radFormFactor_Gauss_spherical { }
   namespace radFormFactor_Gauss_cell { }

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/radiationConfig.param
@@ -83,12 +83,16 @@ namespace radiationNyquist
 
   /* Choose different form factors in order to consider different  particle shapes for radiation
    *  - radFormFactor_CIC_3D ... CIC charge distribution
+   *  - radFormFactor_TSC_3D ... TSC charge distribution
+   *  - radFormFactor_PCS_3D ... PCS charge distribution
    *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
    *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
    *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
    *  - radFormFactor_incoherent ... only incoherent radiation
    */
   namespace radFormFactor_CIC_3D { }
+  namespace radFormFactor_TSC_3D { }
+  namespace radFormFactor_PCS_3D { }
   namespace radFormFactor_CIC_1Dy { }
   namespace radFormFactor_Gauss_spherical { }
   namespace radFormFactor_Gauss_cell { }

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -399,7 +399,7 @@ struct kernelRadiationParticles
                     // if coherent and incoherent radiation of a single macro-particle
                     // is considered, create a form factor object
     #if (__COHERENTINCOHERENTWEIGHTING__==1)
-                    const radFormFactor::radFormFactor myRadFormFactor;
+                    const radFormFactor::radFormFactor myRadFormFactor{ };
     #endif
 
                     /* Particle loop: thread runs through loaded particle data

--- a/src/picongpu/include/plugins/radiation/radFormFactor.hpp
+++ b/src/picongpu/include/plugins/radiation/radFormFactor.hpp
@@ -44,16 +44,17 @@ namespace picongpu
        */
       HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
       {
+        //util::Pow<float_X, 1> pow;
+        const float_X sincX = util::pow( math::sinc( observer_unit_vec.x() * CELL_WIDTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 1 );
+        const float_X sincY = util::pow( math::sinc( observer_unit_vec.y() * CELL_HEIGHT / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 1 );
+        const float_X sincZ = util::pow( math::sinc( observer_unit_vec.z() * CELL_DEPTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 1 );
           return math::sqrt(
-              N + ( N * N - N ) * util::square(
-                  math::sinc( observer_unit_vec.x() * CELL_WIDTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ) *
-                  math::sinc( observer_unit_vec.y() * CELL_HEIGHT / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ) *
-                  math::sinc( observer_unit_vec.z() * CELL_DEPTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega )
-              ) // util::square
+              N + ( N * N - N ) * util::square( sincX * sincY * sincZ )
           ); // math::sqrt
       }
     };
   } // radFormFactor_CIC_3D
+
 
   namespace radFormFactor_CIC_1Dy
   {
@@ -82,6 +83,69 @@ namespace picongpu
       }
     };
   } // radFormFactor_CIC_1Dy
+
+
+  namespace radFormFactor_TSC_3D
+  {
+    class radFormFactor
+    {
+    public:
+      /* Form Factor for TSC charge distribution of N discrete electrons:
+       *
+       * with observation direction (unit vector) \vec{n} = (n_x, n_y, n_z)
+       * and with: N     = weighting
+       *           omega = frequency
+       *           L_d   = the size of the cell in dimension d
+       *
+       * @param N = macro particle weighting
+       * @param omega = frequency at which to calculate the  form factor
+       * @param observer_unit_vec = observation direction
+       * @return the Form Factor: sqrt( | \mathcal{F} |^2 )
+       */
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+      {
+        //util::Pow<float_X, 2> pow;
+        const float_X sincX = util::pow( math::sinc( observer_unit_vec.x() * CELL_WIDTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 2 );
+        const float_X sincY = util::pow( math::sinc( observer_unit_vec.y() * CELL_HEIGHT / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 2 );
+        const float_X sincZ = util::pow( math::sinc( observer_unit_vec.z() * CELL_DEPTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 2 );
+          return math::sqrt(
+              N + ( N * N - N ) * util::square( sincX * sincY * sincZ )
+          ); // math::sqrt
+      }
+    };
+  } // radFormFactor_TSC_3D
+
+
+  namespace radFormFactor_PCS_3D
+  {
+    class radFormFactor
+    {
+    public:
+      /* Form Factor for PCS charge distribution of N discrete electrons:
+       *
+       * with observation direction (unit vector) \vec{n} = (n_x, n_y, n_z)
+       * and with: N     = weighting
+       *           omega = frequency
+       *           L_d   = the size of the cell in dimension d
+       *
+       * @param N = macro particle weighting
+       * @param omega = frequency at which to calculate the  form factor
+       * @param observer_unit_vec = observation direction
+       * @return the Form Factor: sqrt( | \mathcal{F} |^2 )
+       */
+      HDINLINE float_X operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+      {
+        //util::Pow<float_X, 3> pow;
+        const float_X sincX = util::pow( math::sinc( observer_unit_vec.x() * CELL_WIDTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 3 );
+        const float_X sincY = util::pow( math::sinc( observer_unit_vec.y() * CELL_HEIGHT / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 3 );
+        const float_X sincZ = util::pow( math::sinc( observer_unit_vec.z() * CELL_DEPTH / ( SPEED_OF_LIGHT * float_X( 2.0 ) ) * omega ), 3 );
+          return math::sqrt(
+              N + ( N * N - N ) * util::square( sincX * sincY * sincZ )
+          ); // math::sqrt
+      }
+    };
+  } // radFormFactor_PCS_3D
+
 
 
   namespace radFormFactor_Gauss_spherical

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -83,12 +83,16 @@ namespace picongpu
 
     /* Choose different form factors in order to consider different  particle shapes for radiation
      *  - radFormFactor_CIC_3D ... CIC charge distribution
+     *  - radFormFactor_TSC_3D ... TSC charge distribution
+     *  - radFormFactor_PCS_3D ... PCS charge distribution
      *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
      *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
      *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
      *  - radFormFactor_incoherent ... only incoherent radiation
      */
     namespace radFormFactor_CIC_3D { }
+    namespace radFormFactor_TSC_3D { }
+    namespace radFormFactor_PCS_3D { }
     namespace radFormFactor_CIC_1Dy { }
     namespace radFormFactor_Gauss_spherical { }
     namespace radFormFactor_Gauss_cell { }


### PR DESCRIPTION
This pull request extends the currently existing CIC particle shape (for radiation) for the TSC and PCS shape. 

**Requires:**
 - [x] merge of #1686 
 - [x] test CIC, TSC and PCS shape again
 - [x] add documentation on new shapes in `radiationConfig.param`