### PR TITLE
Param: Type List Syntax

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -39,42 +39,25 @@ namespace picongpu
 /*########################### define particle attributes #####################*/
 
 /** describe attributes of a particle*/
-typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultParticleAttributes;
-
-/** \todo: not nice, we change this later with nice interfaces
- * Plugins should add required attributes
- */
-
-/*add old momentum for radiation plugin*/
-typedef MakeSeq<
+using DefaultParticleAttributes = MakeSeq_t<
+    position<position_pic>,
+    momentum,
+    weighting
 #if( ENABLE_RADIATION == 1 )
-momentumPrev1
+    , momentumPrev1
 #endif
->::type AttributMomentum_mt1;
-
-/*add old radiation flag for radiation plugin*/
-typedef MakeSeq<
-#if( RAD_MARK_PARTICLE>1 ) || ( RAD_ACTIVATE_GAMMA_FILTER!=0 )
-radiationFlag
+#if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
+    , radiationFlag
 #endif
->::type AttributRadiationFlag;
-
-/* attribute sequence for species: electrons */
-typedef
-MakeSeq<
-DefaultParticleAttributes,
-AttributMomentum_mt1,
-AttributRadiationFlag
->::type AttributeSeqElectrons;
+>;
 
 /* attribute sequence for species: ions */
-typedef
-MakeSeq<
-DefaultParticleAttributes,
-AttributMomentum_mt1,
-AttributRadiationFlag,
-boundElectrons
->::type AttributeSeqIons;
+using AttributeSeqIons = MakeSeq_t<
+    DefaultParticleAttributes,
+#if( PARAM_IONIZATION == 1 )
+    boundElectrons
+#endif
+>;
 
 /*########################### end particle attributes ########################*/
 
@@ -84,30 +67,30 @@ boundElectrons
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioElectrons, 1.0);
-value_identifier(float_X, ChargeRatioElectrons, 1.0);
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-typedef bmpl::vector<
-    particlePusher<UsedParticlePusher>,
-    shape<UsedParticleShape>,
-    interpolation<UsedField2Particle>,
-    current<UsedParticleCurrentSolver>,
-    massRatio<MassRatioElectrons>,
-    chargeRatio<ChargeRatioElectrons>
-> ParticleFlagsElectrons;
+using ParticleFlagsElectrons = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioElectrons >,
+    chargeRatio< ChargeRatioElectrons >
+>;
 
 /* define species: electrons */
-typedef Particles<
-    bmpl::string<'e'>,
-    AttributeSeqElectrons,
+using PIC_Electrons = Particles<
+    bmpl::string< 'e' >,
+    DefaultParticleAttributes,
     ParticleFlagsElectrons
-> PIC_Electrons;
+>;
 
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioIons, 1836.152672);
-value_identifier(float_X, ChargeRatioIons, -1.0);
+value_identifier( float_X, MassRatioIons, 1836.152672 );
+value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /*! Specify (chemical) element
  *
@@ -146,30 +129,32 @@ struct Hydrogen
  *
  * Usage: Add a flag to the list of particle flags that has the following structure
  *
- *        ionizer<IonizationModel<Species2BCreated> >
+ *        ionizer< IonizationModel< Species2BCreated > >
  */
 
-typedef bmpl::vector<
-    particlePusher<UsedParticlePusher>,
-    shape<UsedParticleShape>,
-    interpolation<UsedField2Particle>,
-    current<UsedParticleCurrentSolver>,
-    massRatio<MassRatioIons>,
-    chargeRatio<ChargeRatioIons>,
+using ParticleFlagsIons = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioIons >,
+    chargeRatio< ChargeRatioIons >,
 #if( PARAM_IONIZATION == 1 )
-    ionizer<particles::ionization::BSIEffectiveZ<PIC_Electrons> >,
-    ionizationEnergies<AU::IONIZATION_ENERGY_HYDROGEN_t>,
-    effectiveAtomicNumbers<Z_EFFECTIVE_HYDROGEN_t>,
+    ionizer<
+        particles::ionization::BSIEffectiveZ< PIC_Electrons >
+    >,
+    ionizationEnergies< AU::IONIZATION_ENERGY_HYDROGEN_t >,
+    effectiveAtomicNumbers< Z_EFFECTIVE_HYDROGEN_t >,
 #endif
-    atomicNumbers<Hydrogen>
-> ParticleFlagsIons;
+    atomicNumbers< Hydrogen >
+>;
 
 /* define species: ions */
-typedef Particles<
-    bmpl::string<'i'>,
+using PIC_Ions = Particles<
+    bmpl::string< 'i' >,
     AttributeSeqIons,
     ParticleFlagsIons
-> PIC_Ions;
+>;
 
 /*########################### end species ####################################*/
 
@@ -177,22 +162,21 @@ typedef Particles<
 /*! we delete this ugly definition of VectorAllSpecies after all picongpu components
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
-typedef MakeSeq<
+using Species1 = MakeSeq_t<
 #if( ENABLE_ELECTRONS == 1 )
-PIC_Electrons
+    PIC_Electrons
 #endif
->::type Species1;
+>;
 
-typedef MakeSeq<
+using Species2 = MakeSeq_t<
 #if( ENABLE_IONS == 1 )
-PIC_Ions
+    PIC_Ions
 #endif
->::type Species2;
+>;
 
-typedef MakeSeq<
-Species1,
-Species2
->::type VectorAllSpecies;
-
+using VectorAllSpecies = MakeSeq_t<
+    Species1,
+    Species2
+>;
 
 } //namespace picongpu

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -30,40 +30,23 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-
 namespace picongpu
 {
 
 /*########################### define particle attributes #####################*/
 
 /** describe attributes of a particle*/
-typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultParticleAttributes;
-
-
-/** \todo: not nice, we change this later with nice interfaces
- * Plugins should add required attributes
- */
-
-/*add old momentum for radiation plugin*/
-typedef MakeSeq<
+using DefaultParticleAttributes = MakeSeq_t<
+    position<position_pic>,
+    momentum,
+    weighting
 #if( ENABLE_RADIATION == 1 )
-momentumPrev1
+    , momentumPrev1
 #endif
->::type AttributMomentum_mt1;
-
-/*add old radiation flag for radiation plugin*/
-typedef MakeSeq<
 #if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
-radiationFlag
+    , radiationFlag
 #endif
->::type AttributRadiationFlag;
-
-typedef MakeSeq<
-DefaultParticleAttributes,
-AttributMomentum_mt1,
-AttributRadiationFlag
->::type DefaultAttributesSeq;
+>;
 
 /*########################### end particle attributes ########################*/
 
@@ -80,7 +63,7 @@ AttributRadiationFlag
 value_identifier(float_X, MassRatioElectrons, 1.0);
 value_identifier(float_X, ChargeRatioElectrons, 1.0);
 
-typedef bmpl::vector<
+using ParticleFlagsElectrons = bmpl::vector<
 /* enable the pusher only if PARAM_ENABLEPUSHER is defined as one `1` */
 #if( PARAM_ENABLEPUSHER == 1 )
     particlePusher<UsedParticlePusher>,
@@ -90,76 +73,22 @@ typedef bmpl::vector<
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioElectrons>,
     chargeRatio<ChargeRatioElectrons>
-> ParticleFlagsElectrons;
+>;
 
-/*define specie electrons*/
-typedef Particles<
+/* define species electrons */
+using PIC_Electrons = Particles<
     bmpl::string<'e'>,
-    DefaultAttributesSeq,
+    DefaultParticleAttributes,
     ParticleFlagsElectrons
-> PIC_Electrons;
-
-/*--------------------------- ions -------------------------------------------*/
-
-/* ratio relative to BASE_CHARGE and BASE_MASS */
-//value_identifier(float_X, MassRatioIons, 1836.152672);
-//value_identifier(float_X, ChargeRatioIons, -1.0);
-
-/*! Specify (chemical) element
- *
- * Proton and neutron numbers define the chemical element that the ion species
- * is based on. This value can be non-integer for physical models taking
- * charge shielding effects into account.
- * @see http://en.wikipedia.org/wiki/Effective_nuclear_charge
- *
- * It is wrapped into a struct because of C++ restricting floats from being
- * template arguments.
- *
- * Do not forget to set the correct mass of the atom in
- * @see physicalConstants.param !
- */
-//struct Hydrogen
-//{
-//    static constexpr float_X numberOfProtons  = 1.0;
-//    static constexpr float_X numberOfNeutrons = 0.0;
-//};
-
-/*! Ionization Model Configuration ----------------------------------------
- *
- * - None : no particle is ionized
- * - BSIHydrogenLike : simple barrier suppression ionization
- * - ADKLinPol : Ammosov-Delone-Krainov tunneling ionization (H-like)
- *               -> linearly polarized lasers
- * - ADKCircPol : Ammosov-Delone-Krainov tunneling ionization (H-like)
- *                -> circularly polarized lasers
- * - Keldysh : Keldysh ionization model
- *
- * Research and development: ----------------------------------------------
- * - BSIEffectiveZ : BSI taking electron shielding into account via an effective
- *                   atomic number Z_eff
- * - BSIStarkShifted : BSI for hydrogen-like atoms and ions considering the
- *                     Stark upshift of ionization potentials
- *
- * Usage: Add a flag to the list of particle flags that has the following structure
- *
- *        ionizer<IonizationModel<Species2BCreated> >
- */
+>;
 
 /*########################### end species ####################################*/
 
-
-/*! we delete this ugly definition of VectorAllSpecies after all picongpu components
- * support multi species */
-/** \todo: not nice, but this should be changed in the future*/
-typedef MakeSeq<
+using VectorAllSpecies = MakeSeq_t<
 #if( ENABLE_ELECTRONS == 1 )
-PIC_Electrons
+    PIC_Electrons
 #endif
->::type Species1;
-
-typedef MakeSeq<
-Species1
->::type VectorAllSpecies;
+>;
 
 
 } //namespace picongpu

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -37,33 +37,18 @@ namespace picongpu
 
 /*########################### define particle attributes #####################*/
 
-/** describe attributes of a particle*/
-typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultParticleAttributes;
-
-
-/** \todo: not nice, we change this later with nice interfaces
- * Plugins should add required attributes
- */
-
-/*add old momentum for radiation plugin*/
-typedef MakeSeq<
+/** describe attributes of a particle */
+using DefaultParticleAttributes = MakeSeq_t<
+    position<position_pic>,
+    momentum,
+    weighting
 #if( ENABLE_RADIATION == 1 )
-momentumPrev1
+    , momentumPrev1
 #endif
->::type AttributMomentum_mt1;
-
-/*add old radiation flag for radiation plugin*/
-typedef MakeSeq<
 #if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
-radiationFlag
+    , radiationFlag
 #endif
->::type AttributRadiationFlag;
-
-typedef MakeSeq<
-DefaultParticleAttributes,
-AttributMomentum_mt1,
-AttributRadiationFlag
->::type DefaultAttributesSeq;
+>;
 
 /*########################### end particle attributes ########################*/
 
@@ -73,30 +58,30 @@ AttributRadiationFlag
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioElectrons, 1.0);
-value_identifier(float_X, ChargeRatioElectrons, 1.0);
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-typedef bmpl::vector<
+using ParticleFlagsElectrons = bmpl::vector<
     particlePusher<UsedParticlePusher>,
     shape<UsedParticleShape>,
     interpolation<UsedField2Particle>,
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioElectrons>,
     chargeRatio<ChargeRatioElectrons>
-> ParticleFlagsElectrons;
+>;
 
-/*define specie electrons*/
-typedef Particles<
-    bmpl::string<'e'>,
-    DefaultAttributesSeq,
+/* define species electrons */
+using PIC_Electrons = Particles<
+    bmpl::string< 'e' >,
+    DefaultParticleAttributes,
     ParticleFlagsElectrons
-> PIC_Electrons;
+>;
 
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioIons, 1.0);
-value_identifier(float_X, ChargeRatioIons, -1.0);
+value_identifier( float_X, MassRatioIons, 1.0 );
+value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /*! Specify (chemical) element
  *
@@ -135,24 +120,24 @@ struct Hydrogen
  *
  * Usage: Add a flag to the list of particle flags that has the following structure
  *
- *        ionizer<IonizationModel<Species2BCreated> >
+ *        ionizer< IonizationModel< Species2BCreated > >
  */
 
-typedef bmpl::vector<
+using ParticleFlagsIons = bmpl::vector<
     particlePusher<UsedParticlePusher>,
     shape<UsedParticleShape>,
     interpolation<UsedField2Particle>,
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioIons>,
     chargeRatio<ChargeRatioIons>
-> ParticleFlagsIons;
+>;
 
 /*define specie ions*/
-typedef Particles<
+using PIC_Ions = Particles<
     bmpl::string<'i'>,
-    DefaultAttributesSeq,
+    DefaultParticleAttributes,
     ParticleFlagsIons
-> PIC_Ions;
+>;
 
 /*########################### end species ####################################*/
 
@@ -160,22 +145,21 @@ typedef Particles<
 /*! we delete this ugly definition of VectorAllSpecies after all picongpu components
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
-typedef MakeSeq<
+using Species1 = MakeSeq_t<
 #if( ENABLE_ELECTRONS == 1 )
-PIC_Electrons
+    PIC_Electrons
 #endif
->::type Species1;
+>;
 
-typedef MakeSeq<
+using Species2 = MakeSeq_t<
 #if( ENABLE_IONS == 1 )
-PIC_Ions
+    PIC_Ions
 #endif
->::type Species2;
+>;
 
-typedef MakeSeq<
-Species1,
-Species2
->::type VectorAllSpecies;
-
+using VectorAllSpecies = MakeSeq_t<
+    Species1,
+    Species2
+>;
 
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -54,54 +54,60 @@ namespace picongpu
     using namespace particleToGrid;
 
     /* ChargeDensity section */
-    typedef bmpl::transform<
-            VectorAllSpecies,
-            CreateChargeDensityOperation<bmpl::_1>
-            >::type ChargeDensity_Seq;
+    using ChargeDensity_Seq = bmpl::transform<
+        VectorAllSpecies,
+        CreateChargeDensityOperation< bmpl::_1 >
+    >::type;
 
     /* ParticleCounter section */
-    typedef bmpl::transform<
-            VectorAllSpecies,
-            CreateCounterOperation<bmpl::_1>
-            >::type Counter_Seq;
+    using Counter_Seq = bmpl::transform<
+        VectorAllSpecies,
+        CreateCounterOperation< bmpl::_1 >
+    >::type;
 
     /* EnergyDensity section */
-    typedef bmpl::transform<
-            VectorAllSpecies,
-            CreateEnergyDensityOperation<bmpl::_1>
-            >::type EnergyDensity_Seq;
+    using EnergyDensity_Seq = bmpl::transform<
+        VectorAllSpecies,
+        CreateEnergyDensityOperation< bmpl::_1 >
+    >::type;
 
     /* CreateMomentumComponentOperation section: define "component" as
        0=X (default), 1=Y or 2=Z (results: [-1.:1.])
      */
-    typedef bmpl::transform<
-            VectorAllSpecies,
-            CreateMomentumComponentOperation<bmpl::_1, bmpl::int_<0> >
-            >::type MomentumComponent_Seq;
+    using MomentumComponent_Seq = bmpl::transform<
+        VectorAllSpecies,
+        CreateMomentumComponentOperation<
+            bmpl::_1,
+            bmpl::int_< 0 >
+        >
+    >::type;
 
 
     /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
      *
      * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
      */
-    typedef MakeSeq<
+    using FieldTmpSolvers = MakeSeq_t<
         ChargeDensity_Seq,
         Counter_Seq,
         EnergyDensity_Seq,
         MomentumComponent_Seq
-    >::type FieldTmpSolvers;
+    >;
 
 
     /** FileOutputFields: Groups all Fields that shall be dumped *************/
 
     /** Possible native fields: FieldE, FieldB, FieldJ
      */
-    typedef MakeSeq<FieldE, FieldB>::type NativeFileOutputFields;
+    using NativeFileOutputFields = MakeSeq_t<
+        FieldE,
+        FieldB
+    >;
 
-    typedef MakeSeq<
+    using FileOutputFields = MakeSeq_t<
         NativeFileOutputFields,
         FieldTmpSolvers
-    >::type FileOutputFields;
+    >;
 
 
     /** FileOutputParticles: Groups all Species that shall be dumped **********
@@ -109,6 +115,6 @@ namespace picongpu
      * hint: to disable particle output set to
      *   typedef bmpl::vector0< > FileOutputParticles;
      */
-    typedef VectorAllSpecies FileOutputParticles;
+    using FileOutputParticles = VectorAllSpecies;
 
 }

--- a/src/picongpu/include/simulation_defines/param/isaac.param
+++ b/src/picongpu/include/simulation_defines/param/isaac.param
@@ -25,17 +25,24 @@ namespace picongpu
 namespace isaacP
 {
 
-    //Native fields to visualize
-    typedef MakeSeq<FieldE, FieldB, FieldJ>::type Native_Seq;
+    // Native fields to visualize
+    using Native_Seq = MakeSeq_t<
+        FieldE,
+        FieldB,
+        FieldJ
+    >;
 
-    //Creating a density field for every species to visualize
-    typedef bmpl::transform<
-            VectorAllSpecies,
-            CreateDensityOperation<bmpl::_1>
-            >::type Density_Seq;
+    // Creating a density field for every species to visualize
+    using Density_Seq = bmpl::transform<
+        VectorAllSpecies,
+        CreateDensityOperation< bmpl::_1 >
+    >::type;
 
-    //bmpl::list of all fields to visualize
-    typedef MakeSeq<Native_Seq,Density_Seq>::type Fields_Seq;
+    // list of all fields to visualize
+    using Fields_Seq = MakeSeq_t<
+        Native_Seq,
+        Density_Seq
+    >;
 
 } // namespace isaacP
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -39,32 +39,17 @@ namespace picongpu
 /*########################### define particle attributes #####################*/
 
 /** describe attributes of a particle*/
-typedef MakeSeq<position<position_pic>, momentum, weighting>::type DefaultParticleAttributes;
-
-
-/** \todo: not nice, we change this later with nice interfaces
- * Plugins should add required attributes
- */
-
-/*add old momentum for radiation plugin*/
-typedef MakeSeq<
+using DefaultParticleAttributes = MakeSeq_t<
+    position< position_pic >,
+    momentum,
+    weighting
 #if( ENABLE_RADIATION == 1 )
-momentumPrev1
+    , momentumPrev1
 #endif
->::type AttributMomentum_mt1;
-
-/*add old radiation flag for radiation plugin*/
-typedef MakeSeq<
 #if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
-radiationFlag
+    , radiationFlag
 #endif
->::type AttributRadiationFlag;
-
-typedef MakeSeq<
-DefaultParticleAttributes,
-AttributMomentum_mt1,
-AttributRadiationFlag
->::type DefaultAttributesSeq;
+>;
 
 /*########################### end particle attributes ########################*/
 
@@ -72,55 +57,55 @@ AttributRadiationFlag
 
 /*--------------------------- photons -------------------------------------------*/
 
-value_identifier(float_X, DummyMass, 1.0);
-value_identifier(float_X, DummyCharge, 0.0);
+value_identifier( float_X, DummyMass, 1.0 );
+value_identifier( float_X, DummyCharge, 0.0 );
 
-typedef bmpl::vector<
-    particlePusher<particles::pusher::Photon>,
-    shape<UsedParticleShape>,
-    interpolation<UsedField2Particle>,
-    current<UsedParticleCurrentSolver>,
-    massRatio<DummyMass>,
-    chargeRatio<DummyCharge>
-> ParticleFlagsPhotons;
+using ParticleFlagsPhotons = bmpl::vector<
+    particlePusher< particles::pusher::Photon >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< DummyMass >,
+    chargeRatio< DummyCharge >
+>;
 
-/*define species photons*/
-typedef Particles<
-    bmpl::string<'p', 'h'>,
-    DefaultAttributesSeq,
+/* define species photons */
+using PIC_Photons = Particles<
+    bmpl::string< 'p', 'h' >,
+    DefaultParticleAttributes,
     ParticleFlagsPhotons
-> PIC_Photons;
+>;
 
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioElectrons, 1.0);
-value_identifier(float_X, ChargeRatioElectrons, 1.0);
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-typedef bmpl::vector<
-    particlePusher<UsedParticlePusher>,
-    shape<UsedParticleShape>,
-    interpolation<UsedField2Particle>,
-    current<UsedParticleCurrentSolver>,
-    massRatio<MassRatioElectrons>,
-    chargeRatio<ChargeRatioElectrons>
+using ParticleFlagsElectrons = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioElectrons >,
+    chargeRatio< ChargeRatioElectrons >
 #if( ENABLE_SYNCHROTRON_PHOTONS == 1 )
-    , synchrotronPhotons<PIC_Photons>
+    , synchrotronPhotons< PIC_Photons >
 #endif
-> ParticleFlagsElectrons;
+>;
 
-/*define specie electrons*/
-typedef Particles<
-    bmpl::string<'e'>,
-    DefaultAttributesSeq,
+/* define species electrons */
+using PIC_Electrons = Particles<
+    bmpl::string< 'e' >,
+    DefaultParticleAttributes,
     ParticleFlagsElectrons
-> PIC_Electrons;
+>;
 
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioIons, 1836.152672);
-value_identifier(float_X, ChargeRatioIons, -1.0);
+value_identifier( float_X, MassRatioIons, 1836.152672 );
+value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /*! Specify (chemical) element
  *
@@ -159,24 +144,24 @@ struct Hydrogen
  *
  * Usage: Add a flag to the list of particle flags that has the following structure
  *
- *        ionizer<IonizationModel<Species2BCreated> >
+ *        ionizer< IonizationModel< Species2BCreated > >
  */
 
-typedef bmpl::vector<
-    particlePusher<UsedParticlePusher>,
-    shape<UsedParticleShape>,
-    interpolation<UsedField2Particle>,
-    current<UsedParticleCurrentSolver>,
-    massRatio<MassRatioIons>,
-    chargeRatio<ChargeRatioIons>
-> ParticleFlagsIons;
+using ParticleFlagsIons = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioIons >,
+    chargeRatio< ChargeRatioIons >
+>;
 
-/*define specie ions*/
-typedef Particles<
-    bmpl::string<'i'>,
-    DefaultAttributesSeq,
+/* define species ions */
+using PIC_Ions = Particles<
+    bmpl::string< 'i' >,
+    DefaultParticleAttributes,
     ParticleFlagsIons
-> PIC_Ions;
+>;
 
 /*########################### end species ####################################*/
 
@@ -184,24 +169,24 @@ typedef Particles<
 /*! we delete this ugly definition of VectorAllSpecies after all picongpu components
  * support multi species */
 /** \todo: not nice, but this should be changed in the future*/
-typedef MakeSeq<
+using Species1 = MakeSeq_t<
 #if( ENABLE_ELECTRONS == 1 )
-PIC_Electrons
+    PIC_Electrons
 #endif
->::type Species1;
+>;
 
-typedef MakeSeq<
+using Species2 = MakeSeq_t<
 #if( ENABLE_IONS == 1 )
-PIC_Ions
+    PIC_Ions
 #endif
->::type Species2;
+>;
 
-typedef MakeSeq<
-Species1,
-Species2
+using VectorAllSpecies = MakeSeq_t<
+    Species1,
+    Species2
 #if( ENABLE_SYNCHROTRON_PHOTONS == 1 )
-,PIC_Photons
+    , PIC_Photons
 #endif
->::type VectorAllSpecies;
+>;
 
 } //namespace picongpu

--- a/src/picongpu/include/simulation_defines/unitless/checkpoints.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/checkpoints.unitless
@@ -30,13 +30,16 @@ namespace picongpu
     /** Note: we need at least FieldE and FieldB for restart
      *        capabilities!
      */
-    typedef MakeSeq<FieldE, FieldB>::type NativeFileCheckpointFields;
+    using NativeFileCheckpointFields = MakeSeq_t<
+        FieldE,
+        FieldB
+    >;
 
     /* List of particle species for checkpoint/restart */
-    typedef VectorAllSpecies FileCheckpointParticles;
+    using FileCheckpointParticles = VectorAllSpecies;
 
     /**  List of fields for checkpoint/restart */
-    typedef MakeSeq<
-            NativeFileCheckpointFields
-    >::type FileCheckpointFields;
+    using FileCheckpointFields = MakeSeq_t<
+        NativeFileCheckpointFields
+    >;
 }


### PR DESCRIPTION
Use a more natural `using Sequence = MakeSeq_t< 1, 2, 3 >;` syntax for user input of type lists via `MakeSeq_t` and C++11 `using`.

Avoids boiler plate code without `=` and additional `::type` access:
`typedef Seq< 1, 2, 3 >::type List;`

Cleaned up syntax of `speciesDefinition` on the way.