### PR TITLE
fix float to int cast warnings

### DIFF
--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -129,7 +129,7 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
  * create type definition `name_t`
  */
 #define PMACC_CONST_VECTOR_DEF(type,dim,name,...)                              \
-    PMACC_STATIC_CONST_VECTOR_DIM_DEF(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(__VA_ARGS__),__VA_ARGS__)
+    PMACC_STATIC_CONST_VECTOR_DIM_DEF(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(type,__VA_ARGS__),__VA_ARGS__)
 
 /** Create global constant math::Vector with compile time values which can be
  *  used on device and host
@@ -148,4 +148,4 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
  *      The type of the created vector is "name_t" -> in this case "myVector_t"
  */
 #define PMACC_CONST_VECTOR(type,dim,name,...)                                   \
-    PMACC_STATIC_CONST_VECTOR_DIM(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(__VA_ARGS__),__VA_ARGS__)
+    PMACC_STATIC_CONST_VECTOR_DIM(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(type,__VA_ARGS__),__VA_ARGS__)

--- a/src/libPMacc/include/ppFunctions.hpp
+++ b/src/libPMacc/include/ppFunctions.hpp
@@ -37,11 +37,10 @@
 /**
  * Returns number of args... arguments.
  *
- * Can only count values of ... which can be casted to int type.
- *
+ * @param type type of the arguments in ...
  * @param ... arguments
  */
-#define PMACC_COUNT_ARGS(...)  (sizeof((int[]){0, ##__VA_ARGS__})/sizeof(int)-1)
+#define PMACC_COUNT_ARGS(type,...)  (sizeof((type[]){type{}, ##__VA_ARGS__})/sizeof(type)-1u)
 
 /**
  * Check if ... has arguments or not


### PR DESCRIPTION
`PMACC_COUNT_ARGS` casts each value to `int` this creates warnings with `-Wconversion`

- fix implicit type cast in `PMACC_COUNT_ARGS` by passing the type of the arguments to the macro
- update usage of `PMACC_COUNT_ARGS` in `PMACC_CONST_VECTOR`