### PR TITLE
fix missing '%%' to use ptx special register

### DIFF
--- a/src/libPMacc/include/nvidia/warp.hpp
+++ b/src/libPMacc/include/nvidia/warp.hpp
@@ -41,7 +41,7 @@ namespace nvidia
 DINLINE uint32_t getLaneId()
 {
     uint32_t id;
-    asm("mov.u32 %0, %laneid;" : "=r" (id));
+    asm("mov.u32 %0, %%laneid;" : "=r" (id));
     return id;
 }
 #endif


### PR DESCRIPTION
assembler ptx command: add `%%` to use the laneid register

This changes is needed to compile with `clang++`, `nvcc` is relaxed and accept the special register also with one `%`.
Helpful [link](http://stackoverflow.com/a/40205665) with the explanation why we need to use `%%`

**There is no need to back port this change, because the current release only supports nvcc.**