### PR TITLE
Doc: References & Citation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ It describes the dynamics of a plasma by computing the motion of electrons and i
    :caption: USAGE
    :maxdepth: 1
 
+   usage/reference
    usage/basics
    usage/param
    usage/particles

--- a/docs/source/usage/REFERENCE.md
+++ b/docs/source/usage/REFERENCE.md
@@ -1,0 +1,1 @@
+../../../REFERENCE.md

--- a/docs/source/usage/reference.rst
+++ b/docs/source/usage/reference.rst
@@ -1,0 +1,33 @@
+Reference
+=========
+
+PIConGPU is a year-long, scientific project with many people contributing to it.
+In order to credit the work of others, we expect you to cite our latest paper describing PIConGPU when publishing and/or presenting scientific results.
+
+In addition to that and out of good scientific practice, you should document the version of PIConGPU that was used and any modifications you applied.
+A list of releases alongside a DOI to reference it can be found here:
+  https://github.com/ComputationalRadiationPhysics/picongpu/releases
+
+
+Citation
+--------
+
+BibTeX code:
+
+.. include:: REFERENCE.md
+   :code: TeX
+   :start-line: 1
+   :end-line: -1
+
+
+Acknowledgements
+----------------
+
+In many cases you receive support and code base maintainance from us or the PIConGPU community without directly justifying a full co-authorship.
+Additional to the citation, please consider adding an acknowledgement of the following form to reflect that:
+
+    We acknowledge all contributors to the open-source code PIConGPU for enabling our simulations.
+
+or
+
+    We acknowledge [list of specific persons that helped you] and all further contributors to the open-source code PIConGPU for enabling our simulations.


### PR DESCRIPTION
Close #1438 add a doc section explaining when and how to cite and acknowledge the PIConGPU community.

Independent of this elementary expectation of proper referencing, one could add a *separate page* on *reproducible science recommendations*:
  - describe which files are recommended to publish for input/algorithm description
  - document software versions of dependencies
  - remind to cite the system, hardware & program that provided the computing resources