### PR TITLE
Documentation: Empty Example & TBG_macros.cfg

### DIFF
--- a/doc/TBG_macros.cfg
+++ b/doc/TBG_macros.cfg
@@ -39,12 +39,15 @@
 # Batch system walltime
 TBG_wallTime="1:00:00"
 
-# Number of GPUs in each dimension (x,y,z) to use for the simunaltion.
+# Number of GPUs in each dimension (x,y,z) to use for the simulation
 TBG_gpu_x=1
 TBG_gpu_y=2
 TBG_gpu_z=1
 
 # Size of the simulation grid in cells as "-g X Y Z"
+# note: the number of cells needs to be an exact multiple of a supercell
+#       and has to be at least 3 supercells per GPU,
+#       the size of a supercell (in cells) is defined in `memory.param`
 TBG_gridSize="-g 128 256 128"
 
 # Number of simulation steps/iterations as "-s N"
@@ -124,8 +127,8 @@ TBG_<species>_pos_dbg="--<species>_position.period 1"
 
 
 # Create a particle-energy histogram [in keV] per species for every .period steps
-TBG_<species>_Histogram="--<species>_energyHistogram.period 500 --<species>_energyHistogram.binCount 1024 \
-                       --<species>_energyHistogram.minEnergy 0 --<species>_energyHistogram.maxEnergy 500000"
+TBG_<species>_histogram="--<species>_energyHistogram.period 500 --<species>_energyHistogram.binCount 1024    \
+                         --<species>_energyHistogram.minEnergy 0 --<species>_energyHistogram.maxEnergy 500000"
 
 
 # Calculate a 2D phase space

--- a/examples/Empty/submit/1gpu.cfg
+++ b/examples/Empty/submit/1gpu.cfg
@@ -1,0 +1,67 @@
+# Copyright 2013-2016 Axel Huebl, Rene Widera, Felix Schmitt
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      doc/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="2:00:00"
+
+TBG_gpu_x=1
+TBG_gpu_y=1
+TBG_gpu_z=1
+
+TBG_gridSize="-g 128 256 128"
+TBG_steps="-s 1000"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+# Create a particle-energy histogram [in keV] for species "e" for every 100 steps
+TBG_e_histogram="--e_energyHistogram.period 100 --e_energyHistogram.binCount 1024    \
+                 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 500000"
+
+TBG_plugins="!TBG_e_histogram"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+
+TBG_programParams="!TBG_devices      \
+                   !TBG_gridSize     \
+                   !TBG_steps        \
+                   !TBG_plugins"
+
+# TOTAL number of GPUs
+TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+
+"$TBG_cfgPath"/submitAction.sh


### PR DESCRIPTION
Fixes a small typo in `TBG_macros` and a spelling inconsistency, adds a bit further description on cells per GPU and supercells and adds a 1 GPU `.cfg` file to `Empty` so people cloning from that have an example to adjust instead of writing from scratch.