### PR TITLE
Tpl: Variable Profile

### DIFF
--- a/src/picongpu/submit/bash/bash_mpiexec.tpl
+++ b/src/picongpu/submit/bash/bash_mpiexec.tpl
@@ -22,6 +22,7 @@
 
 # settings that can be controlled by environment variables before submit
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
@@ -34,7 +35,7 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-. ~/picongpu.profile
+. !TBG_profile
 unset MODULES_NO_OUTPUT
 
 #set user rights to u=rwx;g=r-x;o=---

--- a/src/picongpu/submit/bash/bash_mpirun.tpl
+++ b/src/picongpu/submit/bash/bash_mpirun.tpl
@@ -22,6 +22,7 @@
 
 # settings that can be controlled by environment variables before submit
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
@@ -34,7 +35,7 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-. ~/picongpu.profile
+. !TBG_profile
 unset MODULES_NO_OUTPUT
 
 #set user rights to u=rwx;g=r-x;o=---

--- a/src/picongpu/submit/davinci-rice/picongpu.tpl
+++ b/src/picongpu/submit/davinci-rice/picongpu.tpl
@@ -46,6 +46,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}"
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 ## end tbg calculation
 

--- a/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/fermi_profile.tpl
@@ -43,6 +43,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -59,9 +60,9 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
 if [ $? -ne 0 ] ; then
-  echo "Error: ~/picongpu.profile not found!"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 unset MODULES_NO_OUTPUT

--- a/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_autoWait_profile.tpl
@@ -44,6 +44,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # get the ID of the last job of the submitting user waiting in the k20 queue
 .TBG_waitJob=`qstat -u $(whoami) | grep $TBG_queue | tail -n 1 | awk '{print $1}'`
@@ -63,9 +64,9 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
 if [ $? -ne 0 ] ; then
-  echo "Error: ~/picongpu.profile not found!"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 unset MODULES_NO_OUTPUT

--- a/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_profile.tpl
@@ -42,6 +42,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -58,9 +59,9 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
 if [ $? -ne 0 ] ; then
-  echo "Error: ~/picongpu.profile not found!"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 unset MODULES_NO_OUTPUT

--- a/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_vampir_profile.tpl
@@ -42,6 +42,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -58,9 +59,9 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
 if [ $? -ne 0 ] ; then
-  echo "Error: ~/picongpu.profile not found!"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 unset MODULES_NO_OUTPUT

--- a/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k20_wait_profile.tpl
@@ -44,6 +44,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -60,9 +61,9 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
 if [ $? -ne 0 ] ; then
-  echo "Error: ~/picongpu.profile not found!"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 unset MODULES_NO_OUTPUT

--- a/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k80_profile.tpl
@@ -42,6 +42,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
@@ -58,9 +59,9 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
 if [ $? -ne 0 ] ; then
-  echo "Error: ~/picongpu.profile not found!"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 unset MODULES_NO_OUTPUT

--- a/src/picongpu/submit/hypnos-hzdr/k80_profileRestart.tpl
+++ b/src/picongpu/submit/hypnos-hzdr/k80_profileRestart.tpl
@@ -26,6 +26,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
@@ -57,9 +58,9 @@ echo 'Running program...' | tee -a output
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
 if [ $? -ne 0 ] ; then
-  echo "Error: ~/picongpu.profile not found!"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 unset MODULES_NO_OUTPUT

--- a/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
+++ b/src/picongpu/submit/hypnos-hzdr/picongpu.profile.example
@@ -34,6 +34,7 @@ alias getk20='qsub -I -q k20 -lwalltime=00:30:00 -lnodes=1:ppn=8'
 alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
 export PICSRC=/home/`whoami`/src/picongpu
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 export MY_MAILNOTIFY="n"

--- a/src/picongpu/submit/joker-tud/fermi.tpl
+++ b/src/picongpu/submit/joker-tud/fermi.tpl
@@ -44,6 +44,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`

--- a/src/picongpu/submit/joker-tud/fermi_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/fermi_vampir.tpl
@@ -44,6 +44,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`

--- a/src/picongpu/submit/joker-tud/tesla.tpl
+++ b/src/picongpu/submit/joker-tud/tesla.tpl
@@ -44,6 +44,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`

--- a/src/picongpu/submit/joker-tud/tesla_vampir.tpl
+++ b/src/picongpu/submit/joker-tud/tesla_vampir.tpl
@@ -44,6 +44,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`

--- a/src/picongpu/submit/judge-fzj/m2050.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050.tpl
@@ -45,6 +45,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 

--- a/src/picongpu/submit/judge-fzj/m2050_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2050_profile.tpl
@@ -45,6 +45,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 
@@ -67,8 +68,11 @@ pwd
 
 
 export MODULES_NO_OUTPUT=1
-
-source ~/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 
 mkdir simOutput 2> /dev/null
 cd simOutput

--- a/src/picongpu/submit/judge-fzj/m2070.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070.tpl
@@ -45,6 +45,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 

--- a/src/picongpu/submit/judge-fzj/m2070_profile.tpl
+++ b/src/picongpu/submit/judge-fzj/m2070_profile.tpl
@@ -45,6 +45,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 
@@ -67,8 +68,11 @@ pwd
 
 
 export MODULES_NO_OUTPUT=1
-
-source ~/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 
 mkdir simOutput 2> /dev/null
 cd simOutput

--- a/src/picongpu/submit/keeneland-gt/parallel.tpl
+++ b/src/picongpu/submit/keeneland-gt/parallel.tpl
@@ -41,6 +41,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 3 gpus per node if we need more than 3 gpus else same count as TBG_tasks
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 3 ] ; then echo 3; else echo $TBG_tasks; fi`

--- a/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/fermi_profile.tpl
@@ -54,6 +54,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 2 gpus per node
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
@@ -77,7 +78,11 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
 
 #set user rights to u=rwx;g=r-x;o=---

--- a/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
+++ b/src/picongpu/submit/lawrencium-lbnl/k20_profile.tpl
@@ -54,6 +54,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 1 gpu per node
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 1 ] ; then echo 1; else echo $TBG_tasks; fi`
@@ -75,7 +76,11 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
 
 #set user rights to u=rwx;g=r-x;o=---

--- a/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
+++ b/src/picongpu/submit/lawrencium-lbnl/picongpu.profile.example
@@ -35,6 +35,7 @@ alias allocK20='salloc --time=0:30:00 --nodes=1 --ntasks-per-node=1 --cpus-per-t
 alias allocFermi='salloc --time=0:30:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task=6 --partition mako_manycore'
 
 export PICSRC=$HOME/src/picongpu
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # fix pic-create: re-enable rsync
 #   ssh lrc-xfer.scs00

--- a/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/normal_profile.tpl
@@ -46,6 +46,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"${SCRATCH}/picongpu.profile"}
 
 # 1 gpus per node
 .TBG_gpusPerNode=1
@@ -67,7 +68,11 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source $SCRATCH/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
 
 mkdir simOutput 2> /dev/null

--- a/src/picongpu/submit/pizdaint-cscs/picongpu.profile.example
+++ b/src/picongpu/submit/pizdaint-cscs/picongpu.profile.example
@@ -47,6 +47,8 @@ export CC=`which cc`
 export CXX=`which CC`
 
 export PICSRC=$HOME/src/picongpu
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin
 

--- a/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
+++ b/src/picongpu/submit/pizdaint-cscs/total_profile.tpl
@@ -46,6 +46,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"${SCRATCH}/picongpu.profile"}
 
 # 1 gpus per node
 .TBG_gpusPerNode=1
@@ -67,7 +68,11 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source $SCRATCH/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
 
 mkdir simOutput 2> /dev/null

--- a/src/picongpu/submit/taurus-tud/k20x_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k20x_profile.tpl
@@ -48,6 +48,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 2 gpus per node
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 2 ] ; then echo 2; else echo $TBG_tasks; fi`
@@ -69,7 +70,11 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
 
 #set user rights to u=rwx;g=r-x;o=---

--- a/src/picongpu/submit/taurus-tud/k80_profile.tpl
+++ b/src/picongpu/submit/taurus-tud/k80_profile.tpl
@@ -48,6 +48,7 @@
 .TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # 4 gpus per node
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
@@ -69,7 +70,11 @@ echo 'Running program...'
 cd !TBG_dstPath
 
 export MODULES_NO_OUTPUT=1
-source ~/picongpu.profile
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
 unset MODULES_NO_OUTPUT
 
 #set user rights to u=rwx;g=r-x;o=---

--- a/src/picongpu/submit/taurus-tud/picongpu.profile.example
+++ b/src/picongpu/submit/taurus-tud/picongpu.profile.example
@@ -37,6 +37,8 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/pngwriter/lib/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
 
 export PICSRC=$HOME/src/picongpu
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin
 

--- a/src/picongpu/submit/titan-ornl/batch_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_profile.tpl
@@ -45,6 +45,7 @@
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_nameProject=${proj:-""}
+.TBG_profile=${PIC_PROFILE:-"${PROJWORK}/!TBG_nameProject/${USER}/picongpu.profile"}
 
 # use ceil to caculate nodes
 .TBG_nodes=!TBG_tasks
@@ -58,9 +59,9 @@ echo -n "present working directory:"
 pwd
 
 
-source $PROJWORK/!TBG_nameProject/$USER/picongpu.profile 2>/dev/null
+source !TBG_profile 2>/dev/null
 if [ $? -ne 0 ] ; then
-  echo "Error: picongpu.profile not found in PROJWORK"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 

--- a/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
+++ b/src/picongpu/submit/titan-ornl/batch_scorep_profile.tpl
@@ -45,6 +45,7 @@
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_nameProject=${proj:-""}
+.TBG_profile=${PIC_PROFILE:-"${PROJWORK}/!TBG_nameProject/${USER}/picongpu.profile"}
 
 # use ceil to caculate nodes
 .TBG_nodes=!TBG_tasks
@@ -57,10 +58,9 @@ cd !TBG_dstPath
 echo -n "present working directory:"
 pwd
 
-
-source $PROJWORK/!TBG_nameProject/$USER/picongpu.profile 2>/dev/null
+source !TBG_profile 2>/dev/null
 if [ $? -ne 0 ] ; then
-  echo "Error: picongpu.profile not found in PROJWORK"
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
   exit 1
 fi
 

--- a/src/picongpu/submit/titan-ornl/picongpu.profile.example
+++ b/src/picongpu/submit/titan-ornl/picongpu.profile.example
@@ -80,6 +80,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGWRITER_ROOT/lib
 
 # helper variables and tools ########################################
 export PICSRC=$HOME/src/picongpu
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin


### PR DESCRIPTION
Enable a way to control which PIConGPU profile shall be used in our `.tpl` files via en environment variable.

The default (if unset) still falls back to `~/picongpu.profile` but setting `PIC_PROFILE` in the environment profile allows to use various profiles for different
- versions of PIConGPU and/or
- versions of CUDA and/or
- queues

on the same system. Also, a preparation for #1969 

### RT tests

- [x] not set (fallback)
- [x] set to other file (a copy with different name)
- [x] set to non-existent path/file (fail with error msg)