### PR TITLE
add missing HDINLINE

### DIFF
--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -317,6 +317,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::zone() const
 }
 
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+HDINLINE
 bool
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::isContigousMemory() const
 {


### PR DESCRIPTION
Compiling with clang is not possible if the prefix in the implementation is not equal to the prefix of the forward signature.

This fix is needed for #1731