### PR TITLE
ReadTheDocs: Fix the Build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,4 @@
+requirements_file: docs/requirements.txt
+
+formats:
+    - htmlzip

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ PIConGPU - A Many GPGPU PIC Code
 
 [![Code Status master](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/master.svg?label=master)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
 [![Code Status dev](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/dev.svg?label=dev)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
-[![Documentation Status](https://readthedocs.org/projects/picongpu/badge/?version=latest)](http://picongpu.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/picongpu/badge/?version=master)](http://picongpu.readthedocs.io/en/latest/?badge=master)
+[![Documentation Status](https://readthedocs.org/projects/picongpu/badge/?version=dev)](http://picongpu.readthedocs.io/en/latest/?badge=dev)
 [![Language](https://img.shields.io/badge/language-C%2B%2B11-orange.svg)](https://isocpp.org/)
 [![License PIConGPU](https://img.shields.io/badge/license-GPLv3-blue.svg?label=PIConGPU)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![License PMacc](https://img.shields.io/badge/license-LGPLv3-blue.svg?label=PMacc)](https://www.gnu.org/licenses/lgpl-3.0.html)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,15 @@
 #
 import os
 import subprocess
+from recommonmark.parser import CommonMarkParser
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- General configuration ------------------------------------------------
+
+# RTD
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
@@ -31,7 +35,10 @@ import subprocess
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax', 'sphinx.ext.githubpages', 'breathe']
+extensions = ['sphinx.ext.mathjax', 'breathe']
+
+if not on_rtd:
+    extensions.append('sphinx.ext.githubpages')
 
 # breathe config
 breathe_projects = { 'PIConGPU': '../xml' }
@@ -52,8 +59,6 @@ breathe_domain_by_extension = {
 
 highlight_language = 'c++'
 
-# RTD
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
     subprocess.call('cd ..; doxygen', shell=True)
 else:
@@ -67,8 +72,11 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
+source_parsers = {
+    '.md': CommonMarkParser,
+}
+
 source_suffix = ['.rst', '.md']
-#source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/doxyindex.rst
+++ b/docs/source/doxyindex.rst
@@ -1,7 +1,9 @@
 Index of Doxygen Documentation
 ==============================
 
-.. doxygenindex::
+This command is currently taking up to 2 GB of RAM, so we can't run it on read-the-docs:
+
+  doxygenindex::
    :project: PIConGPU
    :path: '../xml'
    :outline:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ It describes the dynamics of a plasma by computing the motion of electrons and i
    :maxdepth: 2
 
    basic_usage
-   param_files
+   param
    example_cases
 
 .. toctree::

--- a/docs/source/param.rst
+++ b/docs/source/param.rst
@@ -1,0 +1,13 @@
+.param Files
+============
+
+.. toctree::
+   :caption: USAGE
+   :maxdepth: 2
+
+   param_core
+   param_memory
+   param_extensions
+   param_plugins
+   param_misc
+

--- a/docs/source/param_core.rst
+++ b/docs/source/param_core.rst
@@ -1,6 +1,3 @@
-.param Files
-============
-
 PIC Core
 --------
 
@@ -107,58 +104,3 @@ speciesInitialization.param
    :project: PIConGPU
    :path: src/picongpu/include/simulation_defines/param/speciesInitialization.param
    :no-link:
-
-Memory
-------
-
-memory.param
-^^^^^^^^^^^^
-precision.param
-^^^^^^^^^^^^^^^
-mallocMC.param
-^^^^^^^^^^^^^^
-
-PIC Extensions
---------------
-
-fieldBackground.param
-^^^^^^^^^^^^^^^^^^^^^
-
-bremsstrahlung.param
-^^^^^^^^^^^^^^^^^^^^
-synchrotronPhotons.param
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-ionizerConfig.param
-^^^^^^^^^^^^^^^^^^^
-ionizationEnergies.param
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Plugins
--------
-
-fileOutput.param
-^^^^^^^^^^^^^^^^
-isaac.param
-^^^^^^^^^^^
-particleCalorimeter.param
-^^^^^^^^^^^^^^^^^^^^^^^^^
-radiationConfig.param
-^^^^^^^^^^^^^^^^^^^^^
-radiationObserver.param
-^^^^^^^^^^^^^^^^^^^^^^^
-visualization.param
-^^^^^^^^^^^^^^^^^^^
-visColorScales.param
-^^^^^^^^^^^^^^^^^^^^
-
-Misc
-----
-
-starter.param
-^^^^^^^^^^^^^
-seed.param
-^^^^^^^^^^
-physicalConstants.param
-^^^^^^^^^^^^^^^^^^^^^^^
-

--- a/docs/source/param_extensions.rst
+++ b/docs/source/param_extensions.rst
@@ -1,0 +1,43 @@
+PIC Extensions
+--------------
+
+fieldBackground.param
+^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: fieldBackground.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/fieldBackground.param
+   :no-link:
+
+bremsstrahlung.param
+^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: bremsstrahlung.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/bremsstrahlung.param
+   :no-link:
+
+synchrotronPhotons.param
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: synchrotronPhotons.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+   :no-link:
+
+ionizerConfig.param
+^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: ionizerConfig.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/ionizerConfig.param
+   :no-link:
+
+ionizationEnergies.param
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: ionizationEnergies.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/ionizationEnergies.param
+   :no-link:
+

--- a/docs/source/param_memory.rst
+++ b/docs/source/param_memory.rst
@@ -1,0 +1,27 @@
+Memory
+------
+
+memory.param
+^^^^^^^^^^^^
+
+.. doxygenfile:: memory.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/memory.param
+   :no-link:
+
+precision.param
+^^^^^^^^^^^^^^^
+
+.. doxygenfile:: precision.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/precision.param
+   :no-link:
+
+mallocMC.param
+^^^^^^^^^^^^^^
+
+.. doxygenfile:: mallocMC.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/mallocMC.param
+   :no-link:
+

--- a/docs/source/param_misc.rst
+++ b/docs/source/param_misc.rst
@@ -1,0 +1,27 @@
+Misc
+----
+
+starter.param
+^^^^^^^^^^^^^
+
+.. doxygenfile:: starter.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/starter.param
+   :no-link:
+
+seed.param
+^^^^^^^^^^
+
+.. doxygenfile:: seed.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/seed.param
+   :no-link:
+
+physicalConstants.param
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: physicalConstants.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/physicalConstants.param
+   :no-link:
+

--- a/docs/source/param_plugins.rst
+++ b/docs/source/param_plugins.rst
@@ -1,0 +1,59 @@
+Plugins
+-------
+
+fileOutput.param
+^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: fileOutput.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/fileOutput.param
+   :no-link:
+
+isaac.param
+^^^^^^^^^^^
+
+.. doxygenfile:: isaac.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/isaac.param
+   :no-link:
+
+particleCalorimeter.param
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: particleCalorimeter.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/particleCalorimeter.param
+   :no-link:
+
+radiationConfig.param
+^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: radiationConfig.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/radiationConfig.param
+   :no-link:
+
+radiationObserver.param
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: radiationObserver.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/radiationObserver.param
+   :no-link:
+
+visualization.param
+^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: visualization.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/visualization.param
+   :no-link:
+
+visColorScales.param
+^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: visColorScales.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/visColorScales.param
+   :no-link:
+

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,0 @@
-requirements_file: docs/requirements.txt
-
-conda:
-  channels:
-    - conda-forge
-  dependencies:
-    - doxygen

--- a/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -80,13 +80,17 @@ struct MaxCudaBlockDim<DIM3>
     typedef math::CT::Size_t<8, 8, 8> type;
 };
 
-/* Check if MaxCudaBlockDim holds the cuda specification limits */
+/** Check if MaxCudaBlockDim holds the cuda specification limits
+ *
+ * @cond
+ */
 PMACC_CASSERT_MSG(_cuda_blockDim_exceeds_maximum_number_of_threads_per_block,
     math::CT::volume<typename MaxCudaBlockDim<DIM1>::type >::type::value <= cudaSpecs::maxNumThreadsPerBlock);
 PMACC_CASSERT_MSG(_cuda_blockDim_exceeds_maximum_number_of_threads_per_block,
     math::CT::volume<typename MaxCudaBlockDim<DIM2>::type >::type::value <= cudaSpecs::maxNumThreadsPerBlock);
 PMACC_CASSERT_MSG(_cuda_blockDim_exceeds_maximum_number_of_threads_per_block,
     math::CT::volume<typename MaxCudaBlockDim<DIM3>::type >::type::value <= cudaSpecs::maxNumThreadsPerBlock);
+/** @endcond */
 
 /** Return a suitable cuda blockDim for a given gridDim.
  *


### PR DESCRIPTION
This fixes the build on readthedocs:

### Fixes

- clean Up RTD Setup
  - doxygen is provided
  - include for markdown
  - github extensions is not available on rtd
- doxygen: skip parsing three static asserts that are fasely interpreted as declarations
- sphinx: the full doxygen index currently takes ~2GB ram to build which is above the 1 GB limit on RTD, so we skip it for now

### Misc

- update badges
- finish param file structure
- after merging, the build will be triggered and you can find the first doc (stubs) under http://picongpu.readthedocs.io