### PR TITLE
PngPlugin: help message if dependency is not compiled

### DIFF
--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -58,9 +58,7 @@
 #include "plugins/ILightweightPlugin.hpp"
 #include "plugins/ISimulationPlugin.hpp"
 
-#if(PIC_ENABLE_PNG==1)
 #include "plugins/output/images/PngCreator.hpp"
-#endif
 
 
 /// That's an abstract plugin for Png and Binary Density output
@@ -178,9 +176,7 @@ private:
 #if(ENABLE_RADIATION == 1)
       , Radiation<bmpl::_1>
 #endif
-#if(PIC_ENABLE_PNG==1)
      , PngPlugin< Visualisation<bmpl::_1, PngCreator> >
-#endif
 #if(ENABLE_HDF5 == 1)
       , ParticleCalorimeter<bmpl::_1>
       , PerSuperCell<bmpl::_1>

--- a/src/picongpu/include/plugins/PngPlugin.hpp
+++ b/src/picongpu/include/plugins/PngPlugin.hpp
@@ -71,11 +71,16 @@ namespace picongpu
 
         void pluginRegisterHelp(po::options_description& desc)
         {
+#if( PIC_ENABLE_PNG == 1 )
             desc.add_options()
                     ((analyzerPrefix + ".period").c_str(), po::value<std::vector<uint32_t> > (&notifyFrequencys)->multitoken(), "enable data output [for each n-th step]")
                     ((analyzerPrefix + ".axis").c_str(), po::value<std::vector<std::string > > (&axis)->multitoken(), "axis which are shown [valid values x,y,z] example: yz")
                     ((analyzerPrefix + ".slicePoint").c_str(), po::value<std::vector<float_32> > (&slicePoints)->multitoken(), "value range: 0 <= x <= 1 , point of the slice")
                     ((analyzerPrefix + ".folder").c_str(), po::value<std::vector<std::string> > (&folders)->multitoken(), "folder for output files");
+#else
+            desc.add_options()
+                    ((analyzerPrefix).c_str(), "plugin disabled [compiled without dependency PNGwriter]");
+#endif
         }
 
         void setMappingDescription(MappingDesc *cellDescription)

--- a/src/picongpu/include/plugins/output/images/PngCreator.hpp
+++ b/src/picongpu/include/plugins/output/images/PngCreator.hpp
@@ -22,26 +22,17 @@
 
 #include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include "simulation_types.hpp"
 
 #include <string>
-#include "mappings/simulation/GridController.hpp"
-
-#include <pngwriter.h>
-
 #include <iostream>
 #include <sstream>
-
 #include <iomanip>
 
-#include "memory/boxes/PitchedBox.hpp"
 #include "memory/boxes/DataBox.hpp"
 #include "plugins/output/header/MessageHeader.hpp"
 
-
 #include <boost/thread.hpp>
-//c includes
-#include <sys/stat.h>
+
 
 namespace picongpu
 {
@@ -136,75 +127,6 @@ namespace picongpu
 
     };
 
-    template<class Box>
-    inline void PngCreator::createImage(
-                                        const Box data,
-                                        const Size2D size,
-                                        const MessageHeader header
-                                        )
-    {
-        if (m_createFolder)
-        {
-            Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(m_folder);
-            m_createFolder = false;
-        }
-
-        std::stringstream step;
-        step << std::setw(6) << std::setfill('0') << header.sim.step;
-        std::string filename(m_name + "_" + step.str() + ".png");
-
-        pngwriter png(size.x(), size.y(), 0, filename.c_str());
-
-        /* default compression: 6
-         * zlib level 1 is ~12% bigger but ~2.3x faster in write_png()
-         */
-        png.setcompressionlevel(1);
-
-        //PngWriter coordinate system begin with 1,1
-        for (int y = 0; y < size.y(); ++y)
-        {
-            for (int x = 0; x < size.x(); ++x)
-            {
-                float3_X p = data[y ][x ];
-                png.plot(x + 1, size.y() - y, p.x(), p.y(), p.z());
-            }
-        }
-
-        /* scale the image by a user defined relative factor
-         * `scale_image` is defined in `visualization.param`
-         */
-        float_X scale_x(scale_image);
-        float_X scale_y(scale_image);
-
-
-        if (scale_to_cellsize)
-        {
-            // scale to real cell size
-            scale_x *= header.sim.scale[0];
-            scale_y *= header.sim.scale[1];
-        }
-
-        /* to prevent artifacts scale only, if at least one of scale_x and
-         * scale_y is != 1.0
-         */
-        if ((scale_x != float_X(1.0)) || (scale_y != float_X(1.0)))
-            //process the cell size and by factor scaling within one step
-            png.scale_kxky(scale_x, scale_y);
-
-        // add some meta information
-        //header.writeToConsole( std::cout );
-
-        std::ostringstream description( std::ostringstream::out );
-        header.writeToConsole( description );
-
-        char title[] = "PIConGPU preview image";
-        std::string author = Environment<>::get().SimulationDescription().getAuthor();
-        char software[] = "PIConGPU with PNGwriter";
-
-        png.settext( title, author.c_str(), description.str().c_str(), software);
-
-        // write to disk and close object
-        png.close();
-    }
-
 } /* namespace picongpu */
+
+#include "plugins/output/images/PngCreator.tpp"

--- a/src/picongpu/include/plugins/output/images/PngCreator.tpp
+++ b/src/picongpu/include/plugins/output/images/PngCreator.tpp
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2013-2016 Axel Huebl, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
+#include "plugins/output/images/PngCreator.hpp"
+#include "memory/boxes/DataBox.hpp"
+#include "plugins/output/header/MessageHeader.hpp"
+#include "verify.hpp"
+
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+#include <boost/core/ignore_unused.hpp>
+
+#if( PIC_ENABLE_PNG == 1 )
+#   include <pngwriter.h>
+#endif
+
+namespace picongpu
+{
+    template< class Box >
+    inline void PngCreator::createImage(
+        const Box data,
+        const Size2D size,
+        const MessageHeader header
+    )
+    {
+#if( PIC_ENABLE_PNG == 1 )
+        if ( m_createFolder )
+        {
+            Environment< simDim >::get( ).Filesystem( ).createDirectoryWithPermissions( m_folder );
+            m_createFolder = false;
+        }
+
+        std::stringstream step;
+        step << std::setw( 6 ) << std::setfill( '0' ) << header.sim.step;
+        std::string filename( m_name + "_" + step.str( ) + ".png" );
+
+        pngwriter png( size.x( ), size.y( ), 0, filename.c_str( ) );
+
+        /* default compression: 6
+         * zlib level 1 is ~12% bigger but ~2.3x faster in write_png( )
+         */
+        png.setcompressionlevel( 1 );
+
+        //PngWriter coordinate system begin with 1,1
+        for( int y = 0; y < size.y( ); ++y)
+        {
+            for( int x = 0; x < size.x( ); ++x )
+            {
+                float3_X p = data[ y ][ x ];
+                png.plot( x + 1, size.y( ) - y, p.x( ), p.y( ), p.z( ) );
+            }
+        }
+
+        /* scale the image by a user defined relative factor
+         * `scale_image` is defined in `visualization.param`
+         */
+        float_X scale_x( scale_image );
+        float_X scale_y( scale_image );
+
+
+        if( scale_to_cellsize )
+        {
+            // scale to real cell size
+            scale_x *= header.sim.scale[ 0 ];
+            scale_y *= header.sim.scale[ 1 ];
+        }
+
+        /* to prevent artifacts scale only, if at least one of scale_x and
+         * scale_y is != 1.0
+         */
+        if( ( scale_x != float_X( 1.0 ) ) ||
+            ( scale_y != float_X( 1.0 ) )
+        )
+            //process the cell size and by factor scaling within one step
+            png.scale_kxky( scale_x, scale_y );
+
+        // add some meta information
+        //header.writeToConsole( std::cout );
+
+        std::ostringstream description( std::ostringstream::out );
+        header.writeToConsole( description );
+
+        char title[ ] = "PIConGPU preview image";
+        std::string author = Environment<>::get().SimulationDescription().getAuthor( );
+        char software[ ] = "PIConGPU with PNGwriter";
+
+        png.settext( title, author.c_str( ), description.str( ).c_str( ), software );
+
+        // write to disk and close object
+        png.close( );
+#else
+        boost::ignore_unused( data, size, header );
+        /* always fail with an exception at runtime */
+        PMACC_VERIFY_MSG( false, "not allowed to call createImage (missing dependency PNGwriter)" );
+#endif
+
+    }
+
+} /* namespace picongpu */


### PR DESCRIPTION
If `pngwriter` is not available at compile time, the plugin `PngPlugin` register a help with information why the plugin can't use at runtime.

- PngCreator: add "tpp` file for `operator()`
- PngPlugin: add help message if `pngwriter` is not avail


This is the first plugin which full fill #1700


```bash
./picongpu --help
# ...
PositionsParticles: write position of one particle of a species to std::cout:
  --i_position.period arg               enable analyser [for each n-th step]

PngPlugin: create pngs of a species and fields:
  --i_png                               plugin disabled [compiled without 
                                        dependency pngwriter]
# ...
PositionsParticles: write position of one particle of a species to std::cout:
  --e_position.period arg               enable analyser [for each n-th step]

PngPlugin: create pngs of a species and fields:
  --e_png                               plugin disabled [compiled without 
                                        dependency pngwriter]
# ...
```