### PR TITLE
Fix #1207 Species can omit a Current Solver

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
@@ -63,7 +63,6 @@ using ParticleFlagsPhotons = bmpl::vector<
     particlePusher< particles::pusher::Photon >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
-    current< UsedParticleCurrentSolver >,
     massRatio< MassRatioPhotons >,
     chargeRatio< ChargeRatioPhotons >
 >;

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -59,14 +59,19 @@ fieldJ( cellDescription.getGridLayout( ) ), fieldE( nullptr ), fieldB( nullptr )
     const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout( ).getDataSpaceWithoutGuarding( );
 
     /* cell margins the current might spread to due to particle shapes */
-    typedef bmpl::accumulate<
+    typedef typename PMacc::particles::traits::FilterByFlag<
         VectorAllSpecies,
+        current<>
+    >::type AllSpeciesWithCurrent;
+
+    typedef bmpl::accumulate<
+        AllSpeciesWithCurrent,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetLowerMargin< GetCurrentSolver<bmpl::_2> > >
         >::type LowerMarginShapes;
 
     typedef bmpl::accumulate<
-        VectorAllSpecies,
+        AllSpeciesWithCurrent,
         typename PMacc::math::CT::make_Int<simDim, 0>::type,
         PMacc::math::CT::max<bmpl::_1, GetUpperMargin< GetCurrentSolver<bmpl::_2> > >
         >::type UpperMarginShapes;

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -64,7 +64,6 @@ using ParticleFlagsPhotons = bmpl::vector<
     particlePusher< particles::pusher::Photon >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
-    current< UsedParticleCurrentSolver >,
     massRatio< MassRatioPhotons >,
     chargeRatio< ChargeRatioPhotons >
 >;


### PR DESCRIPTION
Fix #1207 and allow to skip the current solver in `speciesDefinition.param` so neutral particles do not run this algorithm.