### PR TITLE
move functor `Manipulate` to separate file

### DIFF
--- a/src/picongpu/include/particles/InitFunctors.hpp
+++ b/src/picongpu/include/particles/InitFunctors.hpp
@@ -19,22 +19,25 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include <boost/mpl/if.hpp>
-#include "traits/HasFlag.hpp"
-#include "traits/GetFlagType.hpp"
 #include "fields/Fields.def"
-#include "math/MapTuple.hpp"
-#include <boost/mpl/plus.hpp>
-#include <boost/mpl/accumulate.hpp>
-#include <boost/mpl/apply.hpp>
-#include <boost/mpl/apply_wrap.hpp>
 #include "compileTime/conversion/TypeToPointerPair.hpp"
 #include "particles/manipulators/manipulators.def"
 #include "particles/densityProfiles/IProfile.def"
 #include "particles/startPosition/IFunctor.def"
+#include "particles/Manipulate.hpp"
+
 #include "traits/Resolve.hpp"
+#include "traits/HasFlag.hpp"
+#include "traits/GetFlagType.hpp"
+#include "math/MapTuple.hpp"
+
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/plus.hpp>
+#include <boost/mpl/accumulate.hpp>
+#include <boost/mpl/apply.hpp>
+#include <boost/mpl/apply_wrap.hpp>
+
 
 namespace picongpu
 {
@@ -150,36 +153,6 @@ struct ManipulateDeriveSpecies
 template<typename T_SrcSpeciesType, typename T_DestSpeciesType = bmpl::_1>
 struct DeriveSpecies : ManipulateDeriveSpecies<manipulators::NoneImpl, T_SrcSpeciesType, T_DestSpeciesType>
 {
-};
-
-
-/** run a user defined functor for every particle
- *
- * - constructor with current time step is called for the functor on the host side
- * - \warning `fillAllGaps()` is not called
- *
- * @tparam T_Functor unary lambda functor
- * @tparam T_SpeciesType type of the used species
- */
-template<typename T_Functor, typename T_SpeciesType = bmpl::_1>
-struct Manipulate
-{
-    typedef T_SpeciesType SpeciesType;
-    typedef typename MakeIdentifier<SpeciesType>::type SpeciesName;
-
-    typedef typename bmpl::apply1<T_Functor, SpeciesType>::type UserFunctor;
-    typedef manipulators::IManipulator<UserFunctor> Functor;
-
-    template<typename T_StorageTuple>
-    HINLINE void operator()(
-                            T_StorageTuple& tuple,
-                            const uint32_t currentStep
-                            )
-    {
-        auto speciesPtr = tuple[SpeciesName()];
-        Functor functor(currentStep);
-        speciesPtr->manipulateAllParticles(currentStep, functor);
-    }
 };
 
 

--- a/src/picongpu/include/particles/Manipulate.hpp
+++ b/src/picongpu/include/particles/Manipulate.hpp
@@ -1,0 +1,72 @@
+/* Copyright 2014-2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "particles/manipulators/manipulators.def"
+#include <boost/mpl/apply.hpp>
+
+
+namespace picongpu
+{
+namespace particles
+{
+
+    /** run a user defined functor for every particle
+     *
+     * - constructor with current time step is called for the functor on the host side
+     * - \warning `fillAllGaps()` is not called
+     *
+     * @tparam T_Functor unary lambda functor
+     * @tparam T_SpeciesType type of the used species
+     */
+    template<
+        typename T_Functor,
+        typename T_SpeciesType = bmpl::_1
+    >
+    struct Manipulate
+    {
+        using SpeciesType = T_SpeciesType;
+        using SpeciesName = typename MakeIdentifier< SpeciesType >::type;
+
+        using UserFunctor = typename bmpl::apply1<
+            T_Functor,
+            SpeciesType
+        >::type;
+        using Functor = manipulators::IManipulator< UserFunctor >;
+
+        template<typename T_StorageTuple>
+        HINLINE void
+        operator()(
+            T_StorageTuple& tuple,
+            const uint32_t currentStep
+        )
+        {
+            auto speciesPtr = tuple[ SpeciesName() ];
+            Functor functor( currentStep );
+            speciesPtr->manipulateAllParticles(
+                currentStep,
+                functor
+            );
+        }
+    };
+
+} //namespace particles
+} //namespace picongpu


### PR DESCRIPTION
- copy functor `Manipulate` from `InitFunctors.hpp` to `Manipulate.hpp`
- fix include order
- use new code style

Note: `InitFunctors.hpp` includes `Manipulate.hpp`, to keep the includes in the `speciesInitialization.param` small. All in all we should move all functors in `InitFunctors.hpp` in own files and use a collective include to include all once.