### PR TITLE
Ionization Configs: Add He, C, O, Al, Cu

### DIFF
--- a/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
+++ b/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2017 Marco Garten
+ * Copyright 2014-2017 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -63,15 +63,36 @@ namespace AU
      * @see libPMacc/include/math/ConstVector.hpp
      * for finding ionization energies,
      * @see http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html
+     *
+     * Reference: Kramida, A., Ralchenko, Yu., Reader, J., and NIST ASD Team (2014)
+     *            NIST Atomic Spectra Database (ver. 5.2), [Online]
+     *            Available: http://physics.nist.gov/asd [2017, February 8]
+     *            National Institute of Standards and Technology, Gaithersburg, MD
      */
 
     /* ionization energy for ground state hydrogen in atomic units */
-    PMACC_CONST_VECTOR(float_X,1,IONIZATION_ENERGY_HYDROGEN,
-        13.60569 * UNITCONV_eV_to_AU
+    PMACC_CONST_VECTOR(float_X, 1, IONIZATION_ENERGY_HYDROGEN,
+        13.59843 * UNITCONV_eV_to_AU
     );
 
-    /* ionization energy for nitrogen atomic units */
-    PMACC_CONST_VECTOR(float_X,7,IONIZATION_ENERGY_NITROGEN,
+    /* ionization energy for ground state helium in atomic units */
+    PMACC_CONST_VECTOR(float_X, 2, IONIZATION_ENERGY_HELIUM,
+        24.58739 * UNITCONV_eV_to_AU,
+        54.41776 * UNITCONV_eV_to_AU
+    );
+
+    /* ionization energy for carbon in atomic units */
+    PMACC_CONST_VECTOR(float_X, 6, IONIZATION_ENERGY_CARBON,
+        11.2603 * UNITCONV_eV_to_AU,
+        24.3845 * UNITCONV_eV_to_AU,
+        47.88778 * UNITCONV_eV_to_AU,
+        64.49351 * UNITCONV_eV_to_AU,
+        392.0905 * UNITCONV_eV_to_AU,
+        489.993177 * UNITCONV_eV_to_AU
+    );
+
+    /* ionization energy for nitrogen in atomic units */
+    PMACC_CONST_VECTOR(float_X, 7, IONIZATION_ENERGY_NITROGEN,
         14.53413 * UNITCONV_eV_to_AU,
         29.60125 * UNITCONV_eV_to_AU,
         47.4453 * UNITCONV_eV_to_AU,
@@ -79,6 +100,68 @@ namespace AU
         97.89013 * UNITCONV_eV_to_AU,
         552.06731 * UNITCONV_eV_to_AU,
         667.04609 * UNITCONV_eV_to_AU
+    );
+
+    /* ionization energy for oxygen in atomic units */
+    PMACC_CONST_VECTOR(float_X, 8, IONIZATION_ENERGY_OXYGEN,
+        13.61805 * UNITCONV_eV_to_AU,
+        35.12112 * UNITCONV_eV_to_AU,
+        54.93554 * UNITCONV_eV_to_AU,
+        77.41350 * UNITCONV_eV_to_AU,
+        113.8989 * UNITCONV_eV_to_AU,
+        138.1189 * UNITCONV_eV_to_AU,
+        739.3268 * UNITCONV_eV_to_AU,
+        871.4098 * UNITCONV_eV_to_AU
+    );
+
+    /* ionization energy for aluminium in atomic units */
+    PMACC_CONST_VECTOR(float_X, 13, IONIZATION_ENERGY_ALUMINIUM,
+        5.98577 * UNITCONV_eV_to_AU,
+        18.8285 * UNITCONV_eV_to_AU,
+        28.4476 * UNITCONV_eV_to_AU,
+        119.992 * UNITCONV_eV_to_AU,
+        153.825 * UNITCONV_eV_to_AU,
+        190.495 * UNITCONV_eV_to_AU,
+        241.769 * UNITCONV_eV_to_AU,
+        284.647 * UNITCONV_eV_to_AU,
+        330.214 * UNITCONV_eV_to_AU,
+        398.656 * UNITCONV_eV_to_AU,
+        442.006 * UNITCONV_eV_to_AU,
+        2085.97 * UNITCONV_eV_to_AU,
+        2304.14 * UNITCONV_eV_to_AU
+    );
+
+    /* ionization energy for copper in atomic units */
+    PMACC_CONST_VECTOR(float_X, 29, IONIZATION_ENERGY_COPPER,
+        7.72638 * UNITCONV_eV_to_AU,
+        20.2924 * UNITCONV_eV_to_AU,
+        36.8411 * UNITCONV_eV_to_AU,
+        57.385  * UNITCONV_eV_to_AU,
+        79.87   * UNITCONV_eV_to_AU,
+        103.010 * UNITCONV_eV_to_AU,
+        139.012 * UNITCONV_eV_to_AU,
+        166.021 * UNITCONV_eV_to_AU,
+        198.022 * UNITCONV_eV_to_AU,
+        232.25  * UNITCONV_eV_to_AU,
+        265.332 * UNITCONV_eV_to_AU,
+        367.09  * UNITCONV_eV_to_AU,
+        401.03  * UNITCONV_eV_to_AU,
+        436.06  * UNITCONV_eV_to_AU,
+        483.19  * UNITCONV_eV_to_AU,
+        518.712 * UNITCONV_eV_to_AU,
+        552.821 * UNITCONV_eV_to_AU,
+        632.56  * UNITCONV_eV_to_AU,
+        670.608 * UNITCONV_eV_to_AU,
+        1690.59 * UNITCONV_eV_to_AU,
+        1800.3  * UNITCONV_eV_to_AU,
+        1918.4  * UNITCONV_eV_to_AU,
+        2044.6  * UNITCONV_eV_to_AU,
+        2179.4  * UNITCONV_eV_to_AU,
+        2307.32 * UNITCONV_eV_to_AU,
+        2479.12 * UNITCONV_eV_to_AU,
+        2586.95 * UNITCONV_eV_to_AU,
+        11062.4 * UNITCONV_eV_to_AU,
+        11567.6 * UNITCONV_eV_to_AU
     );
 
 } // namespace SI

--- a/src/picongpu/include/simulation_defines/param/ionizerConfig.param
+++ b/src/picongpu/include/simulation_defines/param/ionizerConfig.param
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2017 Marco Garten
+ * Copyright 2014-2017 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -22,6 +22,7 @@
 
 #include "particles/ionization/byField/fieldIonizationCalc.def"
 
+
 namespace picongpu
 {
     /** Effective Atomic Numbers
@@ -34,19 +35,47 @@ namespace picongpu
      * @see https://en.wikipedia.org/wiki/Effective_nuclear_charge
      * or refer directly to the calculations by Slater or Clementi and Raimondi
      *
+     * References:
+     *   Clementi, E.; Raimondi, D. L. (1963)
+     *     "Atomic Screening Constants from SCF Functions"
+     *     J. Chem. Phys. 38 (11): 2686–2689. doi:10.1063/1.1733573
+     *   Clementi, E.; Raimondi, D. L.; Reinhardt, W. P. (1967)
+     *     "Atomic Screening Constants from SCF Functions. II. Atoms with 37 to 86 Electrons"
+     *     Journal of Chemical Physics. 47: 1300–1307. doi:10.1063/1.1712084
+     *
      * IMPORTANT NOTE:
      * You have to insert the values in REVERSE order since the lowest shell
      * corresponds to the last ionization process!
      */
 
     /* For hydrogen Z_eff is obviously equal to Z */
-    PMACC_CONST_VECTOR(float_X,1,Z_EFFECTIVE_HYDROGEN,
+    PMACC_CONST_VECTOR(float_X, 1, Z_EFFECTIVE_HYDROGEN,
         /* 1s */
         1.
-        );
+    );
+
+    /* Example: helium */
+    PMACC_CONST_VECTOR(float_X, 2, Z_EFFECTIVE_HELIUM,
+        /* 1s */
+        1.688,
+        1.688
+    );
+
+    /* Example: carbon */
+    PMACC_CONST_VECTOR(float_X, 6, Z_EFFECTIVE_CARBON,
+        /* 2p */
+        3.136,
+        3.136,
+        /* 2s */
+        3.217,
+        3.217,
+        /* 1s */
+        5.673,
+        5.673
+    );
 
     /* Example: nitrogen */
-    PMACC_CONST_VECTOR(float_X,7,Z_EFFECTIVE_NITROGEN,
+    PMACC_CONST_VECTOR(float_X, 7, Z_EFFECTIVE_NITROGEN,
         /* 2p */
         3.834,
         3.834,
@@ -57,5 +86,82 @@ namespace picongpu
         /* 1s */
         6.665,
         6.665
-        );
+    );
+
+    /* Example: oxygen */
+    PMACC_CONST_VECTOR(float_X, 8, Z_EFFECTIVE_OXYGEN,
+        /* 2p */
+        4.453,
+        4.453,
+        4.453,
+        4.453,
+        /* 2s */
+        4.492,
+        4.492,
+        /* 1s */
+        7.658,
+        7.658
+    );
+
+    /* Example: aluminium */
+    PMACC_CONST_VECTOR(float_X, 13, Z_EFFECTIVE_ALUMINIUM,
+        /* 3p */
+        4.066,
+        /* 3s */
+        4.117,
+        4.117,
+        /* 2p */
+        8.963,
+        8.963,
+        8.963,
+        8.963,
+        8.963,
+        8.963,
+        /* 2s */
+        8.214,
+        8.214,
+        /* 1s */
+        12.591,
+        12.591
+    );
+
+    /* Example: copper */
+    PMACC_CONST_VECTOR(float_X, 29, Z_EFFECTIVE_COPPER,
+        /* 3d */
+        13.201,
+        13.201,
+        13.201,
+        13.201,
+        13.201,
+        13.201,
+        13.201,
+        13.201,
+        13.201,
+        /* 4s */
+        5.842,
+        5.842,
+        /* 3p */
+        14.731,
+        14.731,
+        14.731,
+        14.731,
+        14.731,
+        14.731,
+        /* 3s */
+        15.594,
+        15.594,
+        /* 2p */
+        25.097,
+        25.097,
+        25.097,
+        25.097,
+        25.097,
+        25.097,
+        /* 2s */
+        21.020,
+        21.020,
+        /* 1s */
+        28.339,
+        28.339
+    );
 }


### PR DESCRIPTION
Adds NIST tables for commonly used elements in our experiments, so users can use them directly. Covers: Dopants (He, N, also Ar could be relevant), Plastics & Surface Dirt (C, O, N), and commonly used benchmark materials (Al, Cu).