### PR TITLE
Doxygen: File Comments in Ionization

### DIFF
--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
@@ -26,7 +26,9 @@
 #include "particles/traits/GetEffectiveAtomicNumbers.hpp"
 #include "traits/attribute/GetChargeState.hpp"
 
-/** IONIZATION ALGORITHM for the BSI model
+/** @file AlgorithmBSIEffectiveZ.hpp
+ *
+ * IONIZATION ALGORITHM for the BSI model
  *
  * - implements the calculation of ionization probability and changes charge states
  *   by decreasing the number of bound electrons

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIHydrogenLike.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIHydrogenLike.hpp
@@ -25,7 +25,9 @@
 #include "particles/traits/GetAtomicNumbers.hpp"
 #include "traits/attribute/GetChargeState.hpp"
 
-/** IONIZATION ALGORITHM for the BSI model
+/** @file AlgorithmBSIHydrogenLike.hpp
+ *
+ * IONIZATION ALGORITHM for the BSI model
  *
  * - implements the calculation of ionization probability and changes charge states
  *   by decreasing the number of bound electrons

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
@@ -25,7 +25,9 @@
 #include "particles/traits/GetAtomicNumbers.hpp"
 #include "traits/attribute/GetChargeState.hpp"
 
-/** IONIZATION ALGORITHM for the BSIStarkShifted model
+/** @file AlgorithmBSIStarkShifted.hpp
+ *
+ * IONIZATION ALGORITHM for the BSIStarkShifted model
  *
  * - implements the calculation of ionization probability and changes charge states
  *   by decreasing the number of bound electrons


### PR DESCRIPTION
Fix falsly placed `@file` doxygen comments which spammed the namespace that came after it.