### PR TITLE
fileOutput: MacroParticleCounter

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -131,6 +131,18 @@ struct CreateCounterOperation
     typedef FieldTmpOperation< ParticleCounter, T_Species > type;
 };
 
+/* MacroParticleCounter */
+template<typename T_Species>
+struct CreateMacroCounterOperation
+{
+    typedef ComputeGridValuePerFrame<
+        particles::shapes::Counter,
+        particleToGrid::derivedAttributes::MacroCounter
+    > MacroParticleCounter;
+
+    typedef FieldTmpOperation< MacroParticleCounter, T_Species > type;
+};
+
 /* EnergyDensity */
 template<typename T_Species>
 struct CreateEnergyDensityOperation

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "particles/particleToGrid/derivedAttributes/Counter.def"
 
 #include "simulation_defines.hpp"
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -22,6 +22,7 @@
 
 #include "particles/particleToGrid/derivedAttributes/Density.def"
 #include "particles/particleToGrid/derivedAttributes/Counter.def"
+#include "particles/particleToGrid/derivedAttributes/MacroCounter.def"
 #include "particles/particleToGrid/derivedAttributes/ChargeDensity.def"
 #include "particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
 #include "particles/particleToGrid/derivedAttributes/EnergyDensity.def"

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.def
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include <vector>
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct MacroCounter
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * Counter is unitless
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+
+           return unitDimension;
+        }
+
+        HINLINE std::string
+        getName() const
+        {
+            return "macroParticleCounter";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 Axel Huebl, Richard Pausch
+ * Copyright 2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -20,12 +20,31 @@
 
 #pragma once
 
-#include "particles/particleToGrid/derivedAttributes/Density.hpp"
-#include "particles/particleToGrid/derivedAttributes/Counter.hpp"
-#include "particles/particleToGrid/derivedAttributes/MacroCounter.hpp"
-#include "particles/particleToGrid/derivedAttributes/ChargeDensity.hpp"
-#include "particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp"
-#include "particles/particleToGrid/derivedAttributes/EnergyDensity.hpp"
-#include "particles/particleToGrid/derivedAttributes/Energy.hpp"
-#include "particles/particleToGrid/derivedAttributes/MomentumComponent.hpp"
-#include "particles/particleToGrid/derivedAttributes/LarmorPower.hpp"
+#include "particles/particleToGrid/derivedAttributes/MacroCounter.def"
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    MacroCounter::getUnit() const
+    {
+        return 1.0;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    MacroCounter::operator()( T_Particle& particle ) const
+    {
+        /* return attribute */
+        return 1.0;
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -62,6 +62,7 @@ namespace picongpu
      *   - CreateMidCurrentDensityComponentOperation:
      *       density * charge * velocity_component
      *   - CreateCounterOperation: counts point like particles per cell
+     *   - CreateMacroCounterOperation: counts point like macro particles per cell
      */
     using namespace particleToGrid;
 
@@ -69,12 +70,6 @@ namespace picongpu
     using ChargeDensity_Seq = bmpl::transform<
         VectorAllSpecies,
         CreateChargeDensityOperation< bmpl::_1 >
-    >::type;
-
-    /* ParticleCounter section */
-    using Counter_Seq = bmpl::transform<
-        VectorAllSpecies,
-        CreateCounterOperation< bmpl::_1 >
     >::type;
 
     /* EnergyDensity section */
@@ -101,7 +96,6 @@ namespace picongpu
      */
     using FieldTmpSolvers = MakeSeq_t<
         ChargeDensity_Seq,
-        Counter_Seq,
         EnergyDensity_Seq,
         MomentumComponent_Seq
     >;


### PR DESCRIPTION
Add a macro particle counter to the `FieldTmp` per cell particle to grid operations. Assumes all (macro) particles are point like in space and can be used to validate particle memory structures.

Removes Counter as a default used FieldTmp output since it is actually a debug quantity and wastes spaces.