### PR TITLE
remove usage of pmacc and boost auto

### DIFF
--- a/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleCurrent/include/particles/ParticlesInitOneParticle.hpp
@@ -57,7 +57,7 @@ struct kernelAddOneParticle
         for (unsigned i = 0; i < 1; ++i)
         {
 
-            PMACC_AUTO(par, frame[i]);
+            auto par = frame[i];
 
             /** we now initialize all attributes of the new particle to their default values
              *   some attributes, such as the position, localCellIdx, weighting or the

--- a/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleRadiationWithLaser/include/particles/ParticlesInitOneParticle.hpp
@@ -59,7 +59,7 @@ struct kernelAddOneParticle
         // many particle loop:
         for (unsigned i = 0; i < 1; ++i)
         {
-            PMACC_AUTO(par, frame[i]);
+            auto par = frame[i];
 
             /** we now initialize all attributes of the new particle to their default values
              *   some attributes, such as the position, localCellIdx, weighting or the

--- a/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
+++ b/examples/SingleParticleTest/include/particles/ParticlesInitOneParticle.hpp
@@ -56,7 +56,7 @@ struct kernelAddOneParticle
         // many particle loop:
         for (unsigned i = 0; i < 1; ++i)
         {
-            PMACC_AUTO(par, frame[i]);
+            auto par = frame[i];
 
             /** we now initialize all attributes of the new particle to their default values
              *   some attributes, such as the position, localCellIdx, weighting or the

--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -81,9 +81,9 @@ public:
 
         using namespace ::PMacc::math;
 
-        BOOST_AUTO(fieldE_coreBorder,
+        auto fieldE_coreBorder =
              this->fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
-                   precisionCast<int>(GuardDim().toRT()), -precisionCast<int>(GuardDim().toRT())));
+                   precisionCast<int>(GuardDim().toRT()), -precisionCast<int>(GuardDim().toRT()));
 
         this->eField_zt[0] = new container::HostBuffer<float, 2 > (Size_t < 2 > (fieldE_coreBorder.size().z(), this->collectTimesteps));
         this->eField_zt[1] = new container::HostBuffer<float, 2 >(this->eField_zt[0]->size());
@@ -109,7 +109,7 @@ public:
     {
         using namespace ::PMacc::math;
 
-        PMACC_AUTO(&con,Environment<simDim>::get().GridController());
+        auto& con = Environment<simDim>::get().GridController();
         Size_t<SIMDIM> gpuDim = (Size_t<SIMDIM>)con.getGpuNodes();
         Int<3> gpuPos = (Int<3>)con.getPosition();
         zone::SphericZone<SIMDIM> gpuGatheringZone(Size_t<SIMDIM > (1, 1, gpuDim.z()));
@@ -168,9 +168,9 @@ public:
 
         using namespace math;
 
-        BOOST_AUTO(fieldE_coreBorder,
+        auto fieldE_coreBorder =
            this->fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
-                precisionCast<int>(GuardDim().toRT()), -precisionCast<int>(GuardDim().toRT())));
+                precisionCast<int>(GuardDim().toRT()), -precisionCast<int>(GuardDim().toRT()));
 
         for (size_t z = 0; z < eField_zt[0]->size().x(); z++)
         {

--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -52,12 +52,12 @@ namespace gol
                         math::CT::Int< 1, 1 >,
                         math::CT::Int< 1, 1 >
                         > BlockArea;
-                PMACC_AUTO(cache, CachedBox::create < 0, Type > (BlockArea()));
+                auto cache = CachedBox::create < 0, Type > (BlockArea());
 
                 const Space block(mapper.getSuperCellIndex(Space(blockIdx)));
                 const Space blockCell = block * Mapping::SuperCellSize::toRT();
                 const Space threadIndex(threadIdx);
-                PMACC_AUTO(buffRead_shifted, buffRead.shift(blockCell));
+                auto buffRead_shifted = buffRead.shift(blockCell);
 
                 ThreadCollective<BlockArea> collective(threadIndex);
 
@@ -103,9 +103,9 @@ namespace gol
                         blockCell + threadIndex);
 
                 /* get uniform random number from seed  */
-                PMACC_AUTO(rng, nvidia::rng::create(
+                auto rng = nvidia::rng::create(
                                     nvidia::rng::methods::Xor(seed, cellIdx),
-                                    nvidia::rng::distributions::Uniform_float()));
+                                    nvidia::rng::distributions::Uniform_float());
 
                 /* write 1(white) if uniform random number 0<rng<1 is smaller than 'fraction' */
                 buffWrite(blockCell + threadIndex) = (rng() <= fraction);

--- a/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -209,7 +209,7 @@ private:
 
     void oneStep(uint32_t currentStep, Buffer* read, Buffer* write)
     {
-        PMACC_AUTO(splitEvent, __getTransactionEvent());
+        auto splitEvent = __getTransactionEvent();
         /* GridBuffer 'read' will use 'splitEvent' to schedule transaction    *
          * tasks from the Borders of the neighboring areas to the Guards of   *
          * this local Area added by 'addExchange'. All transactions in        *
@@ -217,7 +217,7 @@ private:
          * calculations in the core. In order to synchronize the data         *
          * transfer for the case the core calculation is finished earlier,    *
          * GridBuffer.asyncComm returns a transaction handle we can check     */
-        PMACC_AUTO(send, read->asyncCommunication(splitEvent));
+        auto send = read->asyncCommunication(splitEvent);
         evo.run<CORE>( read->getDeviceBuffer().getDataBox(),
                        write->getDeviceBuffer().getDataBox() );
         /* Join communication with worker tasks, Now all next tasks run sequential */
@@ -229,7 +229,7 @@ private:
 
         /* gather::operator() gathers all the buffers and assembles those to  *
          * a complete picture discarding the guards.                          */
-        PMACC_AUTO(picture, gather(write->getHostBuffer().getDataBox()));
+        auto picture = gather(write->getHostBuffer().getDataBox());
         PngCreator png;
         if (isMaster) png(currentStep, picture, gridSize);
 

--- a/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
@@ -48,7 +48,7 @@ namespace cudaBlock
     /*                     (      C0 c0, ..., C(N-1) c(N-1)           ,       ) */ \
     DINLINE void operator()(Zone, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), const Functor& functor) \
     {                                                                              \
-        BOOST_AUTO(functor_, lambda::make_Functor(functor));                       \
+        auto functor_ = lambda::make_Functor(functor);                       \
         const int dataVolume = math::CT::volume<typename Zone::Size>::type::value; \
         const int blockVolume = math::CT::volume<BlockDim>::type::value;           \
                                                                                    \

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
@@ -52,9 +52,9 @@ struct Reduce
 
         cursor::MapTo1DNavigator<Zone::dim> myNavi(p_zone.size);
 
-        BOOST_AUTO(_srcCursor, cursor::make_Cursor(cursor::CursorAccessor<SrcCursor>(),
+        auto _srcCursor = cursor::make_Cursor(cursor::CursorAccessor<SrcCursor>(),
                                                    myNavi,
-                                                   srcCursor_shifted));
+                                                   srcCursor_shifted);
 
         PMacc::nvidia::reduce::Reduce reduce(1024);
         return reduce(functor, _srcCursor, p_zone.size.productOfComponents());

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
@@ -42,7 +42,7 @@ Reduce<dim>::Reduce(const zone::SphericZone<dim>& p_zone, bool setThisAsRoot) : 
 {
     using namespace math;
 
-    PMACC_AUTO(&con,Environment<dim>::get().GridController());
+    auto& con = Environment<dim>::get().GridController();
 
     typedef std::pair<Int<dim>, bool> PosFlag;
     PosFlag posFlag;

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -51,12 +51,12 @@ struct D2DCopier
         Cursor bufCursorSrc(source, pitchSource);
         cursor::MapTo1DNavigator<dim> myNavi(size);
 
-        BOOST_AUTO(srcCursor, cursor::make_Cursor(cursor::CursorAccessor<Cursor>(),
+        auto srcCursor = cursor::make_Cursor(cursor::CursorAccessor<Cursor>(),
                                                   myNavi,
-                                                  bufCursorSrc));
-        BOOST_AUTO(destCursor, cursor::make_Cursor(cursor::CursorAccessor<Cursor>(),
+                                                  bufCursorSrc);
+        auto destCursor = cursor::make_Cursor(cursor::CursorAccessor<Cursor>(),
                                                    myNavi,
-                                                   bufCursorDest));
+                                                   bufCursorDest);
         size_t sizeProd = size.productOfComponents();
         for(size_t i = 0; i < sizeProd; i++)
         {

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -126,7 +126,7 @@ public:
     {
         __startOperation(ITask::TASK_HOST);
         size_t current_size = this->getCurrentSize();
-        PMACC_AUTO(memBox,getDataBox());
+        auto memBox = getDataBox();
         typedef DataBoxDim1Access<DataBoxType > D1Box;
         D1Box d1Box(memBox, this->getDataSpace());
         #pragma omp parallel for

--- a/src/libPMacc/include/mpi/SeedPerRank.hpp
+++ b/src/libPMacc/include/mpi/SeedPerRank.hpp
@@ -56,7 +56,7 @@ namespace mpi
         uint32_t
         operator()( uint32_t localSeed )
         {
-            PMACC_AUTO(&gc, PMacc::Environment<T_DIM>::get().GridController());
+            auto& gc = PMacc::Environment<T_DIM>::get().GridController();
 
             uint32_t rank = gc.getGlobalRank( );
             /* We put the rank into the upper bits to allow values which start

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -188,12 +188,12 @@ struct KernelShiftParticles
                     direction += numExchanges;
                     destParticleIdx -= frameSize;
                 }
-                PMACC_AUTO( dstParticle, destFrames[direction][destParticleIdx] );
-                PMACC_AUTO( srcParticle, frame[linearThreadIdx] );
+                auto dstParticle = destFrames[direction][destParticleIdx];
+                auto srcParticle = frame[linearThreadIdx];
                 dstParticle[multiMask_] = 1;
                 srcParticle[multiMask_] = 0;
-                PMACC_AUTO( dstFilteredParticle,
-                            particles::operations::deselect<multiMask>(dstParticle) );
+                auto dstFilteredParticle =
+                            particles::operations::deselect<multiMask>(dstParticle);
                 particles::operations::assign( dstFilteredParticle, srcParticle );
             }
             __syncthreads( );
@@ -283,13 +283,13 @@ struct KernelFillGapsLastFrame
                 //any particle search a gap
                 const int srcGapIdx = nvidia::atomicAllInc( &srcGap );
                 const int gapIdx = gapIndices_sh[srcGapIdx];
-                PMACC_AUTO( parDestFull, lastFrame[gapIdx] );
+                auto parDestFull = lastFrame[gapIdx];
                 /*enable particle*/
                 parDestFull[multiMask_] = 1;
                 /* we not update multiMask because copy from mem to mem is to slow
                  * we have enabled particle explicit */
-                PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
-                PMACC_AUTO( parSrc, (lastFrame[threadIdx.x]) );
+                auto parDest = deselect<multiMask>(parDestFull);
+                auto parSrc = (lastFrame[threadIdx.x]);
                 assign( parDest, parSrc );
                 parSrc[multiMask_] = 0; //delete old partice
             }
@@ -373,13 +373,13 @@ struct KernelFillGaps
             if ( localGapIdx < counterParticles )
             {
                 const int parIdx = particleIndices_sh[localGapIdx];
-                PMACC_AUTO( parDestFull, (firstFrame[threadIdx.x]) );
+                auto parDestFull = (firstFrame[threadIdx.x]);
                 /*enable particle*/
                 parDestFull[multiMask_] = 1;
                 /* we not update multiMask because copy from mem to mem is to slow
                  * we have enabled particle explicit */
-                PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
-                PMACC_AUTO( parSrc, (lastFrame[parIdx]) );
+                auto parDest = deselect<multiMask>(parDestFull);
+                auto parSrc = (lastFrame[parIdx]);
                 assign( parDest, parSrc );
                 parSrc[multiMask_] = 0;
             }
@@ -444,7 +444,7 @@ struct KernelDeleteParticles
         while ( frame.isValid( ) )
         {
 
-            PMACC_AUTO( particle, (frame[linearThreadIdx]) );
+            auto particle = (frame[linearThreadIdx]);
             particle[multiMask_] = 0; //delete particle
 
             __syncthreads( );
@@ -524,8 +524,8 @@ struct KernelBashParticles
 
                 if ( bashIdx != INV_LOC_IDX && bashIdx < tmpBorder.getSize( ) )
                 {
-                    PMACC_AUTO( parDest, tmpBorder[bashIdx][0] );
-                    PMACC_AUTO( parSrc, (frame[threadIdx.x]) );
+                    auto parDest = tmpBorder[bashIdx][0];
+                    auto parSrc = (frame[threadIdx.x]);
                     assign( parDest, parSrc );
                     parSrc[multiMask_] = 0;
                 }
@@ -590,11 +590,11 @@ struct KernelInsertParticles
         __syncthreads( );
         if ( threadIdx.x < elementCount )
         {
-            PMACC_AUTO( parDestFull, (frame[threadIdx.x]) );
+            auto parDestFull = (frame[threadIdx.x]);
             parDestFull[multiMask_] = 1;
-            PMACC_AUTO( parSrc, ((tmpBorder[threadIdx.x])[0]) );
+            auto parSrc = ((tmpBorder[threadIdx.x])[0]);
             /*we know that source has no multiMask*/
-            PMACC_AUTO( parDest, deselect<multiMask>(parDestFull) );
+            auto parDest = deselect<multiMask>(parDestFull);
             assign( parDest, parSrc );
         }
         /*if this syncronize fix the kernel crash in spezial cases,

--- a/src/libPMacc/include/particles/operations/ConcatListOfFrames.hpp
+++ b/src/libPMacc/include/particles/operations/ConcatListOfFrames.hpp
@@ -113,7 +113,7 @@ struct ConcatListOfFrames
                 int curNumParticles = 0;
                 for (int threadIdx = 0; threadIdx < particlesPerFrame; ++threadIdx)
                 {
-                    PMACC_AUTO(parSrc, (srcFramePtr[threadIdx]));
+                    auto parSrc = (srcFramePtr[threadIdx]);
                     /* Check if particle exists and is not filtered */
                     if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx))
                         localIdxs[threadIdx] = curNumParticles++;
@@ -133,9 +133,9 @@ struct ConcatListOfFrames
                 {
                     if (localIdxs[threadIdx] != -1)
                     {
-                        PMACC_AUTO(parSrc, (srcFramePtr[threadIdx]));
-                        PMACC_AUTO(parDest, destFrame[globalOffset + localIdxs[threadIdx]]);
-                        PMACC_AUTO(parDestNoDomainIdx, deselect<T_Identifier>(parDest));
+                        auto parSrc = (srcFramePtr[threadIdx]);
+                        auto parDest = destFrame[globalOffset + localIdxs[threadIdx]];
+                        auto parDestNoDomainIdx = deselect<T_Identifier>(parDest);
                         assign(parDestNoDomainIdx, parSrc);
                         /* calculate cell index for user-defined domain */
                         DataSpace<Mapping::Dim> localCellIdx(DataSpaceOperations<Mapping::Dim>::template map<SuperCellSize>(parSrc[localCellIdx_]));

--- a/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
+++ b/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
@@ -145,8 +145,8 @@ namespace kernel
             if (hasValidParticle)
             {
                 /* copy attributes and activate particle*/
-                PMACC_AUTO(parDest, destFramePtr[masterIdx][linearThreadIdx]);
-                PMACC_AUTO(parDestDeselect, deselect<bmpl::vector2<localCellIdx, multiMask> >(parDest));
+                auto parDest = destFramePtr[masterIdx][linearThreadIdx];
+                auto parDestDeselect = deselect<bmpl::vector2<localCellIdx, multiMask> >(parDest);
                 assign(parDestDeselect, srcFrame[srcParticleIdx]);
                 parDest[localCellIdx_] = lCellIdx;
                 parDest[multiMask_] = 1;

--- a/src/libPMacc/include/pmacc_types.hpp
+++ b/src/libPMacc/include/pmacc_types.hpp
@@ -43,8 +43,6 @@
 #include <stdint.h>
 #include <stdexcept>
 
-#define PMACC_AUTO_TPL(var,...) BOOST_AUTO_TPL(var,(__VA_ARGS__))
-#define PMACC_AUTO(var,...) BOOST_AUTO(var,(__VA_ARGS__))
 
 namespace PMacc
 {

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -68,7 +68,7 @@ namespace random
         const uint32_t blockSize = 256;
         const uint32_t gridSize = (m_size.productOfComponents() + blockSize - 1u) / blockSize; // Round up
 
-        PMACC_AUTO(bufferBox, buffer->getDeviceBuffer().getDataBox());
+        auto bufferBox = buffer->getDeviceBuffer().getDataBox();
 
         PMACC_KERNEL(kernel::InitRNGProvider<RNGMethod>{})
         (gridSize, blockSize)

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
@@ -78,7 +78,7 @@ struct FieldToParticleInterpolation
         typename Cursor::ValueType result;
         for(uint32_t i = 0; i < Cursor::ValueType::dim; i++)
         {
-            BOOST_AUTO(fieldComponent, PMacc::cursor::make_FunctorCursor(field, _1[i]));
+            auto fieldComponent = PMacc::cursor::make_FunctorCursor(field, _1[i]);
             floatD_X particlePosShifted = particlePos;
             ShiftCoordinateSystem<Supports>()(fieldComponent, particlePosShifted, fieldPos[i]);
             result[i] = InterpolationMethod::template interpolate<AssignmentFunction, begin, end > (fieldComponent, particlePosShifted);

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
@@ -70,17 +70,17 @@ struct FieldToParticleInterpolationNative
          * _1[mpl::int_<0>()] is equivalent to _1[0] but has no runtime cost.
          */
 
-        BOOST_AUTO(field_x, PMacc::cursor::make_FunctorCursor(field, _1[mpl::int_ < 0 > ()]));
+        auto field_x = PMacc::cursor::make_FunctorCursor(field, _1[mpl::int_ < 0 > ()]);
         floatD_X pos_tmp(particlePos);
         ShiftCoordinateSystemNative<supp>()(field_x, pos_tmp, fieldPos.x());
         float_X result_x = InterpolationMethod::template interpolate<AssignmentFunction, -lowerMargin, upperMargin > (field_x, pos_tmp);
 
-        BOOST_AUTO(field_y, PMacc::cursor::make_FunctorCursor(field, _1[mpl::int_ < 1 > ()]));
+        auto field_y = PMacc::cursor::make_FunctorCursor(field, _1[mpl::int_ < 1 > ()]);
         pos_tmp = particlePos;
         ShiftCoordinateSystemNative<supp>()(field_y, pos_tmp, fieldPos.y());
         float_X result_y = InterpolationMethod::template interpolate<AssignmentFunction, -lowerMargin, upperMargin > (field_y, pos_tmp);
 
-        BOOST_AUTO(field_z, PMacc::cursor::make_FunctorCursor(field, _1[mpl::int_ < 2 > ()]));
+        auto field_z = PMacc::cursor::make_FunctorCursor(field, _1[mpl::int_ < 2 > ()]);
         pos_tmp = particlePos;
         ShiftCoordinateSystemNative<supp>()(field_z, pos_tmp, fieldPos.z());
         float_X result_z = InterpolationMethod::template interpolate<AssignmentFunction, -lowerMargin, upperMargin > (field_z, pos_tmp);

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -162,7 +162,7 @@ struct ComputeCurrent
         typedef T_SpeciesName SpeciesName;
         typedef typename SpeciesName::type SpeciesType;
 
-        PMACC_AUTO(speciesPtr, tuple[SpeciesName()]);
+        auto speciesPtr = tuple[SpeciesName()];
         fieldJ->computeCurrent<T_Area::value, SpeciesType> (*speciesPtr, currentStep);
     }
 };

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -86,7 +86,7 @@ struct KernelComputeCurrent
         }
 
         /* This memory is used by all virtual blocks*/
-        PMACC_AUTO(cachedJ, CachedBox::create < 0, typename JBox::ValueType > (BlockDescription_()));
+        auto cachedJ = CachedBox::create < 0, typename JBox::ValueType > (BlockDescription_());
 
         Set<typename JBox::ValueType > set(float3_X::create(0.0));
         ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveSet(linearThreadIdx);
@@ -119,7 +119,7 @@ struct KernelComputeCurrent
         nvidia::functors::Add add;
         const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
         ThreadCollective<BlockDescription_, cellsPerSuperCell * workerMultiplier> collectiveAdd(linearThreadIdx);
-        PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
+        auto fieldJBlock = fieldJ.shift(blockCell);
         collectiveAdd(add, fieldJBlock, cachedJ);
     }
 };
@@ -137,7 +137,7 @@ struct ComputeCurrentPerFrame
     DINLINE void operator()(FrameType& frame, const int localIdx, BoxJ & jBox)
     {
 
-        PMACC_AUTO(particle, frame[localIdx]);
+        auto particle = frame[localIdx];
         const float_X weighting = particle[weighting_];
         const floatD_X pos = particle[position_];
         const int particleCellIdx = particle[localCellIdx_];
@@ -148,7 +148,7 @@ struct ComputeCurrentPerFrame
         const float3_X vel = velocity(
                                       particle[momentum_],
                                       attribute::getMass(weighting,particle));
-        PMACC_AUTO(fieldJShiftToParticle, jBox.shift(localCell));
+        auto fieldJShiftToParticle = jBox.shift(localCell);
         ParticleAlgo perParticle;
         perParticle(fieldJShiftToParticle,
                     pos,
@@ -178,14 +178,14 @@ struct KernelAddCurrentToEMF
                     typename T_CurrentInterpolation::UpperMargin
                     > BlockArea;
 
-        PMACC_AUTO(cachedJ, CachedBox::create < 0, typename J_DataBox::ValueType > (BlockArea()));
+        auto cachedJ = CachedBox::create < 0, typename J_DataBox::ValueType > (BlockArea());
 
         nvidia::functors::Assign assign;
         const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
         const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
 
         const DataSpace<simDim > threadIndex(threadIdx);
-        PMACC_AUTO(fieldJBlock, fieldJ.shift(blockCell));
+        auto fieldJBlock = fieldJ.shift(blockCell);
 
         ThreadCollective<BlockArea> collective(threadIndex);
         collective(

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -73,7 +73,7 @@ namespace picongpu
             if( !frame.isValid() )
                 return; //end kernel if we have no frames
 
-            PMACC_AUTO( cachedVal, CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) ) );
+            auto cachedVal = CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) );
             Set<typename TmpBox::ValueType > set( float_X( 0.0 ) );
 
             ThreadCollective<BlockDescription_> collective( linearThreadIdx );
@@ -97,7 +97,7 @@ namespace picongpu
 
             nvidia::functors::Add add;
             const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT( );
-            PMACC_AUTO( fieldTmpBlock, fieldTmp.shift( blockCell ) );
+            auto fieldTmpBlock = fieldTmp.shift( blockCell );
             collective( add, fieldTmpBlock, cachedVal );
             __syncthreads( );
         }

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -78,7 +78,7 @@ private:
         using namespace cursor::tools;
         using namespace PMacc::math;
 
-        PMACC_AUTO(gridSizeTwisted, twistComponents<OrientationTwist>(gridSize));
+        auto gridSizeTwisted = twistComponents<OrientationTwist>(gridSize);
 
         /* twist components of the supercell */
         typedef typename CT::TwistComponents<SuperCellSize, OrientationTwist>::type BlockDim;

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -84,8 +84,8 @@ struct DirSplittingKernel
             foreach(CacheB::Zone(), cacheB.origin(), globalB(-1 + x_offset, 0, 0), _1 = _2);
             __syncthreads();
 
-            BOOST_AUTO(cursorE, cacheE.origin()(1, 0, 0)(threadPos_x, threadIdx.y, threadIdx.z));
-            BOOST_AUTO(cursorB, cacheB.origin()(1, 0, 0)(threadPos_x, threadIdx.y, threadIdx.z));
+            auto cursorE = cacheE.origin()(1, 0, 0)(threadPos_x, threadIdx.y, threadIdx.z);
+            auto cursorB = cacheB.origin()(1, 0, 0)(threadPos_x, threadIdx.y, threadIdx.z);
 
             if(threadPos_x == BlockDim::x::value - 1)
             {

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
@@ -42,10 +42,8 @@ namespace traits
     {
         static StringProperty get()
         {
-            PMACC_AUTO(
-                propList,
-                ::picongpu::leheSolver::LeheSolver::getStringProperties()
-            );
+            auto propList =
+                ::picongpu::leheSolver::LeheSolver::getStringProperties();
             // overwrite the name of the yee solver (inherit all other properties)
             propList["name"].value = "Lehe";
             return propList;

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
@@ -41,14 +41,14 @@ struct KernelUpdateE
     ) const
     {
 
-        PMACC_AUTO(cachedB, CachedBox::create < 0, typename T_BBox::ValueType > (BlockDescription_()));
+        auto cachedB = CachedBox::create < 0, typename T_BBox::ValueType > (BlockDescription_());
 
         nvidia::functors::Assign assign;
         const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
         const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
 
         const DataSpace<simDim > threadIndex(threadIdx);
-        PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
+        auto fieldBBlock = fieldB.shift(blockCell);
 
         ThreadCollective<BlockDescription_> collective(threadIndex);
         collective(
@@ -83,13 +83,13 @@ struct KernelUpdateBHalf
     ) const
     {
 
-        PMACC_AUTO(cachedE, CachedBox::create < 0, typename T_EBox::ValueType > (BlockDescription_()));
+        auto cachedE = CachedBox::create < 0, typename T_EBox::ValueType > (BlockDescription_());
 
         nvidia::functors::Assign assign;
         const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
         const DataSpace<simDim> blockCell = block * MappingDesc::SuperCellSize::toRT();
         const DataSpace<simDim > threadIndex(threadIdx);
-        PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
+        auto fieldEBlock = fieldE.shift(blockCell);
 
         ThreadCollective<BlockDescription_> collective(threadIndex);
         collective(

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -76,7 +76,7 @@ struct Esirkepov<T_ParticleShape, DIM3>
                                            velocity.z() * deltaTime / cellSize.z());
         const PosType oldPos = pos - deltaPos;
         Line<float3_X> line(oldPos, pos);
-        BOOST_AUTO(cursorJ, dataBoxJ.toCursor());
+        auto cursorJ = dataBoxJ.toCursor();
 
         if (supp % 2 == 1)
         {

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -78,7 +78,7 @@ struct Esirkepov<T_ParticleShape, DIM2>
                                            velocity.y() * deltaTime / cellSize.y());
         const PosType oldPos = pos - deltaPos;
         Line<float2_X> line(oldPos, pos);
-        BOOST_AUTO(cursorJ, dataBoxJ.toCursor());
+        auto cursorJ = dataBoxJ.toCursor();
 
         if (supp % 2 == 1)
         {

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -78,7 +78,7 @@ struct EsirkepovNative
                                            velocity.z() * deltaTime / cellSize.z());
         const PosType oldPos = pos - deltaPos;
         Line<float3_X> line(oldPos, pos);
-        BOOST_AUTO(cursorJ, dataBoxJ.toCursor());
+        auto cursorJ = dataBoxJ.toCursor();
 
         /**
          * \brief the following three calls separate the 3D current deposition

--- a/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -99,7 +99,7 @@ private:
                             math::float2int_rd(meanPos.y()),
                             math::float2int_rd(meanPos.z()));
 
-        PMACC_AUTO(mem, memIn.shift(off));
+        auto mem = memIn.shift(off);
 
         //fit meanPos into the range [0,1)
         meanPos.x() -= math::floor(meanPos.x());

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -123,7 +123,7 @@ struct AssignChargeToCell
         const uint32_t currentComponent = CurrentComponent::value;
 
         /* shift memory cursor to cell (grid point)*/
-        PMACC_AUTO(cursorToValue, cursor(GridPointVec::toRT()));
+        auto cursorToValue = cursor(GridPointVec::toRT());
         /* add current to component of the cell*/
         atomicAddWrapper(&((*cursorToValue)[currentComponent]), j);
     }
@@ -295,7 +295,7 @@ struct ZigZag
                 flux[d] = (parId == 0 ? charge * velocity[d] * volume_reci : float_X(0.0));
             }
 
-            PMACC_AUTO(cursorJ, dataBoxJ.shift(precisionCast<int>(I[parId])).toCursor());
+            auto cursorJ = dataBoxJ.shift(precisionCast<int>(I[parId])).toCursor();
 
             /*the current has three components*/
             typedef boost::mpl::range_c<int, 0, 3 > ComponentsRange;

--- a/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -60,7 +60,7 @@ namespace traits
 
         HDINLINE ReturnType operator()() const
         {
-            const PMACC_AUTO(center, PosType::create( 0.5 ));
+            const auto center = PosType::create( 0.5 );
 
             return ReturnType::create( center );
         }

--- a/src/picongpu/include/particles/InitFunctors.hpp
+++ b/src/picongpu/include/particles/InitFunctors.hpp
@@ -95,7 +95,7 @@ struct CreateGas
                             const uint32_t currentStep
                             )
     {
-        PMACC_AUTO(speciesPtr, tuple[SpeciesName()]);
+        auto speciesPtr = tuple[SpeciesName()];
         GasFunctor gasFunctor(currentStep);
         PositionFunctor positionFunctor(currentStep);
         speciesPtr->initGas(gasFunctor, positionFunctor, currentStep);
@@ -129,8 +129,8 @@ struct ManipulateDeriveSpecies
                             const uint32_t currentStep
                             )
     {
-        PMACC_AUTO(speciesPtr, tuple[DestSpeciesName()]);
-        PMACC_AUTO(srcSpeciesPtr, tuple[SrcSpeciesName()]);
+        auto speciesPtr = tuple[DestSpeciesName()];
+        auto srcSpeciesPtr = tuple[SrcSpeciesName()];
 
         ManipulateFunctor manipulateFunctor(currentStep);
 
@@ -177,7 +177,7 @@ struct Manipulate
                             const uint32_t currentStep
                             )
     {
-        PMACC_AUTO(speciesPtr, tuple[SpeciesName()]);
+        auto speciesPtr = tuple[SpeciesName()];
         Functor functor(currentStep);
         speciesPtr->manipulateAllParticles(currentStep, functor);
     }
@@ -200,7 +200,7 @@ struct FillAllGaps
                             const uint32_t currentStep
                             )
     {
-        PMACC_AUTO(speciesPtr, tuple[SpeciesName()]);
+        auto speciesPtr = tuple[SpeciesName()];
         speciesPtr->fillAllGaps();
     }
 };

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -91,8 +91,8 @@ struct KernelDeriveParticles
         __syncthreads();
         while (frame.isValid()) //move over all Frames
         {
-            PMACC_AUTO(parDest, myFrame[threadIdx.x]);
-            PMACC_AUTO(parSrc, frame[threadIdx.x]);
+            auto parDest = myFrame[threadIdx.x];
+            auto parSrc = frame[threadIdx.x];
             assign(parDest, deselect<particleId>(parSrc));
 
             const DataSpace<simDim> localCellIdx = block * SuperCellSize::toRT()
@@ -160,7 +160,7 @@ struct KernelManipulateAllParticles
 
         while (frame.isValid())
         {
-            PMACC_AUTO(particle, frame[linearThreadIdx]);
+            auto particle = frame[linearThreadIdx];
             particleFunctor(localCellIdx, particle, particle, isParticle, isParticle);
 
             __syncthreads();
@@ -215,15 +215,15 @@ struct KernelMoveAndMarkParticles
        frame = pb.getLastFrame(block);
        particlesInSuperCell = pb.getSuperCell(block).getSizeLastFrame();
 
-       PMACC_AUTO(cachedB, CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_()));
-       PMACC_AUTO(cachedE, CachedBox::create < 1, typename EBox::ValueType > (BlockDescription_()));
+       auto cachedB = CachedBox::create < 0, typename BBox::ValueType > (BlockDescription_());
+       auto cachedE = CachedBox::create < 1, typename EBox::ValueType > (BlockDescription_());
 
        __syncthreads();
        if (!frame.isValid())
            return; //end kernel if we have no frames
 
 
-       PMACC_AUTO(fieldBBlock, fieldB.shift(blockCell));
+       auto fieldBBlock = fieldB.shift(blockCell);
 
        nvidia::functors::Assign assign;
        ThreadCollective<BlockDescription_> collective(linearThreadIdx);
@@ -233,7 +233,7 @@ struct KernelMoveAndMarkParticles
                  fieldBBlock
                  );
 
-       PMACC_AUTO(fieldEBlock, fieldE.shift(blockCell));
+       auto fieldEBlock = fieldE.shift(blockCell);
        collective(
                  assign,
                  cachedE,
@@ -275,7 +275,7 @@ struct PushParticlePerFrame
         typedef typename BoxB::ValueType BType;
         typedef typename BoxE::ValueType EType;
 
-        PMACC_AUTO(particle, frame[localIdx]);
+        auto particle = frame[localIdx];
         const float_X weighting = particle[weighting_];
 
         floatD_X pos = particle[position_];
@@ -286,8 +286,8 @@ struct PushParticlePerFrame
         const fieldSolver::numericalCellType::traits::FieldPosition<FieldE> fieldPosE;
         const fieldSolver::numericalCellType::traits::FieldPosition<FieldB> fieldPosB;
 
-        PMACC_AUTO(functorEfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( eBox.shift(localCell).toCursor(), fieldPosE() ));
-        PMACC_AUTO(functorBfield, CreateInterpolationForPusher<Field2ParticleInterpolation>()( bBox.shift(localCell).toCursor(), fieldPosB() ));
+        auto functorEfield = CreateInterpolationForPusher<Field2ParticleInterpolation>()( eBox.shift(localCell).toCursor(), fieldPosE() );
+        auto functorBfield = CreateInterpolationForPusher<Field2ParticleInterpolation>()( bBox.shift(localCell).toCursor(), fieldPosB() );
 
         float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass(weighting,particle);

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -152,7 +152,7 @@ struct PushSpecies
                             T_EventList& updateEvent
                             ) const
     {
-        PMACC_AUTO(speciesPtr, tuple[SpeciesName()]);
+        auto speciesPtr = tuple[SpeciesName()];
 
         __startTransaction(eventInt);
         speciesPtr->update(currentStep);
@@ -285,9 +285,9 @@ struct CallIonization
              */
             typedef typename SelectIonizer::DestSpecies DestSpecies;
             /* alias for pointer on source species */
-            PMACC_AUTO(srcSpeciesPtr, tuple[SpeciesName()]);
+            auto srcSpeciesPtr = tuple[SpeciesName()];
             /* alias for pointer on destination species */
-            PMACC_AUTO(electronsPtr,  tuple[typename MakeIdentifier<DestSpecies>::type()]);
+            auto electronsPtr = tuple[typename MakeIdentifier<DestSpecies>::type()];
 
             /* 3-dim vector : number of threads to be started in every dimension */
             auto block = MappingDesc::SuperCellSize::toRT();
@@ -350,9 +350,9 @@ struct CallSynchrotronPhotons
         typedef typename SelectedPhotonCreator::PhotonSpecies PhotonSpecies;
 
         /* alias for pointer on source species */
-        PMACC_AUTO(electronSpeciesPtr, tuple[SpeciesName()]);
+        auto electronSpeciesPtr = tuple[SpeciesName()];
         /* alias for pointer on destination species */
-        PMACC_AUTO(photonSpeciesPtr, tuple[typename MakeIdentifier<PhotonSpecies>::type()]);
+        auto photonSpeciesPtr = tuple[typename MakeIdentifier<PhotonSpecies>::type()];
 
         using namespace synchrotronPhotons;
         SelectedPhotonCreator photonCreator(

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -142,7 +142,7 @@ struct KernelFillGridWithParticles
             if (numParsPerCell > 0)
             {
                 floatD_X pos = positionFunctor(totalNumParsPerCell - numParsPerCell);
-                PMACC_AUTO(particle, (frame[linearThreadIdx]));
+                auto particle = (frame[linearThreadIdx]);
 
                 /** we now initialize all attributes of the new particle to their default values
                  *   some attributes, such as the position, localCellIdx, weighting or the

--- a/src/picongpu/include/particles/creation/creation.hpp
+++ b/src/picongpu/include/particles/creation/creation.hpp
@@ -56,11 +56,11 @@ void createParticlesFromSpecies(T_SourceSpecies& sourceSpecies,
     const PMacc::math::Int<simDim> coreBorderSuperCells = coreBorderGuardSuperCells - 2*guardSuperCells;
 
     /* Functor holding the actual generic particle creation kernel */
-    PMACC_AUTO(createParticlesKernel, make_CreateParticlesKernel(
+    auto createParticlesKernel = make_CreateParticlesKernel(
         sourceSpecies.getDeviceParticlesBox(),
         targetSpecies.getDeviceParticlesBox(),
         particleCreator,
-        guardSuperCells));
+        guardSuperCells);
 
     /* This zone represents the core+border area with guard offset in unit of cells */
     const zone::SphericZone<simDim> zone(

--- a/src/picongpu/include/particles/creation/creation.kernel
+++ b/src/picongpu/include/particles/creation/creation.kernel
@@ -227,9 +227,9 @@ struct CreateParticlesKernel
                 if ((0 <= targetParId) && (targetParId < maxParticlesInFrame))
                 {
                     /* each thread makes the attributes of its source particle accessible */
-                    PMACC_AUTO(sourceParticle,(sourceFrame[linearThreadIdx]));
+                    auto sourceParticle = (sourceFrame[linearThreadIdx]);
                     /* each thread initializes an target particle if one should be created */
-                    PMACC_AUTO(targetParticle,(targetFrame[targetParId]));
+                    auto targetParticle = (targetFrame[targetParId]);
 
                     /* create an target particle in the new target particle frame: */
                     particleCreator(sourceParticle, targetParticle);
@@ -262,9 +262,9 @@ struct CreateParticlesKernel
                     targetParId -= maxParticlesInFrame;
 
                     /* each thread makes the attributes of its source particle accessible */
-                    PMACC_AUTO(sourceParticle,(sourceFrame[linearThreadIdx]));
+                    auto sourceParticle = (sourceFrame[linearThreadIdx]);
                     /* each thread initializes an target particle if one should be created */
-                    PMACC_AUTO(targetParticle,(targetFrame[targetParId]));
+                    auto targetParticle = (targetFrame[targetParId]);
 
                     /* create an target particle in the new target particle frame: */
                     particleCreator(sourceParticle, targetParticle);

--- a/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
+++ b/src/picongpu/include/particles/gasProfiles/FromHDF5Impl.hpp
@@ -51,7 +51,7 @@ struct FromHDF5Impl : public T_ParamClass
     HINLINE FromHDF5Impl(uint32_t currentStep)
     {
         const uint32_t numSlides = MovingWindow::getInstance( ).getSlideCounter( currentStep );
-        PMACC_AUTO(window, MovingWindow::getInstance().getWindow(currentStep));
+        auto window = MovingWindow::getInstance().getWindow(currentStep);
         loadHDF5(window);
         const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
         DataSpace<simDim> localCells = subGrid.getLocalDomain( ).size;
@@ -81,7 +81,7 @@ private:
             fieldTmpNumSlots > 0
         );
         FieldTmp& fieldTmp = dc.getData<FieldTmp >( FieldTmp::getUniqueId( 0 ), true );
-        PMACC_AUTO(&fieldBuffer, fieldTmp.getGridBuffer());
+        auto& fieldBuffer = fieldTmp.getGridBuffer();
 
         deviceDataBox = fieldBuffer.getDeviceBuffer().getDataBox();
 
@@ -206,7 +206,7 @@ private:
                 }
 
                 /* get the databox of the host buffer */
-                PMACC_AUTO(dataBox, fieldBuffer.getHostBuffer().getDataBox());
+                auto dataBox = fieldBuffer.getHostBuffer().getDataBox();
                 /* get a 1D access object to the databox */
                 typedef DataBoxDim1Access< typename FieldTmp::DataBoxType > D1Box;
                 DataSpace<simDim> guards = fieldBuffer.getGridLayout().getGuard();

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -152,7 +152,7 @@ namespace ionization
                 /* instance of nvidia assignment operator */
                 nvidia::functors::Assign assign;
                 /* copy fields from global to shared */
-                PMACC_AUTO(fieldBBlock, bBox.shift(blockCell));
+                auto fieldBBlock = bBox.shift(blockCell);
                 ThreadCollective<BlockArea> collective(linearThreadIdx);
                 collective(
                           assign,
@@ -160,7 +160,7 @@ namespace ionization
                           fieldBBlock
                           );
                 /* copy fields from global to shared */
-                PMACC_AUTO(fieldEBlock, eBox.shift(blockCell));
+                auto fieldEBlock = eBox.shift(blockCell);
                 collective(
                           assign,
                           cachedE,
@@ -184,7 +184,7 @@ namespace ionization
             DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
             {
                 /* alias for the single macro-particle */
-                PMACC_AUTO(particle,ionFrame[localIdx]);
+                auto particle = ionFrame[localIdx];
                 /* particle position, used for field-to-particle interpolation */
                 floatD_X pos = particle[position_];
                 const int particleCellIdx = particle[localCellIdx_];

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -131,7 +131,7 @@ namespace ionization
 
                 ThreadCollective<BlockArea> collective(linearThreadIdx);
                 /* copy fields from global to shared */
-                PMACC_AUTO(fieldEBlock, eBox.shift(blockCell));
+                auto fieldEBlock = eBox.shift(blockCell);
                 collective(
                           assign,
                           cachedE,
@@ -149,7 +149,7 @@ namespace ionization
             DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
             {
                 /* alias for the single macro-particle */
-                PMACC_AUTO(particle,ionFrame[localIdx]);
+                auto particle = ionFrame[localIdx];
                 /* particle position, used for field-to-particle interpolation */
                 floatD_X pos = particle[position_];
                 const int particleCellIdx = particle[localCellIdx_];

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -152,7 +152,7 @@ namespace ionization
                 /* instance of nvidia assignment operator */
                 nvidia::functors::Assign assign;
                 /* copy fields from global to shared */
-                PMACC_AUTO(fieldBBlock, bBox.shift(blockCell));
+                auto fieldBBlock = bBox.shift(blockCell);
                 ThreadCollective<BlockArea> collective(linearThreadIdx);
                 collective(
                           assign,
@@ -160,7 +160,7 @@ namespace ionization
                           fieldBBlock
                           );
                 /* copy fields from global to shared */
-                PMACC_AUTO(fieldEBlock, eBox.shift(blockCell));
+                auto fieldEBlock = eBox.shift(blockCell);
                 collective(
                           assign,
                           cachedE,
@@ -184,7 +184,7 @@ namespace ionization
             DINLINE void operator()(FrameType& ionFrame, int localIdx, unsigned int& newMacroElectrons)
             {
                 /* alias for the single macro-particle */
-                PMACC_AUTO(particle,ionFrame[localIdx]);
+                auto particle = ionFrame[localIdx];
                 /* particle position, used for field-to-particle interpolation */
                 floatD_X pos = particle[position_];
                 const int particleCellIdx = particle[localCellIdx_];

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -244,9 +244,9 @@ struct KernelIonizeParticles
                 if ((0 <= electronId) && (electronId < maxParticlesInFrame))
                 {
                     /* each thread makes the attributes of its ion accessible */
-                    PMACC_AUTO(parentIon,(ionFrame[linearThreadIdx]));
+                    auto parentIon = (ionFrame[linearThreadIdx]);
                     /* each thread initializes an electron if one should be created */
-                    PMACC_AUTO(targetElectronFull,(electronFrame[electronId]));
+                    auto targetElectronFull = (electronFrame[electronId]);
 
                     /* create an electron in the new electron frame:
                      * - see particles/ionization/ionizationMethods.hpp
@@ -284,9 +284,9 @@ struct KernelIonizeParticles
                     electronId -= maxParticlesInFrame;
 
                     /* each thread makes the attributes of its ion accessible */
-                    PMACC_AUTO(parentIon,((*ionFrame)[linearThreadIdx]));
+                    auto parentIon = ((*ionFrame)[linearThreadIdx]);
                     /* each thread initializes an electron if one should be produced */
-                    PMACC_AUTO(targetElectronFull,(electronFrame[electronId]));
+                    auto targetElectronFull = (electronFrame[electronId]);
 
                     /* create an electron in the new electron frame:
                      * - see particles/ionization/ionizationMethods.hpp

--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -72,7 +72,7 @@ namespace ionization
              * - boundElectrons: because species other than ions or atoms do not have them
              * (gets AUTOMATICALLY deselected because electrons do not have this attribute)
              */
-            PMACC_AUTO(targetElectronClone, partOp::deselect<bmpl::vector2<multiMask, momentum> >(childElectron));
+            auto targetElectronClone = partOp::deselect<bmpl::vector2<multiMask, momentum> >(childElectron);
 
             partOp::assign(targetElectronClone, partOp::deselect<particleId>(parentIon));
 

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -132,7 +132,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
             --numParToCreate;
             if (freeSlot>-1 && freeSlot < cellsInSuperCell)
             {
-                PMACC_AUTO(destParticle, destFrame[freeSlot]);
+                auto destParticle = destFrame[freeSlot];
                 Functor::operator()(destParticle, particle);
             }
             __syncthreads();
@@ -154,7 +154,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
             //second flush
             if (freeSlot >= cellsInSuperCell)
             {
-                PMACC_AUTO(destParticle, (*destFrame)[freeSlot - cellsInSuperCell]);
+                auto destParticle = (*destFrame)[freeSlot - cellsInSuperCell];
                 Functor::operator()(destParticle, particle);
             }
             __syncthreads();

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -69,11 +69,11 @@ ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::operator()
     /* \todo in the future and if useful, the functor can be a parameter */
     T_DerivedAttribute particleAttribute;
 
-    PMACC_AUTO(particle, frame[localIdx]);
+    auto particle = frame[localIdx];
 
     /* particle attributes: in-cell position and generic, derived attribute */
     const floatD_X pos = particle[position_];
-    const PMACC_AUTO(particleAttr, particleAttribute( particle ));
+    const auto particleAttr = particleAttribute( particle );
 
     /** Shift to the cell the particle belongs to
      * range of particleCell: [DataSpace<simDim>::create(0), TVecSuperCell]
@@ -82,7 +82,7 @@ ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::operator()
     const DataSpace<TVecSuperCell::dim> particleCell(
         DataSpaceOperations<TVecSuperCell::dim>::map( superCell, particleCellIdx )
     );
-    PMACC_AUTO(fieldTmpShiftToParticle, tmpBox.shift(particleCell));
+    auto fieldTmpShiftToParticle = tmpBox.shift(particleCell);
 
     /* loop around the particle's cell (according to shape) */
     const DataSpace<simDim> lowMargin(LowerMargin().toRT());

--- a/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
@@ -74,8 +74,8 @@ namespace picongpu
             {
                 typedef T_Mom MomType;
 
-                PMACC_AUTO( bField , functorBField(pos));
-                PMACC_AUTO( eField , functorEField(pos));
+                auto bField  = functorBField(pos);
+                auto eField  = functorEField(pos);
 
                 Gamma gammaCalc;
                 Velocity velocityCalc;

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -51,8 +51,8 @@ struct Push
     {
         typedef T_Mom MomType;
 
-        PMACC_AUTO( bField , functorBField(pos));
-        PMACC_AUTO( eField , functorEField(pos));
+        auto bField  = functorBField(pos);
+        auto eField  = functorEField(pos);
 
         const float_X QoM = charge / mass;
 
@@ -63,7 +63,7 @@ struct Push
         Gamma gamma;
         const float_X gamma_reci = float_X(1.0) / gamma(mom_minus, mass);
         const float3_X t = float_X(0.5) * QoM * bField * gamma_reci * deltaT;
-        PMACC_AUTO( s , float_X(2.0) * t * (float_X(1.0) / (float_X(1.0) + math::abs2(t))));
+        auto s  = float_X(2.0) * t * (float_X(1.0) / (float_X(1.0) + math::abs2(t)));
 
         const MomType mom_prime = mom_minus + math::cross(mom_minus, t);
         const MomType mom_plus = mom_minus + math::cross(mom_prime, s);

--- a/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -137,10 +137,10 @@ struct Push
           pos[i] = var[i] * cellSize[i];
       }
 
-      PMACC_AUTO( fieldE , fieldEFunc( posInterpolation,
-                                       picongpu::particles::interpolationMemoryPolicy::ShiftToValidRange() ) );
-      PMACC_AUTO( fieldB , fieldBFunc( posInterpolation,
-                                       picongpu::particles::interpolationMemoryPolicy::ShiftToValidRange() ) );
+      auto fieldE = fieldEFunc( posInterpolation,
+                                       picongpu::particles::interpolationMemoryPolicy::ShiftToValidRange() );
+      auto fieldB = fieldBFunc( posInterpolation,
+                                       picongpu::particles::interpolationMemoryPolicy::ShiftToValidRange() );
 
       // transfer momentum
       const uint32_t dimMomentum = GetNComponents<MomentumType>::value;

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -51,8 +51,8 @@ struct Push
     {
         typedef T_Mom MomType;
 
-        PMACC_AUTO( bField , functorBField(pos));
-        PMACC_AUTO( eField , functorEField(pos));
+        auto bField  = functorBField(pos);
+        auto eField  = functorEField(pos);
         /*
              time index in paper is reduced by a half: i=0 --> i=-1/2 so that momenta are
              at half time steps and fields and locations are at full time steps

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -154,7 +154,7 @@ public:
         /* instance of nvidia assignment operator */
         nvidia::functors::Assign assign;
         /* copy fields from global to shared */
-        PMACC_AUTO(fieldBBlock, bBox.shift(blockCell));
+        auto fieldBBlock = bBox.shift(blockCell);
         ThreadCollective<BlockArea> collective(linearThreadIdx);
         collective(
                   assign,
@@ -162,7 +162,7 @@ public:
                   fieldBBlock
                   );
         /* copy fields from global to shared */
-        PMACC_AUTO(fieldEBlock, eBox.shift(blockCell));
+        auto fieldEBlock = eBox.shift(blockCell);
         collective(
                   assign,
                   cachedE,
@@ -244,7 +244,7 @@ public:
     {
         using namespace PMacc::algorithms;
 
-        PMACC_AUTO(particle, sourceFrame[localIdx]);
+        auto particle = sourceFrame[localIdx];
 
         /* particle position, used for field-to-particle interpolation */
         const floatD_X pos = particle[position_];
@@ -325,14 +325,13 @@ public:
     DINLINE void operator()(Electron& electron, Photon& photon) const
     {
         namespace parOp = PMacc::particles::operations;
-        PMACC_AUTO(destPhoton,
+        auto destPhoton =
             parOp::deselect<
                 boost::mpl::vector<
                     multiMask,
                     momentum
                 >
-            >(photon)
-        );
+            >(photon);
         parOp::assign( destPhoton, parOp::deselect<particleId>(electron) );
 
         photon[multiMask_] = 1;

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -112,7 +112,7 @@ struct KernelBinEnergyParticles
         {
             if (linearThreadIdx < particlesInSuperCell)
             {
-                PMACC_AUTO(particle,frame[linearThreadIdx]);
+                auto particle = frame[linearThreadIdx];
                 /* kinetic Energy for Particles: E^2 = p^2*c^2 + m^2*c^4
                  *                                   = c^2 * [p^2 + m^2*c^2] */
                 const float3_X mom = particle[momentum_];

--- a/src/picongpu/include/plugins/ChargeConservation.tpp
+++ b/src/picongpu/include/plugins/ChargeConservation.tpp
@@ -206,18 +206,18 @@ void ChargeConservation::notify(uint32_t currentStep)
     __setTransactionEvent(fieldTmpEvent);
 
     /* cast libPMacc Buffer to cuSTL Buffer */
-    BOOST_AUTO(fieldTmp_coreBorder,
+    auto fieldTmp_coreBorder =
                  fieldTmp->getGridBuffer().
                  getDeviceBuffer().cartBuffer().
                  view(this->cellDescription->getGuardingSuperCells()*BlockDim::toRT(),
-                      this->cellDescription->getGuardingSuperCells()*-BlockDim::toRT()));
+                      this->cellDescription->getGuardingSuperCells()*-BlockDim::toRT());
 
     /* cast libPMacc Buffer to cuSTL Buffer */
-    BOOST_AUTO(fieldE_coreBorder,
+    auto fieldE_coreBorder =
                  dc.getData<FieldE > (FieldE::getName(), true).getGridBuffer().
                  getDeviceBuffer().cartBuffer().
                  view(this->cellDescription->getGuardingSuperCells()*BlockDim::toRT(),
-                      this->cellDescription->getGuardingSuperCells()*-BlockDim::toRT()));
+                      this->cellDescription->getGuardingSuperCells()*-BlockDim::toRT());
 
     /* run calculation: fieldTmp = | div E * eps_0 - rho | */
     using namespace lambda;

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -98,7 +98,7 @@ struct KernelEnergyParticles
             if (isParticle)
             {
 
-                PMACC_AUTO(particle,frame[linearThreadIdx]); /* get one particle */
+                auto particle = frame[linearThreadIdx]; /* get one particle */
                 const float3_X mom = particle[momentum_]; /* get particle momentum */
                 /* and compute square of absolute momentum of one particle: */
                 const float_X mom2 = mom.x() * mom.x() + mom.y() * mom.y() + mom.z() * mom.z();

--- a/src/picongpu/include/plugins/IntensityPlugin.hpp
+++ b/src/picongpu/include/plugins/IntensityPlugin.hpp
@@ -69,7 +69,7 @@ struct KernelIntensity
             PMacc::math::CT::Int<SuperCellSize::x::value,SuperCellSize::y::value>
             > SuperCell2D;
 
-        PMACC_AUTO(s_field, CachedBox::create < 0, float_32> (SuperCell2D()));
+        auto s_field = CachedBox::create < 0, float_32 > (SuperCell2D());
 
         int y = blockIdx.y * SuperCellSize::y::value + threadIdx.y;
         int yGlobal = y + SuperCellSize::y::value;
@@ -341,7 +341,7 @@ private:
         DataSpace<DIM2> grid(1,cellDescription->getGridSuperCells().y() - cellDescription->getGuardingSuperCells());
         /*use only 2D slice XY for supercell handling*/
         typedef typename MappingDesc::SuperCellSize SuperCellSize;
-        auto  block = PMacc::math::CT::Vector<SuperCellSize::x,SuperCellSize::y>::toRT();
+        auto block = PMacc::math::CT::Vector<SuperCellSize::x,SuperCellSize::y>::toRT();
 
         PMACC_KERNEL(KernelIntensity{})
             (grid, block)

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -84,7 +84,7 @@ namespace picongpu
                     const uint32_t el_p,
                     const std::pair<float_X, float_X>& axis_p_range )
         {
-            PMACC_AUTO( particle, frame[particleID] );
+            auto particle = frame[particleID];
             /** \todo this can become a functor to be even more flexible */
             const float_X mom_i = particle[momentum_][el_p];
 

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -132,7 +132,7 @@ struct KernelPositionsParticles
         {
             if (isParticle)
             {
-                PMACC_AUTO(particle,frame[linearThreadIdx]);
+                auto particle = frame[linearThreadIdx];
                 gParticle->position = particle[position_];
                 gParticle->momentum = particle[momentum_];
                 gParticle->weighting = particle[weighting_];

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -109,10 +109,10 @@ void SliceFieldPrinter<Field>::notify(uint32_t currentStep)
       namespace vec = ::PMacc::math;
       typedef SuperCellSize BlockDim;
       DataConnector &dc = Environment<>::get().DataConnector();
-      BOOST_AUTO(field_coreBorder,
+      auto field_coreBorder =
                  dc.getData<Field > (Field::getName(), true).getGridBuffer().
                  getDeviceBuffer().cartBuffer().
-                 view(BlockDim::toRT(), -BlockDim::toRT()));
+                 view(BlockDim::toRT(), -BlockDim::toRT());
 
       std::ostringstream filename;
       filename << this->fileName << "_" << currentStep << ".dat";

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1042,7 +1042,7 @@ private:
         }
         log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) counting particles.");
 
-        PMACC_AUTO(idProviderState, IdProvider<simDim>::getState());
+        auto idProviderState = IdProvider<simDim>::getState();
         WriteNDScalars<uint64_t, uint64_t> writeIdProviderStartId("picongpu/idProvider/startId", "maxNumProc");
         WriteNDScalars<uint64_t, uint64_t> writeIdProviderNextId("picongpu/idProvider/nextId");
         writeIdProviderStartId.prepare(*threadParams, idProviderState.maxNumProc);

--- a/src/picongpu/include/plugins/adios/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/adios/WriteMeta.hpp
@@ -77,8 +77,8 @@ namespace writeMeta
                 }
             }
             helper::GetADIOSArrayOfString getADIOSArrayOfString;
-            PMACC_AUTO(arrParticleBoundary, getADIOSArrayOfString( listParticleBoundary ));
-            PMACC_AUTO(arrParticleBoundaryParam, getADIOSArrayOfString( listParticleBoundaryParam ));
+            auto arrParticleBoundary = getADIOSArrayOfString( listParticleBoundary );
+            auto arrParticleBoundaryParam = getADIOSArrayOfString( listParticleBoundaryParam );
 
             ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
                 "particleBoundary", fullMeshesPath.c_str(), adios_string_array,
@@ -200,8 +200,8 @@ namespace writeMeta
                 }
             }
             helper::GetADIOSArrayOfString getADIOSArrayOfString;
-            PMACC_AUTO(arrFieldBoundary, getADIOSArrayOfString( listFieldBoundary ));
-            PMACC_AUTO(arrFieldBoundaryParam, getADIOSArrayOfString( listFieldBoundaryParam ));
+            auto arrFieldBoundary = getADIOSArrayOfString( listFieldBoundary );
+            auto arrFieldBoundaryParam = getADIOSArrayOfString( listFieldBoundaryParam );
 
             ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
                 "fieldBoundary", fullMeshesPath.c_str(), adios_string_array,

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -67,7 +67,7 @@ public:
 
         DataSpace<simDim> local_domain_size = params->window.localDimensions.size;
 
-        PMACC_AUTO(destBox, field.getHostBuffer().getDataBox());
+        auto destBox = field.getHostBuffer().getDataBox();
         for (uint32_t n = 0; n < numComponents; ++n)
         {
             // Read the subdomain which belongs to our mpi position.

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -429,7 +429,7 @@ private:
         }
         log<picLog::INPUT_OUTPUT > ("HDF5: ( end ) writing particle species.");
 
-        PMACC_AUTO(idProviderState, IdProvider<simDim>::getState());
+        auto idProviderState = IdProvider<simDim>::getState();
         log<picLog::INPUT_OUTPUT>("HDF5: Writing IdProvider state (StartId: %1%, NextId: %2%, maxNumProc: %3%)")
                 % idProviderState.startId % idProviderState.nextId % idProviderState.maxNumProc;
         WriteNDScalars<uint64_t, uint64_t>()(*threadParams,

--- a/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
@@ -83,9 +83,9 @@ namespace writeMeta
                 }
             }
             helper::GetSplashArrayOfString getSplashArrayOfString;
-            PMACC_AUTO(arrParticleBoundary, getSplashArrayOfString( listParticleBoundary ));
+            auto arrParticleBoundary = getSplashArrayOfString( listParticleBoundary );
             ColTypeString ctParticleBoundary( arrParticleBoundary.maxLen );
-            PMACC_AUTO(arrParticleBoundaryParam, getSplashArrayOfString( listParticleBoundaryParam ));
+            auto arrParticleBoundaryParam = getSplashArrayOfString( listParticleBoundaryParam );
             ColTypeString ctParticleBoundaryParam( arrParticleBoundaryParam.maxLen );
 
             dc->writeAttribute( currentStep, ctParticleBoundary, meshesPath.c_str(),
@@ -235,9 +235,9 @@ namespace writeMeta
                 }
             }
             helper::GetSplashArrayOfString getSplashArrayOfString;
-            PMACC_AUTO(arrFieldBoundary, getSplashArrayOfString( listFieldBoundary ));
+            auto arrFieldBoundary = getSplashArrayOfString( listFieldBoundary );
             ColTypeString ctFieldBoundaries( arrFieldBoundary.maxLen );
-            PMACC_AUTO(arrFieldBoundaryParam, getSplashArrayOfString( listFieldBoundaryParam ));
+            auto arrFieldBoundaryParam = getSplashArrayOfString( listFieldBoundaryParam );
             ColTypeString ctFieldBoundariesParam( arrFieldBoundaryParam.maxLen );
 
             dc->writeAttribute( currentStep, ctFieldBoundaries, meshesPath.c_str(),

--- a/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -77,7 +77,7 @@ public:
         for (uint32_t d = 0; d < simDim; ++d)
             local_domain_size[d] = params->window.localDimensions.size[d];
 
-        PMACC_AUTO(destBox, field.getHostBuffer().getDataBox());
+        auto destBox = field.getHostBuffer().getDataBox();
         for (uint32_t i = 0; i < numComponents; ++i)
         {
             // Read the subdomain which belongs to our mpi position.

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -97,7 +97,7 @@ struct CopySpecies
         __syncthreads();
         while (srcFramePtr.isValid()) //move over all Frames
         {
-            PMACC_AUTO(parSrc, (srcFramePtr[threadIdx.x]));
+            auto parSrc = (srcFramePtr[threadIdx.x]);
             storageOffset = -1;
             /*count particle in frame*/
             if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, threadIdx.x))
@@ -111,8 +111,8 @@ struct CopySpecies
             __syncthreads();
             if (storageOffset != -1)
             {
-                PMACC_AUTO(parDest, destFrame[globalOffset + storageOffset]);
-                PMACC_AUTO(parDestNoDomainIdx, deselect<T_Identifier>(parDest));
+                auto parDest = destFrame[globalOffset + storageOffset];
+                auto parDestNoDomainIdx = deselect<T_Identifier>(parDest);
                 assign(parDestNoDomainIdx, parSrc);
                 /* calculate cell index for user-defined domain */
                 DataSpace<Mapping::Dim> localCell(DataSpaceOperations<Mapping::Dim>::template map<Block>(parSrc[localCellIdx_]));

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -336,7 +336,7 @@ struct KernelPaintParticles3D
 
         while (frame.isValid()) //move over all Frames
         {
-            PMACC_AUTO(particle, frame[localId]);
+            auto particle = frame[localId];
             if (particle[multiMask_] == 1)
             {
                 int cellIdx = particle[localCellIdx_];
@@ -602,7 +602,7 @@ public:
 
         DataSpace<DIM2> size = img->getGridLayout().getDataSpace();
 
-        PMACC_AUTO(hostBox, img->getHostBuffer().getDataBox());
+        auto hostBox = img->getHostBuffer().getDataBox();
 
         if (picongpu::white_box_per_GPU)
         {
@@ -611,7 +611,7 @@ public:
             hostBox[0 ][size.x() - 1] = float3_X(1.0, 1.0, 1.0);
             hostBox[size.y() - 1 ][size.x() - 1] = float3_X(1.0, 1.0, 1.0);
         }
-        PMACC_AUTO(resultBox, gather(hostBox, *header));
+        auto resultBox = gather(hostBox, *header);
         if (isMaster)
         {
             m_output(resultBox.shift(header->window.offset), header->window.size, *header);

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -227,7 +227,7 @@ struct KernelRadiationParticles
                 if (linearThreadIdx < particlesInFrame)
                 {
 
-                    PMACC_AUTO(par,frame[linearThreadIdx]);
+                    auto par = frame[linearThreadIdx];
                     // get old and new particle momenta
                     const vector_X particle_momentumNow = vector_X(par[momentum_]);
                     const vector_X particle_momentumOld = vector_X(par[momentumPrev1_]);


### PR DESCRIPTION
@axel denied #1738 and want's that `PMACC_AUTO` and `BOOST_AUTO` must be removed by the native C++11 `auto`

- use native C++11 `auto` instead of our macro
