### PR TITLE
add missing typename's

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
@@ -57,9 +57,9 @@ namespace cudaBlock
                                                                                    \
         for(int i = this->linearThreadIdx; i < dataVolume; i += blockVolume)       \
         {                                                                          \
-            PosType pos = Zone::Offset().toRT() +                                  \
+            PosType pos = Zone::Offset::toRT() +                                   \
                           precisionCast<typename PosType::type>(                   \
-                            math::MapToPos<Zone::dim>()( Zone::Size(), i ) );      \
+                            math::MapToPos<Zone::dim>()( typename Zone::Size(), i ) ); \
             functor_(BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _));                     \
         }                                                                          \
     }

--- a/src/libPMacc/include/particles/IdProvider.hpp
+++ b/src/libPMacc/include/particles/IdProvider.hpp
@@ -99,7 +99,7 @@ namespace PMacc {
     }
 
     template<unsigned T_dim>
-    IdProvider<T_dim>::State IdProvider<T_dim>::getState()
+    typename IdProvider<T_dim>::State IdProvider<T_dim>::getState()
     {
         HostDeviceBuffer<uint64_cu, 1> nextIdBuf(DataSpace<1>(1));
         PMACC_KERNEL(idDetail::GetNextId{})(1, 1)(nextIdBuf.getDeviceBuffer().getDataBox());

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -95,14 +95,14 @@ namespace random
     }
 
     template<uint32_t T_dim, class T_RNGMethod>
-    RNGProvider<T_dim, T_RNGMethod>::Buffer&
+    typename RNGProvider<T_dim, T_RNGMethod>::Buffer&
     RNGProvider<T_dim, T_RNGMethod>::getStateBuffer()
     {
         return *buffer;
     }
 
     template<uint32_t T_dim, class T_RNGMethod>
-    RNGProvider<T_dim, T_RNGMethod>::DataBoxType
+    typename RNGProvider<T_dim, T_RNGMethod>::DataBoxType
     RNGProvider<T_dim, T_RNGMethod>::getDeviceDataBox()
     {
         return buffer->getDeviceBuffer().getDataBox();

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -80,8 +80,8 @@ struct DirSplittingKernel
         algorithm::cudaBlock::Foreach<BlockDim> foreach;
         for (int x_offset = 0; x_offset < this->m_totalLength; x_offset += BlockDim::x::value)
         {
-            foreach(CacheE::Zone(), cacheE.origin(), globalE(-1 + x_offset, 0, 0), _1 = _2);
-            foreach(CacheB::Zone(), cacheB.origin(), globalB(-1 + x_offset, 0, 0), _1 = _2);
+            foreach(typename CacheE::Zone(), cacheE.origin(), globalE(-1 + x_offset, 0, 0), _1 = _2);
+            foreach(typename CacheB::Zone(), cacheB.origin(), globalB(-1 + x_offset, 0, 0), _1 = _2);
             __syncthreads();
 
             BOOST_AUTO(cursorE, cacheE.origin()(1, 0, 0)(threadPos_x, threadIdx.y, threadIdx.z));


### PR DESCRIPTION
- add missing typename
- use static method to get runtime type from compile time vector

This is needed to support device side compile with `clang++`, see #1731