### PR TITLE
fix `CopyAttribute`

### DIFF
--- a/src/picongpu/include/particles/manipulators/CopyAttribute.hpp
+++ b/src/picongpu/include/particles/manipulators/CopyAttribute.hpp
@@ -44,7 +44,7 @@ namespace manipulators
              * @param particle particle to be manipulated
              */
             template< typename T_Particle >
-            DINLINE void operator()( T_Particle const & particle )
+            DINLINE void operator()( T_Particle & particle )
             {
                 particle[ T_DestAttribute{} ] = particle[ T_SrcAttribute{} ];
             }


### PR DESCRIPTION
fix that a attribute of a constant(read only) particle is changed

Bug was introduced with #1861 and results in a compile time bug if `CopyAttribute` is used.