### PR TITLE
refactor `Particle` constructor interface 

### DIFF
--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -78,7 +78,7 @@ public:
     typedef typename ParticlesBaseType::ParticlesBoxType ParticlesBoxType;
 
 
-    Particles(GridLayout<simDim> gridLayout, MappingDesc cellDescription, SimulationDataId datasetID);
+    Particles(MappingDesc cellDescription, SimulationDataId datasetID);
 
     void createParticleBuffer();
 

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -64,7 +64,6 @@ Particles<
     T_Attributes,
     T_Flags
 >::Particles(
-    GridLayout<simDim>,
     MappingDesc cellDescription,
     SimulationDataId datasetID
 ) :

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -78,7 +78,7 @@ struct CreateSpecies
     template<typename T_StorageTuple, typename T_CellDescription>
     HINLINE void operator()(T_StorageTuple& tuple, T_CellDescription* cellDesc) const
     {
-        tuple[SpeciesName()] = new SpeciesType(cellDesc->getGridLayout(), *cellDesc, SpeciesType::FrameType::getName());
+        tuple[SpeciesName()] = new SpeciesType(*cellDesc, SpeciesType::FrameType::getName());
     }
 };
 


### PR DESCRIPTION
- remove `GridLayout<>` from the constructor interface
- ParticlesFunctors: remove `GridLayout` from constructor call


- [x] rebase against #1791