### PR TITLE
Fix energy density

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+ * Copyright 2013-2017 Axel Huebl, Rene Widera, Heiko Burau
  *
  * This file is part of PIConGPU.
  *
@@ -35,7 +35,7 @@ namespace derivedAttributes
     HDINLINE float1_64
     EnergyDensity::getUnit() const
     {
-        const float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
+        constexpr float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
         return UNIT_ENERGY / UNIT_VOLUME;
     }
 
@@ -48,12 +48,9 @@ namespace derivedAttributes
         const float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass( weighting, particle );
 
-        const float_X energy = KinEnergy<>()( mom, mass );
+        constexpr float_X INV_CELL_VOLUME = float_X(1.0) / CELL_VOLUME;
 
-        const float_X particleEnergyDensity = energy / CELL_VOLUME;
-
-        /* return attribute */
-        return particleEnergyDensity;
+        return KinEnergy<>()( mom, mass ) * INV_CELL_VOLUME;
     }
 } /* namespace derivedAttributes */
 } /* namespace particleToGrid */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -36,8 +36,7 @@ namespace derivedAttributes
     EnergyDensity::getUnit() const
     {
         const float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
-        return UNIT_ENERGY * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
-               / UNIT_VOLUME;
+        return UNIT_ENERGY / UNIT_VOLUME;
     }
 
     template< class T_Particle >
@@ -51,10 +50,7 @@ namespace derivedAttributes
 
         const float_X energy = KinEnergy<>()( mom, mass );
 
-        const float_X particleDensity = weighting /
-            ( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME );
-
-        const float_X particleEnergyDensity = energy * particleDensity;
+        const float_X particleEnergyDensity = energy / CELL_VOLUME;
 
         /* return attribute */
         return particleEnergyDensity;

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -37,19 +37,31 @@ namespace picongpu
 {
     /** FieldTmp output (calculated at runtime) *******************************
      *
+     * Those operations derive scalar field quantities from particle species
+     * at runtime. Each value is mapped per cell. Some operations are identical
+     * up to a constant, so avoid writing those twice to save storage.
+     *
      * you can choose any of these particle to grid projections:
      *   - CreateDensityOperation: particle position + shape on the grid
      *   - CreateChargeDensityOperation: density * charge
-     *   - CreateMidCurrentDensityComponentOperation:
-     *                                   density * charge * velocity_component
-     *   - CreateCounterOperation: counts point like particles per cell (debug)
-     *   - CreateEnergyDensityOperation: particle energy density with respect
-     *                                   to shape
-     *   - CreateEnergyOperation: particle energy with respect to shape
+     *       note: for species that do not change their charge state, this is
+     *             the same as the density times a constant for the charge
+     *   - CreateEnergyOperation: sum of kinetic particle energy per cell with
+     *                            respect to shape (deprecated)
+     *   - CreateEnergyDensityOperation: average kinetic particle energy per
+     *                                   cell times the particle density
+     *       note: this is the same as the sum of kinetic particle energy
+     *             divided by a constant for the cell volume
      *   - CreateMomentumComponentOperation: ratio between a selected momentum
      *                                       component and the absolute
      *                                       momentum with respect to shape
-     *   - CreateLarmorPowerOperation: radiated larmor power (needs ENABLE_RADIATION)
+     *   - CreateLarmorPowerOperation: radiated larmor power
+     *                                 (needs ENABLE_RADIATION)
+     *
+     * for debugging:
+     *   - CreateMidCurrentDensityComponentOperation:
+     *       density * charge * velocity_component
+     *   - CreateCounterOperation: counts point like particles per cell
      */
     using namespace particleToGrid;
 


### PR DESCRIPTION
Fix energy density calculation. Prior to this the weighting factor was wrongly included in the energy density expression resulting in a quadratic dependency.

**Work-Around:** Use `CreateEnergyOperation` instead and divide by cell volume.