### PR TITLE
Ionization Methods: Const-Ness

### DIFF
--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -76,10 +76,10 @@ namespace ionization
 
             partOp::assign(targetElectronClone, partOp::deselect<particleId>(parentIon));
 
-            float_X massIon = attribute::getMass(weighting,parentIon);
+            const float_X massIon = attribute::getMass(weighting,parentIon);
             const float_X massElectron = attribute::getMass(weighting,childElectron);
 
-            float3_X electronMomentum (parentIon[momentum_]*(massElectron/massIon));
+            const float3_X electronMomentum (parentIon[momentum_]*(massElectron/massIon));
 
             childElectron[momentum_] = electronMomentum;
 


### PR DESCRIPTION
Use more `const` vars in ionization methods.