### PR TITLE
Bremsstrahlung: Missing Include & Const

### DIFF
--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -17,6 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "simulation_defines.hpp"
 #include "cuSTL/container/HostBuffer.hpp"
 
 namespace picongpu
@@ -37,8 +38,10 @@ namespace detail
 HDINLINE LookupTableFunctor::LookupTableFunctor(LinInterpCursor linInterpCursor)
     : linInterpCursor(linInterpCursor)
 {
-    this->lnEMin = math::log(electron::MIN_ENERGY);
-    this->lnEMax = math::log(electron::MAX_ENERGY);
+    float_X const lnEMinTmp( electron::MIN_ENERGY );
+    float_X const lnEMaxTmp( electron::MAX_ENERGY );
+    this->lnEMin = math::log( lnEMinTmp );
+    this->lnEMax = math::log( lnEMaxTmp);
 }
 
 /** scaled differential cross section


### PR DESCRIPTION
make the `constexpr` from input available on device by storing it on a temporal `const`:
```
src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp(42): error:
  identifier "picongpu::particles::bremsstrahlung::electron::MIN_ENERGY" is undefined in device code
src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp(43): error:
  identifier "picongpu::particles::bremsstrahlung::electron::MAX_ENERGY" is undefined in device code
```

Add missing simulation_defines include.

Only showed up with `-g -G`, fixes #1774