### PR TITLE
Doxygen: Fix Warnings Ionization

### DIFF
--- a/src/picongpu/include/particles/ionization/None/AlgorithmNone.hpp
+++ b/src/picongpu/include/particles/ionization/None/AlgorithmNone.hpp
@@ -22,7 +22,7 @@
 
 #include "pmacc_types.hpp"
 
-/** \file AlgorithNone.hpp
+/** \file AlgorithmNone.hpp
  *
  * IONIZATION ALGORITHM for the model None
  *

--- a/src/picongpu/include/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -60,6 +60,7 @@ namespace ionization
          * \param bField magnetic field value at t=0
          * \param eField electric field value at t=0
          * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+         * \param randNr random number, equally distributed in range [0.:1.0]
          */
         template<typename EType, typename BType, typename ParticleType >
         HDINLINE void

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -56,6 +56,7 @@ namespace ionization
          * \param bField magnetic field value at t=0
          * \param eField electric field value at t=0
          * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+         * \param randNr random number, equally distributed in range [0.:1.0]
          */
         template<typename EType, typename BType, typename ParticleType >
         HDINLINE void


### PR DESCRIPTION
Fixes doxygen warnings and forgotten params in ionization routines.