### PR TITLE
Refactor MallocMCBuffer Share

### DIFF
--- a/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/src/libPMacc/include/particles/memory/buffers/MallocMCBuffer.tpp
@@ -23,9 +23,7 @@
 
 #include "particles/memory/buffers/MallocMCBuffer.hpp"
 #include "pmacc_types.hpp"
-#include "Environment.hpp"
 #include "eventSystem/EventSystem.hpp"
-#include "dataManagement/DataConnector.hpp"
 
 #include <memory>
 
@@ -39,7 +37,6 @@ MallocMCBuffer< T_DeviceHeap >::MallocMCBuffer( const std::shared_ptr<DeviceHeap
     deviceHeapInfo( deviceHeap->getHeapLocations( )[ 0 ] ),
     hostBufferOffset( 0 )
 {
-    Environment<>::get().DataConnector().share( std::shared_ptr< ISimulationData >( this ) );
 }
 
 template< typename T_DeviceHeap >

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -101,7 +101,6 @@ public:
      */
     MySimulation() :
     laser(nullptr),
-    mallocMCBuffer(nullptr),
     myFieldSolver(nullptr),
     myCurrentInterpolation(nullptr),
     pushBGField(nullptr),
@@ -249,8 +248,6 @@ public:
 
         __delete(myFieldSolver);
 
-        dc.unshare( mallocMCBuffer->getUniqueId() );
-
         __delete(myCurrentInterpolation);
 
         /** unshare all registered ISimulationData sets
@@ -377,7 +374,8 @@ public:
 
         // initializing the heap for particles
         deviceHeap->destructiveResize(heapSize);
-        this->mallocMCBuffer = new MallocMCBuffer<DeviceHeap>(deviceHeap);
+        MallocMCBuffer<DeviceHeap>* mallocMCBuffer = new MallocMCBuffer<DeviceHeap>(deviceHeap);
+        dc.share( std::shared_ptr< ISimulationData >( mallocMCBuffer ) );
 
         ForEach< VectorAllSpecies, particles::CallCreateParticleBuffer<bmpl::_1> > createParticleBuffer;
         createParticleBuffer( deviceHeap );
@@ -724,7 +722,6 @@ private:
     }
 
 protected:
-    MallocMCBuffer<DeviceHeap> *mallocMCBuffer;
     std::shared_ptr<DeviceHeap> deviceHeap;
 
     // field solver


### PR DESCRIPTION
Follow-up to #1963: share the `MallocMCBuffer` from `MySimulation` explicitly instead of implicitly from its constructor.

RT tested with LWFA example, case 10 with ions and ionization (set to use lin. pol. ADK).