### PR TITLE
RTD: Remove Linenumbers

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -23,35 +23,30 @@ Hypnos (HZDR)
 
 .. literalinclude:: submit/hypnos-hzdr/picongpu.profile.example
    :language: bash
-   :linenos:
 
 Titan (ORNL)
 ------------
 
 .. literalinclude:: submit/titan-ornl/picongpu.profile.example
    :language: bash
-   :linenos:
 
 Piz Daint (CSCS)
 ----------------
 
 .. literalinclude:: submit/pizdaint-cscs/picongpu.profile.example
    :language: bash
-   :linenos:
 
 Taurus (TU Dresden)
 -------------------
 
 .. literalinclude:: submit/taurus-tud/picongpu.profile.example
    :language: bash
-   :linenos:
 
 Lawrencium (LBNL)
 -----------------
 
 .. literalinclude:: submit/lawrencium-lbnl/picongpu.profile.example
    :language: bash
-   :linenos:
 
 Judge (FZJ)
 -----------

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -35,4 +35,3 @@ Feel free to copy & paste sections of the files below into your `.cfg`, e.g. to 
 
 .. literalinclude:: ../../TBG_macros.cfg
    :language: bash
-   :linenos:


### PR DESCRIPTION
on literal file includes with line numbers in front the RTD style seems to mismatch the line numbers line height and the quoted text's line height.

We remove the line numbers for now in those includes.