### PR TITLE
Close #1687 Fix Pre-Compiler Spaces

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -51,14 +51,14 @@ typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultPartic
 
 /*add old momentum for radiation plugin*/
 typedef MakeSeq<
-#if(ENABLE_RADIATION == 1)
+#if( ENABLE_RADIATION == 1 )
 momentumPrev1
 #endif
 >::type AttributMomentum_mt1;
 
 /*add old radiation flag for radiation plugin*/
 typedef MakeSeq<
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( RAD_MARK_PARTICLE>1 ) || ( RAD_ACTIVATE_GAMMA_FILTER!=0 )
 radiationFlag
 #endif
 >::type AttributRadiationFlag;
@@ -163,11 +163,11 @@ typedef bmpl::vector<
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioIons>,
     chargeRatio<ChargeRatioIons>,
-    #if(PARAM_IONIZATION == 1)
+#if( PARAM_IONIZATION == 1 )
     ionizer<particles::ionization::BSIEffectiveZ<PIC_Electrons> >,
     ionizationEnergies<AU::IONIZATION_ENERGY_HYDROGEN_t>,
     effectiveAtomicNumbers<Z_EFFECTIVE_HYDROGEN_t>,
-    #endif
+#endif
     atomicNumbers<Hydrogen>
 > ParticleFlagsIons;
 
@@ -188,13 +188,13 @@ typedef Particles<
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
 typedef MakeSeq<
-#if (ENABLE_ELECTRONS == 1)
+#if( ENABLE_ELECTRONS == 1 )
 PIC_Electrons
 #endif
 >::type Species1;
 
 typedef MakeSeq<
-#if (ENABLE_IONS == 1)
+#if( ENABLE_IONS == 1 )
 PIC_Ions
 #endif
 >::type Species2;

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
@@ -83,12 +83,12 @@ namespace particles
  * the functors are called in order (from first to last functor)
  */
 typedef mpl::vector<
-#if (PARAM_IONIZATION == 0)
+#if( PARAM_IONIZATION == 0 )
 
     CreateGas<gasProfiles::Gaussian, startPosition::Random, PIC_Electrons>
-    #if (ENABLE_IONS == 1)
-        ,DeriveSpecies<PIC_Electrons,PIC_Ions>
-    #endif
+#   if( ENABLE_IONS == 1 )
+    , DeriveSpecies<PIC_Electrons,PIC_Ions>
+#   endif
 
 #else
 

--- a/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
@@ -89,11 +89,11 @@ struct kernelAddOneParticle
             par[localCellIdx_] = linearIdx;
             par[weighting_] = parWeighting;
 
-    #if(ENABLE_RADIATION == 1)
-    #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( ENABLE_RADIATION == 1 )
+#   if( RAD_MARK_PARTICLE>1 ) || ( RAD_ACTIVATE_GAMMA_FILTER!=0 )
             par[radiationFlag_] = true;
-    #endif
-    #endif
+#   endif
+#endif
         }
     }
 };

--- a/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
@@ -94,11 +94,11 @@ struct kernelAddOneParticle
             par[localCellIdx_] = linearIdx;
             par[weighting_] = parWeighting;
 
-    #if(ENABLE_RADIATION == 1)
-    #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( ENABLE_RADIATION == 1 )
+#   if( RAD_MARK_PARTICLE>1 ) || ( RAD_ACTIVATE_GAMMA_FILTER!=0 )
             par[radiationFlag_] = true;
-    #endif
-    #endif
+#   endif
+#endif
         }
     }
 };

--- a/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
@@ -90,11 +90,11 @@ struct kernelAddOneParticle
             par[localCellIdx_] = linearIdx;
             par[weighting_] = parWeighting;
 
-    #if(ENABLE_RADIATION == 1)
-    #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( ENABLE_RADIATION == 1 )
+#   if( RAD_MARK_PARTICLE>1 ) || ( RAD_ACTIVATE_GAMMA_FILTER!=0 )
             par[radiationFlag_] = true;
-    #endif
-    #endif
+#   endif
+#endif
         }
     }
 };

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -51,14 +51,14 @@ typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultPartic
 
 /*add old momentum for radiation plugin*/
 typedef MakeSeq<
-#if(ENABLE_RADIATION == 1)
+#if( ENABLE_RADIATION == 1 )
 momentumPrev1
 #endif
 >::type AttributMomentum_mt1;
 
 /*add old radiation flag for radiation plugin*/
 typedef MakeSeq<
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
 radiationFlag
 #endif
 >::type AttributRadiationFlag;
@@ -86,7 +86,7 @@ value_identifier(float_X, ChargeRatioElectrons, 1.0);
 
 typedef bmpl::vector<
 /* enable the pusher only if PARAM_ENABLEPUSHER is defined as one `1` */
-#if ( PARAM_ENABLEPUSHER == 1 )
+#if( PARAM_ENABLEPUSHER == 1 )
     particlePusher<UsedParticlePusher>,
 #endif
     shape<UsedParticleShape>,
@@ -159,7 +159,7 @@ typedef Particles<
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
 typedef MakeSeq<
-#if (ENABLE_ELECTRONS == 1)
+#if( ENABLE_ELECTRONS == 1 )
 PIC_Electrons
 #endif
 >::type Species1;

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -51,14 +51,14 @@ typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultPartic
 
 /*add old momentum for radiation plugin*/
 typedef MakeSeq<
-#if(ENABLE_RADIATION == 1)
+#if( ENABLE_RADIATION == 1 )
 momentumPrev1
 #endif
 >::type AttributMomentum_mt1;
 
 /*add old radiation flag for radiation plugin*/
 typedef MakeSeq<
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
 radiationFlag
 #endif
 >::type AttributRadiationFlag;
@@ -171,13 +171,13 @@ typedef Particles<
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
 typedef MakeSeq<
-#if (ENABLE_ELECTRONS == 1)
+#if( ENABLE_ELECTRONS == 1 )
 PIC_Electrons
 #endif
 >::type Species1;
 
 typedef MakeSeq<
-#if (ENABLE_IONS == 1)
+#if( ENABLE_IONS == 1 )
 PIC_Ions
 #endif
 >::type Species2;

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -39,11 +39,11 @@
 /*if this flag is defined all kernel calls would be checked and synchronize
  * this flag must set by the compiler or inside of the Makefile
  */
-#if (PMACC_SYNC_KERNEL  == 1)
-    #define CUDA_CHECK_KERNEL_MSG(...)  CUDA_CHECK_MSG(__VA_ARGS__)
+#if( PMACC_SYNC_KERNEL  == 1 )
+#   define CUDA_CHECK_KERNEL_MSG(...)  CUDA_CHECK_MSG(__VA_ARGS__)
 #else
     /*no synchronize and check of kernel calls*/
-    #define CUDA_CHECK_KERNEL_MSG(...)  ;
+#   define CUDA_CHECK_KERNEL_MSG(...)  ;
 #endif
 
 

--- a/src/libPMacc/include/identifier/alias.hpp
+++ b/src/libPMacc/include/identifier/alias.hpp
@@ -38,12 +38,12 @@ identifier(pmacc_isAlias);
 } //namespace PMacc
 
 #ifdef __CUDACC__
-    #define PMACC_alias_CUDA(name,id)                                          \
+#   define PMACC_alias_CUDA(name,id)                                          \
         namespace PMACC_JOIN(device_placeholder,id){                           \
             __constant__ PMACC_JOIN(placeholder_definition,id)::name<> PMACC_JOIN(name,_); \
         }
 #else
-    #define PMACC_alias_CUDA(name,id)
+#   define PMACC_alias_CUDA(name,id)
 #endif
 
 /*define special makros for creating classes which are only used as identifer*/

--- a/src/libPMacc/include/identifier/identifier.hpp
+++ b/src/libPMacc/include/identifier/identifier.hpp
@@ -28,18 +28,18 @@
 /* No namespace is needed because we only have defines*/
 
 #ifdef __CUDA_ARCH__ //we are on gpu
-#define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(device_placeholder,id)
+#   define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(device_placeholder,id)
 #else
-#define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(host_placeholder,id)
+#   define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(host_placeholder,id)
 #endif
 
 #ifdef __CUDACC__
-    #define PMACC_identifier_CUDA(name,id)                                         \
+#   define PMACC_identifier_CUDA(name,id)                                         \
         namespace PMACC_JOIN(device_placeholder,id){                               \
             __constant__ PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
         }
 #else
-    #define PMACC_identifier_CUDA(name,id)
+#   define PMACC_identifier_CUDA(name,id)
 #endif
 
 /*define special macros for creating classes which are only used as identifier*/

--- a/src/libPMacc/include/lambda/Expression.hpp
+++ b/src/libPMacc/include/lambda/Expression.hpp
@@ -45,7 +45,7 @@
 #include <boost/preprocessor/cat.hpp>
 
 #ifndef LAMBDA_MAX_PARAMS
-#define LAMBDA_MAX_PARAMS 8
+#   define LAMBDA_MAX_PARAMS 8
 #endif
 
 namespace mpl = boost::mpl;
@@ -76,14 +76,14 @@ struct Expression : public math::Tuple<_Childs>
     HDINLINE Expression(FirstChild const & child0 = FirstChild())
      : Base(child0) {}
 
-    #define EXPRESSION_CTOR(Z, N, _)                                         \
+#define EXPRESSION_CTOR(Z, N, _)                                             \
         template<BOOST_PP_ENUM_PARAMS(N, typename Arg)>                      \
         HDINLINE Expression(BOOST_PP_ENUM_BINARY_PARAMS(N, const Arg, &arg)) \
          : Base(BOOST_PP_ENUM_PARAMS(N, arg)) {}
 
     BOOST_PP_REPEAT_FROM_TO(2, LAMBDA_MAX_PARAMS, EXPRESSION_CTOR, _)
 
-    #undef EXPRESSION_CTOR
+#undef EXPRESSION_CTOR
 
     template<typename Idx>
     HDINLINE
@@ -149,10 +149,10 @@ struct Expression : public math::Tuple<_Childs>
         (*this, make_Expr(rhs));
     }
 
-    #define RESULT_OF_MAKE_EXPR(Z, N, _) typename result_of::make_Expr<Arg ## N>::type
-    #define MAKE_EXPR(Z, N, _) make_Expr(arg ## N)
+#define RESULT_OF_MAKE_EXPR(Z, N, _) typename result_of::make_Expr<Arg ## N>::type
+#define MAKE_EXPR(Z, N, _) make_Expr(arg ## N)
 
-    #define OPERATOR_CALL(Z, N, _) \
+#define OPERATOR_CALL(Z, N, _) \
         template<BOOST_PP_ENUM_PARAMS(N, typename Arg)> \
         HDINLINE \
         Expression<exprTypes::call, mpl::vector<This BOOST_PP_ENUM_TRAILING(N, RESULT_OF_MAKE_EXPR, _)> > \
@@ -164,9 +164,9 @@ struct Expression : public math::Tuple<_Childs>
 
     BOOST_PP_REPEAT_FROM_TO(1, LAMBDA_MAX_PARAMS, OPERATOR_CALL, _)
 
-    #undef RESULT_OF_MAKE_EXPR
-    #undef MAKE_EXPR
-    #undef OPERATOR_CALL
+#undef RESULT_OF_MAKE_EXPR
+#undef MAKE_EXPR
+#undef OPERATOR_CALL
 
     template<typename Arg>
     HDINLINE
@@ -197,4 +197,3 @@ DECLARE_PLACEHOLDERS()
 
 } // lambda
 } // PMacc
-

--- a/src/libPMacc/include/lambda/make_Functor.hpp
+++ b/src/libPMacc/include/lambda/make_Functor.hpp
@@ -30,7 +30,7 @@
 #include "CT/FillTerminalList.hpp"
 #include <math/Tuple.hpp>
 #include "RefWrapper.hpp"
- #include <boost/type_traits/is_reference.hpp>
+#include <boost/type_traits/is_reference.hpp>
 
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/front.hpp>
@@ -102,9 +102,9 @@ struct ExprFunctor
         CT::FillTerminalList<Expr, CTExpr>()(expr, this->terminalTuple);
     }
 
-    #define CREF_TYPE_LIST(Z, N, _) const Arg ## N &
+#define CREF_TYPE_LIST(Z, N, _) const Arg ## N &
 
-    #define OPERATOR_CALL(Z,N,_)                                                                        \
+#define OPERATOR_CALL(Z,N,_)                                                                        \
         template<BOOST_PP_ENUM_PARAMS(N, typename Arg)>                                                 \
         HDINLINE                                                                                        \
         typename ::PMacc::result_of::Functor<ExprFunctor<Expr>, BOOST_PP_ENUM_PARAMS(N, Arg)>::type     \
@@ -118,8 +118,8 @@ struct ExprFunctor
 
     BOOST_PP_REPEAT_FROM_TO(1, LAMBDA_MAX_PARAMS, OPERATOR_CALL, _)
 
-    #undef OPERATOR_CALL
-    #undef CREF_TYPE_LIST
+#undef OPERATOR_CALL
+#undef CREF_TYPE_LIST
 };
 
 namespace result_of
@@ -158,4 +158,3 @@ make_Functor(const Expression<ExprType, Childs>& expr)
 
 } // lambda
 } // PMacc
-

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -28,20 +28,20 @@
 
 /* select namespace depending on __CUDA_ARCH__ compiler flag*/
 #ifdef __CUDA_ARCH__ //we are on gpu
-#define PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id) using namespace PMACC_JOIN(pmacc_static_const_vector_device,id)
+#   define PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id) using namespace PMACC_JOIN(pmacc_static_const_vector_device,id)
 #else
-#define PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id) using namespace PMACC_JOIN(pmacc_static_const_vector_host,id)
+#   define PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id) using namespace PMACC_JOIN(pmacc_static_const_vector_host,id)
 #endif
 
 #ifdef __CUDACC__
-    #define PMACC_STATIC_CONST_VECTOR_DIM_DEF_CUDA(id,Name,Type,...)               \
+#   define PMACC_STATIC_CONST_VECTOR_DIM_DEF_CUDA(id,Name,Type,...)                \
         namespace PMACC_JOIN(pmacc_static_const_vector_device,id)                  \
         {                                                                          \
            /* store all values in a const C array on device*/                      \
             __constant__ const Type PMACC_JOIN(Name, _data)[]={__VA_ARGS__};       \
         } /*namespace pmacc_static_const_vector_device + id */
 #else
-    #define PMACC_STATIC_CONST_VECTOR_DIM_DEF_CUDA(id,Name,Type,...)
+#   define PMACC_STATIC_CONST_VECTOR_DIM_DEF_CUDA(id,Name,Type,...)
 #endif
 
 /** define a const vector
@@ -86,14 +86,14 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
 using namespace PMACC_JOIN(pmacc_static_const_storage,id)
 
 #ifdef __CUDACC__
-    #define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE_CUDA(Name,id)               \
+#   define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE_CUDA(Name,id)                \
         namespace PMACC_JOIN(pmacc_static_const_vector_device,id)              \
         {                                                                      \
             /* create const instance on device */                              \
             __constant__ const PMACC_JOIN(Name,_t) Name;                       \
         } /* namespace pmacc_static_const_vector_device + id */
 #else
-    #define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE_CUDA(Name,id)
+#   define PMACC_STATIC_CONST_VECTOR_DIM_INSTANCE_CUDA(Name,id)
 #endif
 
 /** create a instance of type `Name_t` with the name `Name`

--- a/src/libPMacc/test/memory/memoryUT.cu
+++ b/src/libPMacc/test/memory/memoryUT.cu
@@ -97,9 +97,9 @@ BOOST_GLOBAL_FIXTURE(MyPMaccFixture);
 BOOST_AUTO_TEST_SUITE( memory )
 
   BOOST_AUTO_TEST_SUITE( HostBufferIntern )
-  #include "HostBufferIntern/copyFrom.hpp"
-  #include "HostBufferIntern/reset.hpp"
-  #include "HostBufferIntern/setValue.hpp"
+#   include "HostBufferIntern/copyFrom.hpp"
+#   include "HostBufferIntern/reset.hpp"
+#   include "HostBufferIntern/setValue.hpp"
   BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -18,17 +18,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FIELDE_KERNEL
-#define    FIELDE_KERNEL
+#pragma once
 
 #include "math/Vector.hpp"
-
 #include "simulation_classTypes.hpp"
-
 #include "dimensions/DataSpace.hpp"
-
 #include "memory/boxes/CachedBox.hpp"
-
 #include "nvidia/functors/Assign.hpp"
 #include "mappings/threads/ThreadCollective.hpp"
 
@@ -48,12 +43,10 @@ struct KernelLaserE
         EFieldOffset.x() = cellOffset.x() + (MappingDesc::SuperCellSize::x::value * GUARD_SIZE);
         EFieldOffset.y() = MappingDesc::SuperCellSize::y::value*GUARD_SIZE;
 
-    #if (SIMDIM==DIM3)
+#if( SIMDIM==DIM3 )
         cellOffset.z() = (blockIdx.y * blockDim.y) + threadIdx.y;
         EFieldOffset.z() = cellOffset.z() + (MappingDesc::SuperCellSize::z::value * GUARD_SIZE);
-    #endif
-
-        //uint32_t zOffset
+#endif
 
         /** Calculate how many neighbors to the left we have
          * to initialize the laser in the E-Field
@@ -84,13 +77,10 @@ struct KernelLaserE
              *
              *  \todo What about the B-Field in the second plane?
              */
-            cellOffset.y()=totalOffsetY;
+            cellOffset.y() = totalOffsetY;
             fieldE(EFieldOffset) = lMan.getManipulation(cellOffset);
         }
     }
 };
 
 }
-
-
-#endif  //end FIELDE_KERNEL

--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#ifndef FIELDMANIPULATOR_KERNEL
-#define    FIELDMANIPULATOR_KERNEL
+#pragma once
 
 #include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
@@ -106,12 +103,10 @@ struct KernelAbsorbBorder
             absorb < 0 > (field, thickness, absorber_strength, mapper, direction);
         else if (direction.y() != 0)
             absorb < 1 > (field, thickness, absorber_strength, mapper, direction);
-    #if (SDIMDIM==DIM3)
+#if( SDIMDIM==DIM3 )
         else if (direction.z() != 0)
             absorb < 2 > (field, thickness, absorber_strength, mapper, direction);
-    #endif
+#endif
     }
 };
-} //namespace
-#endif    /* FIELDMANIPULATOR_KERNEL */
-
+} // picongpu

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -163,14 +163,14 @@ struct KernelFillGridWithParticles
                 particle[localCellIdx_] = linearThreadIdx;
                 particle[weighting_] = macroWeighting;
 
-    #if(ENABLE_RADIATION == 1)
-    #    if(RAD_MARK_PARTICLE>1) && (RAD_ACTIVATE_GAMMA_FILTER==0)
+#if( ENABLE_RADIATION == 1 )
+#   if( RAD_MARK_PARTICLE>1 ) && ( RAD_ACTIVATE_GAMMA_FILTER==0 )
                 particle[radiationFlag_] = (bool)(rng() < (1.0 / (float_32) RAD_MARK_PARTICLE));
-    #    endif
-    #    if(RAD_ACTIVATE_GAMMA_FILTER!=0)
+#   endif
+#   if( RAD_ACTIVATE_GAMMA_FILTER!=0 )
                 particle[radiationFlag_] = (bool)(false);
-    #    endif
-    #endif
+#   endif
+#endif
 
                 numParsPerCell--;
                 if (numParsPerCell > 0)

--- a/src/picongpu/include/plugins/IsaacPlugin.hpp
+++ b/src/picongpu/include/plugins/IsaacPlugin.hpp
@@ -199,17 +199,17 @@ public:
         DataSpace< simDim >,
         textureDim,
         float3_X,
-        #if (ISAAC_STEREO == 0)
+#if( ISAAC_STEREO == 0 )
             isaac::DefaultController,
             isaac::DefaultCompositor
-        #else
+#else
             isaac::StereoController,
-            #if (ISAAC_STEREO == 1)
+#   if( ISAAC_STEREO == 1 )
                 isaac::StereoCompositorSideBySide<isaac::StereoController>
-            #else
+#   else
                 isaac::StereoCompositorAnaglyph<isaac::StereoController,0x000000FF,0x00FFFF00>
-            #endif
-        #endif
+#   endif
+#endif
     > * visualization;
 
     IsaacPlugin() :
@@ -370,17 +370,17 @@ private:
                 SourceList,
                 DataSpace< simDim >,
                 textureDim, float3_X,
-                #if (ISAAC_STEREO == 0)
+#if( ISAAC_STEREO == 0 )
                     isaac::DefaultController,
                     isaac::DefaultCompositor
-                #else
+#else
                     isaac::StereoController,
-                    #if (ISAAC_STEREO == 1)
+#   if( ISAAC_STEREO == 1 )
                         isaac::StereoCompositorSideBySide<isaac::StereoController>
-                    #else
+#   else
                         isaac::StereoCompositorAnaglyph<isaac::StereoController,0x000000FF,0x00FFFF00>
-                    #endif
-                #endif
+#   endif
+#endif
             > (
                 name,
                 0,

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -203,12 +203,12 @@ struct KernelPaintFields
                                         realCell[transpose.y()]);
         const DataSpace<simDim> realCell2(blockOffset + threadId); //delete guard from cell idx
 
-    #if (SIMDIM==DIM3)
+#if( SIMDIM==DIM3 )
         uint32_t globalCell = realCell2[sliceDim] + globalOffset;
 
         if (globalCell != slice)
             return;
-    #endif
+#endif
         // set fields of this cell to vars
         typename BBox::ValueType field_b = fieldB(cell);
         typename EBox::ValueType field_e = fieldE(cell);
@@ -292,11 +292,11 @@ struct KernelPaintParticles3D
         //\todo: guard size should not be set to (fixed) 1 here
         const DataSpace<simDim> realCell(blockOffset + threadId); //delete guard from cell idx
 
-    #if(SIMDIM==DIM3)
+#if( SIMDIM==DIM3 )
         uint32_t globalCell = realCell[sliceDim] + globalOffset;
 
         if (globalCell == slice)
-    #endif
+#endif
         {
             nvidia::atomicAllExch(&isValid,1); /*WAW Error in cuda-memcheck racecheck*/
             isImageThread = true;
@@ -341,10 +341,10 @@ struct KernelPaintParticles3D
                 int cellIdx = particle[localCellIdx_];
                 // we only draw the first slice of cells in the super cell (z == 0)
                 const DataSpace<simDim> particleCellId(DataSpaceOperations<simDim>::template map<Block > (cellIdx));
-    #if(SIMDIM==DIM3)
+#if( SIMDIM==DIM3 )
                 uint32_t globalParticleCell = particleCellId[sliceDim] + globalOffset + blockOffset[sliceDim];
                 if (globalParticleCell == slice)
-    #endif
+#endif
                 {
                     const DataSpace<DIM2> reducedCell(particleCellId[transpose.x()], particleCellId[transpose.y()]);
                     atomicAddWrapper(&(counter(reducedCell)), particle[weighting_] / particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -49,8 +49,8 @@
 #include "nvidia/atomic.hpp"
 
 
-#if (__NYQUISTCHECK__==1)
-#include "plugins/radiation/nyquist_low_pass.hpp"
+#if( __NYQUISTCHECK__ == 1 )
+#   include "plugins/radiation/nyquist_low_pass.hpp"
 #endif
 
 #include "plugins/radiation/radFormFactor.hpp"
@@ -139,18 +139,18 @@ struct KernelRadiationParticles
         // storage for macro particle weighting needed if
         // the coherent and incoherent radiation of a single
         // macro-particle needs to be considered
-    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+#if( __COHERENTINCOHERENTWEIGHTING__ == 1 )
         __shared__ float_X radWeighting_s[blockSize];
-    #endif
+#endif
 
         // particle counter used if not all particles are considered for
         // radiation calculation
         __shared__ int counter_s;
 
         // memory for Nyquist frequency at current time step
-    #if (__NYQUISTCHECK__==1)
+#if( __NYQUISTCHECK__ == 1 )
         __shared__ NyquistLowPass lowpass_s[blockSize];
-    #endif
+#endif
 
 
         const int theta_idx = blockIdx.x; //blockIdx.x is used to determine theta
@@ -248,9 +248,9 @@ struct KernelRadiationParticles
                          * for radiation calculation, check if particle contributes
                          * to the radiation calculation by checking its flag.
                          */
-    #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
                         if (par[radiationFlag_])
-    #endif
+#endif
                         saveParticleAt = nvidia::atomicAllInc(&counter_s);
                         /* for information:
                         *   atomicAdd returns an int with the previous
@@ -296,9 +296,9 @@ struct KernelRadiationParticles
                              * considered, the weighting of each macro-particle needs to be stored
                              * in order to be considered when the actual frequency calculation is done
                              */
-    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+#if( __COHERENTINCOHERENTWEIGHTING__ == 1 )
                            radWeighting_s[saveParticleAt] = weighting;
-    #endif
+#endif
 
                             // mass of macro-particle
                             const float_X particle_mass = attribute::getMass(weighting,par);
@@ -325,7 +325,7 @@ struct KernelRadiationParticles
 
 
                         // if coherent and incoherent of single macro-particle is considered
-    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+#if( __COHERENTINCOHERENTWEIGHTING__ == 1 )
                             // get charge of single electron ! (weighting=1.0f)
                             const picongpu::float_X particle_charge = frame::getCharge<FRAME>();
 
@@ -334,7 +334,7 @@ struct KernelRadiationParticles
                             real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
                               particle_charge *
                               picongpu::float_64(DELTA_T);
-    #else
+#else
                             // if coherent and incoherent of single macro-particle is NOT considered
 
                             // get charge of entire macro-particle
@@ -344,16 +344,16 @@ struct KernelRadiationParticles
                             real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look) *
                               particle_charge *
                               picongpu::float_64(DELTA_T);
-    #endif
+#endif
 
                             // retarded time stored in shared memory
                             t_ret_s[saveParticleAt] = amplitude3.get_t_ret(look);
 
                             // if Nyquist-limiter is used, then the NyquistLowPlass object
                             // is setup and stored in shared memory
-    #if (__NYQUISTCHECK__==1)
+#if( __NYQUISTCHECK__ == 1 )
                             lowpass_s[saveParticleAt] = NyquistLowPass(look, particle);
-    #endif
+#endif
 
 
                             /* the particle amplitude is used to include the weighting
@@ -398,9 +398,9 @@ struct KernelRadiationParticles
 
                     // if coherent and incoherent radiation of a single macro-particle
                     // is considered, create a form factor object
-    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+#    if (__COHERENTINCOHERENTWEIGHTING__==1)
                     const radFormFactor::radFormFactor myRadFormFactor{ };
-    #endif
+#    endif
 
                     /* Particle loop: thread runs through loaded particle data
                      *
@@ -412,11 +412,11 @@ struct KernelRadiationParticles
                       {
 
                         // if Nyquist-limiter is on
-    #if (__NYQUISTCHECK__==1)
+#    if (__NYQUISTCHECK__==1)
                         // check Nyquist-limit for each particle "j" and each frequency "omega"
                         if (lowpass_s[j].check(omega))
                           {
-    #endif
+#    endif
 
                             /****************************************************
                              **** Here happens the true physical calculation ****
@@ -426,15 +426,15 @@ struct KernelRadiationParticles
                             // if coherent/incoherent radiation of single macro-particle
                             // is considered
                             // the form factor influences the real amplitude
-    #if (__COHERENTINCOHERENTWEIGHTING__==1)
+#    if (__COHERENTINCOHERENTWEIGHTING__==1)
                             const vector_64 weighted_real_amp = real_amplitude_s[j] * precisionCast<float_64 >
                               (myRadFormFactor(radWeighting_s[j], omega, look));
-    #else
+#    else
                             // if coherent/incoherent radiation of single macro-particle
                             // is NOT considered
                             // no change on real amplitude is performed
                             const vector_64 weighted_real_amp = real_amplitude_s[j];
-    #endif
+#    endif
 
                             // complex amplitude for j-th particle
                             Amplitude amplitude_add(weighted_real_amp,
@@ -444,9 +444,9 @@ struct KernelRadiationParticles
                             amplitude += amplitude_add;
 
                             // if Nyquist limiter is on
-    #if (__NYQUISTCHECK__==1)
+#    if (__NYQUISTCHECK__==1)
                           }// END: check Nyquist-limit for each particle "j" and each frequency "omega"
-    #endif
+#    endif
 
                       }// END: Particle loop
 

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -79,7 +79,7 @@ namespace picongpu
     // corect treatment of coherent and incoherent  radiation from macroparticles
     // 1 = on  (slower and more memory, but correct quantitativ treatment)
     // 0 = off (faster but macroparticles are treated as highly charged, point-like particle)
-    #define __COHERENTINCOHERENTWEIGHTING__ 0
+#define __COHERENTINCOHERENTWEIGHTING__ 0
 
     /* Choose different form factors in order to consider different  particle shapes for radiation
      *  - radFormFactor_CIC_3D ... CIC charge distribution
@@ -107,22 +107,22 @@ namespace picongpu
     namespace parameters
     {
         /*!enable radiation calculation*/
-        #define ENABLE_RADIATION 0
+#define ENABLE_RADIATION 0
 
         // Nyquist low pass allows only amplitudes for frequencies below Nyquist frequency
         // 1 = on  (slower and more memory, no fourier reflections)
         // 0 = off (faster but with fourier reflections)
-        #define __NYQUISTCHECK__ 0
+#define __NYQUISTCHECK__ 0
 
 
 
         //marked every N particle for calculate radiation
         //mark no particle at beginning
-        #define RAD_MARK_PARTICLE 1
+#define RAD_MARK_PARTICLE 1
 
         //disable or enable gamme filter
         //diable (0) / enable (1)
-        #define RAD_ACTIVATE_GAMMA_FILTER 0
+#define RAD_ACTIVATE_GAMMA_FILTER 0
 
         constexpr float_32 RadiationGamma = 5.;
 

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -52,14 +52,14 @@ typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultPartic
 
 /*add old momentum for radiation plugin*/
 typedef MakeSeq<
-#if(ENABLE_RADIATION == 1)
+#if( ENABLE_RADIATION == 1 )
 momentumPrev1
 #endif
 >::type AttributMomentum_mt1;
 
 /*add old radiation flag for radiation plugin*/
 typedef MakeSeq<
-#if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
+#if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
 radiationFlag
 #endif
 >::type AttributRadiationFlag;
@@ -111,7 +111,7 @@ typedef bmpl::vector<
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioElectrons>,
     chargeRatio<ChargeRatioElectrons>
-#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
+#if( ENABLE_SYNCHROTRON_PHOTONS == 1 )
     , synchrotronPhotons<PIC_Photons>
 #endif
 > ParticleFlagsElectrons;
@@ -198,13 +198,13 @@ typedef Particles<
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
 typedef MakeSeq<
-#if (ENABLE_ELECTRONS == 1)
+#if( ENABLE_ELECTRONS == 1 )
 PIC_Electrons
 #endif
 >::type Species1;
 
 typedef MakeSeq<
-#if (ENABLE_IONS == 1)
+#if( ENABLE_IONS == 1 )
 PIC_Ions
 #endif
 >::type Species2;
@@ -212,7 +212,7 @@ PIC_Ions
 typedef MakeSeq<
 Species1,
 Species2
-#if(ENABLE_SYNCHROTRON_PHOTONS == 1)
+#if( ENABLE_SYNCHROTRON_PHOTONS == 1 )
 ,PIC_Photons
 #endif
 >::type VectorAllSpecies;

--- a/src/picongpu/include/simulation_defines/param/visualization.param
+++ b/src/picongpu/include/simulation_defines/param/visualization.param
@@ -47,9 +47,9 @@ namespace picongpu
         // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
         //             regime causes a bubble with radius of approx. the laser's
         //             beam waist (use for bubble fields)
-        #define EM_FIELD_SCALE_CHANNEL1 -1
-        #define EM_FIELD_SCALE_CHANNEL2 -1
-        #define EM_FIELD_SCALE_CHANNEL3 -1
+#define EM_FIELD_SCALE_CHANNEL1 -1
+#define EM_FIELD_SCALE_CHANNEL2 -1
+#define EM_FIELD_SCALE_CHANNEL3 -1
 
         // multiply highest undisturbed particle density with factor
         constexpr float_X preParticleDens_opacity = 0.25;

--- a/src/picongpu/include/simulation_defines/unitless/visualization.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/visualization.unitless
@@ -29,29 +29,29 @@ namespace picongpu
     // asserts for wrong user configurations
     //
     // setting 1: Laser
-    #if (EM_FIELD_SCALE_CHANNEL1 == 1 || EM_FIELD_SCALE_CHANNEL2 == 1 || EM_FIELD_SCALE_CHANNEL3 == 1)
-      PMACC_DEF_IN_NAMESPACE_MSG( You_can_not_scale_your_preview_to_laser_without_using_a_laser___change_visualization_param, laserProfile, AMPLITUDE );
-    #endif
+#if( EM_FIELD_SCALE_CHANNEL1 == 1 || EM_FIELD_SCALE_CHANNEL2 == 1 || EM_FIELD_SCALE_CHANNEL3 == 1 )
+    PMACC_DEF_IN_NAMESPACE_MSG( You_can_not_scale_your_preview_to_laser_without_using_a_laser___change_visualization_param, laserProfile, AMPLITUDE );
+#endif
 
     // setting 2: Drifting Plasma
-    #if (EM_FIELD_SCALE_CHANNEL1 == 2 || EM_FIELD_SCALE_CHANNEL2 == 2 || EM_FIELD_SCALE_CHANNEL3 == 2)
-      PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_drift_without_a_initially_drifting_plasma___change_visualization_param, ((PARTICLE_INIT_DRIFT_GAMMA)>1.0) );
-    #endif
+#if( EM_FIELD_SCALE_CHANNEL1 == 2 || EM_FIELD_SCALE_CHANNEL2 == 2 || EM_FIELD_SCALE_CHANNEL3 == 2 )
+    PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_drift_without_a_initially_drifting_plasma___change_visualization_param, ((PARTICLE_INIT_DRIFT_GAMMA)>1.0) );
+#endif
 
     // setting 3: Plasma Wave
-    #if (EM_FIELD_SCALE_CHANNEL1 == 3 || EM_FIELD_SCALE_CHANNEL2 == 3 || EM_FIELD_SCALE_CHANNEL3 == 3)
-      PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_plasma_density___change_visualization_param, ((GAS_DENSITY)>0.0 && gasProfile::GAS_ENABLED) );
-    #endif
+#if( EM_FIELD_SCALE_CHANNEL1 == 3 || EM_FIELD_SCALE_CHANNEL2 == 3 || EM_FIELD_SCALE_CHANNEL3 == 3 )
+    PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_plasma_density___change_visualization_param, ((GAS_DENSITY)>0.0 && gasProfile::GAS_ENABLED) );
+#endif
 
     // setting 4: Thermal Warm Plasma
-    #if (EM_FIELD_SCALE_CHANNEL1 == 4 || EM_FIELD_SCALE_CHANNEL2 == 4 || EM_FIELD_SCALE_CHANNEL3 == 4)
-      PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_plasma_density___change_visualization_param, ((GAS_DENSITY)>0.0 && gasProfile::GAS_ENABLED) );
-      PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_electron_temperature___change_visualization_param, ((ELECTRON_TEMPERATURE)>0.0) );
-    #endif
+#if( EM_FIELD_SCALE_CHANNEL1 == 4 || EM_FIELD_SCALE_CHANNEL2 == 4 || EM_FIELD_SCALE_CHANNEL3 == 4 )
+    PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_plasma_density___change_visualization_param, ((GAS_DENSITY)>0.0 && gasProfile::GAS_ENABLED) );
+    PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_electron_temperature___change_visualization_param, ((ELECTRON_TEMPERATURE)>0.0) );
+#endif
 
     // setting 5: Blow Out
-    #if (EM_FIELD_SCALE_CHANNEL1 == 5 || EM_FIELD_SCALE_CHANNEL2 == 5 || EM_FIELD_SCALE_CHANNEL3 == 5)
-      //PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_plasma_density___change_visualization_param, ((GAS_DENSITY)>0.0 && gasProfile::GAS_ENABLED) );
-      PMACC_DEF_IN_NAMESPACE_MSG( You_can_not_scale_your_preview_to_blowout_with_a_laser_without_beam_waist___change_visualization_param, laserProfile, W0 );
-    #endif
+#if( EM_FIELD_SCALE_CHANNEL1 == 5 || EM_FIELD_SCALE_CHANNEL2 == 5 || EM_FIELD_SCALE_CHANNEL3 == 5 )
+    //PMACC_CASSERT_MSG( You_can_not_scale_your_preview_to_a_zero_plasma_density___change_visualization_param, ((GAS_DENSITY)>0.0 && gasProfile::GAS_ENABLED) );
+    PMACC_DEF_IN_NAMESPACE_MSG( You_can_not_scale_your_preview_to_blowout_with_a_laser_without_beam_waist___change_visualization_param, laserProfile, W0 );
+#endif
 }


### PR DESCRIPTION
Close #1687: Updated with sed script (see separate PR) and comitted via generic "tools" user.

~~Looks a bit odd for `pragma omp ...` and `pragma unroll ...` instructions. Not sure if we really want that for `#pragma`, too because in such a case it is not a `pre-compiler` instruction but a *non-standard, extended type description* (attributes, no-inline, etc.) or *non-standard, compiler-specific compile-time hint*.~~ script and style rule updated