### PR TITLE
Freedom for Fields (& Species)

### DIFF
--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -80,12 +80,17 @@ public:
 
         using namespace ::PMacc::math;
 
+        DataConnector &dc = Environment<>::get().DataConnector();
+        auto fieldE = dc.get< FieldE >( FieldE::getName(), true );
+
         auto fieldE_coreBorder =
-             this->fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
+             fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
                    precisionCast<int>(GuardDim().toRT()), -precisionCast<int>(GuardDim().toRT()));
 
         this->eField_zt[0] = new container::HostBuffer<float, 2 > (Size_t < 2 > (fieldE_coreBorder.size().z(), this->collectTimesteps));
         this->eField_zt[1] = new container::HostBuffer<float, 2 >(this->eField_zt[0]->size());
+
+        dc.releaseData( FieldE::getName() );
     }
 
     void pluginRegisterHelp(po::options_description& desc)
@@ -166,8 +171,11 @@ public:
 
         using namespace math;
 
+        DataConnector &dc = Environment<>::get().DataConnector();
+        auto fieldE = dc.get< FieldE >( FieldE::getName(), true );
+
         auto fieldE_coreBorder =
-           this->fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
+           fieldE->getGridBuffer().getDeviceBuffer().cartBuffer().view(
                 precisionCast<int>(GuardDim().toRT()), -precisionCast<int>(GuardDim().toRT()));
 
         for (size_t z = 0; z < eField_zt[0]->size().x(); z++)
@@ -183,6 +191,8 @@ public:
                          nvidia::functors::Add());
             }
         }
+
+        dc.releaseData( FieldE::getName() );
 
         if (currentStep == this->collectTimesteps + firstTimestep)
             writeOutput();

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -63,19 +63,6 @@ struct AssignNull
 };
 
 template<typename T_SpeciesType>
-struct CallDelete
-{
-    using SpeciesType = T_SpeciesType;
-    using FrameType = typename SpeciesType::FrameType;
-
-    void operator()()
-    {
-        DataConnector &dc = Environment<>::get().DataConnector();
-        dc.unshare( FrameType::getName() );
-    }
-};
-
-template<typename T_SpeciesType>
 struct CreateSpecies
 {
     using SpeciesType = T_SpeciesType;


### PR DESCRIPTION
Remove fields and species from `MySimulation` member lists.

> *"We [open data activists] do not want to emancipate the [data], we want the [data] to emancipate themselves.”*
> -- Errico Malatesta

This simplifies the `MySimulation` interface to allow easier overloading and re-implementing of parts of it (like runOneStep) without the need to manage too many members. This becomes especially helpful if one tries to reimplement the `MySimulation` class in Python to *hack the PIC cycle*.

> *"[DataConnector] could never get a man to the moon, but it may the only mode that can allow us to survive on earth."*
> -- Sheldon B. Kopp

Global singleton classes like E, B, J, FieldTmp slots, species are only created via functors once and then shared with `DataConnector`. All algorithms accessing those can then query (`dc.get( ... )`) for reads & manipulation.

> *"The [authors of DataConnector] never have claimed that liberty [of data] will bring perfection; they simply say that its results are vastly preferable to those that follow [a one-class has to own all gobal data structures] authority."*
> -- Benjamin Tucker

- [x] rebase: depends on #1886