### PR TITLE
add Bremsstrahlung example

### DIFF
--- a/examples/Bremsstrahlung/README.rst
+++ b/examples/Bremsstrahlung/README.rst
@@ -1,27 +1,23 @@
 Emission of Bremsstrahlung from Laser-foil interaction
 ======================================================
 
-
 * author:      Heiko Burau <h.burau (at) hzdr.de>
 * maintainer:  Heiko Burau <h.burau (at) hzdr.de>
 
-This is a simulation of a flat solid density target hit head-on 
-by a high-intensity laser pulse. At the front surface free electrons 
-are accelerated up to ultra relativistic energies and start travelling 
-throught the bulk then. Meanwhile, due to ion interaction, the hot electrons 
-loose a small fraction of their kinectic energy in favor of emission of 
-Bremsstrahlung-photons. Passing over the back surface hot electrons are eventually reflected
-and re-enter the foil in opposite direction. Because of the ultra-relativistic energy
-Bremsstrahlung (BS) is throughoutly emitted mainly along the direction of motion of the electron.
-The BS-module models the electron-ion scattering as three single processes, including
-electron deflection, electron decceleration and photon creation with respect to the emission
-angle. Details of the implementation and the numerical model can be found in [BurauDipl]_. 
+This is a simulation of a flat solid density target hit head-on by a high-intensity laser pulse. 
+At the front surface free electrons are accelerated up to ultra relativistic energies and start travelling throught the bulk then. 
+Meanwhile, due to ion interaction, the hot electrons loose a small fraction of their kinectic energy in favor of emission of Bremsstrahlung-photons. 
+Passing over the back surface hot electrons are eventually reflected and re-enter the foil in opposite direction. 
+Because of the ultra-relativistic energy Bremsstrahlung (BS) is throughoutly emitted mainly along the direction of motion of the electron.
+The BS-module models the electron-ion scattering as three single processes, including electron deflection, electron decceleration and photon creation with respect to the emission angle. 
+Details of the implementation and the numerical model can be found in [BurauDipl]_. 
 Details of the theoretical description can be found in [Jackson]_ and [Salvat]_.
                
-This 2D test simulates a laser pulse of a_0=40, lambda=0.8µm, w0=1.5µm in head-on collision
-with a fully pre-ionized gold foil of 2µm thickness.
+This 2D test simulates a laser pulse of a_0=40, lambda=0.8µm, w0=1.5µm in head-on collision with a fully pre-ionized gold foil of 2µm thickness.
 
-Checks:
+Checks
+------
+
  - check appearence of photons moving along (forward) and against (backward) the incident laser pulse direction.
  - check photon energy spectrum in both directions for having the forward moving photons a higher energy.
 

--- a/examples/Bremsstrahlung/README.rst
+++ b/examples/Bremsstrahlung/README.rst
@@ -5,21 +5,21 @@ Emission of Bremsstrahlung from Laser-foil interaction
 * maintainer:  Heiko Burau <h.burau (at) hzdr.de>
 
 This is a simulation of a flat solid density target hit head-on by a high-intensity laser pulse. 
-At the front surface free electrons are accelerated up to ultra relativistic energies and start travelling throught the bulk then. 
-Meanwhile, due to ion interaction, the hot electrons loose a small fraction of their kinectic energy in favor of emission of Bremsstrahlung-photons. 
+At the front surface free electrons are accelerated up to ultra relativistic energies and start travelling through the bulk then. 
+Meanwhile, due to ion interaction, the hot electrons lose a small fraction of their kinectic energy in favor of emission of Bremsstrahlung-photons. 
 Passing over the back surface hot electrons are eventually reflected and re-enter the foil in opposite direction. 
-Because of the ultra-relativistic energy Bremsstrahlung (BS) is throughoutly emitted mainly along the direction of motion of the electron.
-The BS-module models the electron-ion scattering as three single processes, including electron deflection, electron decceleration and photon creation with respect to the emission angle. 
+Because of the ultra-relativistic energy Bremsstrahlung (BS) is continuously emitted mainly along the direction of motion of the electron.
+The BS-module models the electron-ion scattering as three single processes, including electron deflection, electron deceleration and photon creation with respect to the emission angle. 
 Details of the implementation and the numerical model can be found in [BurauDipl]_. 
 Details of the theoretical description can be found in [Jackson]_ and [Salvat]_.
-               
+
 This 2D test simulates a laser pulse of a_0=40, lambda=0.8µm, w0=1.5µm in head-on collision with a fully pre-ionized gold foil of 2µm thickness.
 
 Checks
 ------
 
  - check appearence of photons moving along (forward) and against (backward) the incident laser pulse direction.
- - check photon energy spectrum in both directions for having the forward moving photons a higher energy.
+ - check photon energy spectrum in both directions for the forward moving photons having a higher energy.
 
 References
 ----------

--- a/examples/Bremsstrahlung/README.rst
+++ b/examples/Bremsstrahlung/README.rst
@@ -1,0 +1,48 @@
+Emission of Bremsstrahlung from Laser-foil interaction
+======================================================
+
+
+* author:      Heiko Burau <h.burau (at) hzdr.de>
+* maintainer:  Heiko Burau <h.burau (at) hzdr.de>
+
+This is a simulation of a flat solid density target hit head-on 
+by a high-intensity laser pulse. At the front surface free electrons 
+are accelerated up to ultra relativistic energies and start travelling 
+throught the bulk then. Meanwhile, due to ion interaction, the hot electrons 
+loose a small fraction of their kinectic energy in favor of emission of 
+Bremsstrahlung-photons. Passing over the back surface hot electrons are eventually reflected
+and re-enter the foil in opposite direction. Because of the ultra-relativistic energy
+Bremsstrahlung (BS) is throughoutly emitted mainly along the direction of motion of the electron.
+The BS-module models the electron-ion scattering as three single processes, including
+electron deflection, electron decceleration and photon creation with respect to the emission
+angle. Details of the implementation and the numerical model can be found in [BurauDipl]_. 
+Details of the theoretical description can be found in [Jackson]_ and [Salvat]_.
+               
+This 2D test simulates a laser pulse of a_0=40, lambda=0.8µm, w0=1.5µm in head-on collision
+with a fully pre-ionized gold foil of 2µm thickness.
+
+Checks:
+ - check appearence of photons moving along (forward) and against (backward) the incident laser pulse direction.
+ - check photon energy spectrum in both directions for having the forward moving photons a higher energy.
+
+References
+----------
+
+.. [BurauDipl]
+    Heiko Burau.
+    Entwicklung und Überprüfung eines Photonenmodells für die Abstrahlung durch hochenergetische Elektronen,
+    Diploma Thesis TU Dresden (2016),
+    https://doi.org/10.5281/zenodo.192116
+
+.. [Jackson]
+    Jackson, J. David.
+    Electrodynamics,
+    Wiley‐VCH Verlag GmbH & Co. KGaA (1975),
+    http://onlinelibrary.wiley.com/doi/10.1002/9783527600441.oe014
+
+.. [Salvat]
+    F. Salvat, J. Fernández-Varea, J. Sempau, and X. Llovet.
+    Monte carlo simulation of bremsstrahlung emission by electrons,
+    Radiation Physics and Chemistry (2006),
+    http://dx.doi.org/10.1016/j.radphyschem.2005.05.008
+

--- a/examples/Bremsstrahlung/cmakeFlags
+++ b/examples/Bremsstrahlung/cmakeFlags
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2017 Heiko Burau, Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+
+flags[0]="-DCUDA_ARCH=20"
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/examples/Bremsstrahlung/include/simulation_defines/param/bremsstrahlung.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/bremsstrahlung.param
@@ -1,0 +1,132 @@
+/* Copyright 2016-2017 Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace bremsstrahlung
+{
+
+
+/** params related to the energy loss and deflection of the incident electron */
+namespace electron
+{
+    /** Minimal kinectic electron energy in MeV for the lookup table.
+     *
+     * For electrons below this value Bremsstrahlung is not taken into account.
+     */
+    constexpr float_64 MIN_ENERGY_MeV = 0.5;
+
+    /** Maximal kinetic electron energy in MeV for the lookup table.
+     *
+     * Electrons above this value cause a out-of-bounds access at the
+     * lookup table. Bounds checking is enabled for "CRITICAL" log level.
+     */
+    constexpr float_64 MAX_ENERGY_MeV = 100.0;
+
+    /** Minimal polar deflection angle due to screening. */
+    constexpr float_64 MIN_THETA = 0.001;
+
+    /** number of lookup table divisions for the kappa axis.
+     *
+     * Kappa is the energy loss normalized to the initial kinetic energy.
+     * The axis is scaled linearly.
+     */
+    constexpr uint32_t NUM_SAMPLES_KAPPA = 64;
+
+    /** number of lookup table divisions for the initial kinetic energy axis.
+     *
+     * The axis is scaled logarithmically.
+     */
+    constexpr uint32_t NUM_SAMPLES_EKIN = 128;
+
+    /** Kappa is the energy loss normalized to the initial kinetic energy.
+     *
+     * This minimal value is needed by the numerics to avoid a division by zero.
+     */
+    constexpr float_64 MIN_KAPPA = 1.0e-10;
+
+} // namespace electron
+
+/** params related to the creation and the emission angle of the photon */
+namespace photon
+{
+    /** Low-energy threshold in keV of the incident electron for the creation of photons.
+     *
+     * Below this value photon emission is neglected.
+     */
+    constexpr float_64 SOFT_PHOTONS_CUTOFF_keV = 5.0;
+
+    /** number of lookup table divisions for the delta axis.
+     *
+     * Delta is the angular emission probability (normalized to one) integrated from zero to theta,
+     * where theta is the angle between the photon momentum and the final electron momentum.
+     *
+     * The axis is scaled linearly.
+     */
+    constexpr uint32_t NUM_SAMPLES_DELTA = 256;
+
+    /** number of lookup table divisions for the gamma axis.
+     *
+     * Gamma is the relativistic factor of the incident electron.
+     *
+     * The axis is scaled logarithmically.
+     */
+    constexpr uint32_t NUM_SAMPLES_GAMMA = 64;
+
+    /** Maximal value of delta for the lookup table.
+     *
+     * Delta is the angular emission probability (normalized to one) integrated from zero to theta,
+     * where theta is the angle between the photon momentum and the final electron momentum.
+     *
+     * A value close to one is reasonable. Though exactly one was actually correct,
+     * because it would map to theta = pi (maximum polar angle), the sampling then would be bad
+     * in the ultrarelativistic case. In this regime the emission primarily takes place at small thetas.
+     * So a maximum delta close to one maps to a reasonable maximum theta.
+     */
+    constexpr float_64 MAX_DELTA = 0.95;
+
+    /** minimal gamma for the lookup table. */
+    constexpr float_64 MIN_GAMMA = 1.0;
+
+    /** maximal gamma for the lookup table.
+     *
+     * Bounds checking is enabled for "CRITICAL" log level.
+     */
+    constexpr float_64 MAX_GAMMA = 200;
+
+    /** if the emission probability per timestep is higher than this value and the log level is set to
+     *  "CRITICAL" a warning will be raised.
+     */
+    constexpr float_64 SINGLE_EMISSION_PROB_LIMIT = 0.4;
+
+    /** ratio between macro electron weighting (numerator) and macro photon weighting (denominator)
+     *  at the time of creation.
+     *
+     * The emission probability is proportional to this parameter.
+     */
+    constexpr float_64 WEIGHTING_RATIO = 100;
+} // namespace photon
+
+} // namespace bremsstrahlung
+} // namespace particles
+} // namespace picongpu

--- a/examples/Bremsstrahlung/include/simulation_defines/param/componentsConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/componentsConfig.param
@@ -1,0 +1,55 @@
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+/*! Simulation Starter ---------------------------------------------------
+ *  - defaultPIConGPU         : default PIConGPU configuration
+ */
+namespace simulation_starter = defaultPIConGPU;
+
+/*! Laser Configuration --------------------------------------------------
+ *  - laserNone             : no laser init
+ *  - laserGaussianBeam     : Gaussian beam (focusing)
+ *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
+ *                            in 'x' direction
+ *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
+ *  - laserPlaneWave        : a plane wave
+ *  - laserPolynom          : a polynomial laser envelope
+ */
+namespace laserProfile = laserGaussianBeam;
+
+/*! Field Configuration --------------------------------------------------
+ *  - fieldSolverYee : standard Yee solver
+ *  - fieldSolverLehe: Num. Cherenkov free field solver in a chosen direction
+ *  - fieldSolverDirSplitting: Sentoku's Directional Splitting Method
+ *  - fieldSolverNone: disable the vacuum update of E and B
+ *
+ * * For development purposes: ---------------------------------------------
+ *  - fieldSolverYeeNative : generic version of fieldSolverYee
+ *    (need more shared memory per GPU and is slow)
+ */
+namespace fieldSolver = fieldSolverYee;
+
+/*enable (1) or disable (0) current calculation*/
+#define ENABLE_CURRENT 1
+
+}

--- a/examples/Bremsstrahlung/include/simulation_defines/param/densityConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/densityConfig.param
@@ -1,0 +1,82 @@
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/densityProfiles/profiles.def"
+/* preprocessor struct generator */
+#include "preprocessor/struct.hpp"
+
+namespace picongpu
+{
+namespace SI
+{
+    /** The maximum density in particles per m^3 in the gas distribution
+     *  unit: ELEMENTS/m^3
+     *
+     * He (2e- / Atom ) with 1.e15 He / m^3
+     *                      = 2.e15 e- / m^3 */
+
+    constexpr float_64 BASE_DENSITY_SI = 5.9e28; // solid gold
+
+}
+
+namespace densityProfiles
+{
+
+struct FoilFunctor
+{
+
+    /**
+     * This formula uses SI quantities only
+     * The profile will be multiplied by BASE_DENSITY_SI.
+     *
+     * @param position_SI total offset including all slides [in meter]
+     * @param cellSize_SI cell sizes [in meter]
+     *
+     * @return float_X density [normalized to 1.0]
+     */
+    HDINLINE float_X operator()(float2_64 pos, const float3_64& cellSize_SI)
+    {
+        /* center point of foil */
+        constexpr float_64 plateauPos = 4e-6;
+        /* thickness of foil */
+        constexpr float_64 plateauLength = 2e-6;
+        /* gaussian ramp length of density above the surface */
+        constexpr float_64 rampLength = 0.1e-6;
+
+        using namespace PMacc::algorithms::math;
+
+        if(abs(pos.y() - plateauPos) < plateauLength / 2.0)
+        {
+            return float_X(1.0);
+        }
+        const float_64 d = min(abs(pos.y() - plateauPos + plateauLength / 2.0),
+                               abs(pos.y() - plateauPos - plateauLength / 2.0));
+        return exp(-d*d / (2.0 * rampLength*rampLength));
+    }
+};
+
+/* definition of free formula profile */
+using Foil = FreeFormulaImpl< FoilFunctor >;
+
+}//namespace densityProfiles
+
+} //namepsace picongpu

--- a/examples/Bremsstrahlung/include/simulation_defines/param/dimension.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/dimension.param
@@ -1,0 +1,27 @@
+/* Copyright 2014-2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SIMDIM DIM2
+
+namespace picongpu
+{
+    constexpr uint32_t simDim = SIMDIM;
+} // namespace picongpu

--- a/examples/Bremsstrahlung/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/gridConfig.param
@@ -1,0 +1,77 @@
+/* Copyright 2013-2017 Rene Widera, Richard Pausch, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+
+    namespace SI
+    {
+        /** extent of one cell in x-direction
+         *
+         * The simulation frame has a width of 8µm and 2048 cells.
+         *
+         * unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = 8.e-6 / 2048;
+        /** equals Y - the propagation direction
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** epsilon to be >= 1 per mill close to CFL */
+        constexpr float_64 EPS_CFL = 1.001;
+        constexpr float_64 SQRT_OF_2 = 1.4142135623730951
+        /** Duration of one timestep
+         *  unit: seconds */
+        constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / SPEED_OF_LIGHT_SI / SQRT_OF_2 / EPS_CFL;
+    } //namespace SI
+
+    //! Defines the size of the absorbing zone (in cells)
+    const uint32_t ABSORBER_CELLS[3][2] = {
+        {32, 32},  /*x direction [negative,positive]*/
+        {32, 32},  /*y direction [negative,positive]*/
+        {32, 32}   /*z direction [negative,positive]*/
+    }; //unit: number of cells
+
+    //! Define the strength of the absorber for any direction
+    const float_X ABSORBER_STRENGTH[3][2] = {
+        {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
+    }; //unit: none
+
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
+
+    /** When to move the co-moving window.
+     *  An initial pseudo particle, flying with the speed of light,
+     *  is fired at the begin of the simulation.
+     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  the co-moving window starts to move with the speed of light.
+     *
+     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
+     *            when you use the co-moving window
+     *  0.75 means only 75% of simulation area is used for real simulation
+     */
+    constexpr float_64 slide_point = 0.90;
+
+}
+

--- a/examples/Bremsstrahlung/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/gridConfig.param
@@ -39,7 +39,7 @@ namespace picongpu
 
         /** epsilon to be >= 1 per mill close to CFL */
         constexpr float_64 EPS_CFL = 1.001;
-        constexpr float_64 SQRT_OF_2 = 1.4142135623730951
+        constexpr float_64 SQRT_OF_2 = 1.4142135623730951;
         /** Duration of one timestep
          *  unit: seconds */
         constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / SPEED_OF_LIGHT_SI / SQRT_OF_2 / EPS_CFL;

--- a/examples/Bremsstrahlung/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/laserConfig.param
@@ -1,0 +1,320 @@
+/* Copyright 2013-2017 Anton Helm, Richard Pausch, Axel Huebl, Alexander Debus
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+namespace laserGaussianBeam
+{
+// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+namespace SI
+{
+/** unit: meter */
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+/** UNITCONV */
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+/** unit: W / m^2 */
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+/** unit: none */
+constexpr float_64 _A0 = 40;
+
+/** unit: Volt /meter */
+constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+/** unit: Volt /meter */
+//constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+/** Pulse length: sigma of std. gauss for intensity (E^2)
+ *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+ *                                          [   2.354820045      ]
+ *  Info:             FWHM_of_Intensity = FWHM_Illumination
+ *                      = what a experimentalist calls "pulse duration"
+ *  unit: seconds (1 sigma) */
+constexpr float_64 PULSE_LENGTH_SI = 8.0e-15;
+
+/** beam waist: distance from the axis where the pulse intensity (E^2)
+ *              decreases to its 1/e^2-th part,
+ *              at the focus position of the laser
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
+ *  unit: meter */
+constexpr float_64 W0_SI = 1.5e-6;
+/** the distance to the laser focus in y-direction
+ *  unit: meter */
+constexpr float_64 FOCUS_POS_SI = 4e-6;
+}
+/** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+ *  unit: none */
+constexpr float_64 PULSE_INIT = 6.0;
+
+/* laser phase shift (no shift: 0.0) */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+/* Use only the 0th Laguerremode for a standard Gaussian */
+constexpr uint32_t MODENUMBER = 0;
+PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+
+enum PolarisationType
+{
+    LINEAR_X = 1u,
+    LINEAR_Z = 2u,
+    CIRCULAR = 4u,
+};
+constexpr PolarisationType Polarisation = LINEAR_X;
+}
+
+namespace laserPulseFrontTilt
+{
+// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+namespace SI
+{
+/** unit: meter */
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+/** UNITCONV */
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+/** unit: Volt /meter */
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+/** Pulse length: sigma of std. gauss for intensity (E^2)
+    *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+    *                                          [    2.354820045     ]
+    *  Info:             FWHM_of_Intensity = FWHM_Illumination
+    *                      = what a experimentalist calls "pulse duration"
+    *  unit: seconds (1 sigma) */
+constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
+
+/** beam waist: distance from the axis where the pulse intensity (E^2)
+ *              decreases to its 1/e^2-th part,
+ *              at the focus position of the laser
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
+ *  unit: meter */
+constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
+
+/** the distance to the laser focus in y-direction
+    *  unit: meter */
+constexpr float_64 FOCUS_POS_SI = 4.62e-5;
+
+/** the tilt angle between laser propagation in y-direction and laser axis in
+    *  x-direction (0 degree == no tilt)
+    *  unit: degree */
+constexpr float_64 TILT_X_SI = 0;
+}
+/** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+*  unit: none */
+constexpr float_64 PULSE_INIT = 20.0;
+
+/* laser phase shift (no shift: 0.0) */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+enum PolarisationType
+{
+LINEAR_X = 1u,
+LINEAR_Z = 2u,
+CIRCULAR = 4u
+};
+constexpr PolarisationType Polarisation = LINEAR_X;
+}
+
+namespace laserPlaneWave
+{
+// NOT-symetric sinus used: starts with phase=0 --> E-field=0
+namespace SI
+{
+/** unit: meter */
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+/** UNITCONV */
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+/** unit: W / m^2 */
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+/** unit: none */
+constexpr float_64 _A0 = 1.0;
+
+/** unit: Volt /meter */
+constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+/** unit: Volt /meter */
+//constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+/** The profile of the test Lasers 0 and 2 can be stretched by a
+ *      constant area between the up and downramp
+ *  unit: seconds */
+constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 50.0*WAVE_LENGTH_SI/::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+/** Pulse length: sigma of std. gauss for intensity (E^2)
+ *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+ *                                          [    2.354820045     ]
+ *  Info:             FWHM_of_Intensity = FWHM_Illumination
+ *                      = what a experimentalist calls "pulse duration"
+ *  unit: seconds (1 sigma) */
+constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
+
+}
+
+/** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
+ *  unit: none */
+constexpr float_64 RAMP_INIT = 20.6146;
+
+/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+enum PolarisationType
+  {
+    LINEAR_X = 1u,
+    LINEAR_Z = 2u,
+    CIRCULAR = 4u,
+  };
+constexpr PolarisationType Polarisation = LINEAR_X;
+}
+
+namespace laserWavepacket
+{
+// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+namespace SI
+{
+/** unit: meter */
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+/** UNITCONV */
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+/** unit: W / m^2 */
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+/** unit: none */
+//constexpr float_64 _A0  = 3.9;
+
+/** unit: Volt /meter */
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+/** unit: Volt /meter */
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+/** The profile of the test Lasers 0 and 2 can be stretched by a
+ *      constant area between the up and downramp
+ *  unit: seconds */
+constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+/** Pulse length: sigma of std. gauss for intensity (E^2)
+ *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+ *                                          [    2.354820045     ]
+ *  Info:             FWHM_of_Intensity = FWHM_Illumination
+ *                      = what a experimentalist calls "pulse duration"
+ *  unit: seconds (1 sigma) */
+constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
+
+/** beam waist: distance from the axis where the pulse intensity (E^2)
+ *              decreases to its 1/e^2-th part,
+ *              WO_X_SI is this distance in x-direction
+ *              W0_Z_SI is this distance in z-direction
+ *              if both values are equal, the laser has a circular shape in x-z
+ * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+ *                             [   1.17741    ]
+ *  unit: meter */
+constexpr float_64 W0_X_SI = 4.246e-6;
+constexpr float_64 W0_Z_SI = W0_X_SI;
+}
+/** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+and half at the end of the plateau
+ *  unit: none */
+constexpr float_64 RAMP_INIT = 20.0;
+
+/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+enum PolarisationType
+{
+    LINEAR_X = 1u,
+    LINEAR_Z = 2u,
+    CIRCULAR = 4u,
+};
+constexpr PolarisationType Polarisation = LINEAR_X;
+}
+
+
+namespace laserPolynom
+{
+// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+namespace SI
+{
+/** unit: meter */
+constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+/** UNITCONV */
+constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+/** unit: W / m^2 */
+// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+/** unit: none */
+//constexpr float_64 _A0  = 3.9;
+
+/** unit: Volt /meter */
+//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+/** unit: Volt /meter */
+constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+
+/** Pulse length:
+ *  PULSE_LENGTH_SI = total length of polynamial laser pulse
+ *  Rise time = 0.5 * PULSE_LENGTH_SI
+ *  Fall time = 0.5 * PULSE_LENGTH_SI
+ *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
+ *  unit: seconds  */
+constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
+
+/** beam waist: distance from the axis where the pulse intensity (E^2)
+ *              decreases to its 1/e^2-th part,
+ *              at the focus position of the laser
+ *  unit: meter */
+constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
+constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
+}
+
+/* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
+constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+}
+
+namespace laserNone
+{
+namespace SI
+{
+/** unit: meter */
+constexpr float_64 WAVE_LENGTH_SI = 0.0;
+
+/** unit: Volt /meter */
+constexpr float_64 AMPLITUDE_SI = 0.0;
+
+constexpr float_64 PULSE_LENGTH_SI = 0.0;
+}
+}
+
+}
+

--- a/examples/Bremsstrahlung/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/laserConfig.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2017 Anton Helm, Richard Pausch, Axel Huebl, Alexander Debus
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -17,304 +17,309 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+
 #pragma once
 
 
 namespace picongpu
 {
-namespace laserGaussianBeam
-{
-// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
-namespace SI
-{
-/** unit: meter */
-constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+    namespace laserGaussianBeam
+    {
+        // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
-/** UNITCONV */
-constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
-/** unit: W / m^2 */
-// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
 
-/** unit: none */
-constexpr float_64 _A0 = 40;
+            /** unit: none */
+            constexpr float_64 _A0  = 40;
 
-/** unit: Volt /meter */
-constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
-/** unit: Volt /meter */
-//constexpr float_64 AMPLITUDE_SI = 1.738e13;
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 8.0e-15;
 
-/** Pulse length: sigma of std. gauss for intensity (E^2)
- *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                          [   2.354820045      ]
- *  Info:             FWHM_of_Intensity = FWHM_Illumination
- *                      = what a experimentalist calls "pulse duration"
- *  unit: seconds (1 sigma) */
-constexpr float_64 PULSE_LENGTH_SI = 8.0e-15;
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            constexpr float_64 W0_SI = 1.5e-6;
+            /** the distance to the laser focus in y-direction
+             *  unit: meter */
+            constexpr float_64 FOCUS_POS_SI = 4.e-6;
+        }
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+         *  unit: none */
+        constexpr float_64 PULSE_INIT = 6.0;
 
-/** beam waist: distance from the axis where the pulse intensity (E^2)
- *              decreases to its 1/e^2-th part,
- *              at the focus position of the laser
- * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
- *                             [   1.17741    ]
- *  unit: meter */
-constexpr float_64 W0_SI = 1.5e-6;
-/** the distance to the laser focus in y-direction
- *  unit: meter */
-constexpr float_64 FOCUS_POS_SI = 4e-6;
+        /* laser phase shift (no shift: 0.0) */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+        /* Use only the 0th Laguerremode for a standard Gaussian */
+        constexpr uint32_t MODENUMBER = 0;
+        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+        /* This is just an example for a more complicated set of Laguerre modes. */
+        //constexpr uint32_t MODENUMBER = 12;
+        //PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321, -0.0160788);
+
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+    namespace laserPulseFrontTilt
+    {
+        // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+                *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                *                                          [   2.354820045      ]
+                *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                *                      = what a experimentalist calls "pulse duration"
+                *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
+
+            /** the distance to the laser focus in y-direction
+                *  unit: meter */
+            constexpr float_64 FOCUS_POS_SI = 4.62e-5;
+
+            /** the tilt angle between laser propagation in y-direction and laser axis in
+                *  x-direction (0 degree == no tilt)
+                *  unit: degree */
+            constexpr float_64 TILT_X_SI = 0;
+        }
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+        *  unit: none */
+        constexpr float_64 PULSE_INIT = 20.0;
+
+        /* laser phase shift (no shift: 0.0) */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u
+        };
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+    namespace laserPlaneWave
+    {
+        // NOT-symetric sinus used: starts with phase=0 --> E-field=0
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0 = 1.5;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt /meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** The profile of the test Lasers 0 and 2 can be stretched by a
+             *      constexprant area between the up and downramp
+             *  unit: seconds */
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+
+        }
+
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 20.6146;
+
+        /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+    namespace laserWavepacket
+    {
+    // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+    namespace SI
+    {
+        /** unit: meter */
+        constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+        /** UNITCONV */
+        constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+        /** unit: W / m^2 */
+        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+        /** unit: none */
+        //constexpr float_64 _A0  = 3.9;
+
+        /** unit: Volt /meter */
+        //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+        /** unit: Volt /meter */
+        constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+        /** The profile of the test Lasers 0 and 2 can be stretched by a
+         *      constexprant area between the up and downramp
+         *  unit: seconds */
+        constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+        /** Pulse length: sigma of std. gauss for intensity (E^2)
+         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+         *                                          [    2.354820045     ]
+         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+         *                      = what a experimentalist calls "pulse duration"
+         *  unit: seconds (1 sigma) */
+        constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+
+        /** beam waist: distance from the axis where the pulse intensity (E^2)
+         *              decreases to its 1/e^2-th part,
+         *              WO_X_SI is this distance in x-direction
+         *              W0_Z_SI is this distance in z-direction
+         *              if both values are equal, the laser has a circular shape in x-z
+         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+         *                             [   1.17741    ]
+         *  unit: meter */
+        constexpr float_64 W0_X_SI = 4.246e-6;
+        constexpr float_64 W0_Z_SI = W0_X_SI;
+
+    }
+    /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+    and half at the end of the plateau
+     *  unit: none */
+    constexpr float_64 RAMP_INIT = 20.0;
+
+    /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
+    constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+
+    enum PolarisationType
+    {
+        LINEAR_X = 1u,
+        LINEAR_Z = 2u,
+        CIRCULAR = 4u,
+    };
+    constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+
+    namespace laserPolynom
+    {
+        // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            //constexpr float_64 _A0  = 3.9;
+
+            /** unit: Volt /meter */
+            //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+
+            /** Pulse length:
+             *  PULSE_LENGTH_SI = total length of polynamial laser pulse
+             *  Rise time = 0.5 * PULSE_LENGTH_SI
+             *  Fall time = 0.5 * PULSE_LENGTH_SI
+             *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
+             *  unit: seconds  */
+            constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             *  unit: meter */
+            constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
+            constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
+        }
+
+        /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
+        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+    }
+
+    namespace laserNone
+    {
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.0;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = 0.0;
+
+            constexpr float_64 PULSE_LENGTH_SI = 0.0;
+        }
+    }
+
 }
-/** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
- *  unit: none */
-constexpr float_64 PULSE_INIT = 6.0;
-
-/* laser phase shift (no shift: 0.0) */
-constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
-
-/* Use only the 0th Laguerremode for a standard Gaussian */
-constexpr uint32_t MODENUMBER = 0;
-PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
-
-enum PolarisationType
-{
-    LINEAR_X = 1u,
-    LINEAR_Z = 2u,
-    CIRCULAR = 4u,
-};
-constexpr PolarisationType Polarisation = LINEAR_X;
-}
-
-namespace laserPulseFrontTilt
-{
-// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
-namespace SI
-{
-/** unit: meter */
-constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
-
-/** UNITCONV */
-constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
-
-/** unit: Volt /meter */
-constexpr float_64 AMPLITUDE_SI = 1.738e13;
-
-/** Pulse length: sigma of std. gauss for intensity (E^2)
-    *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-    *                                          [    2.354820045     ]
-    *  Info:             FWHM_of_Intensity = FWHM_Illumination
-    *                      = what a experimentalist calls "pulse duration"
-    *  unit: seconds (1 sigma) */
-constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
-
-/** beam waist: distance from the axis where the pulse intensity (E^2)
- *              decreases to its 1/e^2-th part,
- *              at the focus position of the laser
- * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
- *                             [   1.17741    ]
- *  unit: meter */
-constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
-
-/** the distance to the laser focus in y-direction
-    *  unit: meter */
-constexpr float_64 FOCUS_POS_SI = 4.62e-5;
-
-/** the tilt angle between laser propagation in y-direction and laser axis in
-    *  x-direction (0 degree == no tilt)
-    *  unit: degree */
-constexpr float_64 TILT_X_SI = 0;
-}
-/** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
-*  unit: none */
-constexpr float_64 PULSE_INIT = 20.0;
-
-/* laser phase shift (no shift: 0.0) */
-constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
-
-enum PolarisationType
-{
-LINEAR_X = 1u,
-LINEAR_Z = 2u,
-CIRCULAR = 4u
-};
-constexpr PolarisationType Polarisation = LINEAR_X;
-}
-
-namespace laserPlaneWave
-{
-// NOT-symetric sinus used: starts with phase=0 --> E-field=0
-namespace SI
-{
-/** unit: meter */
-constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
-
-/** UNITCONV */
-constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
-
-/** unit: W / m^2 */
-// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
-
-/** unit: none */
-constexpr float_64 _A0 = 1.0;
-
-/** unit: Volt /meter */
-constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
-
-/** unit: Volt /meter */
-//constexpr float_64 AMPLITUDE_SI = 1.738e13;
-
-/** The profile of the test Lasers 0 and 2 can be stretched by a
- *      constant area between the up and downramp
- *  unit: seconds */
-constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 50.0*WAVE_LENGTH_SI/::picongpu::SI::SPEED_OF_LIGHT_SI;
-
-/** Pulse length: sigma of std. gauss for intensity (E^2)
- *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                          [    2.354820045     ]
- *  Info:             FWHM_of_Intensity = FWHM_Illumination
- *                      = what a experimentalist calls "pulse duration"
- *  unit: seconds (1 sigma) */
-constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
-
-}
-
-/** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
- *  unit: none */
-constexpr float_64 RAMP_INIT = 20.6146;
-
-/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
-
-enum PolarisationType
-  {
-    LINEAR_X = 1u,
-    LINEAR_Z = 2u,
-    CIRCULAR = 4u,
-  };
-constexpr PolarisationType Polarisation = LINEAR_X;
-}
-
-namespace laserWavepacket
-{
-// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
-namespace SI
-{
-/** unit: meter */
-constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
-
-/** UNITCONV */
-constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
-
-/** unit: W / m^2 */
-// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
-
-/** unit: none */
-//constexpr float_64 _A0  = 3.9;
-
-/** unit: Volt /meter */
-//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
-
-/** unit: Volt /meter */
-constexpr float_64 AMPLITUDE_SI = 1.738e13;
-
-/** The profile of the test Lasers 0 and 2 can be stretched by a
- *      constant area between the up and downramp
- *  unit: seconds */
-constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
-
-/** Pulse length: sigma of std. gauss for intensity (E^2)
- *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
- *                                          [    2.354820045     ]
- *  Info:             FWHM_of_Intensity = FWHM_Illumination
- *                      = what a experimentalist calls "pulse duration"
- *  unit: seconds (1 sigma) */
-constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
-
-/** beam waist: distance from the axis where the pulse intensity (E^2)
- *              decreases to its 1/e^2-th part,
- *              WO_X_SI is this distance in x-direction
- *              W0_Z_SI is this distance in z-direction
- *              if both values are equal, the laser has a circular shape in x-z
- * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
- *                             [   1.17741    ]
- *  unit: meter */
-constexpr float_64 W0_X_SI = 4.246e-6;
-constexpr float_64 W0_Z_SI = W0_X_SI;
-}
-/** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
-and half at the end of the plateau
- *  unit: none */
-constexpr float_64 RAMP_INIT = 20.0;
-
-/* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
-
-enum PolarisationType
-{
-    LINEAR_X = 1u,
-    LINEAR_Z = 2u,
-    CIRCULAR = 4u,
-};
-constexpr PolarisationType Polarisation = LINEAR_X;
-}
 
 
-namespace laserPolynom
-{
-// Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
-namespace SI
-{
-/** unit: meter */
-constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
-
-/** UNITCONV */
-constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
-
-/** unit: W / m^2 */
-// calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
-
-/** unit: none */
-//constexpr float_64 _A0  = 3.9;
-
-/** unit: Volt /meter */
-//constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
-
-/** unit: Volt /meter */
-constexpr float_64 AMPLITUDE_SI = 1.738e13;
-
-
-/** Pulse length:
- *  PULSE_LENGTH_SI = total length of polynamial laser pulse
- *  Rise time = 0.5 * PULSE_LENGTH_SI
- *  Fall time = 0.5 * PULSE_LENGTH_SI
- *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
- *  unit: seconds  */
-constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
-
-/** beam waist: distance from the axis where the pulse intensity (E^2)
- *              decreases to its 1/e^2-th part,
- *              at the focus position of the laser
- *  unit: meter */
-constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
-constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
-}
-
-/* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
-constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
-}
-
-namespace laserNone
-{
-namespace SI
-{
-/** unit: meter */
-constexpr float_64 WAVE_LENGTH_SI = 0.0;
-
-/** unit: Volt /meter */
-constexpr float_64 AMPLITUDE_SI = 0.0;
-
-constexpr float_64 PULSE_LENGTH_SI = 0.0;
-}
-}
-
-}
 

--- a/examples/Bremsstrahlung/include/simulation_defines/param/particleConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/particleConfig.param
@@ -1,0 +1,68 @@
+/* Copyright 2013-2017 Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/startPosition/functors.def"
+#include "particles/manipulators/manipulators.def"
+#include "nvidia/functors/Add.hpp"
+#include "nvidia/functors/Assign.hpp"
+
+namespace picongpu
+{
+
+namespace particles
+{
+
+    /** a particle with a weighting below MIN_WEIGHTING will not
+     *      be created / will be deleted
+     *  unit: none */
+    constexpr float_X MIN_WEIGHTING = 1.0;
+
+    constexpr float_X TYPICAL_PARTICLES_PER_CELL = 100;
+
+namespace startPosition
+{
+
+    struct RandomParameter
+    {
+        /** Count of particles per cell at initial state
+         *  unit: none */
+        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+    };
+
+    /* definition of random particle start */
+    typedef RandomImpl< RandomParameter > Random;
+
+
+    struct QuietParameter
+    {
+        /** Count of particles per cell per direction at initial state
+         *  unit: none */
+        typedef mCT::shrinkTo<mCT::Int<1, 1, 1>, simDim>::type numParticlesPerDimension;
+    };
+
+    /* definition of quiet particle start*/
+    typedef QuietImpl<QuietParameter> Quiet;
+
+} //namespace startPosition
+
+} //namespace particles
+
+} //namespace picongpu

--- a/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
@@ -1,0 +1,137 @@
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "particles/Identifier.hpp"
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "identifier/value_identifier.hpp"
+
+#include "particles/traits/FilterByFlag.hpp"
+#include "particles/Particles.hpp"
+#include <boost/mpl/string.hpp>
+
+#include "particles/ionization/byField/ionizers.def"
+
+namespace picongpu
+{
+
+/*########################### define particle attributes #####################*/
+
+/** describe attributes of a particle*/
+using DefaultParticleAttributes = MakeSeq_t<
+    position< position_pic >,
+    momentum,
+    weighting,
+    particleId,
+    momentumPrev1
+#if( RAD_MARK_PARTICLE > 1 ) || ( RAD_ACTIVATE_GAMMA_FILTER != 0 )
+    , radiationFlag
+#endif
+>;
+
+/*########################### end particle attributes ########################*/
+
+/*########################### define species #################################*/
+
+/*--------------------------- photons -------------------------------------------*/
+
+value_identifier( float_X, MassRatioPhotons, 0.0 );
+value_identifier( float_X, ChargeRatioPhotons, 0.0 );
+
+using ParticleFlagsPhotons = bmpl::vector<
+    particlePusher< particles::pusher::Photon >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    massRatio< MassRatioPhotons >,
+    chargeRatio< ChargeRatioPhotons >
+>;
+
+/* define species photons */
+using PIC_Photons = Particles<
+    bmpl::string< 'p', 'h' >,
+    DefaultParticleAttributes,
+    ParticleFlagsPhotons
+>;
+
+
+/*--------------------------- ions -------------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier(float_X, MassRatioIons, 359100);
+value_identifier(float_X, ChargeRatioIons, -79.0);
+value_identifier(float_X, DensityRatioIons, 1.0);
+
+using ParticleFlagsIons = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioIons >,
+    chargeRatio< ChargeRatioIons >,
+    densityRatio< DensityRatioIons >,
+    atomicNumbers< ionization::atomicNumbers::Gold_t >
+>;
+
+/* define species ions */
+using PIC_Ions = Particles<
+    bmpl::string< 'i' >,
+    DefaultParticleAttributes,
+    ParticleFlagsIons
+>;
+
+
+/*--------------------------- electrons --------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+value_identifier( float_X, DensityRatioElectrons, 79.0 );
+
+using ParticleFlagsElectrons = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioElectrons >,
+    chargeRatio< ChargeRatioElectrons >,
+    densityRatio< DensityRatioElectrons >,
+    bremsstrahlungIons< PIC_Ions >,
+    bremsstrahlungPhotons< PIC_Photons >
+>;
+
+/* define species electrons */
+using PIC_Electrons = Particles<
+    bmpl::string< 'e' >,
+    DefaultParticleAttributes,
+    ParticleFlagsElectrons
+>;
+
+
+/*########################### end species ####################################*/
+
+
+using VectorAllSpecies = MakeSeq_t<
+    PIC_Electrons,
+    PIC_Ions,
+    PIC_Photons
+>;
+
+} //namespace picongpu

--- a/examples/Bremsstrahlung/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/speciesInitialization.param
@@ -1,0 +1,98 @@
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/InitFunctors.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+
+/* Available species functors
+ *   in src/picongpu/include/particles/InitFunctors.hpp
+ *
+ * - CreateGas<T_GasFunctor, T_PositionFunctor, T_SpeciesType>
+ *     Create particle distribution based on a gas profile and an in-cell
+ *     positioning.
+ *     Fills a particle species (`fillAllGaps()` is called).
+ *     @tparam T_GasFunctor      unary lambda functor with gas description,
+ *                               \see gasConfig.param
+ *                               \example gasProfiles::Homogenous,
+ *     @tparam T_PositionFunctor unary lambda functor with position description,
+ *                               \see particlesConfig.param
+ *                               \example startPosition::Quiet
+ *                                        startPosition::Random
+ *     @tparam T_SpeciesType type of the used species,
+ *                               \see speciesDefinition.param
+ *                               \example PIC_Electrons
+ *
+ * - CloneSpecies<T_SrcSpeciesType, T_DestSpeciesType>
+ *     Create a particle species by copying all matching attributes from an
+ *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
+ *     @tparam T_SrcSpeciesType  source species
+ *     @tparam T_DestSpeciesType destination species
+ *
+ * - Manipulate<T_Functor, typename T_SpeciesType>
+ *     Run a user defined functor for every particle.
+ *     \warning does not call `fillAllGaps()` if one removes or
+ *              adds particles with it (\see FillAllGaps below)
+ *     @tparam T_Functor     unary lambda functor,
+ *                           \see particleConfig.param
+ *     @tparam T_SpeciesType type of the used species
+ *
+ * - ManipulateCloneSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
+ *     Same as \see CloneSpecies but allows a T_ManipulateFunctor to be called
+ *     after cloning to manipulate the two particles that took part
+ *     in the cloning (e.g., assign and increase an attribute such as weighting).
+ *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
+ *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
+ *                                 species: destination and source,
+ *                                 \see particleConfig.param
+ *     @tparam T_SrcSpeciesType    source species
+ *     @tparam T_DestSpeciesType   destination species
+ *
+ * - FillAllGaps<T_SpeciesType>
+ *     The manipulate functor does not call `fillAllGaps` on
+ *     the particle list of frames. For user-defined functors
+ *     that are called via Manipulate and create/remove
+ *     particles into/from frame lists, this must be called
+ *     afterward to create a valid data structure.
+ */
+
+/** InitPipeline define in which order species are initialized
+ *
+ * the functors are called in order (from first to last functor)
+ */
+typedef mpl::vector<
+    CreateDensity<
+        densityProfiles::Foil,
+        startPosition::Quiet,
+        PIC_Ions
+    >,
+    CreateDensity<
+        densityProfiles::Foil,
+        startPosition::Random,
+        PIC_Electrons
+    >
+> InitPipeline;
+
+} /* namespace particles */
+} /* namespace picongpu  */

--- a/examples/Bremsstrahlung/submit/0008gpus.cfg
+++ b/examples/Bremsstrahlung/submit/0008gpus.cfg
@@ -1,0 +1,70 @@
+# Copyright 2013-2017 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      doc/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="8:00:00"
+
+TBG_gpu_x=8
+TBG_gpu_y=1
+TBG_gpu_z=1
+
+TBG_gridSize="-g 2048 2048 1"
+TBG_steps="-s 5000"
+
+TBG_periodic="--periodic 0 0 0"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+
+TBG_plugins="--hdf5.period 1000  \
+             --e_macroParticlesCount.period 1000 \
+             --i_macroParticlesCount.period 1000 \
+             --ph_macroParticlesCount.period 1000"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+
+TBG_programParams="!TBG_devices     \
+                   !TBG_gridSize    \
+                   !TBG_steps       \
+                   !TBG_plugins"
+
+# TOTAL number of GPUs
+TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+
+"$TBG_cfgPath"/submitAction.sh


### PR DESCRIPTION
This is a simulation of a flat solid density target hit head-on by a high-intensity laser pulse.  

In this process Bremsstrahlung is emitted via creation of macrophotons.

Macrophotons are travelling in every direction, yet they have a higher energy in laser direction.