### PR TITLE
Topic use remove shared keyword

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -33,6 +33,8 @@
 #include "particles/operations/Deselect.hpp"
 #include "traits/NumberOfExchanges.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
 
 namespace PMacc
 {
@@ -59,7 +61,6 @@ struct KernelShiftParticles
         typedef T_ParBox ParBox;
         typedef typename ParBox::FrameType FrameType;
         typedef typename ParBox::FramePtr FramePtr;
-        typedef typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type FramePtrShared;
 
         const uint32_t dim = Mapping::Dim;
         const uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
@@ -70,14 +71,15 @@ struct KernelShiftParticles
          * index range [0,numExchanges-1] are being referred to as `low frames`
          * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
          */
-        __shared__ FramePtrShared destFrames[numExchanges * 2];
-        __shared__ int destFramesCounter[numExchanges]; //count particles per frame
+        PMACC_SMEM( destFrames, memory::Array< FramePtr, numExchanges * 2 > );
+        //count particles per frame
+        PMACC_SMEM( destFramesCounter, memory::Array< int, numExchanges > );
 
         /* lastFrameSize is only valid for threads with `linearThreadIdx` < numExchanges */
         uint32_t lastFrameSize = 0;
 
-        __shared__ FramePtrShared frame;
-        __shared__ bool mustShift;
+        PMACC_SMEM( frame, FramePtr );
+        PMACC_SMEM( mustShift, bool );
 
         DataSpace<dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<dim> (blockIdx) );
         const uint32_t linearThreadIdx = threadIdx.x;
@@ -106,7 +108,7 @@ struct KernelShiftParticles
             destFrames[linearThreadIdx] = FramePtr();
             destFrames[linearThreadIdx + numExchanges] = FramePtr();
             /* load last frame of neighboring supercell */
-            FramePtrShared tmpFrame(pb.getLastFrame( relative ));
+            FramePtr tmpFrame(pb.getLastFrame( relative ));
 
             if ( tmpFrame.isValid() )
             {
@@ -155,7 +157,7 @@ struct KernelShiftParticles
                     /* if we had no `low frame` we load a new empty one */
                     if ( !destFrames[linearThreadIdx].isValid() )
                     {
-                        FramePtrShared tmpFrame(pb.getEmptyFrame( ));
+                        FramePtr tmpFrame(pb.getEmptyFrame( ));
                         destFrames[linearThreadIdx] = tmpFrame;
                         pb.setAsLastFrame( tmpFrame, relative );
                     }
@@ -163,7 +165,7 @@ struct KernelShiftParticles
                     if ( destFramesCounter[linearThreadIdx] > frameSize )
                     {
                             lastFrameSize = destFramesCounter[linearThreadIdx] - frameSize;
-                            FramePtrShared tmpFrame(pb.getEmptyFrame( ));
+                            FramePtr tmpFrame(pb.getEmptyFrame( ));
                             destFrames[linearThreadIdx + numExchanges] = tmpFrame;
                             pb.setAsLastFrame( tmpFrame, relative );
                     }
@@ -243,14 +245,12 @@ struct KernelFillGapsLastFrame
 
         DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
+        PMACC_SMEM( lastFrame, FramePtr );
 
-        __shared__ int gapIndices_sh[TileSize];
-        __shared__ int counterGaps;
-        __shared__ int counterParticles;
-
-        __shared__ int srcGap;
-
+        PMACC_SMEM( gapIndices_sh, memory::Array< int, TileSize > );
+        PMACC_SMEM( counterGaps, int);
+        PMACC_SMEM( counterParticles, int);
+        PMACC_SMEM( srcGap, int);
 
         if ( threadIdx.x == 0 )
         {
@@ -318,12 +318,12 @@ struct KernelFillGaps
         DataSpace<Dim> superCellIdx( mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) ) );
 
         //data copied from right (last) to left (first)
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type firstFrame;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type lastFrame;
+        PMACC_SMEM( firstFrame, FramePtr );
+        PMACC_SMEM( lastFrame, FramePtr );
 
-        __shared__ int particleIndices_sh[TileSize];
-        __shared__ int counterGaps;
-        __shared__ int counterParticles;
+        PMACC_SMEM( particleIndices_sh, memory::Array< int, TileSize> );
+        PMACC_SMEM( counterGaps, int );
+        PMACC_SMEM( counterParticles, int );
 
 
         if ( threadIdx.x == 0 )
@@ -432,7 +432,7 @@ struct KernelDeleteParticles
         DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
         const int linearThreadIdx = threadIdx.x;
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        PMACC_SMEM( frame, FramePtr );
 
         if ( linearThreadIdx == 0 )
         {
@@ -482,10 +482,10 @@ struct KernelBashParticles
 
         DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
 
-        __shared__ int numBashedParticles;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-        __shared__ bool hasMemory;
-        __shared__ TileDataBox<BORDER> tmpBorder;
+        PMACC_SMEM( numBashedParticles, int );
+        PMACC_SMEM( frame, FramePtr );
+        PMACC_SMEM( hasMemory, bool );
+        PMACC_SMEM( tmpBorder, TileDataBox<BORDER> );
 
         if ( threadIdx.x == 0 )
         {
@@ -571,9 +571,9 @@ struct KernelInsertParticles
         };
 
         typedef typename ParBox::FramePtr FramePtr;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-        __shared__ int elementCount;
-        __shared__ TileDataBox<BORDER> tmpBorder;
+        PMACC_SMEM( frame, FramePtr );
+        PMACC_SMEM( elementCount, int );
+        PMACC_SMEM( tmpBorder, TileDataBox<BORDER> );
 
 
         DataSpace < Mapping::Dim - 1 > superCell;

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -31,6 +31,7 @@
 #include "particles/particleFilter/FilterFactory.hpp"
 #include "particles/particleFilter/PositionFilter.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
 
 
 
@@ -55,9 +56,9 @@ struct KernelCountParticles
         typedef typename PBox::FramePtr FramePtr;
         const uint32_t Dim = Mapping::Dim;
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-        __shared__ int counter;
-        __shared__ lcellId_t particlesInSuperCell;
+        PMACC_SMEM( frame, FramePtr );
+        PMACC_SMEM( counter, int );
+        PMACC_SMEM( particlesInSuperCell, lcellId_t );
 
 
         typedef typename Mapping::SuperCellSize SuperCellSize;

--- a/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
+++ b/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
@@ -29,6 +29,8 @@
 #include "particles/frame_types.hpp"
 #include "nvidia/atomic.hpp"
 #include "debug/VerboseLog.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
 
 namespace PMacc
 {
@@ -76,9 +78,9 @@ namespace kernel
             constexpr unsigned NumDims = T_DestBox::Dim;
             constexpr uint32_t particlesPerFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
-            __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<DestFramePtr>::type destFramePtr[particlesPerFrame];
-            __shared__ int linearSuperCellIds[particlesPerFrame];
-            __shared__ int srcParticleOffset;
+            PMACC_SMEM( destFramePtr, memory::Array< DestFramePtr, particlesPerFrame > );
+            PMACC_SMEM( linearSuperCellIds, memory::Array< int, particlesPerFrame > );
+            PMACC_SMEM( srcParticleOffset, int );
 
 
             const int linearThreadIdx = threadIdx.x;

--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -24,6 +24,7 @@
 #include "simulation_defines.hpp"
 #include "simulation_classTypes.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -44,7 +45,7 @@ DINLINE void absorb(BoxedMemory field, uint32_t thickness, float_X absorber_stre
     //cells in simulation
     const DataSpace<simDim> gCells = mapper.getGridSuperCells() * SuperCellSize::toRT();
 
-    __shared__ int finish;
+    PMACC_SMEM( finish, int );
 
 
     float_X factor = float_X(0.0);

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -38,6 +38,7 @@
 #include "algorithms/Set.hpp"
 
 #include "particles/frame_types.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -57,9 +58,9 @@ namespace picongpu
             const DataSpace<simDim > threadIndex( threadIdx );
             const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > ( threadIndex );
 
-            __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+            PMACC_SMEM( frame, FramePtr );
 
-            __shared__ lcellId_t particlesInSuperCell;
+            PMACC_SMEM( particlesInSuperCell, lcellId_t );
 
 
             if( linearThreadIdx == 0 )

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -52,6 +52,7 @@
 #include "particles/operations/Deselect.hpp"
 #include "nvidia/atomic.hpp"
 #include "particles/InterpolationForPusher.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -68,9 +69,9 @@ struct KernelDeriveParticles
         typedef typename T_MyParBox::FramePtr MyFramePtr;
         typedef typename T_OtherFrameBox::FramePtr OtherFramePtr;
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<OtherFramePtr>::type frame;
+        PMACC_SMEM( frame, OtherFramePtr );
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<MyFramePtr>::type myFrame;
+        PMACC_SMEM( myFrame, MyFramePtr );
 
 
         typedef typename Mapping::SuperCellSize SuperCellSize;
@@ -128,7 +129,7 @@ struct KernelManipulateAllParticles
         Mapping mapper) const
     {
         typedef typename T_ParBox::FramePtr FramePtr;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        PMACC_SMEM( frame, FramePtr );
 
         typedef typename Mapping::SuperCellSize SuperCellSize;
 
@@ -203,7 +204,7 @@ struct KernelMoveAndMarkParticles
 
        FramePtr frame;
 
-       __shared__ int mustShift;
+       PMACC_SMEM( mustShift, int );
        lcellId_t particlesInSuperCell;
 
 

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -33,6 +33,7 @@
 #include "particles/startPosition/MacroParticleCfg.hpp"
 #include "particles/traits/GetDensityRatio.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -75,7 +76,7 @@ struct KernelFillGridWithParticles
         typedef typename ParBox::FramePtr FramePtr;
         const DataSpace<simDim> superCells(mapper.getGridSuperCells());
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        PMACC_SMEM( frame, FramePtr );
 
 
         typedef typename Mapping::SuperCellSize SuperCellSize;
@@ -100,7 +101,7 @@ struct KernelFillGridWithParticles
 
         const float_X realParticlesPerCell = realDensity * CELL_VOLUME;
 
-        __shared__ int finished;
+        PMACC_SMEM( finished, int );
         if (linearThreadIdx == 0)
             finished = 1;
         __syncthreads();

--- a/src/picongpu/include/particles/access/Cell2Particle.tpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.tpp
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include "math/Vector.hpp"
 #include "math/MapTuple.hpp"
+#include "memory/shared/Allocate.hpp"
 #include <boost/mpl/void.hpp>
 
 namespace particleAccess
@@ -47,8 +48,8 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
     \
     typedef typename TParticlesBox::FramePtr FramePtr; \
     typedef typename TParticlesBox::FrameType Frame; \
-    __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame; \
-    __shared__ uint16_t particlesInSuperCell; \
+    PMACC_SMEM( frame, FramePtr ); \
+    PMACC_SMEM( particlesInSuperCell, uint16_t ); \
     \
     if(linearThreadIdx == 0) \
     { \

--- a/src/picongpu/include/particles/creation/creation.kernel
+++ b/src/picongpu/include/particles/creation/creation.kernel
@@ -30,6 +30,7 @@
 #include "traits/Resolve.hpp"
 #include "math/vector/Int.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
 #include <iostream>
 
 namespace picongpu
@@ -107,8 +108,8 @@ struct CreateParticlesKernel
         /* for not mixing operations::assign up with the nvidia functor assign */
         namespace partOp = PMacc::particles::operations;
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SourceFramePtr>::type sourceFrame;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<TargetFramePtr>::type targetFrame;
+        PMACC_SMEM( sourceFrame, SourceFramePtr );
+        PMACC_SMEM( targetFrame, TargetFramePtr );
         const lcellId_t maxParticlesInFrame = PMacc::math::CT::volume<SuperCellSize>::type::value;
 
         /* find last frame in super cell
@@ -130,7 +131,7 @@ struct CreateParticlesKernel
         /* Declare counter in shared memory that will later tell the current fill level or
          * occupation of the newly created target frames.
          */
-        __shared__ int newFrameFillLvl;
+        PMACC_SMEM( newFrameFillLvl, int );
 
         /* Declare local variable oldFrameFillLvl for each thread */
         int oldFrameFillLvl;

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -36,6 +36,7 @@
 #include "pmacc_types.hpp"
 
 #include "particles/ionization/ionizationMethods.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -118,9 +119,9 @@ struct KernelIonizeParticles
         typedef typename particles::ionization::WriteElectronIntoFrame WriteElectronIntoFrame;
 
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<IonFramePtr>::type ionFrame;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ElectronFramePtr>::type electronFrame;
-        __shared__ lcellId_t maxParticlesInFrame;
+        PMACC_SMEM( ionFrame, IonFramePtr );
+        PMACC_SMEM( electronFrame,ElectronFramePtr );
+        PMACC_SMEM( maxParticlesInFrame, lcellId_t );
 
 
         /* find last frame in super cell
@@ -142,7 +143,7 @@ struct KernelIonizeParticles
         /* Declare counter in shared memory that will later tell the current fill level or
          * occupation of the newly created target electron frames.
          */
-        __shared__ int newFrameFillLvl;
+        PMACC_SMEM( newFrameFillLvl, int );
 
         /* Declare local variable oldFrameFillLvl for each thread */
         int oldFrameFillLvl;

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -24,6 +24,7 @@
 #include "simulation_defines.hpp"
 #include "nvidia/atomic.hpp"
 #include "particles/operations/Deselect.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -86,8 +87,8 @@ struct CreateParticlesFromParticleImpl : private T_Functor
         typedef typename DestFrameType::FramePtr DestFramePtr;
 
 
-        __shared__ DestFramePtr destFrame;
-        __shared__ int particlesInDestSuperCell;
+        PMACC_SMEM( destFrame, DestFramePtr );
+        PMACC_SMEM( particlesInDestSuperCell, int );
 
 
         uint32_t ltid = DataSpaceOperations<simDim>::template map<SuperCellSize>(DataSpace<simDim>(threadIdx));

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -42,6 +42,7 @@
 #include "nvidia/functors/Add.hpp"
 
 #include "algorithms/Gamma.hpp"
+#include "memory/shared/Allocate.hpp"
 
 #include "common/txtFileHandling.hpp"
 
@@ -69,9 +70,9 @@ struct KernelBinEnergyParticles
         typedef typename MappingDesc::SuperCellSize Block;
         typedef typename ParBox::FramePtr FramePtr;
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        PMACC_SMEM( frame, FramePtr );
 
-        __shared__ lcellId_t particlesInSuperCell;
+        PMACC_SMEM( particlesInSuperCell, lcellId_t );
 
         const bool enableDetector = maximumSlopeToDetectorX != float_X(0.0) && maximumSlopeToDetectorZ != float_X(0.0);
 

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -40,6 +40,7 @@
 #include "nvidia/functors/Add.hpp"
 
 #include "algorithms/Gamma.hpp"
+#include "memory/shared/Allocate.hpp"
 
 #include "common/txtFileHandling.hpp"
 
@@ -61,9 +62,9 @@ struct KernelEnergyParticles
     {
 
         typedef typename ParBox::FramePtr FramePtr;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame; /* pointer to particle data frame */
-        __shared__ float_X shEnergyKin; /* shared kinetic energy */
-        __shared__ float_X shEnergy; /* shared total energy */
+        PMACC_SMEM( frame, FramePtr ); /* pointer to particle data frame */
+        PMACC_SMEM( shEnergyKin, float_X ); /* shared kinetic energy */
+        PMACC_SMEM( shEnergy, float_X ); /* shared total energy */
 
         float_X _local_energyKin = float_X(0.0); /* sum kinetic energy for this thread */
         float_X _local_energy = float_X(0.0); /* sum total energy for this thread */

--- a/src/picongpu/include/plugins/IntensityPlugin.hpp
+++ b/src/picongpu/include/plugins/IntensityPlugin.hpp
@@ -43,6 +43,8 @@
 #include "basicOperations.hpp"
 #include "dimensions/SuperCellDescription.hpp"
 #include "math/Vector.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
 
 namespace picongpu
 {
@@ -58,8 +60,8 @@ struct KernelIntensity
     {
 
         typedef MappingDesc::SuperCellSize SuperCellSize;
-        __shared__ float_X s_integrated[SuperCellSize::y::value];
-        __shared__ float_X s_max[SuperCellSize::y::value];
+        PMACC_SMEM( s_integrated, memory::Array< float_X,SuperCellSize::y::value > );
+        PMACC_SMEM( s_max, memory::Array< float_X, SuperCellSize::y::value > );
 
 
         /*descripe size of a worker block for cached memory*/

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -33,6 +33,7 @@
 
 #include "algorithms/Gamma.hpp"
 #include "plugins/ILightweightPlugin.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -105,7 +106,7 @@ struct KernelPositionsParticles
     {
 
         typedef typename ParBox::FramePtr FramePtr;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        PMACC_SMEM( frame, FramePtr );
 
 
         typedef typename Mapping::SuperCellSize SuperCellSize;

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -33,6 +33,7 @@
 
 #include "dimensions/DataSpaceOperations.hpp"
 #include "plugins/ILightweightPlugin.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -49,7 +50,7 @@ struct KernelSumCurrents
     {
         typedef typename Mapping::SuperCellSize SuperCellSize;
 
-        __shared__ float3_X sh_sumJ;
+        PMACC_SMEM( sh_sumJ, float3_X );
 
         const DataSpace<simDim > threadIndex(threadIdx);
         const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -27,6 +27,7 @@
 #include "simulation_types.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
 
 
 namespace picongpu
@@ -78,9 +79,9 @@ struct CopySpecies
         typedef T_Mapping Mapping;
         typedef typename Mapping::SuperCellSize Block;
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<SrcFramePtr>::type srcFramePtr;
-        __shared__ int localCounter;
-        __shared__ int globalOffset;
+        PMACC_SMEM( srcFramePtr, SrcFramePtr );
+        PMACC_SMEM( localCounter, int );
+        PMACC_SMEM( globalOffset, int );
 
         int storageOffset;
 

--- a/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -34,6 +34,7 @@
 #include "plugins/ILightweightPlugin.hpp"
 
 #include "memory/buffers/GridBuffer.hpp"
+#include "memory/shared/Allocate.hpp"
 
 
 #include <splash/splash.h>
@@ -61,8 +62,8 @@ struct CountMakroParticle
         const DataSpace<simDim > threadIndex(threadIdx);
         const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
 
-        __shared__ uint64_cu counterValue;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
+        PMACC_SMEM( counterValue, uint64_cu );
+        PMACC_SMEM( frame, FramePtr );
 
         if (linearThreadIdx == 0)
         {

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -71,6 +71,7 @@
 #include "memory/boxes/DataBoxDim1Access.hpp"
 #include "nvidia/functors/Max.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -271,8 +272,8 @@ struct KernelPaintParticles3D
     {
         typedef typename ParBox::FramePtr FramePtr;
         typedef typename MappingDesc::SuperCellSize Block;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame;
-        __shared__ int isValid;
+        PMACC_SMEM( frame, FramePtr );
+        PMACC_SMEM( isValid, int );
 
         bool isImageThread = false;
 

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "math/Vector.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -44,7 +45,7 @@ struct KernelParticleCalorimeter
         const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
 
         typedef typename ParticlesBox::FramePtr ParticlesFramePtr;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ParticlesFramePtr>::type particlesFrame;
+        PMACC_SMEM( particlesFrame, ParticlesFramePtr );
 
         /* find last frame in super cell
          */

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -23,6 +23,7 @@
 #include "simulation_defines.hpp"
 #include "math/Vector.hpp"
 #include "algorithms/math.hpp"
+#include "memory/shared/Allocate.hpp"
 
 namespace picongpu
 {
@@ -177,7 +178,7 @@ struct ParticleCalorimeterKernel
             threadIndex);
 
         typedef typename ParticlesBox::FramePtr ParticlesFramePtr;
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<ParticlesFramePtr>::type particlesFrame;
+        PMACC_SMEM( particlesFrame, ParticlesFramePtr );
 
         /* find last frame in super cell
          */

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -47,6 +47,8 @@
 #include "mpi/MPIReduce.hpp"
 #include "nvidia/functors/Add.hpp"
 #include "nvidia/atomic.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
 
 
 #if( __NYQUISTCHECK__ == 1 )
@@ -114,8 +116,8 @@ struct KernelRadiationParticles
         typedef typename ParBox::FrameType FRAME;
         typedef typename ParBox::FramePtr FramePtr;
 
-        __shared__ typename PMacc::traits::GetEmptyDefaultConstructibleType<FramePtr>::type frame; // pointer to  frame storing particles
-        __shared__ lcellId_t particlesInFrame; // number  of particles in current frame
+        PMACC_SMEM( frame, FramePtr ); // pointer to  frame storing particles
+        PMACC_SMEM( particlesInFrame, lcellId_t ); // number  of particles in current frame
 
         using namespace parameters; // parameters of radiation
 
@@ -131,25 +133,25 @@ struct KernelRadiationParticles
 
         const int blockSize=PMacc::math::CT::volume<Block>::type::value;
         // vectorial part of the integrand in the Jackson formula
-        __shared__ vector_64 real_amplitude_s[blockSize];
+        PMACC_SMEM( real_amplitude_s, memory::Array< vector_64, blockSize > );
 
         // retarded time
-        __shared__ picongpu::float_64 t_ret_s[blockSize];
+        PMACC_SMEM( t_ret_s, memory::Array< picongpu::float_64, blockSize > );
 
         // storage for macro particle weighting needed if
         // the coherent and incoherent radiation of a single
         // macro-particle needs to be considered
 #if( __COHERENTINCOHERENTWEIGHTING__ == 1 )
-        __shared__ float_X radWeighting_s[blockSize];
+        PMACC_SMEM( radWeighting_s, memory::Array< float_X, blockSize > );
 #endif
 
         // particle counter used if not all particles are considered for
         // radiation calculation
-        __shared__ int counter_s;
+        PMACC_SMEM( counter_s, int );
 
         // memory for Nyquist frequency at current time step
 #if( __NYQUISTCHECK__ == 1 )
-        __shared__ NyquistLowPass lowpass_s[blockSize];
+        PMACC_SMEM( lowpass_s, memory::Array< NyquistLowPass, blockSize > );
 #endif
 
 


### PR DESCRIPTION
- use PMacc macro `PMACC_SMEM` instead of CUDA native keyword `__shared__`
- remove usage of `GetEmptyDefaultConstructibleType<>` to workaround nvcc warnings

Commits from ~~#1726~~ and ~~#1725~~ are included in this pull request and would be deleted after the rebase.

The trait "GetEmptyDefaultConstructibleType<>" was introduced with #1045 to suppress nvcc warning if   a class with a non empty constructor is stored in shared memory. This is not longer the case if ~~#1726~~ is used to create variables in the shared memory. I removed the use of the trait because I need to touch all lines with the usage to use the new `PMACC_SMEM()` macro.
I will remove the trait `GetEmptyDefaultConstructibleType<>` in an separate pull request.

Not changed
-----------------
- The keyword `__shared__` in `SharedMemoryBox` and `SharedMemAllocator` are not removed. I will refactor this part to a more clean implementation in a follow up pull request.
- extern shared memory is not touched

dependencies
------------------

- [x] depends on ~~#1726~~
- [x] depends on ~~#1725~~
- [x] runtime KHI test 