### PR TITLE
Source Files: Move to Headers

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -324,15 +324,19 @@ include_directories(BEFORE ${PIC_EXTENSION_PATH}/include)
 # Compile & Link PIConGPU
 ################################################################################
 
-file(GLOB CUDASRCFILES "*.cu")
-file(GLOB SRCFILES "*.cpp")
+file(GLOB_RECURSE CUDASRCFILES "*.cu")
+file(GLOB_RECURSE SRCFILES "*.cpp")
 
-cuda_add_executable(picongpu
-    ${CUDASRCFILES}
+add_library(picongpu-hostonly
+    STATIC
     ${SRCFILES}
 )
 
-target_link_libraries(picongpu ${LIBS} m)
+cuda_add_executable(picongpu
+    ${CUDASRCFILES}
+)
+
+target_link_libraries(picongpu ${LIBS} picongpu-hostonly m)
 
 ################################################################################
 # Install PIConGPU

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -327,8 +327,6 @@ include_directories(BEFORE ${PIC_EXTENSION_PATH}/include)
 file(GLOB CUDASRCFILES "*.cu")
 file(GLOB SRCFILES "*.cpp")
 
-
-
 cuda_add_executable(picongpu
     ${CUDASRCFILES}
     ${SRCFILES}

--- a/src/picongpu/include/ArgsParser.cpp
+++ b/src/picongpu/include/ArgsParser.cpp
@@ -23,7 +23,7 @@
 #include <sstream>
 #include <fstream>
 
-#include "include/ArgsParser.hpp"
+#include "ArgsParser.hpp"
 
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>

--- a/src/picongpu/include/plugins/common/particlePatches.cpp
+++ b/src/picongpu/include/plugins/common/particlePatches.cpp
@@ -18,7 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "include/plugins/common/particlePatches.hpp"
+#include "particlePatches.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/common/particlePatches.cpp
+++ b/src/picongpu/include/plugins/common/particlePatches.cpp
@@ -18,7 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "particlePatches.hpp"
+#include "plugins/common/particlePatches.hpp"
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/common/stringHelpers.cpp
+++ b/src/picongpu/include/plugins/common/stringHelpers.cpp
@@ -18,7 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "include/plugins/common/stringHelpers.hpp"
+#include "stringHelpers.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/common/stringHelpers.cpp
+++ b/src/picongpu/include/plugins/common/stringHelpers.cpp
@@ -18,7 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "stringHelpers.hpp"
+#include "plugins/common/stringHelpers.hpp"
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/hdf5/openPMD/patchReader.cpp
+++ b/src/picongpu/include/plugins/hdf5/openPMD/patchReader.cpp
@@ -20,7 +20,7 @@
 
 #if( ENABLE_HDF5 == 1 )
 
-#  include "include/plugins/hdf5/openPMD/patchReader.hpp"
+#  include "patchReader.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/hdf5/openPMD/patchReader.cpp
+++ b/src/picongpu/include/plugins/hdf5/openPMD/patchReader.cpp
@@ -20,7 +20,8 @@
 
 #if( ENABLE_HDF5 == 1 )
 
-#  include "patchReader.hpp"
+#  include "plugins/hdf5/openPMD/patchReader.hpp"
+
 
 namespace picongpu
 {


### PR DESCRIPTION
- not the cleanest way to keep them in `include/` too, but better then accumulating all in the root path
- CMakeLists: Compile host code separately without nvcc "code splitting" and link it statically