### PR TITLE
fix broken clang compile

### DIFF
--- a/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -64,7 +64,7 @@ Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::Bremsstrahlung
 
     /* compute ion density */
     typedef typename CreateEnergyDensityOperation<T_IonSpecies>::type::Solver DensitySolver;
-    fieldIonDensity->computeValue < CORE + BORDER, DensitySolver > (*ionSpecies, currentStep);
+    fieldIonDensity->template computeValue< CORE + BORDER, DensitySolver >(*ionSpecies, currentStep);
     dc.releaseData(T_IonSpecies::FrameType::getName());
 
     /* initialize device-side tmp-field databoxes */

--- a/src/picongpu/include/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -156,14 +156,14 @@ namespace ionization
                 auto srcSpecies = dc.get< SrcSpecies >( SrcSpecies::FrameType::getName(), true );
 
                 /* kernel call for weighted ion density calculation */
-                density->computeValue < CORE + BORDER, DensitySolver > (*srcSpecies, currentStep);
+                density->template computeValue< CORE + BORDER, DensitySolver >(*srcSpecies, currentStep);
                 dc.releaseData( SrcSpecies::FrameType::getName() );
 
                 /* load species without copying the particle data to the host */
                 auto destSpecies = dc.get< DestSpecies >( DestSpecies::FrameType::getName(), true );
 
                 /* kernel call for weighted electron energy density calculation */
-                eneKinDens->computeValue < CORE + BORDER, EnergyDensitySolver > (*destSpecies, currentStep);
+                eneKinDens->template computeValue< CORE + BORDER, EnergyDensitySolver >(*destSpecies, currentStep);
                 dc.releaseData( DestSpecies::FrameType::getName() );
 
                 /* initialize device-side density- and energy density field databox pointers */

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -242,7 +242,7 @@ private:
 
             fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType::create(0.0));
             /*run algorithm*/
-            fieldTmp->computeValue < CORE + BORDER, Solver > (*speciesTmp, params->currentStep);
+            fieldTmp->template computeValue< CORE + BORDER, Solver >(*speciesTmp, params->currentStep);
 
             EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
             __setTransactionEvent(fieldTmpEvent);

--- a/src/picongpu/include/plugins/hdf5/WriteFields.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteFields.hpp
@@ -183,7 +183,7 @@ private:
 
         fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType::create(0.0));
         /*run algorithm*/
-        fieldTmp->computeValue < CORE + BORDER, Solver > (*speciesTmp, params->currentStep);
+        fieldTmp->template computeValue< CORE + BORDER, Solver >(*speciesTmp, params->currentStep);
 
         EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
         __setTransactionEvent(fieldTmpEvent);


### PR DESCRIPTION
annotate template function calls with the keyword `template`

The fix is needed for #1731
This bug is also in the current release, but has **no effect** because we not support compiling with clang. Therefore I do not add the flag `effects latest release`