### PR TITLE
boundElectrons: non-weighted attribute

### DIFF
--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -399,10 +399,10 @@ struct UnitDimension<boundElectrons>
 template<>
 struct MacroWeighted<boundElectrons>
 {
-    // bound electrons are distributed over all macro ions
+    // bound electrons are counted for a single real ion
     static bool get()
     {
-        return true;
+        return false;
     }
 };
 template<>


### PR DESCRIPTION
The openPMD output and general description for a particle species' `boundElectrons` per ion is ill-described, mismatching that this attribute is, similar to our constant mass and charge attributes, not weighted for a macro particle but just for an underlying real particle.

Influence: post-processing tools, e.g. openPMD-viewer, did weight the number of bound electrons "twice".

Reference: https://github.com/openPMD/openPMD-standard/blob/1.0.0/EXT_ED-PIC.md#additional-attributes-for-each-particle-record