### PR TITLE
Particle StartPosition: OnePosition

### DIFF
--- a/src/picongpu/include/particles/startPosition/OnePositionImpl.def
+++ b/src/picongpu/include/particles/startPosition/OnePositionImpl.def
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2017 Rene Widera
+ * Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -18,10 +18,18 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include "particles/startPosition/IFunctor.def"
-#include "particles/startPosition/QuietImpl.def"
-#include "particles/startPosition/RandomImpl.def"
-#include "particles/startPosition/OnePositionImpl.def"
+namespace picongpu
+{
+namespace particles
+{
+namespace startPosition
+{
+
+    template< typename T_ParamClass >
+    struct OnePositionImpl;
+
+} // namespace startPosition
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/startPosition/OnePositionImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/OnePositionImpl.hpp
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+
+#include "simulation_defines.hpp"
+#include "particles/startPosition/MacroParticleCfg.hpp"
+#include "particles/startPosition/IFunctor.def"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace startPosition
+{
+
+    template< typename T_ParamClass >
+    struct OnePositionImpl
+    {
+
+        typedef T_ParamClass ParamClass;
+
+        template< typename T_SpeciesType >
+        struct apply
+        {
+            typedef OnePositionImpl< ParamClass > type;
+        };
+
+        HINLINE
+        OnePositionImpl( uint32_t )
+        {
+        }
+
+        DINLINE void
+        init( const DataSpace<simDim>& /*totalCellOffset*/ )
+        {
+        }
+
+        /** Distributes the initial particles all on one position in the cell.
+         *
+         * @param curParticle the number of this particle: [0, totalNumParsPerCell-1]
+         * @return float3_X with components between [0.0, 1.0)
+         */
+        DINLINE floatD_X
+        operator()( const uint32_t curParticle )
+        {
+            return ParamClass().
+                   inCellOffset.
+                   template shrink< simDim >();
+        }
+
+        /** If the particles to initialize (numParsPerCell) end up with a
+         *  related particle weighting (macroWeighting) below MIN_WEIGHTING,
+         *  reduce the number of particles if possible to satisfy this condition.
+         *
+         * @param realParticlesPerCell  the number of real particles in this cell
+         * @return macroWeighting the intended weighting per macro particle
+         */
+        DINLINE MacroParticleCfg
+        mapRealToMacroParticle( const float_X realParticlesPerCell )
+        {
+            uint32_t numParsPerCell = ParamClass::numParticlesPerCell;
+            float_X macroWeighting = float_X(0.0);
+            if( numParsPerCell > 0 )
+                macroWeighting =
+                    realParticlesPerCell /
+                    float_X( numParsPerCell );
+
+            while(
+                macroWeighting < MIN_WEIGHTING &&
+                numParsPerCell > 0
+            )
+            {
+                --numParsPerCell;
+                if( numParsPerCell > 0 )
+                    macroWeighting =
+                        realParticlesPerCell /
+                        float_X( numParsPerCell );
+                else
+                    macroWeighting = float_X( 0.0 );
+            }
+            MacroParticleCfg macroParCfg;
+            macroParCfg.weighting = macroWeighting;
+            macroParCfg.numParticlesPerCell = numParsPerCell;
+
+            return macroParCfg;
+        }
+    };
+} // namespace startPosition
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/startPosition/functors.hpp
+++ b/src/picongpu/include/particles/startPosition/functors.hpp
@@ -24,3 +24,4 @@
 #include "particles/startPosition/IFunctor.hpp"
 #include "particles/startPosition/QuietImpl.hpp"
 #include "particles/startPosition/RandomImpl.hpp"
+#include "particles/startPosition/OnePositionImpl.hpp"

--- a/src/picongpu/include/simulation_defines/param/particleConfig.param
+++ b/src/picongpu/include/simulation_defines/param/particleConfig.param
@@ -105,7 +105,7 @@ namespace startPosition
          *  unit: none */
         static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
     };
-    /* definition of random particle start*/
+    /* definition of random particle start */
     typedef RandomImpl<RandomParameter> Random;
 
     struct QuietParam
@@ -115,9 +115,30 @@ namespace startPosition
        typedef mCT::shrinkTo<mCT::Int<1, TYPICAL_PARTICLES_PER_CELL, 1>, simDim>::type numParticlesPerDimension;
     };
 
-    /* definition of quiet particle start*/
+    /* definition of quiet particle start */
     typedef QuietImpl<QuietParam> Quiet;
 
+    /* sit directly in lower corner of the cell */
+    CONST_VECTOR(
+        float_X,
+        3,
+        InCellOffset,
+        /* each x, y, z in-cell position component in range [0.0, 1.0) */
+        0.0,
+        0.0,
+        0.0
+    );
+    struct OnePositionParameter
+    {
+        /** Count of particles per cell at initial state
+         *  unit: none */
+        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+
+        const InCellOffset_t inCellOffset;
+    };
+
+    /* definition of one specific position for particle start */
+    using OnePosition = OnePositionImpl< OnePositionParameter >;
 
 } //namespace startPosition
 } //namespace particles


### PR DESCRIPTION
Add a new starting position called `OnePosition` which is exactly one fixed position within a cell for all particles that will be initialized there.

Useful for particle pusher tests with single or few particles.

(Used and tested in #1716)