### PR TITLE
remove CUDA native static shared memory

### DIFF
--- a/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/src/libPMacc/include/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -21,8 +21,12 @@
 
 #pragma once
 
-#include "math/Vector.hpp"
 #include "cuSTL/cursor/compile-time/BufferCursor.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
+#include "math/Vector.hpp"
+#include "pmacc_types.hpp"
+
 
 namespace PMacc
 {
@@ -43,8 +47,14 @@ struct SharedMemAllocator<Type, Size, 1, uid>
 
     __device__ static Cursor allocate()
     {
-        __shared__ Type shMem[Size::x::value];
-        return Cursor((Type*)shMem);
+        auto& shMem = PMacc::memory::shared::allocate<
+            uid,
+            memory::Array<
+                Type,
+                math::CT::volume< Size >::type::value
+            >
+        >( );
+        return Cursor(shMem.data());
     }
 };
 
@@ -58,8 +68,14 @@ struct SharedMemAllocator<Type, Size, 2, uid>
 
     __device__ static Cursor allocate()
     {
-        __shared__ Type shMem[Size::x::value][Size::y::value];
-        return Cursor((Type*)shMem);
+        auto& shMem = PMacc::memory::shared::allocate<
+            uid,
+            memory::Array<
+                Type,
+                math::CT::volume< Size >::type::value
+            >
+        >( );
+        return Cursor(shMem.data());
     }
 };
 
@@ -74,8 +90,14 @@ struct SharedMemAllocator<Type, Size, 3, uid>
 
     __device__ static Cursor allocate()
     {
-        __shared__ Type shMem[Size::x::value][Size::y::value][Size::z::value];
-        return Cursor((Type*)shMem);
+        auto& shMem = PMacc::memory::shared::allocate<
+            uid,
+            memory::Array<
+                Type,
+                math::CT::volume< Size >::type::value
+            >
+        >( );
+        return Cursor(shMem.data());
     }
 };
 

--- a/src/libPMacc/include/memory/boxes/SharedBox.hpp
+++ b/src/libPMacc/include/memory/boxes/SharedBox.hpp
@@ -21,10 +21,14 @@
 
 #pragma once
 
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
+#include "pmacc_types.hpp"
+
 #include <cuSTL/cursor/compile-time/BufferCursor.hpp>
 #include <math/vector/Float.hpp>
 #include <math/Vector.hpp>
-#include "pmacc_types.hpp"
+
 
 namespace PMacc
 {
@@ -95,8 +99,14 @@ public:
     /* This call synchronizes a block and must be called from all threads and not inside a if clauses*/
     static DINLINE This init()
     {
-        __shared__ ValueType mem_sh[Size::x::value];
-        return This((ValueType*) mem_sh);
+        auto& mem_sh = PMacc::memory::shared::allocate<
+            T_id,
+            memory::Array<
+                ValueType,
+                math::CT::volume< Size >::type::value
+            >
+        >( );
+        return SharedBox( mem_sh.data() );
     }
 
 protected:
@@ -154,8 +164,14 @@ public:
     /* This call synchronizes a block and must be called from all threads and not inside a if clauses*/
     static DINLINE This init()
     {
-        __shared__ ValueType mem_sh[Size::y::value][Size::x::value];
-        return This((ValueType*) mem_sh);
+        auto& mem_sh = PMacc::memory::shared::allocate<
+            T_id,
+            memory::Array<
+                ValueType,
+                math::CT::volume< Size >::type::value
+            >
+        >( );
+        return SharedBox( mem_sh.data() );
     }
 
     HDINLINE PMacc::cursor::CT::BufferCursor<ValueType, ::PMacc::math::CT::Int<sizeof (ValueType) * Size::x::value> >
@@ -229,8 +245,14 @@ public:
     /*this call synchronize a block and must called from any thread and not inside a if clauses*/
     static DINLINE This init()
     {
-        __shared__ ValueType mem_sh[Size::z::value][Size::y::value][Size::x::value];
-        return This((ValueType*) mem_sh);
+        auto& mem_sh = PMacc::memory::shared::allocate<
+            T_id,
+            memory::Array<
+                ValueType,
+                math::CT::volume< Size >::type::value
+            >
+        >( );
+        return SharedBox( mem_sh.data() );
     }
 
 protected:


### PR DESCRIPTION
replace `__shared__ type varName` with `PMacc::memory::shared::allocate<...>()`

This is a follow up of #1727 and fix #1927 by flat all N dimensional arrays to 1D. 

There is a very small performance increase due to more 32Bit integer calculations (instead of 64Bit) during the address calculation for each shared memory access. 

Tests:
- [x] KHI with electrons/positrons (heating and charge conservation)

