### PR TITLE
refactor `Particles<>` interface 

### DIFF
--- a/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
@@ -67,8 +67,8 @@ using ParticleFlagsPhotons = bmpl::vector<
 /* define species photons */
 using PIC_Photons = Particles<
     bmpl::string< 'p', 'h' >,
-    DefaultParticleAttributes,
-    ParticleFlagsPhotons
+    ParticleFlagsPhotons,
+    DefaultParticleAttributes
 >;
 
 
@@ -93,8 +93,8 @@ using ParticleFlagsIons = bmpl::vector<
 /* define species ions */
 using PIC_Ions = Particles<
     bmpl::string< 'i' >,
-    DefaultParticleAttributes,
-    ParticleFlagsIons
+    ParticleFlagsIons,
+    DefaultParticleAttributes
 >;
 
 
@@ -120,8 +120,8 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* define species electrons */
 using PIC_Electrons = Particles<
     bmpl::string< 'e' >,
-    DefaultParticleAttributes,
-    ParticleFlagsElectrons
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
 >;
 
 

--- a/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
@@ -75,8 +75,8 @@ using ParticleFlagsPhotons = bmpl::vector<
 /* define species photons */
 using PIC_Photons = Particles<
     bmpl::string< 'p', 'h' >,
-    DefaultParticleAttributes,
-    ParticleFlagsPhotons
+    ParticleFlagsPhotons,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- electrons --------------------------------------*/
@@ -100,8 +100,8 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* define species electrons */
 using PIC_Electrons = Particles<
     bmpl::string< 'e' >,
-    DefaultParticleAttributes,
-    ParticleFlagsElectrons
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
 >;
 
 /*########################### end species ####################################*/

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
@@ -75,8 +75,8 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* define species electrons */
 using PIC_Electrons = Particles<
     bmpl::string< 'e' >,
-    DefaultParticleAttributes,
-    ParticleFlagsElectrons
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -102,8 +102,8 @@ using ParticleFlagsIons = bmpl::vector<
 /* define species ions */
 using PIC_Ions = Particles<
     bmpl::string< 'i' >,
-    DefaultParticleAttributes,
-    ParticleFlagsIons
+    ParticleFlagsIons,
+    DefaultParticleAttributes
 >;
 
 /*########################### end species ####################################*/

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -76,8 +76,8 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* define species: electrons */
 using PIC_Electrons = Particles<
     bmpl::string< 'e' >,
-    DefaultParticleAttributes,
-    ParticleFlagsElectrons
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -106,8 +106,8 @@ using ParticleFlagsIons = bmpl::vector<
 /* define species: ions */
 using PIC_Ions = Particles<
     bmpl::string< 'i' >,
-    AttributeSeqIons,
-    ParticleFlagsIons
+    ParticleFlagsIons,
+    AttributeSeqIons
 >;
 
 /*########################### end species ####################################*/

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -71,8 +71,8 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* define species electrons */
 using PIC_Electrons = Particles<
     bmpl::string<'e'>,
-    DefaultParticleAttributes,
-    ParticleFlagsElectrons
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
 >;
 
 /*########################### end species ####################################*/

--- a/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
@@ -74,8 +74,8 @@ using ParticleFlagsPhotons = bmpl::vector<
 /* define species photons */
 using Photons = Particles<
     bmpl::string< 'p', 'h' >,
-    DefaultParticleAttributes,
-    ParticleFlagsPhotons
+    ParticleFlagsPhotons,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- electrons --------------------------------------*/
@@ -111,21 +111,21 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* thermal bulk electrons */
 using BulkElectrons = Particles<
     bmpl::string< 'e', 't', 'h' >,
-    DefaultParticleAttributes,
     MakeSeq_t<
         ParticleFlagsElectrons,
         densityRatio< DensityRatioBulkElectrons >
-    >
+    >,
+    DefaultParticleAttributes
 >;
 
 /* non-thermal "hot"/prompt electrons */
 using PromptElectrons = Particles<
     bmpl::string< 'e', 'h', 'o', 't' >,
-    DefaultParticleAttributes,
     MakeSeq_t<
         ParticleFlagsElectrons,
         densityRatio< DensityRatioPromptElectrons >
-    >
+    >,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -155,14 +155,14 @@ using ParticleFlagsCopper = bmpl::vector<
 /* define species ions */
 using CopperIons = Particles<
     bmpl::string< 'C', 'u' >,
+    ParticleFlagsCopper,
     MakeSeq_t<
         position< position_pic >,
         momentum,
         weighting,
         particleId,
         boundElectrons
-    >,
-    ParticleFlagsCopper
+    >
 >;
 
 /*########################### end species ####################################*/

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -66,8 +66,8 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* define species electrons */
 using PIC_Electrons = Particles<
     bmpl::string< 'e' >,
-    DefaultParticleAttributes,
-    ParticleFlagsElectrons
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -93,8 +93,8 @@ using ParticleFlagsIons = bmpl::vector<
 /*define specie ions*/
 using PIC_Ions = Particles<
     bmpl::string<'i'>,
-    DefaultParticleAttributes,
-    ParticleFlagsIons
+    ParticleFlagsIons,
+    DefaultParticleAttributes
 >;
 
 /*########################### end species ####################################*/

--- a/src/libPMacc/include/particles/traits/ResolveAliasFromSpecies.hpp
+++ b/src/libPMacc/include/particles/traits/ResolveAliasFromSpecies.hpp
@@ -50,13 +50,10 @@ namespace traits
  *   synchrotronPhotons<PIC_Photons>
  * > ParticleFlagsElectrons;
  *
- * typedef Particles<
- *   ParticleDescription<
- *       bmpl::string<'e'>,
- *       SuperCellSize,
- *       DefaultAttributesSeq,
- *       ParticleFlagsElectrons
- *   >
+ * typedef picongpu::Particles<
+ *     bmpl::string<'e'>,
+ *     ParticleFlagsElectrons,
+ *     DefaultAttributesSeq
  * > PIC_Electrons;
  *
  * typedef typename ResolveAliasFromSpecies<

--- a/src/picongpu/include/particles/Particles.hpp
+++ b/src/picongpu/include/particles/Particles.hpp
@@ -50,8 +50,8 @@ using namespace PMacc;
  */
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 class Particles : public ParticlesBase<
     ParticleDescription<

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -56,13 +56,13 @@ using namespace PMacc;
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::Particles(
     const std::shared_ptr<DeviceHeap>& heap,
     MappingDesc cellDescription,
@@ -122,14 +122,14 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::createParticleBuffer( )
 {
     this->particlesBuffer->createParticleBuffer( );
@@ -137,14 +137,14 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 SimulationDataId
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::getUniqueId( )
 {
     return m_datasetID;
@@ -152,14 +152,14 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::synchronize( )
 {
     this->particlesBuffer->deviceToHost();
@@ -167,14 +167,14 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::syncToDevice( )
 {
 
@@ -182,28 +182,28 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::init( )
 {
 }
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::update(uint32_t )
 {
     typedef typename GetFlagType<FrameType,particlePusher<> >::type PusherAlias;
@@ -250,15 +250,15 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 template<typename T_DensityFunctor, typename T_PositionFunctor>
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::initDensityProfile(
     T_DensityFunctor& densityFunctor,
     T_PositionFunctor& positionFunctor,
@@ -285,8 +285,8 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 template<
     typename T_SrcName,
@@ -297,8 +297,8 @@ template<
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::deviceDeriveFrom(
     Particles<
         T_SrcName,
@@ -319,15 +319,15 @@ Particles<
 
 template<
     typename T_Name,
-    typename T_Attributes,
-    typename T_Flags
+    typename T_Flags,
+    typename T_Attributes
 >
 template< typename T_Functor>
 void
 Particles<
     T_Name,
-    T_Attributes,
-    T_Flags
+    T_Flags,
+    T_Attributes
 >::manipulateAllParticles( uint32_t currentStep, T_Functor& functor )
 {
 

--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -77,8 +77,8 @@ using ParticleFlagsPhotons = bmpl::vector<
 /* define species photons */
 using PIC_Photons = Particles<
     bmpl::string< 'p', 'h' >,
-    DefaultParticleAttributes,
-    ParticleFlagsPhotons
+    ParticleFlagsPhotons,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- electrons --------------------------------------*/
@@ -102,8 +102,8 @@ using ParticleFlagsElectrons = bmpl::vector<
 /* define species electrons */
 using PIC_Electrons = Particles<
     bmpl::string< 'e' >,
-    DefaultParticleAttributes,
-    ParticleFlagsElectrons
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
 >;
 
 /*--------------------------- ions -------------------------------------------*/
@@ -129,8 +129,8 @@ using ParticleFlagsIons = bmpl::vector<
 /* define species ions */
 using PIC_Ions = Particles<
     bmpl::string< 'i' >,
-    DefaultParticleAttributes,
-    ParticleFlagsIons
+    ParticleFlagsIons,
+    DefaultParticleAttributes
 >;
 
 /*########################### end species ####################################*/


### PR DESCRIPTION
- change order of the template arguments `T_Flags` and `T_Attributes`
- update `speciesDefinition.param`

This refactoring would help to add species attributes in a future follow up automatically depending of the user selected solvers (species flags).