### PR TITLE
Backport 0.2.3: Bash TBG templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ the ion species' proton number.
  - MovingWindow: slide_point now can be set to zero #1783
  - energy density #1750 #1744 (partial)
  - possible NAN momenta in ionization #1817
+ - `tbg` bash templates were outdated/broken #1831
 
 **Misc:**
  - ConstVector:

--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
@@ -25,10 +25,10 @@
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
     
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"

--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
@@ -25,10 +25,10 @@
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
     
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"

--- a/src/picongpu/submit/bash/bash_mpiexec.tpl
+++ b/src/picongpu/submit/bash/bash_mpiexec.tpl
@@ -22,10 +22,10 @@
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
     
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"

--- a/src/picongpu/submit/bash/bash_mpirun.tpl
+++ b/src/picongpu/submit/bash/bash_mpirun.tpl
@@ -22,10 +22,10 @@
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"

--- a/src/picongpu/submit/keeneland-gt/parallel.tpl
+++ b/src/picongpu/submit/keeneland-gt/parallel.tpl
@@ -38,9 +38,9 @@
 .TBG_queue="parallel"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 3 gpus per node if we need more than 3 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`


### PR DESCRIPTION
Fix `bash` tbg templates as described in #1831 

This is a quick & dirty version of #1833 that goes to `dev`