### PR TITLE
fix `PMacc::MallocMCBuffer`

### DIFF
--- a/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.hpp
@@ -25,9 +25,9 @@
 #include "dataManagement/ISimulationData.hpp"
 
 #include "mallocMC/mallocMC.hpp"
+
 #include <string>
 #include <memory>
-#include <utility>
 
 namespace PMacc
 {
@@ -63,12 +63,7 @@ namespace PMacc
 
         char* hostPtr;
         int64_t hostBufferOffset;
-        decltype(
-            std::declval<
-                T_DeviceHeap
-            >().getHeapLocations()[0]
-        ) deviceHeapInfo;
-
+        mallocMC::HeapInfo deviceHeapInfo;
     };
 
 


### PR DESCRIPTION
close  #1934

The bug is that `decltype` returned a reference pointing to temporary memory and was introduced with #1798.
Use explicit `mallocMC::HeapInfo` instead of catching the type with `std::declval` and `decltype`.

This bug is not effecting the latest release!

Tests: 

- [x] KHI restart