### PR TITLE
add visual studio code files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /*.cbp
 /*.layout
 
+# Visual Studio Code configuration files
+.vscode
+
 # python byte code
 *.pyc
 


### PR DESCRIPTION
This pull request avoids that configuration files from [Visual Studio Code](https://github.com/Microsoft/vscode) are included into this git repository. 