### PR TITLE
Add Manipulator `CopyAttribute`

### DIFF
--- a/src/picongpu/include/particles/manipulators/CopyAttribute.def
+++ b/src/picongpu/include/particles/manipulators/CopyAttribute.def
@@ -1,0 +1,67 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "particles/manipulators/FreeImpl.def"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+    namespace detail
+    {
+        /**  helper functor to copy a particle source attribute to a destination attribute
+         *
+         * @tparam T_DestAttribute type of the destination attribute e.g. `momentumPrev1`
+         * @tparam T_SrcAttribute type of the source attribute e.g. `momentum`
+         */
+        template<
+            typename T_DestAttribute,
+            typename T_SrcAttribute
+        >
+        struct CopyAttributeFunctor;
+
+    } // namespace detail
+
+    /**  copy a particle source attribute to a destination attribute
+     *
+     * This is an unary functor and operates on one particle.
+     *
+     * @tparam T_DestAttribute type of the destination attribute e.g. `momentumPrev1`
+     * @tparam T_SrcAttribute type of the source attribute e.g. `momentum`
+     */
+    template<
+        typename T_DestAttribute,
+        typename T_SrcAttribute
+    >
+    using CopyAttribute = FreeImpl<
+        detail::CopyAttributeFunctor<
+            T_DestAttribute,
+            T_SrcAttribute
+        >
+    >;
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/CopyAttribute.hpp
+++ b/src/picongpu/include/particles/manipulators/CopyAttribute.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "particles/manipulators/FreeImpl.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+    namespace detail
+    {
+        template<
+            typename T_DestAttribute,
+            typename T_SrcAttribute
+        >
+        struct CopyAttributeFunctor
+        {
+            /** copy attribute
+             *
+             * @tparam T_Particle particle type
+             * @param particle particle to be manipulated
+             */
+            template< typename T_Particle >
+            DINLINE void operator()( T_Particle const & particle )
+            {
+                particle[ T_DestAttribute{} ] = particle[ T_SrcAttribute{} ];
+            }
+        };
+    } // namespace detail
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/manipulators.def
+++ b/src/picongpu/include/particles/manipulators/manipulators.def
@@ -17,9 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
-
 
 #include "particles/manipulators/IManipulator.def"
 #include "particles/manipulators/NoneImpl.def"
@@ -33,3 +31,4 @@
 #include "particles/manipulators/RandomPositionImpl.def"
 #include "particles/manipulators/DensityWeighting.def"
 #include "particles/manipulators/ProtonTimesWeighting.def"
+#include "particles/manipulators/CopyAttribute.def"

--- a/src/picongpu/include/particles/manipulators/manipulators.hpp
+++ b/src/picongpu/include/particles/manipulators/manipulators.hpp
@@ -17,7 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "particles/manipulators/IManipulator.hpp"
@@ -32,3 +31,4 @@
 #include "particles/manipulators/RandomPositionImpl.hpp"
 #include "particles/manipulators/DensityWeighting.hpp"
 #include "particles/manipulators/ProtonTimesWeighting.hpp"
+#include "particles/manipulators/CopyAttribute.hpp"


### PR DESCRIPTION
The manipulator copies one attribute of a particle to another one.

example usage:
```C++
using VectorSpeciesWithMementumPrev1 = PMacc::particles::traits::FilterByIdentifier<
    VectorAllSpecies,
    momentumPrev1
>::type;

        /* copy attribute momentum to momentumPrev1 */
        ForEach<
            VectorSpeciesWithMementumPrev1,
            particles::Manipulate<
                particles::manipulators::CopyAttribute<
                    momentumPrev1,
                    momentum
                >,
                bmpl::_1
            >
        > copyMomentumPrev1;

        copyMomentumPrev1(
            forward( particleStorage ),
            currentStep
        );
```