### PR TITLE
Add kinetic energy algorithm

### DIFF
--- a/src/picongpu/include/algorithms/KinEnergy.hpp
+++ b/src/picongpu/include/algorithms/KinEnergy.hpp
@@ -23,6 +23,7 @@
 #include "simulation_defines.hpp"
 #include "algorithms/Gamma.hpp"
 
+
 namespace picongpu
 {
 
@@ -42,14 +43,12 @@ struct KinEnergy
     typedef T_PrecisionType ValueType;
 
     template< typename MomType, typename MassType >
-    HDINLINE ValueType operator()( const MomType& mom, const MassType& mass )
+    HDINLINE ValueType operator()( MomType const & mom, MassType const & mass )
     {
         if( mass == MassType( 0.0 ) )
-        {
             return SPEED_OF_LIGHT * math::abs( precisionCast< ValueType >( mom ) );
-        }
 
-        /* If mass is non-zero then gamma is well defined */
+        /* if mass is non-zero then gamma is well defined */
         const ValueType gamma = Gamma< ValueType >()( mom, mass );
 
         ValueType kinEnergy;
@@ -58,13 +57,13 @@ struct KinEnergy
         {
             const ValueType mom2 = math::abs2( precisionCast< ValueType >( mom ) );
             /* non relativistic kinetic energy expression */
-            kinEnergy = mom2 / (ValueType( 2.0 ) * mass);
+            kinEnergy = mom2 / ( ValueType( 2.0 ) * mass );
         }
         else
         {
-            const ValueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
-            /* kinetic Energy for Particles: E = (gamma - 1) * m * c^2 */
-            kinEnergy = (gamma - ValueType( 1.0 )) * mass*c2;
+            constexpr ValueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+            /* kinetic energy for particles: E = (gamma - 1) * m * c^2 */
+            kinEnergy = ( gamma - ValueType( 1.0 ) ) * mass * c2;
         }
 
         return kinEnergy;
@@ -72,4 +71,3 @@ struct KinEnergy
 };
 
 }
-

--- a/src/picongpu/include/algorithms/KinEnergy.hpp
+++ b/src/picongpu/include/algorithms/KinEnergy.hpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2017 Axel Huebl, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "algorithms/Gamma.hpp"
+
+namespace picongpu
+{
+
+using namespace PMacc;
+
+/** Computes the kinetic energy of a particle given its momentum and mass.
+ *
+ * The mass may be zero.
+ *
+ * For massive particle with low energy the non-relativistic
+ * kinetic energy expression is used in order to avoid bad roundings.
+ *
+ */
+template< typename T_PrecisionType = float_X >
+struct KinEnergy
+{
+    typedef T_PrecisionType ValueType;
+
+    template< typename MomType, typename MassType >
+    HDINLINE ValueType operator()( const MomType& mom, const MassType& mass )
+    {
+        if( mass == MassType( 0.0 ) )
+        {
+            return SPEED_OF_LIGHT * math::abs( precisionCast< ValueType >( mom ) );
+        }
+
+        /* If mass is non-zero then gamma is well defined */
+        const ValueType gamma = Gamma< ValueType >()( mom, mass );
+
+        ValueType kinEnergy;
+
+        if( gamma < GAMMA_THRESH )
+        {
+            const ValueType mom2 = math::abs2( precisionCast< ValueType >( mom ) );
+            /* non relativistic kinetic energy expression */
+            kinEnergy = mom2 / (ValueType( 2.0 ) * mass);
+        }
+        else
+        {
+            const ValueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+            /* kinetic Energy for Particles: E = (gamma - 1) * m * c^2 */
+            kinEnergy = (gamma - ValueType( 1.0 )) * mass*c2;
+        }
+
+        return kinEnergy;
+    }
+};
+
+}
+

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
@@ -23,6 +23,7 @@
 #include "particles/particleToGrid/derivedAttributes/Energy.def"
 
 #include "simulation_defines.hpp"
+#include "algorithms/KinEnergy.hpp"
 
 
 namespace picongpu
@@ -47,17 +48,7 @@ namespace derivedAttributes
         const float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass( weighting, particle );
 
-        /* calculate new attribute */
-        Gamma<float_X> calcGamma;
-        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
-        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
-
-        const float_X energy = ( gamma <= float_X(GAMMA_THRESH) ) ?
-            math::abs2(mom) / ( float_X(2.0) * mass ) :   /* non-relativistic */
-            (gamma - float_X(1.0)) * mass * c2;           /* relativistic     */
-
-        /* return attribute */
-        return energy;
+        return KinEnergy<>()( mom, mass );
     }
 } /* namespace derivedAttributes */
 } /* namespace particleToGrid */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -23,7 +23,7 @@
 #include "particles/particleToGrid/derivedAttributes/EnergyDensity.def"
 
 #include "simulation_defines.hpp"
-
+#include "algorithms/KinEnergy.hpp"
 
 namespace picongpu
 {
@@ -49,14 +49,7 @@ namespace derivedAttributes
         const float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass( weighting, particle );
 
-        /* calculate new attribute */
-        Gamma<float_X> calcGamma;
-        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
-        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
-
-        const float_X energy = ( gamma <= float_X(GAMMA_THRESH) ) ?
-            math::abs2(mom) / ( float_X(2.0) * mass ) :   /* non-relativistic */
-            (gamma - float_X(1.0)) * mass * c2;           /* relativistic     */
+        const float_X energy = KinEnergy<>()( mom, mass );
 
         const float_X particleDensity = weighting /
             ( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME );

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -42,6 +42,7 @@
 #include "nvidia/functors/Add.hpp"
 
 #include "algorithms/Gamma.hpp"
+#include "algorithms/KinEnergy.hpp"
 #include "memory/shared/Allocate.hpp"
 
 #include "common/txtFileHandling.hpp"
@@ -131,32 +132,16 @@ struct KernelBinEnergyParticles
 
                 if (calcParticle)
                 {
-                    /* \todo: this is a duplication of the code in EnergyParticles - in separate file? */
-                    const float_X mom2 = math::abs2(mom);
                     const float_X weighting = particle[weighting_];
                     const float_X mass = attribute::getMass(weighting,particle);
-                    const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
 
-                    Gamma<> calcGamma;
-                    const float_X gamma = calcGamma(mom, mass);
+                    // calculate kinetic energy of the macro particle
+                    float_X localEnergy = KinEnergy<>()(mom, mass);
 
-                    float_X _local_energy;
-
-                    if (gamma < GAMMA_THRESH)
-                    {
-                        _local_energy = mom2 / (2.0f * mass); /* not relativistic use equation with more precision */
-                    }
-                    else
-                    {
-                        /* kinetic Energy for Particles: E = (sqrt[p^2*c^2 /(m^2*c^4)+ 1] -1) m*c^2
-                         *                                   = c^2 * [p^2 + m^2*c^2]-m*c^2
-                         *                                 = (gamma - 1) * m * c^2   */
-                        _local_energy = (gamma - float_X(1.0)) * mass*c2;
-                    }
-                    _local_energy /= weighting;
+                    localEnergy /= weighting;
 
                     /* +1 move value from 1 to numBins+1 */
-                    int binNumber = math::floor((_local_energy - minEnergy) /
+                    int binNumber = math::floor((localEnergy - minEnergy) /
                                           (maxEnergy - minEnergy) * (float_32) numBins) + 1;
 
                     const int maxBin = numBins + 1;


### PR DESCRIPTION
Computes the kinetic energy from momentum and mass. If the mass is zero, `E = cp` is used. Otherwise it is distinguished between non-relativistic momenta and the general relativistic case.

Tested with a small test script.