### PR TITLE
Backport to 0.2.3: ConstVector Casts Warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log / Release Log for PIConGPU
 
 0.2.3
 -----
-**Date:** 2017-02-10
+**Date:** 2017-02-13
 
 Energy Density, Ionization NaNs and openPMD
 
@@ -29,7 +29,9 @@ the ion species' proton number.
  - possible NAN momenta in ionization #1817
 
 **Misc:**
- - ConstVector: check arguments init full length #1803
+ - ConstVector:
+   - check arguments init full length #1803
+   - float to int cast warnings #1819
  - verify number of ionization energy levels == proton number #1809
 
 Thanks to Axel Huebl, René Widera, Richard Pausch, Alexander Debus,

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -129,7 +129,7 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
  * create type definition `name_t`
  */
 #define PMACC_CONST_VECTOR_DEF(type,dim,name,...)                              \
-    PMACC_STATIC_CONST_VECTOR_DIM_DEF(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(__VA_ARGS__),__VA_ARGS__)
+    PMACC_STATIC_CONST_VECTOR_DIM_DEF(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(type,__VA_ARGS__),__VA_ARGS__)
 
 /** Create global constant math::Vector with compile time values which can be
  *  used on device and host
@@ -148,4 +148,4 @@ namespace PMACC_JOIN(pmacc_static_const_storage,id)                            \
  *      The type of the created vector is "name_t" -> in this case "myVector_t"
  */
 #define PMACC_CONST_VECTOR(type,dim,name,...)                                   \
-    PMACC_STATIC_CONST_VECTOR_DIM(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(__VA_ARGS__),__VA_ARGS__)
+    PMACC_STATIC_CONST_VECTOR_DIM(__COUNTER__,name,type,dim,PMACC_COUNT_ARGS(type,__VA_ARGS__),__VA_ARGS__)

--- a/src/libPMacc/include/ppFunctions.hpp
+++ b/src/libPMacc/include/ppFunctions.hpp
@@ -37,11 +37,10 @@
 /**
  * Returns number of args... arguments.
  *
- * Can only count values of ... which can be casted to int type.
- *
+ * @param type type of the arguments in ...
  * @param ... arguments
  */
-#define PMACC_COUNT_ARGS(...)  (sizeof((int[]){0, ##__VA_ARGS__})/sizeof(int)-1)
+#define PMACC_COUNT_ARGS(type,...)  (sizeof((type[]){type(), ##__VA_ARGS__})/sizeof(type)-1u)
 
 /**
  * Check if ... has arguments or not


### PR DESCRIPTION
C++98 backport of fixes to 0.2.3:

- ConstVector: float to int cast warnings #1819

### Tested

- [x] C++98 compile with
```
  1) mpfr/3.1.2                    8) openmpi/1.8.4.kepler.cuda70
  2) mpc/1.0.1                     9) pngwriter/0.5.6
  3) gmp/5.1.1                    10) hdf5-parallel/1.8.14
  4) gcc/4.8.2                    11) libsplash/1.4.0  # outdated!
  5) cmake/3.3.0                  12) libmxml/2.8
  6) boost/1.62.0                 13) adios/1.9.0
  7) cuda/7.0
```

### Review

Please take extra care if I missed C++11 features, `0.2.X` must be C++98 compatible.