### PR TITLE
Travis: Check PR Destination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,21 @@
 language: cpp
 sudo: false
 
+cache:
+  apt: true
+
+addons:
+  apt:
+    packages:
+      - jq
+
 script:
+  #############################################################################
+  # Disallow PRs to `ComputationalRadiationPhysics/picongpu` branch `master`  #
+  # if not an other mainline branch such as `dev` or `release-...`            #
+  #############################################################################
+  - . test/correctBranchPR
+
   #############################################################################
   # Conformance with Alpaka: Do not write __global__ CUDA kernels directly    #
   #############################################################################

--- a/test/correctBranchPR
+++ b/test/correctBranchPR
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Disallow PRs to `ComputationalRadiationPhysics/picongpu` branch `master`
+# if not an other mainline branch such as `dev` or `release-...`
+#
+# See: https://docs.travis-ci.com/user/environment-variables/
+#      https://developer.github.com/v3/pulls/#get-a-single-pull-request
+#
+# -> only enforced for `master` branch
+#    -> only enforced for mainline repo (not for forks)
+#       -> travis lacks the PRs origin information, so we ask the GitHub API
+#
+# This file needs to be sourced in .travis.yml to work.
+#
+# @result 0 if correct target (or not in travis CI for mainline), else 1
+#
+
+# Are we even in travis? Otherwise pass this test.
+if [ "$TRAVIS" != "true" ]
+then
+  echo "Not in travis, so I have nothing to do :)"
+  exit 0
+fi
+
+mainline_slug="ComputationalRadiationPhysics/picongpu"
+gh_api="https://api.github.com"
+
+# only enforced for PRs
+if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]
+then
+  # only enforced for `master` branch
+  if [ "$TRAVIS_BRANCH" == "master" ]
+  then
+    # only enforced for mainline repo (not for forks)
+    if [ "$TRAVIS_REPO_SLUG" == "$mainline_slug" ]
+    then
+      # travis lacks the origin information, so we ask the GitHub API
+      # note: we are limited to 60/hr unauthenticated and
+      #       OAUTH + travis encr. var are not possible for PRs from forks
+      pr_json=$(curl -H "Accept:application/json" \
+                     -X GET -s                    \
+                "$gh_api/repos/$mainline_slug/pulls/$TRAVIS_PULL_REQUEST")
+      pr_slug=$(echo "$pr_json" | jq -r '.head.repo.full_name')
+      if [ "$pr_slug" != "$mainline_slug" ]
+      then
+        pr_author=$(echo "$pr_json" | jq -r '.head.repo.owner.login')
+        pr_branch=$TRAVIS_PULL_REQUEST_BRANCH
+        echo ""
+        echo "Pull request opened to wrong branch!"
+        echo ""
+        echo "New features need to go to our 'dev' branch but your"
+        echo "pull-request from '"$pr_slug"' was sent to 'master' which is"
+        echo "only updated by our maintainers for new stable releases."
+        echo ""
+        echo "Please re-open your pull-request against our 'dev' branch:"
+        echo "  https://github.com/ComputationalRadiationPhysics/picongpu/compare/dev...$pr_author:$pr_branch?expand=1"
+        echo ""
+        echo "For further information, please see:"
+        echo "  https://github.com/ComputationalRadiationPhysics/picongpu/blob/dev/CONTRIBUTING.md"
+        exit 1
+      fi
+    fi
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
Check that pull requests from forks are not accidentially opened to `master` (our default branch).

`master` is only updated with new stable releases. PRs to it will always be done by a maintainer that either merges `dev` from the mainline repo itself or a `release-...` branch, also from mainline.

If you want to see the help that is posted to the user that opened a PR falsely to `master`, check out https://travis-ci.org/ComputationalRadiationPhysics/picongpu/builds/188309672 that was triggered by #1730 . As always, we provide a one-click (or copy&paste) solution to fix the test, so developers can easily fix their problem and do not get annoyed.

```
Pull request opened to wrong branch!

New features need to go to our 'dev' branch but your
pull-request from 'ax3l/picongpu' was sent to 'master' which is
only updated by our maintainers for new stable releases.

Please re-open your pull-request against our 'dev' branch:
  https://github.com/ComputationalRadiationPhysics/picongpu/compare/dev...ax3l:topic-forbidPRmasterExtern?expand=1

For further information, please see:
  https://github.com/ComputationalRadiationPhysics/picongpu/blob/dev/CONTRIBUTING.md
```

### Notes

The current limit for unauthenticated GitHub API requests *per IP* are 60 per hour. That is not much and likely to be depleted, also with other travis users getting the same virtual machine before/after us. Using OAUTH and travis encrypted environment variables does not solve that issue, since they are not supported for PRs originating from forks due to security reasons. I am still in contact with travis' support and hope they will ask engineering to expose the PR origin "slug" (owner/repo) to us, so I can avoid the GitHub API call.

### Resources

- https://docs.travis-ci.com/user/environment-variables/
- https://developer.github.com/v3/pulls/#get-a-single-pull-reques