### PR TITLE
Backport to 0.2.3: Energy Density, Ionization NaNs

### DIFF
--- a/src/picongpu/include/algorithms/KinEnergy.hpp
+++ b/src/picongpu/include/algorithms/KinEnergy.hpp
@@ -23,6 +23,7 @@
 #include "simulation_defines.hpp"
 #include "algorithms/Gamma.hpp"
 
+
 namespace picongpu
 {
 
@@ -42,14 +43,12 @@ struct KinEnergy
     typedef T_PrecisionType ValueType;
 
     template< typename MomType, typename MassType >
-    HDINLINE ValueType operator()( const MomType& mom, const MassType& mass )
+    HDINLINE ValueType operator()( MomType const & mom, MassType const & mass )
     {
         if( mass == MassType( 0.0 ) )
-        {
             return SPEED_OF_LIGHT * math::abs( precisionCast< ValueType >( mom ) );
-        }
 
-        /* If mass is non-zero then gamma is well defined */
+        /* if mass is non-zero then gamma is well defined */
         const ValueType gamma = Gamma< ValueType >()( mom, mass );
 
         ValueType kinEnergy;
@@ -58,13 +57,13 @@ struct KinEnergy
         {
             const ValueType mom2 = math::abs2( precisionCast< ValueType >( mom ) );
             /* non relativistic kinetic energy expression */
-            kinEnergy = mom2 / (ValueType( 2.0 ) * mass);
+            kinEnergy = mom2 / ( ValueType( 2.0 ) * mass );
         }
         else
         {
             const ValueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
-            /* kinetic Energy for Particles: E = (gamma - 1) * m * c^2 */
-            kinEnergy = (gamma - ValueType( 1.0 )) * mass*c2;
+            /* kinetic energy for particles: E = (gamma - 1) * m * c^2 */
+            kinEnergy = ( gamma - ValueType( 1.0 ) ) * mass * c2;
         }
 
         return kinEnergy;
@@ -72,4 +71,3 @@ struct KinEnergy
 };
 
 }
-

--- a/src/picongpu/include/algorithms/KinEnergy.hpp
+++ b/src/picongpu/include/algorithms/KinEnergy.hpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2017 Axel Huebl, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "algorithms/Gamma.hpp"
+
+namespace picongpu
+{
+
+using namespace PMacc;
+
+/** Computes the kinetic energy of a particle given its momentum and mass.
+ *
+ * The mass may be zero.
+ *
+ * For massive particle with low energy the non-relativistic
+ * kinetic energy expression is used in order to avoid bad roundings.
+ *
+ */
+template< typename T_PrecisionType = float_X >
+struct KinEnergy
+{
+    typedef T_PrecisionType ValueType;
+
+    template< typename MomType, typename MassType >
+    HDINLINE ValueType operator()( const MomType& mom, const MassType& mass )
+    {
+        if( mass == MassType( 0.0 ) )
+        {
+            return SPEED_OF_LIGHT * math::abs( precisionCast< ValueType >( mom ) );
+        }
+
+        /* If mass is non-zero then gamma is well defined */
+        const ValueType gamma = Gamma< ValueType >()( mom, mass );
+
+        ValueType kinEnergy;
+
+        if( gamma < GAMMA_THRESH )
+        {
+            const ValueType mom2 = math::abs2( precisionCast< ValueType >( mom ) );
+            /* non relativistic kinetic energy expression */
+            kinEnergy = mom2 / (ValueType( 2.0 ) * mass);
+        }
+        else
+        {
+            const ValueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+            /* kinetic Energy for Particles: E = (gamma - 1) * m * c^2 */
+            kinEnergy = (gamma - ValueType( 1.0 )) * mass*c2;
+        }
+
+        return kinEnergy;
+    }
+};
+
+}
+

--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -63,7 +63,7 @@ namespace ionization
 
             /* each thread sets the multiMask hard on "particle" (=1) */
             childElectron[multiMask_] = 1;
-            const uint32_t weighting = parentIon[weighting_];
+            const float_X weighting = parentIon[weighting_];
 
             /* each thread initializes a clone of the parent ion but leaving out
              * some attributes:

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
@@ -23,6 +23,7 @@
 #include "particles/particleToGrid/derivedAttributes/Energy.def"
 
 #include "simulation_defines.hpp"
+#include "algorithms/KinEnergy.hpp"
 
 
 namespace picongpu
@@ -47,17 +48,7 @@ namespace derivedAttributes
         const float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass( weighting, particle );
 
-        /* calculate new attribute */
-        Gamma<float_X> calcGamma;
-        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
-        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
-
-        const float_X energy = ( gamma <= float_X(GAMMA_THRESH) ) ?
-            math::abs2(mom) / ( float_X(2.0) * mass ) :   /* non-relativistic */
-            (gamma - float_X(1.0)) * mass * c2;           /* relativistic     */
-
-        /* return attribute */
-        return energy;
+        return KinEnergy<>()( mom, mass );
     }
 } /* namespace derivedAttributes */
 } /* namespace particleToGrid */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2016 Axel Huebl, Rene Widera
+ * Copyright 2013-2017 Axel Huebl, Rene Widera, Heiko Burau
  *
  * This file is part of PIConGPU.
  *
@@ -35,7 +35,7 @@ namespace derivedAttributes
     HDINLINE float1_64
     EnergyDensity::getUnit() const
     {
-        const float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
+        BOOST_CONSTEXPR_OR_CONST float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
         return UNIT_ENERGY / UNIT_VOLUME;
     }
 
@@ -48,12 +48,9 @@ namespace derivedAttributes
         const float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass( weighting, particle );
 
-        const float_X energy = KinEnergy<>()( mom, mass );
+        BOOST_CONSTEXPR_OR_CONST float_X INV_CELL_VOLUME = float_X(1.0) / CELL_VOLUME;
 
-        const float_X particleEnergyDensity = energy / CELL_VOLUME;
-
-        /* return attribute */
-        return particleEnergyDensity;
+        return KinEnergy<>()( mom, mass ) * INV_CELL_VOLUME;
     }
 } /* namespace derivedAttributes */
 } /* namespace particleToGrid */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -23,7 +23,7 @@
 #include "particles/particleToGrid/derivedAttributes/EnergyDensity.def"
 
 #include "simulation_defines.hpp"
-
+#include "algorithms/KinEnergy.hpp"
 
 namespace picongpu
 {
@@ -49,14 +49,7 @@ namespace derivedAttributes
         const float3_X mom = particle[momentum_];
         const float_X mass = attribute::getMass( weighting, particle );
 
-        /* calculate new attribute */
-        Gamma<float_X> calcGamma;
-        const typename Gamma<float_X>::valueType gamma = calcGamma( mom, mass );
-        const float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
-
-        const float_X energy = ( gamma <= float_X(GAMMA_THRESH) ) ?
-            math::abs2(mom) / ( float_X(2.0) * mass ) :   /* non-relativistic */
-            (gamma - float_X(1.0)) * mass * c2;           /* relativistic     */
+        const float_X energy = KinEnergy<>()( mom, mass );
 
         const float_X particleDensity = weighting /
             ( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME );

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -36,8 +36,7 @@ namespace derivedAttributes
     EnergyDensity::getUnit() const
     {
         const float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
-        return UNIT_ENERGY * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
-               / UNIT_VOLUME;
+        return UNIT_ENERGY / UNIT_VOLUME;
     }
 
     template< class T_Particle >
@@ -51,10 +50,7 @@ namespace derivedAttributes
 
         const float_X energy = KinEnergy<>()( mom, mass );
 
-        const float_X particleDensity = weighting /
-            ( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME );
-
-        const float_X particleEnergyDensity = energy * particleDensity;
+        const float_X particleEnergyDensity = energy / CELL_VOLUME;
 
         /* return attribute */
         return particleEnergyDensity;

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -37,17 +37,31 @@ namespace picongpu
 {
     /** FieldTmp output (calculated at runtime) *******************************
      *
+     * Those operations derive scalar field quantities from particle species
+     * at runtime. Each value is mapped per cell. Some operations are identical
+     * up to a constant, so avoid writing those twice to save storage.
+     *
      * you can choose any of these particle to grid projections:
      *   - CreateDensityOperation: particle position + shape on the grid
      *   - CreateChargeDensityOperation: density * charge
-     *   - CreateCounterOperation: counts point like particles per cell (debug)
-     *   - CreateEnergyDensityOperation: particle energy density with respect
-     *                                   to shape
-     *   - CreateEnergyOperation: particle energy with respect to shape
+     *       note: for species that do not change their charge state, this is
+     *             the same as the density times a constant for the charge
+     *   - CreateEnergyOperation: sum of kinetic particle energy per cell with
+     *                            respect to shape (deprecated)
+     *   - CreateEnergyDensityOperation: average kinetic particle energy per
+     *                                   cell times the particle density
+     *       note: this is the same as the sum of kinetic particle energy
+     *             divided by a constant for the cell volume
      *   - CreateMomentumComponentOperation: ratio between a selected momentum
      *                                       component and the absolute
      *                                       momentum with respect to shape
-     *   - CreateLarmorPowerOperation: radiated larmor power (needs ENABLE_RADIATION)
+     *   - CreateLarmorPowerOperation: radiated larmor power
+     *                                 (needs ENABLE_RADIATION)
+     *
+     * for debugging:
+     *   - CreateMidCurrentDensityComponentOperation:
+     *       density * charge * velocity_component
+     *   - CreateCounterOperation: counts point like particles per cell
      */
     using namespace particleToGrid;
 


### PR DESCRIPTION
C++98 backport of fixes to 0.2.3:

- Fix energy density #1750 #1744 (partial)
- fix possible NAN momenta in ionization #1817

### Tested

C++98 compile with
```
  1) mpfr/3.1.2                    8) openmpi/1.8.4.kepler.cuda70
  2) mpc/1.0.1                     9) pngwriter/0.5.6
  3) gmp/5.1.1                    10) hdf5-parallel/1.8.14
  4) gcc/4.8.2                    11) libsplash/1.4.0
  5) cmake/3.3.0                  12) libmxml/2.8
  6) boost/1.62.0                 13) adios/1.9.0
  7) cuda/7.0
```

### Review

Please take extra care if I missed C++11 features, `0.2.X` must be C++98 compatible.