### PR TITLE
Ionization: Fix Charge of Ionized Ions

### DIFF
--- a/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteSpecies.hpp
@@ -24,6 +24,7 @@
 #include "plugins/hdf5/HDF5Writer.def"
 #include "traits/SIBaseUnits.hpp"
 #include "traits/PICToOpenPMD.hpp"
+#include "traits/HasIdentifier.hpp"
 #include "assert.hpp"
 
 #include "plugins/ISimulationPlugin.hpp"
@@ -239,20 +240,29 @@ public:
             numParticlesGlobal
         );
 
-        /* write constant particle records to hdf5 file */
-        const float_64 charge( frame::getCharge<FrameType>() );
-        std::vector<float_64> chargeUnitDimension( NUnitDimension, 0.0 );
-        chargeUnitDimension.at(SIBaseUnits::time) = 1.0;
-        chargeUnitDimension.at(SIBaseUnits::electricCurrent) = 1.0;
+        /* write constant particle records to hdf5 file
+         *   ions with variable charge due to a boundElectrons attribute do not write charge
+         */
+        using hasBoundElectrons = typename PMacc::traits::HasIdentifier<
+            FrameType,
+            boundElectrons
+        >::type;
+        if( ! hasBoundElectrons::value )
+        {
+            const float_64 charge( frame::getCharge<FrameType>() );
+            std::vector<float_64> chargeUnitDimension( NUnitDimension, 0.0 );
+            chargeUnitDimension.at(SIBaseUnits::time) = 1.0;
+            chargeUnitDimension.at(SIBaseUnits::electricCurrent) = 1.0;
 
-        writeConstantRecord(
-            params,
-            speciesPath + std::string("/charge"),
-            numParticlesGlobal,
-            charge,
-            UNIT_CHARGE,
-            chargeUnitDimension
-        );
+            writeConstantRecord(
+                params,
+                speciesPath + std::string("/charge"),
+                numParticlesGlobal,
+                charge,
+                UNIT_CHARGE,
+                chargeUnitDimension
+            );
+        }
 
         const float_64 mass( frame::getMass<FrameType>() );
         std::vector<float_64> massUnitDimension( NUnitDimension, 0.0 );

--- a/src/picongpu/include/traits/attribute/GetCharge.hpp
+++ b/src/picongpu/include/traits/attribute/GetCharge.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -47,25 +47,26 @@ struct LoadBoundElectrons
     /** Functor implementation
      *
      * \tparam T_Particle particle type
-     * \param singlyChargedResult charge resulting from multiplying a single
-     * electron charge (positive OR negative) by the macro particle weighting
+     * \param weighting the particle's weighting
      * \param particle particle reference
      */
     template<typename T_Particle>
-    HDINLINE float_X operator()(const float_X singlyChargedResult, const T_Particle& particle)
+    HDINLINE float_X operator()(const float_X weighting, const T_Particle& particle)
     {
         const float_X protonNumber = GetAtomicNumbers<T_Particle>::type::numberOfProtons;
 
-        return singlyChargedResult * (protonNumber - particle[boundElectrons_]);
+        /* note: ELECTRON_CHARGE is negative and the second term is also negative
+         */
+        return
+            ELECTRON_CHARGE *
+            ( particle[boundElectrons_] - protonNumber ) *
+            weighting;
     }
 };
 
 /**  Calculate the real charge of a particle
  *
  * This is the fallback implementation if no `boundElectrons` are available for a particle
- *
- * \tparam T_HasBoundElectrons boolean that describes if species allows multiple charge states
- * due to bound electrons
  */
 template<>
 struct LoadBoundElectrons<false>
@@ -73,14 +74,13 @@ struct LoadBoundElectrons<false>
     /** Functor implementation
      *
      * \tparam T_Particle particle type
-     * \param singlyChargedResult charge resulting from multiplying a single
-     * electron charge (positive OR negative) by the macro particle weighting
+     * \param weighting the particle's weighting
      * \param particle particle reference
      */
     template<typename T_Particle>
-    HDINLINE float_X operator()(const float_X singlyChargedResult, const T_Particle& particle)
+    HDINLINE float_X operator()(const float_X weighting, const T_Particle&)
     {
-        return singlyChargedResult;
+        return frame::getCharge< typename T_Particle::FrameType >() * weighting;
     }
 };
 } // namespace detail
@@ -99,8 +99,9 @@ HDINLINE float_X getCharge(const float_X weighting, const T_Particle& particle)
     typedef T_Particle ParticleType;
     typedef typename PMacc::traits::HasIdentifier<ParticleType, boundElectrons>::type hasBoundElectrons;
     return detail::LoadBoundElectrons<hasBoundElectrons::value >()(
-                                                      frame::getCharge<typename ParticleType::FrameType > () * weighting,
-                                                      particle);
+        weighting,
+        particle
+    );
 }
 
 }// namespace attribute


### PR DESCRIPTION
The charge of all but hydrogen ion species, as seen by the PIC algorithm, was wrong after ionizing an atom/ion.

Accidentially, the charge state inside our `GetCharge` trait was calculated as
```
    proton number * ( proton number - bound electrons)
```
instead of
```
    proton number - bound electrons
```

in case `chargeRatio` of the species in `speciesDefinition.param` was different from `1.0` (we usually set it to the fully ionized species' charge density).

**Affected Setups**

If all of the following criteria are true for at least one of your ion species, your simulation is affected:

- your species in `speciesDefinition.param` used an `ionizer`
- your species is not hydrogen
- your species moves and/or creates currents (pusher, current solver)
- you defined `chargeRatio` for that species different from `1.0`

Pre-ionized setups without ionization physics are unaffected.

**Implications**

The following quantities were falsely calculated:

- plasma dynamics (pusher used wrong charge to mass ratio,
  current solver used wrong charge)
- outputs to files (`fields/<species>_chargeDensity`)

Note that the wrong plasma dynamics resulting from that highly overcharged ion species is a severe bug and will likely render the complete simulation unphysical if the above mentioned criteria are met.

**Kudos**

Thanks to @HighIander for reporting the issue.