### PR TITLE
HDF5/ADIOS: Fix ill-places helper incl

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -54,7 +54,6 @@
 #include "plugins/adios/restart/LoadSpecies.hpp"
 #include "plugins/adios/restart/RestartFieldLoader.hpp"
 #include "plugins/adios/NDScalars.hpp"
-#include "plugins/common/stringHelpers.hpp"
 
 #include <adios.h>
 #include <adios_read.h>

--- a/src/picongpu/include/plugins/adios/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/adios/WriteMeta.hpp
@@ -22,6 +22,7 @@
 #include "simulation_defines.hpp"
 
 #include "plugins/adios/ADIOSWriter.def"
+#include "plugins/common/stringHelpers.hpp"
 #include "Environment.hpp"
 
 #include "fields/FieldManipulator.hpp"

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -24,6 +24,7 @@
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
 #include "traits/PICToAdios.hpp"
+#include "traits/PICToOpenPMD.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
 #include "traits/Resolve.hpp"

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -33,7 +33,6 @@
 #include "plugins/hdf5/HDF5Writer.def"
 #include "traits/SplashToPIC.hpp"
 #include "traits/PICToSplash.hpp"
-#include "plugins/common/stringHelpers.hpp"
 
 #include "particles/frame_types.hpp"
 

--- a/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
@@ -25,6 +25,7 @@
 #include "simulation_defines.hpp"
 
 #include "plugins/hdf5/HDF5Writer.def"
+#include "plugins/common/stringHelpers.hpp"
 #include "Environment.hpp"
 
 #include "fields/FieldManipulator.hpp"


### PR DESCRIPTION
Compile errors fixed, mainly when ADIOS is used and HDF5 is not available.

- Fix ill-places string helper includes inside HDF5 and ADIOS.
- Adds missing openPMD trait include.

Might be responsible for failing compile in #1821.