### PR TITLE
`ParticlesBase` allocate member memory

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -83,9 +83,15 @@ protected:
 
     ParticlesBase(MappingDesc description) : SimulationFieldHelper<MappingDesc>(description), particlesBuffer(NULL)
     {
+        this->particlesBuffer = new BufferType(
+            description.getGridLayout().getDataSpace( ),
+            description.getGridLayout().getGuard( )
+        );
     }
 
-    virtual ~ParticlesBase(){}
+    virtual ~ParticlesBase(){
+        __delete(particlesBuffer);
+    }
 
     /* Shift all particle in a AREA
      * @tparam AREA area which is used (CORE,BORDER,GUARD or a combination)

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -80,8 +80,6 @@ public:
 
     Particles(GridLayout<simDim> gridLayout, MappingDesc cellDescription, SimulationDataId datasetID);
 
-    virtual ~Particles();
-
     void createParticleBuffer();
 
     void init(FieldE &fieldE, FieldB &fieldB);
@@ -159,8 +157,6 @@ public:
 
 private:
     SimulationDataId m_datasetID;
-    GridLayout<simDim> m_gridLayout;
-
 
     FieldE *fieldE;
     FieldB *fieldB;

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -64,7 +64,7 @@ Particles<
     T_Attributes,
     T_Flags
 >::Particles(
-    GridLayout<simDim> gridLayout,
+    GridLayout<simDim>,
     MappingDesc cellDescription,
     SimulationDataId datasetID
 ) :
@@ -74,13 +74,9 @@ Particles<
     >( cellDescription ),
     fieldB( NULL ),
     fieldE( NULL ),
-    m_gridLayout(gridLayout),
     m_datasetID( datasetID )
 {
     size_t sizeOfExchanges = 2 * 2 * ( BYTES_EXCHANGE_X + BYTES_EXCHANGE_Y + BYTES_EXCHANGE_Z ) + BYTES_EXCHANGE_X * 2 * 8;
-
-
-    this->particlesBuffer = new BufferType( m_gridLayout.getDataSpace( ), m_gridLayout.getGuard( ) );
 
     log<picLog::MEMORY > ( "size for all exchange = %1% MiB" ) % ( (float_64) sizeOfExchanges / 1024. / 1024. );
 
@@ -135,20 +131,6 @@ Particles<
 >::createParticleBuffer( )
 {
     this->particlesBuffer->createParticleBuffer( );
-}
-
-template<
-    typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
->
-Particles<
-    T_Name,
-    T_Attributes,
-    T_Flags
->::~Particles( )
-{
-    delete this->particlesBuffer;
 }
 
 template<


### PR DESCRIPTION
This change is transparent for the PIConGPU user.
PMacc user needs to remove the `ParticleBuffer` allocation inside its own particle class.

- `ParticlesBase`:
  - allocate member `ParticleBuffer` inside the constructor
  - destructor: delete all member
- `Particles`
  - remove the allocation of member from the parent class
  - remove destructor (now empty)
  - remove unused member `m_gridLayout`