### PR TITLE
Fix #1775 tbg config newline check

### DIFF
--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -374,7 +374,7 @@ if [ ! -f "$cfg_file" ] ; then
 fi
 
 # cfg file sanity check - space after \ at EOL ?
-cfg_err=`egrep "\\\\\[[:space:]]+$" $cfg_file | wc -l`
+cfg_err=`egrep "\\\\\[[:blank:]]+$" $cfg_file | wc -l`
 if [ $cfg_err != 0 ] ; then
     echo "ERROR: file \"$cfg_file\" contains spaces after line continuation \\"
     echo "Check the following lines for end-of-line spaces:"

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -379,7 +379,7 @@ if [ $cfg_err != 0 ] ; then
     echo "ERROR: file \"$cfg_file\" contains spaces after line continuation \\"
     echo "Check the following lines for end-of-line spaces:"
     echo ""
-    egrep -n "\\\[[:space:]]+$" $cfg_file
+    egrep -n "\\\[[:blank:]]+$" $cfg_file
     echo ""
     echo "Run the following command on the file to remove your"
     echo "end-of-line (EOL) white spaces:"

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -380,6 +380,23 @@ if [ $cfg_err != 0 ] ; then
     echo "Check the following lines for end-of-line spaces:"
     echo ""
     egrep -n "\\\[[:space:]]+$" $cfg_file
+    echo ""
+    echo "Run the following command on the file to remove your"
+    echo "end-of-line (EOL) white spaces:"
+    echo ""
+    echo "sed -i 's/[[:blank:]]\+$//' $cfg_file"
+    exit 1;
+fi
+
+# cfg file sanity check - windows EOL? (CR LF)
+cfg_err=`grep -c $'\r' $cfg_file`
+if [ $cfg_err != 0 ] ; then
+    echo "ERROR: file \"$cfg_file\" contains" $cfg_err "non-unix new lines (\r)."
+    echo ""
+    echo "Run the following command on the file to convert all line endings"
+    echo "to pure unix line endings:"
+    echo ""
+    echo "dos2unix $cfg_file"
     exit 1;
 fi
 


### PR DESCRIPTION
This PR fixes the check for end lines allowing windows new lines (Issue https://github.com/ComputationalRadiationPhysics/picongpu/issues/1775)
Furthermore as tbg does only support unix new lines, the config files are check for this trait.