### PR TITLE
Copyright Header is no Doxygen

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/componentsConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/densityConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/densityConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/Bunch/include/simulation_defines/param/fieldBackground.param
+++ b/examples/Bunch/include/simulation_defines/param/fieldBackground.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Alexander Debus, Richard Pausch
+/* Copyright 2014-2017 Axel Huebl, Alexander Debus, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/laserConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Anton Helm, Richard Pausch, Axel Huebl, Alexander Debus
+/* Copyright 2013-2017 Anton Helm, Richard Pausch, Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/memory.param
+++ b/examples/Bunch/include/simulation_defines/param/memory.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Richard Pausch, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Richard Pausch, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/particleConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/precision.param
+++ b/examples/Bunch/include/simulation_defines/param/precision.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Richard Pausch
+/* Copyright 2013-2017 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/radiationObserver.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationObserver.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/species.param
+++ b/examples/Bunch/include/simulation_defines/param/species.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Richard Pausch
+/* Copyright 2014-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/starter.param
+++ b/examples/Bunch/include/simulation_defines/param/starter.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Richard Pausch
+/* Copyright 2013-2017 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/visColorScales.param
+++ b/examples/Bunch/include/simulation_defines/param/visColorScales.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/Bunch/include/simulation_defines/param/visualization.param
+++ b/examples/Bunch/include/simulation_defines/param/visualization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/extensionParam.loader
+++ b/examples/KelvinHelmholtz/include/simulation_defines/extensionParam.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/extensionUnitless.loader
+++ b/examples/KelvinHelmholtz/include/simulation_defines/extensionUnitless.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/componentsConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/densityConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/densityConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/dimension.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/dimension.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationObserver.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/species.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Richard Pausch
+/* Copyright 2014-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/speciesInitialization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/visColorScales.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/visColorScales.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/visualization.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/visualization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/componentsConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/LaserWakefield/include/simulation_defines/param/densityConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/densityConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Marco Garten
  *
  * This file is part of PIConGPU.

--- a/examples/LaserWakefield/include/simulation_defines/param/dimension.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/dimension.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/memory.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/memory.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/LaserWakefield/include/simulation_defines/param/precision.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/precision.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/species.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/species.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Richard Pausch
+/* Copyright 2014-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Marco Garten, Richard Pausch,
+/* Copyright 2013-2017 Rene Widera, Marco Garten, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/starter.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/starter.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/visColorScales.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/visColorScales.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/LaserWakefield/include/simulation_defines/param/visualization.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/visualization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/componentsConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/densityConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/densityConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/SingleParticleTest/include/simulation_defines/param/dimension.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/dimension.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2014-2017 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/fieldBackground.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/fieldBackground.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Alexander Debus
+/* Copyright 2014-2017 Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/fileOutput.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/fileOutput.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/SingleParticleTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/particleConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/SingleParticleTest/include/simulation_defines/param/species.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/species.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Richard Pausch
+/* Copyright 2014-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesInitialization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/ThermalTest/include/simulation_defines/param/componentsConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/ThermalTest/include/simulation_defines/param/densityConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/densityConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/ThermalTest/include/simulation_defines/param/memory.param
+++ b/examples/ThermalTest/include/simulation_defines/param/memory.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/ThermalTest/include/simulation_defines/param/particleConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/ThermalTest/include/simulation_defines/param/starter.param
+++ b/examples/ThermalTest/include/simulation_defines/param/starter.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/ThermalTest/include/simulation_defines/unitless/starter.unitless
+++ b/examples/ThermalTest/include/simulation_defines/unitless/starter.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/extensionParam.loader
+++ b/examples/WeibelTransverse/include/simulation_defines/extensionParam.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/extensionUnitless.loader
+++ b/examples/WeibelTransverse/include/simulation_defines/extensionUnitless.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/param/componentsConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/param/densityConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/densityConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/param/memory.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/memory.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/param/visColorScales.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/visColorScales.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/examples/WeibelTransverse/include/simulation_defines/param/visualization.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/visualization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Marco Garten
+/* Copyright 2013-2017 Rene Widera, Marco Garten
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Maximilian Knespel, Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/examples/gameOfLife2D/include/PngCreator.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/PngCreator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Maximilian Knespel, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Maximilian Knespel, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/examples/gameOfLife2D/include/types.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/types.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/examples/gameOfLife2D/main.cu
+++ b/src/libPMacc/examples/gameOfLife2D/main.cu
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/Environment.def
+++ b/src/libPMacc/include/Environment.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/Environment.hpp
+++ b/src/libPMacc/include/Environment.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt, Conrad Schumann,
+/* Copyright 2014-2017 Felix Schmitt, Conrad Schumann,
  *                     Alexander Grund, Axel Huebl
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/HandleGuardRegion.hpp
+++ b/src/libPMacc/include/HandleGuardRegion.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/RefWrapper.hpp
+++ b/src/libPMacc/include/RefWrapper.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/ForEach.hpp
+++ b/src/libPMacc/include/algorithms/ForEach.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/GlobalReduce.hpp
+++ b/src/libPMacc/include/algorithms/GlobalReduce.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/PromoteType.hpp
+++ b/src/libPMacc/include/algorithms/PromoteType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/TypeCast.hpp
+++ b/src/libPMacc/include/algorithms/TypeCast.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math.hpp
+++ b/src/libPMacc/include/algorithms/math.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Debus
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Debus
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/abs.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/abs.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/comparison.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/comparison.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/cross.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/cross.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/dot.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/dot.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/erf.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/erf.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/exp.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/exp.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/floatingPoint.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/fmod.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/fmod.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Debus
+/* Copyright 2016-2017 Alexander Debus
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/modf.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/modf.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/pow.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/pow.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/sqrt.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/sqrt.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/defines/trigo.hpp
+++ b/src/libPMacc/include/algorithms/math/defines/trigo.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Alexander Debus
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Alexander Debus
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/abs.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/comparison.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Benjamin Worpitz, Richard Pausch
+/* Copyright 2015-2017 Benjamin Worpitz, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/erf.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/erf.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Richard Pausch
+/* Copyright 2014-2017 Axel Huebl, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/exp.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/floatingPoint.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/fmod.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Debus
+/* Copyright 2016-2017 Alexander Debus
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/modf.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/modf.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/pow.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/sqrt.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/doubleMath/trigo.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Axel Huebl, Alexander Debus
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/abs.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/comparison.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Benjamin Worpitz, Richard Pausch
+/* Copyright 2015-2017 Benjamin Worpitz, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/floatMath/erf.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/erf.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Richard Pausch
+/* Copyright 2014-2017 Axel Huebl, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/exp.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/floatingPoint.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/fmod.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Debus
+/* Copyright 2016-2017 Alexander Debus
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/floatMath/modf.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/modf.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/pow.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/sqrt.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
+++ b/src/libPMacc/include/algorithms/math/floatMath/trigo.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Axel Huebl, Alexander Debus
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/algorithms/reverseBits.hpp
+++ b/src/libPMacc/include/algorithms/reverseBits.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/assert.hpp
+++ b/src/libPMacc/include/assert.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/basicOperations.hpp
+++ b/src/libPMacc/include/basicOperations.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/communication/AsyncCommunication.hpp
+++ b/src/libPMacc/include/communication/AsyncCommunication.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/communication/CommunicatorMPI.hpp
+++ b/src/libPMacc/include/communication/CommunicatorMPI.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/communication/ICommunicator.hpp
+++ b/src/libPMacc/include/communication/ICommunicator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/communication/manager_common.hpp
+++ b/src/libPMacc/include/communication/manager_common.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Wolfgang Hoenig, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Wolfgang Hoenig, Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/AllCombinations.hpp
+++ b/src/libPMacc/include/compileTime/AllCombinations.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2014-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/GetKeyFromAlias.hpp
+++ b/src/libPMacc/include/compileTime/GetKeyFromAlias.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/accessors/First.hpp
+++ b/src/libPMacc/include/compileTime/accessors/First.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/accessors/Identity.hpp
+++ b/src/libPMacc/include/compileTime/accessors/Identity.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/accessors/Second.hpp
+++ b/src/libPMacc/include/compileTime/accessors/Second.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/JoinToSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/JoinToSeq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/MakeSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/MakeSeq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/MakeSeqFromNestedSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/MakeSeqFromNestedSeq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/OperateOnSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/OperateOnSeq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/RemoveFromSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/RemoveFromSeq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/ResolveAliases.hpp
+++ b/src/libPMacc/include/compileTime/conversion/ResolveAliases.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/ResolveAndRemoveFromSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/ResolveAndRemoveFromSeq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Alexander Grund
+/* Copyright 2014-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/SeqToMap.hpp
+++ b/src/libPMacc/include/compileTime/conversion/SeqToMap.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/ToSeq.hpp
+++ b/src/libPMacc/include/compileTime/conversion/ToSeq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/TypeToAliasPair.hpp
+++ b/src/libPMacc/include/compileTime/conversion/TypeToAliasPair.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/TypeToPair.hpp
+++ b/src/libPMacc/include/compileTime/conversion/TypeToPair.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/conversion/TypeToPointerPair.hpp
+++ b/src/libPMacc/include/compileTime/conversion/TypeToPointerPair.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnType.hpp
+++ b/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnValue.hpp
+++ b/src/libPMacc/include/compileTime/errorHandlerPolicies/ReturnValue.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp
+++ b/src/libPMacc/include/compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/cudaBlock/Foreach.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/host/Foreach.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/FFT.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Foreach.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/Reduce.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau
+/* Copyright 2013-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau
+/* Copyright 2013-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Gather.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
@@ -1,4 +1,3 @@
-#pragma once
 
 /**
  * Copyright 2013-2017 Heiko Burau

--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/DeviceBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/HostBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/IndexBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/PNGBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/PNGBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/PseudoBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/PseudoBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/PseudoBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/PseudoBuffer.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemAllocator.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/EmptyAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/EmptyAllocator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/allocator/tag.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/tag.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/src/libPMacc/include/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/CartBuffer.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/compile-time/SharedBuffer.hpp
+++ b/src/libPMacc/include/cuSTL/container/compile-time/SharedBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/D2DCopier.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/H2HCopier.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/cuSTL/container/copier/Memcopy.hpp
+++ b/src/libPMacc/include/cuSTL/container/copier/Memcopy.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/tag.hpp
+++ b/src/libPMacc/include/cuSTL/container/tag.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/container/view/View.hpp
+++ b/src/libPMacc/include/cuSTL/container/view/View.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/BufferCursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/Cursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/FunctorCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/FunctorCursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/MultiIndexCursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/NestedCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/NestedCursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/SafeCursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/accessor/CursorAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/CursorAccessor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/accessor/FunctorAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/FunctorAccessor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/accessor/MarkerAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/MarkerAccessor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/accessor/PointerAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/PointerAccessor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/BufferCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/BufferCursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/CursorNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/CursorNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/EmptyNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/EmptyNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/PlusNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/PlusNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/compile-time/TwistedAxesNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/navigator/tag.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/navigator/tag.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/tools/LinearInterp.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/LinearInterp.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/tools/slice.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/slice.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/tools/twistAxes.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/twistAxes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/cursor/traits.hpp
+++ b/src/libPMacc/include/cuSTL/cursor/traits.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/SphericZone.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/StaggeredZone.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/ToricZone.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
+++ b/src/libPMacc/include/cuSTL/zone/compile-time/SphericZone.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/cudaSpecs.hpp
+++ b/src/libPMacc/include/cudaSpecs.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/dataManagement/AbstractInitialiser.hpp
+++ b/src/libPMacc/include/dataManagement/AbstractInitialiser.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/dataManagement/DataConnector.hpp
+++ b/src/libPMacc/include/dataManagement/DataConnector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/dataManagement/IDataSorter.hpp
+++ b/src/libPMacc/include/dataManagement/IDataSorter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/dataManagement/ISimulationData.hpp
+++ b/src/libPMacc/include/dataManagement/ISimulationData.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz,
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/debug/DebugBuffers.hpp
+++ b/src/libPMacc/include/debug/DebugBuffers.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/debug/DebugDataSpace.hpp
+++ b/src/libPMacc/include/debug/DebugDataSpace.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/debug/DebugExchangeTypes.hpp
+++ b/src/libPMacc/include/debug/DebugExchangeTypes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/debug/PMaccVerbose.hpp
+++ b/src/libPMacc/include/debug/PMaccVerbose.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/debug/VerboseLog.hpp
+++ b/src/libPMacc/include/debug/VerboseLog.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/debug/VerboseLogMakros.hpp
+++ b/src/libPMacc/include/debug/VerboseLogMakros.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/debug/abortWithError.hpp
+++ b/src/libPMacc/include/debug/abortWithError.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/dimensions/DataSpace.hpp
+++ b/src/libPMacc/include/dimensions/DataSpace.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/dimensions/DataSpace.tpp
+++ b/src/libPMacc/include/dimensions/DataSpace.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/dimensions/DataSpaceOperations.hpp
+++ b/src/libPMacc/include/dimensions/DataSpaceOperations.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/dimensions/GridLayout.hpp
+++ b/src/libPMacc/include/dimensions/GridLayout.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/dimensions/SuperCellDescription.hpp
+++ b/src/libPMacc/include/dimensions/SuperCellDescription.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/EventSystem.hpp
+++ b/src/libPMacc/include/eventSystem/EventSystem.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/EventSystem.tpp
+++ b/src/libPMacc/include/eventSystem/EventSystem.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/Manager.tpp
+++ b/src/libPMacc/include/eventSystem/Manager.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/CudaEvent.def
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/CudaEventHandle.hpp
+++ b/src/libPMacc/include/eventSystem/events/CudaEventHandle.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventDataReceive.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/events/EventNotify.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/events/EventNotify.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventNotify.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/EventPool.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventPool.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/EventTask.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventTask.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/EventTask.tpp
+++ b/src/libPMacc/include/eventSystem/events/EventTask.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/IEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/IEvent.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/events/IEventData.hpp
+++ b/src/libPMacc/include/eventSystem/events/IEventData.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.tpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/streams/EventStream.hpp
+++ b/src/libPMacc/include/eventSystem/streams/EventStream.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/streams/StreamController.hpp
+++ b/src/libPMacc/include/eventSystem/streams/StreamController.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/Factory.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/Factory.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/tasks/ITask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/ITask.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/MPITask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/MPITask.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyDeviceToHost.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskCopyHostToDevice.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskKernel.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskKernel.tpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskKernel.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskReceive.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskReceiveMPI.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskReceiveMPI.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSend.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSendMPI.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/Transaction.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/expressions/DoNothing.hpp
+++ b/src/libPMacc/include/expressions/DoNothing.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/expressions/SetToNull.hpp
+++ b/src/libPMacc/include/expressions/SetToNull.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/fields/SimulationFieldHelper.hpp
+++ b/src/libPMacc/include/fields/SimulationFieldHelper.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/forward.hpp
+++ b/src/libPMacc/include/forward.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/identifier/alias.hpp
+++ b/src/libPMacc/include/identifier/alias.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz,
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/identifier/identifier.hpp
+++ b/src/libPMacc/include/identifier/identifier.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/identifier/named_type.hpp
+++ b/src/libPMacc/include/identifier/named_type.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/identifier/value_identifier.hpp
+++ b/src/libPMacc/include/identifier/value_identifier.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/CT/Eval.hpp
+++ b/src/libPMacc/include/lambda/CT/Eval.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/CT/Expression.hpp
+++ b/src/libPMacc/include/lambda/CT/Expression.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/CT/FillTerminalList.hpp
+++ b/src/libPMacc/include/lambda/CT/FillTerminalList.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/CT/TerminalTL.hpp
+++ b/src/libPMacc/include/lambda/CT/TerminalTL.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/ExprTypes.hpp
+++ b/src/libPMacc/include/lambda/ExprTypes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/Expression.hpp
+++ b/src/libPMacc/include/lambda/Expression.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/ProxyClass.hpp
+++ b/src/libPMacc/include/lambda/ProxyClass.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/is_Expression.hpp
+++ b/src/libPMacc/include/lambda/is_Expression.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/make_Expr.hpp
+++ b/src/libPMacc/include/lambda/make_Expr.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/make_Functor.hpp
+++ b/src/libPMacc/include/lambda/make_Functor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/lambda/placeholder.hpp
+++ b/src/libPMacc/include/lambda/placeholder.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/AreaMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/AreaMapping.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/AreaMappingMethods.hpp
+++ b/src/libPMacc/include/mappings/kernel/AreaMappingMethods.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/BorderMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/BorderMapping.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Alexander Grund
+/* Copyright 2013-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/ExchangeMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/ExchangeMapping.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/ExchangeMappingMethods.hpp
+++ b/src/libPMacc/include/mappings/kernel/ExchangeMappingMethods.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/MappingDescription.hpp
+++ b/src/libPMacc/include/mappings/kernel/MappingDescription.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/StrideMapping.hpp
+++ b/src/libPMacc/include/mappings/kernel/StrideMapping.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/kernel/StrideMappingMethods.hpp
+++ b/src/libPMacc/include/mappings/kernel/StrideMappingMethods.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
+++ b/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/simulation/Filesystem.hpp
+++ b/src/libPMacc/include/mappings/simulation/Filesystem.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt
+/* Copyright 2014-2017 Felix Schmitt
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/simulation/GridController.hpp
+++ b/src/libPMacc/include/mappings/simulation/GridController.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Erik Zenker
+/* Copyright 2016-2017 Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
+++ b/src/libPMacc/include/mappings/simulation/ResourceMonitor.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Erik Zenker
+/* Copyright 2016-2017 Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/simulation/Selection.hpp
+++ b/src/libPMacc/include/mappings/simulation/Selection.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt
+/* Copyright 2014-2017 Felix Schmitt
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/simulation/SubGrid.hpp
+++ b/src/libPMacc/include/mappings/simulation/SubGrid.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
+++ b/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/Complex.hpp
+++ b/src/libPMacc/include/math/Complex.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Debus
+/* Copyright 2015-2017 Alexander Debus
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/ConstVector.hpp
+++ b/src/libPMacc/include/math/ConstVector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2014-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/MapTuple.hpp
+++ b/src/libPMacc/include/math/MapTuple.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/RungeKutta.hpp
+++ b/src/libPMacc/include/math/RungeKutta.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Richard Pausch
+/* Copyright 2015-2017 Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/RungeKutta/RungeKutta4.hpp
+++ b/src/libPMacc/include/math/RungeKutta/RungeKutta4.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Richard Pausch
+/* Copyright 2015-2017 Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/Tuple.hpp
+++ b/src/libPMacc/include/math/Tuple.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/Vector.hpp
+++ b/src/libPMacc/include/math/Vector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/VectorOperations.hpp
+++ b/src/libPMacc/include/math/VectorOperations.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/complex/Complex.hpp
+++ b/src/libPMacc/include/math/complex/Complex.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/complex/Complex.tpp
+++ b/src/libPMacc/include/math/complex/Complex.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Alexander Debus, Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/math/vector/Float.hpp
+++ b/src/libPMacc/include/math/vector/Float.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/Int.hpp
+++ b/src/libPMacc/include/math/vector/Int.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/Size_t.hpp
+++ b/src/libPMacc/include/math/vector/Size_t.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/TwistComponents.hpp
+++ b/src/libPMacc/include/math/vector/TwistComponents.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/UInt32.hpp
+++ b/src/libPMacc/include/math/vector/UInt32.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/UInt64.hpp
+++ b/src/libPMacc/include/math/vector/UInt64.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/Vector.hpp
+++ b/src/libPMacc/include/math/vector/Vector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/math/vector/Vector.tpp
+++ b/src/libPMacc/include/math/vector/Vector.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/accessor/StandardAccessor.hpp
+++ b/src/libPMacc/include/math/vector/accessor/StandardAccessor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/compile-time/Float.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Float.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/compile-time/Int.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Int.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/compile-time/Size_t.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Size_t.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/compile-time/TwistComponents.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/TwistComponents.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/compile-time/UInt32.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/UInt32.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/compile-time/UInt64.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/UInt64.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/compile-time/Vector.hpp
+++ b/src/libPMacc/include/math/vector/compile-time/Vector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/math_functor/abs.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/abs.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/math_functor/cosf.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/cosf.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/math_functor/max.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/max.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/math_functor/min.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/min.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/math_functor/sin.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/sin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/math_functor/sqrtf.hpp
+++ b/src/libPMacc/include/math/vector/math_functor/sqrtf.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/navigator/PermutedNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/PermutedNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/navigator/StackedNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/StackedNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2014-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/math/vector/navigator/StandardNavigator.hpp
+++ b/src/libPMacc/include/math/vector/navigator/StandardNavigator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/Array.hpp
+++ b/src/libPMacc/include/memory/Array.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/boxes/CachedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/CachedBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/boxes/DataBox.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxDim1Access.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/src/libPMacc/include/memory/boxes/DataBoxUnaryTransform.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/boxes/MultiBox.hpp
+++ b/src/libPMacc/include/memory/boxes/MultiBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/boxes/PitchedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/PitchedBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/boxes/SharedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/SharedBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/Buffer.hpp
+++ b/src/libPMacc/include/memory/buffers/Buffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/memory/buffers/Exchange.hpp
+++ b/src/libPMacc/include/memory/buffers/Exchange.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/ExchangeIntern.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/GridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/GridBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/HostBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
+++ b/src/libPMacc/include/memory/buffers/HostDeviceBuffer.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Axel Huebl, Benjamin Worpitz,
+/* Copyright 2014-2017 Rene Widera, Axel Huebl, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
+++ b/src/libPMacc/include/memory/buffers/MultiGridBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/dataTypes/BitData.hpp
+++ b/src/libPMacc/include/memory/dataTypes/BitData.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/dataTypes/Mask.hpp
+++ b/src/libPMacc/include/memory/dataTypes/Mask.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/memory/shared/Allocate.hpp
+++ b/src/libPMacc/include/memory/shared/Allocate.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/GetMPI_Op.hpp
+++ b/src/libPMacc/include/mpi/GetMPI_Op.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/GetMPI_StructAsArray.hpp
+++ b/src/libPMacc/include/mpi/GetMPI_StructAsArray.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
+++ b/src/libPMacc/include/mpi/GetMPI_StructAsArray.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/MPIReduce.hpp
+++ b/src/libPMacc/include/mpi/MPIReduce.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/MPI_StructAsArray.hpp
+++ b/src/libPMacc/include/mpi/MPI_StructAsArray.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/SeedPerRank.hpp
+++ b/src/libPMacc/include/mpi/SeedPerRank.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Alexander Grund
+/* Copyright 2014-2017 Axel Huebl, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/reduceMethods/AllReduce.hpp
+++ b/src/libPMacc/include/mpi/reduceMethods/AllReduce.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mpi/reduceMethods/Reduce.hpp
+++ b/src/libPMacc/include/mpi/reduceMethods/Reduce.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/atomic.hpp
+++ b/src/libPMacc/include/nvidia/atomic.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Alexander Grund
+/* Copyright 2015-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/functors/Add.hpp
+++ b/src/libPMacc/include/nvidia/functors/Add.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/functors/Assign.hpp
+++ b/src/libPMacc/include/nvidia/functors/Assign.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/functors/Max.hpp
+++ b/src/libPMacc/include/nvidia/functors/Max.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/functors/Min.hpp
+++ b/src/libPMacc/include/nvidia/functors/Min.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/functors/Mul.hpp
+++ b/src/libPMacc/include/nvidia/functors/Mul.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/functors/Sub.hpp
+++ b/src/libPMacc/include/nvidia/functors/Sub.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/gpuEntryFunction.hpp
+++ b/src/libPMacc/include/nvidia/gpuEntryFunction.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Felix Rene Widera
+/* Copyright 2016-2017 Felix Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
+++ b/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/reduce/Reduce.hpp
+++ b/src/libPMacc/include/nvidia/reduce/Reduce.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/nvidia/rng/RNG.hpp
+++ b/src/libPMacc/include/nvidia/rng/RNG.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/rng/distributions/Normal_float.hpp
+++ b/src/libPMacc/include/nvidia/rng/distributions/Normal_float.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/rng/distributions/Uniform_float.hpp
+++ b/src/libPMacc/include/nvidia/rng/distributions/Uniform_float.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/rng/distributions/Uniform_int32.hpp
+++ b/src/libPMacc/include/nvidia/rng/distributions/Uniform_int32.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/rng/methods/Xor.hpp
+++ b/src/libPMacc/include/nvidia/rng/methods/Xor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/nvidia/warp.hpp
+++ b/src/libPMacc/include/nvidia/warp.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Alexander Grund
+/* Copyright 2015-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/AsyncCommunicationImpl.hpp
+++ b/src/libPMacc/include/particles/AsyncCommunicationImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/IdProvider.def
+++ b/src/libPMacc/include/particles/IdProvider.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/IdProvider.hpp
+++ b/src/libPMacc/include/particles/IdProvider.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/Identifier.hpp
+++ b/src/libPMacc/include/particles/Identifier.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/ParticleDescription.hpp
+++ b/src/libPMacc/include/particles/ParticleDescription.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/boostExtension/InheritGenerators.hpp
+++ b/src/libPMacc/include/particles/boostExtension/InheritGenerators.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/boostExtension/InheritLinearly.hpp
+++ b/src/libPMacc/include/particles/boostExtension/InheritLinearly.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/frame_types.hpp
+++ b/src/libPMacc/include/particles/frame_types.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/boxes/ExchangePopDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ExchangePopDataBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/PushDataBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/particles/memory/boxes/TileDataBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/TileDataBox.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Alexander Grund
+/* Copyright 2015-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/buffers/StackExchangeBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/StackExchangeBuffer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/dataTypes/FramePointer.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/FramePointer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/dataTypes/ListPointer.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/ListPointer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/dataTypes/Pointer.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Pointer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017  Rene Widera
+/* Copyright 2014-2017  Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/dataTypes/StaticArray.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/StaticArray.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/SuperCell.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/frames/Frame.hpp
+++ b/src/libPMacc/include/particles/memory/frames/Frame.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/memory/frames/NullFrame.hpp
+++ b/src/libPMacc/include/particles/memory/frames/NullFrame.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/Assign.hpp
+++ b/src/libPMacc/include/particles/operations/Assign.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/ConcatListOfFrames.hpp
+++ b/src/libPMacc/include/particles/operations/ConcatListOfFrames.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Alexander Grund
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/CopyIdentifier.hpp
+++ b/src/libPMacc/include/particles/operations/CopyIdentifier.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Erik Zenker
+/* Copyright 2013-2017 Rene Widera, Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/Deselect.hpp
+++ b/src/libPMacc/include/particles/operations/Deselect.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/SetAttributeToDefault.hpp
+++ b/src/libPMacc/include/particles/operations/SetAttributeToDefault.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
+++ b/src/libPMacc/include/particles/operations/splitIntoListOfFrames.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Alexander Grund
+/* Copyright 2014-2017 Rene Widera, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/particleFilter/FilterFactory.hpp
+++ b/src/libPMacc/include/particles/particleFilter/FilterFactory.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/PositionFilter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/DefaultFilter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/particleFilter/system/FalseFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/FalseFilter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
+++ b/src/libPMacc/include/particles/particleFilter/system/TrueFilter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/policies/DeleteParticles.hpp
+++ b/src/libPMacc/include/particles/policies/DeleteParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/policies/ExchangeParticles.hpp
+++ b/src/libPMacc/include/particles/policies/ExchangeParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
+++ b/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/tasks/ParticleFactory.tpp
+++ b/src/libPMacc/include/particles/tasks/ParticleFactory.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/tasks/TaskParticlesReceive.hpp
+++ b/src/libPMacc/include/particles/tasks/TaskParticlesReceive.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/tasks/TaskParticlesSend.hpp
+++ b/src/libPMacc/include/particles/tasks/TaskParticlesSend.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/tasks/TaskReceiveParticlesExchange.hpp
+++ b/src/libPMacc/include/particles/tasks/TaskReceiveParticlesExchange.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/src/libPMacc/include/particles/tasks/TaskSendParticlesExchange.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/traits/FilterByFlag.hpp
+++ b/src/libPMacc/include/particles/traits/FilterByFlag.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/particles/traits/ResolveAliasFromSpecies.hpp
+++ b/src/libPMacc/include/particles/traits/ResolveAliasFromSpecies.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/pluginSystem/INotify.hpp
+++ b/src/libPMacc/include/pluginSystem/INotify.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl,
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl,
  *                     Richard Pausch
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/pluginSystem/IPlugin.hpp
+++ b/src/libPMacc/include/pluginSystem/IPlugin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Richard Pausch
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Richard Pausch
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl, Benjamin Worpitz,
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl, Benjamin Worpitz,
  *                     Heiko Burau
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/pmacc_types.hpp
+++ b/src/libPMacc/include/pmacc_types.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/src/libPMacc/include/ppFunctions.hpp
+++ b/src/libPMacc/include/ppFunctions.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/preprocessor/facilities.hpp
+++ b/src/libPMacc/include/preprocessor/facilities.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/preprocessor/struct.hpp
+++ b/src/libPMacc/include/preprocessor/struct.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/RNGHandle.hpp
+++ b/src/libPMacc/include/random/RNGHandle.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/RNGProvider.hpp
+++ b/src/libPMacc/include/random/RNGProvider.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/RNGState.hpp
+++ b/src/libPMacc/include/random/RNGState.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/Random.hpp
+++ b/src/libPMacc/include/random/Random.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/distributions/Normal.hpp
+++ b/src/libPMacc/include/random/distributions/Normal.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/distributions/Uniform.hpp
+++ b/src/libPMacc/include/random/distributions/Uniform.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/distributions/normal/Normal_float.hpp
+++ b/src/libPMacc/include/random/distributions/normal/Normal_float.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/distributions/uniform/Range.hpp
+++ b/src/libPMacc/include/random/distributions/uniform/Range.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/distributions/uniform/Uniform_Integral32Bit.hpp
+++ b/src/libPMacc/include/random/distributions/uniform/Uniform_Integral32Bit.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/distributions/uniform/Uniform_float.hpp
+++ b/src/libPMacc/include/random/distributions/uniform/Uniform_float.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund, Rene Widera
+/* Copyright 2015-2017 Alexander Grund, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/methods/MRG32k3a.hpp
+++ b/src/libPMacc/include/random/methods/MRG32k3a.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/methods/MRG32k3aMin.hpp
+++ b/src/libPMacc/include/random/methods/MRG32k3aMin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/methods/Xor.hpp
+++ b/src/libPMacc/include/random/methods/Xor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/random/methods/XorMin.hpp
+++ b/src/libPMacc/include/random/methods/XorMin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/result_of_Functor.hpp
+++ b/src/libPMacc/include/result_of_Functor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/simulationControl/SimulationDescription.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationDescription.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
  *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of libPMacc.

--- a/src/libPMacc/include/simulationControl/TimeInterval.hpp
+++ b/src/libPMacc/include/simulationControl/TimeInterval.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/static_assert.hpp
+++ b/src/libPMacc/include/static_assert.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetComponentsType.hpp
+++ b/src/libPMacc/include/traits/GetComponentsType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetEmptyDefaultConstructibleType.hpp
+++ b/src/libPMacc/include/traits/GetEmptyDefaultConstructibleType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetFlagType.hpp
+++ b/src/libPMacc/include/traits/GetFlagType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetInitializedInstance.hpp
+++ b/src/libPMacc/include/traits/GetInitializedInstance.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetNComponents.hpp
+++ b/src/libPMacc/include/traits/GetNComponents.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetStringProperties.hpp
+++ b/src/libPMacc/include/traits/GetStringProperties.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetUniqueTypeId.hpp
+++ b/src/libPMacc/include/traits/GetUniqueTypeId.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetValueType.hpp
+++ b/src/libPMacc/include/traits/GetValueType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetValueType.tpp
+++ b/src/libPMacc/include/traits/GetValueType.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/HasFlag.hpp
+++ b/src/libPMacc/include/traits/HasFlag.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/HasIdentifier.hpp
+++ b/src/libPMacc/include/traits/HasIdentifier.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/IsSameType.hpp
+++ b/src/libPMacc/include/traits/IsSameType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/Limits.hpp
+++ b/src/libPMacc/include/traits/Limits.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/Limits.tpp
+++ b/src/libPMacc/include/traits/Limits.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/NumberOfExchanges.hpp
+++ b/src/libPMacc/include/traits/NumberOfExchanges.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/Resolve.hpp
+++ b/src/libPMacc/include/traits/Resolve.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/verify.hpp
+++ b/src/libPMacc/include/verify.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/PMaccFixture.hpp
+++ b/src/libPMacc/test/PMaccFixture.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/TemplateUT.cu
+++ b/src/libPMacc/test/TemplateUT.cu
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Erik Zenker
+/* Copyright 2015-2017 Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/main.cpp
+++ b/src/libPMacc/test/main.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Erik Zenker, Alexander Grund
+/* Copyright 2015-2017 Erik Zenker, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/memory/HostBufferIntern/copyFrom.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/copyFrom.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Erik Zenker
+/* Copyright 2015-2017 Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/memory/HostBufferIntern/reset.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/reset.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Erik Zenker
+/* Copyright 2015-2017 Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
+++ b/src/libPMacc/test/memory/HostBufferIntern/setValue.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Erik Zenker
+/* Copyright 2015-2017 Erik Zenker
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/memory/memoryUT.cu
+++ b/src/libPMacc/test/memory/memoryUT.cu
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Erik Zenker, Alexander Grund
+/* Copyright 2015-2017 Erik Zenker, Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/particles/IdProvider.hpp
+++ b/src/libPMacc/test/particles/IdProvider.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/particles/particlesUT.cu
+++ b/src/libPMacc/test/particles/particlesUT.cu
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/test/random/2DDistribution.cu
+++ b/src/libPMacc/test/random/2DDistribution.cu
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of libPMacc.
  *

--- a/src/mpiInfo/main.cpp
+++ b/src/mpiInfo/main.cpp
@@ -1,5 +1,4 @@
-/*
- * Copyright 2013-2017  Rene Widera
+/* Copyright 2013-2017  Rene Widera
  *
  * This file is part of mpiInfo.
  *

--- a/src/picongpu/include/ArgsParser.cpp
+++ b/src/picongpu/include/ArgsParser.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/ArgsParser.hpp
+++ b/src/picongpu/include/ArgsParser.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/DifferenceToLower.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToLower.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/DifferenceToUpper.hpp
+++ b/src/picongpu/include/algorithms/DifferenceToUpper.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/src/picongpu/include/algorithms/FieldToParticleInterpolationNative.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/Gamma.hpp
+++ b/src/picongpu/include/algorithms/Gamma.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/KinEnergy.hpp
+++ b/src/picongpu/include/algorithms/KinEnergy.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
+++ b/src/picongpu/include/algorithms/LinearInterpolateWithUpper.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau, Rene Widera
+/* Copyright 2015-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/Set.hpp
+++ b/src/picongpu/include/algorithms/Set.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/ShiftCoordinateSystem.hpp
+++ b/src/picongpu/include/algorithms/ShiftCoordinateSystem.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/ShiftCoordinateSystemNative.hpp
+++ b/src/picongpu/include/algorithms/ShiftCoordinateSystemNative.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/algorithms/Velocity.hpp
+++ b/src/picongpu/include/algorithms/Velocity.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/debug/PIConGPUVerbose.hpp
+++ b/src/picongpu/include/debug/PIConGPUVerbose.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldManipulator.hpp
+++ b/src/picongpu/include/fields/FieldManipulator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/FieldTmp.hpp
+++ b/src/picongpu/include/fields/FieldTmp.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Marco Garten
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/Fields.def
+++ b/src/picongpu/include/fields/Fields.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/Fields.hpp
+++ b/src/picongpu/include/fields/Fields.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/Fields.tpp
+++ b/src/picongpu/include/fields/Fields.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/LaserPhysics.def
+++ b/src/picongpu/include/fields/LaserPhysics.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/LaserPhysics.hpp
+++ b/src/picongpu/include/fields/LaserPhysics.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.def
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau
+/* Copyright 2013-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheCurl.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheCurl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Remi Lehe
+/* Copyright 2013-2017 Axel Huebl, Remi Lehe
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Lehe/LeheSolver.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/None/NoSolver.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Solvers.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Solvers.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/Curl.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/Curl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.def
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/cellwiseOperation.hpp
+++ b/src/picongpu/include/fields/background/cellwiseOperation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus, Axel Huebl
+/* Copyright 2014-2017 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/BField.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus, Axel Huebl
+/* Copyright 2014-2017 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus, Axel Huebl
+/* Copyright 2014-2017 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/EField.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus, Axel Huebl
+/* Copyright 2014-2017 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus
+/* Copyright 2014-2017 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/RotateField.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/RotateField.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus, Rene Widera
+/* Copyright 2014-2017 Alexander Debus, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/TWTS.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/TWTS.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus
+/* Copyright 2014-2017 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/TWTS.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/TWTS.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus
+/* Copyright 2014-2017 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/getFieldPositions_SI.tpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/getFieldPositions_SI.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus
+/* Copyright 2014-2017 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/background/templates/TWTS/numComponents.hpp
+++ b/src/picongpu/include/fields/background/templates/TWTS/numComponents.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Alexander Debus, Axel Huebl
+/* Copyright 2014-2017 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/src/picongpu/include/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.def
+++ b/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/src/picongpu/include/fields/currentDeposition/EmZ/EmZ.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.def
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/Esirkepov/Line.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Esirkepov/Line.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/RelayPoint.hpp
+++ b/src/picongpu/include/fields/currentDeposition/RelayPoint.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Rene Widera
+/* Copyright 2016-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/Solver.def
+++ b/src/picongpu/include/fields/currentDeposition/Solver.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/Solver.hpp
+++ b/src/picongpu/include/fields/currentDeposition/Solver.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.def
+++ b/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/src/picongpu/include/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.def
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/src/picongpu/include/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.def
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl, Benjamin Worpitz
+/* Copyright 2015-2017 Axel Huebl, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.def
+++ b/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/CurrentInterpolation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/None/None.def
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/None/None.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/None/None.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl, Benjamin Worpitz
+/* Copyright 2015-2017 Axel Huebl, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.def
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/src/picongpu/include/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl, Benjamin Worpitz
+/* Copyright 2015-2017 Axel Huebl, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserGaussianBeam.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/laserProfiles/laserNone.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserNone.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPlaneWave.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPolynom.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Anton Helm, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Heiko Burau, Anton Helm, Rene Widera, Richard Pausch,
  *                     Axel Huebl
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserWavepacket.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Stefan Tietze
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Stefan Tietze
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/numericalCellTypes/NumericalCellTypes.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/NumericalCellTypes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
+++ b/src/picongpu/include/fields/numericalCellTypes/YeeCell.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/tasks/FieldFactory.hpp
+++ b/src/picongpu/include/fields/tasks/FieldFactory.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/tasks/FieldFactory.tpp
+++ b/src/picongpu/include/fields/tasks/FieldFactory.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/tasks/TaskFieldSend.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldSend.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
+++ b/src/picongpu/include/fields/tasks/TaskFieldSendExchange.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/initialization/IInitPlugin.hpp
+++ b/src/picongpu/include/initialization/IInitPlugin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/initialization/InitPluginNone.hpp
+++ b/src/picongpu/include/initialization/InitPluginNone.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/initialization/InitialiserController.hpp
+++ b/src/picongpu/include/initialization/InitialiserController.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/initialization/ParserGridDistribution.hpp
+++ b/src/picongpu/include/initialization/ParserGridDistribution.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/initialization/SimStartInitialiser.hpp
+++ b/src/picongpu/include/initialization/SimStartInitialiser.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/InitFunctors.hpp
+++ b/src/picongpu/include/particles/InitFunctors.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/InterpolationForPusher.hpp
+++ b/src/picongpu/include/particles/InterpolationForPusher.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Richard Pausch
+/* Copyright 2015-2017 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Marco Garten, Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu,
  *                     Marco Garten, Alexander Grund, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Marco Garten, Alexander Grund,
+/* Copyright 2014-2017 Rene Widera, Marco Garten, Alexander Grund,
  *                     Heiko Burau
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/access/Cell2Particle.hpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/access/Cell2Particle.tpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/creation/creation.hpp
+++ b/src/picongpu/include/particles/creation/creation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/creation/creation.kernel
+++ b/src/picongpu/include/particles/creation/creation.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2015-2017 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/densityProfiles/FreeFormulaImpl.def
+++ b/src/picongpu/include/particles/densityProfiles/FreeFormulaImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/FreeFormulaImpl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/FreeFormulaImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/FromHDF5Impl.def
+++ b/src/picongpu/include/particles/densityProfiles/FromHDF5Impl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/FromHDF5Impl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/FromHDF5Impl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/GaussianCloudImpl.def
+++ b/src/picongpu/include/particles/densityProfiles/GaussianCloudImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/GaussianCloudImpl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/GaussianCloudImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/GaussianImpl.def
+++ b/src/picongpu/include/particles/densityProfiles/GaussianImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/GaussianImpl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/GaussianImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/HomogenousImpl.def
+++ b/src/picongpu/include/particles/densityProfiles/HomogenousImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/HomogenousImpl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/HomogenousImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/IProfile.def
+++ b/src/picongpu/include/particles/densityProfiles/IProfile.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/IProfile.hpp
+++ b/src/picongpu/include/particles/densityProfiles/IProfile.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/LinearExponentialImpl.def
+++ b/src/picongpu/include/particles/densityProfiles/LinearExponentialImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/LinearExponentialImpl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/LinearExponentialImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/SphereFlanksImpl.def
+++ b/src/picongpu/include/particles/densityProfiles/SphereFlanksImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/SphereFlanksImpl.hpp
+++ b/src/picongpu/include/particles/densityProfiles/SphereFlanksImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/profiles.def
+++ b/src/picongpu/include/particles/densityProfiles/profiles.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Alexander Grund
+/* Copyright 2014-2017 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/densityProfiles/profiles.hpp
+++ b/src/picongpu/include/particles/densityProfiles/profiles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
+++ b/src/picongpu/include/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Richard Pausch
+/* Copyright 2016-2017 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/None/AlgorithmNone.hpp
+++ b/src/picongpu/include/particles/ionization/None/AlgorithmNone.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten
+/* Copyright 2014-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK.def
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten
+/* Copyright 2014-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIHydrogenLike.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIHydrogenLike.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten
+/* Copyright 2014-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten
+/* Copyright 2014-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Marco Garten
+/* Copyright 2016-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh.def
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Marco Garten
+/* Copyright 2016-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Marco Garten
+/* Copyright 2016-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
+++ b/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.hpp
+++ b/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/ionizers.def
+++ b/src/picongpu/include/particles/ionization/byField/ionizers.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/byField/ionizers.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ionizers.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2014-2017 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/ionization/ionizationMethods.hpp
+++ b/src/picongpu/include/particles/ionization/ionizationMethods.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten
+/* Copyright 2014-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/ionization/utilities.hpp
+++ b/src/picongpu/include/particles/ionization/utilities.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Marco Garten, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Marco Garten, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/AssignImpl.def
+++ b/src/picongpu/include/particles/manipulators/AssignImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/AssignImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/AssignImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.def
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/DensityWeighting.def
+++ b/src/picongpu/include/particles/manipulators/DensityWeighting.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/DensityWeighting.hpp
+++ b/src/picongpu/include/particles/manipulators/DensityWeighting.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl, Richard Pausch
+/* Copyright 2015-2017 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/DriftImpl.def
+++ b/src/picongpu/include/particles/manipulators/DriftImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/DriftImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/DriftImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/FreeImpl.def
+++ b/src/picongpu/include/particles/manipulators/FreeImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/FreeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/FreeImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/IManipulator.def
+++ b/src/picongpu/include/particles/manipulators/IManipulator.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/IManipulator.hpp
+++ b/src/picongpu/include/particles/manipulators/IManipulator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.def
+++ b/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/NoneImpl.def
+++ b/src/picongpu/include/particles/manipulators/NoneImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/NoneImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/NoneImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.def
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.hpp
+++ b/src/picongpu/include/particles/manipulators/ProtonTimesWeighting.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.def
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Alexander Grund
+/* Copyright 2015-2017 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/SetAttributeImpl.def
+++ b/src/picongpu/include/particles/manipulators/SetAttributeImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten
+/* Copyright 2015-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten, Axel Huebl
+/* Copyright 2015-2017 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.def
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/manipulators/manipulators.def
+++ b/src/picongpu/include/particles/manipulators/manipulators.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Axel Huebl
+/* Copyright 2014-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/manipulators/manipulators.hpp
+++ b/src/picongpu/include/particles/manipulators/manipulators.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Axel Huebl
+/* Copyright 2014-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl, Richard Pausch
+/* Copyright 2015-2017 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl, Richard Pausch
+/* Copyright 2015-2017 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Heiko Burau
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2017 Axel Huebl
+/* Copyright 2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2017 Axel Huebl
+/* Copyright 2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MomentumComponent.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MomentumComponent.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherAxel.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherBoris.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/pusher/particlePusherFree.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherFree.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherPhoton.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/pusher/particlePusherVay.hpp
+++ b/src/picongpu/include/particles/pusher/particlePusherVay.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/shapes.hpp
+++ b/src/picongpu/include/particles/shapes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/shapes/CIC.hpp
+++ b/src/picongpu/include/particles/shapes/CIC.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/shapes/Counter.hpp
+++ b/src/picongpu/include/particles/shapes/Counter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/shapes/NGP.hpp
+++ b/src/picongpu/include/particles/shapes/NGP.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/shapes/P4S.hpp
+++ b/src/picongpu/include/particles/shapes/P4S.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/shapes/PCS.hpp
+++ b/src/picongpu/include/particles/shapes/PCS.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/shapes/TSC.hpp
+++ b/src/picongpu/include/particles/shapes/TSC.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/IFunctor.def
+++ b/src/picongpu/include/particles/startPosition/IFunctor.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/IFunctor.hpp
+++ b/src/picongpu/include/particles/startPosition/IFunctor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/MacroParticleCfg.hpp
+++ b/src/picongpu/include/particles/startPosition/MacroParticleCfg.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/OnePositionImpl.def
+++ b/src/picongpu/include/particles/startPosition/OnePositionImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/OnePositionImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/OnePositionImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/QuietImpl.def
+++ b/src/picongpu/include/particles/startPosition/QuietImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/QuietImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/QuietImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/RandomImpl.def
+++ b/src/picongpu/include/particles/startPosition/RandomImpl.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/RandomImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/RandomImpl.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/particles/startPosition/functors.def
+++ b/src/picongpu/include/particles/startPosition/functors.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/startPosition/functors.hpp
+++ b/src/picongpu/include/particles/startPosition/functors.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.def
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetAtomicNumbers.hpp
+++ b/src/picongpu/include/particles/traits/GetAtomicNumbers.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten, Rene Widera
+/* Copyright 2015-2017 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetCurrentSolver.hpp
+++ b/src/picongpu/include/particles/traits/GetCurrentSolver.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetDensityRatio.hpp
+++ b/src/picongpu/include/particles/traits/GetDensityRatio.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Richard Pausch
+/* Copyright 2015-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetEffectiveAtomicNumbers.hpp
+++ b/src/picongpu/include/particles/traits/GetEffectiveAtomicNumbers.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten, Rene Widera
+/* Copyright 2015-2017 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetInterpolation.hpp
+++ b/src/picongpu/include/particles/traits/GetInterpolation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetIonizationEnergies.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizationEnergies.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Marco Garten, Rene Widera
+/* Copyright 2015-2017 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetIonizer.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten
+/* Copyright 2014-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetMarginPusher.hpp
+++ b/src/picongpu/include/particles/traits/GetMarginPusher.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Richard Pausch
+/* Copyright 2015-2017 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
+++ b/src/picongpu/include/particles/traits/GetPhotonCreator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetPusher.hpp
+++ b/src/picongpu/include/particles/traits/GetPusher.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Richard Pausch
+/* Copyright 2014-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetShape.hpp
+++ b/src/picongpu/include/particles/traits/GetShape.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/GetSpeciesFlagName.hpp
+++ b/src/picongpu/include/particles/traits/GetSpeciesFlagName.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/MacroWeighted.hpp
+++ b/src/picongpu/include/particles/traits/MacroWeighted.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/particles/traits/WeightingPower.hpp
+++ b/src/picongpu/include/particles/traits/WeightingPower.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau,
  *                     Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/ChargeConservation.hpp
+++ b/src/picongpu/include/plugins/ChargeConservation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/ChargeConservation.tpp
+++ b/src/picongpu/include/plugins/ChargeConservation.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/CountParticles.hpp
+++ b/src/picongpu/include/plugins/CountParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau,
  *                     Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/ILightweightPlugin.hpp
+++ b/src/picongpu/include/plugins/ILightweightPlugin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt
+/* Copyright 2014-2017 Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/ISimulationPlugin.hpp
+++ b/src/picongpu/include/plugins/ISimulationPlugin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/IntensityPlugin.hpp
+++ b/src/picongpu/include/plugins/IntensityPlugin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/IsaacPlugin.hpp
+++ b/src/picongpu/include/plugins/IsaacPlugin.hpp
@@ -1,4 +1,4 @@
-/**
+/*
 * Copyright 2013-2017 Alexander Matthes,
 *
 * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/LiveViewPlugin.hpp
+++ b/src/picongpu/include/plugins/LiveViewPlugin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PhaseSpace/AxisDescription.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/AxisDescription.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PhaseSpace/DumpHBufferSplashP.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/DumpHBufferSplashP.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpace.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceMulti.hpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceMulti.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceMulti.tpp
+++ b/src/picongpu/include/plugins/PhaseSpace/PhaseSpaceMulti.tpp
@@ -1,4 +1,4 @@
-/** Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Benjamin Schneider, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Benjamin Schneider, Felix Schmitt,
  *                     Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Erik Zenker
  *

--- a/src/picongpu/include/plugins/PngPlugin.hpp
+++ b/src/picongpu/include/plugins/PngPlugin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/SliceFieldPrinter.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSCountParticles.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt, Axel Huebl
+/* Copyright 2014-2017 Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.def
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt, Axel Huebl
+/* Copyright 2014-2017 Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/adios/NDScalars.hpp
+++ b/src/picongpu/include/plugins/adios/NDScalars.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/adios/WriteMeta.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/WriteSpecies.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Felix Schmitt, Axel Huebl,
+/* Copyright 2014-2017 Rene Widera, Felix Schmitt, Axel Huebl,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/adios/restart/LoadSpecies.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/restart/ReadAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/restart/ReadAttribute.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/adios/restart/RestartFieldLoader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttribute.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt, Axel Huebl
+/* Copyright 2014-2017 Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/common/particlePatches.cpp
+++ b/src/picongpu/include/plugins/common/particlePatches.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/common/particlePatches.hpp
+++ b/src/picongpu/include/plugins/common/particlePatches.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/common/stringHelpers.cpp
+++ b/src/picongpu/include/plugins/common/stringHelpers.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/common/stringHelpers.hpp
+++ b/src/picongpu/include/plugins/common/stringHelpers.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/common/txtFileHandling.hpp
+++ b/src/picongpu/include/plugins/common/txtFileHandling.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl, Richard Pausch
+/* Copyright 2015-2017 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.def
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.def
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/hdf5/NDScalars.hpp
+++ b/src/picongpu/include/plugins/hdf5/NDScalars.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Grund
+/* Copyright 2016-2017 Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/openPMD/patchReader.cpp
+++ b/src/picongpu/include/plugins/hdf5/openPMD/patchReader.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/openPMD/patchReader.hpp
+++ b/src/picongpu/include/plugins/hdf5/openPMD/patchReader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/restart/LoadSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/LoadSpecies.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/src/picongpu/include/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/writer/Field.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/Field.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/ParticleAttribute.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/GatherSlice.hpp
+++ b/src/picongpu/include/plugins/output/GatherSlice.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
+++ b/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Felix Schmitt
+/* Copyright 2014-2017 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/compression/ZipConnector.hpp
+++ b/src/picongpu/include/plugins/output/compression/ZipConnector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/header/ColorHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/ColorHeader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/header/DataHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/DataHeader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/header/MessageHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/MessageHeader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/header/NodeHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/NodeHeader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/header/SimHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/SimHeader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/header/WindowHeader.hpp
+++ b/src/picongpu/include/plugins/output/header/WindowHeader.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/images/LiveViewClient.hpp
+++ b/src/picongpu/include/plugins/output/images/LiveViewClient.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/images/PngCreator.hpp
+++ b/src/picongpu/include/plugins/output/images/PngCreator.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/images/PngCreator.tpp
+++ b/src/picongpu/include/plugins/output/images/PngCreator.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2016 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2016 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/output/sockets/SocketConnector.hpp
+++ b/src/picongpu/include/plugins/output/sockets/SocketConnector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Axel Huebl
+/* Copyright 2013-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/src/picongpu/include/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/plugins/radiation/amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/amplitude.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
+++ b/src/picongpu/include/plugins/radiation/calc_amplitude.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/check_consistency.hpp
+++ b/src/picongpu/include/plugins/radiation/check_consistency.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
+++ b/src/picongpu/include/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
+++ b/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/parameters.hpp
+++ b/src/picongpu/include/plugins/radiation/parameters.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/particle.hpp
+++ b/src/picongpu/include/plugins/radiation/particle.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/particles/Momentum_mt1.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/Momentum_mt1.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/PushExtension.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/particles/RadiationFlag.hpp
+++ b/src/picongpu/include/plugins/radiation/particles/RadiationFlag.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/radFormFactor.hpp
+++ b/src/picongpu/include/plugins/radiation/radFormFactor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/taylor.hpp
+++ b/src/picongpu/include/plugins/radiation/taylor.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/utilities.hpp
+++ b/src/picongpu/include/plugins/radiation/utilities.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/vector.hpp
+++ b/src/picongpu/include/plugins/radiation/vector.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/plugins/radiation/windowFunctions.hpp
+++ b/src/picongpu/include/plugins/radiation/windowFunctions.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Richard Pausch
+/* Copyright 2014-2017 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/pmacc_renamings.hpp
+++ b/src/picongpu/include/pmacc_renamings.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulationControl/GuardHandlerCallPlugins.hpp
+++ b/src/picongpu/include/simulationControl/GuardHandlerCallPlugins.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulationControl/ISimulationStarter.hpp
+++ b/src/picongpu/include/simulationControl/ISimulationStarter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulationControl/MovingWindow.hpp
+++ b/src/picongpu/include/simulationControl/MovingWindow.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt, Alexander Debus
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund
  *

--- a/src/picongpu/include/simulationControl/SimulationStarter.hpp
+++ b/src/picongpu/include/simulationControl/SimulationStarter.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulationControl/Window.hpp
+++ b/src/picongpu/include/simulationControl/Window.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_classTypes.hpp
+++ b/src/picongpu/include/simulation_classTypes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines.hpp
+++ b/src/picongpu/include/simulation_defines.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/_defaultParam.loader
+++ b/src/picongpu/include/simulation_defines/_defaultParam.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/_defaultUnitless.loader
+++ b/src/picongpu/include/simulation_defines/_defaultUnitless.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                      Marco Garten
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/extensionParam.loader
+++ b/src/picongpu/include/simulation_defines/extensionParam.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/extensionUnitless.loader
+++ b/src/picongpu/include/simulation_defines/extensionUnitless.loader
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/bremsstrahlung.param
+++ b/src/picongpu/include/simulation_defines/param/bremsstrahlung.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/componentsConfig.param
+++ b/src/picongpu/include/simulation_defines/param/componentsConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm,
  *                     Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/param/densityConfig.param
+++ b/src/picongpu/include/simulation_defines/param/densityConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/param/dimension.param
+++ b/src/picongpu/include/simulation_defines/param/dimension.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/fieldBackground.param
+++ b/src/picongpu/include/simulation_defines/param/fieldBackground.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Alexander Debus
+/* Copyright 2014-2017 Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/fieldSolver.param
+++ b/src/picongpu/include/simulation_defines/param/fieldSolver.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
  * Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
+++ b/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten, Axel Huebl
+/* Copyright 2014-2017 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/ionizerConfig.param
+++ b/src/picongpu/include/simulation_defines/param/ionizerConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten, Axel Huebl
+/* Copyright 2014-2017 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/isaac.param
+++ b/src/picongpu/include/simulation_defines/param/isaac.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Alexander Matthes
+/* Copyright 2016-2017 Alexander Matthes
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/mallocMC.param
+++ b/src/picongpu/include/simulation_defines/param/mallocMC.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Carlchristian Eckert
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/param/memory.param
+++ b/src/picongpu/include/simulation_defines/param/memory.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/particleCalorimeter.param
+++ b/src/picongpu/include/simulation_defines/param/particleCalorimeter.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/particleConfig.param
+++ b/src/picongpu/include/simulation_defines/param/particleConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/param/physicalConstants.param
+++ b/src/picongpu/include/simulation_defines/param/physicalConstants.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Marco Garten
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/param/precision.param
+++ b/src/picongpu/include/simulation_defines/param/precision.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/pusherConfig.param
+++ b/src/picongpu/include/simulation_defines/param/pusherConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/radiationObserver.param
+++ b/src/picongpu/include/simulation_defines/param/radiationObserver.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/seed.param
+++ b/src/picongpu/include/simulation_defines/param/seed.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl, Rene Widera
+/* Copyright 2014-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Richard Pausch
+/* Copyright 2014-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl, Heiko Burau
+/* Copyright 2014-2017 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/speciesConstants.param
+++ b/src/picongpu/include/simulation_defines/param/speciesConstants.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/speciesInitialization.param
+++ b/src/picongpu/include/simulation_defines/param/speciesInitialization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera, Axel Huebl
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/starter.param
+++ b/src/picongpu/include/simulation_defines/param/starter.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/visColorScales.param
+++ b/src/picongpu/include/simulation_defines/param/visColorScales.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/param/visualization.param
+++ b/src/picongpu/include/simulation_defines/param/visualization.param
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/unitless/bremsstrahlung.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/bremsstrahlung.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Heiko Burau
+/* Copyright 2016-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/checkpoints.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/checkpoints.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/densityConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/densityConfig.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/unitless/fieldBackground.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/fieldBackground.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Axel Huebl
+/* Copyright 2014-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/fieldSolver.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/fileOutput.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/fileOutput.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/gridConfig.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/unitless/ionizerConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/ionizerConfig.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten
+/* Copyright 2014-2017 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/laserConfig.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/particleConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/particleConfig.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/physicalConstants.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/precision.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/precision.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/pusherConfig.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl,
+/* Copyright 2013-2017 Rene Widera, Felix Schmitt, Axel Huebl,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/src/picongpu/include/simulation_defines/unitless/speciesConstants.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesConstants.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/speciesDefinition.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesDefinition.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/speciesInitialization.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesInitialization.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/starter.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/starter.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/synchrotronPhotons.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Heiko Burau
+/* Copyright 2015-2017 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_defines/unitless/visualization.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/visualization.unitless
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/simulation_types.hpp
+++ b/src/picongpu/include/simulation_types.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/AdiosToPIC.hpp
+++ b/src/picongpu/include/traits/AdiosToPIC.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/AdiosToPIC.tpp
+++ b/src/picongpu/include/traits/AdiosToPIC.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/GetDataBoxType.hpp
+++ b/src/picongpu/include/traits/GetDataBoxType.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Rene Widera
+/* Copyright 2015-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/GetMargin.hpp
+++ b/src/picongpu/include/traits/GetMargin.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/PICToAdios.hpp
+++ b/src/picongpu/include/traits/PICToAdios.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/PICToAdios.tpp
+++ b/src/picongpu/include/traits/PICToAdios.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/PICToOpenPMD.hpp
+++ b/src/picongpu/include/traits/PICToOpenPMD.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/PICToOpenPMD.tpp
+++ b/src/picongpu/include/traits/PICToOpenPMD.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Axel Huebl
+/* Copyright 2016-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/PICToSplash.hpp
+++ b/src/picongpu/include/traits/PICToSplash.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/PICToSplash.tpp
+++ b/src/picongpu/include/traits/PICToSplash.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/SIBaseUnits.hpp
+++ b/src/picongpu/include/traits/SIBaseUnits.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/SplashToPIC.hpp
+++ b/src/picongpu/include/traits/SplashToPIC.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/SplashToPIC.tpp
+++ b/src/picongpu/include/traits/SplashToPIC.tpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl
+/* Copyright 2013-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/Unit.hpp
+++ b/src/picongpu/include/traits/Unit.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Rene Widera
+/* Copyright 2013-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/UnitDimension.hpp
+++ b/src/picongpu/include/traits/UnitDimension.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/UsesRNG.hpp
+++ b/src/picongpu/include/traits/UsesRNG.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016-2017 Marco Garten, Rene Widera
+/* Copyright 2016-2017 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/attribute/GetCharge.hpp
+++ b/src/picongpu/include/traits/attribute/GetCharge.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/attribute/GetChargeState.hpp
+++ b/src/picongpu/include/traits/attribute/GetChargeState.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Marco Garten, Rene Widera
+/* Copyright 2014-2017 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/attribute/GetMass.hpp
+++ b/src/picongpu/include/traits/attribute/GetMass.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/frame/GetCharge.hpp
+++ b/src/picongpu/include/traits/frame/GetCharge.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/traits/frame/GetMass.hpp
+++ b/src/picongpu/include/traits/frame/GetMass.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/include/version.hpp
+++ b/src/picongpu/include/version.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2017 Axel Huebl
+/* Copyright 2015-2017 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/src/picongpu/main.cu
+++ b/src/picongpu/main.cu
@@ -1,5 +1,4 @@
-/**
- * Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/src/tools/bin/addLicense
+++ b/src/tools/bin/addLicense
@@ -84,6 +84,6 @@ fi
 
 sed -s -i '1i\'"$text"  $fileName
 
-sed -s -i '1i\/**\n * Copyright '`date +%G`' '"$author" $fileName
+sed -s -i '1i\/* Copyright '`date +%G`' '"$author" $fileName
 
 exit 0

--- a/src/tools/png2gas/png2gas.cpp
+++ b/src/tools/png2gas/png2gas.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2014-2017 Felix Schmitt, Axel Huebl, Richard Pausch
+/* Copyright 2014-2017 Felix Schmitt, Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/src/tools/splash2txt/include/ITools.hpp
+++ b/src/tools/splash2txt/include/ITools.hpp
@@ -1,5 +1,4 @@
-/*
- * Copyright 2013-2017 Felix Schmitt
+/* Copyright 2013-2017 Felix Schmitt
  *
  * This file is part of splash2txt.
  *

--- a/src/tools/splash2txt/include/splash2txt.hpp
+++ b/src/tools/splash2txt/include/splash2txt.hpp
@@ -1,5 +1,4 @@
-/*
- * Copyright 2013-2017 Felix Schmitt, Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Axel Huebl, Rene Widera
  *
  * This file is part of splash2txt.
  *

--- a/src/tools/splash2txt/include/tools_splash_parallel.hpp
+++ b/src/tools/splash2txt/include/tools_splash_parallel.hpp
@@ -1,5 +1,4 @@
-/*
- * Copyright 2013-2017 Felix Schmitt
+/* Copyright 2013-2017 Felix Schmitt
  *
  * This file is part of splash2txt.
  *

--- a/src/tools/splash2txt/splash2txt.cpp
+++ b/src/tools/splash2txt/splash2txt.cpp
@@ -1,5 +1,4 @@
-/*
- * Copyright 2013-2017 Felix Schmitt, Axel Huebl, Rene Widera,
+/* Copyright 2013-2017 Felix Schmitt, Axel Huebl, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of splash2txt.

--- a/src/tools/splash2txt/tools_adios_parallel.cpp
+++ b/src/tools/splash2txt/tools_adios_parallel.cpp
@@ -1,5 +1,4 @@
-/*
- * Copyright 2014-2017 Felix Schmitt, Conrad Schumann, Axel Huebl
+/* Copyright 2014-2017 Felix Schmitt, Conrad Schumann, Axel Huebl
  *
  * This file is part of splash2txt.
  *

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -1,5 +1,4 @@
-/*
- * Copyright 2013-2017 Felix Schmitt, Axel Huebl, Rene Widera
+/* Copyright 2013-2017 Felix Schmitt, Axel Huebl, Rene Widera
  *
  * This file is part of splash2txt.
  *


### PR DESCRIPTION
The copyright header is no doxygen and if put as such, spams the doc of what ever comes after it (most of the time it's appended to the `namespace picongpu` documentation).

```bash
grep -iR "\* Copyright" examples | awk -F: '{print $1}' | sort -u | xargs -n1 -P1 -I{} sed -i '1d' {}
grep -iR "\* Copyright" examples | awk -F: '{print $1}' | sort -u | xargs -n1 -P1 -I{} sed -i '1 s/ \*/\/\*/' {}

GIT_AUTHOR_NAME="Tools" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" git commit -a -S
```