### PR TITLE
checker script for `__global__` keyword

### DIFF
--- a/test/hasCudaGlobalKeyword
+++ b/test/hasCudaGlobalKeyword
@@ -1,0 +1,31 @@
+# Copyright 2016 Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# search recursive inside a folder if the keyword `__global__` is used
+# @param $1 path to the folder
+# @result 0 if keyword is not found else 1
+
+folderName=$1
+result=`grep -rn "__global__" $folderName`
+if [ $? -eq 0 ] ; then
+    echo "Not allowed keyword __global__ found in the following files:" >&2
+    echo "$result" | cut -f1-2 -d":" >&2
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
The script search if the `__global__` keyword is used within one file in a folder.

Native CUDA kernel break the compatibility with [alpaka](https://github.com/ComputationalRadiationPhysics/alpaka). Therefore @ax3l suggest to add a travis test with this little script to avoid the usage of `__global__` within PMacc and PIConGPU. 

usage:
```Bash
test/hasCudaGlobalKeyword src/libPMacc
test/hasCudaGlobalKeyword src/picongpu
test/hasCudaGlobalKeyword examples
```