### PR TITLE
DataConnector: Fix Includes

### DIFF
--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
@@ -22,13 +22,14 @@
 
 // PMacc
 #include "Environment.hpp"
-#include <particles/operations/CountParticles.hpp>
+#include "particles/operations/CountParticles.hpp"
 #include "pmacc_types.hpp"
 #include "forward.hpp"
 #include "dimensions/DataSpace.hpp"
 #include "algorithms/ForEach.hpp"
 #include "dataManagement/DataConnector.hpp"
 #include "mappings/simulation/ResourceMonitor.hpp"
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -24,6 +24,8 @@
 
 #include "random/RNGProvider.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
+#include "dataManagement/DataConnector.hpp"
+
 
 namespace PMacc
 {

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -24,17 +24,18 @@
 
 #include "simulation_defines.hpp"
 
-#include <fields/MaxwellSolver/DirSplitting/DirSplitting.kernel>
-#include <math/vector/Int.hpp>
-#include <dataManagement/DataConnector.hpp>
-#include <fields/FieldB.hpp>
-#include <fields/FieldE.hpp>
+#include "fields/MaxwellSolver/DirSplitting/DirSplitting.kernel"
+#include "dataManagement/DataConnector.hpp"
+#include "fields/FieldB.hpp"
+#include "fields/FieldE.hpp"
+#include "lambda/Expression.hpp"
+#include "cuSTL/algorithm/kernel/ForeachBlock.hpp"
+#include "cuSTL/cursor/NestedCursor.hpp"
 #include "math/Vector.hpp"
-#include <cuSTL/algorithm/kernel/ForeachBlock.hpp>
-#include <lambda/Expression.hpp>
-#include <cuSTL/cursor/NestedCursor.hpp>
-#include <math/vector/TwistComponents.hpp>
-#include <math/vector/compile-time/TwistComponents.hpp>
+#include "math/vector/Int.hpp"
+#include "math/vector/TwistComponents.hpp"
+#include "math/vector/compile-time/TwistComponents.hpp"
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
@@ -18,18 +18,17 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "YeeSolver.def"
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
 
 #include "fields/SimulationFieldHelper.hpp"
-#include "dataManagement/ISimulationData.hpp"
-
+#include "fields/FieldE.hpp"
+#include "fields/FieldB.hpp"
+#include "fields/FieldManipulator.hpp"
+#include "fields/MaxwellSolver/Yee/YeeSolver.kernel"
 
 #include "simulation_classTypes.hpp"
 #include "memory/boxes/SharedBox.hpp"
@@ -37,11 +36,8 @@
 #include "mappings/threads/ThreadCollective.hpp"
 #include "memory/boxes/CachedBox.hpp"
 #include "dimensions/DataSpace.hpp"
-#include <fields/FieldE.hpp>
-#include <fields/FieldB.hpp>
+#include "dataManagement/DataConnector.hpp"
 
-#include "fields/FieldManipulator.hpp"
-#include "fields/MaxwellSolver/Yee/YeeSolver.kernel"
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include <boost/mpl/if.hpp>
 #include "traits/HasFlag.hpp"
 #include "fields/Fields.def"
 #include "math/MapTuple.hpp"
@@ -37,9 +35,11 @@
 #include "particles/bremsstrahlung/Bremsstrahlung.hpp"
 #include "particles/creation/creation.hpp"
 
-#include <memory>
 #include <boost/mpl/plus.hpp>
 #include <boost/mpl/accumulate.hpp>
+
+#include <memory>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -20,16 +20,19 @@
 
 #pragma once
 
-#include "particles/particleToGrid/derivedAttributes/Density.hpp"
 #include "algorithms/Gamma.hpp"
-#include "algorithms/math/defines/sqrt.hpp"
-#include "algorithms/math/defines/dot.hpp"
-#include "algorithms/math/defines/cross.hpp"
 #include "traits/frame/GetMass.hpp"
 #include "traits/frame/GetCharge.hpp"
+#include "particles/particleToGrid/ComputeGridValuePerFrame.def"
 #include "particles/operations/Assign.hpp"
 #include "particles/operations/Deselect.hpp"
 #include "particles/traits/GetAtomicNumbers.hpp"
+
+#include "dataManagement/DataConnector.hpp"
+#include "algorithms/math/defines/sqrt.hpp"
+#include "algorithms/math/defines/dot.hpp"
+#include "algorithms/math/defines/cross.hpp"
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/densityProfiles/FromHDF5Impl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/FromHDF5Impl.hpp
@@ -20,12 +20,13 @@
 
 #pragma once
 
-#include "static_assert.hpp"
 #include "simulation_defines.hpp"
+#include "fields/Fields.hpp"
+#include "simulationControl/MovingWindow.hpp"
+
+#include "static_assert.hpp"
 #include "memory/buffers/GridBuffer.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
-#include "simulationControl/MovingWindow.hpp"
-#include "fields/Fields.hpp"
 #include "dataManagement/DataConnector.hpp"
 
 #include <splash/splash.h>

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -20,12 +20,9 @@
 
 #pragma once
 
-#include <boost/type_traits/integral_constant.hpp>
-
 #include "simulation_defines.hpp"
 #include "traits/Resolve.hpp"
 #include "traits/UsesRNG.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
@@ -33,15 +30,18 @@
 #include "particles/ionization/byField/ADK/ADK.def"
 #include "particles/ionization/byField/ADK/AlgorithmADK.hpp"
 #include "particles/ionization/ionization.hpp"
-
-#include "compileTime/conversion/TypeToPointerPair.hpp"
-#include "memory/boxes/DataBox.hpp"
-
 #include "particles/ionization/ionizationMethods.hpp"
 
 #include "random/methods/XorMin.hpp"
 #include "random/distributions/Uniform.hpp"
 #include "random/RNGProvider.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "compileTime/conversion/TypeToPointerPair.hpp"
+#include "memory/boxes/DataBox.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+
+#include <boost/type_traits/integral_constant.hpp>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -21,8 +21,6 @@
 #pragma once
 
 #include "simulation_defines.hpp"
-#include "traits/Resolve.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
@@ -32,11 +30,14 @@
 #include "particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp"
 #include "particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp"
 #include "particles/ionization/ionization.hpp"
+#include "particles/ParticlesFunctors.hpp"
 
 #include "compileTime/conversion/TypeToPointerPair.hpp"
 #include "memory/boxes/DataBox.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "traits/Resolve.hpp"
 
-#include "particles/ParticlesFunctors.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -20,12 +20,8 @@
 
 #pragma once
 
-#include <boost/type_traits/integral_constant.hpp>
-
 #include "simulation_defines.hpp"
-#include "traits/Resolve.hpp"
 #include "traits/UsesRNG.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
@@ -33,15 +29,20 @@
 #include "particles/ionization/byField/Keldysh/Keldysh.def"
 #include "particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp"
 #include "particles/ionization/ionization.hpp"
-
-#include "compileTime/conversion/TypeToPointerPair.hpp"
-#include "memory/boxes/DataBox.hpp"
-
 #include "particles/ionization/ionizationMethods.hpp"
 
 #include "random/methods/XorMin.hpp"
 #include "random/distributions/Uniform.hpp"
 #include "random/RNGProvider.hpp"
+
+#include "compileTime/conversion/TypeToPointerPair.hpp"
+#include "memory/boxes/DataBox.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "traits/Resolve.hpp"
+
+#include <boost/type_traits/integral_constant.hpp>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -18,13 +18,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "simulation_defines.hpp"
 #include "nvidia/atomic.hpp"
 #include "particles/operations/Deselect.hpp"
 #include "memory/shared/Allocate.hpp"
+#include "dataManagement/DataConnector.hpp"
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -21,8 +21,8 @@
 #pragma once
 
 #include "simulation_defines.hpp"
+
 #include "SynchrotronFunctions.hpp"
-#include "pmacc_types.hpp"
 #include "algorithms/Gamma.hpp"
 #include "algorithms/math/defines/sqrt.hpp"
 #include "algorithms/math/defines/dot.hpp"
@@ -32,6 +32,8 @@
 #include "particles/operations/Assign.hpp"
 #include "particles/operations/Deselect.hpp"
 #include "particles/traits/ResolveAliasFromSpecies.hpp"
+#include "fields/FieldB.hpp"
+#include "fields/FieldE.hpp"
 
 #include "random/methods/XorMin.hpp"
 #include "random/distributions/Uniform.hpp"
@@ -39,12 +41,11 @@
 
 #include "traits/Resolve.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
-
-#include "fields/FieldB.hpp"
-#include "fields/FieldE.hpp"
+#include "dataManagement/DataConnector.hpp"
 
 #include "compileTime/conversion/TypeToPointerPair.hpp"
 #include "memory/boxes/DataBox.hpp"
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -19,33 +19,30 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
+#include "simulation_defines.hpp"
+
+#include "plugins/ISimulationPlugin.hpp"
+#include "algorithms/Gamma.hpp"
+#include "algorithms/KinEnergy.hpp"
+
+#include "mpi/reduceMethods/Reduce.hpp"
+#include "mpi/MPIReduce.hpp"
+#include "nvidia/functors/Add.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "basicOperations.hpp"
+#include "dimensions/DataSpace.hpp"
+
+#include "common/txtFileHandling.hpp"
 
 #include <string>
 #include <iostream>
 #include <iomanip>
 #include <fstream>
 
-#include "pmacc_types.hpp"
-#include "simulation_defines.hpp"
-#include "simulation_types.hpp"
-#include "basicOperations.hpp"
-#include "dimensions/DataSpace.hpp"
-
-#include "simulation_classTypes.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
-#include "plugins/ISimulationPlugin.hpp"
-
-#include "mpi/reduceMethods/Reduce.hpp"
-#include "mpi/MPIReduce.hpp"
-#include "nvidia/functors/Add.hpp"
-
-#include "algorithms/Gamma.hpp"
-#include "algorithms/KinEnergy.hpp"
-#include "memory/shared/Allocate.hpp"
-
-#include "common/txtFileHandling.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/ChargeConservation.tpp
+++ b/src/picongpu/include/plugins/ChargeConservation.tpp
@@ -18,28 +18,35 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "static_assert.hpp"
+
+#include "fields/FieldJ.hpp"
+
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"
 #include "math/vector/Size_t.hpp"
 #include "math/vector/math_functor/abs.hpp"
 #include "math/vector/math_functor/max.hpp"
-#include "cuSTL/container/PseudoBuffer.hpp"
 #include "dataManagement/DataConnector.hpp"
-#include "fields/FieldJ.hpp"
 #include "math/Vector.hpp"
-#include "cuSTL/algorithm/mpi/Gather.hpp"
 #include "cuSTL/container/DeviceBuffer.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
+#include "cuSTL/container/PseudoBuffer.hpp"
+#include "cuSTL/cursor/NestedCursor.hpp"
 #include "cuSTL/algorithm/kernel/Foreach.hpp"
 #include "cuSTL/algorithm/host/Foreach.hpp"
-#include "cuSTL/cursor/NestedCursor.hpp"
-#include "lambda/Expression.hpp"
-#include <sstream>
-#include "algorithms/ForEach.hpp"
+#include "cuSTL/algorithm/mpi/Gather.hpp"
 #include "cuSTL/algorithm/kernel/Reduce.hpp"
+#include "lambda/Expression.hpp"
+#include "algorithms/ForEach.hpp"
 #include "nvidia/functors/Add.hpp"
+
 #include "common/txtFileHandling.hpp"
+
+#include <sstream>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/CountParticles.hpp
+++ b/src/picongpu/include/plugins/CountParticles.hpp
@@ -20,17 +20,10 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include "simulation_types.hpp"
 
 #include "simulation_classTypes.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
-
-#include <string>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
 
 #include "plugins/ISimulationPlugin.hpp"
 
@@ -38,12 +31,17 @@
 #include "mpi/MPIReduce.hpp"
 #include "nvidia/functors/Add.hpp"
 #include "nvidia/functors/Max.hpp"
-
-#include "simulation_classTypes.hpp"
+#include "dataManagement/DataConnector.hpp"
 
 #include "particles/operations/CountParticles.hpp"
 
 #include "common/txtFileHandling.hpp"
+
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -19,22 +19,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <iostream>
-#include <fstream>
-
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include "simulation_types.hpp"
-
-#include "simulation_classTypes.hpp"
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
 
-#include "dimensions/DataSpaceOperations.hpp"
 #include "plugins/ISimulationPlugin.hpp"
 
 #include "mpi/reduceMethods/Reduce.hpp"
@@ -43,8 +34,15 @@
 #include "nvidia/reduce/Reduce.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
 #include "memory/boxes/DataBoxUnaryTransform.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "dimensions/DataSpaceOperations.hpp"
 
 #include "common/txtFileHandling.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <memory>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -19,17 +19,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <string>
-#include <iostream>
-#include <fstream>
 #include <mpi.h>
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include "simulation_types.hpp"
 
 #include "simulation_classTypes.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
@@ -41,8 +35,14 @@
 
 #include "algorithms/KinEnergy.hpp"
 #include "memory/shared/Allocate.hpp"
+#include "dataManagement/DataConnector.hpp"
 
 #include "common/txtFileHandling.hpp"
+
+#include <string>
+#include <iostream>
+#include <fstream>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/IntensityPlugin.hpp
+++ b/src/picongpu/include/plugins/IntensityPlugin.hpp
@@ -19,32 +19,29 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
-#include "pmacc_types.hpp"
-#include "simulation_defines.hpp"
-#include "simulation_types.hpp"
+#include <mpi.h>
 
-#include "simulation_classTypes.hpp"
+#include "simulation_defines.hpp"
+
+#include "plugins/ILightweightPlugin.hpp"
+#include "fields/FieldE.hpp"
+
+#include "memory/boxes/CachedBox.hpp"
+#include "basicOperations.hpp"
+#include "dimensions/SuperCellDescription.hpp"
+#include "math/Vector.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
+#include "dataManagement/DataConnector.hpp"
 
 #include <string>
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-#include <mpi.h>
 
-#include "plugins/ILightweightPlugin.hpp"
-
-#include "fields/FieldE.hpp"
-#include "memory/boxes/CachedBox.hpp"
-#include "basicOperations.hpp"
-#include "dimensions/SuperCellDescription.hpp"
-#include "math/Vector.hpp"
-#include "memory/shared/Allocate.hpp"
-#include "memory/Array.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
@@ -39,6 +39,7 @@
 #include <boost/mpl/int.hpp>
 #include <boost/mpl/accumulate.hpp>
 
+
 namespace picongpu
 {
     using namespace PMacc;

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
@@ -20,8 +20,10 @@
 
 #pragma once
 
-#include <vector>
-#include <algorithm>
+#include "PhaseSpace.hpp"
+#include "PhaseSpaceFunctors.hpp"
+
+#include "DumpHBufferSplashP.hpp"
 
 #include "cuSTL/container/DeviceBuffer.hpp"
 #include "cuSTL/cursor/MultiIndexCursor.hpp"
@@ -32,14 +34,13 @@
 #include "cuSTL/algorithm/host/Foreach.hpp"
 #include "math/vector/Int.hpp"
 #include "math/vector/Size_t.hpp"
-
 #include "mappings/simulation/GridController.hpp"
 #include "mappings/simulation/SubGrid.hpp"
+#include "dataManagement/DataConnector.hpp"
 
-#include "PhaseSpace.hpp"
-#include "PhaseSpaceFunctors.hpp"
+#include <vector>
+#include <algorithm>
 
-#include "DumpHBufferSplashP.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -21,19 +21,18 @@
 
 #pragma once
 
-#include <string>
-#include <iostream>
-
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include "simulation_types.hpp"
 
-#include "simulation_classTypes.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
 
 #include "algorithms/Gamma.hpp"
 #include "plugins/ILightweightPlugin.hpp"
 #include "memory/shared/Allocate.hpp"
+#include "dataManagement/DataConnector.hpp"
+
+#include <string>
+#include <iostream>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -21,12 +21,14 @@
 
 #pragma once
 
+#include "SliceFieldPrinter.hpp"
+#include "fields/FieldB.hpp"
+#include "fields/FieldE.hpp"
+
 #include "math/vector/Int.hpp"
 #include "math/vector/Float.hpp"
 #include "math/vector/Size_t.hpp"
 #include "dataManagement/DataConnector.hpp"
-#include "fields/FieldB.hpp"
-#include "fields/FieldE.hpp"
 #include "math/Vector.hpp"
 #include "cuSTL/algorithm/mpi/Gather.hpp"
 #include "cuSTL/container/DeviceBuffer.hpp"
@@ -35,8 +37,9 @@
 #include "cuSTL/algorithm/kernel/run-time/Foreach.hpp"
 #include "cuSTL/algorithm/host/Foreach.hpp"
 #include "lambda/Expression.hpp"
-#include "SliceFieldPrinter.hpp"
+
 #include <sstream>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -21,19 +21,17 @@
 
 #pragma once
 
-#include <iostream>
-
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include "simulation_types.hpp"
-
-#include "simulation_classTypes.hpp"
 
 #include "fields/FieldJ.hpp"
 
 #include "dimensions/DataSpaceOperations.hpp"
 #include "plugins/ILightweightPlugin.hpp"
 #include "memory/shared/Allocate.hpp"
+#include "dataManagement/DataConnector.hpp"
+
+#include <iostream>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
@@ -22,11 +22,22 @@
 
 #include <mpi.h>
 
-#include "pmacc_types.hpp"
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
 
 #include "plugins/ISimulationPlugin.hpp"
+
+#include "plugins/output/WriteSpeciesCommon.hpp"
+#include "particles/traits/GetSpeciesFlagName.hpp"
+#include "traits/PICToAdios.hpp"
+
+#include "mappings/kernel/AreaMapping.hpp"
+#include "math/Vector.hpp"
+#include "plugins/adios/writer/ParticleAttributeSize.hpp"
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "compileTime/conversion/RemoveFromSeq.hpp"
+#include "dataManagement/DataConnector.hpp"
+
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/pair.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -34,21 +45,10 @@
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/begin_end.hpp>
 #include <boost/mpl/find.hpp>
-#include "compileTime/conversion/MakeSeq.hpp"
-
 #include <boost/type_traits.hpp>
 
-#include "plugins/output/WriteSpeciesCommon.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
-#include "math/Vector.hpp"
-
-#include "traits/PICToAdios.hpp"
-#include "plugins/adios/writer/ParticleAttributeSize.hpp"
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-
-#include "particles/traits/GetSpeciesFlagName.hpp"
-
 #include <string>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -21,12 +21,6 @@
 
 #pragma once
 
-#include <pthread.h>
-#include <sstream>
-#include <string>
-#include <list>
-#include <vector>
-
 #include "pmacc_types.hpp"
 #include "static_assert.hpp"
 #include "simulation_types.hpp"
@@ -35,10 +29,6 @@
 #include "particles/frame_types.hpp"
 #include "particles/IdProvider.def"
 #include "assert.hpp"
-
-#include <adios.h>
-#include <adios_read.h>
-#include <adios_error.h>
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
@@ -57,19 +47,6 @@
 #include "traits/Limits.hpp"
 
 #include "plugins/ILightweightPlugin.hpp"
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/pair.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/mpl/size.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/begin_end.hpp>
-#include <boost/mpl/find.hpp>
-#include <boost/filesystem.hpp>
-
-#include <boost/type_traits.hpp>
-#if !defined(_WIN32)
-#include <unistd.h>
-#endif
 
 #include "plugins/adios/WriteMeta.hpp"
 #include "plugins/adios/WriteSpecies.hpp"
@@ -78,6 +55,30 @@
 #include "plugins/adios/restart/RestartFieldLoader.hpp"
 #include "plugins/adios/NDScalars.hpp"
 #include "plugins/common/stringHelpers.hpp"
+
+#include <adios.h>
+#include <adios_read.h>
+#include <adios_error.h>
+
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/find.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/type_traits.hpp>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
+#include <pthread.h>
+#include <sstream>
+#include <string>
+#include <list>
+#include <vector>
 
 
 namespace picongpu

--- a/src/picongpu/include/plugins/adios/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/WriteSpecies.hpp
@@ -21,34 +21,34 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
 #include "assert.hpp"
 
 #include "plugins/ISimulationPlugin.hpp"
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/pair.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/mpl/size.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/begin_end.hpp>
-#include <boost/mpl/find.hpp>
-#include "compileTime/conversion/MakeSeq.hpp"
-
-#include <boost/type_traits.hpp>
 
 #include "plugins/output/WriteSpeciesCommon.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
-
 #include "plugins/adios/writer/ParticleAttribute.hpp"
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-#include "particles/ParticleDescription.hpp"
 
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "compileTime/conversion/RemoveFromSeq.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "particles/ParticleDescription.hpp"
 #include "particles/operations/ConcatListOfFrames.hpp"
 #include "particles/particleFilter/FilterFactory.hpp"
 #include "particles/particleFilter/PositionFilter.hpp"
 #include "particles/memory/buffers/MallocMCBuffer.hpp"
+
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/find.hpp>
+#include <boost/type_traits.hpp>
+#include <boost/type_traits/is_same.hpp>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
@@ -25,6 +25,17 @@
 #include "plugins/adios/ADIOSWriter.def"
 #include "plugins/ISimulationPlugin.hpp"
 
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "compileTime/conversion/RemoveFromSeq.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
+#include "particles/ParticleDescription.hpp"
+#include "particles/operations/splitIntoListOfFrames.kernel"
+
+#include "plugins/output/WriteSpeciesCommon.hpp"
+#include "plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp"
+
+#include "dataManagement/DataConnector.hpp"
+
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/pair.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -34,14 +45,6 @@
 #include <boost/mpl/find.hpp>
 #include <boost/type_traits.hpp>
 
-#include "compileTime/conversion/MakeSeq.hpp"
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
-#include "particles/ParticleDescription.hpp"
-#include "particles/operations/splitIntoListOfFrames.kernel"
-
-#include "plugins/output/WriteSpeciesCommon.hpp"
-#include "plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -37,7 +37,8 @@
 
 #include <string>
 #include <sstream>
-#include <stdexcept> // throw std::runtime_error
+#include <stdexcept>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -27,7 +27,10 @@
 #include "plugins/hdf5/HDF5Writer.def"
 #include "plugins/hdf5/writer/Field.hpp"
 
+#include "dataManagement/DataConnector.hpp"
+
 #include <vector>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -18,10 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
-
 
 #include "pmacc_types.hpp"
 #include "simulation_types.hpp"
@@ -31,6 +28,19 @@
 #include "assert.hpp"
 
 #include "plugins/ISimulationPlugin.hpp"
+
+#include "plugins/output/WriteSpeciesCommon.hpp"
+#include "plugins/kernel/CopySpecies.kernel"
+#include "mappings/kernel/AreaMapping.hpp"
+
+#include "plugins/hdf5/writer/ParticleAttribute.hpp"
+
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "compileTime/conversion/RemoveFromSeq.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "particles/ParticleDescription.hpp"
+#include "particles/traits/GetSpeciesFlagName.hpp"
+
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/pair.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -38,20 +48,10 @@
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/begin_end.hpp>
 #include <boost/mpl/find.hpp>
-#include "compileTime/conversion/MakeSeq.hpp"
-
 #include <boost/type_traits.hpp>
 
-#include "plugins/output/WriteSpeciesCommon.hpp"
-#include "plugins/kernel/CopySpecies.kernel"
-#include "mappings/kernel/AreaMapping.hpp"
-
-#include "plugins/hdf5/writer/ParticleAttribute.hpp"
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-#include "particles/ParticleDescription.hpp"
-#include "particles/traits/GetSpeciesFlagName.hpp"
-
 #include <string>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/hdf5/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/LoadSpecies.hpp
@@ -18,36 +18,35 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
-
 
 #include "simulation_types.hpp"
 
 #include "plugins/hdf5/HDF5Writer.def"
 #include "plugins/ISimulationPlugin.hpp"
 
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/pair.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/mpl/size.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/begin_end.hpp>
-#include <boost/mpl/find.hpp>
-#include <boost/type_traits.hpp>
+#include "plugins/output/WriteSpeciesCommon.hpp"
+#include "plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp"
+
+#include "plugins/common/particlePatches.hpp"
+#include "plugins/hdf5/openPMD/patchReader.hpp"
 
 #include "compileTime/conversion/MakeSeq.hpp"
 #include "compileTime/conversion/RemoveFromSeq.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
 #include "particles/ParticleDescription.hpp"
 #include "particles/operations/splitIntoListOfFrames.kernel"
+#include "dataManagement/DataConnector.hpp"
 
-#include "plugins/output/WriteSpeciesCommon.hpp"
-#include "plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp"
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/find.hpp>
+#include <boost/type_traits.hpp>
+#include <boost/type_traits/is_same.hpp>
 
-#include "plugins/common/particlePatches.hpp"
-#include "plugins/hdf5/openPMD/patchReader.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -20,19 +20,22 @@
 
 #pragma once
 
-#include <string>
-#include <sstream>
-#include <splash/splash.h>
-
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
+
 #include "particles/frame_types.hpp"
-#include "dataManagement/DataConnector.hpp"
-#include "dimensions/DataSpace.hpp"
-#include "dimensions/GridLayout.hpp"
 #include "fields/FieldE.hpp"
 #include "fields/FieldB.hpp"
 #include "simulationControl/MovingWindow.hpp"
+
+#include "dataManagement/DataConnector.hpp"
+#include "dimensions/DataSpace.hpp"
+#include "dimensions/GridLayout.hpp"
+
+#include <splash/splash.h>
+
+#include <string>
+#include <sstream>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -18,27 +18,25 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
 
 #include "mappings/kernel/AreaMapping.hpp"
+
+#include "plugins/ILightweightPlugin.hpp"
+
+#include "memory/buffers/GridBuffer.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "dataManagement/DataConnector.hpp"
+
+#include <splash/splash.h>
 
 #include <string>
 #include <iostream>
 #include <iomanip>
 #include <fstream>
 
-#include "plugins/ILightweightPlugin.hpp"
-
-#include "memory/buffers/GridBuffer.hpp"
-#include "memory/shared/Allocate.hpp"
-
-
-#include <splash/splash.h>
-#include <sys/stat.h>
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
+++ b/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
@@ -20,10 +20,17 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_types.hpp"
 
 #include "plugins/ISimulationPlugin.hpp"
+
+#include "mappings/kernel/AreaMapping.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "compileTime/conversion/RemoveFromSeq.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "traits/Resolve.hpp"
+
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/pair.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -31,14 +38,8 @@
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/begin_end.hpp>
 #include <boost/mpl/find.hpp>
-#include "compileTime/conversion/MakeSeq.hpp"
-
 #include <boost/type_traits.hpp>
 
-#include "mappings/kernel/AreaMapping.hpp"
-
-#include "compileTime/conversion/RemoveFromSeq.hpp"
-#include "traits/Resolve.hpp"
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -18,60 +18,40 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "simulation_defines.hpp"
-#include "pmacc_types.hpp"
 #include "assert.hpp"
 
 #include "fields/FieldB.hpp"
 #include "fields/FieldE.hpp"
 #include "fields/FieldJ.hpp"
 
-#include "dimensions/DataSpace.hpp"
-#include "dimensions/DataSpaceOperations.hpp"
-
-#include "memory/buffers/GridBuffer.hpp"
-
-#include "particles/memory/boxes/ParticlesBox.hpp"
-
-#include "dataManagement/DataConnector.hpp"
 #include "plugins/ILightweightPlugin.hpp"
-#include "math/Vector.hpp"
-
-#include "memory/boxes/DataBox.hpp"
-#include "memory/boxes/SharedBox.hpp"
-#include "memory/boxes/PitchedBox.hpp"
-#include "memory/buffers/GridBuffer.hpp"
-
-#include "simulationControl/MovingWindow.hpp"
-
-#include "mappings/kernel/MappingDescription.hpp"
-
-
-//c includes
-#include "sys/stat.h"
-#include <cfloat>
-
-
-#include "mappings/simulation/GridController.hpp"
-
-
-
-#include <string>
-
-#include "memory/boxes/PitchedBox.hpp"
-
 #include "plugins/output/header/MessageHeader.hpp"
 #include "plugins/output/GatherSlice.hpp"
+#include "simulationControl/MovingWindow.hpp"
 
 #include "algorithms/GlobalReduce.hpp"
 #include "memory/boxes/DataBoxDim1Access.hpp"
 #include "nvidia/functors/Max.hpp"
 #include "nvidia/atomic.hpp"
 #include "memory/shared/Allocate.hpp"
+#include "memory/boxes/DataBox.hpp"
+#include "memory/boxes/SharedBox.hpp"
+#include "memory/boxes/PitchedBox.hpp"
+#include "memory/buffers/GridBuffer.hpp"
+#include "particles/memory/boxes/ParticlesBox.hpp"
+#include "dimensions/DataSpace.hpp"
+#include "dimensions/DataSpaceOperations.hpp"
+#include "mappings/kernel/MappingDescription.hpp"
+#include "mappings/simulation/GridController.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "math/Vector.hpp"
+
+#include <string>
+#include <cfloat>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -25,6 +25,7 @@
 
 #include "traits/PICToSplash.hpp"
 #include "plugins/ISimulationPlugin.hpp"
+
 #include "cuSTL/container/DeviceBuffer.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
 #include "cuSTL/algorithm/kernel/Foreach.hpp"
@@ -32,17 +33,19 @@
 #include "cuSTL/algorithm/mpi/Reduce.hpp"
 #include "cuSTL/algorithm/host/Foreach.hpp"
 #include "particles/policies/ExchangeParticles.hpp"
+#include "dataManagement/DataConnector.hpp"
 #include "math/Vector.hpp"
 #include "algorithms/math.hpp"
-#include <boost/shared_ptr.hpp>
 
-/* libSplash data output */
 #include <splash/splash.h>
 #include <boost/filesystem.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include <string>
 #include <iostream>
 #include <fstream>
 #include <stdlib.h>
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -19,7 +19,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #if(ENABLE_HDF5 != 1)
@@ -31,28 +30,26 @@
 #include "traits/SplashToPIC.hpp"
 #include "traits/PICToSplash.hpp"
 
-#include "dimensions/DataSpaceOperations.hpp"
 
-#include "simulation_classTypes.hpp"
-#include "mappings/kernel/AreaMapping.hpp"
+#include "plugins/radiation/Radiation.kernel"
 #include "plugins/ISimulationPlugin.hpp"
 #include "plugins/common/stringHelpers.hpp"
 
 #include "mpi/reduceMethods/Reduce.hpp"
 #include "mpi/MPIReduce.hpp"
 #include "nvidia/functors/Add.hpp"
+#include "dimensions/DataSpaceOperations.hpp"
+#include "dataManagement/DataConnector.hpp"
+#include "mappings/kernel/AreaMapping.hpp"
 
-#include "sys/stat.h"
-
-#include "plugins/radiation/Radiation.kernel"
-
-/* libSplash data output */
 #include <splash/splash.h>
 #include <boost/filesystem.hpp>
+
 #include <string>
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
+
 
 namespace picongpu
 {


### PR DESCRIPTION
Fix missing `DataConnector` includes and clean up:

- include order:
  - header/forward declaration of same file
  - PIConGPU includes
  - PMacc includes
  - other external library includes (if not required to be included first: exceptions are mpi/boost.fusion/cuda/...)
  - boost includes (because its a very common, external C++ lib)
  - stdlib includes
- correct style via `"`
- correct spaces (one before pragma once, 2 after all includes)
- remove includes in PIConGPU core which are already included via `simulation_defines.hpp`