### PR TITLE
Travis: Simple Style Checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: cpp
+sudo: false
+
+script:
+  #############################################################################
+  # Conformance with Alpaka: Do not write __global__ CUDA kernels directly    #
+  #############################################################################
+  - test/hasCudaGlobalKeyword src/libPMacc
+  - test/hasCudaGlobalKeyword src/picongpu
+  - test/hasCudaGlobalKeyword examples
+
+  #############################################################################
+  # Disallow end-of-line (EOL) white spaces                                   #
+  #############################################################################
+  - test/hasEOLwhiteSpace
+
+  #############################################################################
+  # Disallow non-ASCII in source files and scripts                            #
+  #############################################################################
+  - test/hasNonASCII

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 PIConGPU - A Many GPGPU PIC Code
 ================================================================
 
+[![Code Status master](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/master.svg?label=master)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
+[![Code Status dev](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/dev.svg?label=dev)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
+[![Language](https://img.shields.io/badge/language-C%2B%2B11-orange.svg)](https://isocpp.org/)
+[![License PIConGPU](https://img.shields.io/badge/license-GPLv3-blue.svg?label=PIConGPU)](https://www.gnu.org/licenses/gpl-3.0.html)
+[![License PMacc](https://img.shields.io/badge/license-LGPLv3-blue.svg?label=PMacc)](https://www.gnu.org/licenses/lgpl-3.0.html)
+
 [![PIConGPU Presentation Video](http://img.youtube.com/vi/nwZuG-XtUDE/0.jpg)](http://www.youtube.com/watch?v=nwZuG-XtUDE)
 [![PIConGPU Release](doc/logo/pic_logo_vert_158x360.png)](http://www.youtube.com/watch?v=nwZuG-XtUDE)
 

--- a/test/hasCudaGlobalKeyword
+++ b/test/hasCudaGlobalKeyword
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Copyright 2016 Rene Widera
 #
 # This file is part of PIConGPU.

--- a/test/hasEOLwhiteSpace
+++ b/test/hasEOLwhiteSpace
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# search recursive inside a folder if a file contains end-of-line
+#   (EOL) white spaces
+#
+# @result 0 if no files are found, else 1
+#
+# note: .md files can contain EOL white spaces for syntax reasons
+#       (newline without starting a new paragraph)
+
+ok=0
+
+for i in $(find . \
+                -not -path "./.git/*" \
+                -not -path "./thirdParty/*" \
+                -type f | \
+           egrep "\.def$|\.h$|\.cpp$|\.cu$|\.hpp$|\.tpp$|\.kernel$|\.loader$|\
+                  \.param$|\.unitless$|\.sh$|\.bash$|\.cfg$|\.tpl$|\.conf$|\
+                  \.awk$|\.gnuplot$|\.cmake$|\.profile$|\.example$|\.py$")
+do
+  grep -q "[[:blank:]]\+$" $i
+  if [ $? -eq 0 ]
+  then
+    echo "$i contains EOL white spaces!"
+    ok=1
+  fi
+done
+
+if [ $ok -ne 0 ]
+then
+  echo ""
+  echo "SUMMARY"
+  echo "-------"
+  echo "Run the following command on the above files to remove your"
+  echo "end-of-line (EOL) white spaces:"
+  echo "  sed -i 's/[[:blank:]]\+$//' putYourFileNameHere"
+fi
+
+exit $ok

--- a/test/hasNonASCII
+++ b/test/hasNonASCII
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Search recursive inside a folder if a shell scripts or batch system files
+# contains non-ASCII characters. This causes problems with some systems.
+# We can also not guarantee that everyone has UTF8 locales installed, so
+# why depend on it.
+#
+# @result 0 if no files are found, else 1
+#
+
+ok=0
+
+for i in $(find . \
+                -not -path "./.git/*" \
+                -not -path "./thirdParty/*" \
+                -type f | \
+           egrep "\.def$|\.h$|\.cpp$|\.cu$|\.hpp$|\.tpp$|\.kernel$|\.loader$|\
+                  \.param$|\.unitless$|\.sh$|\.bash$|\.cfg$|\.tpl$|\.conf$|\
+                  \.awk$|\.gnuplot$|\.cmake$|\.profile$|\.example$\.py$")
+do
+  # non-ASCII test regex via jerrymouse at stackoverflow under CC-By-SA 3.0:
+  #   http://stackoverflow.com/questions/3001177/how-do-i-grep-for-all-non-ascii-characters-in-unix/9395552#9395552
+  result=$(grep --color='always' -P -n "[\x80-\xFF]" $i)
+
+  if [ $? -eq 0 ]
+  then
+    echo "$i contains non-ASCII characters!"
+    echo "$result"
+    ok=1
+  fi
+done
+
+exit $ok


### PR DESCRIPTION
We add travis to do tests on source files which are light-weight. This currently only includes #1672 but could also look for things like "careful, found a new external include", "found a new usage of a boost library", etc.

Let the scripts come!
- no `__global__` keyword
- no EOL white spaces
- non non-ASCII chars in source and script files