### PR TITLE
Remove nyquist limit switch

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -110,10 +110,6 @@ namespace parameters
 /*!enable radiation calculation*/
 #define ENABLE_RADIATION 1
 
-// Nyquist low pass allows only amplitudes for frequencies below Nyquist frequency
-// 1 = on  (slower and more memory, no fourier reflections)
-// 0 = off (faster but with fourier reflections)
-#define __NYQUISTCHECK__ 1
 
 constexpr unsigned int N_observer = 128; // number of looking directions
 

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -117,10 +117,6 @@ namespace parameters
 #endif
 #define ENABLE_RADIATION PARAM_RADIATION
 
-// Nyquist low pass allows only amplitudes for frequencies below Nyquist frequency
-// 1 = on  (slower and more memory, no fourier reflections)
-// 0 = off (faster but with fourier reflections)
-#define __NYQUISTCHECK__ 0
 
 constexpr unsigned int N_observer = 256; // number of looking directions
 

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -51,9 +51,7 @@
 #include "memory/Array.hpp"
 
 
-#if( __NYQUISTCHECK__ == 1 )
-#   include "plugins/radiation/nyquist_low_pass.hpp"
-#endif
+#include "plugins/radiation/nyquist_low_pass.hpp"
 
 #include "plugins/radiation/radFormFactor.hpp"
 #include "sys/stat.h"
@@ -145,10 +143,7 @@ struct KernelRadiationParticles
         // radiation calculation
         PMACC_SMEM( counter_s, int );
 
-        // memory for Nyquist frequency at current time step
-#if( __NYQUISTCHECK__ == 1 )
         PMACC_SMEM( lowpass_s, memory::Array< NyquistLowPass, blockSize > );
-#endif
 
 
         const int theta_idx = blockIdx.x; //blockIdx.x is used to determine theta
@@ -341,11 +336,7 @@ struct KernelRadiationParticles
                             // retarded time stored in shared memory
                             t_ret_s[saveParticleAt] = amplitude3.get_t_ret(look);
 
-                            // if Nyquist-limiter is used, then the NyquistLowPlass object
-                            // is setup and stored in shared memory
-#if( __NYQUISTCHECK__ == 1 )
                             lowpass_s[saveParticleAt] = NyquistLowPass(look, particle);
-#endif
 
 
                             /* the particle amplitude is used to include the weighting
@@ -403,12 +394,9 @@ struct KernelRadiationParticles
                     for (int j = 0; j < counter_s; ++j)
                       {
 
-                        // if Nyquist-limiter is on
-#    if (__NYQUISTCHECK__==1)
                         // check Nyquist-limit for each particle "j" and each frequency "omega"
                         if (lowpass_s[j].check(omega))
                           {
-#    endif
 
                             /****************************************************
                              **** Here happens the true physical calculation ****
@@ -435,10 +423,7 @@ struct KernelRadiationParticles
                             // add this single amplitude those previously considered
                             amplitude += amplitude_add;
 
-                            // if Nyquist limiter is on
-#    if (__NYQUISTCHECK__==1)
                           }// END: check Nyquist-limit for each particle "j" and each frequency "omega"
-#    endif
 
                       }// END: Particle loop
 

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -114,10 +114,6 @@ namespace picongpu
  */
 #define ENABLE_RADIATION 0
 
-// Nyquist low pass allows only amplitudes for frequencies below Nyquist frequency
-// 1 = on  (slower and more memory, no fourier reflections)
-// 0 = off (faster but with fourier reflections)
-#define __NYQUISTCHECK__ 0
 
         constexpr unsigned int N_observer = 256; // number of looking directions
 

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -28,6 +28,8 @@
 
 PMACC_CASSERT_MSG(ENABLE_ELECTRONS_must_set_to_1__change_ENABLE_ELECTRONS_in_file_componentsConfig_param,ENABLE_ELECTRONS==1);
 
+PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_below_one, ( picongpu::radiationNyquist::NyquistFactor < 1.0 ) );
+PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_larger_than_zero, ( picongpu::radiationNyquist::NyquistFactor > 0.0 ) );
 
 namespace picongpu
 {


### PR DESCRIPTION
This pull request removes the pre-compiler switch to exclude the Nyquist limit calculation and thus partially solves issue #667. 

Not calculating the Nyquist limit makes only sense if computing low frequency radiation - below `omega < pi / (2 * delta_t) ` (factor 2 due to propagation away from the detector at the speed of light). This is already resolved by the grid. In most cases, the Nyquist limit should be taken into account. Thus removing the option avoid misconfiguration by accidentally not activating this limit. 