### PR TITLE
Collection of Backports for 0.2.4

### DIFF
--- a/examples/ThermalTest/include/ThermalTestSimulation.hpp
+++ b/examples/ThermalTest/include/ThermalTestSimulation.hpp
@@ -128,8 +128,7 @@ public:
 
                 algorithm::mpi::Reduce<3> reduce(gpuReducingZone, reduceRoot);
 
-                using namespace lambda;
-                reduce(eField_zt_reduced, *(eField_zt[i]), _1 + _2);
+                reduce(eField_zt_reduced, *(eField_zt[i]), lambda::_1 + lambda::_2);
             }
             if(!reduceRoot) continue;
 
@@ -175,13 +174,12 @@ public:
         for (size_t z = 0; z < eField_zt[0]->size().x(); z++)
         {
             zone::SphericZone < 2 > reduceZone(fieldE_coreBorder.size().shrink<2>());
-            using namespace lambda;
             for (int i = 0; i < 2; i++)
             {
                 *(eField_zt[i]->origin()(z, currentStep - firstTimestep)) =
                     algorithm::kernel::Reduce()
                         (cursor::make_FunctorCursor(cursor::tools::slice(fieldE_coreBorder.origin()(0, 0, z)),
-                                                   _1[i == 0 ? 0 : 2]),
+                                                    lambda::_1[i == 0 ? 0 : 2]),
                          reduceZone,
                          nvidia::functors::Add());
             }

--- a/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
+++ b/src/libPMacc/include/cuSTL/container/CartBuffer.tpp
@@ -298,6 +298,7 @@ CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::zone() const
 }
 
 template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
+HDINLINE
 bool
 CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::isContigousMemory() const
 {

--- a/src/libPMacc/include/eventSystem/events/CudaEvent.def
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.def
@@ -20,11 +20,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "pmacc_types.hpp"
 #include <cuda_runtime.h>
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
+++ b/src/libPMacc/include/eventSystem/events/CudaEvent.hpp
@@ -20,13 +20,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "eventSystem/events/CudaEvent.def"
 #include "eventSystem/events/CudaEventHandle.hpp"
-#include "eventSystem/events/CudaEvent.hpp"
+#include "pmacc_types.hpp"
+
 #include <cuda_runtime.h>
+
 
 namespace PMacc
 {

--- a/src/libPMacc/include/lambda/CT/Eval.hpp
+++ b/src/libPMacc/include/lambda/CT/Eval.hpp
@@ -22,9 +22,6 @@
 
 #pragma once
 
-#define BOOST_BIND_NO_PLACEHOLDERS
-
-
 #include "Expression.hpp"
 #include "../placeholder.h"
 #include "../ExprTypes.h"

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
@@ -19,22 +19,20 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "plugins/SliceFieldPrinter.hpp"
 #include "cuSTL/container/DeviceBuffer.hpp"
 #include "math/vector/Float.hpp"
 
+#include <string>
+
+
 namespace picongpu
 {
 
 using namespace PMacc;
-
 namespace po = boost::program_options;
-
-#include <string>
 
 template<typename Field>
 class SliceFieldPrinterMulti : public ILightweightPlugin

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -21,13 +21,6 @@
 
 #pragma once
 
-#include <pthread.h>
-#include <cassert>
-#include <sstream>
-#include <string>
-#include <list>
-#include <vector>
-
 #include "pmacc_types.hpp"
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
@@ -76,7 +69,13 @@
 #include "plugins/adios/restart/LoadSpecies.hpp"
 #include "plugins/adios/restart/RestartFieldLoader.hpp"
 #include "plugins/adios/NDScalars.hpp"
-#include "plugins/common/stringHelpers.hpp"
+
+#include <pthread.h>
+#include <cassert>
+#include <sstream>
+#include <string>
+#include <list>
+#include <vector>
 
 
 namespace picongpu

--- a/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
+++ b/src/picongpu/include/plugins/adios/ADIOSWriter.hpp
@@ -351,9 +351,10 @@ private:
                 adios_string_array, simDim, axisLabels ));
         }
 
+        // cellSize is {x, y, z} but fields are F[z][y][x]
         std::vector<float_X> gridSpacing(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridSpacing.at(d) = cellSize[d];
+            gridSpacing.at(simDim-1-d) = cellSize[d];
 
         ADIOS_CMD(adios_define_attribute_byvalue(params->adiosGroupHandle,
             "gridSpacing", recordName.c_str(),
@@ -368,9 +369,10 @@ private:
         const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
         globalSlideOffset.y() += numSlides * localDomain.size.y();
 
+        // globalDimensions is {x, y, z} but fields are F[z][y][x]
         std::vector<float_64> gridGlobalOffset(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridGlobalOffset.at(d) =
+            gridGlobalOffset.at(simDim-1-d) =
                 float_64(cellSize[d]) *
                 float_64(params->window.globalDimensions.offset[d] +
                          globalSlideOffset[d]);

--- a/src/picongpu/include/plugins/adios/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/adios/WriteMeta.hpp
@@ -22,6 +22,7 @@
 #include "simulation_defines.hpp"
 
 #include "plugins/adios/ADIOSWriter.def"
+#include "plugins/common/stringHelpers.hpp"
 #include "Environment.hpp"
 
 #include "fields/FieldManipulator.hpp"

--- a/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/src/picongpu/include/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -24,6 +24,7 @@
 #include "simulation_types.hpp"
 #include "plugins/adios/ADIOSWriter.def"
 #include "traits/PICToAdios.hpp"
+#include "traits/PICToOpenPMD.hpp"
 #include "traits/GetComponentsType.hpp"
 #include "traits/GetNComponents.hpp"
 #include "traits/Resolve.hpp"

--- a/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
+++ b/src/picongpu/include/plugins/hdf5/HDF5Writer.hpp
@@ -33,7 +33,6 @@
 #include "plugins/hdf5/HDF5Writer.def"
 #include "traits/SplashToPIC.hpp"
 #include "traits/PICToSplash.hpp"
-#include "plugins/common/stringHelpers.hpp"
 
 #include "particles/frame_types.hpp"
 

--- a/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
+++ b/src/picongpu/include/plugins/hdf5/WriteMeta.hpp
@@ -25,6 +25,7 @@
 #include "simulation_defines.hpp"
 
 #include "plugins/hdf5/HDF5Writer.def"
+#include "plugins/common/stringHelpers.hpp"
 #include "Environment.hpp"
 
 #include "fields/FieldManipulator.hpp"

--- a/src/picongpu/include/plugins/hdf5/writer/Field.hpp
+++ b/src/picongpu/include/plugins/hdf5/writer/Field.hpp
@@ -206,19 +206,22 @@ struct Field
                                               1u, Dimensions(simDim,0,0),
                                               axisLabels);
 
+        // cellSize is {x, y, z} but fields are F[z][y][x]
         std::vector<float_X> gridSpacing(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridSpacing.at(d) = cellSize[d];
+            gridSpacing.at(simDim-1-d) = cellSize[d];
         params->dataCollector->writeAttribute(params->currentStep,
                                               splashFloatXType, recordName.c_str(),
                                               "gridSpacing",
                                               1u, Dimensions(simDim,0,0),
                                               &(*gridSpacing.begin()));
 
+        // splashGlobalDomainOffset is {x, y, z} but fields are F[z][y][x]
         std::vector<float_64> gridGlobalOffset(simDim, 0.0);
         for( uint32_t d = 0; d < simDim; ++d )
-            gridGlobalOffset.at(d) = float_64(cellSize[d]) *
-                                     float_64(splashGlobalDomainOffset[d]);
+            gridGlobalOffset.at(simDim-1-d) =
+                float_64(cellSize[d]) *
+                float_64(splashGlobalDomainOffset[d]);
         params->dataCollector->writeAttribute(params->currentStep,
                                               ctDouble, recordName.c_str(),
                                               "gridGlobalOffset",


### PR DESCRIPTION
C++98 backport of fixes to `0.2.4`:

- openPMD: Fix Grid Spacing, GlobalOffset #1900
- remove BOOST_BIND_NO_PLACEHOLDERS #1849
- std Include: Never inside Namespaces #1835
- HDF5/ADIOS: Fix ill-places helper incl #1846
- add missing HDINLINE #1825
- CudaEvent: Fix Cyclic Include #1836

### To Do

- [x] separete PR: Ionization - Fix Charge of Ionized Ions #1844
- [x] separate PR: ~~@psychocoderHPC can we try to add~~ *Particle manipulators: Fix Position Offset* #1852
- [x] separate PR: changelog, version bump #1904

### Tested

- [x] C++98 compile with
```
  1) mpfr/3.1.2                    8) openmpi/1.8.4.kepler.cuda70
  2) mpc/1.0.1                     9) pngwriter/0.5.6
  3) gmp/5.1.1                    10) hdf5-parallel/1.8.14
  4) gcc/4.8.2                    11) libsplash/1.6.0 (build from source)
  5) cmake/3.3.0                  12) libmxml/2.8
  6) boost/1.62.0                 13) adios/1.9.0
  7) cuda/7.0
```

### Review

Please take extra care if I missed C++11 features, `0.2.X` must be C++98 compatible.