### PR TITLE
use new host device warning suppressor

### DIFF
--- a/src/libPMacc/include/pmacc_types.hpp
+++ b/src/libPMacc/include/pmacc_types.hpp
@@ -77,7 +77,7 @@ typedef long long int int64_cu;
 #define PMACC_GLOBAL_KEYWORD __location__(global)
 
 /*
- * Disable nvcc warning:
+ * Disable nvcc warnings and errors:
  * calling a __host__ function from __host__ __device__ function.
  *
  * Usage:
@@ -90,8 +90,8 @@ typedef long long int int64_cu;
  * WARNING: only use this method if there is no other way to create runable code.
  * Most cases can solved by #ifdef __CUDA_ARCH__ or #ifdef __CUDACC__.
  */
-#if defined(__CUDACC__)
-#define PMACC_NO_NVCC_HDWARNING _Pragma("hd_warning_disable")
+#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
+#define PMACC_NO_NVCC_HDWARNING _Pragma("nv_exec_check_disable")
 #else
 #define PMACC_NO_NVCC_HDWARNING
 #endif


### PR DESCRIPTION
- use `#pragma nv_exec_check_disable` instead of `#pragma hd_warning_disable`
- `nv_exec_check_disable` is available since CUDA 7.5

PMacc only supports CUDA 7.5+ therefore we can fully switch to the new flag.

There is no documentation about the old and the new flag available. [thrust](https://github.com/thrust/thrust/blob/8e35dce3d2003f9e9f7eed8dac31be7f050c8b2d/thrust/detail/config/exec_check_disable.h) and [VTK-m](http://m.vtk.org/documentation/ExportMacros_8h_source.html) changed the flag from `hd_warning_disable` to `nv_exec_check_disable`. 
From the [thrust pull request](https://github.com/thrust/thrust/pull/680) it looks like the new prgma can also suppress error messages.