### PR TITLE
Remove BOOST_BIND_NO_PLACEHOLDERS

### DIFF
--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -128,8 +128,7 @@ public:
 
                 algorithm::mpi::Reduce<3> reduce(gpuReducingZone, reduceRoot);
 
-                using namespace lambda;
-                reduce(eField_zt_reduced, *(eField_zt[i]), _1 + _2);
+                reduce(eField_zt_reduced, *(eField_zt[i]), lambda::_1 + lambda::_2);
             }
             if(!reduceRoot) continue;
 
@@ -175,13 +174,12 @@ public:
         for (size_t z = 0; z < eField_zt[0]->size().x(); z++)
         {
             zone::SphericZone < 2 > reduceZone(fieldE_coreBorder.size().shrink<2>());
-            using namespace lambda;
             for (int i = 0; i < 2; i++)
             {
                 *(eField_zt[i]->origin()(z, currentStep - firstTimestep)) =
                     algorithm::kernel::Reduce()
                         (cursor::make_FunctorCursor(cursor::tools::slice(fieldE_coreBorder.origin()(0, 0, z)),
-                                                   _1[i == 0 ? 0 : 2]),
+                                                    lambda::_1[i == 0 ? 0 : 2]),
                          reduceZone,
                          nvidia::functors::Add());
             }

--- a/src/libPMacc/include/lambda/CT/Eval.hpp
+++ b/src/libPMacc/include/lambda/CT/Eval.hpp
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#define BOOST_BIND_NO_PLACEHOLDERS
-
 #include "Expression.hpp"
 #include "../placeholder.hpp"
 #include "../ExprTypes.hpp"


### PR DESCRIPTION
Fix #1848: Remove the general definition of `BOOST_BIND_NO_PLACEHOLDERS` which breaks all usages below this header of `boost::placeholders` which are in the context of `boost::bind` often assumed to be present. This is especially true for some boost internals, which due to that break for us from [time](https://svn.boost.org/trac/boost/ticket/10932) to [time](https://svn.boost.org/trac/boost/ticket/12841).