### PR TITLE
Particle manipulators: Fix Position Offset

### DIFF
--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -77,6 +77,10 @@ struct KernelDeriveParticles
 
 
         const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
+        /* offset of the superCell (in cells, without any guards) to the origin of the local domain */
+        const DataSpace<simDim> localSuperCellOffset =
+            block * SuperCellSize::toRT()
+            - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
         if (threadIdx.x == 0)
         {
@@ -94,10 +98,7 @@ struct KernelDeriveParticles
             auto parSrc = frame[threadIdx.x];
             assign(parDest, deselect<particleId>(parSrc));
 
-            const DataSpace<simDim> localCellIdx = block * SuperCellSize::toRT()
-                + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x)
-                - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-            manipulateFunctor(localCellIdx,
+            manipulateFunctor(localSuperCellOffset,
                               parDest, parSrc,
                               true, parSrc[multiMask_] == 1);
 
@@ -151,16 +152,17 @@ struct KernelManipulateAllParticles
          * volatile prohibits that the compiler creates wrong code*/
         volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
 
-        const DataSpace<simDim> idx(superCellIdx * SuperCellSize::toRT() + threadIndex);
-        const DataSpace<simDim> localCellIdx = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-
+        /* offset of the superCell (in cells, without any guards) to the origin of the local domain */
+        const DataSpace<simDim> localSuperCellOffset =
+            superCellIdx * SuperCellSize::toRT()
+            - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
         __syncthreads();
 
         while (frame.isValid())
         {
             auto particle = frame[linearThreadIdx];
-            particleFunctor(localCellIdx, particle, particle, isParticle, isParticle);
+            particleFunctor(localSuperCellOffset, particle, particle, isParticle, isParticle);
 
             __syncthreads();
             if (linearThreadIdx == 0)

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -74,7 +74,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {
@@ -92,7 +92,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
 
 
         uint32_t ltid = DataSpaceOperations<simDim>::template map<SuperCellSize>(DataSpace<simDim>(threadIdx));
-        const DataSpace<simDim> superCell((guardCells + localCellIdx) / SuperCellSize::toRT());
+        const DataSpace<simDim> superCell((guardCells + localSuperCellOffset) / SuperCellSize::toRT());
         if (ltid == 0)
         {
             if (firstCall)

--- a/src/picongpu/include/particles/manipulators/DriftImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/DriftImpl.hpp
@@ -44,7 +44,7 @@ struct DriftImpl : private T_ValueFunctor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>&,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {

--- a/src/picongpu/include/particles/manipulators/IManipulator.hpp
+++ b/src/picongpu/include/particles/manipulators/IManipulator.hpp
@@ -40,12 +40,23 @@ struct IManipulator : private T_Base
     {
     }
 
+    /** interface to operate on two particles
+     *
+     * @tparam T_Particle1 type of the first particle
+     * @tparam T_Particle2 type of the second particle
+     * @param localSuperCellOffset offset of the superCell (in cells, without any guards)
+     *                             to the origin of the local domain where both particles are located
+     * @param particleSpecies1 first particle
+     * @param particleSpecies2 second particle, can be equal to the first particle
+     * @param isParticle1 define if the reference @p particleSpecies1 is valid
+     * @param isParticle2 define if the reference @p particleSpecies2 is valid
+     */
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particleSpecies1, T_Particle2& particleSpecies2,
                             const bool isParticle1, const bool isParticle2)
     {
-        return Base::operator()(localCellIdx, particleSpecies1, particleSpecies2, isParticle1, isParticle2);
+        return Base::operator()(localSuperCellOffset, particleSpecies1, particleSpecies2, isParticle1, isParticle2);
     }
 };
 

--- a/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
@@ -45,30 +45,54 @@ struct IfRelativeGlobalPositionImpl : private T_Functor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particle1, T_Particle2& particle2,
                             const bool isParticle1, const bool isParticle2)
     {
         typedef typename SpeciesType::FrameType FrameType;
 
+        /* offset of the superCell (in cells, without any guards) to the origin of the global domain */
+        const DataSpace<simDim> globalSuperCellOffset = localSuperCellOffset + localDomainOffset;
+        bool particleInRange1 = isParticle1;
+        bool particleInRange2 = isParticle2;
 
-        DataSpace<simDim> myCellPosition = localCellIdx + localDomainOffset;
+        if( isParticle1 )
+        {
+            particleInRange1 = isParticleInsideRange( particle1, globalSuperCellOffset);
+        }
+        if( isParticle1 )
+        {
+            particleInRange2 = isParticleInsideRange( particle2, globalSuperCellOffset);
+        }
 
-        float_X relativePosition = float_X(myCellPosition[ParamClass::dimension]) /
-            float_X(globalDomainSize[ParamClass::dimension]);
-
-        const bool inRange=(ParamClass::lowerBound <= relativePosition &&
-            relativePosition < ParamClass::upperBound);
-        const bool particleInRange1 = isParticle1 && inRange;
-        const bool particleInRange2 = isParticle2 && inRange;
-
-        Functor::operator()(localCellIdx,
+        Functor::operator()(localSuperCellOffset,
                             particle1, particle2,
                             particleInRange1, particleInRange2);
 
     }
 
 private:
+
+    /** check if a particle is located in the user defined range
+     *
+     * @tparam T_Particle type of the particle
+     * @param particle particle than needs to be checked
+     * @param globalSuperCellOffset offset of the superCell (in cells, without any guards)
+     *                              to the origin of the global domain
+     */
+    template< typename T_Particle >
+    DINLINE bool isParticleInsideRange( const T_Particle& particle, const DataSpace<simDim>& globalSuperCellOffset ) const
+    {
+        const int particleCellIdx = particle[localCellIdx_];
+        const DataSpace<simDim> cellInSuperCell(DataSpaceOperations<simDim>::template map< SuperCellSize >(particleCellIdx));
+        const DataSpace<simDim> globalParticleOffset(globalSuperCellOffset + cellInSuperCell);
+
+        const float_X relativePosition = float_X(globalParticleOffset[ParamClass::dimension]) /
+            float_X(globalDomainSize[ParamClass::dimension]);
+
+        return (ParamClass::lowerBound <= relativePosition &&
+            relativePosition < ParamClass::upperBound);
+    }
 
     DataSpace<simDim> localDomainOffset;
     DataSpace<simDim> globalDomainSize;

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -60,7 +60,7 @@ struct RandomPositionImpl
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {
@@ -68,9 +68,15 @@ struct RandomPositionImpl
 
         if (!isInitialized)
         {
+            /** @todo: it is a wrong assumption that the threadIdx can be used to
+             * define the cell within the superCell. This is only allowed if we not
+             * use alpaka. We need to distinguish between manipulators those are working on the
+             * cell domain and on the particle domain.
+             */
+            const DataSpace<simDim > threadIndex(threadIdx);
             const uint32_t cellIdx = DataSpaceOperations<simDim>::map(
                                                                       localCells,
-                                                                      localCellIdx);
+                                                                      localSuperCellOffset + threadIndex);
             rng = nvrng::create(rngMethods::Xor(seed, cellIdx), rngDistributions::Uniform_float());
             isInitialized = true;
         }

--- a/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
@@ -43,7 +43,7 @@ struct SetAttributeImpl : private T_ValueFunctor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>&,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -64,7 +64,7 @@ struct TemperatureImpl : private T_ValueFunctor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {
@@ -72,9 +72,15 @@ struct TemperatureImpl : private T_ValueFunctor
 
         if (!isInitialized)
         {
+            /** @todo: it is a wrong assumption that the threadIdx can be used to
+             * define the cell within the superCell. This is only allowed if we not
+             * use alpaka. We need to distinguish between manipulators those are working on the
+             * cell domain and on the particle domain.
+             */
+            const DataSpace<simDim > threadIndex(threadIdx);
             const uint32_t cellIdx = DataSpaceOperations<simDim>::map(
                                                                       localCells,
-                                                                      localCellIdx );
+                                                                      localSuperCellOffset + threadIndex );
             rng = nvrng::create(rngMethods::Xor(seed, cellIdx), rngDistributions::Normal_float());
             isInitialized = true;
         }


### PR DESCRIPTION
The first parameter for a particle manipulator is the offset to the origin of the local domain. IN the current dev it was not defined if it is the offset of the superCell or of a cell inside of a superCell. Some manipulators need the superCell offset (in cell) some a cell offset e.g. to create a global unique id.
This fix defined the offset as offset from the superCell to the origin of the local domain.

There will be a future full refactoring of the interfaces to support alpaka, therefore please ignore the new TODO within the code.

- rename `localCellIdx` to `localSuperCellOffset`
- add interface documentation
- Particles.kernel: give superCell offset to particle manipulators

tests:
- [x] KHI positrons/electrons (TSC shape) heating and charge conservation