### PR TITLE
Doc: PMacc Kernel Start

### DIFF
--- a/docs/source/dev/pmacc.rst
+++ b/docs/source/dev/pmacc.rst
@@ -142,6 +142,18 @@ ForEach
    :protected-members:
    :undoc-members:
 
+Kernel Start
+------------
+
+.. doxygenstruct:: PMacc::exec::Kernel
+   :project: PIConGPU
+   :members:
+   :protected-members:
+   :undoc-members:
+
+.. doxygendefine:: PMACC_KERNEL
+   :project: PIConGPU
+
 Struct Factory
 --------------
 


### PR DESCRIPTION
Document the kernel start via a macro and which class is build behind it to explain the order of parameters.