### PR TITLE
FieldTmp: Multiple Slots

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/memory.param
+++ b/examples/Bunch/include/simulation_defines/param/memory.param
@@ -53,4 +53,8 @@ constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
 constexpr uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
 constexpr uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
 constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
+
+/** number of scalar fields that are reserved as temporary fields */
+constexpr uint32_t fieldTmpNumSlots = 1;
+
 }//namespace picongpu

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
@@ -53,4 +53,8 @@ constexpr uint32_t BYTES_EXCHANGE_Y = 12 * 512 * 1024; //12 MiB
 constexpr uint32_t BYTES_EXCHANGE_Z = 8 * 256 * 1024; //8 MiB
 constexpr uint32_t BYTES_CORNER = 16 * 1024; //16 kiB;
 constexpr uint32_t BYTES_EDGES = 64 * 1024; //64 kiB;
+
+/** number of scalar fields that are reserved as temporary fields */
+constexpr uint32_t fieldTmpNumSlots = 1;
+
 }//namespace picongpu

--- a/examples/LaserWakefield/include/simulation_defines/param/memory.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/memory.param
@@ -53,4 +53,8 @@ constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 512 * 1024; //6 MiB
 constexpr uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
 constexpr uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
 constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
+
+/** number of scalar fields that are reserved as temporary fields */
+constexpr uint32_t fieldTmpNumSlots = 1;
+
 }//namespace picongpu

--- a/examples/ThermalTest/include/simulation_defines/param/memory.param
+++ b/examples/ThermalTest/include/simulation_defines/param/memory.param
@@ -53,4 +53,8 @@ constexpr uint32_t BYTES_EXCHANGE_Y = 40 * 1024 * 1024; //6 MiB
 constexpr uint32_t BYTES_EXCHANGE_Z = 40 * 1024 * 1024; //4 MiB
 constexpr uint32_t BYTES_CORNER = 800 * 1024; //8 kiB;
 constexpr uint32_t BYTES_EDGES = 3200 * 1024; //32 kiB;
+
+/** number of scalar fields that are reserved as temporary fields */
+constexpr uint32_t fieldTmpNumSlots = 1;
+
 }//namespace picongpu

--- a/examples/WeibelTransverse/include/simulation_defines/param/memory.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/memory.param
@@ -52,4 +52,8 @@ constexpr uint32_t BYTES_EXCHANGE_Y = 12 * 512 * 1024; //12 MiB
 constexpr uint32_t BYTES_EXCHANGE_Z = 256 * 256 * 1024; //256 MiB
 constexpr uint32_t BYTES_CORNER = 2 * 256 * 1024; //2 MiB
 constexpr uint32_t BYTES_EDGES = 8 * 256 * 1024; //8 MiB
+
+/** number of scalar fields that are reserved as temporary fields */
+constexpr uint32_t fieldTmpNumSlots = 1;
+
 }//namespace picongpu

--- a/src/picongpu/include/fields/FieldTmp.hpp
+++ b/src/picongpu/include/fields/FieldTmp.hpp
@@ -50,7 +50,9 @@ namespace picongpu
     /** Tmp (at the moment: scalar) field for analysers and tmp data like
      *  "gridded" particle data (charge density, energy density, ...)
      */
-    class FieldTmp : public SimulationFieldHelper<MappingDesc>, public ISimulationData
+    class FieldTmp :
+        public SimulationFieldHelper<MappingDesc>,
+        public ISimulationData
     {
     public:
         typedef float1_X ValueType;
@@ -64,13 +66,16 @@ namespace picongpu
             return this->cellDescription;
         }
 
-        FieldTmp( MappingDesc cellDescription );
+        FieldTmp(
+            MappingDesc cellDescription,
+            uint32_t slotId
+        );
 
         virtual ~FieldTmp( );
 
         virtual void reset( uint32_t currentStep );
 
-        template<class FrameSolver >
+        template< class FrameSolver >
         HDINLINE static UnitValueType getUnit();
 
         /** powers of the 7 base measures
@@ -84,7 +89,7 @@ namespace picongpu
 
         static std::string getName();
 
-        static uint32_t getCommTag();
+        uint32_t getCommTag();
 
         virtual EventTask asyncCommunication( EventTask serialEvent );
 
@@ -100,6 +105,8 @@ namespace picongpu
 
         template<uint32_t AREA, class FrameSolver, class ParticlesClass>
         void computeValue(ParticlesClass& parClass, uint32_t currentStep);
+
+        static SimulationDataId getUniqueId( uint32_t slotId );
 
         SimulationDataId getUniqueId();
 
@@ -117,8 +124,12 @@ namespace picongpu
         void insertField( uint32_t exchangeType );
 
     private:
+
         GridBuffer<ValueType, simDim> *fieldTmp;
 
+        uint32_t m_slotId;
+
+        uint32_t m_commTag;
     };
 
 

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -84,7 +84,7 @@ public:
 
     void createParticleBuffer();
 
-    void init(FieldE &fieldE, FieldB &fieldB, FieldJ &fieldJ, FieldTmp &fieldTmp);
+    void init(FieldE &fieldE, FieldB &fieldB);
 
     void update(uint32_t currentStep);
 
@@ -164,8 +164,6 @@ private:
 
     FieldE *fieldE;
     FieldB *fieldB;
-    FieldJ *fieldJcurrent;
-    FieldTmp *fieldTmp;
 };
 
 namespace traits

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -32,8 +32,6 @@
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
-#include "fields/FieldJ.hpp"
-#include "fields/FieldTmp.hpp"
 
 #include "particles/memory/buffers/ParticlesBuffer.hpp"
 #include "ParticlesInit.kernel"
@@ -76,8 +74,6 @@ Particles<
     >( cellDescription ),
     fieldB( NULL ),
     fieldE( NULL ),
-    fieldJcurrent( NULL ),
-    fieldTmp( NULL ),
     m_gridLayout(gridLayout),
     m_datasetID( datasetID )
 {
@@ -210,12 +206,10 @@ Particles<
     T_Name,
     T_Attributes,
     T_Flags
->::init( FieldE &fieldE, FieldB &fieldB, FieldJ &fieldJ, FieldTmp &fieldTmp )
+>::init( FieldE &fieldE, FieldB &fieldB )
 {
     this->fieldE = &fieldE;
     this->fieldB = &fieldB;
-    this->fieldJcurrent = &fieldJ;
-    this->fieldTmp = &fieldTmp;
 
     Environment<>::get( ).DataConnector( ).registerData( *this );
 }

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -111,11 +111,9 @@ struct CallInit
     template<typename T_StorageTuple>
     HINLINE void operator()(T_StorageTuple& tuple,
                             FieldE* fieldE,
-                            FieldB* fieldB,
-                            FieldJ* fieldJ,
-                            FieldTmp* fieldTmp) const
+                            FieldB* fieldB) const
     {
-        tuple[SpeciesName()]->init(*fieldE, *fieldB, *fieldJ, *fieldTmp);
+        tuple[SpeciesName()]->init( *fieldE, *fieldB );
     }
 };
 

--- a/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "static_assert.hpp"
 #include "simulation_defines.hpp"
 #include "memory/buffers/GridBuffer.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
@@ -74,7 +75,12 @@ private:
     {
         using namespace splash;
         DataConnector &dc = Environment<>::get().DataConnector();
-        FieldTmp& fieldTmp = dc.getData<FieldTmp > (FieldTmp::getName(), true);
+
+        PMACC_CASSERT_MSG(
+            _please_allocate_at_least_one_FieldTmp_in_memory_param,
+            fieldTmpNumSlots > 0
+        );
+        FieldTmp& fieldTmp = dc.getData<FieldTmp >( FieldTmp::getUniqueId( 0 ), true );
         PMACC_AUTO(&fieldBuffer, fieldTmp.getGridBuffer());
 
         deviceDataBox = fieldBuffer.getDeviceBuffer().getDataBox();

--- a/src/picongpu/include/plugins/ChargeConservation.tpp
+++ b/src/picongpu/include/plugins/ChargeConservation.tpp
@@ -18,6 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "static_assert.hpp"
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"
 #include "math/vector/Size_t.hpp"
@@ -188,7 +189,11 @@ void ChargeConservation::notify(uint32_t currentStep)
     DataConnector &dc = Environment<>::get().DataConnector();
 
     /* load FieldTmp without copy data to host */
-    FieldTmp* fieldTmp = &(dc.getData<FieldTmp > (FieldTmp::getName(), true));
+    PMACC_CASSERT_MSG(
+        _please_allocate_at_least_one_FieldTmp_in_memory_param,
+        fieldTmpNumSlots > 0
+    );
+    FieldTmp* fieldTmp = &(dc.getData< FieldTmp >( FieldTmp::getUniqueId( 0 ), true ));
     /* reset density values to zero */
     fieldTmp->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
 

--- a/src/picongpu/include/plugins/IsaacPlugin.hpp
+++ b/src/picongpu/include/plugins/IsaacPlugin.hpp
@@ -25,7 +25,10 @@
 
 #include "plugins/ILightweightPlugin.hpp"
 #include "dataManagement/DataConnector.hpp"
+#include "static_assert.hpp"
+
 #include <isaac.hpp>
+
 #include <boost/fusion/container/list.hpp>
 #include <boost/fusion/include/list.hpp>
 #include <boost/fusion/container/list/list_fwd.hpp>
@@ -134,8 +137,14 @@ class TFieldSource< FieldTmpOperation< FrameSolver, ParticleType > >
                 uint32_t* currentStep = (uint32_t*)pointer;
                 const SubGrid<simDim>& subGrid = Environment< simDim >::get().SubGrid();
                 DataConnector &dc = Environment< simDim >::get().DataConnector();
-                FieldTmp * fieldTmp = &(dc.getData< FieldTmp > (FieldTmp::getName(), true));
+
+                PMACC_CASSERT_MSG(
+                    _please_allocate_at_least_one_FieldTmp_in_memory_param,
+                    fieldTmpNumSlots > 0
+                );
+                FieldTmp * fieldTmp = &(dc.getData< FieldTmp >( FieldTmp::getUniqueId( 0 ), true ));
                 ParticleType * particles = &(dc.getData< ParticleType > ( ParticleType::FrameType::getName(), true));
+
                 fieldTmp->getGridBuffer().getDeviceBuffer().setValue( FieldTmp::ValueType(0.0) );
                 fieldTmp->computeValue < CORE + BORDER, FrameSolver > (*particles, *currentStep);
                 EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "pmacc_types.hpp"
+#include "static_assert.hpp"
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
 
@@ -232,7 +233,11 @@ private:
             /*## update field ##*/
 
             /*load FieldTmp without copy data to host*/
-            FieldTmp* fieldTmp = &(dc.getData<FieldTmp > (FieldTmp::getName(), true));
+            PMACC_CASSERT_MSG(
+                _please_allocate_at_least_one_FieldTmp_in_memory_param,
+                fieldTmpNumSlots > 0
+            );
+            FieldTmp* fieldTmp = &(dc.getData<FieldTmp > (FieldTmp::getUniqueId( 0 ), true));
             /*load particle without copy particle data to host*/
             Species* speciesTmp = &(dc.getData<Species >(Species::FrameType::getName(), true));
 
@@ -259,7 +264,7 @@ private:
                        getName(),
                        fieldTmp->getHostDataBox().getPointer());
 
-            dc.releaseData(FieldTmp::getName());
+            dc.releaseData( FieldTmp::getUniqueId( 0 ) );
 
         }
 

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "static_assert.hpp"
 #include "simulation_types.hpp"
 #include "plugins/hdf5/HDF5Writer.def"
 #include "plugins/hdf5/writer/Field.hpp"
@@ -170,7 +171,11 @@ private:
         /*## update field ##*/
 
         /*load FieldTmp without copy data to host*/
-        FieldTmp* fieldTmp = &(dc.getData<FieldTmp > (FieldTmp::getName(), true));
+        PMACC_CASSERT_MSG(
+            _please_allocate_at_least_one_FieldTmp_in_memory_param,
+            fieldTmpNumSlots > 0
+        );
+        FieldTmp* fieldTmp = &(dc.getData<FieldTmp >( FieldTmp::getUniqueId( 0 ), true ));
         /*load particle without copy particle data to host*/
         Species* speciesTmp = &(dc.getData<Species >(Species::FrameType::getName(), true));
 
@@ -210,7 +215,7 @@ private:
                           fieldTmp->getHostDataBox(),
                           ValueType());
 
-        dc.releaseData(FieldTmp::getName());
+        dc.releaseData( FieldTmp::getUniqueId( 0 ) );
 
     }
 

--- a/src/picongpu/include/simulation_defines/param/memory.param
+++ b/src/picongpu/include/simulation_defines/param/memory.param
@@ -53,4 +53,8 @@ namespace picongpu
     constexpr uint32_t BYTES_EXCHANGE_Z = 4 * 256 * 1024; //4 MiB
     constexpr uint32_t BYTES_CORNER = 8 * 1024; //8 kiB;
     constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
+
+    /** number of scalar fields that are reserved as temporary fields */
+    constexpr uint32_t fieldTmpNumSlots = 1;
+
 } //namespace picongpu

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -44,7 +44,6 @@ enum CommunicationTag
     FIELD_E = 2u,
     FIELD_J = 3u,
     FIELD_JRECV = 4u,
-    FIELD_TMP = 5u,
     SPECIES_FIRSTTAG = 42u
 };
 


### PR DESCRIPTION
Allows to use multiple `GridBuffers` ("slots") in `FieldTmp` for all operations done with it so far.

Required for, e.g., T_e and n_e in Thomas-Fermi Ionization.

Current control: the number of scalar temporary fields can be set in `memory.param` via:
```C++
/** number of scalar fields that are reserved as temporary fields */
constexpr uint32_t fieldTmpNumSlots = 1;
```

~~Still throws dozens of `__host__ __device__` warnings but might compile already.~~

Thanks to @psychocoderHPC for pair programming support.

### Usage

```C++
/* I want to access FieldTmp! */
DataConnector &dc = Environment<>::get().DataConnector();

/* And while we are defining this code, just saying: I will use two (2) slots of it,
 *   <<So, do you copy?! - ... Brzzzz >> */
PMACC_CASSERT_MSG(
    _please_allocate_at_least_two_FieldTmp_slots_in_memory_param,
    fieldTmpNumSlots >= 2
);
 
/* load each (scalar field) slot without copy data to host */
FieldTmp& density = dc.getData< FieldTmp >( FieldTmp::getUniqueId( 0 ), true );
FieldTmp& eneKin = dc.getData< FieldTmp >( FieldTmp::getUniqueId( 1 ), true );

/* reset density and kinetic energy values to zero */
density.getGridBuffer().getDeviceBuffer().setValue( FieldTmp::ValueType( 0.0 ) );
eneKin.getGridBuffer().getDeviceBuffer().setValue( FieldTmp::ValueType( 0.0 ) );
 
/* calculate and add the density values from all species */
ForEach<
    VectorAllSpecies, /* you want to use only e- species here */
    picongpu::detail::ComputeDensity< bmpl::_1, bmpl::int_< CORE + BORDER > >,
    MakeIdentifier< bmpl::_1 >
> computeDensity;
computeDensity( forward(&density), currentStep );

/* calculate and add the kinetic energy values from all species */
ForEach<
    VectorAllSpecies, /* you want to use only e- species here */
    picongpu::detail::ComputeEnergy< bmpl::_1, bmpl::int_< CORE + BORDER > >,
    MakeIdentifier< bmpl::_1 >
> computeEnergy;
computeEnergy( forward(&eneKin), currentStep );
 
/* add results of all species that are still in GUARD to next GPUs BORDER */
EventTask densityEvent = density.asyncCommunication( __getTransactionEvent() );
EventTask energyEvent = eneKin.asyncCommunication( __getTransactionEvent() );
__setTransactionEvent( fieldTmpEvent + energyEvent );

/* do work on density & eneKin */
// ...

/* release data */
dc.releaseData( FieldTmp::getUniqueId( 0 ) );
dc.releaseData( FieldTmp::getUniqueId( 1 ) );
```

### To Do

- [x] remove all new warnings
- [x] RT test in default slot 0
- [x] RT test with a slot number > 0