### PR TITLE
add documentation on slurm job control

### DIFF
--- a/src/picongpu/submit/taurus-tud/Slurm_Tutorial.rst
+++ b/src/picongpu/submit/taurus-tud/Slurm_Tutorial.rst
@@ -36,4 +36,7 @@ Job Control
 
   * `scancel 12345` abort job
   * `scancel -s Number 12345` send signal or signal name to job
-  * `scontrol update timelimit=4:00:00 jobid=12345`
+  * `scontrol update timelimit=4:00:00 jobid=12345` change the walltime of the job
+  * `scontrol update jobid=12345 dependency=afterany:54321` only start the job after job with id `54321` has finished
+  * `scontrol hold jobid=12345` prevent the job from starting
+  * `scontrol unhold jobid=12345` release the job to be eligible for run (after it was set on hold)


### PR DESCRIPTION
This adds some examples to the slurm documentation explaining how to control your job after submission to the scheduler. 