### PR TITLE
PMacc Log: Make Events Own Level

### DIFF
--- a/src/libPMacc/include/debug/PMaccVerbose.hpp
+++ b/src/libPMacc/include/debug/PMaccVerbose.hpp
@@ -45,6 +45,7 @@ DEFINE_VERBOSE_CLASS(PMaccVerbose)
     DEFINE_LOGLVL(8,MPI);
     DEFINE_LOGLVL(16,CUDA_RT);
     DEFINE_LOGLVL(32,COMMUNICATION);
+    DEFINE_LOGLVL(64,EVENT);
 )
 /*set default verbose lvl (integer number)*/
 (NOTHING::lvl|PMACC_VERBOSE_LVL);

--- a/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
@@ -32,7 +32,7 @@ namespace PMacc
 {
     CudaEvent::CudaEvent( ) : isRecorded( false ), finished( true ), refCounter( 0u )
     {
-        log( ggLog::CUDA_RT()+ggLog::MEMORY(), "create event" );
+        log( ggLog::CUDA_RT()+ggLog::EVENT(), "create event" );
         CUDA_CHECK( cudaEventCreateWithFlags( &event, cudaEventDisableTiming ) );
     }
 
@@ -40,7 +40,7 @@ namespace PMacc
     CudaEvent::~CudaEvent( )
     {
         PMACC_ASSERT( refCounter == 0u );
-        log( ggLog::CUDA_RT()+ggLog::MEMORY(), "sync and delete event" );
+        log( ggLog::CUDA_RT()+ggLog::EVENT(), "sync and delete event" );
         // free cuda event
         CUDA_CHECK( cudaEventSynchronize( event ) );
         CUDA_CHECK( cudaEventDestroy( event ) );

--- a/src/libPMacc/include/eventSystem/events/EventPool.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventPool.hpp
@@ -117,7 +117,7 @@ namespace PMacc
          */
         ~EventPool()
         {
-            log( ggLog::CUDA_RT( )+ggLog::MEMORY( ), "shutdown EventPool with %1% events" ) % getEventsCount( );
+            log( ggLog::CUDA_RT( )+ggLog::EVENT( ), "shutdown EventPool with %1% events" ) % getEventsCount( );
             isClosed = true;
             freeEvents.clear( );
             for( std::vector<CudaEvent*>::const_iterator iter = events.begin(); iter != events.end(); ++iter )


### PR DESCRIPTION
Moving event creation, handling and destruction in its own state since it is quite verbose in the already noisy memory level.

- [x] update [wiki](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Debugging#libpmacc-log-levels)