### PR TITLE
rename slide_point to movePoint

### DIFF
--- a/examples/Bremsstrahlung/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/gridConfig.param
@@ -64,14 +64,14 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }
 

--- a/examples/Bunch/include/simulation_defines/param/gridConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/gridConfig.param
@@ -73,14 +73,14 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/gridConfig.param
@@ -94,14 +94,14 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }
 

--- a/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gridConfig.param
@@ -73,14 +73,14 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }
 

--- a/examples/SingleParticleTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/gridConfig.param
@@ -78,14 +78,14 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }
 

--- a/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
+++ b/examples/ThermalTest/include/simulation_defines/param/gridConfig.param
@@ -73,14 +73,14 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }
 

--- a/examples/WarmCopper/include/simulation_defines/param/gridConfig.param
+++ b/examples/WarmCopper/include/simulation_defines/param/gridConfig.param
@@ -84,13 +84,13 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }

--- a/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/gridConfig.param
@@ -73,14 +73,14 @@ namespace picongpu
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.
-     *  When it reaches slide_point % of the absolute(*) simulation area,
+     *  When it reaches movePoint % of the absolute(*) simulation area,
      *  the co-moving window starts to move with the speed of light.
      *
      *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
      *            when you use the co-moving window
      *  0.75 means only 75% of simulation area is used for real simulation
      */
-    constexpr float_64 slide_point = 0.90;
+    constexpr float_64 movePoint = 0.90;
 
 }
 

--- a/src/picongpu/include/simulationControl/MovingWindow.hpp
+++ b/src/picongpu/include/simulationControl/MovingWindow.hpp
@@ -86,7 +86,7 @@ private:
              * depends on half cells.
              */
             const uint32_t virtualParticleInitialStartCell = math::ceil(
-                float_64(globalWindowSizeInMoveDirection) * (float_64(1.0) - slide_point)
+                float_64(globalWindowSizeInMoveDirection) * (float_64(1.0) - movePoint)
             );
 
             /* Is the time step when the virtual particle **passed** the GPU next to the last
@@ -104,7 +104,7 @@ private:
                 cellSizeInMoveDirection;
             /* Is the time step when the virtual particle **passed** the moving window
              * in the current to the next step
-             * Signed type of firstMoveStep to allow for edge case slide_point = 0.0
+             * Signed type of firstMoveStep to allow for edge case movePoint = 0.0
              * for a moving window right from the start of the simulation.
              */
             const int32_t firstMoveStep = math::ceil(

--- a/src/picongpu/include/simulation_defines/param/gridConfig.param
+++ b/src/picongpu/include/simulation_defines/param/gridConfig.param
@@ -87,7 +87,7 @@ namespace picongpu
      *
      *  Slide point model: A virtual photon starts at t=0 at the lower end
      *  of the global simulation box in y-direction of the simulation.
-     *  When it reaches slide_point % of the global simulation box,
+     *  When it reaches movePoint % of the global simulation box,
      *  the co-moving window starts to move with the speed of light.
      *
      *  @note global simulation area: there is one additional "hidden" row
@@ -96,7 +96,7 @@ namespace picongpu
      *        described "virtual photon" from the lower end of the box' Y-axis
      *        reaches the beginning of this "hidden" row of GPUs.
      */
-    constexpr float_64 slide_point = 0.9;
+    constexpr float_64 movePoint = 0.9;
 
 } // namespace picongpu
 


### PR DESCRIPTION
This pull request closes issue #1915 by renaming `slide_point` to `movePoint` because it actually defines the start of the moving window. 