### PR TITLE
Sphinx: Fix PDF Chapters

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,8 +57,6 @@ breathe_domain_by_extension = {
     "loader"   : "cpp"
 }
 
-highlight_language = 'c++'
-
 if on_rtd:
     subprocess.call('cd ..; doxygen', shell=True)
 else:
@@ -145,6 +143,7 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
+    'papersize': 'a4paper',
 
     # The font size ('10pt', '11pt' or '12pt').
     #
@@ -153,6 +152,7 @@ latex_elements = {
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
+    'preamble': r'\setcounter{tocdepth}{2}',
 
     # Latex figure (float) alignment
     #

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -58,6 +58,13 @@ Please check your documentation build is successful and renders as you expected 
     # open it, e.g. with firefox :)
     firefox build/html/index.html
 
+    # now again for the pdf :)
+    make latexpdf
+
+    # open it, e.g. with okular
+    build/latex/PIConGPU.pdf
+
+
 Useful Links
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,4 @@
+:orphan:
 .. only:: html
 
   .. image:: ../logo/pic_logo.svg
@@ -6,10 +7,7 @@
 
   .. image:: ../logo/pic_logo.pdf
 
-A particle-in-cell code for GPGPUs
-
-Introduction
-============
+*A particle-in-cell code for GPGPUs*
 
 PIConGPU is a fully relativistic, many GPGPU, 3D3V particle-in-cell (PIC) code.
 The Particle-in-Cell algorithm is a central tool in plasma physics.
@@ -34,6 +32,9 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
 .. _wiki: https://github.com/ComputationalRadiationPhysics/picongpu/wiki
 .. _official homepage: http://picongpu.hzdr.de
 
+************
+Installation
+************
 .. toctree::
    :caption: INSTALLATION
    :maxdepth: 1
@@ -43,6 +44,9 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    install/dependencies
    install/profile
 
+*****
+Usage
+*****
 .. toctree::
    :caption: USAGE
    :maxdepth: 1
@@ -55,6 +59,9 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    usage/tbg
    usage/examples
 
+******
+Models
+******
 .. toctree::
    :caption: MODELS
    :maxdepth: 1
@@ -64,6 +71,9 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    models/ionization
    models/photons
 
+***************
+Post-Processing
+***************
 .. toctree::
    :caption: Post-Processing
    :maxdepth: 2
@@ -72,6 +82,9 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    postprocessing/openPMD
    postprocessing/paraview
 
+***********
+Development
+***********
 .. toctree::
    :caption: DEVELOPMENT
    :maxdepth: 1

--- a/docs/source/usage/reference.rst
+++ b/docs/source/usage/reference.rst
@@ -10,7 +10,8 @@ In order to credit the work of others, we expect you to cite our latest paper de
 
 In addition to that and out of good scientific practice, you should document the version of PIConGPU that was used and any modifications you applied.
 A list of releases alongside a DOI to reference it can be found here:
-  https://github.com/ComputationalRadiationPhysics/picongpu/releases
+
+https://github.com/ComputationalRadiationPhysics/picongpu/releases
 
 
 Citation
@@ -32,6 +33,6 @@ Additional to the citation, please consider adding an acknowledgement of the fol
 
     We acknowledge all contributors to the open-source code PIConGPU for enabling our simulations.
 
-or
+or:
 
     We acknowledge [list of specific persons that helped you] and all further contributors to the open-source code PIConGPU for enabling our simulations.


### PR DESCRIPTION
Fixes pdf chapter building on sphinx. Now looks great and table of contents is useful.

End of the HTML index page is still a bit messy, but ok.

```bash
cd docs
make pdflatex
okular build/latex/PIConGPU.pdf
```