### PR TITLE
Fix #1831 Bash TBG Templates

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
@@ -21,20 +21,14 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
 
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
-
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 

--- a/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
+++ b/src/libPMacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
@@ -21,20 +21,14 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
 
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
-
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 

--- a/src/picongpu/submit/bash/bash_mpiexec.tpl
+++ b/src/picongpu/submit/bash/bash_mpiexec.tpl
@@ -18,20 +18,14 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
 
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
-
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 

--- a/src/picongpu/submit/bash/bash_mpirun.tpl
+++ b/src/picongpu/submit/bash/bash_mpirun.tpl
@@ -18,20 +18,14 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
 
-#number of cores per parallel node / default is 2 cores per gpu on k20 queue
-TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
-
-# use ceil to caculate nodes
-TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
 ## end calculations ##
 
 

--- a/src/picongpu/submit/keeneland-gt/parallel.tpl
+++ b/src/picongpu/submit/keeneland-gt/parallel.tpl
@@ -38,9 +38,9 @@
 .TBG_queue="parallel"
 
 # settings that can be controlled by environment variables before submit
-TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
-TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 
 # 3 gpus per node if we need more than 3 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`


### PR DESCRIPTION
Fix #1831: bash templates for `tbg` use an outdated syntax.