### PR TITLE
Hypnos: Use CMake 3.7

### DIFF
--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -9,7 +9,7 @@ then
 
         # Core Dependencies
         module load gcc/4.9.2
-        module load cmake/3.3.0
+        module load cmake/3.7.2
         module load boost/1.62.0
         module load cuda/8.0
         module load openmpi/1.8.6.kepler.cuda80


### PR DESCRIPTION
Since CMake 3.7 fixes -isystem includes with CUDA, let's recommend using that cmake version by default.

[1] https://gitlab.kitware.com/cmake/cmake/issues/14201
[2] https://cmake.org/cmake/help/v3.0/command/include_directories.html