### PR TITLE
MySimulation: Remove particleStorage

### DIFF
--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -149,20 +149,22 @@ private:
     FieldB *fieldB;
 };
 
-template<typename T_SpeciesName, typename T_Area>
+template<typename T_SpeciesType, typename T_Area>
 struct ComputeCurrent
 {
+    using SpeciesType = T_SpeciesType;
+    using FrameType = typename SpeciesType::FrameType;
 
-    template<typename T_StorageTuple>
-    HINLINE void operator()( FieldJ* fieldJ,
-                            T_StorageTuple& tuple,
-                            const uint32_t currentStep) const
+    HINLINE void operator()( const uint32_t currentStep ) const
     {
-        typedef T_SpeciesName SpeciesName;
-        typedef typename SpeciesName::type SpeciesType;
+        DataConnector &dc = Environment<>::get().DataConnector();
+        auto species = dc.get< SpeciesType >( FrameType::getName(), true );
+        auto fieldJ = dc.get< FieldJ >( FieldJ::getName(), true );
 
-        auto speciesPtr = tuple[SpeciesName()];
-        fieldJ->computeCurrent<T_Area::value, SpeciesType> (*speciesPtr, currentStep);
+        fieldJ->computeCurrent< T_Area::value, SpeciesType >( *species, currentStep );
+
+        dc.releaseData( FrameType::getName() );
+        dc.releaseData( FieldJ::getName() );
     }
 };
 

--- a/src/picongpu/include/particles/Manipulate.hpp
+++ b/src/picongpu/include/particles/Manipulate.hpp
@@ -21,6 +21,9 @@
 
 #include "simulation_defines.hpp"
 #include "particles/manipulators/manipulators.def"
+
+#include "Environment.hpp"
+
 #include <boost/mpl/apply.hpp>
 
 
@@ -44,7 +47,7 @@ namespace particles
     struct Manipulate
     {
         using SpeciesType = T_SpeciesType;
-        using SpeciesName = typename MakeIdentifier< SpeciesType >::type;
+        using FrameType = typename SpeciesType::FrameType;
 
         using UserFunctor = typename bmpl::apply1<
             T_Functor,
@@ -52,19 +55,19 @@ namespace particles
         >::type;
         using Functor = manipulators::IManipulator< UserFunctor >;
 
-        template<typename T_StorageTuple>
         HINLINE void
-        operator()(
-            T_StorageTuple& tuple,
-            const uint32_t currentStep
-        )
+        operator()( const uint32_t currentStep )
         {
-            auto speciesPtr = tuple[ SpeciesName() ];
+            DataConnector &dc = Environment<>::get().DataConnector();
+            auto speciesPtr = dc.get< SpeciesType >( FrameType::getName(), true );
+
             Functor functor( currentStep );
             speciesPtr->manipulateAllParticles(
                 currentStep,
                 functor
             );
+
+            dc.releaseData( FrameType::getName() );
         }
     };
 

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -82,7 +82,7 @@ public:
 
     void createParticleBuffer();
 
-    void init(FieldE &fieldE, FieldB &fieldB);
+    void init();
 
     void update(uint32_t currentStep);
 


### PR DESCRIPTION
Remove the `particleStorage` member tuple from `MySimulation`. Access to singleton species memory can now be done via the the PMacc `DataConnector` in all places, reducing interface complexity dramatically.

`Particle` class: external DataConnector registration.

KHI RT test was successful.