### PR TITLE
Array: store elements without a default constructor

### DIFF
--- a/src/libPMacc/include/memory/Array.hpp
+++ b/src/libPMacc/include/memory/Array.hpp
@@ -66,19 +66,19 @@ namespace memory
         HDINLINE
         pointer data( )
         {
-            return m_data;
+            return reinterpret_cast< pointer >( m_data );
         }
 
         HDINLINE
         const_pointer data( ) const
         {
-            return m_data;
+            return reinterpret_cast< const_pointer >( m_data );
         }
         /** @} */
 
         /** default constructor
          *
-         * the default constructor of each member is called
+         * all members are uninitialized
          */
         HDINLINE Array() = default;
 
@@ -91,7 +91,7 @@ namespace memory
         HDINLINE Array( T_Type const & value )
         {
             for( size_type i = 0; i < size(); ++i )
-                m_data[ i ] = value;
+                reinterpret_cast< T_Type* >( m_data )[ i ] = value;
         }
 
         /** get N-th value
@@ -106,7 +106,7 @@ namespace memory
         const_reference
         operator[]( T_Idx const idx ) const
         {
-            return m_data[ idx ];
+            return reinterpret_cast< T_Type const * >( m_data )[ idx ];
         }
 
         template< typename T_Idx >
@@ -114,13 +114,19 @@ namespace memory
         reference
         operator[]( T_Idx const idx )
         {
-            return m_data[ idx ];
+            return reinterpret_cast< T_Type* >( m_data )[ idx ];
         }
         /** @} */
 
     private:
-        /** data storage */
-        value_type m_data[ T_size ];
+        /** data storage
+         *
+         * std::array is a so-called "aggregate" which does not default-initialize
+         * its members. In order to allow arbitrary types to skip implementing
+         * a default constructur, this member is not stored as
+         * `value_type m_data[ T_size ]` but as type-size aligned Byte type.
+         */
+        uint8_t m_data alignas( alignof( T_Type ) ) [ T_size * sizeof( T_Type ) ];
     };
 
 } // namespace memory


### PR DESCRIPTION
This pull request is equal to #1767 and allows that elements stored within the Array are not default constructed.
The reason for this pull request is that we need to construct array of user defined object from PIConGPU param files. Without this change the user must always write/implement a default constructor, this would make the code more complex and would be complicated for a non computer scientist. 

- [x] **This pull request should not be merged before the release candidate is created.**