### PR TITLE
optimize `AssignedTrilinearInterpolation`

### DIFF
--- a/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
@@ -74,24 +74,21 @@ struct AssignedTrilinearInterpolation
         typedef typename ::PMacc::result_of::Functor<AssignedTrilinearInterpolation, Cursor>::type type;
 
         type result_z = type(0.0);
-#pragma unroll 4
-        for (float_X z = Begin; z <= End; z += float_X(1.0))
+        for (int z = Begin; z <= End; ++z)
         {
             type result_y = type(0.0);
-#pragma unroll 4
-            for (float_X y = Begin; y <= End; y += float_X(1.0))
+            for (int y = Begin; y <= End; ++y)
             {
                 type result_x = type(0.0);
-#pragma unroll 4
-                for (float_X x = Begin; x <= End; x += float_X(1.0))
+                for (int x = Begin; x <= End; ++x)
                     //a form factor is the "amount of particle" that is affected by this cell
                     //so we have to sum over: cell_value * form_factor
-                    result_x += *cursor(x, y, z) * AssignmentFunction()(x - pos.x());
+                    result_x += *cursor(x, y, z) * AssignmentFunction()(float_X(x) - pos.x());
 
-                result_y += result_x * AssignmentFunction()(y - pos.y());
+                result_y += result_x * AssignmentFunction()(float_X(y) - pos.y());
             }
 
-            result_z += result_y * AssignmentFunction()(z - pos.z());
+            result_z += result_y * AssignmentFunction()(float_X(z) - pos.z());
         }
         return result_z;
     }
@@ -106,17 +103,15 @@ struct AssignedTrilinearInterpolation
 
 
         type result_y = type(0.0);
-#pragma unroll 4
-        for (float_X y = Begin; y <= End; y += float_X(1.0))
+        for (int y = Begin; y <= End; ++y)
         {
             type result_x = type(0.0);
-#pragma unroll 4
-            for (float_X x = Begin; x <= End; x += float_X(1.0))
+            for (int x = Begin; x <= End; ++x)
                 //a form factor is the "amount of particle" that is affected by this cell
                 //so we have to sum over: cell_value * form_factor
-                result_x += *cursor(x, y ) * AssignmentFunction()(x - pos.x());
+                result_x += *cursor(x, y ) * AssignmentFunction()(float_X(x) - pos.x());
 
-            result_y += result_x * AssignmentFunction()(y - pos.y());
+            result_y += result_x * AssignmentFunction()(float_X(y) - pos.y());
         }
         return result_y;
     }

--- a/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/src/picongpu/include/algorithms/AssignedTrilinearInterpolation.hpp
@@ -17,31 +17,33 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "pmacc_types.hpp"
 #include <boost/type_traits/remove_reference.hpp>
 #include <result_of_Functor.hpp>
 
+
 // forward declaration
 namespace picongpu
 {
-struct AssignedTrilinearInterpolation;
-}
+    struct AssignedTrilinearInterpolation;
+} // namespace picongpu
 
 namespace PMacc
 {
 namespace result_of
 {
 
-template<typename Cursor>
-struct Functor<picongpu::AssignedTrilinearInterpolation, Cursor>
-{
-    typedef typename
-    boost::remove_reference<typename Cursor::type>::type type;
-};
+    template< typename T_Cursor >
+    struct Functor<
+        picongpu::AssignedTrilinearInterpolation,
+        T_Cursor
+    >
+    {
+        using type =
+            typename boost::remove_reference< typename T_Cursor::type >::type;
+    };
 
 } // result_of
 } // PMacc
@@ -49,78 +51,113 @@ struct Functor<picongpu::AssignedTrilinearInterpolation, Cursor>
 namespace picongpu
 {
 
-
-struct AssignedTrilinearInterpolation
-{
-
-    /** Does a 3D trilinear field-to-point interpolation for
-     * arbitrary assignment function and arbitrary field_value types.
-     *
-     * \tparam AssignmentFunction function for assignment
-     * \tparam Begin lower margin for interpolation
-     * \tparam End upper margin for interpolation
-     *
-     * \param cursor cursor pointing to the field
-     * \param pos position of the interpolation point
-     * \return sum over: field_value * assignment
-     *
-     * interpolate on grid points in range [Begin;End]
-     */
-    template<class AssignmentFunction,int Begin,int End,class Cursor >
-    static HDINLINE
-    typename ::PMacc::result_of::Functor<AssignedTrilinearInterpolation, Cursor>::type
-    interpolate(const Cursor& cursor, const float3_X & pos)
+    struct AssignedTrilinearInterpolation
     {
-        typedef typename ::PMacc::result_of::Functor<AssignedTrilinearInterpolation, Cursor>::type type;
 
-        type result_z = type(0.0);
-        for (int z = Begin; z <= End; ++z)
+        /** Does a 3D trilinear field-to-point interpolation for
+         * arbitrary assignment function and arbitrary field_value types.
+         *
+         * \tparam T_AssignmentFunction function for assignment
+         * \tparam T_begin lower margin for interpolation
+         * \tparam T_end upper margin for interpolation
+         *
+         * \param cursor cursor pointing to the field
+         * \param pos position of the interpolation point
+         * \return sum over: field_value * assignment
+         *
+         * interpolate on grid points in range [T_begin;T_end]
+         */
+        template<
+            typename T_AssignmentFunction,
+            int T_begin,
+            int T_end,
+            typename T_Cursor
+        >
+        HDINLINE static
+        auto
+        interpolate(
+            const T_Cursor& cursor,
+            const float3_X & pos
+        )
+        -> typename ::PMacc::result_of::Functor<
+            AssignedTrilinearInterpolation,
+            T_Cursor
+        >::type
         {
-            type result_y = type(0.0);
-            for (int y = Begin; y <= End; ++y)
+            using type = typename ::PMacc::result_of::Functor<
+                AssignedTrilinearInterpolation,
+                T_Cursor
+            >::type;
+
+            type result_z = type( 0.0 );
+            for( int z = T_begin; z <= T_end; ++z )
             {
-                type result_x = type(0.0);
-                for (int x = Begin; x <= End; ++x)
+                type result_y = type( 0.0 );
+                for( int y = T_begin; y <= T_end; ++y )
+                {
+                    type result_x = type( 0.0 );
+                    for( int x = T_begin; x <= T_end; ++x )
+                        /* a form factor is the "amount of particle" that is affected by this cell
+                         * so we have to sum over: cell_value * form_factor
+                         */
+                        result_x += *cursor( x, y, z ) * T_AssignmentFunction()( float_X( x ) - pos.x() );
+
+                    result_y += result_x * T_AssignmentFunction()( float_X( y ) - pos.y() );
+                }
+
+                result_z += result_y * T_AssignmentFunction()( float_X( z ) - pos.z() );
+            }
+            return result_z;
+        }
+
+        /** Implementation for 2D position*/
+        template<
+            class T_AssignmentFunction,
+            int T_begin,
+            int T_end,
+            class T_Cursor
+        >
+        HDINLINE static
+        auto
+        interpolate(
+            T_Cursor const & cursor,
+            float2_X const & pos
+        )
+        -> typename ::PMacc::result_of::Functor<
+            AssignedTrilinearInterpolation,
+            T_Cursor
+        >::type
+        {
+            using type = typename ::PMacc::result_of::Functor<
+                AssignedTrilinearInterpolation,
+                T_Cursor
+            >::type;
+
+            type result_y = type( 0.0 );
+            for( int y = T_begin; y <= T_end; ++y )
+            {
+                type result_x = type( 0.0 );
+                for( int x = T_begin; x <= T_end; ++x )
                     //a form factor is the "amount of particle" that is affected by this cell
                     //so we have to sum over: cell_value * form_factor
-                    result_x += *cursor(x, y, z) * AssignmentFunction()(float_X(x) - pos.x());
+                    result_x += *cursor(x, y ) * T_AssignmentFunction()( float_X( x ) - pos.x() );
 
-                result_y += result_x * AssignmentFunction()(float_X(y) - pos.y());
+                result_y += result_x * T_AssignmentFunction()( float_X( y ) - pos.y() );
             }
-
-            result_z += result_y * AssignmentFunction()(float_X(z) - pos.z());
+            return result_y;
         }
-        return result_z;
-    }
 
-    /** Implementation for 2D position*/
-    template<class AssignmentFunction, int Begin, int End, class Cursor >
-    static HDINLINE
-    typename ::PMacc::result_of::Functor<AssignedTrilinearInterpolation, Cursor>::type
-    interpolate(const Cursor& cursor, const float2_X & pos)
-    {
-        typedef typename ::PMacc::result_of::Functor<AssignedTrilinearInterpolation, Cursor>::type type;
-
-
-        type result_y = type(0.0);
-        for (int y = Begin; y <= End; ++y)
+        static
+        auto
+        getStringProperties()
+        -> PMacc::traits::StringProperty
         {
-            type result_x = type(0.0);
-            for (int x = Begin; x <= End; ++x)
-                //a form factor is the "amount of particle" that is affected by this cell
-                //so we have to sum over: cell_value * form_factor
-                result_x += *cursor(x, y ) * AssignmentFunction()(float_X(x) - pos.x());
-
-            result_y += result_x * AssignmentFunction()(float_X(y) - pos.y());
+            PMacc::traits::StringProperty propList(
+                "name",
+                "uniform"
+            );
+            return propList;
         }
-        return result_y;
-    }
+    };
 
-    static PMacc::traits::StringProperty getStringProperties()
-    {
-        PMacc::traits::StringProperty propList( "name", "uniform" );
-        return propList;
-    }
-};
-
-} // picongpu
+} // namespace picongpu


### PR DESCRIPTION
This pull request remove the usage of floats for loop indices. The advantage is that the loop length is known at compile time and the compiler can optimize much more.

- use integer indices for the loops
- remove pragma unroll

Tests KHI positrons/electrons:
- clang [version 4.0.0 (trunk 290769)]
  - [X] speed: no speedup
  - [X] heating test
- nvcc [release 8.0, V8.0.44] 
  - [X] speed: 2-4% speedup
  - [X] heating test