### PR TITLE
Fix RatioWeighting (DensityWeighting) manipulator

### DIFF
--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -83,6 +83,8 @@ using PIC_Electrons = Particles<
 value_identifier( float_X, MassRatioIons, 1.0 );
 value_identifier( float_X, ChargeRatioIons, -1.0 );
 
+value_identifier( float_X, DensityRatioIons, 1.0 );
+
 /*! Specify (chemical) element
  *
  * Proton and neutron numbers define the chemical element that the ion species
@@ -129,7 +131,9 @@ using ParticleFlagsIons = bmpl::vector<
     interpolation<UsedField2Particle>,
     current<UsedParticleCurrentSolver>,
     massRatio<MassRatioIons>,
-    chargeRatio<ChargeRatioIons>
+    chargeRatio<ChargeRatioIons>,
+    densityRatio<DensityRatioIons>,
+    atomicNumbers<Hydrogen>
 >;
 
 /*define specie ions*/

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
@@ -84,7 +84,7 @@ namespace particles
  */
 typedef mpl::vector<
     CreateGas<gasProfiles::Homogenous, startPosition::Quiet, PIC_Ions>,
-    DeriveSpecies<PIC_Ions,PIC_Electrons>,
+    ManipulateDeriveSpecies<manipulators::RatioWeightingImpl,PIC_Ions,PIC_Electrons>,
     Manipulate<manipulators::AssignZDriftIons, PIC_Ions>,
     Manipulate<manipulators::AssignZDriftElectrons, PIC_Electrons>,
     Manipulate<manipulators::AddTemperature, PIC_Electrons>

--- a/src/picongpu/include/particles/manipulators/RatioWeightingImpl.def
+++ b/src/picongpu/include/particles/manipulators/RatioWeightingImpl.def
@@ -40,7 +40,7 @@ namespace manipulators
  * note: needs the densityRatio flag on both species,
  *       used by the GetDensityRatio trait.
  */
-struct RatioWeighting;
+struct RatioWeightingImpl;
 
 } //namespace manipulators
 } //namespace particles

--- a/src/picongpu/include/particles/manipulators/RatioWeightingImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RatioWeightingImpl.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 Axel Huebl
+ * Copyright 2015-2017 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -73,9 +73,9 @@ struct RatioWeightingImpl
         if (isDesParticle && isSrcParticle)
         {
             const float_X densityRatioDes =
-                traits::GetDensityRatio<T_DesParticle>::type::getDefaultValue();
+                traits::GetDensityRatio<T_DesParticle>::type::getValue();
             const float_X densityRatioSrc =
-                traits::GetDensityRatio<T_SrcParticle>::type::getDefaultValue();
+                traits::GetDensityRatio<T_SrcParticle>::type::getValue();
 
             particleDes[weighting_] *= densityRatioDes / densityRatioSrc;
         }

--- a/src/picongpu/include/particles/traits/GetDensityRatio.hpp
+++ b/src/picongpu/include/particles/traits/GetDensityRatio.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 Rene Widera
+ * Copyright 2015-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -23,8 +23,10 @@
 #include "simulation_defines.hpp"
 #include "traits/GetFlagType.hpp"
 #include "traits/Resolve.hpp"
+#include "traits/HasFlag.hpp"
 
 #include <boost/mpl/if.hpp>
+
 
 namespace picongpu
 {
@@ -34,7 +36,7 @@ namespace traits
 namespace detail
 {
     value_identifier(float_X, DefaultDensityRatio, 1.0);
-} //namespace detail
+} // namespace detail
 
 
 /** get density ratio of a species
@@ -55,12 +57,11 @@ struct GetDensityRatio
     >::type DensityRatioOfSpecies;
 
     typedef typename bmpl::if_<
-         hasDensityRatio,
+        hasDensityRatio,
         DensityRatioOfSpecies,
         detail::DefaultDensityRatio
     >::type type;
 };
 
-} //namespace traits
-
-}// namespace picongpu
+} // namespace traits
+} // namespace picongpu


### PR DESCRIPTION
This pull request fixes compile errors when using `RatioWeightingImpl` during species initialization as manipulator. 

- [x] It is **still required to add** `#include "particles/manipulators/RatioWeightingImpl.hpp"` in `speciesInitialization.param`. @ax3l and @psychocoderHPC is this intended? -> fixed

Thanks @n01r for finding this bug and helping to fix it. 

This closes #1758 and also (the wrongly defined) #1757. 

***

@ax3l's notes:
- only the first two commits are relevant for a backport