### PR TITLE
remove define `ENABLE_RADIATION`

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/radiationConfig.param
+++ b/examples/Bunch/include/simulation_defines/param/radiationConfig.param
@@ -107,8 +107,6 @@ namespace radiationNyquist
 
 namespace parameters
 {
-/*!enable radiation calculation*/
-#define ENABLE_RADIATION 1
 
 
 constexpr unsigned int N_observer = 128; // number of looking directions

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiationConfig.param
@@ -111,11 +111,6 @@ namespace radiationNyquist
 
 namespace parameters
 {
-/*!enable radiation calculation*/
-#ifndef PARAM_RADIATION
-#define PARAM_RADIATION 0
-#endif
-#define ENABLE_RADIATION PARAM_RADIATION
 
 
 constexpr unsigned int N_observer = 256; // number of looking directions

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
@@ -17,18 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file
- *
- * Define particle species.
- *
- * This file collects all previous declarations of base (reference) quantities
- * and configured solvers for species and defines particle species. This
- * includes "attributes" (lvalues to store with each species) and "flags"
- * (rvalues & aliases for solvers to perform with the species for each timestep
- * and ratios to base quantities). With those information, a `Particles` class
- * is defined for each species and then collected in the list
- * `VectorAllSpecies`.
- */
 
 #pragma once
 
@@ -45,6 +33,11 @@
 #include "particles/ionization/byCollision/ionizers.def"
 
 
+#ifndef PARAM_RADIATION
+    /* disable radiation calculation */
+#   define PARAM_RADIATION 0
+#endif
+
 namespace picongpu
 {
 
@@ -55,31 +48,14 @@ using DefaultParticleAttributes = MakeSeq_t<
     position< position_pic >,
     momentum,
     weighting
+#if( PARAM_RADIATION == 1 )
+    , momentumPrev1
+#endif
 >;
 
 /*########################### end particle attributes ########################*/
 
 /*########################### define species #################################*/
-
-/*--------------------------- photons -------------------------------------------*/
-
-value_identifier( float_X, MassRatioPhotons, 0.0 );
-value_identifier( float_X, ChargeRatioPhotons, 0.0 );
-
-using ParticleFlagsPhotons = bmpl::vector<
-    particlePusher< particles::pusher::Photon >,
-    shape< UsedParticleShape >,
-    interpolation< UsedField2Particle >,
-    massRatio< MassRatioPhotons >,
-    chargeRatio< ChargeRatioPhotons >
->;
-
-/* define species photons */
-using PIC_Photons = Particles<
-    bmpl::string< 'p', 'h' >,
-    DefaultParticleAttributes,
-    ParticleFlagsPhotons
->;
 
 /*--------------------------- electrons --------------------------------------*/
 
@@ -94,9 +70,6 @@ using ParticleFlagsElectrons = bmpl::vector<
     current< UsedParticleCurrentSolver >,
     massRatio< MassRatioElectrons >,
     chargeRatio< ChargeRatioElectrons >
-#if( ENABLE_SYNCHROTRON_PHOTONS == 1 )
-    , synchrotronPhotons< PIC_Photons >
-#endif
 >;
 
 /* define species electrons */
@@ -159,9 +132,6 @@ using Species2 = MakeSeq_t<
 using VectorAllSpecies = MakeSeq_t<
     Species1,
     Species2
-#if( ENABLE_SYNCHROTRON_PHOTONS == 1 )
-    , PIC_Photons
-#endif
 >;
 
 } // namespace picongpu

--- a/examples/SingleParticleTest/include/simulation_defines/param/fileOutput.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/fileOutput.param
@@ -54,7 +54,7 @@ namespace picongpu
      *                                       component and the absolute
      *                                       momentum with respect to shape
      *   - CreateLarmorPowerOperation: radiated larmor power
-     *                                 (needs ENABLE_RADIATION)
+     *                                 (species must contain the attribute `momentumPrev1`)
      *
      * for debugging:
      *   - CreateMidCurrentDensityComponentOperation:

--- a/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/src/picongpu/include/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -309,7 +309,6 @@ struct CreateMomentumComponentOperation
     typedef FieldTmpOperation< ParticleMomentumComponent, T_Species > type;
 };
 
-#if(ENABLE_RADIATION == 1)
 /** Radiated Larmor Power Operation for Particle to Grid Projections
  *
  * Derives a scalar field with the radiated power according to the Larmor
@@ -334,6 +333,6 @@ struct CreateLarmorPowerOperation
 
     typedef FieldTmpOperation< ParticleLarmorPower, T_Species > type;
 };
-#endif
+
 } /* namespace particleToGrid */
 } /* namespace picongpu */

--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "static_assert.hpp"
 #include "particles/particleToGrid/derivedAttributes/LarmorPower.def"
 
 #include "simulation_defines.hpp"
@@ -41,6 +42,13 @@ namespace derivedAttributes
     DINLINE float_X
     LarmorPower::operator()( T_Particle& particle ) const
     {
+
+        static constexpr bool hasMomentumPrev1 = PMacc::traits::HasIdentifier<
+            typename T_Particle::FrameType,
+            momentumPrev1
+        >::type::value;
+        PMACC_CASSERT_MSG_TYPE( species_must_have_the_attribute_momentumPrev1, T_Particle, hasMomentumPrev1 );
+
         /* read existing attributes */
         const float3_X mom = particle[momentum_];
         const float3_X mom_mt1 = particle[momentumPrev1_];

--- a/src/picongpu/include/plugins/PluginController.hpp
+++ b/src/picongpu/include/plugins/PluginController.hpp
@@ -34,17 +34,14 @@
 #include "plugins/BinEnergyParticles.hpp"
 #include "plugins/ChargeConservation.hpp"
 #if(ENABLE_HDF5 == 1)
+#include "plugins/radiation/parameters.hpp"
+#include "plugins/radiation/Radiation.hpp"
 #include "plugins/particleCalorimeter/ParticleCalorimeter.hpp"
 #include "plugins/PhaseSpace/PhaseSpaceMulti.hpp"
 #endif
 
 #if (ENABLE_INSITU_VOLVIS == 1)
 #include "plugins/InSituVolumeRenderer.hpp"
-#endif
-
-#if(ENABLE_RADIATION == 1)
-#include "plugins/radiation/parameters.hpp"
-#include "plugins/radiation/Radiation.hpp"
 #endif
 
 #include "simulation_classTypes.hpp"
@@ -172,12 +169,10 @@ private:
         EnergyParticles<bmpl::_1>,
         BinEnergyParticles<bmpl::_1>,
         LiveViewPlugin<bmpl::_1>,
-        PositionsParticles<bmpl::_1>
-#if(ENABLE_RADIATION == 1)
-      , Radiation<bmpl::_1>
-#endif
-     , PngPlugin< Visualisation<bmpl::_1, PngCreator> >
+        PositionsParticles<bmpl::_1>,
+        PngPlugin< Visualisation<bmpl::_1, PngCreator> >
 #if(ENABLE_HDF5 == 1)
+      , Radiation<bmpl::_1>
       , ParticleCalorimeter<bmpl::_1>
       , PerSuperCell<bmpl::_1>
       , PhaseSpaceMulti<particles::shapes::Counter::ChargeAssignment, bmpl::_1>

--- a/src/picongpu/include/plugins/radiation/Radiation.hpp
+++ b/src/picongpu/include/plugins/radiation/Radiation.hpp
@@ -41,6 +41,7 @@
 #include "dimensions/DataSpaceOperations.hpp"
 #include "dataManagement/DataConnector.hpp"
 #include "mappings/kernel/AreaMapping.hpp"
+#include "traits/HasIdentifier.hpp"
 
 #include <splash/splash.h>
 #include <boost/filesystem.hpp>
@@ -114,6 +115,16 @@ private:
     std::string folderRadPerGPU;
     DataSpace<simDim> lastGPUpos;
 
+    /** defines if all kernel dependencies are full filled
+     *
+     * dependencies:
+     *   - species contains the attribute `momentumPrev1`
+     */
+    static constexpr bool dependenciesFulfilled = PMacc::traits::HasIdentifier<
+        typename ParticlesType::FrameType,
+        momentumPrev1
+    >::type::value;
+
     /**
      * Data structure for storage and summation of the intermediate values of
      * the calculated Amplitude from every host for every direction and
@@ -178,7 +189,7 @@ public:
      */
     void notify(uint32_t currentStep)
     {
-        if (currentStep >= radStart)
+        if (dependenciesFulfilled && currentStep >= radStart)
         {
             // radEnd = 0 is default, calculates radiation until simulation
             // end
@@ -199,19 +210,27 @@ public:
     void pluginRegisterHelp(po::options_description& desc)
     {
 
-        desc.add_options()
-            ((pluginPrefix + ".period").c_str(), po::value<uint32_t > (&notifyFrequency), "enable plugin [for each n-th step]")
-            ((pluginPrefix + ".dump").c_str(), po::value<uint32_t > (&dumpPeriod)->default_value(0), "dump integrated radiation from last dumped step [for each n-th step] (0 = only print data at end of simulation)")
-            ((pluginPrefix + ".lastRadiation").c_str(), po::bool_switch(&lastRad), "enable calculation of integrated radiation from last dumped step")
-            ((pluginPrefix + ".folderLastRad").c_str(), po::value<std::string > (&folderLastRad)->default_value("lastRad"), "folder in which the integrated radiation from last dumped step is written")
-            ((pluginPrefix + ".totalRadiation").c_str(), po::bool_switch(&totalRad), "enable calculation of integrated radiation from start of simulation")
-            ((pluginPrefix + ".folderTotalRad").c_str(), po::value<std::string > (&folderTotalRad)->default_value("totalRad"), "folder in which the integrated radiation from start of simulation is written")
-            ((pluginPrefix + ".start").c_str(), po::value<uint32_t > (&radStart)->default_value(2), "time index when radiation should start with calculation")
-            ((pluginPrefix + ".end").c_str(), po::value<uint32_t > (&radEnd)->default_value(0), "time index when radiation should end with calculation")
-            ((pluginPrefix + ".omegaList").c_str(), po::value<std::string > (&pathOmegaList)->default_value("_noPath_"), "path to file containing all frequencies to calculate")
-            ((pluginPrefix + ".radPerGPU").c_str(), po::bool_switch(&radPerGPU), "enable radiation output from each GPU individually")
-            ((pluginPrefix + ".folderRadPerGPU").c_str(), po::value<std::string > (&folderRadPerGPU)->default_value("radPerGPU"), "folder in which the radiation of each GPU is written")
-            ((pluginPrefix + ".compression").c_str(), po::bool_switch(&compressionOn), "enable compression of hdf5 output");
+        if(dependenciesFulfilled)
+        {
+            desc.add_options()
+                ((pluginPrefix + ".period").c_str(), po::value<uint32_t > (&notifyFrequency), "enable plugin [for each n-th step]")
+                ((pluginPrefix + ".dump").c_str(), po::value<uint32_t > (&dumpPeriod)->default_value(0), "dump integrated radiation from last dumped step [for each n-th step] (0 = only print data at end of simulation)")
+                ((pluginPrefix + ".lastRadiation").c_str(), po::bool_switch(&lastRad), "enable calculation of integrated radiation from last dumped step")
+                ((pluginPrefix + ".folderLastRad").c_str(), po::value<std::string > (&folderLastRad)->default_value("lastRad"), "folder in which the integrated radiation from last dumped step is written")
+                ((pluginPrefix + ".totalRadiation").c_str(), po::bool_switch(&totalRad), "enable calculation of integrated radiation from start of simulation")
+                ((pluginPrefix + ".folderTotalRad").c_str(), po::value<std::string > (&folderTotalRad)->default_value("totalRad"), "folder in which the integrated radiation from start of simulation is written")
+                ((pluginPrefix + ".start").c_str(), po::value<uint32_t > (&radStart)->default_value(2), "time index when radiation should start with calculation")
+                ((pluginPrefix + ".end").c_str(), po::value<uint32_t > (&radEnd)->default_value(0), "time index when radiation should end with calculation")
+                ((pluginPrefix + ".omegaList").c_str(), po::value<std::string > (&pathOmegaList)->default_value("_noPath_"), "path to file containing all frequencies to calculate")
+                ((pluginPrefix + ".radPerGPU").c_str(), po::bool_switch(&radPerGPU), "enable radiation output from each GPU individually")
+                ((pluginPrefix + ".folderRadPerGPU").c_str(), po::value<std::string > (&folderRadPerGPU)->default_value("radPerGPU"), "folder in which the radiation of each GPU is written")
+                ((pluginPrefix + ".compression").c_str(), po::bool_switch(&compressionOn), "enable compression of hdf5 output");
+        }
+        else
+        {
+            desc.add_options()
+                (pluginPrefix.c_str(), "plugin disabled [missing species attribute `momentumPrev1`]");
+        }
     }
 
 
@@ -233,7 +252,7 @@ public:
         if(notifyFrequency == 0)
             return;
 
-        if(isMaster)
+        if(dependenciesFulfilled && isMaster)
         {
             // this will lead to wrong lastRad output right after the checkpoint if the restart point is
             // not a dump point. The correct lastRad data can be reconstructed from hdf5 data
@@ -250,15 +269,18 @@ public:
         if(notifyFrequency == 0)
             return;
 
-        // collect data GPU -> CPU -> Master
-        copyRadiationDeviceToHost();
-        collectRadiationOnMaster();
-        sumAmplitudesOverTime(tmp_result, timeSumArray);
-
-        // write backup file
-        if (isMaster)
+        if(dependenciesFulfilled)
         {
-            writeHDF5file(tmp_result, restartDirectory + "/" + speciesName + std::string("_radRestart_"));
+            // collect data GPU -> CPU -> Master
+            copyRadiationDeviceToHost();
+            collectRadiationOnMaster();
+            sumAmplitudesOverTime(tmp_result, timeSumArray);
+
+            // write backup file
+            if (isMaster)
+            {
+                writeHDF5file(tmp_result, restartDirectory + "/" + speciesName + std::string("_radRestart_"));
+            }
         }
     }
 
@@ -277,78 +299,81 @@ private:
      * is created.       */
     void pluginLoad()
     {
-        // allocate memory for all amplitudes for temporal data collection
-        tmp_result = new Amplitude[elements_amplitude()];
-
-        if (notifyFrequency > 0)
+        if(dependenciesFulfilled)
         {
-            /*only rank 0 create a file*/
-            isMaster = reduce.hasResult(mpi::reduceMethods::Reduce());
+            // allocate memory for all amplitudes for temporal data collection
+            tmp_result = new Amplitude[elements_amplitude()];
 
-            radiation = new GridBuffer<Amplitude, DIM1 > (DataSpace<DIM1 > (elements_amplitude())); //create one int on GPU and host
-
-            freqInit.Init(pathOmegaList);
-            freqFkt = freqInit.getFunctor();
-
-
-            Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyFrequency);
-            PMacc::Filesystem<simDim>& fs = Environment<simDim>::get().Filesystem();
-
-            if (isMaster)
+            if (notifyFrequency > 0)
             {
-                timeSumArray = new Amplitude[elements_amplitude()];
+                /*only rank 0 create a file*/
+                isMaster = reduce.hasResult(mpi::reduceMethods::Reduce());
 
-                /* save detector position / observation direction */
-                detectorPositions = new vector_64[parameters::N_observer];
-                for(uint32_t detectorIndex=0; detectorIndex < parameters::N_observer; ++detectorIndex)
+                radiation = new GridBuffer<Amplitude, DIM1 > (DataSpace<DIM1 > (elements_amplitude())); //create one int on GPU and host
+
+                freqInit.Init(pathOmegaList);
+                freqFkt = freqInit.getFunctor();
+
+
+                Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyFrequency);
+                PMacc::Filesystem<simDim>& fs = Environment<simDim>::get().Filesystem();
+
+                if (isMaster)
                 {
-                    detectorPositions[detectorIndex] = radiation_observer::observation_direction(detectorIndex);
+                    timeSumArray = new Amplitude[elements_amplitude()];
+
+                    /* save detector position / observation direction */
+                    detectorPositions = new vector_64[parameters::N_observer];
+                    for(uint32_t detectorIndex=0; detectorIndex < parameters::N_observer; ++detectorIndex)
+                    {
+                        detectorPositions[detectorIndex] = radiation_observer::observation_direction(detectorIndex);
+                    }
+
+                    /* save detector frequencies */
+                    detectorFrequencies = new float_64[radiation_frequencies::N_omega];
+                    for(uint32_t detectorIndex=0; detectorIndex < radiation_frequencies::N_omega; ++detectorIndex)
+                    {
+                        detectorFrequencies[detectorIndex] = freqFkt(detectorIndex);
+                    }
+
                 }
 
-                /* save detector frequencies */
-                detectorFrequencies = new float_64[radiation_frequencies::N_omega];
-                for(uint32_t detectorIndex=0; detectorIndex < radiation_frequencies::N_omega; ++detectorIndex)
+                if (isMaster && totalRad)
                 {
-                    detectorFrequencies[detectorIndex] = freqFkt(detectorIndex);
+                    fs.createDirectory("radiationHDF5");
+                    fs.setDirectoryPermissions("radiationHDF5");
+                }
+
+
+                if (isMaster && radPerGPU)
+                {
+                    fs.createDirectory(folderRadPerGPU);
+                    fs.setDirectoryPermissions(folderRadPerGPU);
+                }
+
+                if (isMaster && totalRad)
+                {
+                    //create folder for total output
+                    fs.createDirectory(folderTotalRad);
+                    fs.setDirectoryPermissions(folderTotalRad);
+                    for (unsigned int i = 0; i < elements_amplitude(); ++i)
+                        timeSumArray[i] = Amplitude::zero();
+                }
+                if (isMaster && lastRad)
+                {
+                    //create folder for total output
+                    fs.createDirectory(folderLastRad);
+                    fs.setDirectoryPermissions(folderLastRad);
                 }
 
             }
-
-            if (isMaster && totalRad)
-            {
-                fs.createDirectory("radiationHDF5");
-                fs.setDirectoryPermissions("radiationHDF5");
-            }
-
-
-            if (isMaster && radPerGPU)
-            {
-                fs.createDirectory(folderRadPerGPU);
-                fs.setDirectoryPermissions(folderRadPerGPU);
-            }
-
-            if (isMaster && totalRad)
-            {
-                //create folder for total output
-                fs.createDirectory(folderTotalRad);
-                fs.setDirectoryPermissions(folderTotalRad);
-                for (unsigned int i = 0; i < elements_amplitude(); ++i)
-                    timeSumArray[i] = Amplitude::zero();
-            }
-            if (isMaster && lastRad)
-            {
-                //create folder for total output
-                fs.createDirectory(folderLastRad);
-                fs.setDirectoryPermissions(folderLastRad);
-            }
-
         }
     }
 
 
     void pluginUnload()
     {
-        if (notifyFrequency > 0)
+        if(dependenciesFulfilled && notifyFrequency > 0)
         {
 
             // Some funny things that make it possible for the kernel to calculate
@@ -1180,7 +1205,7 @@ private:
 
 
       // PIC-like kernel call of the radiation kernel
-      PMACC_KERNEL(KernelRadiationParticles{})
+      PMACC_KERNEL(KernelRadiationParticles<dependenciesFulfilled>{})
         (gridDim_rad, blockDim_rad)
         (
          /*Pointer to particles memory on the device*/

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -64,7 +64,14 @@ using namespace PMacc;
 namespace po = boost::program_options;
 
 
-/** calculate the radiation of a species */
+/** calculate the radiation of a species
+ *
+ * If \p T_dependenciesFulfilled is false a dummy kernel without functionality is created
+ *
+ * @tparam T_dependenciesFulfilled true if all dependencies(species attributes) are full filled
+ *                                  else false
+ */
+template< bool T_dependenciesFulfilled >
 struct KernelRadiationParticles
 {
     /**
@@ -470,7 +477,26 @@ struct KernelRadiationParticles
     } // end radiation kernel
 };
 
+/** specialization if a dependency is missing
+ *
+ * this functor is empty.
+ */
+template< >
+struct KernelRadiationParticles< false >
+{
+    template<class ParBox, class DBox, class Mapping>
+    DINLINE
+    void operator()(
+        ParBox,
+        DBox,
+        DataSpace<simDim>,
+        uint32_t,
+        Mapping,
+        radiation_frequencies::FreqFunctor,
+        DataSpace<simDim>
+    ) const
+    {
+    }
+};
+
 }
-
-
-

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -68,7 +68,7 @@ namespace po = boost::program_options;
  *
  * If \p T_dependenciesFulfilled is false a dummy kernel without functionality is created
  *
- * @tparam T_dependenciesFulfilled true if all dependencies(species attributes) are full filled
+ * @tparam T_dependenciesFulfilled true if all dependencies (species attributes) are full filled
  *                                  else false
  */
 template< bool T_dependenciesFulfilled >

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -17,18 +17,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
 
-
-
-
-#if (ENABLE_RADIATION == 1 )
 
 namespace picongpu
 {
@@ -67,7 +59,3 @@ namespace picongpu
 
   }
 }
-
-
-#endif
-

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -17,17 +17,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
 #include <fstream>
 #include <cstdio>
 #include "memory/buffers/GridBuffer.hpp"
-
-#if (ENABLE_RADIATION == 1)
 
 
 namespace picongpu
@@ -122,7 +117,3 @@ namespace picongpu
 
   }
 }
-
-
-
-#endif

--- a/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/src/picongpu/include/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -17,18 +17,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-
 #pragma once
 
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-
-
-
-
-#if (ENABLE_RADIATION == 1 )
 
 
 namespace picongpu
@@ -77,6 +68,3 @@ namespace picongpu
   }
 
 }
-
-#endif
-

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -54,7 +54,7 @@ namespace picongpu
      *                                       component and the absolute
      *                                       momentum with respect to shape
      *   - CreateLarmorPowerOperation: radiated larmor power
-     *                                 (needs ENABLE_RADIATION)
+     *                                 (species must contain the attribute `momentumPrev1`)
      *
      * for debugging:
      *   - CreateMidCurrentDensityComponentOperation:

--- a/src/picongpu/include/simulation_defines/param/radiationConfig.param
+++ b/src/picongpu/include/simulation_defines/param/radiationConfig.param
@@ -108,11 +108,6 @@ namespace picongpu
 
     namespace parameters
     {
-/*! enable radiation calculation
- *
- * If radiation is enabled the attribute `momentumPrev1` needs to be added to electron species
- */
-#define ENABLE_RADIATION 0
 
 
         constexpr unsigned int N_observer = 256; // number of looking directions

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -55,7 +55,7 @@ using DefaultParticleAttributes = MakeSeq_t<
     position< position_pic >,
     momentum,
     weighting
-#if( ENABLE_RADIATION == 1 )
+#if( PARAM_RADIATION == 1 )
     , momentumPrev1
 #endif
 >;

--- a/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/radiationConfig.unitless
@@ -17,20 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "static_assert.hpp"
 
 
-#if (ENABLE_RADIATION == 1 )
-
-PMACC_CASSERT_MSG(ENABLE_ELECTRONS_must_set_to_1__change_ENABLE_ELECTRONS_in_file_componentsConfig_param,ENABLE_ELECTRONS==1);
-
 PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_below_one, ( picongpu::radiationNyquist::NyquistFactor < 1.0 ) );
 PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_larger_than_zero, ( picongpu::radiationNyquist::NyquistFactor > 0.0 ) );
-
 namespace picongpu
 {
   namespace rad_linear_frequencies
@@ -66,9 +59,6 @@ namespace parameters
 }
 
 } //namespace picongpu
-
-#endif
-
 
 #include "plugins/radiation/frequencies/radiation_lin_freq.hpp"
 #include "plugins/radiation/frequencies/radiation_log_freq.hpp"


### PR DESCRIPTION
- Radiation: 
  - disable help if dependencies for the solver are not fulfilled (announce the missing dependency to the user)
  - add kernel dummy `KernelRadiationParticles<>` for missing dependencies
- `PluginController.hpp` always register the plugin `Radiation` (if HDF5 is available)
- remove usage of `ENABLE_RADIATION`

The plugin is now only available for species with the attribute  `momentumPrev1`. Before this pull request `momentumPrev1` must be added to all species to allow the usage of the radiation plugin.

Related to #667
