### PR TITLE
explicit cast `blockIdx` and `threadIdx` to `dim3`

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -61,7 +61,7 @@ template<typename Mapper, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor>
                                                 /* C0 c0, C1 c1, ... */                                     \
 DINLINE void operator()(Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) const         \
 {                                                                                                           \
-    math::Int<Mapper::dim> cellIndex(mapper(blockIdx));                                                     \
+    math::Int<Mapper::dim> cellIndex(mapper(dim3(blockIdx)));                                               \
          /* c0[cellIndex], c1[cellIndex], ... */                                                            \
     functor(BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _));                                                       \
 }

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -44,7 +44,7 @@ template<typename Mapper, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor>
 /*                                          C0 c0, ..., CN cN   */ \
 DINLINE void operator()(Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) const \
 { \
-    math::Int<Mapper::dim> cellIndex(mapper(blockIdx, threadIdx)); \
+    math::Int<Mapper::dim> cellIndex(mapper(dim3(blockIdx), dim3(threadIdx))); \
 /*          forward(c0[cellIndex]), ..., forward(cN[cellIndex])     */ \
     functor(BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _)); \
 }


### PR DESCRIPTION
add excplicit cast to support clang structs for `threadIdx` and `blockIdx`

This is needed to support the `clang++` device compiler, see #1731 
Clang has it's own type for `threadIdx`,`blockIdx`,... to be compatible with our specializations for `dim3` we need to cast the magic CUDA variable explicit to `dim3`