### PR TITLE
allow to define the laser initialization plane

### DIFF
--- a/examples/Bremsstrahlung/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/laserConfig.param
@@ -24,6 +24,20 @@
 
 namespace picongpu
 {
+namespace laser
+{
+    /** cell from top where the laser is initialized
+     *
+     * if `initPlaneY == 0` than the absorber are disabled.
+     * if `initPlaneY > absorbercells negative Y` the negative absorber in y
+     * direction is enabled
+     *
+     * valid ranges:
+     *   - initPlaneY == 0
+     *   - absorber cells negative Y < initPlaneY < cells in y direction of the top gpu
+    */
+    constexpr uint32_t initPlaneY = 0;
+}
     namespace laserGaussianBeam
     {
         // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -28,15 +28,15 @@ namespace laser
 {
 /** cell from top where the laser is initialized
  *
- * if `laserInitPlaneY == 0` than the absorber are disabled.
- * if `laserInitPlaneY > absorbercells negative Y` the negative absorber in y
+ * if `initPlaneY == 0` than the absorber are disabled.
+ * if `initPlaneY > absorbercells negative Y` the negative absorber in y
  * direction is enabled
  *
  * valid ranges:
- *   - laserInitPlaneY == 0
- *   - absorber cells negative Y < laserInitPlaneY < cells in y direction of the top gpu
+ *   - initPlaneY == 0
+ *   - absorber cells negative Y < initPlaneY < cells in y direction of the top gpu
 */
-constexpr uint32_t laserInitPlaneY = 0;
+constexpr uint32_t initPlaneY = 0;
 }
 
 namespace laserGaussianBeam

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -24,6 +24,21 @@
 
 namespace picongpu
 {
+namespace laser
+{
+/** cell from top where the laser is initialized
+ *
+ * if `laserInitPlaneY == 0` than the absorber are disabled.
+ * if `laserInitPlaneY > absorbercells negative Y` the negative absorber in y
+ * direction is enabled
+ *
+ * valid ranges:
+ *   - laserInitPlaneY == 0
+ *   - absorber cells negative Y < laserInitPlaneY < cells in y direction of the top gpu
+*/
+constexpr uint32_t laserInitPlaneY = 0;
+}
+
 namespace laserGaussianBeam
 {
 // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -24,6 +24,21 @@
 
 namespace picongpu
 {
+    namespace laser
+    {
+        /** cell from top where the laser is initialized
+         *
+         * if `laserInitPlaneY == 0` than the absorber are disabled.
+         * if `laserInitPlaneY > absorbercells negative Y` the negative absorber in y
+         * direction is enabled
+         *
+         * valid ranges:
+         *   - laserInitPlaneY == 0
+         *   - absorber cells negative Y < laserInitPlaneY < cells in y direction of the top gpu
+        */
+        constexpr uint32_t laserInitPlaneY = 0;
+    }
+
     namespace laserGaussianBeam
     {
         // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -28,15 +28,15 @@ namespace picongpu
     {
         /** cell from top where the laser is initialized
          *
-         * if `laserInitPlaneY == 0` than the absorber are disabled.
-         * if `laserInitPlaneY > absorbercells negative Y` the negative absorber in y
+         * if `initPlaneY == 0` than the absorber are disabled.
+         * if `initPlaneY > absorbercells negative Y` the negative absorber in y
          * direction is enabled
          *
          * valid ranges:
-         *   - laserInitPlaneY == 0
-         *   - absorber cells negative Y < laserInitPlaneY < cells in y direction of the top gpu
+         *   - initPlaneY == 0
+         *   - absorber cells negative Y < initPlaneY < cells in y direction of the top gpu
         */
-        constexpr uint32_t laserInitPlaneY = 0;
+        constexpr uint32_t initPlaneY = 0;
     }
 
     namespace laserGaussianBeam

--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -69,6 +69,8 @@ struct KernelLaserE
         //const int max_y_neighbors = Get<fieldSolver::FieldSolver::OffsetOrigin_E, 1 >::value;
         const int max_y_neighbors = 1;
 
+        cellOffset.y() += laser::laserInitPlaneY;
+        EFieldOffset.y() += laser::laserInitPlaneY;
         for (int totalOffsetY = 0; totalOffsetY < max_y_neighbors; ++totalOffsetY)
         {
             /** \todo Right now, the phase could be wrong ( == is cloned)
@@ -76,8 +78,25 @@ struct KernelLaserE
              *
              *  \todo What about the B-Field in the second plane?
              */
-            cellOffset.y() = totalOffsetY;
-            fieldE(EFieldOffset) = lMan.getManipulation(cellOffset);
+            if (laser::laserInitPlaneY != 0) // compile time if
+            {
+                /* If the laser is not initialized in the first cell we create a negative
+                 * and positive moving wave. Therefore we need to multiply the
+                 * amplitude with a correction factor depending of the cell size in
+                 * propagation direction.
+                 * The negative moving wave is filtered by the absorber.
+                 *
+                 * The `correctionFactor` assume that the wave is moving in y direction.
+                 */
+                auto correctionFactor = (SPEED_OF_LIGHT * DELTA_T) / CELL_HEIGHT * float_X(2.);
+                fieldE(EFieldOffset) +=  correctionFactor * lMan.getManipulation(cellOffset);
+            }
+            else
+            {
+                fieldE(EFieldOffset) = lMan.getManipulation(cellOffset);
+            }
+            cellOffset.y() += 1;
+            EFieldOffset.y() += 1;
         }
     }
 };

--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -46,6 +46,9 @@ struct KernelLaserE
         cellOffset.z() = (blockIdx.y * blockDim.y) + threadIdx.y;
         EFieldOffset.z() = cellOffset.z() + (MappingDesc::SuperCellSize::z::value * GUARD_SIZE);
 #endif
+        // shift offsets to the laser initialization plane
+        cellOffset.y() += laser::initPlaneY;
+        EFieldOffset.y() += laser::initPlaneY;
 
         /** Calculate how many neighbors to the left we have
          * to initialize the laser in the E-Field
@@ -65,12 +68,13 @@ struct KernelLaserE
          *
          * Problem: that's still not our case. For example our Yee does a
          *          dE = curlLeft(B) - therefor, we should init B, too.
+         *
+         *
+         *  @todo: might also lack temporal offset since our formulas are E(x,z,t) instead of E(x,y,z,t)
+         *  `const int max_y_neighbors = Get<fieldSolver::FieldSolver::OffsetOrigin_E, 1 >::value;`
          */
-        //const int max_y_neighbors = Get<fieldSolver::FieldSolver::OffsetOrigin_E, 1 >::value;
         const int max_y_neighbors = 1;
 
-        cellOffset.y() += laser::laserInitPlaneY;
-        EFieldOffset.y() += laser::laserInitPlaneY;
         for (int totalOffsetY = 0; totalOffsetY < max_y_neighbors; ++totalOffsetY)
         {
             /** \todo Right now, the phase could be wrong ( == is cloned)
@@ -78,13 +82,13 @@ struct KernelLaserE
              *
              *  \todo What about the B-Field in the second plane?
              */
-            if (laser::laserInitPlaneY != 0) // compile time if
+            if (laser::initPlaneY != 0) // compile time if
             {
-                /* If the laser is not initialized in the first cell we create a negative
-                 * and positive moving wave. Therefore we need to multiply the
+                /* If the laser is not initialized in the first cell we emit a
+                 * negatively and positively propagating wave. Therefore we need to multiply the
                  * amplitude with a correction factor depending of the cell size in
                  * propagation direction.
-                 * The negative moving wave is filtered by the absorber.
+                 * The negatively propagating wave is damped by the absorber.
                  *
                  * The `correctionFactor` assume that the wave is moving in y direction.
                  */
@@ -95,6 +99,7 @@ struct KernelLaserE
             {
                 fieldE(EFieldOffset) = lMan.getManipulation(cellOffset);
             }
+            /* move to next cell @see max_y_neighbors */
             cellOffset.y() += 1;
             EFieldOffset.y() += 1;
         }

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -184,7 +184,7 @@ void FieldE::laserManipulation( uint32_t currentStep )
     /* initialize the laser not in the first cell is equal to a negative shift
      * in time
      */
-    constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+    constexpr float_X laserTimeShift = laser::initPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
     /* Disable laser if
      * - init time of laser is over or
      * - we have periodic boundaries in Y direction or
@@ -201,15 +201,15 @@ void FieldE::laserManipulation( uint32_t currentStep )
     else
     {
         PMACC_VERIFY_MSG(
-            laser::laserInitPlaneY < static_cast<uint32_t>( Environment<simDim>::get().SubGrid().getLocalDomain().size.y() ),
-            "laserInitPlaneY must be located in the top GPU"
+            laser::initPlaneY < static_cast<uint32_t>( Environment<simDim>::get().SubGrid().getLocalDomain().size.y() ),
+            "initPlaneY must be located in the top GPU"
         );
     }
 
     PMACC_CASSERT_MSG(
-        __laserInitPlaneY_need_to_be_greate_than_the_top_absorber_cells_or_zero,
-        laser::laserInitPlaneY > ABSORBER_CELLS[1][0] ||
-        laser::laserInitPlaneY == 0 ||
+        __initPlaneY_needs_to_be_greate_than_the_top_absorber_cells_or_zero,
+        laser::initPlaneY > ABSORBER_CELLS[1][0] ||
+        laser::initPlaneY == 0 ||
         laserProfile::INIT_TIME == float_X(0.0) /* laser is disabled e.g. laserNone */
     );
 

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -64,10 +64,10 @@ public:
 
                 if (thickness == 0) continue; /*if the absorber has no thickness we check the next side*/
 
-                /* allow to disable the absorber on the top side if the laser
+                /* allow to enable the absorber on the top side if the laser
                  * initialization plane in y direction is *not* in cell zero
                  */
-                if (laser::laserInitPlaneY == 0)
+                if (laser::initPlaneY == 0)
                 {
                     /* disable the absorber on top side if
                      *      no slide was performed and
@@ -75,7 +75,8 @@ public:
                      */
                     if (numSlides == 0 && ((currentStep * DELTA_T) <= laserProfile::INIT_TIME))
                     {
-                        if (i == TOP) continue; /*disable laser on top side*/
+                        /* disable absorber on top side */
+                        if (i == TOP) continue;
                     }
                 }
 

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -64,13 +64,19 @@ public:
 
                 if (thickness == 0) continue; /*if the absorber has no thickness we check the next side*/
 
-                /* disable the absorber on top side if
-                 *      no slide was performed and
-                 *      laser init time is not over
+                /* allow to disable the absorber on the top side if the laser
+                 * initialization plane in y direction is *not* in cell zero
                  */
-                if (numSlides == 0 && ((currentStep * DELTA_T) <= laserProfile::INIT_TIME))
+                if (laser::laserInitPlaneY == 0)
                 {
-                    if (i == TOP) continue; /*disable laser on top side*/
+                    /* disable the absorber on top side if
+                     *      no slide was performed and
+                     *      laser init time is not over
+                     */
+                    if (numSlides == 0 && ((currentStep * DELTA_T) <= laserProfile::INIT_TIME))
+                    {
+                        if (i == TOP) continue; /*disable laser on top side*/
+                    }
                 }
 
                 /* if sliding window is active we disable absorber on bottom side*/

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -37,8 +37,15 @@ namespace picongpu
          */
         HINLINE float3_X laserLongitudinal( uint32_t currentStep, float_X& phase )
         {
-            const float_64 runTime = DELTA_T*currentStep;
+            /* initialize the laser not in the first cell is equal to a negative shift
+             * in time
+             */
+            constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            const float_64 runTime = DELTA_T * currentStep - laserTimeShift;
             const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+
+            /* calculate focus position relative to the laser initialization plane */
+            const float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
 
             float3_X elong(float3_X::create(0.0));
 
@@ -58,7 +65,7 @@ namespace picongpu
             //rayleigh length (in y-direction)
             const float_64 y_R = PI * W0 * W0 / WAVE_LENGTH;
             //gaussian beam waist in the nearfield: w_y(y=0) == W0
-            const float_64 w_y = W0 * sqrt( 1.0 + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
+            const float_64 w_y = W0 * sqrt( 1.0 + ( focusPos / y_R )*( focusPos / y_R ) );
 
             float_64 envelope = float_64( AMPLITUDE );
             if( simDim == DIM2 )
@@ -81,7 +88,7 @@ namespace picongpu
                 elong.z() = float_X( envelope / sqrt(2.0) );
             }
 
-            phase = float_X(2.0) * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - FOCUS_POS / SPEED_OF_LIGHT) + LASER_PHASE;
+            phase = float_X(2.0) * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - focusPos / SPEED_OF_LIGHT) + LASER_PHASE;
 
             return elong;
         }
@@ -122,13 +129,15 @@ namespace picongpu
          */
         HDINLINE float3_X laserTransversal( float3_X elong, float_X phase, const float_X posX, const float_X posZ )
         {
+            /* calculate focus position relative to the laser initialization plane */
+            const float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
             const float_X r2 = posX * posX + posZ * posZ;
 
             //rayleigh length (in y-direction)
             const float_X y_R = float_X( PI ) * W0 * W0 / WAVE_LENGTH;
 
             // the radius of curvature of the beam's  wavefronts
-            const float_X R_y = -FOCUS_POS * ( float_X(1.0) + ( y_R / FOCUS_POS )*( y_R / FOCUS_POS ) );
+            const float_X R_y = -focusPos * ( float_X(1.0) + ( y_R / focusPos )*( y_R / focusPos ) );
 
             // initialize temporary variables
             float_X etrans = float_X(0.0);
@@ -139,18 +148,18 @@ namespace picongpu
                 etrans_norm += LAGUERREMODES[m];
 
             //beam waist in the near field: w_y(y=0) == W0
-            const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
+            const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( focusPos / y_R )*( focusPos / y_R ) );
             //! the Gouy phase shift
-            const float_X xi_y = algorithms::math::atan( -FOCUS_POS / y_R );
+            const float_X xi_y = algorithms::math::atan( -focusPos / y_R );
 
             if( Polarisation == LINEAR_X || Polarisation == LINEAR_Z )
             {
                 for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
                 {
                     etrans += LAGUERREMODES[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
-                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
-                        * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                              *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
+                        * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              *( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
                               / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
                 }
                 elong *= etrans / etrans_norm;
@@ -160,9 +169,9 @@ namespace picongpu
                 for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
                 {
                     etrans += LAGUERREMODES[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
-                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
-                        * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                              *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
+                        * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              *( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
                               / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
                 }
                 elong.x() *= etrans / etrans_norm;
@@ -171,9 +180,9 @@ namespace picongpu
                 for ( uint32_t m = 0 ; m <= MODENUMBER ; ++m )
                 {
                     etrans += LAGUERREMODES[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
-                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
-                        * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                              *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + phase )
+                        * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                              *( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
                               / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
                 }
                 elong.z() *= etrans / etrans_norm;

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -40,12 +40,12 @@ namespace picongpu
             /* initialize the laser not in the first cell is equal to a negative shift
              * in time
              */
-            constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            constexpr float_X laserTimeShift = laser::initPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
             const float_64 runTime = DELTA_T * currentStep - laserTimeShift;
             const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
             /* calculate focus position relative to the laser initialization plane */
-            const float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            const float_X focusPos = FOCUS_POS - laser::initPlaneY * CELL_HEIGHT;
 
             float3_X elong(float3_X::create(0.0));
 
@@ -130,7 +130,7 @@ namespace picongpu
         HDINLINE float3_X laserTransversal( float3_X elong, float_X phase, const float_X posX, const float_X posZ )
         {
             /* calculate focus position relative to the laser initialization plane */
-            const float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            const float_X focusPos = FOCUS_POS - laser::initPlaneY * CELL_HEIGHT;
             const float_X r2 = posX * posX + posZ * posZ;
 
             //rayleigh length (in y-direction)

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -65,7 +65,7 @@ namespace picongpu
             /* initialize the laser not in the first cell is equal to a negative shift
              * in time
              */
-            constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            constexpr float_X laserTimeShift = laser::initPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
             const float_64 runTime = DELTA_T * currentStep - laserTimeShift;
             const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
 

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -62,7 +62,11 @@ namespace picongpu
          */
         HINLINE float3_X laserLongitudinal( uint32_t currentStep, float_X& phase )
         {
-            const float_64 runTime = DELTA_T*currentStep;
+            /* initialize the laser not in the first cell is equal to a negative shift
+             * in time
+             */
+            constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            const float_64 runTime = DELTA_T * currentStep - laserTimeShift;
             const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
             float_64 envelope = float_64(AMPLITUDE );

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -40,7 +40,11 @@ HDINLINE float_X Tpolynomial(const float_X tau);
  */
 HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
 {
-    const float_X runTime = DELTA_T*currentStep;
+    /* initialize the laser not in the first cell is equal to a negative shift
+     * in time
+     */
+    constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+    const float_X runTime = DELTA_T * currentStep - laserTimeShift;
     const float_X f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
     float3_X elong(float3_X::create(0.0));

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -43,7 +43,7 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
     /* initialize the laser not in the first cell is equal to a negative shift
      * in time
      */
-    constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+    constexpr float_X laserTimeShift = laser::initPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
     const float_X runTime = DELTA_T * currentStep - laserTimeShift;
     const float_X f = SPEED_OF_LIGHT / WAVE_LENGTH;
 

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -40,12 +40,12 @@ namespace picongpu
             /* initialize the laser not in the first cell is equal to a negative shift
              * in time
              */
-            constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            constexpr float_X laserTimeShift = laser::initPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
             const float_64 runTime = DELTA_T * currentStep - laserTimeShift;
             const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
             /* calculate focus position relative to the laser initialization plane */
-            constexpr float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            constexpr float_X focusPos = FOCUS_POS - laser::initPlaneY * CELL_HEIGHT;
 
             float3_X elong(float3_X::create(0.0));
 
@@ -99,7 +99,7 @@ namespace picongpu
             //const float_X modMue = float_X(PI) * float_X(SPEED_OF_LIGHT / WAVE_LENGTH) * INIT_TIME;
             const float_X f = SPEED_OF_LIGHT / WAVE_LENGTH;
             /* calculate focus position relative to the laser initialization plane */
-            constexpr float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            constexpr float_X focusPos = FOCUS_POS - laser::initPlaneY * CELL_HEIGHT;
 
             const float_X timeShift = phase / (float_X(2.0) * float_X(PI) * float_X(f)) + focusPos / SPEED_OF_LIGHT;
             const float_X spaceShift = SPEED_OF_LIGHT * algorithms::math::tan(TILT_X) * timeShift / CELL_HEIGHT;

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -37,8 +37,15 @@ namespace picongpu
          */
         HINLINE float3_X laserLongitudinal( uint32_t currentStep, float_X& phase )
         {
-            const float_64 runTime = DELTA_T*currentStep;
+            /* initialize the laser not in the first cell is equal to a negative shift
+             * in time
+             */
+            constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+            const float_64 runTime = DELTA_T * currentStep - laserTimeShift;
             const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+
+            /* calculate focus position relative to the laser initialization plane */
+            constexpr float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
 
             float3_X elong(float3_X::create(0.0));
 
@@ -51,7 +58,7 @@ namespace picongpu
             //rayleigh length (in y-direction)
             const float_64 y_R = PI * W0 * W0 / WAVE_LENGTH;
             //gaussian beam waist in the nearfield: w_y(y=0) == W0
-            const float_64 w_y = W0 * sqrt( 1.0 + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
+            const float_64 w_y = W0 * sqrt( 1.0 + ( focusPos / y_R )*( focusPos / y_R ) );
 
             float_64 envelope = float_64( AMPLITUDE );
             if( simDim == DIM2 )
@@ -74,7 +81,7 @@ namespace picongpu
                 elong.z() = float_X( envelope / sqrt(2.0) );
             }
 
-            phase = float_X(2.0) * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - FOCUS_POS / SPEED_OF_LIGHT ) + LASER_PHASE;
+            phase = float_X(2.0) * float_X(PI ) * float_X(f ) * ( runTime - float_X(mue ) - focusPos / SPEED_OF_LIGHT ) + LASER_PHASE;
 
             return elong;
         }
@@ -91,9 +98,13 @@ namespace picongpu
         {
             //const float_X modMue = float_X(PI) * float_X(SPEED_OF_LIGHT / WAVE_LENGTH) * INIT_TIME;
             const float_X f = SPEED_OF_LIGHT / WAVE_LENGTH;
-            const float_X timeShift = phase / (float_X(2.0) * float_X(PI) * float_X(f)) + FOCUS_POS / SPEED_OF_LIGHT;
+            /* calculate focus position relative to the laser initialization plane */
+            constexpr float_X focusPos = FOCUS_POS - laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+
+            const float_X timeShift = phase / (float_X(2.0) * float_X(PI) * float_X(f)) + focusPos / SPEED_OF_LIGHT;
             const float_X spaceShift = SPEED_OF_LIGHT * algorithms::math::tan(TILT_X) * timeShift / CELL_HEIGHT;
             const float_X r2 = (posX + spaceShift) * (posX + spaceShift) + posZ * posZ;
+
 
             // pure gaussian
             //const float_X r2 = posX * posX + posZ * posZ;
@@ -102,30 +113,30 @@ namespace picongpu
             const float_X y_R = float_X( PI ) * W0 * W0 / WAVE_LENGTH;
 
             // the radius of curvature of the beam's  wavefronts
-            const float_X R_y = -FOCUS_POS * ( float_X(1.0) + ( y_R / FOCUS_POS )*( y_R / FOCUS_POS ) );
+            const float_X R_y = -focusPos * ( float_X(1.0) + ( y_R / focusPos )*( y_R / focusPos ) );
 
             //beam waist in the near field: w_y(y=0) == W0
-            const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( FOCUS_POS / y_R )*( FOCUS_POS / y_R ) );
+            const float_X w_y = W0 * algorithms::math::sqrt( float_X(1.0) + ( focusPos / y_R )*( focusPos / y_R ) );
             //! the Gouy phase shift
-            const float_X xi_y = algorithms::math::atan( -FOCUS_POS / y_R );
+            const float_X xi_y = algorithms::math::atan( -focusPos / y_R );
 
             if( Polarisation == LINEAR_X || Polarisation == LINEAR_Z )
             {
-                elong *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                elong *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
+                    * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                          *( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
                           / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
             }
             else if( Polarisation == CIRCULAR )
             {
-                elong.x() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                elong.x() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
+                    * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                          *( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
                           / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
                 phase += float_X( PI / 2.0 );
-                elong.z() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * FOCUS_POS - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - FOCUS_POS - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                elong.z() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + phase )
+                    * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
+                          *( r2 / float_X(2.0) / R_y - focusPos - phase / float_X(2.0) / float_X( PI ) * WAVE_LENGTH )
                           / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
                 phase -= float_X( PI / 2.0 );
             }

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -53,7 +53,7 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
     /* initialize the laser not in the first cell is equal to a negative shift
      * in time
      */
-    constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+    constexpr float_X laserTimeShift = laser::initPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
     const float_64 runTime = (DELTA_T * currentStep - laserTimeShift)  - mue;
     const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
 

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -50,7 +50,11 @@ HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
     // the front of the laser pulse.
     const float_64 mue = 0.5 * INIT_TIME;
 
-    const float_64 runTime = DELTA_T*currentStep - mue;
+    /* initialize the laser not in the first cell is equal to a negative shift
+     * in time
+     */
+    constexpr float_X laserTimeShift = laser::laserInitPlaneY * CELL_HEIGHT / SPEED_OF_LIGHT;
+    const float_64 runTime = (DELTA_T * currentStep - laserTimeShift)  - mue;
     const float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
 
     const float_64 w = 2.0 * PI * f;

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -32,15 +32,15 @@ namespace picongpu
     {
         /** cell from top where the laser is initialized
          *
-         * if `laserInitPlaneY == 0` than the absorber are disabled.
-         * if `laserInitPlaneY > absorbercells negative Y` the negative absorber in y
+         * if `initPlaneY == 0` than the absorber are disabled.
+         * if `initPlaneY > absorbercells negative Y` the negative absorber in y
          * direction is enabled
          *
          * valid ranges:
-         *   - laserInitPlaneY == 0
-         *   - absorber cells negative Y < laserInitPlaneY < cells in y direction of the top gpu
+         *   - initPlaneY == 0
+         *   - absorber cells negative Y < initPlaneY < cells in y direction of the top gpu
         */
-        constexpr uint32_t laserInitPlaneY = 0;
+        constexpr uint32_t initPlaneY = 0;
     }
 
     namespace laserGaussianBeam

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -28,6 +28,21 @@
 
 namespace picongpu
 {
+    namespace laser
+    {
+        /** cell from top where the laser is initialized
+         *
+         * if `laserInitPlaneY == 0` than the absorber are disabled.
+         * if `laserInitPlaneY > absorbercells negative Y` the negative absorber in y
+         * direction is enabled
+         *
+         * valid ranges:
+         *   - laserInitPlaneY == 0
+         *   - absorber cells negative Y < laserInitPlaneY < cells in y direction of the top gpu
+        */
+        constexpr uint32_t laserInitPlaneY = 0;
+    }
+
     namespace laserGaussianBeam
     {
         namespace SI


### PR DESCRIPTION
- `FieldE.kernel`: add laser scaling factor if `laser::initPlaneY != 0`
- `FieldE.tpp`:
  - add asserts to check conditions for the laser initialization plane
  - model: a change of initialization plane does not make a change in focus position or time-to-target necessary
- `FieldManipulation.hpp`: enable top absorber if `laser::initPlaneY != 0`
- `laserConfig.param`
  - add namespace laser
  - add parameter `initPlaneY`
- laser profiles (keep first top cell as origin for all laser parameters)
  - manipulate focus depending of the `initPlaneY`
  - shift the internal runtime based of `initPlaneY`


Todo:
- [x] fix typo at all places: `plain` -> `plane`
- [x] add constexpr `gridConfig.param`  change as independent pull request
- [x] discuss the changes with the first cell as origin for laser parameter
- [x] maybe that the scaling factor need to respect cell size X/Z for laser not moving in Y direction (#1893)
- [x] rebase against #1909

scaling factor
--------------
The current implementation calculated a scaling factor for the amplitude to respect that we initialize only the electrical field and not magnetic field. The result of the missing magnetic field is a wave which is moving in positive and negative Y direction. If we use no scaling factor the amplitude of the positive moving wave is too low, depending on the cell size in Y direction.
**Open question**: Do we need care of the laser phase to scale the amplitude for laser those not moving only in Y direction?

origin for laser parameter:
------------------------------------
What should be the origin for e.g. focus? Is it the laser initialization plane or the begin of the simulation.
If we define everything relative to the init plane than it is possible that the laser collide with the bottom outer border of the simulation in the case we enable sliding window.
The physicist need use the non intuitive init plane definition in cells (instead of SI meter) if we define laser parameter relative to the plane.


Test:
------
Gaussian beam focused to cell 300 (linear polarized in X)
==============
![lasergaussianbeam_line_65](https://cloud.githubusercontent.com/assets/4037125/22546230/826c3d16-e93c-11e6-9e8b-8614297fb125.png)
green = dev
blue = pull request (initialized at cell 65)

The amplitude for this pull request is ~1.5% over the defined value. The amplitude for the dev is ~1 under the defined value.

Plane wave test (up ramp)
============
![plainwave_line_256_upramp](https://cloud.githubusercontent.com/assets/4037125/22546337/f82062a8-e93c-11e6-8b51-68ceae0e076d.png)
green = dev
blue = pull request (initialized at cell 65

Small shift in space for the positions of the amplitude.

Plane wave test (down ramp)
==============
![plainwave_line_256_downramp](https://cloud.githubusercontent.com/assets/4037125/22546383/2815ff5e-e93d-11e6-9385-db0e1dc4f7fa.png)

The plot shows the down ramp of the laser after a reflection on the right border. The pulse was long  enough that the reflected wave overlapped the init phase for a longer time. This should show how the laser initialization is influenced by the reflected wave.

CC-ing: @HighIander
