### PR TITLE
fix possible NAN momenta in ionization

### DIFF
--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -63,7 +63,7 @@ namespace ionization
 
             /* each thread sets the multiMask hard on "particle" (=1) */
             childElectron[multiMask_] = 1;
-            const uint32_t weighting = parentIon[weighting_];
+            const float_X weighting = parentIon[weighting_];
 
             /* each thread initializes a clone of the parent ion but leaving out
              * some attributes:


### PR DESCRIPTION
fix #1810

`WriteElectronIntoFrame` creates NAN's for the electron momenta if the weighting of the ion
is less than one.
If the ion weighting is greater than one the electron momentum is not exact.

- [x] tested with foil example and ions species weighting less one.