### PR TITLE
clang compatible static assert usage

### DIFF
--- a/src/libPMacc/include/compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp
+++ b/src/libPMacc/include/compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp
@@ -37,7 +37,15 @@ struct ThrowValueNotFound
     template<typename T_MPLSeq, typename T_Value>
     struct apply
     {
-        PMACC_CASSERT_MSG_TYPE(value_not_found_in_seq, T_Value, false);
+        /* The compiler is allowed to evaluate an expression that does not depend on a template parameter
+         * even if the class is never instantiated. In that case static assert is always
+         * evaluated (e.g. with clang), this results in an error if the condition is false.
+         * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
+         *
+         * A workaround is to add a template dependency to the expression.
+         * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
+         */
+        PMACC_CASSERT_MSG_TYPE(value_not_found_in_seq, T_Value, false && ( sizeof(T_MPLSeq) != 0 ) );
         typedef bmpl::void_ type;
     };
 };

--- a/src/libPMacc/include/traits/GetNComponents.hpp
+++ b/src/libPMacc/include/traits/GetNComponents.hpp
@@ -36,7 +36,15 @@ namespace traits
 template<typename T_Type, bool T_IsFundamental = boost::is_fundamental<T_Type>::value>
 struct GetNComponents
 {
-    PMACC_CASSERT_MSG_TYPE( __GetNComponents_is_not_defined_for_this_type, T_Type, false );
+    /* The compiler is allowed to evaluate an expression that does not depend on a template parameter
+     * even if the class is never instantiated. In that case static assert is always
+     * evaluated (e.g. with clang), this results in an error if the condition is false.
+     * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
+     *
+     * A workaround is to add a template dependency to the expression.
+     * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
+     */
+    PMACC_CASSERT_MSG_TYPE( __GetNComponents_is_not_defined_for_this_type, T_Type, false && ( sizeof(T_Type) != 0 ) );
     static constexpr uint32_t value = 0;
 };
 

--- a/src/libPMacc/include/traits/HasIdentifier.hpp
+++ b/src/libPMacc/include/traits/HasIdentifier.hpp
@@ -40,10 +40,18 @@ namespace traits
 template<typename T_Object, typename T_Key>
 struct HasIdentifier
 {
+    /* The compiler is allowed to evaluate an expression that does not depend on a template parameter
+     * even if the class is never instantiated. In that case static assert is always
+     * evaluated (e.g. with clang), this results in an error if the condition is false.
+     * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
+     *
+     * A workaround is to add a template dependency to the expression.
+     * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
+     */
     PMACC_CASSERT_MSG_TYPE(
         ___HasIdentifier_is_not_specialized_for_T_Object,
         T_Object,
-        false
+        false && ( sizeof(T_Object) != 0 )
     );
 };
 

--- a/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -58,14 +58,25 @@ struct ConditionCheck<DirSplitting, T_Dummy>
     /* Directional Splitting conditions:
      *
      * using SI units to avoid round off errors
+     *
+     * The compiler is allowed to evaluate an expression those not depends on a template parameter
+     * even if the class is never instantiated. In that case static assert is always
+     * evaluated (e.g. with clang), this results in an error if the condition is false.
+     * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
+     *
+     * A workaround is to add a template dependency to the expression.
+     * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
      */
     PMACC_CASSERT_MSG(DirectionSplitting_Set_dX_equal_dt_times_c____check_your_gridConfig_param_file,
-                      (SI::SPEED_OF_LIGHT_SI * SI::DELTA_T_SI) == SI::CELL_WIDTH_SI);
+                      (SI::SPEED_OF_LIGHT_SI * SI::DELTA_T_SI) == SI::CELL_WIDTH_SI &&
+                      (sizeof(T_Dummy) != 0));
     PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_gridConfig_param_file,
-                      SI::CELL_HEIGHT_SI == SI::CELL_WIDTH_SI);
+                      SI::CELL_HEIGHT_SI == SI::CELL_WIDTH_SI &&
+                      (sizeof(T_Dummy) != 0));
 #if (SIMDIM == DIM3)
     PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_gridConfig_param_file,
-                      SI::CELL_DEPTH_SI == SI::CELL_WIDTH_SI);
+                      SI::CELL_DEPTH_SI == SI::CELL_WIDTH_SI &&
+                      (sizeof(T_Dummy) != 0));
 #endif
 };
 

--- a/src/picongpu/include/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -140,9 +140,17 @@ namespace ionization
                 /* create handle for access to host and device data */
                 DataConnector &dc = Environment<>::get().DataConnector();
 
+                /* The compiler is allowed to evaluate an expression that does not depend on a template parameter
+                 * even if the class is never instantiated. In that case static assert is always
+                 * evaluated (e.g. with clang), this results in an error if the condition is false.
+                 * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
+                 *
+                 * A workaround is to add a template dependency to the expression.
+                 * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
+                 */
                 PMACC_CASSERT_MSG(
                     _please_allocate_at_least_two_FieldTmp_slots_in_memory_param,
-                    fieldTmpNumSlots >= 2
+                    ( fieldTmpNumSlots >= 2 ) && ( sizeof( T_IonizationAlgorithm ) != 0 )
                 );
                 /* initialize pointers on host-side density-/energy density field databoxes */
                 auto density = dc.get< FieldTmp >( FieldTmp::getUniqueId( 0 ), true );

--- a/src/picongpu/include/traits/attribute/GetChargeState.hpp
+++ b/src/picongpu/include/traits/attribute/GetChargeState.hpp
@@ -64,7 +64,15 @@ struct LoadChargeState<false>
     template<typename T_Particle>
     HDINLINE void operator()(const T_Particle& particle)
     {
-        PMACC_CASSERT_MSG(This_species_has_only_one_charge_state,1==2);
+        /* The compiler is allowed to evaluate an expression that does not depend on a template parameter
+         * even if the class is never instantiated. In that case static assert is always
+         * evaluated (e.g. with clang), this results in an error if the condition is false.
+         * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
+         *
+         * A workaround is to add a template dependency to the expression.
+         * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
+         */
+        PMACC_CASSERT_MSG(This_species_has_only_one_charge_state,1==2 && (sizeof(T_Particle) != 0));
     }
 };
 } // namespace detail


### PR DESCRIPTION
An expression within a static assert those not depend on a template can be evaluated from the compiler even if the code is never instantiated.
This means that a context check inside the body of a class is not possible with some compiler e.g. clang.
A workaround is to extent the condition for the static assert with a template dependent expression those is always evaluated to `true`.
The expression `sizeof(AnyType)!=0` is always `true` and can be used as workaround.

This pull request is needed by the pull request to compile with clang #1731.

Tested with
- [x] clang
- [x] gcc/nvcc