### PR TITLE
PMacc environment refactoring

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/main.cu
+++ b/src/libPMacc/examples/gameOfLife2D/main.cu
@@ -19,17 +19,16 @@
  */
 
 #include "types.hpp"
-#include <iostream>
+#include "Environment.hpp"
+#include "Simulation.hpp"
 
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/cmdline.hpp>
 #include <boost/program_options/variables_map.hpp>
 
-#include "Simulation.hpp"
+#include <iostream>
 
-#include <mpi.h>
-#include "communication/manager_common.hpp"
 
 namespace po = boost::program_options;
 
@@ -40,9 +39,6 @@ namespace po = boost::program_options;
  */
 int main( int argc, char **argv )
 {
-
-    MPI_CHECK( MPI_Init( &argc, &argv ) );
-
     typedef ::gol::Space Space;
 
     std::vector<uint32_t> devices;  /* will be set by boost program argument option "-d 3 3 3" */
@@ -74,7 +70,6 @@ int main( int argc, char **argv )
     /* print help message and quit simulation */
     if ( vm.count( "help" ) )
     {
-        MPI_CHECK( MPI_Finalize( ) );
         std::cerr << desc << "\n";
         return false;
     }
@@ -138,6 +133,8 @@ int main( int argc, char **argv )
     sim.start( );
     sim.finalize( );
 
-    MPI_CHECK( MPI_Finalize( ) );
+    /* finalize the PMacc context */
+    PMacc::Environment<>::get().finalize();
+
     return 0;
 }

--- a/src/libPMacc/include/Environment.def
+++ b/src/libPMacc/include/Environment.def
@@ -21,9 +21,16 @@
 
 #pragma once
 
+#include "pmacc_types.hpp"
+
 namespace PMacc {
 
-    template <unsigned DIM = DIM1>
+    template< uint32_t T_dim = DIM1 >
     class Environment;
 
-}  // namespace PMacc
+namespace detail
+{
+    struct Environment;
+
+} // namespace detail
+} // namespace PMacc

--- a/src/libPMacc/include/Environment.hpp
+++ b/src/libPMacc/include/Environment.hpp
@@ -36,129 +36,369 @@
 #include "mappings/simulation/Filesystem.hpp"
 #include "eventSystem/events/EventPool.hpp"
 #include "Environment.def"
+#include "communication/manager_common.hpp"
+#include "assert.hpp"
 
 #include <cuda_runtime.h>
+#include <mpi.h>
 
 namespace PMacc
 {
 
-/**
- * Global Environment singleton for Picongpu
- */
+namespace detail
+{
+    /** collect state variables of the environment context
+     *
+     * This class handle the initialization and finalize of the
+     * MPI context and the selection of the GPU.
+     */
+    class EnvironmentContext
+    {
 
-template <unsigned DIM>
-class Environment
+        friend Environment;
+
+        friend PMacc::Environment<DIM1>;
+        friend PMacc::Environment<DIM2>;
+        friend PMacc::Environment<DIM3>;
+
+        EnvironmentContext( ) :
+            m_isMpiInitialized( false ),
+            m_isDeviceSelected( false ),
+            m_isSubGridDefined( false )
+        {
+        }
+
+        /** initialization state of MPI */
+        bool m_isMpiInitialized;
+
+        /** state if a computing device is selected */
+        bool m_isDeviceSelected;
+
+        /** state if the SubGrid is defined */
+        bool m_isSubGridDefined;
+
+        /** get the singleton EnvironmentContext
+         *
+         * @return instance of EnvironmentContext
+         */
+        static EnvironmentContext& getInstance()
+        {
+            static EnvironmentContext instance;
+            return instance;
+        }
+
+        /** state of the MPI context
+         *
+         * @return true if MPI is initialized else false
+         */
+        bool isMpiInitialized()
+        {
+            return m_isMpiInitialized;
+        }
+
+        /** is a computing device selected
+         *
+         * @return true if device is selected else false
+         */
+        bool isDeviceSelected()
+        {
+            return m_isDeviceSelected;
+        }
+
+        /** is the SubGrid defined
+         *
+         * @return true if SubGrid is defined, else false
+         */
+        bool isSubGridDefined()
+        {
+            return m_isSubGridDefined;
+        }
+
+        /** initialize the environment
+         *
+         * After this call it is allowed to use MPI.
+         */
+        void init();
+
+        /** cleanup the environment */
+        void finalize();
+
+        /** select a computing device
+         *
+         * After this call it is allowed to use the computing device.
+         *
+         * @param deviceNumber number of the device
+         */
+        void setDevice(int deviceNumber);
+
+    };
+
+    /** PMacc environment
+     *
+     * Get access to all PMacc singleton classes those not depend on a dimension.
+     */
+    struct Environment
+    {
+        Environment()
+        {
+        }
+
+        /** cleanup the environment */
+        void finalize()
+        {
+            EnvironmentContext::getInstance().finalize();
+        }
+
+        /** get the singleton StreamController
+         *
+         * @return instance of StreamController
+         */
+        PMacc::StreamController& StreamController()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!"
+            );
+            return StreamController::getInstance();
+        }
+
+        /** get the singleton Manager
+         *
+         * @return instance of Manager
+         */
+        PMacc::Manager& Manager()
+        {
+            return Manager::getInstance();
+        }
+
+        /** get the singleton TransactionManager
+         *
+         * @return instance of TransactionManager
+         */
+        PMacc::TransactionManager& TransactionManager() const
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!"
+            );
+            return TransactionManager::getInstance();
+        }
+
+        /** get the singleton EnvironmentController
+         *
+         * @return instance of EnvironmentController
+         */
+        PMacc::EnvironmentController& EnvironmentController()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isMpiInitialized(),
+                "Environment< DIM >::initDevices() must be called before this method!"
+            );
+            return EnvironmentController::getInstance();
+        }
+
+        /** get the singleton Factory
+         *
+         * @return instance of Factory
+         */
+        PMacc::Factory& Factory()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isMpiInitialized() &&
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!"
+            );
+            return Factory::getInstance();
+        }
+
+        /** get the singleton EventPool
+         *
+         * @return instance of EventPool
+         */
+        PMacc::EventPool& EventPool()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!"
+            );
+            return EventPool::getInstance();
+        }
+
+        /** get the singleton ParticleFactory
+         *
+         * @return instance of ParticleFactory
+         */
+        PMacc::ParticleFactory& ParticleFactory()
+        {
+            return ParticleFactory::getInstance();
+        }
+
+        /** get the singleton DataConnector
+         *
+         * @return instance of DataConnector
+         */
+        PMacc::DataConnector& DataConnector()
+        {
+            return DataConnector::getInstance();
+        }
+
+        /** get the singleton PluginConnector
+         *
+         * @return instance of PluginConnector
+         */
+        PMacc::PluginConnector& PluginConnector()
+        {
+            return PluginConnector::getInstance();
+        }
+
+        /** get the singleton MemoryInfo
+         *
+         * @return instance of MemoryInfo
+         */
+        nvidia::memory::MemoryInfo& MemoryInfo()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!"
+            );
+            return nvidia::memory::MemoryInfo::getInstance();
+        }
+
+        /** get the singleton SimulationDescription
+         *
+         * @return instance of SimulationDescription
+         */
+        simulationControl::SimulationDescription& SimulationDescription()
+        {
+            return simulationControl::SimulationDescription::getInstance();
+        }
+    };
+} // namespace detail
+
+/** Global Environment singleton for PMacc
+ */
+template< uint32_t T_dim >
+class Environment : public detail::Environment
 {
 public:
 
-    PMacc::GridController<DIM>& GridController()
+    /** get the singleton GridController
+     *
+     * @return instance of GridController
+     */
+    PMacc::GridController< T_dim >& GridController()
     {
-        return PMacc::GridController<DIM>::getInstance();
+        PMACC_ASSERT_MSG(
+            detail::EnvironmentContext::getInstance().isMpiInitialized(),
+            "Environment< DIM >::initDevices() must be called before this method!"
+        );
+        return PMacc::GridController< T_dim >::getInstance();
     }
 
-    PMacc::StreamController& StreamController()
+    /** get the singleton SubGrid
+     *
+     * @return instance of SubGrid
+     */
+    PMacc::SubGrid< T_dim >& SubGrid()
     {
-        return StreamController::getInstance();
+        PMACC_ASSERT_MSG(
+            detail::EnvironmentContext::getInstance().isSubGridDefined(),
+            "Environment< DIM >::initGrids() must be called before this method!"
+        );
+        return PMacc::SubGrid< T_dim >::getInstance();
     }
 
-    PMacc::Manager& Manager()
+    /** get the singleton Filesystem
+     *
+     * @return instance of Filesystem
+     */
+    PMacc::Filesystem< T_dim >& Filesystem()
     {
-        return Manager::getInstance();
+        return PMacc::Filesystem< T_dim >::getInstance();
     }
 
-    PMacc::TransactionManager& TransactionManager() const
+    /** get the singleton Environment< DIM >
+     *
+     * @return instance of Environment<DIM >
+     */
+    static Environment< T_dim >& get()
     {
-        return TransactionManager::getInstance();
-    }
-
-    PMacc::SubGrid<DIM>& SubGrid()
-    {
-        return PMacc::SubGrid<DIM>::getInstance();
-    }
-
-    PMacc::EnvironmentController& EnvironmentController()
-    {
-        return EnvironmentController::getInstance();
-    }
-
-    PMacc::EventPool& EventPool()
-    {
-        return EventPool::getInstance();
-    }
-
-    PMacc::Factory& Factory()
-    {
-        return Factory::getInstance();
-    }
-
-    PMacc::ParticleFactory& ParticleFactory()
-    {
-        return ParticleFactory::getInstance();
-    }
-
-    PMacc::DataConnector& DataConnector()
-    {
-        return DataConnector::getInstance();
-    }
-
-    PMacc::PluginConnector& PluginConnector()
-    {
-        return PluginConnector::getInstance();
-    }
-
-    nvidia::memory::MemoryInfo& MemoryInfo()
-    {
-        return nvidia::memory::MemoryInfo::getInstance();
-    }
-
-    simulationControl::SimulationDescription& SimulationDescription()
-    {
-        return simulationControl::SimulationDescription::getInstance();
-    }
-
-    PMacc::Filesystem<DIM>& Filesystem()
-    {
-        return PMacc::Filesystem<DIM>::getInstance();
-    }
-
-    static Environment<DIM>& get()
-    {
-        static Environment<DIM> instance;
+        static Environment< T_dim > instance;
         return instance;
     }
 
-    void initDevices(DataSpace<DIM> devices, DataSpace<DIM> periodic)
+    /** create and initialize the environment of PMacc
+     *
+     * Usage of MPI or device(accelerator) function calls before this method
+     * are not allowed.
+     *
+     * @param devices number of devices per simulation dimension
+     * @param periodic periodicity each simulation dimension
+     *                 (0 == not periodic, 1 == periodic)
+     */
+    void initDevices(
+        DataSpace< T_dim > devices,
+        DataSpace< T_dim > periodic
+    )
     {
-        PMacc::GridController<DIM>::getInstance().init(devices, periodic);
+        // initialize the MPI context
+        detail::EnvironmentContext::getInstance().init();
 
-        PMacc::Filesystem<DIM>::getInstance();
+        // create singleton instances
+        GridController().init( devices, periodic );
 
-        setDevice((int) (PMacc::GridController<DIM>::getInstance().getHostRank()));
+        EnvironmentController();
 
-        StreamController::getInstance().activate();
+        Filesystem();
 
-        TransactionManager::getInstance();
+        detail::EnvironmentContext::getInstance().setDevice(
+            static_cast<int>( GridController().getHostRank() )
+        );
+
+        StreamController().activate();
+
+        MemoryInfo();
+
+        TransactionManager();
+
+        SimulationDescription();
 
     }
 
-    void initGrids(DataSpace<DIM> gridSizeGlobal, DataSpace<DIM> gridSizeLocal, DataSpace<DIM> gridOffset)
+    /** initialize the computing domain information of PMacc
+     *
+     * @param globalDomainSize size of the global simulation domain [cells]
+     * @param localDomainSize size of the local simulation domain [cells]
+     * @param localDomainOffset local domain offset [cells]
+     */
+    void initGrids(
+        DataSpace< T_dim > globalDomainSize,
+        DataSpace< T_dim > localDomainSize,
+        DataSpace< T_dim > localDomainOffset
+    )
     {
-        PMacc::SubGrid<DIM>::getInstance().init(gridSizeLocal, gridSizeGlobal, gridOffset);
+        PMACC_ASSERT_MSG(
+            detail::EnvironmentContext::getInstance().isMpiInitialized(),
+            "Environment< DIM >::initDevices() must be called before this method!"
+        );
 
-        EnvironmentController::getInstance();
+        detail::EnvironmentContext::getInstance().m_isSubGridDefined = true;
 
-        DataConnector::getInstance();
+        // create singleton instances
+        SubGrid().init(
+            localDomainSize,
+            globalDomainSize,
+            localDomainOffset
+        );
 
-        PluginConnector::getInstance();
+        DataConnector();
 
-        nvidia::memory::MemoryInfo::getInstance();
-
-        simulationControl::SimulationDescription::getInstance();
+        PluginConnector();
     }
 
-    void finalize()
-    {
-    }
+    Environment(const Environment&) = delete;
+
+    Environment& operator=(const Environment&) = delete;
 
 private:
 
@@ -166,11 +406,41 @@ private:
     {
     }
 
-    Environment(const Environment&);
+    ~Environment()
+    {
 
-    Environment& operator=(const Environment&);
+    }
 
-    void setDevice(int deviceNumber)
+};
+
+namespace detail
+{
+
+    void EnvironmentContext::init()
+    {
+        m_isMpiInitialized = true;
+
+        // MPI_Init with NULL is allowed since MPI 2.0
+        MPI_CHECK(MPI_Init(NULL,NULL));
+    }
+
+    void EnvironmentContext::finalize()
+    {
+        if( m_isMpiInitialized )
+        {
+            PMacc::Environment<>::get().Manager().waitForAllTasks();
+            // Required by scorep for flushing the buffers
+            cudaDeviceSynchronize();
+            m_isMpiInitialized = false;
+            /* Free the MPI context.
+             * The gpu context is freed by the `StreamController`, because
+             * MPI and CUDA are independent.
+             */
+            MPI_CHECK(MPI_Finalize());
+        }
+    }
+
+    void EnvironmentContext::setDevice(int deviceNumber)
     {
         int num_gpus = 0; //number of gpus
         cudaGetDeviceCount(&num_gpus);
@@ -244,10 +514,12 @@ private:
                 CUDA_CHECK(rc); /*error message*/
             }
         }
-    }
-};
 
-}
+        m_isDeviceSelected = true;
+    }
+
+} // namespace detail
+} // namespace PMacc
 
 /* No namespace for macro defines */
 

--- a/src/libPMacc/include/dataManagement/DataConnector.hpp
+++ b/src/libPMacc/include/dataManagement/DataConnector.hpp
@@ -194,9 +194,7 @@ namespace PMacc
 
     private:
 
-        friend class Environment< DIM1 >;
-        friend class Environment< DIM2 >;
-        friend class Environment< DIM3 >;
+        friend class detail::Environment;
 
         static DataConnector&
         getInstance()

--- a/src/libPMacc/include/eventSystem/Manager.hpp
+++ b/src/libPMacc/include/eventSystem/Manager.hpp
@@ -76,9 +76,7 @@ namespace PMacc
 
     private:
 
-        friend class Environment<DIM1>;
-        friend class Environment<DIM2>;
-        friend class Environment<DIM3>;
+        friend class detail::Environment;
 
         inline ITask* getPassiveITaskIfNotFinished(id_t taskId) const;
 

--- a/src/libPMacc/include/eventSystem/events/EventPool.hpp
+++ b/src/libPMacc/include/eventSystem/events/EventPool.hpp
@@ -95,9 +95,8 @@ namespace PMacc
         }
 
     private:
-        friend class Environment< DIM1 >;
-        friend class Environment< DIM2 >;
-        friend class Environment< DIM3 >;
+
+        friend class detail::Environment;
 
         static EventPool& getInstance( )
         {

--- a/src/libPMacc/include/eventSystem/streams/StreamController.hpp
+++ b/src/libPMacc/include/eventSystem/streams/StreamController.hpp
@@ -111,9 +111,7 @@ namespace PMacc
 
     private:
 
-        friend class Environment<DIM1>;
-        friend class Environment<DIM2>;
-        friend class Environment<DIM3>;
+        friend class detail::Environment;
 
         /**
          * Constructor.

--- a/src/libPMacc/include/eventSystem/tasks/Factory.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/Factory.hpp
@@ -164,9 +164,7 @@ namespace PMacc
 
     private:
 
-        friend class Environment<DIM1>;
-        friend class Environment<DIM2>;
-        friend class Environment<DIM3>;
+        friend class detail::Environment;
 
         Factory() {};
 

--- a/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
+++ b/src/libPMacc/include/eventSystem/transactions/TransactionManager.hpp
@@ -87,9 +87,7 @@ public:
 
 private:
 
-    friend class Environment<DIM1>;
-    friend class Environment<DIM2>;
-    friend class Environment<DIM3>;
+    friend class detail::Environment;
 
     TransactionManager();
 

--- a/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
+++ b/src/libPMacc/include/mappings/simulation/EnvironmentController.hpp
@@ -64,9 +64,7 @@ public:
 
 private:
 
-    friend class Environment<DIM1>;
-    friend class Environment<DIM2>;
-    friend class Environment<DIM3>;
+    friend class detail::Environment;
 
     /*! Default constructor.
      */

--- a/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
+++ b/src/libPMacc/include/nvidia/memory/MemoryInfo.hpp
@@ -107,9 +107,8 @@ protected:
     size_t reservedMem;
 
 private:
-    friend class Environment<DIM1>;
-    friend class Environment<DIM2>;
-    friend class Environment<DIM3>;
+
+    friend class detail::Environment;
 
     static MemoryInfo& getInstance()
     {

--- a/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
+++ b/src/libPMacc/include/particles/tasks/ParticleFactory.hpp
@@ -68,9 +68,7 @@ namespace PMacc
 
     private:
 
-        friend class Environment<DIM1>;
-        friend class Environment<DIM2>;
-        friend class Environment<DIM3>;
+        friend class detail::Environment;
 
         /**
          * returns the instance of this factory

--- a/src/libPMacc/include/pluginSystem/PluginConnector.hpp
+++ b/src/libPMacc/include/pluginSystem/PluginConnector.hpp
@@ -213,9 +213,7 @@ namespace PMacc
 
     private:
 
-        friend class Environment<DIM1>;
-        friend class Environment<DIM2>;
-        friend class Environment<DIM3>;
+        friend class detail::Environment;
 
         static PluginConnector& getInstance()
         {

--- a/src/libPMacc/include/simulationControl/SimulationDescription.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationDescription.hpp
@@ -111,9 +111,8 @@ protected:
     uint32_t currentStep;
 
 private:
-    friend class Environment<DIM1>;
-    friend class Environment<DIM2>;
-    friend class Environment<DIM3>;
+
+    friend class detail::Environment;
 
     static SimulationDescription& getInstance()
     {

--- a/src/libPMacc/test/PMaccFixture.hpp
+++ b/src/libPMacc/test/PMaccFixture.hpp
@@ -34,6 +34,12 @@ struct PMaccFixture
         const PMacc::DataSpace<T_dim> periodic = PMacc::DataSpace<T_dim>::create(1);
         PMacc::Environment<T_dim>::get().initDevices(devices, periodic);
     }
+
+    ~PMaccFixture()
+    {
+        /* finalize the PMacc context */
+        PMacc::Environment<>::get().finalize();
+    }
 };
 
 typedef PMaccFixture<2> PMaccFixture2D;

--- a/src/libPMacc/test/main.cpp
+++ b/src/libPMacc/test/main.cpp
@@ -23,12 +23,10 @@
 #define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 
-#include <mpi.h>
 
 int main(int argc, char* argv[], char* envp[])
 {
-    MPI_Init(&argc, &argv);
     int result = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
-    MPI_Finalize();
+
     return result;
 }

--- a/src/picongpu/include/simulation_classTypes.hpp
+++ b/src/picongpu/include/simulation_classTypes.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "pmacc_types.hpp"
+#include "Environment.hpp"
 #include "simulation_defines.hpp"
 
 #include "mappings/kernel/AreaMapping.hpp"

--- a/src/picongpu/main.cu
+++ b/src/picongpu/main.cu
@@ -28,14 +28,10 @@
  */
 
 #include "ArgsParser.hpp"
-#include "communication/manager_common.hpp"
+#include "Environment.hpp"
 
 #include <simulation_defines.hpp>
-#include <mpi.h>
 
-
-using namespace PMacc;
-using namespace picongpu;
 
 /*! start of PIConGPU
  *
@@ -44,9 +40,9 @@ using namespace picongpu;
  */
 int main(int argc, char **argv)
 {
-    MPI_CHECK(MPI_Init(&argc, &argv));
+    using namespace picongpu;
 
-    picongpu::simulation_starter::SimStarter sim;
+    simulation_starter::SimStarter sim;
     ArgsParser::ArgsErrorCode parserCode = sim.parseConfigs(argc, argv);
     int errorCode = 1;
 
@@ -59,14 +55,14 @@ int main(int argc, char **argv)
             sim.load();
             sim.start();
             sim.unload();
-            /*set error code to valid (1) after the simulation terminates*/
+            /* missing `break` is voluntarily to set the error code to 0 */
         case ArgsParser::SUCCESS_EXIT:
             errorCode = 0;
             break;
     };
 
-    // Required by scorep for flushing the buffers
-    cudaDeviceSynchronize();
-    MPI_CHECK(MPI_Finalize());
+    /* finalize the PMacc context */
+    PMacc::Environment<>::get().finalize();
+
     return errorCode;
 }


### PR DESCRIPTION
This change allows to execute `picongpu --help` also if MPI is not available (e.g. on the hypnos head nodes).

- create `detail::Environment` for all singletons without dimension
- add `detial::EnvironmentContext` to hold context information variables
  for `Environment<>` independent of number of simulation dimensions
- add documentation
- change friend from `Environment<>` to `detail::Environment` (for all singletons without dependency to the simulation dimension)
- use clean environment finalize of PMacc
- remove gloable usage of `PMacc` and `picongpu` namespace
- update `gameOfLife`
- update PMacc test cases

- [x] rebase against #1888
- [x] runtime test gameOfLife
- [x] runtime test PMacc test cases