### PR TITLE
Add particle attribute `inCellOffset`

### DIFF
--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -63,6 +63,11 @@ value_identifier(float3_X,momentumPrev1,float3_X::create(0.));
 value_identifier(float_X, weighting, 0.0);
 /** use this particle for radiation diagnostics */
 value_identifier(bool, radiationFlag, false);
+/** offset from current particle to next particle in the same cell in units of
+ *  of frame position
+ *  - used for in-cell sorting and particle-particle (e.g. collisional) methods
+ */
+value_identifier(uint32_t, inCellOffset, 0);
 
 /** number of electrons bound to the atom / ion
  *

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -318,7 +318,7 @@ struct UnitDimension<particleId>
 template<>
 struct MacroWeighted<particleId>
 {
-    // we can only follow maro particles via ids
+    // we can only follow macro particles via ids
     static bool get()
     {
         return false;
@@ -414,6 +414,48 @@ struct WeightingPower<boundElectrons>
     static float_64 get()
     {
         return 1.0;
+    }
+};
+
+template<>
+struct Unit<inCellOffset>
+{
+    /** unitless and not scaled by a factor: 1.0 */
+    static std::vector<double> get()
+    {
+        std::vector<double> unit( 1, 1.0 );
+        return unit;
+    }
+};
+template<>
+struct UnitDimension<inCellOffset>
+{
+    static std::vector<float_64> get()
+    {
+        /** inCellOffset is unitless */
+        std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
+
+        return unitDimension;
+    }
+};
+template<>
+struct MacroWeighted<inCellOffset>
+{
+    /** inCellOffset is a macro particle attribute */
+    static bool get()
+    {
+        return false;
+    }
+};
+template<>
+struct WeightingPower<inCellOffset>
+{
+    /** attribute * weighting^0 == attribute:
+     * same for real and macro particle *
+     */
+    static float_64 get()
+    {
+        return 0.0;
     }
 };
 


### PR DESCRIPTION
Adds a particle attribute which holds the offset from one particle to the next
in the same cell in units of frame position. This is a meta attribute used for
future particle-particle methods like collision.