### PR TITLE
[WIP] allow full compile with clang

### DIFF
--- a/src/libPMacc/include/static_assert.hpp
+++ b/src/libPMacc/include/static_assert.hpp
@@ -46,8 +46,12 @@ namespace PMacc
  * @param pmacc_unique_id pre compiler unique id
  * @param pmacc_typeInfo a type that is shown in error message
  */
-#define PMACC_STATIC_ASSERT_MSG_DO2(pmacc_cond, pmacc_msg, pmacc_unique_id, pmacc_typeInfo) \
-    BOOST_MPL_ASSERT_MSG(pmacc_cond,PMACC_JOIN(pmacc_msg,PMACC_JOIN(_________,pmacc_unique_id)),(pmacc_typeInfo))
+#if ( CLANG_DEVICE_COMPILE != 1 )
+#   define PMACC_STATIC_ASSERT_MSG_DO2(pmacc_cond, pmacc_msg, pmacc_unique_id, pmacc_typeInfo) \
+        BOOST_MPL_ASSERT_MSG(pmacc_cond,PMACC_JOIN(pmacc_msg,PMACC_JOIN(_________,pmacc_unique_id)),(pmacc_typeInfo))
+#else
+#   define PMACC_STATIC_ASSERT_MSG_DO2(pmacc_cond, pmacc_msg, pmacc_unique_id, pmacc_typeInfo) 
+#endif
 
 /*! static assert with error message
  * @param pmacc_cond A condition which return true or false.

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -171,8 +171,8 @@ find_path(CUDA_MEMTEST_DIR
         DOC "path to cuda_memtest"
         )
 
-add_subdirectory(${CUDA_MEMTEST_DIR}
-                 "${CMAKE_CURRENT_BINARY_DIR}/build_cuda_memtest")
+#add_subdirectory(${CUDA_MEMTEST_DIR}
+#                 "${CMAKE_CURRENT_BINARY_DIR}/build_cuda_memtest")
 
 
 ################################################################################
@@ -185,8 +185,8 @@ find_path(MPI_INFO_DIR
         DOC "path to mpiInfo"
         )
 
-add_subdirectory(${MPI_INFO_DIR}
-                 "${CMAKE_CURRENT_BINARY_DIR}/build_mpiInfo")
+#add_subdirectory(${MPI_INFO_DIR}
+#                 "${CMAKE_CURRENT_BINARY_DIR}/build_mpiInfo")
 
 
 ################################################################################
@@ -328,13 +328,27 @@ file(GLOB CUDASRCFILES "*.cu")
 file(GLOB SRCFILES "*.cpp")
 
 
+if(CLANG_DEVICE_COMPILE)
+    add_library(picongpuLibs
+        STATIC
+        ${SRCFILES}
+    )
+    add_executable(picongpu
+        ${CUDASRCFILES}
+    )
+    set_target_properties(picongpu PROPERTIES COMPILE_FLAGS ${CLANG_BUILD_FLAGS})
+    set_target_properties(picongpu PROPERTIES LINKER_LANGUAGE CXX)
+    set_source_files_properties(${CUDASRCFILES} PROPERTIES LANGUAGE CXX)
 
-cuda_add_executable(picongpu
-    ${CUDASRCFILES}
-    ${SRCFILES}
-)
+    target_link_libraries(picongpu ${LIBS} m picongpuLibs)
+else()
+    cuda_add_executable(picongpu
+        ${CUDASRCFILES}
+        ${SRCFILES}
+    )
 
-target_link_libraries(picongpu ${LIBS} m)
+    target_link_libraries(picongpu ${LIBS} m)
+endif()
 
 ################################################################################
 # Install PIConGPU

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -104,8 +104,8 @@ namespace picongpu
             int p_bin = int( rel_bin * float_X(num_pbins) );
 
             /* out-of-range bins back to min/max */
-            p_bin >= 0 ? /* do not change p_bin */ : p_bin=0;
-            p_bin < num_pbins ? /* do not change p_bin */ : p_bin=num_pbins-1;
+            p_bin >= 0 ? p_bin /* do not change p_bin */ : p_bin=0;
+            p_bin < num_pbins ? p_bin/* do not change p_bin */ : p_bin=num_pbins-1;
 
             /** \todo take particle shape into account */
             atomicAddWrapper( &(*curDBufferOriginInBlock( p_bin, r_bin )),

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
@@ -111,7 +111,7 @@ namespace CUDA
     if (__active == __local_id)
 
 
-namespace mallocMC 
+namespace mallocMC
 {
 
   template<int PSIZE>
@@ -133,68 +133,68 @@ namespace mallocMC
   MAMC_ACCELERATOR inline boost::uint32_t laneid()
   {
     boost::uint32_t mylaneid;
-    asm("mov.u32 %0, %laneid;" : "=r" (mylaneid));
+    asm("mov.u32 %0, %%laneid;" : "=r" (mylaneid));
     return mylaneid;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t warpid()
   {
     boost::uint32_t mywarpid;
-    asm("mov.u32 %0, %warpid;" : "=r" (mywarpid));
+    asm("mov.u32 %0, %%warpid;" : "=r" (mywarpid));
     return mywarpid;
   }
   MAMC_ACCELERATOR inline boost::uint32_t nwarpid()
   {
     boost::uint32_t mynwarpid;
-    asm("mov.u32 %0, %nwarpid;" : "=r" (mynwarpid));
+    asm("mov.u32 %0, %%nwarpid;" : "=r" (mynwarpid));
     return mynwarpid;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t smid()
   {
     boost::uint32_t mysmid;
-    asm("mov.u32 %0, %smid;" : "=r" (mysmid));
+    asm("mov.u32 %0, %%smid;" : "=r" (mysmid));
     return mysmid;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t nsmid()
   {
     boost::uint32_t mynsmid;
-    asm("mov.u32 %0, %nsmid;" : "=r" (mynsmid));
+    asm("mov.u32 %0, %%nsmid;" : "=r" (mynsmid));
     return mynsmid;
   }
   MAMC_ACCELERATOR inline boost::uint32_t lanemask()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_eq;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_eq;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_le()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_le;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_le;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_lt()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_lt;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_lt;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_ge()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_ge;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_ge;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_gt()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_gt;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_gt;" : "=r" (lanemask));
     return lanemask;
   }
 


### PR DESCRIPTION
This is only a preview how many changes are needed to support clang for host and device side.

- use clang for host and device compile
- fix missing typedefs
- handle blockDim and `threadDim` for clang
- remove `BOOST_AUTO` with `PMACC_AUTO`
- use native c++11 `auto` for `PMACC_AUTO`
- CMake: add path to compile with clang
- disable static assertion for clang compile (error on compile)
- cuSTL: add missing prefix `HDINLINE`

Changes in the third party library `mallocMC` need to be ported to mallocMC.

- [ ] split into independent parts 

@ax3l this could be interesting for you