### PR TITLE
fix missing/wrong includes

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "traits/SIBaseUnits.hpp"
 #include <vector>
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Counter.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include <vector>
 
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Density.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "traits/SIBaseUnits.hpp"
 #include <vector>
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/Energy.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "traits/SIBaseUnits.hpp"
 #include <vector>
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "traits/SIBaseUnits.hpp"
 #include <vector>
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "traits/SIBaseUnits.hpp"
 #include <vector>
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MacroCounter.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include <vector>
 
 

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "static_assert.hpp"
 #include "traits/SIBaseUnits.hpp"
 #include <vector>

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/MomentumComponent.def
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/MomentumComponent.def
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "static_assert.hpp"
 #include "traits/SIBaseUnits.hpp"
 #include <vector>

--- a/src/picongpu/include/traits/attribute/GetMass.hpp
+++ b/src/picongpu/include/traits/attribute/GetMass.hpp
@@ -21,7 +21,7 @@
 
 #include "simulation_defines.hpp"
 #include "traits/frame/GetMass.hpp"
-#include "traits/HasIdentifier.hpp"
+
 
 namespace picongpu
 {


### PR DESCRIPTION
- `derivedAttributes` remove include `pmacc_types.hpp` with `simulation_defines.hpp`
  `simulation_defines.hpp` is needed for `float_X`, `float_64`, ...
- `GetMass.hpp` remove unused include