### PR TITLE
fix shared memory alignment

### DIFF
--- a/src/libPMacc/include/memory/shared/Allocate.hpp
+++ b/src/libPMacc/include/memory/shared/Allocate.hpp
@@ -24,6 +24,7 @@
 
 
 #include "pmacc_types.hpp"
+#include "memory/Array.hpp"
 
 
 namespace PMacc
@@ -55,7 +56,7 @@ namespace shared
         DINLINE T_Type &
         get()
         {
-            __shared__ uint8_t smem[ sizeof(T_Type) ];
+            __shared__ alignas( alignof( T_Type ) ) uint8_t smem[ sizeof( T_Type ) ];
             return *( reinterpret_cast< T_Type* >( smem ) );
         }
     };


### PR DESCRIPTION
fix #1766 I did not investigate the effect of this bug on other kernels than radiation.

- add type alignment to shared memory allocator

Tests:

- [x] broken bunch example from #1766

This bug was introduced with #1726. The new method to create shard memory in #1726 removed the alignment information from the shared memory, this could result in unaligned memory access errors.