### PR TITLE
Verify number of ionization energy levels == proton number

### DIFF
--- a/src/picongpu/include/particles/traits/GetEffectiveAtomicNumbers.hpp
+++ b/src/picongpu/include/particles/traits/GetEffectiveAtomicNumbers.hpp
@@ -33,7 +33,8 @@ namespace traits
 template<typename T_Species>
 struct GetEffectiveAtomicNumbers
 {
-    typedef typename T_Species::FrameType FrameType;
+    typedef T_Species SpeciesType;
+    typedef typename SpeciesType::FrameType FrameType;
 
     typedef typename HasFlag<FrameType, effectiveAtomicNumbers<> >::type hasEffectiveAtomicNumbers;
     /* throw static assert if species has no predefined effective atomic numbers */
@@ -42,6 +43,15 @@ struct GetEffectiveAtomicNumbers
     typedef typename GetFlagType<FrameType,effectiveAtomicNumbers<> >::type FoundEffectiveAtomicNumbersAlias;
     /* Extract vector of effective atomic numbers */
     typedef typename PMacc::traits::Resolve<FoundEffectiveAtomicNumbersAlias >::type type;
+
+    static constexpr int protonNumber = static_cast<int>(GetAtomicNumbers<SpeciesType>::type::numberOfProtons);
+    /* length of the ionization energy vector */
+    static constexpr int vecLength = type::dim;
+    /* assert that the number of arguments in the vector equal the proton number */
+    PMACC_CASSERT_MSG(
+        __The_given_number_of_effective_atomic_numbers_Z_eff_should_be_exactly_the_proton_number_of_the_species__,
+        vecLength == protonNumber
+    );
 };
 } //namespace traits
 

--- a/src/picongpu/include/particles/traits/GetIonizationEnergies.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizationEnergies.hpp
@@ -33,7 +33,8 @@ namespace traits
 template<typename T_Species>
 struct GetIonizationEnergies
 {
-    typedef typename T_Species::FrameType FrameType;
+    typedef T_Species SpeciesType;
+    typedef typename SpeciesType::FrameType FrameType;
 
     typedef typename HasFlag<FrameType, ionizationEnergies<> >::type hasIonizationEnergies;
     /* throw static assert if species has no protons or neutrons */
@@ -42,6 +43,15 @@ struct GetIonizationEnergies
     typedef typename GetFlagType<FrameType,ionizationEnergies<> >::type FoundIonizationEnergiesAlias;
     /* Extract ionization energy vector from AU namespace */
     typedef typename PMacc::traits::Resolve<FoundIonizationEnergiesAlias >::type type;
+
+    static constexpr int protonNumber = static_cast<int>(GetAtomicNumbers<SpeciesType>::type::numberOfProtons);
+    /* length of the ionization energy vector */
+    static constexpr int vecLength = type::dim;
+    /* assert that the number of arguments in the vector equal the proton number */
+    PMACC_CASSERT_MSG(
+        __The_given_number_of_ionization_energies_should_be_exactly_the_proton_number_of_the_species__,
+        vecLength == protonNumber
+    );
 };
 } //namespace traits
 


### PR DESCRIPTION
Adds a sanity check which verifies that the given number of ionization
energies / effective atomic numbers equals the proton number.