### PR TITLE
Add inCellOffset to list of default attributes

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -42,7 +42,8 @@ namespace picongpu
 using DefaultParticleAttributes = MakeSeq_t<
     position<position_pic>,
     momentum,
-    weighting
+    weighting,
+    inCellOffset
 #if( ENABLE_RADIATION == 1 )
     , momentumPrev1
 #endif


### PR DESCRIPTION
Makes the `inCellOffset` a default particle attribute.