### PR TITLE
add missing minus sign wavepacket laser transversal

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -113,7 +113,7 @@ HDINLINE float3_X laserTransversal(float3_X elong, const float_X, const float_X 
     const float_X exp_x = posX * posX / (W0_X * W0_X);
     const float_X exp_z = posZ * posZ / (W0_Z * W0_Z);
 
-    return elong * math::exp(exp_x + exp_z);
+    return elong * math::exp( float_X( -1.0 ) * ( exp_x + exp_z ) );
 
 }
 


### PR DESCRIPTION
This fixes issue #1720.

Since [December 2015](https://github.com/ComputationalRadiationPhysics/picongpu/commit/0acbd9050fdb4af40aa14434d3cdc11e8a862222) we fixed the implementation of the  transversely asymmetric envelope of the `laserWavepacket`. Due to this change a minus disappeared, which causes different (see issue) numerical artifacts. 

 - [x] test new version