### PR TITLE
openPMD: Fix Grid Spacing, GlobalOffset

### DIFF
--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -355,9 +355,10 @@ private:
                 adios_string_array, simDim, axisLabels ));
         }
 
+        // cellSize is {x, y, z} but fields are F[z][y][x]
         std::vector<float_X> gridSpacing(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridSpacing.at(d) = cellSize[d];
+            gridSpacing.at(simDim-1-d) = cellSize[d];
 
         ADIOS_CMD(adios_define_attribute_byvalue(params->adiosGroupHandle,
             "gridSpacing", recordName.c_str(),
@@ -372,9 +373,10 @@ private:
         const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
         globalSlideOffset.y() += numSlides * localDomain.size.y();
 
+        // globalDimensions is {x, y, z} but fields are F[z][y][x]
         std::vector<float_64> gridGlobalOffset(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridGlobalOffset.at(d) =
+            gridGlobalOffset.at(simDim-1-d) =
                 float_64(cellSize[d]) *
                 float_64(params->window.globalDimensions.offset[d] +
                          globalSlideOffset[d]);

--- a/src/picongpu/include/plugins/hdf5/writer/Field.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/Field.hpp
@@ -206,19 +206,22 @@ struct Field
                                               1u, Dimensions(simDim,0,0),
                                               axisLabels);
 
+        // cellSize is {x, y, z} but fields are F[z][y][x]
         std::vector<float_X> gridSpacing(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridSpacing.at(d) = cellSize[d];
+            gridSpacing.at(simDim-1-d) = cellSize[d];
         params->dataCollector->writeAttribute(params->currentStep,
                                               splashFloatXType, recordName.c_str(),
                                               "gridSpacing",
                                               1u, Dimensions(simDim,0,0),
                                               &(*gridSpacing.begin()));
 
+        // splashGlobalDomainOffset is {x, y, z} but fields are F[z][y][x]
         std::vector<float_64> gridGlobalOffset(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridGlobalOffset.at(d) = float_64(cellSize[d]) *
-                                     float_64(splashGlobalDomainOffset[d]);
+            gridGlobalOffset.at(simDim-1-d) =
+                float_64(cellSize[d]) *
+                float_64(splashGlobalDomainOffset[d]);
         params->dataCollector->writeAttribute(params->currentStep,
                                               ctDouble, recordName.c_str(),
                                               "gridGlobalOffset",


### PR DESCRIPTION
Fix #1899: our PIConGPU arrays describing cell sizes, offsets and sizes are in a rather inconsequent `{x, y, z}` order while the datasets they describe are *labeled* in `F[z][y][x]` order.

(note: this has nothing to do with slow or fast varying index aka C vs F order. This is just a inconsequent *labeling* of our `F[i][j][k]` indizes in PIConGPU, which arbitrarily did choose that `x` will always be the *fastest* varying "index"...)

This fixes the same issue as previously seen with `axisLabels` for openPMD in ADIOS and HDF5 output #1478.

Only affects if at least one of the following is true:
- moving window is used
- non-quadratic cells are used

the size / layout of the simulation box (`-g`) is independent of this issue and works quadratic and non-quadratic.