### PR TITLE
support for clang as host && device compiler

### DIFF
--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -104,7 +104,6 @@ endif(CUDA_KEEP_FILES)
 
 if("${PMACC_CUDA_COMPILER}" STREQUAL "clang")
     add_definitions(-DPMACC_CUDA_COMPILER_CLANG=1)
-    #set(LIBS ${LIBS} cudart_static)
     set(CLANG_BUILD_FLAGS "-O3 -x cuda --cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
     # activation usage of FMA
     set(CLANG_BUILD_FLAGS "${CLANG_BUILD_FLAGS} -ffp-contract=fast")
@@ -174,9 +173,7 @@ elseif("${PMACC_CUDA_COMPILER}" STREQUAL "nvcc")
     endif(CUDA_KEEP_FILES)
 
 else()
-
     message(FATAL_ERROR "selected CUDA compiler '${PMACC_CUDA_COMPILER}' is not supported")
-
 endif()
 
 
@@ -280,7 +277,10 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_VARIADIC_TEMPLATES")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_FENV_H")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_definitions(-DBOOST_NO_CXX11_SMART_PTR)
+    # suppress boost error
+    # 'no member named "impl" in "boost::detail::thread_move_t<boost::detail::nullary_function<void ()> >"'
+    # in 'boost/thread/detail/nullary_function.hpp'
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_SMART_PTR")
 endif()
 
 

--- a/src/libPMacc/include/static_assert.hpp
+++ b/src/libPMacc/include/static_assert.hpp
@@ -45,8 +45,17 @@ namespace PMacc
  * @param pmacc_unique_id pre compiler unique id
  * @param pmacc_typeInfo a type that is shown in error message
  */
-#define PMACC_STATIC_ASSERT_MSG_DO2(pmacc_cond, pmacc_msg, pmacc_unique_id, pmacc_typeInfo) \
-    BOOST_MPL_ASSERT_MSG(pmacc_cond,PMACC_JOIN(pmacc_msg,PMACC_JOIN(_________,pmacc_unique_id)),(pmacc_typeInfo))
+#if ( PMACC_CUDA_COMPILER_CLANG == 1 )
+/* device compile with clang: boost static assert can not be used
+ * error is: calling a `__host__` function from `__device__`
+ * Therefore C++11 `static_assert` is used
+ */
+#   define PMACC_STATIC_ASSERT_MSG_DO2(pmacc_cond, pmacc_msg, pmacc_unique_id, pmacc_typeInfo) \
+        static_assert(pmacc_cond,#pmacc_msg)
+#else
+#   define PMACC_STATIC_ASSERT_MSG_DO2(pmacc_cond, pmacc_msg, pmacc_unique_id, pmacc_typeInfo) \
+        BOOST_MPL_ASSERT_MSG(pmacc_cond,PMACC_JOIN(pmacc_msg,PMACC_JOIN(_________,pmacc_unique_id)),(pmacc_typeInfo))
+#endif
 
 /*! static assert with error message
  * @param pmacc_cond A condition which return true or false.

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -164,29 +164,41 @@ endif(PARAM_OVERWRITES)
 # load cuda_memtest project
 ################################################################################
 
-set(SAME_NVCC_FLAGS_IN_SUBPROJECTS OFF)
-find_path(CUDA_MEMTEST_DIR
-        NAMES CMakeLists.txt
-        PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdParty/cuda_memtest"
-        DOC "path to cuda_memtest"
-        )
+option(CUDAMEMTEST_ENABLE "Build cuda_memtest and the helper mpiInfo \
+                          (allow GPU health test before running PIConGPU)" ON)
 
-add_subdirectory(${CUDA_MEMTEST_DIR}
-                 "${CMAKE_CURRENT_BINARY_DIR}/build_cuda_memtest")
+if("${PMACC_CUDA_COMPILER}" STREQUAL "clang")
+    # cuda_memtest is not compiling with `clang`
+    set(CUDAMEMTEST_ENABLE OFF CACHE BOOL "Build cuda_memtest and the helper mpiInfo \
+                           (allow GPU health test before running PIConGPU)" FORCE)
+    message(STATUS "Disable 'cuda_memtest' build: not supported by clang")
+endif()
+
+if(CUDAMEMTEST_ENABLE)
+    set(SAME_NVCC_FLAGS_IN_SUBPROJECTS OFF)
+    find_path(CUDA_MEMTEST_DIR
+            NAMES CMakeLists.txt
+            PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdParty/cuda_memtest"
+            DOC "path to cuda_memtest"
+            )
+
+    add_subdirectory(${CUDA_MEMTEST_DIR}
+                     "${CMAKE_CURRENT_BINARY_DIR}/build_cuda_memtest")
 
 
-################################################################################
-# Load mpiInfo project
-################################################################################
+    ############################################################################
+    # Load mpiInfo project
+    ############################################################################
 
-find_path(MPI_INFO_DIR
-        NAMES CMakeLists.txt
-        PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../mpiInfo"
-        DOC "path to mpiInfo"
-        )
+    find_path(MPI_INFO_DIR
+            NAMES CMakeLists.txt
+            PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../mpiInfo"
+            DOC "path to mpiInfo"
+            )
 
-add_subdirectory(${MPI_INFO_DIR}
-                 "${CMAKE_CURRENT_BINARY_DIR}/build_mpiInfo")
+    add_subdirectory(${MPI_INFO_DIR}
+                     "${CMAKE_CURRENT_BINARY_DIR}/build_mpiInfo")
+endif()
 
 
 ################################################################################
@@ -332,11 +344,24 @@ add_library(picongpu-hostonly
     ${SRCFILES}
 )
 
-cuda_add_executable(picongpu
-    ${CUDASRCFILES}
-)
+if("${PMACC_CUDA_COMPILER}" STREQUAL "clang")
+    add_executable(picongpu
+        ${CUDASRCFILES}
+    )
 
-target_link_libraries(picongpu ${LIBS} picongpu-hostonly m)
+    set_target_properties(picongpu PROPERTIES COMPILE_FLAGS ${CLANG_BUILD_FLAGS})
+    set_target_properties(picongpu PROPERTIES LINKER_LANGUAGE CXX)
+    set_source_files_properties(${CUDASRCFILES} PROPERTIES LANGUAGE CXX)
+
+    target_link_libraries(picongpu ${LIBS} picongpu-hostonly m )
+else()
+    cuda_add_executable(picongpu
+        ${CUDASRCFILES}
+        ${SRCFILES}
+    )
+
+    target_link_libraries(picongpu ${LIBS} picongpu-hostonly m)
+endif()
 
 ################################################################################
 # Install PIConGPU

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -161,7 +161,7 @@ endif(PARAM_OVERWRITES)
 
 
 ################################################################################
-# load cuda_memtest project
+# load cuda_memtest and mpiInfo projects
 ################################################################################
 
 option(CUDAMEMTEST_ENABLE "Build cuda_memtest and the helper mpiInfo \
@@ -186,10 +186,7 @@ if(CUDAMEMTEST_ENABLE)
                      "${CMAKE_CURRENT_BINARY_DIR}/build_cuda_memtest")
 
 
-    ############################################################################
-    # Load mpiInfo project
-    ############################################################################
-
+    # mpiInfo utility
     find_path(MPI_INFO_DIR
             NAMES CMakeLists.txt
             PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../mpiInfo"


### PR DESCRIPTION
- use C++11 `static_assert` if clang is the device compiler
- `PMaccConfig.cmake`
  - add compiler independent options: CUDA_FAST_MATH, CUDA_FTZ, CUDA_SHOW_REGISTER and CUDA_KEEP_FILES
  - add clang compiler flag preperation section
  - add option to select the device (CUDA) compiler
- PIConGPU `CmakeList.txt`
  - add clang compiler section to create the device code
  - add option `CUDAMEMTEST_ENABLE`
  - set `CUDAMEMTEST_ENABLE=OFF` if clang is the device compiler


## Tests
- [x] compile tests clang
- [x] compile tests nvcc/gcc
- [x] KHI runtime test clang (positrons/electrons)