### PR TITLE
[WIP] make absorber reach a specific damping value

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gridConfig.param
@@ -62,8 +62,8 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -83,8 +83,8 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -62,8 +62,8 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleCurrent/include/simulation_defines/param/gridConfig.param
@@ -62,8 +62,8 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleRadiationWithLaser/include/simulation_defines/param/gridConfig.param
@@ -62,8 +62,8 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
@@ -62,8 +62,8 @@ namespace picongpu
         {0, 0}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
@@ -62,8 +62,8 @@ namespace picongpu
         {0, 0}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -62,7 +62,7 @@ public:
 
                 uint32_t thickness = ABSORBER_CELLS[direction][pos_or_neg];
 
-                float_X absorber_strength = -1.0 * math::log( ABSORBER_STRENGTH[direction][pos_or_neg] ) * thickness;
+                float_X absorber_strength = -1.0 * math::log( ABSORBER_MAXFACTOR[direction][pos_or_neg] ) * thickness;
 
                 if (thickness == 0) continue; /*if the absorber has no thickness we check the next side*/
 

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera
+ * Copyright 2013-2016 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -61,7 +61,8 @@ public:
                 uint32_t pos_or_neg = i % 2;
 
                 uint32_t thickness = ABSORBER_CELLS[direction][pos_or_neg];
-                float_X absorber_strength = ABSORBER_STRENGTH[direction][pos_or_neg];
+
+                float_X absorber_strength = -1.0 * math::log( ABSORBER_STRENGTH[direction][pos_or_neg] ) * thickness;
 
                 if (thickness == 0) continue; /*if the absorber has no thickness we check the next side*/
 

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -63,8 +63,8 @@ namespace picongpu
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
-    //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    //! Define the maximum weakening factor (at the outer border) that em field should be reduced to
+    const float_X ABSORBER_MAXFACTOR[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/


### PR DESCRIPTION
This pull request is a minimal change in the behavior of the absorber.

Currently `ABSORBER_STRENGTH` and `ABSORBER_CELLS` are independent and one might reach no damping if the first is too small compared to the second.

This pull request redefines the meaning of `ABSORBER_STRENGTH` to be the damping factor the be reached (exponentially). 

 - [ ] perform tests
