### PR TITLE
Doc: Start a User Workflows Section

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,6 +58,7 @@ Usage
    usage/plugin
    usage/tbg
    usage/examples
+   usage/workflows
 
 ******
 Models

--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -1,3 +1,5 @@
+.. _usage-params-core:
+
 PIC Core
 --------
 

--- a/docs/source/usage/param/extensions.rst
+++ b/docs/source/usage/param/extensions.rst
@@ -1,3 +1,5 @@
+.. _usage-params-extensions:
+
 PIC Extensions
 --------------
 

--- a/docs/source/usage/param/memory.rst
+++ b/docs/source/usage/param/memory.rst
@@ -1,3 +1,5 @@
+.. _usage-params-memory:
+
 Memory
 ------
 

--- a/docs/source/usage/param/misc.rst
+++ b/docs/source/usage/param/misc.rst
@@ -1,3 +1,5 @@
+.. _usage-params-misc:
+
 Misc
 ----
 

--- a/docs/source/usage/param/plugins.rst
+++ b/docs/source/usage/param/plugins.rst
@@ -1,3 +1,5 @@
+.. _usage-params-plugins:
+
 Plugins
 -------
 

--- a/docs/source/usage/workflows.rst
+++ b/docs/source/usage/workflows.rst
@@ -1,0 +1,13 @@
+.. _usage-workflows:
+
+Workflows
+=========
+
+This section contains typical user workflows and best practices.
+
+.. toctree::
+   :maxdepth: 2
+
+   workflows/numberOfCells
+   workflows/resolution
+

--- a/docs/source/usage/workflows/numberOfCells.rst
+++ b/docs/source/usage/workflows/numberOfCells.rst
@@ -1,0 +1,15 @@
+.. _usage-workflows-numberOfCells:
+
+Setting the Number of Cells
+---------------------------
+
+Together with the grid resolution in :ref:`gridConfig.param <usage-params-core>`, the number of cells in our :ref:`.cfg files <usage-tbg>` determine the overall size of a simulation (box).
+The following rules need to be applied when setting the number of cells:
+
+Each GPU needs to:
+
+#. contain an integer *multiple* of supercells
+#. at least *three* supercells
+
+Supercell sizes in terms of number of cells are set in :ref:`memory.param <usage-params-memory>` and are by default ``8x8x4`` for 3D3V simulations on GPUs.
+For 2D3V simulations, ``16x16`` is usually a good supercell size, however the default is simply cropped to ``8x8``, so make sure to change it to get more performance.

--- a/docs/source/usage/workflows/resolution.rst
+++ b/docs/source/usage/workflows/resolution.rst
@@ -1,0 +1,12 @@
+.. _usage-workflows-resolution:
+
+Changing the Resolution with a Fixed Target
+-------------------------------------------
+
+One often wants to refine an already existing resolution in order to model a setup more precisely or to be able to model a higher density.
+
+#. change cell sizes and time step in :ref:`gridConfig.param <usage-params-core>`
+#. change number of GPUs in :ref:`.cfg file <usage-tbg>`
+#. change number of :ref:`number of cells and distribution over GPUs <usage-workflows-numberOfCells>` in :ref:`.cfg file <usage-tbg>`
+#. adjust (transveral) positioning of targets in :ref:`densityConfig.param <usage-params-core>`
+#. :ref:`recompile <usage-basics>`


### PR DESCRIPTION
Starts a user workflows section in our docs with workflows to:
- set the number of cells of a simulation
- change the resolution of a simulation