### PR TITLE
CudaEvent: Fix Cyclic Include

### DIFF
--- a/src/libPMacc/include/eventSystem/events/CudaEvent.def
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.def
@@ -20,12 +20,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "pmacc_types.hpp"
 #include "assert.hpp"
 #include <cuda_runtime.h>
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
@@ -20,13 +20,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "eventSystem/events/CudaEvent.def"
 #include "eventSystem/events/CudaEventHandle.hpp"
-#include "eventSystem/events/CudaEvent.hpp"
+#include "pmacc_types.hpp"
+
 #include <cuda_runtime.h>
+
 
 namespace PMacc
 {


### PR DESCRIPTION
Fix a cyclic include of itself instead of correctly including its forward declaration.