### PR TITLE
Fix: Remove rendundant comma in speciesDefinition.param

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -42,7 +42,7 @@ namespace picongpu
 using DefaultParticleAttributes = MakeSeq_t<
     position<position_pic>,
     momentum,
-    weighting,
+    weighting
 #if( ENABLE_RADIATION == 1 )
     , momentumPrev1
 #endif


### PR DESCRIPTION
Removes a rendundant comma that was left over from a temporary change in the parameter file.