### PR TITLE
Fix plot radiation matplotlib2.x

### DIFF
--- a/src/tools/bin/plotRadiation
+++ b/src/tools/bin/plotRadiation
@@ -391,13 +391,7 @@ for myfile in args.path2Data:
     CB.ax.yaxis.get_offset_text().set_fontsize(exponentsize)
 
     # set appearance of plot
-    plt.subplots_adjust(left=0.13,
-                        right=0.85,
-                        bottom=0.15,
-                        top=0.95,
-                        wspace=0.0,
-                        hspace=0.0)
-
+    plt.tight_layout()
     # get name of file
     filename = os.path.basename(myfile.name)
 

--- a/src/tools/bin/plotRadiation
+++ b/src/tools/bin/plotRadiation
@@ -70,7 +70,7 @@ parser = argparse.ArgumentParser(
             )
 
 # Path to input files (several are possible) - necesairy argument
-parser.add_argument('path2Data', metavar='Path to input file', type=file, nargs='+',
+parser.add_argument('path2Data', metavar='Path to input file', type=argparse.FileType('r'), nargs='+',
                     help='location of input file (giving several files is possible)')
 
 # Default windows, but pdf version can be switched on.
@@ -122,8 +122,8 @@ parser.add_argument('--labelColorbar', metavar='string',
                             $\\\\frac{\\\\mathrm{d} ^2I}{\\\\mathrm{d} \\\\omega
                             \\\\mathrm{d} \\\\Omega}/$Js$]''')
 
-# set maximum value for imshow/colorbar
-parser.add_argument('--vMax', dest='imshowMax', nargs='?', metavar='float', type=float,
+# set maximum value for colorbar
+parser.add_argument('--vMax', dest='colorbarMax', nargs='?', metavar='float', type=float,
                     default=[],
                     help='''maximum value shown in colorbar (applied after smoothing)
                             [default: actual maximum]''')
@@ -151,9 +151,6 @@ parser.add_argument('--split', dest='split', nargs=2, metavar='float', type=floa
 parser.add_argument('--bw', dest='colorbarBlackAndWhite', action='store_true',
                     help='''use black and white colorbar instead of using rainbow colors''')
 
-# Default no contour is used, but a contour can be added.
-parser.add_argument('--contour', dest='contour', action='store_true',
-                    help='''draw contour lines''')
 
 # Default spline36 color interpolation, but a nearest interpolation can be need for tests.
 parser.add_argument('--nearest', dest='interpolSet', action='store_true',
@@ -213,9 +210,9 @@ else:
 
 # set interpolation
 if(args.interpolSet):
-    my_interpolation = 'nearest'
+    my_interpolation = 'flat'
 else:
-    my_interpolation = 'spline36'
+    my_interpolation = 'gouraud'
 
 
 
@@ -346,44 +343,33 @@ for myfile in args.path2Data:
     plt.yticks(size=tickfontsize)
     SP.set_yticks(linspace(theta_min_draw, theta_max_draw, 5))
 
-    #find max for imshow/colorbar
-    if not args.imshowMax:
+    #find max for colorbar
+    if not args.colorbarMax:
         maxData = dataZoomed.max()
-        imshowMax = maxData
+        colorbarMax = maxData
     else:
-        imshowMax = args.imshowMax
-
-
-    # plot data: (only call!!!)
-    cax =  SP.imshow(dataZoomed,
-                     extent=(omega_min_draw, omega_max_draw,  theta_min_draw, theta_max_draw),
-                     interpolation=my_interpolation,
-                     aspect='auto',
-                     origin='lower',
-                     cmap=my_cmap,
-                     vmax=imshowMax,
-                     norm=colorNorm)
-
-    if(args.contour):
-        # add contour lines
-        CP = SP.contour(dataZoomed,
-                        4,
-                        extent=(omega_min_draw, omega_max_draw,  theta_min_draw, theta_max_draw),
-                        interpolation=my_interpolation,
-                        aspect='auto',
-                        origin='lower',
-                        cmap=plt.cm.gray,
-                        vmax=imshowMax,
-                        linewiths=2,
-                        linestyles='solid',
-                        norm=colorNorm)
-
-        # add labels to contour lines if possible
-        plt.clabel(CP, inline=1, fontsize=16, fmt='%1.1e')
+        colorbarMax = args.colorbarMax
 
     # set omega-(x)-scale to log if needed
+    shape = shape(dataZoomed)
     if(args.logOmega):
         SP.set_xscale('log')
+        x = logspace(log10(omega_min_draw), log10(omega_max_draw), shape[1])
+    else:
+        x = linspace(omega_min_draw, omega_max_draw, shape[1])
+
+    y = linspace(theta_min_draw, theta_max_draw, shape[0])
+
+    # plot data: (only call!!!)
+    cax =  SP.pcolormesh(x, y, dataZoomed,
+                         shading=my_interpolation,
+                         cmap=my_cmap,
+                         vmax=colorbarMax,
+                         norm=colorNorm)
+
+    # set x and y range
+    plt.xlim(x[0], x[-1])
+    plt.ylim(y[0], y[-1])
 
     # set format style of colorbar label
     if args.logIntensity:
@@ -439,9 +425,4 @@ for myfile in args.path2Data:
     FG.clear()
     myfile.close()
 
-    print filename + "\t Done"
-
-
-
-
-
+    print(filename + "\t Done")

--- a/src/tools/bin/plotRadiation
+++ b/src/tools/bin/plotRadiation
@@ -45,7 +45,7 @@ import warnings
 from numpy import *
 from matplotlib.colors import LogNorm
 
-tested_matplotlib_version = ['1.2.0', '1.3.1']
+tested_matplotlib_version = ['1.2.0', '1.3.1', '2.0.0rc1']
 if not matplotlib.__version__ in tested_matplotlib_version:
     warning_msg = '''The matplotlib version differs from that used during
                      development. This might cause the output to appear different.


### PR DESCRIPTION
This pull request fixes the matplotlib2.x incompatibility which occurs when `plt.imshow()` is used with `plt.xscale('log')`. See the following [matplotlib issue](https://github.com/matplotlib/matplotlib/issues/7661) for details. 

Furthermore 
 - the `plt.contour()` option is removed because there is no equivalent for logarithmic axis
 - The final `print`is now python3 compatible
 - the `file`type is replaced 
 - use `plt.tight_layout()`instead of `plt.subplot_adjust()`

The following pictures are the inital radiation of an LWFA - the spectral signatures should be at multiples of `omega_0`. 

**Prior to this fix:**
`matplotlib 1.3.1`
![plot_radiation_lwfa_old](https://cloud.githubusercontent.com/assets/5121158/22984107/a91ccde6-f3a4-11e6-857d-587da79ec259.png)

`matplotlib 2.0.0rc1`
![plot_radiation_lwfa_new](https://cloud.githubusercontent.com/assets/5121158/22984157/cbb849f2-f3a4-11e6-89f4-36845280862d.png)

**With the fix of this pull request:**
`matplotlib 1.3.1`
![plot_radiation_lwfa_oldfixed](https://cloud.githubusercontent.com/assets/5121158/22984181/dcff7820-f3a4-11e6-90e1-132b3db30fab.png)

`matplotlib 2.0.0rc1`
![plot_radiation_lwfa_newfixed](https://cloud.githubusercontent.com/assets/5121158/22984200/e5c05128-f3a4-11e6-9d51-ac8cabaca672.png)



