### PR TITLE
fix clang compile

### DIFF
--- a/src/libPMacc/include/memory/shared/Allocate.hpp
+++ b/src/libPMacc/include/memory/shared/Allocate.hpp
@@ -56,7 +56,7 @@ namespace shared
         DINLINE T_Type &
         get()
         {
-            __shared__ alignas( alignof( T_Type ) ) uint8_t smem[ sizeof( T_Type ) ];
+            __shared__ uint8_t smem alignas( alignof( T_Type ) ) [ sizeof( T_Type ) ];
             return *( reinterpret_cast< T_Type* >( smem ) );
         }
     };


### PR DESCRIPTION
fix alignment definition of shared memory

This bug was introduced with #1767.
You can find more information about this issue in our similar [alpaka shared memory fix](https://github.com/ComputationalRadiationPhysics/alpaka/pull/318).