### PR TITLE
simplify species definition

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -26,13 +26,9 @@
 #include "simulation_defines.hpp"
 #include "particles/Identifier.hpp"
 #include "compileTime/conversion/MakeSeq.hpp"
-#include "dimensions/DataSpace.hpp"
-#include "identifier/identifier.hpp"
-#include "identifier/alias.hpp"
 #include "identifier/value_identifier.hpp"
 
 #include "particles/Particles.hpp"
-#include "particles/ParticleDescription.hpp"
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
@@ -102,12 +98,9 @@ typedef bmpl::vector<
 
 /* define species: electrons */
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'e'>,
-        SuperCellSize,
-        AttributeSeqElectrons,
-        ParticleFlagsElectrons
-    >
+    bmpl::string<'e'>,
+    AttributeSeqElectrons,
+    ParticleFlagsElectrons
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -173,12 +166,9 @@ typedef bmpl::vector<
 
 /* define species: ions */
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'i'>,
-        SuperCellSize,
-        AttributeSeqIons,
-        ParticleFlagsIons
-    >
+    bmpl::string<'i'>,
+    AttributeSeqIons,
+    ParticleFlagsIons
 > PIC_Ions;
 
 /*########################### end species ####################################*/

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -25,13 +25,9 @@
 #include "simulation_defines.hpp"
 #include "particles/Identifier.hpp"
 #include "compileTime/conversion/MakeSeq.hpp"
-#include "dimensions/DataSpace.hpp"
-#include "identifier/identifier.hpp"
-#include "identifier/alias.hpp"
 #include "identifier/value_identifier.hpp"
 
 #include "particles/Particles.hpp"
-#include "particles/ParticleDescription.hpp"
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
@@ -98,12 +94,9 @@ typedef bmpl::vector<
 
 /*define specie electrons*/
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'e'>,
-        SuperCellSize,
-        DefaultAttributesSeq,
-        ParticleFlagsElectrons
-    >
+    bmpl::string<'e'>,
+    DefaultAttributesSeq,
+    ParticleFlagsElectrons
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -25,13 +25,9 @@
 #include "simulation_defines.hpp"
 #include "particles/Identifier.hpp"
 #include "compileTime/conversion/MakeSeq.hpp"
-#include "dimensions/DataSpace.hpp"
-#include "identifier/identifier.hpp"
-#include "identifier/alias.hpp"
 #include "identifier/value_identifier.hpp"
 
 #include "particles/Particles.hpp"
-#include "particles/ParticleDescription.hpp"
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
@@ -91,12 +87,9 @@ typedef bmpl::vector<
 
 /*define specie electrons*/
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'e'>,
-        SuperCellSize,
-        DefaultAttributesSeq,
-        ParticleFlagsElectrons
-    >
+    bmpl::string<'e'>,
+    DefaultAttributesSeq,
+    ParticleFlagsElectrons
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -156,12 +149,9 @@ typedef bmpl::vector<
 
 /*define specie ions*/
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'i'>,
-        SuperCellSize,
-        DefaultAttributesSeq,
-        ParticleFlagsIons
-    >
+    bmpl::string<'i'>,
+    DefaultAttributesSeq,
+    ParticleFlagsIons
 > PIC_Ions;
 
 /*########################### end species ####################################*/

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -25,14 +25,10 @@
 #include "simulation_defines.hpp"
 #include "particles/Identifier.hpp"
 #include "compileTime/conversion/MakeSeq.hpp"
-#include "dimensions/DataSpace.hpp"
-#include "identifier/identifier.hpp"
-#include "identifier/alias.hpp"
 #include "identifier/value_identifier.hpp"
 
 #include "particles/traits/FilterByFlag.hpp"
 #include "particles/Particles.hpp"
-#include "particles/ParticleDescription.hpp"
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
@@ -90,12 +86,9 @@ typedef bmpl::vector<
 
 /*define species photons*/
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'p', 'h'>,
-        SuperCellSize,
-        DefaultAttributesSeq,
-        ParticleFlagsPhotons
-    >
+    bmpl::string<'p', 'h'>,
+    DefaultAttributesSeq,
+    ParticleFlagsPhotons
 > PIC_Photons;
 
 /*--------------------------- electrons --------------------------------------*/
@@ -118,12 +111,9 @@ typedef bmpl::vector<
 
 /*define specie electrons*/
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'e'>,
-        SuperCellSize,
-        DefaultAttributesSeq,
-        ParticleFlagsElectrons
-    >
+    bmpl::string<'e'>,
+    DefaultAttributesSeq,
+    ParticleFlagsElectrons
 > PIC_Electrons;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -183,12 +173,9 @@ typedef bmpl::vector<
 
 /*define specie ions*/
 typedef Particles<
-    ParticleDescription<
-        bmpl::string<'i'>,
-        SuperCellSize,
-        DefaultAttributesSeq,
-        ParticleFlagsIons
-    >
+    bmpl::string<'i'>,
+    DefaultAttributesSeq,
+    ParticleFlagsIons
 > PIC_Ions;
 
 /*########################### end species ####################################*/


### PR DESCRIPTION
This removes the complicated interface to define a species away from the PIConGPU user. Objects like `ParticleDesction` and `SuperCellSize` are hard to handle for the user.

- refactor `Particle<>` interface
- remove `SuperCellSize` and `ParticleDesciption<>` from PIConGPU user interface
- remove unused includes
