### PR TITLE
Backport 0.2.4: Particle manipulators Position Offset

### DIFF
--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -72,8 +72,11 @@ __global__ void kernelDeriveParticles(T_MyParBox myBox, T_OtherFrameBox otherBox
 
     typedef typename Mapping::SuperCellSize SuperCellSize;
 
-
     const DataSpace<Mapping::Dim> block = mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx));
+    /* offset of the superCell (in cells, without any guards) to the origin of the local domain */
+    const DataSpace<simDim> localSuperCellOffset =
+        block * SuperCellSize::toRT()
+        - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
     if (threadIdx.x == 0)
     {
@@ -91,10 +94,7 @@ __global__ void kernelDeriveParticles(T_MyParBox myBox, T_OtherFrameBox otherBox
         PMACC_AUTO(parSrc, frame[threadIdx.x]);
         assign(parDest, deselect<particleId>(parSrc));
 
-        const DataSpace<simDim> localCellIdx = block * SuperCellSize::toRT()
-            + DataSpaceOperations<simDim>::map<SuperCellSize>(threadIdx.x)
-            - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-        manipulateFunctor(localCellIdx,
+        manipulateFunctor(localSuperCellOffset,
                           parDest, parSrc,
                           true, parSrc[multiMask_] == 1);
 
@@ -144,16 +144,18 @@ __global__ void kernelManipulateAllParticles(T_ParBox pb,
      * volatile prohibits that the compiler creates wrong code*/
     volatile bool isParticle = (*frame)[linearThreadIdx][multiMask_];
 
-    const DataSpace<simDim> idx(superCellIdx * SuperCellSize::toRT() + threadIndex);
+    /* offset of the superCell (in cells, without any guards) to the origin of the local domain */
     const DataSpace<simDim> localCellIdx = idx - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-
+    const DataSpace<simDim> localSuperCellOffset =
+        superCellIdx * SuperCellSize::toRT()
+        - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
     __syncthreads();
 
     while (frame.isValid())
     {
         PMACC_AUTO(particle, frame[linearThreadIdx]);
-        particleFunctor(localCellIdx, particle, particle, isParticle, isParticle);
+        particleFunctor(localSuperCellOffset, particle, particle, isParticle, isParticle);
 
         __syncthreads();
         if (linearThreadIdx == 0)
@@ -180,14 +182,10 @@ __global__ void kernelMoveAndMarkParticles(ParBox pb,
 
     const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
 
-
     const DataSpace<simDim > threadIndex(threadIdx);
     const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
 
-
     const DataSpace<simDim> blockCell = block * SuperCellSize::toRT();
-
-
 
     FramePtr frame;
 

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -73,7 +73,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {
@@ -91,7 +91,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
 
 
         uint32_t ltid = DataSpaceOperations<simDim>::template map<SuperCellSize>(DataSpace<simDim>(threadIdx));
-        const DataSpace<simDim> superCell((guardCells + localCellIdx) / SuperCellSize::toRT());
+        const DataSpace<simDim> superCell((guardCells + localSuperCellOffset) / SuperCellSize::toRT());
         if (ltid == 0)
         {
             if (firstCall)

--- a/src/picongpu/include/particles/manipulators/DriftImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/DriftImpl.hpp
@@ -45,7 +45,7 @@ struct DriftImpl : private T_ValueFunctor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>&,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {

--- a/src/picongpu/include/particles/manipulators/IManipulator.hpp
+++ b/src/picongpu/include/particles/manipulators/IManipulator.hpp
@@ -41,12 +41,23 @@ struct IManipulator : private T_Base
     {
     }
 
+    /** interface to operate on two particles
+     *
+     * @tparam T_Particle1 type of the first particle
+     * @tparam T_Particle2 type of the second particle
+     * @param localSuperCellOffset offset of the superCell (in cells, without any guards)
+     *                             to the origin of the local domain where both particles are located
+     * @param particleSpecies1 first particle
+     * @param particleSpecies2 second particle, can be equal to the first particle
+     * @param isParticle1 define if the reference @p particleSpecies1 is valid
+     * @param isParticle2 define if the reference @p particleSpecies2 is valid
+     */
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particleSpecies1, T_Particle2& particleSpecies2,
                             const bool isParticle1, const bool isParticle2)
     {
-        return Base::operator()(localCellIdx, particleSpecies1, particleSpecies2, isParticle1, isParticle2);
+        return Base::operator()(localSuperCellOffset, particleSpecies1, particleSpecies2, isParticle1, isParticle2);
     }
 };
 

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -61,7 +61,7 @@ struct RandomPositionImpl
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {
@@ -69,9 +69,15 @@ struct RandomPositionImpl
 
         if (!isInitialized)
         {
+            /** @todo: it is a wrong assumption that the threadIdx can be used to
+             * define the cell within the superCell. This is only allowed if we not
+             * use alpaka. We need to distinguish between manipulators those are working on the
+             * cell domain and on the particle domain.
+             */
+            const DataSpace<simDim > threadIndex(threadIdx);
             const uint32_t cellIdx = DataSpaceOperations<simDim>::map(
                                                                       localCells,
-                                                                      localCellIdx);
+                                                                      localSuperCellOffset + threadIndex);
             rng = nvrng::create(rngMethods::Xor(seed, cellIdx), rngDistributions::Uniform_float());
             isInitialized = true;
         }

--- a/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/SetAttributeImpl.hpp
@@ -44,7 +44,7 @@ struct SetAttributeImpl : private T_ValueFunctor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>&,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -65,7 +65,7 @@ struct TemperatureImpl : private T_ValueFunctor
     }
 
     template<typename T_Particle1, typename T_Particle2>
-    DINLINE void operator()(const DataSpace<simDim>& localCellIdx,
+    DINLINE void operator()(const DataSpace<simDim>& localSuperCellOffset,
                             T_Particle1& particle, T_Particle2&,
                             const bool isParticle, const bool)
     {
@@ -73,9 +73,15 @@ struct TemperatureImpl : private T_ValueFunctor
 
         if (!isInitialized)
         {
+            /** @todo: it is a wrong assumption that the threadIdx can be used to
+             * define the cell within the superCell. This is only allowed if we not
+             * use alpaka. We need to distinguish between manipulators those are working on the
+             * cell domain and on the particle domain.
+             */
+            const DataSpace<simDim > threadIndex(threadIdx);
             const uint32_t cellIdx = DataSpaceOperations<simDim>::map(
                                                                       localCells,
-                                                                      localCellIdx );
+                                                                      localSuperCellOffset + threadIndex );
             rng = nvrng::create(rngMethods::Xor(seed, cellIdx), rngDistributions::Normal_float());
             isInitialized = true;
         }


### PR DESCRIPTION
C++98 backport of fixes to `0.2.4`:

- Particle manipulators: Fix Position Offset #1852

### Tested

- [ ] C++98 compile with
```
  1) mpfr/3.1.2                    8) openmpi/1.8.4.kepler.cuda70
  2) mpc/1.0.1                     9) pngwriter/0.5.6
  3) gmp/5.1.1                    10) hdf5-parallel/1.8.14
  4) gcc/4.8.2                    11) libsplash/1.4.0
  5) cmake/3.3.0                  12) libmxml/2.8
  6) boost/1.62.0                 13) adios/1.9.0
  7) cuda/7.0
```

### Review

Please take extra care if I missed C++11 features, `0.2.X` must be C++98 compatible.
I also had to solve a few conflicts `src/picongpu/include/particles/Particles.kernel` which hopefully turned out well. Best to compare the diff of that file directly to the diff it got in #1852