### PR TITLE
refactor gamma calculation

### DIFF
--- a/src/picongpu/include/algorithms/Gamma.def
+++ b/src/picongpu/include/algorithms/Gamma.def
@@ -1,0 +1,84 @@
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+
+namespace picongpu
+{
+
+    /** calculate the gamma of a particle
+     *
+     * @tparam T_PrecisionType precision in which the calculation is performed
+     */
+    template< typename T_PrecisionType = float_X >
+    struct Gamma
+    {
+        using valueType = T_PrecisionType;
+
+        /** calculate the gamma of a particle
+         *
+         * @tparam T_MomType type of particle momentum
+         * @tparam T_MassType type of particle mass
+         *
+         * @param mom particle momentum
+         * @param mass particle mass
+         * @return particle gamma
+         */
+        template<
+            typename T_MomType,
+             typename T_MassType
+        >
+        HDINLINE
+        valueType
+        operator()(
+            T_MomType const & mom,
+            T_MassType const mass
+        ) const;
+
+    };
+
+    /** calculate the gamma of a particle
+     *
+     * @tparam T_PrecisionType precision in which the calculation is performed
+     * @tparam T_MomType type of particle momentum
+     * @tparam T_MassType type of particle mass
+     *
+     * @param mom particle momentum
+     * @param mass particle mass
+     * @return particle gamma
+     */
+    template<
+        typename T_PrecisionType,
+        typename T_MomType,
+        typename T_MassType
+    >
+    HDINLINE
+    T_PrecisionType
+    gamma( T_MomType const & mom, T_MassType const mass )
+    {
+        return Gamma< T_PrecisionType >{}(
+            mom,
+            mass
+        );
+    };
+
+} // namespace picongpu

--- a/src/picongpu/include/algorithms/Gamma.hpp
+++ b/src/picongpu/include/algorithms/Gamma.hpp
@@ -19,29 +19,36 @@
 
 #pragma once
 
+#include "simulation_defines.hpp"
+#include "algorithms/Gamma.def"
+
+
 namespace picongpu
 {
 
-using namespace PMacc;
-
-template<typename precisionType = float_X>
-struct Gamma
-{
-    typedef precisionType valueType;
-
-    template<typename MomType, typename MassType >
-        HDINLINE valueType operator()(const MomType mom, const MassType mass)
+    template< typename T_PrecisionType >
+    template<
+        typename T_MomType,
+        typename T_MassType
+    >
+    HDINLINE
+    T_PrecisionType
+    Gamma< T_PrecisionType >::operator()(
+        T_MomType const & mom,
+        T_MassType const mass
+    ) const
     {
-        const valueType fMom2 = math::abs2( precisionCast<valueType >( mom ) );
-        const valueType c2 = SPEED_OF_LIGHT*SPEED_OF_LIGHT;
+        using namespace PMacc;
 
-        const valueType m2_c2_reci = valueType(1.0) / precisionCast<valueType >( mass * mass * c2 );
+        valueType const fMom2 = math::abs2( precisionCast< valueType >( mom ) );
+        constexpr valueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
 
-        return math::sqrt( precisionCast<valueType >( valueType(1.0) + fMom2 * m2_c2_reci ) );
+        valueType const m2_c2_reci = valueType( 1.0 ) /
+            precisionCast<valueType >( mass * mass * c2 );
+
+        return math::sqrt(
+            precisionCast<valueType >( valueType( 1.0 ) + fMom2 * m2_c2_reci )
+        );
     }
 
-
-};
-
-}
-
+} // namespace picongpu


### PR DESCRIPTION
- add a function `gamma<>()` to calculate the gamma of a particle
- add a forward declaration for the class `Gamma<>`

This change is needed to add filter functors for radiation in a follow up.