### PR TITLE
Fix #1953 RNG Shutdown via DataConnector

### DIFF
--- a/src/libPMacc/include/random/RNGProvider.tpp
+++ b/src/libPMacc/include/random/RNGProvider.tpp
@@ -23,7 +23,7 @@
 
 #include "random/RNGProvider.hpp"
 #include "dimensions/DataSpaceOperations.hpp"
-#include "dataManagement/DataConnector.hpp"
+#include "Environment.hpp"
 
 #include <memory>
 
@@ -60,8 +60,6 @@ namespace random
     {
         if(m_size.productOfComponents() == 0)
             throw std::invalid_argument("Cannot create RNGProvider with zero size");
-
-        Environment<T_dim>::get().DataConnector().share( std::shared_ptr< ISimulationData >( this ) );
     }
 
     template<uint32_t T_dim, class T_RNGMethod>


### PR DESCRIPTION
Our RNGFactory should be shared with the `DataConnector` within `MySimulation` and should not share itself in its constructor.

This fixes #1953.

I will also change this behavior for `MallocMCBuffer` in a follow-up, although we have not issues from it.