### PR TITLE
use constexpr for arrays in  `gridConfig.param`

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gridConfig.param
@@ -56,14 +56,14 @@ namespace picongpu
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)
-    const uint32_t ABSORBER_CELLS[3][2] = {
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {32, 32},  /*x direction [negative,positive]*/
         {32, 32},  /*y direction [negative,positive]*/
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
     //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -77,14 +77,14 @@ namespace picongpu
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)
-    const uint32_t ABSORBER_CELLS[3][2] = {
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {32, 32},  /*x direction [negative,positive]*/
         {32, 32},  /*y direction [negative,positive]*/
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
     //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -56,14 +56,14 @@ namespace picongpu
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)
-    const uint32_t ABSORBER_CELLS[3][2] = {
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {32, 32},  /*x direction [negative,positive]*/
         {32, 32},  /*y direction [negative,positive]*/
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
     //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/SingleParticleTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/gridConfig.param
@@ -61,14 +61,14 @@ namespace picongpu
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)
-    const uint32_t ABSORBER_CELLS[3][2] = {
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {32, 32},  /*x direction [negative,positive]*/
         {32, 32},  /*y direction [negative,positive]*/
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
     //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
@@ -56,14 +56,14 @@ namespace picongpu
     } //namespace SI
 
         //! Defines the size of the absorbing zone (in cells)
-    const uint32_t ABSORBER_CELLS[3][2] = {
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {0, 0},  /*x direction [negative,positive]*/
         {0, 0},  /*y direction [negative,positive]*/
         {0, 0}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
     //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
@@ -56,14 +56,14 @@ namespace picongpu
     } //namespace SI
 
         //! Defines the size of the absorbing zone (in cells)
-    const uint32_t ABSORBER_CELLS[3][2] = {
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {0, 0},  /*x direction [negative,positive]*/
         {0, 0},  /*y direction [negative,positive]*/
         {0, 0}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
     //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -57,14 +57,14 @@ namespace picongpu
     } //namespace SI
 
     //! Defines the size of the absorbing zone (in cells)
-    const uint32_t ABSORBER_CELLS[3][2] = {
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {32, 32},  /*x direction [negative,positive]*/
         {32, 32},  /*y direction [negative,positive]*/
         {32, 32}   /*z direction [negative,positive]*/
     }; //unit: number of cells
 
     //! Define the strength of the absorber for any direction
-    const float_X ABSORBER_STRENGTH[3][2] = {
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/


### PR DESCRIPTION
This change allow to use the values of the array's inside static asserts.

define ABSORBER_CELLS and ABSORBER_STRENGTH as `constexpr`