### PR TITLE
openPMD: iterationFormat only Basename

### DIFF
--- a/src/libPMacc/include/mappings/simulation/Filesystem.hpp
+++ b/src/libPMacc/include/mappings/simulation/Filesystem.hpp
@@ -44,7 +44,8 @@ namespace PMacc
              *
              * @param dir name of directory
              */
-            void createDirectory(const std::string dir)
+            void
+            createDirectory( const std::string dir ) const
             {
                 /* does not throw if the directory exists or has been created */
                 bfs::create_directories(dir);
@@ -55,7 +56,8 @@ namespace PMacc
              *
              * @param dir name of directory
              */
-            void setDirectoryPermissions(const std::string dir)
+            void
+            setDirectoryPermissions( const std::string dir )  const
             {
                 /* set permissions */
                 bfs::permissions(dir,
@@ -71,7 +73,8 @@ namespace PMacc
              *
              * @param dir name of directory
              */
-            void createDirectoryWithPermissions(const std::string dir)
+            void
+            createDirectoryWithPermissions( const std::string dir ) const
             {
                 GridController<DIM>& gc = Environment<DIM>::get().GridController();
 
@@ -82,6 +85,17 @@ namespace PMacc
                     /* must be set by only one process to avoid races */
                     setDirectoryPermissions(dir);
                 }
+            }
+
+            /**
+             * Strip path from absolute or relative paths to filenames
+             *
+             * @param path and filename
+             */
+            std::string
+            basename( const std::string pathFilename ) const
+            {
+                return bfs::path( pathFilename ).filename().string();
             }
 
         private:

--- a/src/picongpu/include/plugins/adios/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/adios/WriteMeta.hpp
@@ -144,7 +144,10 @@ namespace writeMeta
             ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
                 "iterationEncoding", "/", adios_string, 1, (void*)iterationEncoding.c_str()));
 
-            const std::string iterationFormat( threadParams->adiosFilename + std::string("_%T.h5") );
+            const std::string iterationFormat(
+                Environment< simDim >::get().Filesystem().basename( threadParams->adiosFilename ) +
+                std::string("_%T.bp")
+            );
             ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
                 "iterationFormat", "/", adios_string, 1, (void*)iterationFormat.c_str()));
 

--- a/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
@@ -173,7 +173,10 @@ namespace writeMeta
                                       ctIterationEncoding, "iterationEncoding",
                                       iterationEncoding.c_str() );
 
-            const std::string iterationFormat( threadParams->h5Filename + std::string("_%T.h5") );
+            const std::string iterationFormat(
+                Environment< simDim >::get().Filesystem().basename( threadParams->h5Filename ) +
+                std::string("_%T.h5")
+            );
             ColTypeString ctIterationFormat( iterationFormat.length() );
             dc->writeGlobalAttribute( threadParams->currentStep,
                                       ctIterationFormat, "iterationFormat",


### PR DESCRIPTION
The `iterationFormat` in `openPMD`'s base attributes in `/` should only contain the *basename*, not the path to the file in "fileBased" `iterationEncoding`.

This is not a minor bug since most post-processing tools I am aware of are currently not reading that attribute, but they might. Nevertheless, it violates the standard (I did not check it carefully when moving `.h5` and `.bp` files to their own dir in `simOutput`).