### PR TITLE
CompileSuite: Clean Up Dot Files

### DIFF
--- a/buildsystem/CompileSuite/autoTests/config.sh
+++ b/buildsystem/CompileSuite/autoTests/config.sh
@@ -24,6 +24,7 @@
 cnf_scheduler_secret="..."
 cnf_scheduler="https://example.com?client="$cnf_scheduler_secret
 
+# temporary git & build directory: careful, will be purged!
 cnf_gitdir="$HOME/picongpu-src/"
 cnf_builddir="$HOME/build/"
 

--- a/buildsystem/CompileSuite/autoTests/get_work.sh
+++ b/buildsystem/CompileSuite/autoTests/get_work.sh
@@ -31,7 +31,7 @@ security_check $thisDir
 
 # clean up old stuff
 #
-rm -rf $cnf_gitdir/* $cnf_gitdir/.git*
+rm -rf $cnf_gitdir
 mkdir -p $cnf_gitdir
 cd $cnf_gitdir
 


### PR DESCRIPTION
Adding new dot files in the root of the repo, such as `.travis.yml` did not get cleaned up properly between tests. Following `git clone` commands in that tmp dir failed.