### PR TITLE
Fields: No Self-Registration

### DIFF
--- a/src/picongpu/include/fields/FieldB.hpp
+++ b/src/picongpu/include/fields/FieldB.hpp
@@ -81,7 +81,7 @@ namespace picongpu
 
         virtual EventTask asyncCommunication(EventTask serialEvent);
 
-        void init(FieldE &fieldE, LaserPhysics &laserPhysics);
+        void init(LaserPhysics &laserPhysics);
 
         DataBoxType getHostDataBox();
 
@@ -105,7 +105,6 @@ namespace picongpu
 
         GridBuffer<ValueType, simDim> *fieldB;
 
-        FieldE *fieldE;
         LaserPhysics *laser;
     };
 

--- a/src/picongpu/include/fields/FieldB.tpp
+++ b/src/picongpu/include/fields/FieldB.tpp
@@ -36,8 +36,6 @@
 
 #include "dimensions/SuperCellDescription.hpp"
 
-#include "FieldE.hpp"
-
 #include "MaxwellSolver/Solvers.hpp"
 #include "fields/numericalCellTypes/NumericalCellTypes.hpp"
 
@@ -63,8 +61,7 @@ namespace picongpu
 using namespace PMacc;
 
 FieldB::FieldB( MappingDesc cellDescription ) :
-SimulationFieldHelper<MappingDesc>( cellDescription ),
-fieldE( nullptr )
+SimulationFieldHelper<MappingDesc>( cellDescription )
 {
     /*#####create FieldB###############*/
     fieldB = new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) );
@@ -164,13 +161,9 @@ EventTask FieldB::asyncCommunication( EventTask serialEvent )
     return eB;
 }
 
-void FieldB::init( FieldE &fieldE, LaserPhysics &laserPhysics )
+void FieldB::init( LaserPhysics &laserPhysics )
 {
-
-    this->fieldE = &fieldE;
     this->laser = &laserPhysics;
-
-    Environment<>::get().DataConnector().share( std::shared_ptr< ISimulationData >( this ) );
 }
 
 GridLayout<simDim> FieldB::getGridLayout( )

--- a/src/picongpu/include/fields/FieldE.hpp
+++ b/src/picongpu/include/fields/FieldE.hpp
@@ -81,7 +81,7 @@ namespace picongpu
 
         virtual EventTask asyncCommunication(EventTask serialEvent);
 
-        void init(FieldB &fieldB,LaserPhysics &laserPhysics);
+        void init(LaserPhysics &laserPhysics);
 
         DataBoxType getDeviceDataBox();
 
@@ -105,8 +105,6 @@ namespace picongpu
 
 
         GridBuffer<ValueType,simDim> *fieldE;
-
-        FieldB *fieldB;
 
         LaserPhysics *laser;
     };

--- a/src/picongpu/include/fields/FieldE.tpp
+++ b/src/picongpu/include/fields/FieldE.tpp
@@ -32,8 +32,6 @@
 #include "fields/FieldManipulator.hpp"
 #include "dimensions/SuperCellDescription.hpp"
 
-#include "FieldB.hpp"
-
 #include "fields/FieldE.kernel"
 
 #include "MaxwellSolver/Solvers.hpp"
@@ -59,8 +57,7 @@ namespace picongpu
 using namespace PMacc;
 
 FieldE::FieldE( MappingDesc cellDescription ) :
-SimulationFieldHelper<MappingDesc>( cellDescription ),
-fieldB( nullptr )
+SimulationFieldHelper<MappingDesc>( cellDescription )
 {
     fieldE = new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) );
     typedef typename PMacc::particles::traits::FilterByFlag
@@ -155,12 +152,9 @@ EventTask FieldE::asyncCommunication( EventTask serialEvent )
     return fieldE->asyncCommunication( serialEvent );
 }
 
-void FieldE::init( FieldB &fieldB, LaserPhysics &laserPhysics )
+void FieldE::init( LaserPhysics &laserPhysics )
 {
-    this->fieldB = &fieldB;
     this->laser = &laserPhysics;
-
-    Environment<>::get().DataConnector().share( std::shared_ptr< ISimulationData >( this ) );
 }
 
 FieldE::DataBoxType FieldE::getDeviceDataBox( )

--- a/src/picongpu/include/fields/FieldJ.hpp
+++ b/src/picongpu/include/fields/FieldJ.hpp
@@ -71,7 +71,7 @@ public:
 
     virtual EventTask asyncCommunication(EventTask serialEvent);
 
-    void init(FieldE &fieldE, FieldB &fieldB);
+    void init();
 
     GridLayout<simDim> getGridLayout();
 

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -267,7 +267,6 @@ namespace picongpu
 
     void FieldTmp::init( )
     {
-        Environment<>::get().DataConnector().share( std::shared_ptr< ISimulationData >( this ) );
     }
 
     FieldTmp::DataBoxType FieldTmp::getDeviceDataBox( )

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -386,9 +386,9 @@ public:
 
         IdProvider<simDim>::init();
 
-        fieldB->init( *fieldE, *laser );
-        fieldE->init( *fieldB, *laser );
-        fieldJ->init( *fieldE, *fieldB );
+        fieldB->init( *laser );
+        fieldE->init( *laser );
+        fieldJ->init( );
         for( uint32_t slot = 0; slot < fieldTmpNumSlots; ++slot)
             fieldTmp.at( slot )->init();
 


### PR DESCRIPTION
Fields `init()` shall not self-register themselves at the `DataConnector` anymore.

Follow-up that should have been in #1887 and fix to #1907.

Removes unnecessary interface params in their `init()` on the way, since it's the same methods and can be cleaned up with the new `DataConnector`.