### PR TITLE
Add Manipulator `FreeRngImpl`

### DIFF
--- a/src/picongpu/include/particles/manipulators/FreeRngImpl.def
+++ b/src/picongpu/include/particles/manipulators/FreeRngImpl.def
@@ -1,0 +1,69 @@
+/* Copyright 2015-2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/mpl/placeholders.hpp>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+    /** call simple free user defined functor and provide a random number generator
+     *
+     *
+     * @tparam T_Functor user defined unary functor
+     * @tparam T_Distribution random number distribution
+     * @tparam T_SpeciesType type of the species that shall be manipulated
+     *
+     * example: add
+     *   @code{.cpp}
+     *   #include "nvidia/rng/distributions/Uniform_float.hpp"
+     *
+     *   struct RandomXFunctor
+     *   {
+     *       template< typename T_Rng, typename T_Particle >
+     *       DINLINE void operator()( T_Rng& rng, T_Particle& particle )
+     *       {
+     *           particle[ position_ ].x() = rng();
+     *       }
+     *   };
+     *
+     *   typedef FreeRngImpl<
+     *      RandomXFunctor,
+     *      nvidia::rng::distributions::Uniform_float
+     *   > RandomXPos;
+     *   particles::Manipulate< RandomXPos, SPECIES_NAME >
+     *   @endcode
+     *   to `InitPipeline` in `speciesInitialization.param`
+     */
+    template<
+        typename T_Functor,
+        typename T_Distribution,
+        typename T_SpeciesType = boost::mpl::_1
+    >
+    struct FreeRngImpl;
+
+} // namespace manipulators
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/manipulators/FreeRngImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/FreeRngImpl.hpp
@@ -1,0 +1,202 @@
+/* Copyright 2015-2017 Rene Widera, Alexander Grund
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "nvidia/rng/RNG.hpp"
+#include "nvidia/rng/methods/Xor.hpp"
+#include "mpi/SeedPerRank.hpp"
+#include "traits/GetUniqueTypeId.hpp"
+
+#include <utility>
+#include <type_traits>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+
+    template<
+        typename T_Functor,
+        typename T_Distribution,
+        typename T_SpeciesType
+    >
+    struct FreeRngImpl : private T_Functor
+    {
+
+        using Functor = T_Functor;
+        using Distribution = T_Distribution;
+        using SpeciesType = T_SpeciesType;
+        using SpeciesName = typename MakeIdentifier<SpeciesType>::type;
+
+        /** constructor
+         *
+         * This constructor is only compiled if the user functor has
+         * a host side constructor with one (uint32_t) argument.
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                      the constructor
+         * @param currentStep current simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = Functor >
+        HINLINE FreeRngImpl(
+            uint32_t currentStep,
+            typename std::enable_if<
+                std::is_constructible<
+                    DeferFunctor,
+                    uint32_t
+                >::value
+            >::type* = 0
+        ) : Functor( currentStep ), isInitialized( false )
+        {
+            hostInit( currentStep );
+        }
+
+        /** constructor
+         *
+         * This constructor is only compiled if the user functor has a default constructor.
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                      the constructor
+         * @param currentStep simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = Functor >
+        HINLINE FreeRngImpl(
+            uint32_t currentStep,
+            typename std::enable_if<
+                std::is_constructible< DeferFunctor >::value
+            >::type* = 0
+        ) : Functor( ), isInitialized( false )
+        {
+            hostInit( currentStep );
+        }
+
+        /** call user functor
+         *
+         * The random number generator is initialized with the first call.
+         *
+         * @param cell superCell index within the local volume
+         * @param unused
+         * @param isParticle1 define if the reference @p particleSpecies1 is valid
+         * @param unused
+         * @return void is used to enable the operator if the user functor except two arguments
+         */
+        template<
+            typename T_Particle1,
+            typename T_Particle2
+        >
+        DINLINE
+        void operator()(
+            DataSpace< simDim > const & localSuperCellOffset,
+            T_Particle1& particle1,
+            T_Particle2&,
+            bool const isParticle1,
+            bool const
+        )
+        {
+            namespace nvrng = nvidia::rng;
+
+            using FrameType = typename T_Particle1::FrameType;
+
+            if( !isInitialized )
+            {
+                /** @todo: it is a wrong assumption that the threadIdx can be used to
+                 * define the cell within the superCell. This is only allowed if we not
+                 * use alpaka. We need to distinguish between manipulators those are working on the
+                 * cell domain and on the particle domain.
+                 */
+                DataSpace< simDim > const threadIndex( threadIdx );
+                uint32_t const cellIdx = DataSpaceOperations< simDim >::map(
+                    localCells,
+                    localSuperCellOffset + threadIndex
+                );
+                rng = nvrng::create(
+                    nvidia::rng::methods::Xor(
+                        seed,
+                        cellIdx
+                    ),
+                    Distribution{}
+                );
+                isInitialized = true;
+            }
+
+            if( isParticle1 )
+            {
+                Functor::operator()(
+                    rng,
+                    particle1
+                );
+            }
+        }
+
+    private:
+
+        /** initialize member variables
+         *
+         * set RNG seed and calculate simulation local size
+         *
+         * @param currentStep time step of the simulation
+         */
+        HINLINE
+        void
+        hostInit( uint32_t currentStep )
+        {
+            using FrameType = typename SpeciesType::FrameType;
+
+            GlobalSeed globalSeed;
+            mpi::SeedPerRank<simDim> seedPerRank;
+            /* generate a global unique id by xor the
+             *   - gpu id `globalSeed()`
+             *   - a species id
+             *   - a fix id for this functor `FREERNG_SEED` (defined in `seed.param`)
+             */
+            seed = globalSeed() ^
+                PMacc::traits::GetUniqueTypeId<
+                    FrameType,
+                    uint32_t
+                >::uid() ^
+                FREERNG_SEED;
+            /* mixing the final seed with the current time step to avoid
+             * correlations between time steps
+             */
+            seed = seedPerRank( seed ) ^ currentStep;
+
+            SubGrid< simDim > const & subGrid = Environment< simDim >::get().SubGrid();
+            localCells = subGrid.getLocalDomain().size;
+        }
+
+        using RngType = PMacc::nvidia::rng::RNG<
+            nvidia::rng::methods::Xor,
+            Distribution
+        >;
+        RngType rng;
+        DataSpace< simDim > localCells;
+        bool isInitialized;
+        uint32_t seed;
+    };
+
+} //namespace manipulators
+} //namespace particles
+} //namespace picongpu

--- a/src/picongpu/include/particles/manipulators/manipulators.def
+++ b/src/picongpu/include/particles/manipulators/manipulators.def
@@ -32,3 +32,4 @@
 #include "particles/manipulators/DensityWeighting.def"
 #include "particles/manipulators/ProtonTimesWeighting.def"
 #include "particles/manipulators/CopyAttribute.def"
+#include "particles/manipulators/FreeRngImpl.def"

--- a/src/picongpu/include/particles/manipulators/manipulators.hpp
+++ b/src/picongpu/include/particles/manipulators/manipulators.hpp
@@ -32,3 +32,4 @@
 #include "particles/manipulators/DensityWeighting.hpp"
 #include "particles/manipulators/ProtonTimesWeighting.hpp"
 #include "particles/manipulators/CopyAttribute.hpp"
+#include "particles/manipulators/FreeRngImpl.hpp"

--- a/src/picongpu/include/simulation_defines/param/particleConfig.param
+++ b/src/picongpu/include/simulation_defines/param/particleConfig.param
@@ -32,6 +32,7 @@
 #include "particles/manipulators/manipulators.def"
 #include "nvidia/functors/Add.hpp"
 #include "nvidia/functors/Assign.hpp"
+#include "nvidia/rng/distributions/Uniform_float.hpp"
 
 
 namespace picongpu
@@ -121,6 +122,19 @@ namespace manipulators
 
     /** definition of a free particle manipulator: double weighting */
     using DoubleWeighting = FreeImpl< DoubleWeightingFunctor >;
+
+    struct RandomEnabledRadiationFunctor
+    {
+        template< typename T_Rng, typename T_Particle >
+        DINLINE void operator()( T_Rng& rng, T_Particle& particle )
+        {
+            // enable radiation for 10% of the particles
+            particle[ radiationFlag_ ] = rng() < ( 0.1 );
+        }
+    };
+
+    /* definition of RandomEnableRadiation start*/
+    typedef FreeRngImpl< RandomEnabledRadiationFunctor, nvidia::rng::distributions::Uniform_float > RandomEnabledRadiation;
 
     /** changes the in-cell position of each particle of a species */
     using RandomPosition = RandomPositionImpl<>;

--- a/src/picongpu/include/simulation_defines/param/seed.param
+++ b/src/picongpu/include/simulation_defines/param/seed.param
@@ -43,7 +43,10 @@ namespace picongpu
     /* seed for randomization of different particle attributes */
     enum Seeds
     {
-        TEMPERATURE_SEED = 255845, POSITION_SEED = 854666252, IONIZATION_SEED = 431630977
+        TEMPERATURE_SEED = 255845,
+        POSITION_SEED = 854666252,
+        IONIZATION_SEED = 431630977,
+        FREERNG_SEED = 99991
     };
 
 } /* namespace picongpu */


### PR DESCRIPTION
The manipulator calls a user defined unary functor and provide a random number generator to it.

- add a new seed `FREERNG_SEED` in `seed.param`
- `particleConfig.param` add example to random enable of radiation

This pull request also close #1420 ( random electrons with radiation can be described with this functor)

```C++
struct RandomEnabledRadiationFunctor
{
      template< typename T_Rng, typename T_Particle >
      DINLINE void operator()( T_Rng& rng, T_Particle& particle )
      {
          // enable radiation for 10% of the particles
          particle[ radiationFlag_ ] = rng() < ( 0.1 );
      }
};
/* definition of RandomEnableRadiation */
using RandomEnabledRadiation = FreeRngImpl<
    RandomEnabledRadiationFunctor,
    nvidia::rng::distributions::Uniform_float
>;
```