### PR TITLE
Move attribute `inCellOffset` to PMacc 

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -43,7 +43,6 @@ using DefaultParticleAttributes = MakeSeq_t<
     position<position_pic>,
     momentum,
     weighting,
-    inCellOffset
 #if( ENABLE_RADIATION == 1 )
     , momentumPrev1
 #endif

--- a/src/libPMacc/include/particles/Identifier.hpp
+++ b/src/libPMacc/include/particles/Identifier.hpp
@@ -47,4 +47,10 @@ value_identifier(lcellId_t,localCellIdx,0);
  */
 value_identifier(uint8_t,multiMask,0);
 
+/** offset from current particle to next particle in the same cell in units of
+ *  of frame position
+ *  - used for in-cell sorting and particle-particle (e.g. collisional) methods
+ */
+value_identifier(uint32_t,inCellOffset,0);
+
 } //namespace PMacc

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -319,7 +319,7 @@ struct KernelFillGaps
             //absolute position in frame list
             auto myID = threadIdx.x + frameNr * TileSize;
             auto & myCell = myParticle[localCellIdx_];
-            myParticle[picongpu::inCellOffset_] = ::atomicExch(&(cellEntryPoint[myCell]),myID);
+            myParticle[inCellOffset_] = ::atomicExch(&(cellEntryPoint[myCell]),myID);
             ::atomicAdd(&(cellCount[myCell]),1);
         }
         __syncthreads( );
@@ -352,7 +352,7 @@ struct KernelFillGaps
         //entry points for all particles in a cell
         PMACC_SMEM( cellEntryPoint_sh, memory::Array< uint32_t, TileSize> );
         for (int i = 0; i < blockDim.x / TileSize; ++i)
-            cellEntryPoint_sh[i * blockDim.x + threadIdx.x] = 0xffffffff; // "-1" == not set
+            cellEntryPoint_sh[i * blockDim.x + threadIdx.x] = INV_IDX; // "-1" == not set
         //number of particles in a cell
         PMACC_SMEM( cellCount_sh, memory::Array< uint32_t, TileSize> );
         for (int i = 0; i < blockDim.x / TileSize; ++i)
@@ -412,8 +412,8 @@ struct KernelFillGaps
                 auto parDestFull = (firstFrame[threadIdx.x]);
                 /*enable particle*/
                 parDestFull[multiMask_] = 1;
-                /* we not update multiMask because copy from mem to mem is too slow
-                 * we have enabled particle explicit */
+                /* we do not update multiMask because copy from mem to mem is too slow
+                 * we have enabled particle explicitly */
                 auto parDest = deselect<multiMask>(parDestFull);
                 auto parSrc = (lastFrame[parIdx]);
                 assign( parDest, parSrc );

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -101,7 +101,8 @@ public:
     typedef typename MakeSeq<
         typename T_ParticleDescription::ValueTypeSeq,
         localCellIdx,
-        multiMask
+        multiMask,
+        inCellOffset
     >::type ParticleAttributeList;
 
     typedef typename MakeSeq<

--- a/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
@@ -32,8 +32,11 @@ template <class TYPE>
 class SuperCell
 {
 public:
+    /** number of cells in the super cell */
     typedef typename math::CT::volume<typename TYPE::SuperCellSize>::type CellsPerSupercell;
+    /** array that holds the absolute in-frame position of the first particle for each cell */
     typedef memory::Array< uint32_t, CellsPerSupercell::value> CellEntryPointType;
+    /** array that holds the number of particles in each cell for a certain species */
     typedef memory::Array< uint32_t, CellsPerSupercell::value> CellCountType;
 
     HDINLINE SuperCell() :

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -63,11 +63,6 @@ value_identifier(float3_X,momentumPrev1,float3_X::create(0.));
 value_identifier(float_X, weighting, 0.0);
 /** use this particle for radiation diagnostics */
 value_identifier(bool, radiationFlag, false);
-/** offset from current particle to next particle in the same cell in units of
- *  of frame position
- *  - used for in-cell sorting and particle-particle (e.g. collisional) methods
- */
-value_identifier(uint32_t, inCellOffset, 0);
 
 /** number of electrons bound to the atom / ion
  *


### PR DESCRIPTION
- move `inCellOffset` from `speciesAttributes.param` to `Identifier.hpp`
  in PMacc
- replace 0xffffffff by `INV_IDX` from `frame_types.hpp`
- add `inCellOffset` to list of PMacc default particle attributes
- add documentation to `SuperCell.hpp`