### PR TITLE
Oxygen: Fix neutron number

### DIFF
--- a/src/picongpu/include/simulation_defines/param/ionizerConfig.param
+++ b/src/picongpu/include/simulation_defines/param/ionizerConfig.param
@@ -106,7 +106,7 @@ namespace atomicNumbers
     struct Oxygen_t
     {
         static constexpr float_X numberOfProtons  = 8.0;
-        static constexpr float_X numberOfNeutrons = 16.0;
+        static constexpr float_X numberOfNeutrons = 8.0;
     };
 
     /** Al-27 ~100% NA */


### PR DESCRIPTION
Follow up to #1855: Fix typo in `atomicNumbers` of `Oxygen`. Thx to @n01r for the review!