### PR TITLE
WarmCopper Example: FLYlite Benchmark

### DIFF
--- a/examples/WarmCopper/README.rst
+++ b/examples/WarmCopper/README.rst
@@ -1,0 +1,29 @@
+Warm Copper: Average Charge State Evolution of Copper irradiated by a laser
+===========================================================================
+
+* author:      Axel Huebl <a.huebl (at) hzdr.de>, Hyun-Kyung Chung
+* maintainer:  Axel Huebl <a.huebl (at) hzdr.de>
+
+This setup initializes a homogenous, non-moving, copper block irradiated by a laser with 10^18 W/cm^3 as a benchmark for [SCFLY]_ [#FLYlite]_ atomic population dynamics.
+We follow the setup from [FLYCHK]_ page 10, figure 4 assuming a quasi 0D setup with homogenous density of a 1+ ionized copper target.
+The laser (not modeled) already generated a thermal electron density at 10, 100 or 1000 eV and a delta-distribution like "hot" electron distribution with 200 keV (directed stream).
+The observable of interest is <Z> over time of the copper ions.
+For low thermal energies, collisional excitation, de-excitation and recombinations should be sufficient to reach the LTE state after about 0.1-1 ps.
+For higher initial temperatures, radiative rates get more relevant and the Non-LTE steady-state solution can only be reached correctly when also adding radiative rates.
+
+.. [#FLYlite] In PIConGPU, we generally refer to the implemented subset of *SCFLY* (solving Non-LTE population kinetics) as *FLYlite*.
+
+References
+----------
+
+.. [FLYCHK]
+        H.-K. Chung, M.H. Chen, W.L. Morgan, Y. Ralchenko, R.W. Lee.
+        *FLYCHK: Generalized population kinetics and spectral model for rapid spectroscopic analysis for all elements*,
+        High Energy Density Physics I (2005),
+        https://dx.doi.org/10.1016/j.hedp.2005.07.001
+
+.. [SCFLY]
+        H.-K. Chung, M.H. Chen, R.W. Lee.
+        *Extension of atomic configuration sets of the Non-LTE model in the application to the Ka diagnostics of hot dense matter*,
+        High Energy Density Physics III (2007),
+        https://dx.doi.org/10.1016/j.hedp.2007.02.001

--- a/examples/WarmCopper/cmakeFlags
+++ b/examples/WarmCopper/cmakeFlags
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2017 Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+
+flags[0]="-DCUDA_ARCH=20"
+flags[1]="-DCUDA_ARCH=20 -DPARAM_OVERWRITES:LIST=-DPARAM_ENABLE_PUSHER=1;-DPARAM_ENABLE_CURRENT=1"
+
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/examples/WarmCopper/cmakeFlags
+++ b/examples/WarmCopper/cmakeFlags
@@ -29,8 +29,8 @@
 #   - start with zero index
 #   - increase by 1, no gaps
 
-flags[0]="-DCUDA_ARCH=20"
-flags[1]="-DCUDA_ARCH=20 -DPARAM_OVERWRITES:LIST=-DPARAM_ENABLE_PUSHER=1;-DPARAM_ENABLE_CURRENT=1"
+flags[0]="-DCUDA_ARCH=20 -DCMAKE_DISABLE_FIND_PACKAGE_ISAAC=True"
+flags[1]="-DCUDA_ARCH=20 -DCMAKE_DISABLE_FIND_PACKAGE_ISAAC=True -DPARAM_OVERWRITES:LIST=-DPARAM_ENABLE_PUSHER=1;-DPARAM_ENABLE_CURRENT=1"
 
 
 ################################################################################

--- a/examples/WarmCopper/include/simulation_defines/param/densityConfig.param
+++ b/examples/WarmCopper/include/simulation_defines/param/densityConfig.param
@@ -1,0 +1,48 @@
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/densityProfiles/profiles.def"
+/* preprocessor struct generator */
+#include "preprocessor/struct.hpp"
+
+
+namespace picongpu
+{
+namespace SI
+{
+    /** Base density in particles per m^3 in the density profiles.
+     *
+     * This is often taken as reference maximum density in normalized profiles.
+     * Individual particle species can define a `densityRatio` flag relative
+     * to this value.
+     *
+     * unit: ELEMENTS/m^3
+     */
+    constexpr float_64 BASE_DENSITY_SI = 8.49e28; // copper ion density
+}
+
+namespace densityProfiles
+{
+    /* definition of homogenous profile */
+    using Homogenous = HomogenousImpl;
+}
+}

--- a/examples/WarmCopper/include/simulation_defines/param/gridConfig.param
+++ b/examples/WarmCopper/include/simulation_defines/param/gridConfig.param
@@ -1,0 +1,96 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+
+    namespace SI
+    {
+        /** Duration of one timestep
+         *
+         *  Non-LTE steady state or LTE respectively should be reached
+         *  within 1 ps. We discretize the time in 1'000 equal steps.
+         *
+         *  unit: seconds */
+        constexpr float_64 DELTA_T_SI = 1.0e-12 / 1000.;
+
+        /** epsilon to be >= 1 per mill close to CFL */
+        constexpr float_64 EPS_CFL = 1.001;
+        constexpr float_64 SQRT_OF_3 = 1.73205 * EPS_CFL;
+
+        /** equals X
+         *
+         *  note: formulated to automatically fullfill the 3D CFL criteria for Yee
+         *
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = DELTA_T_SI * SPEED_OF_LIGHT_SI * SQRT_OF_3;
+        /** equals Y - the laser & moving window propagation direction
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
+
+    } //namespace SI
+
+    //! Defines the size of the absorbing zone (in cells)
+    const uint32_t ABSORBER_CELLS[3][2] = {
+        {32, 32},  /*x direction [negative,positive]*/
+        {32, 32},  /*y direction [negative,positive]*/
+        {32, 32}   /*z direction [negative,positive]*/
+    }; //unit: number of cells
+
+    //! Define the strength of the absorber for any direction
+    const float_X ABSORBER_STRENGTH[3][2] = {
+        {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
+    }; //unit: none
+
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
+
+    /** When to move the co-moving window.
+     *  An initial pseudo particle, flying with the speed of light,
+     *  is fired at the begin of the simulation.
+     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  the co-moving window starts to move with the speed of light.
+     *
+     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
+     *            when you use the co-moving window
+     *  0.75 means only 75% of simulation area is used for real simulation
+     */
+    constexpr float_64 slide_point = 0.90;
+
+}

--- a/examples/WarmCopper/include/simulation_defines/param/particleConfig.param
+++ b/examples/WarmCopper/include/simulation_defines/param/particleConfig.param
@@ -1,0 +1,110 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/startPosition/functors.def"
+#include "particles/manipulators/manipulators.def"
+#include "nvidia/functors/Add.hpp"
+#include "nvidia/functors/Assign.hpp"
+#include "particles/traits/GetAtomicNumbers.hpp"
+
+
+namespace picongpu
+{
+
+namespace particles
+{
+
+    /** a particle with a weighting below MIN_WEIGHTING will not
+     *      be created / will be deleted
+     *  unit: none */
+    constexpr float_X MIN_WEIGHTING = 10.0;
+
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 2;
+
+namespace manipulators
+{
+
+    CONST_VECTOR(float_X, 3, DriftParam_direction, 1.0, 0.0, 0.0);
+    struct Drift200keVParam
+    {
+        static constexpr float_64 gamma = 1.39139;
+        const DriftParam_direction_t direction;
+    };
+    /* define a drift equal to 200 keV for electrons */
+    using Assign200keVDrift = DriftImpl< Drift200keVParam, nvidia::functors::Assign >;
+
+    struct TemperatureParam
+    {
+        /*Initial temperature
+         *  unit: keV
+         */
+        static constexpr float_64 temperature = 0.1;
+    };
+    /* definition of SetDrift start*/
+    using AddTemperature = TemperatureImpl< TemperatureParam, nvidia::functors::Add >;
+
+    struct OnceIonizedImpl
+    {
+        template< typename T_Particle >
+        DINLINE void operator()( T_Particle& particle, T_Particle& )
+        {
+            /** number of bound electrons for a neutral atom */
+            constexpr float_X ion1plus =
+                GetAtomicNumbers< T_Particle >::type::numberOfProtons -
+                float_X(1);
+
+            /* set (Z - 1) bound electrons */
+            particle[boundElectrons_] = ion1plus;
+        }
+    };
+    /* definition of SetDrift start*/
+    using OnceIonized = FreeImpl< OnceIonizedImpl >;
+
+} //namespace manipulators
+
+
+namespace startPosition
+{
+
+    struct RandomParameter
+    {
+        /** Count of particles per cell at initial state
+         *  unit: none */
+        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+    };
+    /* definition of random particle start */
+    typedef RandomImpl< RandomParameter > Random;
+
+    struct QuietParam
+    {
+        /** Count of particles per cell per direction at initial state
+         *  unit: none */
+       typedef mCT::shrinkTo< mCT::Int< 1, TYPICAL_PARTICLES_PER_CELL, 1 >, simDim >::type numParticlesPerDimension;
+    };
+
+    /* definition of quiet particle start */
+    typedef QuietImpl< QuietParam > Quiet;
+
+} //namespace startPosition
+} //namespace particles
+
+} //namespac picongpu

--- a/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
@@ -1,0 +1,177 @@
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "particles/Identifier.hpp"
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "identifier/value_identifier.hpp"
+
+#include "particles/Particles.hpp"
+#include <boost/mpl/string.hpp>
+
+#include "particles/ionization/byField/ionizers.def"
+
+
+namespace picongpu
+{
+
+/*########################### define particle attributes #####################*/
+
+/** describe attributes of a particle*/
+using DefaultParticleAttributes = MakeSeq_t<
+    position< position_pic >,
+    momentum,
+    weighting,
+    particleId
+>;
+
+/** The default example keeps particles in place and does not create a current
+ */
+#ifndef PARAM_ENABLE_PUSHER
+#    define PARAM_ENABLE_PUSHER 0
+#endif
+#ifndef PARAM_ENABLE_CURRENT
+#    define PARAM_ENABLE_CURRENT 0
+#endif
+
+/*########################### end particle attributes ########################*/
+
+/*########################### define species #################################*/
+
+/*--------------------------- photons -------------------------------------------*/
+
+value_identifier( float_X, MassRatioPhotons, 0.0 );
+value_identifier( float_X, ChargeRatioPhotons, 0.0 );
+
+using ParticleFlagsPhotons = bmpl::vector<
+#if( PARAM_ENABLE_PUSHER == 1 )
+    particlePusher< particles::pusher::Photon >,
+#endif
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    massRatio< MassRatioPhotons >,
+    chargeRatio< ChargeRatioPhotons >
+>;
+
+/* define species photons */
+using Photons = Particles<
+    bmpl::string< 'p', 'h' >,
+    DefaultParticleAttributes,
+    ParticleFlagsPhotons
+>;
+
+/*--------------------------- electrons --------------------------------------*/
+/* thermal bulk electrons: 10, 100, 1000 eV
+ *   and
+ * non-thermal "hot"/prompt electrons: 200 keV
+ */
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+
+/* ratio relative to BASE_DENSITY
+ * thermal "bulk": 1x ionized n_Cu
+ * non-thermal "hot"/prompt: 0.1% ne_bulk = 0.001 * n_Cu ~ 1e20 / cm3
+ */
+value_identifier( float_X, DensityRatioBulkElectrons, 0.999 );
+value_identifier( float_X, DensityRatioPromptElectrons, 0.001 );
+
+using ParticleFlagsElectrons = bmpl::vector<
+#if( PARAM_ENABLE_PUSHER == 1 )
+    particlePusher< UsedParticlePusher >,
+#endif
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+#if( PARAM_ENABLE_CURRENT == 1 )
+    current< UsedParticleCurrentSolver >,
+#endif
+    massRatio< MassRatioElectrons >,
+    chargeRatio< ChargeRatioElectrons >
+>;
+
+/* thermal bulk electrons */
+using BulkElectrons = Particles<
+    bmpl::string< 'e', 't', 'h' >,
+    DefaultParticleAttributes,
+    MakeSeq_t<
+        ParticleFlagsElectrons,
+        densityRatio< DensityRatioBulkElectrons >
+    >
+>;
+
+/* non-thermal "hot"/prompt electrons */
+using PromptElectrons = Particles<
+    bmpl::string< 'e', 'h', 'o', 't' >,
+    DefaultParticleAttributes,
+    MakeSeq_t<
+        ParticleFlagsElectrons,
+        densityRatio< DensityRatioPromptElectrons >
+    >
+>;
+
+/*--------------------------- ions -------------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioCopper, 115840. );
+value_identifier( float_X, ChargeRatioCopper, -29.0 );
+
+/* ratio relative to BASE_DENSITY */
+value_identifier( float_X, DensityRatioCopper, 1.0 );
+
+using ParticleFlagsCopper = bmpl::vector<
+#if( PARAM_ENABLE_PUSHER == 1 )
+    particlePusher< UsedParticlePusher >,
+#endif
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+#if( PARAM_ENABLE_CURRENT == 1 )
+    current< UsedParticleCurrentSolver >,
+#endif
+    massRatio< MassRatioCopper >,
+    chargeRatio< ChargeRatioCopper >,
+    densityRatio< DensityRatioCopper >,
+    atomicNumbers< ionization::atomicNumbers::Copper_t >
+>;
+
+/* define species ions */
+using CopperIons = Particles<
+    bmpl::string< 'C', 'u' >,
+    MakeSeq_t<
+        position< position_pic >,
+        momentum,
+        weighting,
+        particleId,
+        boundElectrons
+    >,
+    ParticleFlagsCopper
+>;
+
+/*########################### end species ####################################*/
+
+using VectorAllSpecies = MakeSeq_t<
+    Photons,
+    BulkElectrons,
+    PromptElectrons,
+    CopperIons
+>;
+
+}

--- a/examples/WarmCopper/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesInitialization.param
@@ -1,0 +1,123 @@
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* @file
+ *
+ * Available species functors
+ *   in src/picongpu/include/particles/InitFunctors.hpp
+ *
+ * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
+ *     Create particle distribution based on a density profile and an in-cell
+ *     positioning.
+ *     Fills a particle species (`fillAllGaps()` is called).
+ *     @tparam T_DensityFunctor  unary lambda functor with density description,
+ *                               \see densityConfig.param
+ *                               \example densityProfiles::Homogenous,
+ *     @tparam T_PositionFunctor unary lambda functor with position description,
+ *                               \see particlesConfig.param
+ *                               \example startPosition::Quiet
+ *                                        startPosition::Random
+ *     @tparam T_SpeciesType type of the used species,
+ *                               \see speciesDefinition.param
+ *                               \example PIC_Electrons
+ *
+ * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
+ *     Create a particle species by copying all matching attributes from an
+ *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
+ *     @tparam T_SrcSpeciesType  source species
+ *     @tparam T_DestSpeciesType destination species
+ *
+ * - Manipulate<T_Functor, typename T_SpeciesType>
+ *     Run a user defined functor for every particle.
+ *     \warning does not call `fillAllGaps()` if one removes or
+ *              adds particles with it (\see FillAllGaps below)
+ *     @tparam T_Functor     unary lambda functor,
+ *                           \see particleConfig.param
+ *     @tparam T_SpeciesType type of the used species
+ *
+ * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
+ *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
+ *     after deriving to manipulate the two particles that took part
+ *     in the deriving (e.g., assign and increase an attribute such as weighting).
+ *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
+ *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
+ *                                 species: destination and source,
+ *                                 \see particleConfig.param
+ *     @tparam T_SrcSpeciesType    source species
+ *     @tparam T_DestSpeciesType   destination species
+ *
+ * - FillAllGaps<T_SpeciesType>
+ *     The manipulate functor does not call `fillAllGaps` on
+ *     the particle list of frames. For user-defined functors
+ *     that are called via Manipulate and create/remove
+ *     particles into/from frame lists, this must be called
+ *     afterward to create a valid data structure.
+ */
+
+#pragma once
+
+#include "particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+
+    /** InitPipeline defines in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        /* Generate Densities */
+        CreateDensity<
+            densityProfiles::Homogenous,
+            startPosition::Quiet,
+            CopperIons
+        >,
+        ManipulateDeriveSpecies<
+            manipulators::DensityWeighting,
+            CopperIons,
+            BulkElectrons
+        >,
+        ManipulateDeriveSpecies<
+            manipulators::DensityWeighting,
+            CopperIons,
+            PromptElectrons
+        >,
+        /* Set the Cu ions to Cu_1+ */
+        Manipulate<
+            manipulators::OnceIonized,
+            CopperIons
+        >,
+        /* Set initial temperature of bulk electrons */
+        Manipulate<
+            manipulators::AddTemperature,
+            BulkElectrons
+        >,
+        /* Set initial drift (directed in this case) of delta-distributed 200 keV
+         * prompt electrons */
+        Manipulate<
+            manipulators::Assign200keVDrift,
+            PromptElectrons
+        >
+    >;
+
+} // namespace particles
+} // namespace picongpu

--- a/examples/WarmCopper/submit/1gpu.cfg
+++ b/examples/WarmCopper/submit/1gpu.cfg
@@ -1,0 +1,75 @@
+# Copyright 2013-2017 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      doc/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="2:00:00"
+
+TBG_gpu_x=1
+TBG_gpu_y=1
+TBG_gpu_z=1
+
+TBG_gridSize="-g 32 32 32"
+TBG_steps="-s 1000"
+TBG_period="--periodic 1 1 1"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+# Create a particle-energy histogram [in keV] for e- species every 100 steps
+TBG_eth_histogram="--eth_energyHistogram.period 100 --eth_energyHistogram.binCount 1024       \
+                   --eth_energyHistogram.minEnergy 0 --eth_energyHistogram.maxEnergy 5"
+TBG_ehot_histogram="--ehot_energyHistogram.period 100 --ehot_energyHistogram.binCount 1024    \
+                    --ehot_energyHistogram.minEnergy 0 --ehot_energyHistogram.maxEnergy 250"
+
+# file I/O
+TBG_hdf5="--hdf5.period 100"
+
+TBG_plugins="!TBG_eth_histogram !TBG_ehot_histogram \
+             !TBG_hdf5"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+
+TBG_programParams="!TBG_devices      \
+                   !TBG_gridSize     \
+                   !TBG_steps        \
+                   !TBG_period       \
+                   !TBG_plugins"
+
+# TOTAL number of GPUs
+TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+
+"$TBG_cfgPath"/submitAction.sh


### PR DESCRIPTION
This setup initializes a homogenous, non-moving, copper block irradiated by a laser with 10^18 W/cm^3 as a benchmark for [SCFLY](https://dx.doi.org/10.1016/j.hedp.2007.02.001) (FLYlite) atomic population dynamics.

We follow the setup from [FLYCHK page 10, figure 4](https://dx.doi.org/10.1016/j.hedp.2005.07.001) assuming a quasi 0D setup with homogenous density of a 1+ ionized copper target. The laser (not modeled) already generated a thermal electron density at 10, 100 or 1000 eV and a delta-distribution like "hot" electron distribution with 200 keV (directed stream).

The observable of interest is <Z> over time of the copper ions. For low thermal energies, collisional excitation, de-excitation and recombinations should be sufficient to reach the LTE state after about 0.1-1 ps. For higher initial temperatures, radiative rates get more relevant and the Non-LTE steady-state solution can only be reached correctly when also adding radiative rates.