### PR TITLE
fix missing ptx code within the binary

### DIFF
--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -143,7 +143,7 @@ elseif("${PMACC_CUDA_COMPILER}" STREQUAL "nvcc")
     foreach(PMACC_CUDA_ARCH_ELEM ${CUDA_ARCH})
         # set flags to create device code for the given architecture
         set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
-            "--generate-code arch=compute_${PMACC_CUDA_ARCH_ELEM},code=sm_${PMACC_CUDA_ARCH_ELEM}")
+            "--generate-code arch=compute_${PMACC_CUDA_ARCH_ELEM},code=sm_${PMACC_CUDA_ARCH_ELEM} --generate-code arch=compute_${PMACC_CUDA_ARCH_ELEM},code=compute_${PMACC_CUDA_ARCH_ELEM}")
     endforeach()
 
     if(CUDA_FAST_MATH)


### PR DESCRIPTION
Embedded ptx code within the binary was accidentally removed with #1933.
If the code is compiled with `sm_20` and than performed on e.g. `sm_35` it can result in segfaults, see #1953, #1954

- [ ] fix #1953
- [x] fix #1954

@PrometheusPi, @n01r could you please check if out issues are solved