### PR TITLE
refactor manipulator `FreeImpl`

### DIFF
--- a/src/picongpu/include/particles/manipulators/FreeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/FreeImpl.hpp
@@ -18,11 +18,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "simulation_defines.hpp"
 
+#include <utility>
+#include <type_traits>
 
 namespace picongpu
 {
@@ -31,35 +32,138 @@ namespace particles
 namespace manipulators
 {
 
-template<typename T_Functor>
-struct FreeImpl
-{
-
-    typedef T_Functor Functor;
-
-    template<typename T_SpeciesType>
-    struct apply
+    /** generic manipulator to create user defined manipulators
+     *
+     * @tparam T_Functor user defined functor
+     *
+     * `T_Functor`
+     *   - must implement `void operator()(ParticleType)` or `void operator()(ParticleType1, ParticleType2)`
+     *   - `T_Functor` can implement **only** one `operator()` signature
+     *   - can implement **optional** one host side constructor `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
+     */
+    template< typename T_Functor >
+    struct FreeImpl : private T_Functor
     {
-        typedef FreeImpl<T_Functor> type;
-    };
 
-    HINLINE FreeImpl(uint32_t)
-    {
-    }
+        typedef T_Functor Functor;
 
-    template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>&,
-                            T_Particle1& particleSpecies1, T_Particle2& particleSpecies2,
-                            const bool isParticle1, const bool isParticle2)
-    {
-        if (isParticle1 && isParticle2)
+        template< typename T_SpeciesType >
+        struct apply
         {
-            Functor userFunctor;
-            userFunctor(particleSpecies1, particleSpecies2);
-        }
-    }
+            typedef FreeImpl< T_Functor > type;
+        };
 
-};
+
+        /** constructor
+         *
+         * is activated if the user functor has a constructor with one (uint32_t) argument
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                       the constructor
+         * @param currentStep current simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = Functor >
+        HINLINE FreeImpl(
+            uint32_t currentStep,
+            typename std::enable_if<
+                std::is_constructible<
+                    DeferFunctor,
+                    uint32_t
+                >::value
+            >::type* = 0
+        ) : Functor( currentStep )
+        {
+        }
+
+        /** constructor
+         *
+         * is activated if the user functor has a default constructor
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                       the constructor
+         * @param current simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = Functor >
+        HINLINE FreeImpl(
+            uint32_t,
+            typename std::enable_if<
+                std::is_constructible< DeferFunctor >::value
+            >::type* = 0
+        ) : Functor( )
+        {
+        }
+
+        /** call user functor
+         *
+         * calls the user functor if both given particles are valid
+         *
+         * @param cell index within the local volume
+         * @param particleSpecies1 first particle
+         * @param particleSpecies2 second particle, can be equal to the first particle
+         * @param isParticle1 define if the reference @p particleSpecies1 is valid
+         * @param isParticle1 define if the reference @p particleSpecies2 is valid
+         * @return void is used to enable the operator if the user functor except two arguments
+         */
+        template<
+            typename T_Particle1,
+            typename T_Particle2
+        >
+        DINLINE auto operator()(
+            DataSpace<simDim> const &,
+            T_Particle1 & particleSpecies1,
+            T_Particle2 & particleSpecies2,
+            bool const isParticle1,
+            bool const isParticle2
+        )
+        -> decltype(
+            std::declval< Functor >()(
+                particleSpecies1,
+                particleSpecies2
+            )
+        )
+        {
+            if( isParticle1 && isParticle2 )
+            {
+                Functor::operator()(
+                    particleSpecies1,
+                    particleSpecies2
+                );
+            }
+        }
+
+        /** call user functor
+         *
+         * calls the user functor if the first particle is valid
+         *
+         * @param cell index within the local volume
+         * @param particleSpecies1 first particle
+         * @param particleSpecies2 second particle, can be equal to the first particle
+         * @param isParticle1 define if the reference @p particleSpecies1 is valid
+         * @param isParticle1 define if the reference @p particleSpecies2 is valid
+         * @return void is used to enable the operator if user the functor except one argument
+         */
+        template<typename T_Particle1, typename T_Particle2>
+        DINLINE auto operator()(
+            DataSpace<simDim> const &,
+            T_Particle1 & particleSpecies1,
+            T_Particle2 &,
+            bool const isParticle1,
+            bool const
+        )
+        -> decltype(
+            std::declval<Functor>()
+            ( particleSpecies1 )
+        )
+        {
+            if( isParticle1 )
+            {
+                Functor::operator()( particleSpecies1 );
+            }
+        }
+
+    };
 
 } //namespace manipulators
 } //namespace particles

--- a/src/picongpu/include/particles/manipulators/FreeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/FreeImpl.hpp
@@ -35,11 +35,8 @@ namespace manipulators
     /** generic manipulator to create user defined manipulators
      *
      * @tparam T_Functor user defined functor
-     *
-     * `T_Functor`
-     *   - must implement `void operator()(ParticleType)` or `void operator()(ParticleType1, ParticleType2)`
-     *   - `T_Functor` can implement **only** one `operator()` signature
-     *   - can implement **optional** one host side constructor `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
+     *              - must implement `void operator()(ParticleType)` **or** `void operator()(ParticleType1, ParticleType2)`
+     *              - **optional**: can implement **one** host side constructor `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
      */
     template< typename T_Functor >
     struct FreeImpl : private T_Functor
@@ -56,10 +53,11 @@ namespace manipulators
 
         /** constructor
          *
-         * is activated if the user functor has a constructor with one (uint32_t) argument
+         * This constructor is only compiled if the user functor has
+         * a host side constructor with one (uint32_t) argument.
          *
          * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
-         *                       the constructor
+         *                      the constructor
          * @param currentStep current simulation time step
          * @param is used to enable/disable the constructor (do not pass any value to this parameter)
          */
@@ -78,10 +76,10 @@ namespace manipulators
 
         /** constructor
          *
-         * is activated if the user functor has a default constructor
+         * This constructor is only compiled if the user functor has a default constructor.
          *
          * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
-         *                       the constructor
+         *                      the constructor
          * @param current simulation time step
          * @param is used to enable/disable the constructor (do not pass any value to this parameter)
          */
@@ -97,13 +95,14 @@ namespace manipulators
 
         /** call user functor
          *
-         * calls the user functor if both given particles are valid
+         * This method is only compiled if the user functor is a binary particle functor.
+         * The user functor is called if \p isParticle1 and \p isParticle2 are valid.
          *
          * @param cell index within the local volume
          * @param particleSpecies1 first particle
          * @param particleSpecies2 second particle, can be equal to the first particle
          * @param isParticle1 define if the reference @p particleSpecies1 is valid
-         * @param isParticle1 define if the reference @p particleSpecies2 is valid
+         * @param isParticle2 define if the reference @p particleSpecies2 is valid
          * @return void is used to enable the operator if the user functor except two arguments
          */
         template<
@@ -135,13 +134,14 @@ namespace manipulators
 
         /** call user functor
          *
-         * calls the user functor if the first particle is valid
+         * This method is only compiled if the user functor is a binary particle functor.
+         * The user functor is called if \p isParticle1 is valid.
          *
          * @param cell index within the local volume
          * @param particleSpecies1 first particle
-         * @param particleSpecies2 second particle, can be equal to the first particle
+         * @param unused
          * @param isParticle1 define if the reference @p particleSpecies1 is valid
-         * @param isParticle1 define if the reference @p particleSpecies2 is valid
+         * @param unused
          * @return void is used to enable the operator if user the functor except one argument
          */
         template<typename T_Particle1, typename T_Particle2>


### PR DESCRIPTION
- allow user constructor with and without current step
- allow user `operator()` with one or two particles

The changes allow to write user manipulators with different signatures:

```C++
// unary particle manipulator
struct DoubleWeightingFunctor
{
    template< typename T_Particle >
    DINLINE void operator()( T_Particle& particle )
    {
        particle[ weighting_ ] *= float_X( 2.0 );
    }
};
using DoubleWeighting = FreeImpl<DoubleWeightingFunctor>;

// binary particle operator
struct CloneWeightingFunctor
{
    template<
        typename T_Particle1, 
        typename T_Particle2
    >
    DINLINE void operator()( 
        T_Particle2& particle1, 
        T_Particle2& particle2 
    )
    {
        particle1[ weighting_ ] = particle2[ weighting_ ];
    }
};
using CloneWeighting = FreeImpl<CloneWeightingFunctor>;

// unary particle manipulator with constructor
struct TimeStepWeightingFunctor
{
    uint32_t const m_currentTimeStep;
    TimeStepWeightingFunctor( uint32_t currentTimeStep ) : 
        m_currentTimeStep( currentTimeStep )
    {
    }

    template< typename T_Particle >
    DINLINE void operator()( T_Particle& particle )
    {
        particle[ weighting_ ] *= float_X( m_currentTimeStep );
    }
};
using TimeStepWeighting = FreeImpl<TimeStepWeightingFunctor>;
```