### PR TITLE
Source Files: Remove non-ASCII Chars

### DIFF
--- a/examples/SingleParticleCurrent/include/CheckCurrent.hpp
+++ b/examples/SingleParticleCurrent/include/CheckCurrent.hpp
@@ -42,7 +42,7 @@ struct CheckCurrent
         {
             const float_X unit_current = UNIT_CHARGE / (UNIT_LENGTH * UNIT_LENGTH * UNIT_TIME);
             totalJ *= unit_current;
-            printf("totalJ: (%g, %g, %g) A/m²\n", totalJ.x(), totalJ.y(), totalJ.z());
+            printf("totalJ: (%g, %g, %g) A/m^2\n", totalJ.x(), totalJ.y(), totalJ.z());
         }
 
         HDINLINE void operator()(float3_X data, PMacc::math::Int<3> cellIdx)
@@ -82,7 +82,7 @@ struct CheckCurrent
 
         const float_64 j = BASE_CHARGE / CELL_VOLUME * math::abs(beta) * SPEED_OF_LIGHT;
         const float_64 unit_current = UNIT_CHARGE / (UNIT_LENGTH * UNIT_LENGTH * UNIT_TIME);
-        std::cout << "j = rho * abs(velocity) = " << std::setprecision(6) << j * unit_current << " A/m²" << std::endl;
+        std::cout << "j = rho * abs(velocity) = " << std::setprecision(6) << j * unit_current << " A/m^2" << std::endl;
         std::cout << "------------------------------------------\n\n";
 
         std::cout << "fieldJ facts:\n\n";

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -266,7 +266,7 @@ struct kernelFillGapsLastFrame
         {
             //count particles in last frame
             const bool isParticle = lastFrame[threadIdx.x][multiMask_];
-            if ( isParticle == true ) //\todo: bits zählen
+            if ( isParticle == true ) // \todo: count bits
             {
                 nvidia::atomicAllInc( &counterParticles );
             }

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rémi Lehe
+ * Copyright 2013-2016 Axel Huebl, Remi Lehe
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh.def
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh.def
@@ -51,7 +51,7 @@ namespace ionization
      * - this is a Monte Carlo method: if a random number is smaller
      *   or equal than the ionization probability -> increase the charge state
      * - see for example: D. Bauer and P. Mulser. Exact field ionization rates in the barrier-suppression
-     *   regime from numerical time-dependent Schrödinger-equation calculations.
+     *   regime from numerical time-dependent Schroedinger-equation calculations.
      *   Physical Review A, 59(1):569+, January 1999.
      *
      * wrapper class,

--- a/src/picongpu/include/plugins/IsaacPlugin.hpp
+++ b/src/picongpu/include/plugins/IsaacPlugin.hpp
@@ -398,8 +398,8 @@ private:
             if (rank == 0)
             {
                 json_object_set_new( visualization->getJsonMetaRoot(), "time step", json_string( "Time step" ) );
-                json_object_set_new( visualization->getJsonMetaRoot(), "drawing time", json_string( "Drawing time in µs" ) );
-                json_object_set_new( visualization->getJsonMetaRoot(), "simulation time", json_string( "Simulation time in µs" ) );
+                json_object_set_new( visualization->getJsonMetaRoot(), "drawing time", json_string( "Drawing time in us" ) );
+                json_object_set_new( visualization->getJsonMetaRoot(), "simulation time", json_string( "Simulation time in us" ) );
                 json_object_set_new( visualization->getJsonMetaRoot(), "cell count", json_string( "Total numbers of cells" ) );
                 json_object_set_new( visualization->getJsonMetaRoot(), "particle count", json_string( "Total numbers of particles" ) );
             }

--- a/thirdParty/cuda_memtest/.travis.yml
+++ b/thirdParty/cuda_memtest/.travis.yml
@@ -1,8 +1,29 @@
 language: cpp
 
+sudo: required
+dist: trusty
+
 compiler:
   - gcc
   - clang
+
+matrix:
+  allow_failures:
+    - compiler: clang
+
+addons:
+  apt:
+    #sources:
+    #  - multiverse
+    packages:
+      - build-essential
+      - cmake-data
+      - cmake
+      - g++-4.8
+      - gcc-4.8
+      - nvidia-common
+    #  - nvidia-cuda-toolkit
+    #  - nvidia-cuda-dev
 
 env:
   global:
@@ -10,25 +31,25 @@ env:
     - NVML_FILE=cuda_346.46_gdk_linux.run
     - NVML_LINK=http://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers/
   matrix:
-    - USE_NVML=1
-    - USE_NVML=0
+    - USE_NVML=1 USE_SM=sm_10
+    - USE_NVML=0 USE_SM=sm_20
 
 script:
   - mkdir build_tmp && cd build_tmp
-# CUDA 4.0 on travis... work-around missing atomicAdd
-  - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCUDA_ARCH=sm_10 -DSAME_NVCC_FLAGS_IN_SUBPROJECTS=ON $TRAVIS_BUILD_DIR
+  - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCUDA_ARCH=$USE_SM -DSAME_NVCC_FLAGS_IN_SUBPROJECTS=ON $TRAVIS_BUILD_DIR
   - make
   - make install
 
-before_script:
+before_install:
+  - sudo apt-add-repository multiverse
   - sudo apt-get update -qq
-  - sudo apt-get install -qq build-essential
-  - sudo apt-get install -qq gcc-4.4 g++-4.4
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.4 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.4
+  # nvcc 5.5: <= gcc 4.8
+#  - sudo apt-get install -qq gcc-4.8 g++-4.8
+#  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
   - gcc --version && g++ --version
-  - sudo apt-get install -qq nvidia-common
-  - sudo apt-get install -qq nvidia-current
-  - sudo apt-get install -qq nvidia-cuda-toolkit nvidia-cuda-dev
+  - sudo apt-get install -qq nvidia-cuda-toolkit
+  - sudo apt-get install -qq nvidia-cuda-dev
+  - nvcc --version
   - if [ $USE_NVML -eq 1 ]; then wget $NVML_LINK$NVML_FILE && chmod u+x $NVML_FILE && sudo ./$NVML_FILE --silent --installdir=/ ; fi
   - if [ $USE_NVML -eq 1 ]; then export CMAKE_PREFIX_PATH=/usr/src/gdk/nvml/lib/ ; fi
   - sudo find /usr/ -name libcuda*.so

--- a/thirdParty/cuda_memtest/cuda_memtest.h
+++ b/thirdParty/cuda_memtest/cuda_memtest.h
@@ -4,7 +4,7 @@
  * University of Illinois/NCSA
  * Open Source License
  *
- * Copyright © 2009,    University of Illinois.  All rights reserved.
+ * Copyright 2009,    University of Illinois.  All rights reserved.
  *
  * Developed by:
  *

--- a/thirdParty/cuda_memtest/misc.cpp
+++ b/thirdParty/cuda_memtest/misc.cpp
@@ -49,8 +49,10 @@ get_driver_info(char* info, unsigned int len)
     if ( fgets(info, len, file) == NULL){
 	PRINTF("Warning: reading file failed\n");
 	info[0] = 0;
+	fclose(file);
 	return;
     }
+    fclose(file);
 
     PRINTF("%s", info);
 

--- a/thirdParty/cuda_memtest/ocl_memtest.cpp
+++ b/thirdParty/cuda_memtest/ocl_memtest.cpp
@@ -149,9 +149,11 @@ read_kernel_source(void)
   size_t rc = fread(kernel_source, 1, MAX_KERNEL_FILE_SIZE, fd);
   if (rc < 0 || rc >= MAX_KERNEL_FILE_SIZE){
     printf("ERROR: return value out of range for reading kernel file(rc=%lx)\n", rc);
+    fclose(fd);
     exit(1);
   }
 
+  fclose(fd);
   return;
 }
 

--- a/thirdParty/cuda_memtest/tests.cu
+++ b/thirdParty/cuda_memtest/tests.cu
@@ -4,7 +4,7 @@
  * University of Illinois/NCSA
  * Open Source License
  *
- * Copyright © 2009,    University of Illinois.  All rights reserved.
+ * Copyright 2009,    University of Illinois.  All rights reserved.
  *
  * Developed by:
  *


### PR DESCRIPTION
We should not enforce UTF-8 locales on user systems.

CUDA memtest updated as in #1159, also contains an other minor fix from upstream: https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/7

For comparison, travis does not even handle UTF-8 grep-ing gracefully:
  https://travis-ci.org/ComputationalRadiationPhysics/picongpu/builds/182302127#L209