### PR TITLE
ConstVector: Check Arguments Init Full Length

### DIFF
--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -65,6 +65,9 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
     template<typename T_Type, int T_Dim>                                       \
     struct ConstArrayStorage                                                   \
     {                                                                          \
+        PMACC_CASSERT_MSG(                                                     \
+            __PMACC_CONST_VECTOR_dimension_needs_to_be_less_than_or_equal_to_the_number_of_arguments__, \
+            Dim <= count );                                                    \
         static constexpr bool isConst = true;                                  \
         typedef T_Type type;                                                   \
         static constexpr int dim = T_Dim;                                      \


### PR DESCRIPTION
fix the first part of #1802 

`ConstVector` allows that the number of given arguments is lesser than the dimentsion
of the vector it self. This results in unitialized values.

solution: add static assert to avoid wrong usage