### PR TITLE
fix manipulator `IfRelativeGlobalPositionImpl`

### DIFF
--- a/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/IfRelativeGlobalPositionImpl.hpp
@@ -60,7 +60,7 @@ struct IfRelativeGlobalPositionImpl : private T_Functor
         {
             particleInRange1 = isParticleInsideRange( particle1, globalSuperCellOffset);
         }
-        if( isParticle1 )
+        if( isParticle2 )
         {
             particleInRange2 = isParticleInsideRange( particle2, globalSuperCellOffset);
         }


### PR DESCRIPTION
the position for the second particle is only checked if the first particle is valid

This bug is only triggered if `IfRelativeGlobalPositionImpl` is used as binary operator. The example `KelvinHelmholtz` is only using the unary version of this manipulator.