### PR TITLE
ManipulateDeriveSpecies: Refactor Functors & Tests

### DIFF
--- a/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
@@ -83,10 +83,24 @@ namespace particles
  * the functors are called in order (from first to last functor)
  */
 typedef mpl::vector<
-    CreateGas<gasProfiles::Homogenous, startPosition::Random, PIC_Electrons>,
-    DeriveSpecies<PIC_Electrons, PIC_Ions>,
-    Manipulate<manipulators::AddTemperature, PIC_Electrons>,
-    Manipulate<manipulators::AddTemperature, PIC_Ions>
+    CreateGas<
+        gasProfiles::Homogenous,
+        startPosition::Random,
+        PIC_Ions
+    >,
+    ManipulateDeriveSpecies<
+        manipulators::ProtonTimesWeighting,
+        PIC_Ions,
+        PIC_Electrons
+    >,
+    Manipulate<
+        manipulators::AddTemperature,
+        PIC_Electrons
+    >,
+    Manipulate<
+        manipulators::AddTemperature,
+        PIC_Ions
+    >
 > InitPipeline;
 
 } /* namespace particles */

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -83,6 +83,7 @@ using PIC_Electrons = Particles<
 value_identifier( float_X, MassRatioIons, 1.0 );
 value_identifier( float_X, ChargeRatioIons, -1.0 );
 
+/* ratio relative to GAS_DENSITY_SI */
 value_identifier( float_X, DensityRatioIons, 1.0 );
 
 /*! Specify (chemical) element

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
@@ -83,11 +83,33 @@ namespace particles
  * the functors are called in order (from first to last functor)
  */
 typedef mpl::vector<
-    CreateGas<gasProfiles::Homogenous, startPosition::Quiet, PIC_Ions>,
-    ManipulateDeriveSpecies<manipulators::RatioWeightingImpl,PIC_Ions,PIC_Electrons>,
-    Manipulate<manipulators::AssignZDriftIons, PIC_Ions>,
-    Manipulate<manipulators::AssignZDriftElectrons, PIC_Electrons>,
-    Manipulate<manipulators::AddTemperature, PIC_Electrons>
+    CreateGas<
+        gasProfiles::Homogenous,
+        startPosition::Quiet,
+        PIC_Ions
+    >,
+    ManipulateDeriveSpecies<
+        /* make sure in speciesDefinition.param that
+         *   densityRatio * chargeRatio
+         * of electrons and ions is quasi neutral!
+         * alternatively, use manipulators::ProtonTimesWeighting
+         */
+        manipulators::DensityWeighting,
+        PIC_Ions,
+        PIC_Electrons
+    >,
+    Manipulate<
+        manipulators::AssignZDriftIons,
+        PIC_Ions
+    >,
+    Manipulate<
+        manipulators::AssignZDriftElectrons,
+        PIC_Electrons
+    >,
+    Manipulate<
+        manipulators::AddTemperature,
+        PIC_Electrons
+    >
 > InitPipeline;
 
 } /* namespace particles */

--- a/src/picongpu/include/particles/manipulators/DensityWeighting.def
+++ b/src/picongpu/include/particles/manipulators/DensityWeighting.def
@@ -28,24 +28,19 @@ namespace particles
 namespace manipulators
 {
 
-/* Re-scale the weighting of a cloned species by numberOfProtons
+/* Re-scale the weighting of a cloned species by densityRatio
  *
- * When derive species from each other, the new
+ * When deriving species from each other, the new
  * species "inherits" the macro-particle weighting
  * of the first one.
  * This functor can be used to manipulate the weighting
- * of the new species' macro particles to be a multiplied by
- * the number of protons on the initial species.
+ * of the new species' macro particles to satisfy the
+ * input densityRatio of it.
  *
- * As an example, this comes useful when initializing a quasi-neutral,
- * pre-ionized plasma of ions and electrons. Electrons can be created
- * from ions via deriving and increasing their weight to avoid simulating
- * multiple macro electrons per macro ion (with Z>1).
- *
- * note: needs the atomicNumbers flag on the initial species,
- *       used by the GetAtomicNumbers trait.
+ * note: needs the densityRatio flag on both species,
+ *       used by the GetDensityRatio trait.
  */
-struct ProtonTimesWeightingImpl;
+struct DensityWeighting;
 
 } //namespace manipulators
 } //namespace particles

--- a/src/picongpu/include/particles/manipulators/DensityWeighting.hpp
+++ b/src/picongpu/include/particles/manipulators/DensityWeighting.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "particles/manipulators/RatioWeightingImpl.def"
+#include "particles/manipulators/DensityWeighting.def"
 #include "particles/traits/GetDensityRatio.hpp"
 
 #include "simulation_defines.hpp"
@@ -33,16 +33,16 @@ namespace particles
 namespace manipulators
 {
 
-struct RatioWeightingImpl
+struct DensityWeighting
 {
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef RatioWeightingImpl type;
+        typedef DensityWeighting type;
     };
 
-    HINLINE RatioWeightingImpl(uint32_t)
+    HINLINE DensityWeighting(uint32_t)
     {
     }
 

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.def
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.def
@@ -28,19 +28,24 @@ namespace particles
 namespace manipulators
 {
 
-/* Re-scale the weighting of a cloned species by densityRatio
+/* Re-scale the weighting of a cloned species by numberOfProtons
  *
- * When deriving species from each other, the new
+ * When derive species from each other, the new
  * species "inherits" the macro-particle weighting
  * of the first one.
  * This functor can be used to manipulate the weighting
- * of the new species' macro particles to satisfy the
- * input densityRatio of it.
+ * of the new species' macro particles to be a multiplied by
+ * the number of protons on the initial species.
  *
- * note: needs the densityRatio flag on both species,
- *       used by the GetDensityRatio trait.
+ * As an example, this comes useful when initializing a quasi-neutral,
+ * pre-ionized plasma of ions and electrons. Electrons can be created
+ * from ions via deriving and increasing their weight to avoid simulating
+ * multiple macro electrons per macro ion (with Z>1).
+ *
+ * note: needs the atomicNumbers flag on the initial species,
+ *       used by the GetAtomicNumbers trait.
  */
-struct RatioWeightingImpl;
+struct ProtonTimesWeighting;
 
 } //namespace manipulators
 } //namespace particles

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.hpp
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "particles/manipulators/ProtonTimesWeightingImpl.def"
+#include "particles/manipulators/ProtonTimesWeighting.def"
 #include "particles/traits/GetAtomicNumbers.hpp"
 
 #include "simulation_defines.hpp"
@@ -33,16 +33,16 @@ namespace particles
 namespace manipulators
 {
 
-struct ProtonTimesWeightingImpl
+struct ProtonTimesWeighting
 {
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef ProtonTimesWeightingImpl type;
+        typedef ProtonTimesWeighting type;
     };
 
-    HINLINE ProtonTimesWeightingImpl(uint32_t)
+    HINLINE ProtonTimesWeighting(uint32_t)
     {
     }
 

--- a/src/picongpu/include/particles/manipulators/manipulators.def
+++ b/src/picongpu/include/particles/manipulators/manipulators.def
@@ -32,5 +32,5 @@
 #include "particles/manipulators/FreeImpl.def"
 #include "particles/manipulators/SetAttributeImpl.def"
 #include "particles/manipulators/RandomPositionImpl.def"
-#include "particles/manipulators/RatioWeightingImpl.def"
-#include "particles/manipulators/ProtonTimesWeightingImpl.def"
+#include "particles/manipulators/DensityWeighting.def"
+#include "particles/manipulators/ProtonTimesWeighting.def"

--- a/src/picongpu/include/particles/manipulators/manipulators.hpp
+++ b/src/picongpu/include/particles/manipulators/manipulators.hpp
@@ -31,5 +31,5 @@
 #include "particles/manipulators/FreeImpl.hpp"
 #include "particles/manipulators/SetAttributeImpl.hpp"
 #include "particles/manipulators/RandomPositionImpl.hpp"
-#include "particles/manipulators/RatioWeightingImpl.hpp"
-#include "particles/manipulators/ProtonTimesWeightingImpl.hpp"
+#include "particles/manipulators/DensityWeighting.hpp"
+#include "particles/manipulators/ProtonTimesWeighting.hpp"

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -107,6 +107,9 @@ using PIC_Electrons = Particles<
 value_identifier( float_X, MassRatioIons, 1836.152672 );
 value_identifier( float_X, ChargeRatioIons, -1.0 );
 
+/* ratio relative to GAS_DENSITY_SI */
+value_identifier( float_X, DensityRatioIons, -1.0 );
+
 /*! Specify (chemical) element
  *
  * Proton and neutron numbers define the chemical element that the ion species
@@ -153,7 +156,9 @@ using ParticleFlagsIons = bmpl::vector<
     interpolation< UsedField2Particle >,
     current< UsedParticleCurrentSolver >,
     massRatio< MassRatioIons >,
-    chargeRatio< ChargeRatioIons >
+    chargeRatio< ChargeRatioIons >,
+    densityRatio< DensityRatioIons >,
+    atomicNumbers< Hydrogen >
 >;
 
 /* define species ions */


### PR DESCRIPTION
- [x] Needs rebase. Follow-up to ~~#1759~~.

### ManipulateDeriveSpecies: Refactor Functors

`RatioWeightingImpl` & `ProtonTimesWeightingImpl` are without parameters, so we need no `Impl` interface which clutters the user interface. (Reminder: Manipulators with parameters are first configured in `particleConfig.param` via their `Impl` interface and then used in `speciesInitialization.param`).

`RatioWeighting` is renamed to `DensityWeighting` since it changes the weighting depending on the `denistyRatio` of both species.

### ThermalTest: Add `ProtonTimesWeighting`

Use `ProtonTimesWeighting` to derive electrons from ions (protons) in `ThermalTest` so that manipulator is covered by the compile suite and users have an example for it.

### Default speciesDefinition.param: Density & AtomicNumbers Example

Add the (constant) flags for `densityRatio` and `atomicNumbers` to the standard `speciesDefinition.param` so users know how to add them.

Adds no additional cost since those are constant per particle frame but adds per default more tune-ability and more information to openPMD output (for ions).