### PR TITLE
fix vector.operator[] const access in radiation plugin

### DIFF
--- a/src/picongpu/include/plugins/radiation/vector.hpp
+++ b/src/picongpu/include/plugins/radiation/vector.hpp
@@ -81,7 +81,7 @@ struct cuda_vec : public V
         return (&(this->x()))[dim];
     }
 
-    HDINLINE T &operator[](uint32_t dim) const
+    HDINLINE const T &operator[](uint32_t dim) const
     {
         return (&(this->x()))[dim];
     }


### PR DESCRIPTION
This pull request fixes a compile time bug in the radiation plugin's vector class that prevented using the `[ ]` operator on constant vectors.

This solves issue #1683 