### PR TITLE
PositionFilter: Remove (virtual) Destructor

### DIFF
--- a/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
@@ -51,10 +51,6 @@ public:
     {
     }
 
-    HDINLINE ~PositionFilter()
-    {
-    }
-
     HDINLINE void setWindowPosition(DataSpace<dim> offset, DataSpace<dim> size)
     {
         this->offset = offset;

--- a/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
@@ -40,9 +40,6 @@ class DefaultFilter : public Base
         HDINLINE DefaultFilter() : filterActive(false)
         {}
 
-        HDINLINE virtual ~DefaultFilter()
-        {}
-
         template<class FRAME>
         HDINLINE bool operator()(FRAME & frame,lcellId_t id)
         {
@@ -72,9 +69,6 @@ class DefaultFilter<NullFrame>
     public:
 
         HDINLINE DefaultFilter() : alwaysTrue(true)
-        {}
-
-        HDINLINE virtual ~DefaultFilter()
         {}
 
         template<class FRAME>

--- a/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
@@ -38,10 +38,6 @@ namespace PMacc
         {
         }
 
-        HDINLINE virtual ~TrueFilter()
-        {
-        }
-
         template<class FRAME>
         HDINLINE bool operator()(FRAME&, lcellId_t)
         {


### PR DESCRIPTION
Removes the (virtual) default destructor in the fiter classes since they cause a nvlink warning during separable compilation:
```
nvlink warning : Function 'PMacc::TrueFilter::~TrueFilter()' has address taken but no possible call to it
nvlink warning : Function 'PMacc::privatePositionFilter::PositionFilter<3u, PMacc::TrueFilter>::~PositionFilter()' has address taken but no possible call to it
nvlink warning : Function 'PMacc::PositionFilter3D<PMacc::TrueFilter>::~PositionFilter3D()' has address taken but no possible call to it
nvlink warning : Function 'PMacc::PositionFilter3D<PMacc::TrueFilter>::~PositionFilter3D()' has address taken but no possible call to it
nvlink warning : Function 'PMacc::DefaultFilter<PMacc::PositionFilter3D<PMacc::TrueFilter> >::~DefaultFilter()' has address taken but no possible call to it
nvlink warning : Function 'PMacc::TrueFilter::~TrueFilter()' has address taken but no possible call to it
nvlink warning : Function 'PMacc::privatePositionFilter::PositionFilter<3u, PMacc::TrueFilter>::~PositionFilter()' has address taken but no possible call to it
nvlink warning : Function 'PMacc::DefaultFilter<PMacc::PositionFilter3D<PMacc::TrueFilter> >::~DefaultFilter()' has address taken but no possible call to it
```