### PR TITLE
Docs: Core Param Files

### DIFF
--- a/src/picongpu/include/simulation_defines/param/componentsConfig.param
+++ b/src/picongpu/include/simulation_defines/param/componentsConfig.param
@@ -18,18 +18,28 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Select the laser profile and the field solver here.
+ */
 
 #pragma once
 
 
 namespace picongpu
 {
-/*! Simulation Starter ---------------------------------------------------
+/** @namespace simulation_starter
+ *
+ * Simulation Starter Selection:
+ * This value does usually not need to be changed. Change only if you want to
+ * implement your own `SimulationHelper` (e.g. `MySimulation`) class.
  *  - defaultPIConGPU         : default PIConGPU configuration
  */
 namespace simulation_starter = defaultPIConGPU;
 
-/*! Laser Configuration --------------------------------------------------
+/** @namespace laserProfile
+ *
+ * Laser Profile Selection:
  *  - laserNone             : no laser init
  *  - laserGaussianBeam     : Gaussian beam (focusing)
  *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
@@ -37,22 +47,28 @@ namespace simulation_starter = defaultPIConGPU;
  *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
  *  - laserPlaneWave        : a plane wave
  *  - laserPolynom          : a polynomial laser envelope
+ *
+ * Adjust the settings of the selected profile in laserConfig.param
  */
 namespace laserProfile = laserNone;
 
-/*! Field Configuration --------------------------------------------------
+/** @namespace fieldSolver
+ *
+ * Field Solver Selection:
  *  - fieldSolverYee : standard Yee solver
  *  - fieldSolverLehe: Num. Cherenkov free field solver in a chosen direction
  *  - fieldSolverDirSplitting: Sentoku's Directional Splitting Method
  *  - fieldSolverNone: disable the vacuum update of E and B
  *
- * * For development purposes: ---------------------------------------------
+ * For development purposes:
  *  - fieldSolverYeeNative : generic version of fieldSolverYee
  *    (need more shared memory per GPU and is slow)
+ *
+ * Adjust the settings of the selected field solver in fieldSolver.param
  */
 namespace fieldSolver = fieldSolverYee;
 
-/*enable (1) or disable (0) current calculation*/
+/** enable (1) or disable (0) current calculation (deprecated) */
 #define ENABLE_CURRENT 1
 
 }

--- a/src/picongpu/include/simulation_defines/param/densityConfig.param
+++ b/src/picongpu/include/simulation_defines/param/densityConfig.param
@@ -18,6 +18,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Configure existing or define new normalized density profiles here.
+ * During particle species creation in speciesInitialization.param,
+ * those profiles can be translated to spatial particle distributions.
+ */
+
 #pragma once
 
 #include "particles/densityProfiles/profiles.def"
@@ -38,18 +45,20 @@ namespace SI
      * unit: ELEMENTS/m^3
      */
     constexpr float_64 BASE_DENSITY_SI = 1.e25;
-}
+} // namespace SI
 
 namespace densityProfiles
 {
+    /** Profile Formula:
+     *   `const float_X exponent = abs((y - gasCenter_SI) / gasSigma_SI);`
+     *   `const float_X density = exp(gasFactor * pow(exponent, gasPower));`
+     *
+     *   takes `gasCenterLeft_SI      for y < gasCenterLeft_SI`,
+     *         `gasCenterRight_SI     for y > gasCenterRight_SI`,
+     *   and `exponent = float_X(0.0) for gasCenterLeft_SI < y < gasCenterRight_SI`
+     */
     PMACC_STRUCT(GaussianParam,
-        /** Profile Formula:
-         *   const float_X exponent = abs((y - gasCenter_SI) / gasSigma_SI);
-         *   const float_X density = exp(gasFactor * pow(exponent, gasPower));
-         *
-         *   takes `gasCenterLeft_SI      for y < gasCenterLeft_SI`,
-         *         `gasCenterRight_SI     for y > gasCenterRight_SI`,
-         *   and exponent = float_X(0.0)  for gasCenterLeft_SI < y < gasCenterRight_SI
+        /** ...
          */
         (PMACC_C_VALUE(float_X, gasFactor, -1.0))
         (PMACC_C_VALUE(float_X, gasPower, 4.0))
@@ -76,21 +85,23 @@ namespace densityProfiles
         (PMACC_C_VALUE(float_64, gasSigmaRight_SI, 4.62e-5))
     ); /* struct GaussianParam */
 
-    /* definition of density profile with gaussian profile*/
-    typedef GaussianImpl<GaussianParam> Gaussian;
+    /* definition of density profile with gaussian profile */
+    using Gaussian = GaussianImpl< GaussianParam >;
 
 
     /* definition of homogenous profile */
-    typedef HomogenousImpl Homogenous;
+    using Homogenous = HomogenousImpl;
 
 
     /** parameter for `LinearExponential` profile
      *
+     * @verbatim
      * Density Profile: /\
      *                 /  -,_
      *   linear       /      -,_    exponential
      *   slope       /  |       -,_ slope
      *                  MAX
+     * @endverbatim
      */
     PMACC_STRUCT(LinearExponentialParam,
         /** height of vacuum area on top border
@@ -130,7 +141,7 @@ namespace densityProfiles
     ); /* struct LinearExponentialParam */
 
     /* definition of gas with linear start slop and exponential end slope */
-    typedef LinearExponentialImpl<LinearExponentialParam> LinearExponential;
+    using LinearExponential = LinearExponentialImpl< LinearExponentialParam >;
 
 
     PMACC_STRUCT(GaussianCloudParam,
@@ -160,20 +171,21 @@ namespace densityProfiles
         (PMACC_C_VECTOR_DIM(float_64, simDim, sigma_SI, 7.0e-6, 7.0e-6, 7.0e-6))
     ); /* struct GaussianCloudParam */
 
-    /* definition of cloud profile*/
-    typedef GaussianCloudImpl<GaussianCloudParam> GaussianCloud;
+    /* definition of cloud profile */
+    using GaussianCloud = GaussianCloudImpl< GaussianCloudParam >;
 
 
     /** The profile consists out of the composition of 3 1D profiles
      *  with the scheme: exponential increasing flank, constant sphere,
      *                   exponential decreasing flank
+     * @verbatim
      *           ___
      *  1D:  _,./   \.,_   rho(r)
      *
      *  2D:  ..,x,..   density: . low
      *       .,xxx,.            , middle
      *       ..,x,..            x high (constant)
-     *
+     * @endverbatim
      */
     PMACC_STRUCT(SphereFlanksParam,
         /** height of vacuum area on top border
@@ -210,8 +222,8 @@ namespace densityProfiles
 
     ); /* struct SphereFlanksParam */
 
-    /* definition of sphere profile with flanks*/
-    typedef SphereFlanksImpl<SphereFlanksParam> SphereFlanks;
+    /* definition of sphere profile with flanks */
+    using SphereFlanks = SphereFlanksImpl<SphereFlanksParam>;
 
 
     PMACC_STRUCT(FromHDF5Param,
@@ -229,22 +241,25 @@ namespace densityProfiles
         (PMACC_C_VALUE(float_X, defaultDensity, 0.0))
     ); /* struct FromHDF5Param */
 
-    /* definition of cloud profile*/
-    typedef FromHDF5Impl<FromHDF5Param> FromHDF5;
+    /* definition of cloud profile */
+    using FromHDF5 = FromHDF5Impl< FromHDF5Param >;
 
 
     struct FreeFormulaFunctor
     {
-        /**
-         * This formula uses SI quantities only
-         * The profile will be multiplied by BASE_DENSITY_SI.
+        /** This formula uses SI quantities only.
+         *  The profile will be multiplied by BASE_DENSITY_SI.
          *
-         * @param position_SI total offset including all slides [in meter]
-         * @param cellSize_SI cell sizes [in meter]
+         * @param position_SI total offset including all slides [meter]
+         * @param cellSize_SI cell sizes [meter]
          *
          * @return float_X density [normalized to 1.0]
          */
-        HDINLINE float_X operator()(const floatD_64& position_SI, const float3_64& cellSize_SI)
+        HDINLINE float_X
+        operator()(
+            const floatD_64& position_SI,
+            const float3_64& cellSize_SI
+        )
         {
             const float_64 y( position_SI.y() * 1000.0 ); // m -> mm
             //const uint64_t y_cell_id( uint64_t(position_SI.y() / cellSize_SI[1]) );
@@ -253,7 +268,7 @@ namespace densityProfiles
              * for a density profile from 0 to 400 microns */
             float_64 s = 1.0 - 5.0 * math::abs(y - 0.2);
 
-            /* give it an empty/filled shape for every second cell */
+            /* give it an empty/filled striping for every second cell */
             //s *= float_64( (y_cell_id % 2) == 0 );
 
             /* all parts of the function MUST be > 0 */
@@ -263,6 +278,6 @@ namespace densityProfiles
     };
 
     /* definition of free formula profile */
-    typedef FreeFormulaImpl<FreeFormulaFunctor> FreeFormula;
-}
-}
+    using FreeFormula = FreeFormulaImpl< FreeFormulaFunctor >;
+} // namespace densityProfiles
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/dimension.param
+++ b/src/picongpu/include/simulation_defines/param/dimension.param
@@ -17,8 +17,16 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * The spatial dimensionality of the simulation.
+ */
+
 #pragma once
 
+
+/** Possible values: DIM3 for 3D3V and DIM2 for 2D3V.
+ */
 #define SIMDIM DIM3
 
 namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/fieldSolver.param
+++ b/src/picongpu/include/simulation_defines/param/fieldSolver.param
@@ -17,70 +17,72 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
-#include "fields/currentInterpolation/CurrentInterpolation.def"
-
-/**! Configure the selected field solver method
+/** @file
+ *
+ * Configure the selected field solver method
  *
  * You can set/modify Maxwell solver specific options in the
  * section of each "FieldSolver".
  *
- *
- * @typedef CurrentInterpolation
- *          is used to set a method performing the
+ * CurrentInterpolation is used to set a method performing the
  * interpolate/assign operation from the generated currents of particle
  * species to the electro-magnetic fields.
  *
  * Allowed values are:
- *   - None<simDim>:
+ *   - None< simDim >:
  *     - default for staggered grids/Yee-scheme
  *     - updates E
- *   - Binomial<simDim>: 2nd order Binomial filter
+ *   - Binomial< simDim >: 2nd order Binomial filter
  *     - smooths the current before assignment in staggered grid
  *     - updates E & breaks local charge conservation slightly
- *   - NoneDS<simDim>:
+ *   - NoneDS< simDim >:
  *     - experimental assignment for all-centered/directional splitting
  *     - updates E & B at the same time
  */
+
+#pragma once
+
+#include "fields/currentInterpolation/CurrentInterpolation.def"
+
+
 namespace picongpu
 {
     namespace fieldSolverNone
     {
-        typedef currentInterpolation::None<simDim> CurrentInterpolation;
+        using CurrentInterpolation = currentInterpolation::None< simDim >;
     }
 
     namespace fieldSolverYee
     {
-        typedef currentInterpolation::None<simDim> CurrentInterpolation;
+        using CurrentInterpolation = currentInterpolation::None< simDim >;
     }
 
     namespace fieldSolverYeeNative
     {
-        typedef currentInterpolation::None<simDim> CurrentInterpolation;
+        using CurrentInterpolation = currentInterpolation::None< simDim >;
     }
 
     namespace fieldSolverDirSplitting
     {
-        typedef currentInterpolation::NoneDS<simDim> CurrentInterpolation;
+        using CurrentInterpolation = currentInterpolation::NoneDS< simDim >;
     }
 
-    /**! Lehe Solver
+    /** Lehe Solver
      * The solver proposed by R. Lehe et al
      * in Phys. Rev. ST Accel. Beams 16, 021301 (2013)
      */
     namespace fieldSolverLehe
     {
-        class CherenkovFreeDirection_X {};
-        class CherenkovFreeDirection_Y {};
-        class CherenkovFreeDirection_Z {};
+        class CherenkovFreeDirection_X{};
+        class CherenkovFreeDirection_Y{};
+        class CherenkovFreeDirection_Z{};
 
-        /*! Distinguish the direction where numerical Cherenkov Radiation
+        /** Distinguish the direction where numerical Cherenkov Radiation
          *  by moving particles shall be suppressed.
          */
-        typedef CherenkovFreeDirection_Y CherenkovFreeDir;
+        using CherenkovFreeDir = CherenkovFreeDirection_Y;
 
-        typedef currentInterpolation::None<simDim> CurrentInterpolation;
+        using CurrentInterpolation = currentInterpolation::None< simDim >;
     }
 
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -17,13 +17,34 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+/** @file
+ *
+ * Definition of cell sizes and time step. Our cells are defining a regular,
+ * cartesian grid. Our explicit FDTD field solvers define an upper bound for
+ * the time step value in relation to the cell size for convergence. Make
+ * sure to resolve important wavelengths of your simulation, e.g. shortest
+ * plasma wavelength and central laser wavelength both spatially and
+ * temporarily.
+ *
+ * **Units in reduced dimensions**
+ *
+ * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+ * is still used for normalization of densities, etc..
+ *
+ * A 2D3V simulation in a cartesian PIC simulation such as
+ * ours only changes the degrees of freedom in motion for
+ * (macro) particles and all (field) information in z
+ * travels instantaneous, making the 2D3V simulation
+ * behave like the interaction of infinite "wire particles"
+ * in fields with perfect symmetry in Z.
+ *
+ */
 
 #pragma once
 
+
 namespace picongpu
 {
-
     namespace SI
     {
         /** Duration of one timestep
@@ -40,50 +61,42 @@ namespace picongpu
          *  unit: meter */
         constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
-        /** Note on units in reduced dimensions
-         *
-         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
-         * is still used for normalization of densities, etc.
-         *
-         * A 2D3V simulation in a cartesian PIC simulation such as
-         * ours only changes the degrees of freedom in motion for
-         * (macro) particles and all (field) information in z
-         * travels instantaneous, making the 2D3V simulation
-         * behave like the interaction of infinite "wire particles"
-         * in fields with perfect symmetry in Z.
-         */
+    } // namespace SI
 
-    } //namespace SI
-
-    //! Defines the size of the absorbing zone (in cells)
+    /** Defines the size of the absorbing zone (in cells)
+     *
+     *  unit: none
+     */
     constexpr uint32_t ABSORBER_CELLS[3][2] = {
         {32, 32},  /*x direction [negative,positive]*/
         {32, 32},  /*y direction [negative,positive]*/
         {32, 32}   /*z direction [negative,positive]*/
-    }; //unit: number of cells
+    };
 
-    //! Define the strength of the absorber for any direction
+    /** Define the strength of the absorber for any direction
+     *
+     *  unit: none
+     */
     constexpr float_X ABSORBER_STRENGTH[3][2] = {
         {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
         {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
-    }; //unit: none
+    };
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+    /** When to start moving the co-moving window
+     *
+     *  Slide point model: A virtual photon starts at t=0 at the lower end
+     *  of the global simulation box in y-direction of the simulation.
+     *  When it reaches slide_point % of the global simulation box,
      *  the co-moving window starts to move with the speed of light.
      *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
+     *  @note global simulation area: there is one additional "hidden" row
+     *        of gpus at the y-front, when you use the co-moving window.
+     *        1.0 would correspond to: start moving exactly when the above
+     *        described "virtual photon" from the lower end of the box' Y-axis
+     *        reaches the beginning of this "hidden" row of GPUs.
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 slide_point = 0.9;
 
-}
-
-
+} // namespace picongpu
 

--- a/src/picongpu/include/simulation_defines/param/laserConfig.param
+++ b/src/picongpu/include/simulation_defines/param/laserConfig.param
@@ -1,4 +1,5 @@
-/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
+ *                     Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -17,7 +18,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+/** @file
+ *
+ * Configure laser profiles.
+ */
 
 #pragma once
 
@@ -26,13 +30,12 @@ namespace picongpu
 {
     namespace laserGaussianBeam
     {
-        // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
         namespace SI
         {
             /** unit: meter */
             constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
 
-            /** UNITCONV */
+            /** Convert the normalized laser strength parameter a0 to Volt per meter */
             constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
             /** unit: W / m^2 */
@@ -41,10 +44,10 @@ namespace picongpu
             /** unit: none */
             //constexpr float_64 _A0  = 1.5;
 
-            /** unit: Volt /meter */
+            /** unit: Volt / meter */
             //constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
-            /** unit: Volt /meter */
+            /** unit: Volt / meter */
             constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
@@ -52,6 +55,7 @@ namespace picongpu
              *                                          [    2.354820045     ]
              *  Info:             FWHM_of_Intensity = FWHM_Illumination
              *                      = what a experimentalist calls "pulse duration"
+             *
              *  unit: seconds (1 sigma) */
             constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
 
@@ -60,6 +64,7 @@ namespace picongpu
              *              at the focus position of the laser
              * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
              *                             [   1.17741    ]
+             *
              *  unit: meter */
             constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
             /** the distance to the laser focus in y-direction
@@ -67,31 +72,40 @@ namespace picongpu
             constexpr float_64 FOCUS_POS_SI = 4.62e-5;
         }
         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+         *
          *  unit: none */
         constexpr float_64 PULSE_INIT = 20.0;
 
-        /* laser phase shift (no shift: 0.0) */
-        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
 
-        /* Use only the 0th Laguerremode for a standard Gaussian */
+        /** Use only the 0th Laguerremode for a standard Gaussian */
         constexpr uint32_t MODENUMBER = 0;
         PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
         /* This is just an example for a more complicated set of Laguerre modes. */
         //constexpr uint32_t MODENUMBER = 12;
         //PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321, -0.0160788);
 
+        /** Available polarisation types
+         */
         enum PolarisationType
         {
             LINEAR_X = 1u,
             LINEAR_Z = 2u,
             CIRCULAR = 4u,
         };
+        /** Polarization selection
+         */
         constexpr PolarisationType Polarisation = CIRCULAR;
     }
 
     namespace laserPulseFrontTilt
     {
-        // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
         namespace SI
         {
             /** unit: meter */
@@ -100,7 +114,7 @@ namespace picongpu
             /** UNITCONV */
             constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
 
-            /** unit: Volt /meter */
+            /** unit: Volt / meter */
             constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** Pulse length: sigma of std. gauss for intensity (E^2)
@@ -132,15 +146,24 @@ namespace picongpu
         *  unit: none */
         constexpr float_64 PULSE_INIT = 20.0;
 
-        /* laser phase shift (no shift: 0.0) */
-        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
 
+        /** Available polarisation types
+         */
         enum PolarisationType
         {
             LINEAR_X = 1u,
             LINEAR_Z = 2u,
-            CIRCULAR = 4u
+            CIRCULAR = 4u,
         };
+        /** Polarization selection
+         */
         constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
@@ -186,15 +209,24 @@ namespace picongpu
          *  unit: none */
         constexpr float_64 RAMP_INIT = 20.6146;
 
-        /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
 
+        /** Available polarisation types
+         */
         enum PolarisationType
         {
             LINEAR_X = 1u,
             LINEAR_Z = 2u,
             CIRCULAR = 4u,
         };
+        /** Polarization selection
+         */
         constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
@@ -246,21 +278,30 @@ namespace picongpu
         constexpr float_64 W0_Z_SI = W0_X_SI;
 
     }
-    /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
-    and half at the end of the plateau
-     *  unit: none */
-    constexpr float_64 RAMP_INIT = 20.0;
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+        and half at the end of the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 20.0;
 
-    /* we use a sin(omega*time + laser_phase) function to set up the laser - define phase: */
-    constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
 
-    enum PolarisationType
-    {
-        LINEAR_X = 1u,
-        LINEAR_Z = 2u,
-        CIRCULAR = 4u,
-    };
-    constexpr PolarisationType Polarisation = LINEAR_X;
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
     }
 
 
@@ -304,8 +345,13 @@ namespace picongpu
             constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
         }
 
-        /* we use a sin(omega*(time-riseTime) + laser_phase) function to set up the laser - define phase: */
-        constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
     }
 
     namespace laserNone
@@ -323,6 +369,3 @@ namespace picongpu
     }
 
 }
-
-
-

--- a/src/picongpu/include/simulation_defines/param/particleConfig.param
+++ b/src/picongpu/include/simulation_defines/param/particleConfig.param
@@ -18,7 +18,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+/** @file
+ *
+ * Configurations for particle manipulators. Set up and declare functors that
+ * can be used in speciesInitalization.param for particle species
+ * initialization and manipulation, such as temperature distributions, drifts,
+ * pre-ionization and in-cell position.
+ */
 
 #pragma once
 
@@ -27,31 +33,47 @@
 #include "nvidia/functors/Add.hpp"
 #include "nvidia/functors/Assign.hpp"
 
+
 namespace picongpu
 {
-
 namespace particles
 {
 
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
+     *
      *  unit: none */
     constexpr float_X MIN_WEIGHTING = 10.0;
 
+    /** Number of maximum particles per cell during density profile evaluation.
+     *
+     * Determines the weighting of a macro particle and with it, the number of
+     * particles "sampling" dynamics in phase space.
+     */
     constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 2;
 
 namespace manipulators
 {
 
+    /** Parameter for DriftParam
+     */
     CONST_VECTOR(float_X,3,DriftParam_direction,1.0,0.0,0.0);
+    /** Parameter for a particle drift assignment
+     */
     struct DriftParam
     {
         static constexpr float_64 gamma = 1.0;
         const DriftParam_direction_t direction;
     };
-    /* definition of SetDrift start*/
-    typedef DriftImpl<DriftParam,nvidia::functors::Assign> AssignXDrift;
+    /** definition of manipulator that assigns a dirft in X */
+    using AssignXDrift = DriftImpl<
+        DriftParam,
+        nvidia::functors::Assign
+    >;
 
+
+    /** Parameter for a temperature assignment
+     */
     struct TemperatureParam
     {
         /*Initial temperature
@@ -59,10 +81,15 @@ namespace manipulators
          */
         static constexpr float_64 temperature = 0.0;
     };
-    /* definition of SetDrift start*/
-    typedef TemperatureImpl<TemperatureParam,nvidia::functors::Add> AddTemperature;
+    /* definition a temperature assignment manipulator */
+    using AddTemperature = TemperatureImpl<
+        TemperatureParam,
+        nvidia::functors::Add
+    >;
 
 
+    /** Parameters for an assignment in a relative position selection
+     */
     struct IfRelativeGlobalPositionParam
     {
         /* lowerBound is included in the range*/
@@ -74,25 +101,31 @@ namespace manipulators
          */
         static constexpr uint32_t dimension = 0;
     };
-    /* definition of SetDrift start*/
-    typedef IfRelativeGlobalPositionImpl<IfRelativeGlobalPositionParam,AssignXDrift> AssignXDriftToLowerHalfXPosition;
+    /** definition of a relative position selection that assigns a drift in X
+     */
+    using AssignXDriftToLowerHalfXPosition = IfRelativeGlobalPositionImpl<
+        IfRelativeGlobalPositionParam,
+        AssignXDrift
+    >;
 
+    /** Unary particle manipulator: double each weighting
+     */
     struct DoubleWeightingFunctor
     {
-        template<typename T_Particle>
-        DINLINE void operator()(T_Particle& particle)
+        template< typename T_Particle >
+        DINLINE void operator()( T_Particle& particle )
         {
-            particle[weighting_]*=float_X(2.0);
+            particle[weighting_] *= float_X(2.0);
         }
     };
 
-    /* definition of SetDrift start*/
-    typedef FreeImpl<DoubleWeightingFunctor> DoubleWeighting;
+    /** definition of a free particle manipulator: double weighting */
+    using DoubleWeighting = FreeImpl< DoubleWeightingFunctor >;
 
-    /**  changes the in-cell position of each particle of a species*/
-    typedef RandomPositionImpl<> RandomPosition;
+    /** changes the in-cell position of each particle of a species */
+    using RandomPosition = RandomPositionImpl<>;
 
-} //namespace manipulators
+} // namespace manipulators
 
 
 namespace startPosition
@@ -101,23 +134,32 @@ namespace startPosition
     struct RandomParameter
     {
         /** Count of particles per cell at initial state
+         *
          *  unit: none */
         static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
     };
-    /* definition of random particle start */
-    typedef RandomImpl<RandomParameter> Random;
+    /** definition of random particle start */
+    using Random = RandomImpl< RandomParameter >;
 
     struct QuietParam
     {
         /** Count of particles per cell per direction at initial state
+         *
          *  unit: none */
-       typedef mCT::shrinkTo<mCT::Int<1, TYPICAL_PARTICLES_PER_CELL, 1>, simDim>::type numParticlesPerDimension;
+        using numParticlesPerDimension = mCT::shrinkTo<
+            mCT::Int<
+                1,
+                TYPICAL_PARTICLES_PER_CELL,
+                1
+                >,
+            simDim
+        >::type;
     };
 
-    /* definition of quiet particle start */
-    typedef QuietImpl<QuietParam> Quiet;
+    /** definition of quiet particle start */
+    using Quiet = QuietImpl< QuietParam >;
 
-    /* sit directly in lower corner of the cell */
+    /** sit directly in lower corner of the cell */
     CONST_VECTOR(
         float_X,
         3,
@@ -130,16 +172,16 @@ namespace startPosition
     struct OnePositionParameter
     {
         /** Count of particles per cell at initial state
+         *
          *  unit: none */
         static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
 
         const InCellOffset_t inCellOffset;
     };
 
-    /* definition of one specific position for particle start */
+    /** definition of one specific position for particle start */
     using OnePosition = OnePositionImpl< OnePositionParameter >;
 
-} //namespace startPosition
-} //namespace particles
-
-} //namespac picongpu
+} // namespace startPosition
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/pusherConfig.param
+++ b/src/picongpu/include/simulation_defines/param/pusherConfig.param
@@ -17,11 +17,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**! @file pusherConfig.param
+/** @file
  *
- * describe particle pusher method
- * Define a solver for current with the name "Pusher"
- * etc.: typedef MyOwnPusherClass ParticlePusher;
+ * Configure particle pushers. Those pushers can then be selected by
+ * a particle species in species.param and speciesDefinition.param
  */
 
 #pragma once
@@ -29,7 +28,6 @@
 
 namespace picongpu
 {
-
     namespace particlePusherVay
     {
         /** Precision of the square roots during the push step
@@ -65,6 +63,6 @@ namespace picongpu
         struct Axel;
 #endif
     } // namespace pusher
-    } // namespace partciles
+    } // namespace particles
 
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -17,7 +17,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+/** @file
+ *
+ * Forward declarations for speciesDefinition.param in case one wants to use
+ * the same particle shape, interpolation, current solver and particle pusher
+ * for all particle species.
+ */
 
 #pragma once
 
@@ -32,41 +37,44 @@
 #include "particles/manipulators/manipulators.def"
 
 
-/*enable (1) or disable (0) electrons*/
+/** enable (1) or disable (0) electrons (deprecated) */
 #define ENABLE_ELECTRONS 1
-/*enable (1) or disable (0) ions*/
+/** enable (1) or disable (0) ions (deprecated) */
 #define ENABLE_IONS 1
 
 
 namespace picongpu
 {
-/*---------------------------- generic solver---------------------------------*/
 
-/*! Particle Shape definitions -------------------------------------------------
+/** Particle Shape definitions
  *  - particles::shapes::CIC : 1st order
  *  - particles::shapes::TSC : 2nd order
  *  - particles::shapes::PCS : 3rd order
  *  - particles::shapes::P4S : 4th order
  *
- *  example:             typedef particles::shapes::CIC CICShape;
+ *  example:             using CICShape = particles::shapes::CIC;
  */
-typedef particles::shapes::TSC UsedParticleShape;
+using UsedParticleShape = particles::shapes::TSC;
 
-/* define which interpolation method is used to interpolate fields to particle*/
-typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
+/** define which interpolation method is used to interpolate fields to particles
+ */
+using UsedField2Particle = FieldToParticleInterpolation<
+    UsedParticleShape,
+    AssignedTrilinearInterpolation
+>;
 
-/*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
- * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
+/** select current solver method
+ * - currentSolver::Esirkepov< SHAPE > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune<>        : particle shapes - CIC (1st order) only
  *
- * For development purposes: ---------------------------------------------------
- * - currentSolver::currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
+ * For development purposes:
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE > : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
- * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::ZigZag< SHAPE >    : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
 
-/*! particle pusher configuration ----------------------------------------------
+/** particle pusher configuration
  *
  * Define a pusher is optional for particles
  *
@@ -75,12 +83,12 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
  *
- * For development purposes: ---------------------------------------------------
+ * For development purposes:
  * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  * - particles::pusher::Free : free propagation, ignore fields
  * (= free stream model)
  * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
-typedef particles::pusher::Boris UsedParticlePusher;
+using UsedParticlePusher = particles::pusher::Boris;
 
-}//namespace picongpu
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -17,6 +17,19 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * This file defines available attributes that can be stored with each particle
+ * of a particle species.
+ * Each attribute defined here needs to implement furthermore the traits
+ *   - Unit
+ *   - UnitDimension
+ *   - WeightingPower
+ *   - MacroWeighted
+ * in speciesAttributes.unitless for further information about these
+ * traits see therein.
+ */
+
 #pragma once
 
 #include "simulation_defines.hpp"
@@ -29,18 +42,6 @@
 #include "particles/IdProvider.def"
 
 
-/** \file speciesAttributes.param
- *
- * This file defines available attributes that can be stored with each particle
- * of a particle species.
- * Each attribute defined here needs to implement furthermore the traits
- *   - Unit
- *   - UnitDimension
- *   - WeightingPower
- *   - MacroWeighted
- * in \see speciesAttributes.unitless . For further information about these
- * traits see therein.
- */
 namespace picongpu
 {
 

--- a/src/picongpu/include/simulation_defines/param/speciesConstants.param
+++ b/src/picongpu/include/simulation_defines/param/speciesConstants.param
@@ -17,33 +17,50 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+/** @file
+ *
+ * Constants and thresholds for particle species.
+ *
+ * Defines the reference mass and reference charge to express species
+ * with (default: electrons with negative charge).
+ */
 
 #pragma once
 
+
 namespace picongpu
 {
-    /** Threshold used for calculations that want to separate between
-     *  high-precision formulas for relativistic and non-relativistic
-     *  use-cases, e.g. energy-binning algorithms. */
+    /** Threshold between relativistic and non-relativistic regime
+     *
+     * Threshold used for calculations that want to separate between
+     * high-precision formulas for relativistic and non-relativistic
+     * use-cases, e.g. energy-binning algorithms.
+     */
     constexpr float_X GAMMA_THRESH = float_X(1.005);
 
-    /** This limit is used to decide between a pure 1-sqrt(1-x) calculation
-     *  and a 5th order Taylor approximation of 1-sqrt(1-x) to avoid halving
-     *  of significant digits due to the sqrt() evaluation at x = 1/gamma^2 near 0.0.
-     *  With 0.18 the relative error between Taylor approximation and real value
-     *  will be below 0.001% = 1e-5 * for x=1/gamma^2 < 0.18 */
+    /** Threshold in radiation plugin between relativistic and non-relativistic regime
+     *
+     * This limit is used to decide between a pure 1-sqrt(1-x) calculation
+     * and a 5th order Taylor approximation of 1-sqrt(1-x) to avoid halving
+     * of significant digits due to the sqrt() evaluation at x = 1/gamma^2 near 0.0.
+     * With 0.18 the relative error between Taylor approximation and real value
+     * will be below 0.001% = 1e-5 * for x=1/gamma^2 < 0.18
+     */
     constexpr float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
 
     namespace SI
     {
         /** base particle mass
          *
+         * reference for massRatio in speciesDefinition.param
+         *
          * unit: kg
          */
         constexpr float_64 BASE_MASS_SI = ELECTRON_MASS_SI;
 
         /** base particle charge
+         *
+         * reference for chargeRatio in speciesDefinition.param
          *
          * unit: C
          */

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -17,7 +17,18 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+/** @file
+ *
+ * Define particle species.
+ *
+ * This file collects all previous declarations of base (reference) quantities
+ * and configured solvers for species and defines particle species. This
+ * includes "attributes" (lvalues to store with each species) and "flags"
+ * (rvalues & aliases for solvers to perform with the species for each timestep
+ * and ratios to base quantities). With those information, a `Particles` class
+ * is defined for each species and then collected in the list
+ * `VectorAllSpecies`.
+ */
 
 #pragma once
 
@@ -31,6 +42,7 @@
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
+
 
 namespace picongpu
 {
@@ -144,6 +156,11 @@ using Species2 = MakeSeq_t<
 #endif
 >;
 
+/** All known particle species of the simulation
+ *
+ * List all defined particle species from above in this list
+ * to make them available to the PIC algorithm.
+ */
 using VectorAllSpecies = MakeSeq_t<
     Species1,
     Species2
@@ -152,4 +169,4 @@ using VectorAllSpecies = MakeSeq_t<
 #endif
 >;
 
-} //namespace picongpu
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/speciesInitialization.param
+++ b/src/picongpu/include/simulation_defines/param/speciesInitialization.param
@@ -17,16 +17,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
-#include "particles/InitFunctors.hpp"
-
-namespace picongpu
-{
-namespace particles
-{
-
-/* Available species functors
+/** @file
+ *
+ * Available species functors
  *   in src/picongpu/include/particles/InitFunctors.hpp
  *
  * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
@@ -77,11 +70,21 @@ namespace particles
  *     afterward to create a valid data structure.
  */
 
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-typedef mpl::vector<> InitPipeline;
+#pragma once
 
-} /* namespace particles */
-} /* namespace picongpu  */
+#include "particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+
+    /** InitPipeline defines in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<>;
+
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
Adds file descriptions and fixed doxygen strings to all `.param` input files that define the "core" particle-in-cell algorithm in PIConGPU. Fixed and added missing descriptions for our sphinx+breathe+doxygen [online docs](http://picongpu.readthedocs.io).

Since there have been questions resently between the scope of "default" files in `src/picongpu/include/simulation_defines/param/` and "specific" files in `examples/` here is a short summary.

`src/picongpu/include/simulation_defines/param/`:
- general point of reference for functionality
- must describe all available options
- define a basic EM PIC cycle without domain specific parts
  (no lasers, no plugins, no fancy solvers, ...)
- do NOT need to explain complex combinations of the above

`examples/`:
- shall cover options and extensions for our compile/test suite
- define a specific case with the necessary complexity
- **minimal**: only add files and configs that differ from the defaults
- **minimal**: no need to copy all doc strings of already described methods but need to describe extensively what the example is used for and how it is set up with the methods PIConGPU provides (e.g. needs a custom manipulator (docstrings!), requires its own `SimulationHelper` (docstrings!), needs a Photon species, needs certain additional settings in memory or plugin param files, etc.)

ccing @n01r @PrometheusPi @Heikman 