### PR TITLE
feature `ForEachIdx`

### DIFF
--- a/src/libPMacc/include/mappings/threads/ForEachIdx.hpp
+++ b/src/libPMacc/include/mappings/threads/ForEachIdx.hpp
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2017 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "mappings/threads/IdxConfig.hpp"
+#include "pmacc_types.hpp"
+
+namespace PMacc
+{
+namespace mappings
+{
+namespace threads
+{
+
+    /** execute a functor for each index
+     *
+     * Distribute the indices even over all worker and execute a user defined functor.
+     * There is no guarantee in which order the indices will be processed.
+     *
+     * @tparam T_IdxConfig index domain description
+     */
+    template<
+        typename T_IdxConfig
+    >
+    struct ForEachIdx : public T_IdxConfig
+    {
+        using T_IdxConfig::domainSize;
+        using T_IdxConfig::workerSize;
+        using T_IdxConfig::simdSize;
+        using T_IdxConfig::numCollIter;
+
+        uint32_t const m_workerIdx;
+
+        static constexpr bool outerLoopCondition =
+            ( domainSize % (simdSize * workerSize) ) == 0 ||
+            ( simdSize * workerSize == 1 );
+
+        static constexpr bool innerLoopCondition =
+            ( domainSize % simdSize ) == 0 ||
+            ( simdSize == 1 );
+
+        /** constructor
+         *
+         * @param workerIdx index of the worker: range [0;workerSize)
+         */
+        HDINLINE
+        ForEachIdx( uint32_t const workerIdx ) : m_workerIdx( workerIdx )
+        {
+        }
+
+        /** execute a functor
+         *
+         * @p functor is called for each index which is mapped to the worker.
+         * The functor must fulfill the following interface:
+         *
+         * @code
+         * template< typename ... T_Args >
+         * void operator()( uint32_t const linearIdx, uint32_t const idx, T_Args && ... );
+         * @endcode
+         *
+         * @{
+         */
+        template<
+            typename T_Functor,
+            typename ... T_Args
+        >
+        HDINLINE void
+        operator()(
+            T_Functor const & functor,
+            T_Args && ... args
+        ) const
+        {
+            for( uint32_t i = 0; i < numCollIter; ++i )
+            {
+                const uint32_t beginWorker = i * simdSize;
+                const uint32_t beginIdx = beginWorker * workerSize + simdSize * m_workerIdx;
+                if(
+                    outerLoopCondition ||
+                    !innerLoopCondition ||
+                    beginIdx < domainSize
+                )
+                {
+                    for( uint32_t j = 0; j < simdSize; ++j )
+                    {
+                        const uint32_t localIdx = beginIdx + j;
+                        if(
+                            innerLoopCondition ||
+                            localIdx < domainSize
+                        )
+                            functor(
+                                localIdx,
+                                beginWorker + j,
+                                std::forward(args) ...
+                            );
+                    }
+                }
+            }
+        }
+
+        template<
+            typename T_Functor,
+            typename ... T_Args
+        >
+        HDINLINE void
+        operator()(
+            T_Functor & functor,
+            T_Args && ... args
+        ) const
+        {
+            for( uint32_t i = 0; i < numCollIter; ++i )
+            {
+                const uint32_t beginWorker = i * simdSize;
+                const uint32_t beginIdx = beginWorker * workerSize + simdSize * m_workerIdx;
+                if(
+                    outerLoopCondition ||
+                    !innerLoopCondition ||
+                    beginIdx < domainSize
+                )
+                {
+                    for( uint32_t j = 0; j < simdSize; ++j )
+                    {
+                        const uint32_t localIdx = beginIdx + j;
+                        if(
+                            innerLoopCondition ||
+                            localIdx < domainSize
+                        )
+                            functor(
+                                localIdx,
+                                beginWorker + j,
+                                std::forward(args) ...
+                            );
+                    }
+                }
+            }
+        }
+
+        /** @} */
+
+    };
+
+} // namespace threads
+} // namespace mappings
+} // namespace PMacc

--- a/src/libPMacc/include/mappings/threads/ForEachIdx.hpp
+++ b/src/libPMacc/include/mappings/threads/ForEachIdx.hpp
@@ -25,6 +25,7 @@
 #include "mappings/threads/IdxConfig.hpp"
 #include "pmacc_types.hpp"
 
+
 namespace PMacc
 {
 namespace mappings
@@ -52,12 +53,12 @@ namespace threads
         uint32_t const m_workerIdx;
 
         static constexpr bool outerLoopCondition =
-            ( domainSize % (simdSize * workerSize) ) == 0 ||
-            ( simdSize * workerSize == 1 );
+            ( domainSize % (simdSize * workerSize) ) == 0u ||
+            ( simdSize * workerSize == 1u );
 
         static constexpr bool innerLoopCondition =
-            ( domainSize % simdSize ) == 0 ||
-            ( simdSize == 1 );
+            ( domainSize % simdSize ) == 0u ||
+            ( simdSize == 1u );
 
         /** constructor
          *
@@ -70,9 +71,9 @@ namespace threads
 
         /** execute a functor
          *
-         * @p functor is called for each index which is mapped to the worker.
-         * The functor must fulfill the following interface:
+         * @param functor is called for each index which is mapped to the worker
          *
+         * The functor must fulfill the following interface:
          * @code
          * template< typename ... T_Args >
          * void operator()( uint32_t const linearIdx, uint32_t const idx, T_Args && ... );
@@ -90,19 +91,19 @@ namespace threads
             T_Args && ... args
         ) const
         {
-            for( uint32_t i = 0; i < numCollIter; ++i )
+            for( uint32_t i = 0u; i < numCollIter; ++i )
             {
-                const uint32_t beginWorker = i * simdSize;
-                const uint32_t beginIdx = beginWorker * workerSize + simdSize * m_workerIdx;
+                uint32_t const beginWorker = i * simdSize;
+                uint32_t const beginIdx = beginWorker * workerSize + simdSize * m_workerIdx;
                 if(
                     outerLoopCondition ||
                     !innerLoopCondition ||
                     beginIdx < domainSize
                 )
                 {
-                    for( uint32_t j = 0; j < simdSize; ++j )
+                    for( uint32_t j = 0u; j < simdSize; ++j )
                     {
-                        const uint32_t localIdx = beginIdx + j;
+                        uint32_t const localIdx = beginIdx + j;
                         if(
                             innerLoopCondition ||
                             localIdx < domainSize
@@ -127,19 +128,19 @@ namespace threads
             T_Args && ... args
         ) const
         {
-            for( uint32_t i = 0; i < numCollIter; ++i )
+            for( uint32_t i = 0u; i < numCollIter; ++i )
             {
-                const uint32_t beginWorker = i * simdSize;
-                const uint32_t beginIdx = beginWorker * workerSize + simdSize * m_workerIdx;
+                uint32_t const beginWorker = i * simdSize;
+                uint32_t const beginIdx = beginWorker * workerSize + simdSize * m_workerIdx;
                 if(
                     outerLoopCondition ||
                     !innerLoopCondition ||
                     beginIdx < domainSize
                 )
                 {
-                    for( uint32_t j = 0; j < simdSize; ++j )
+                    for( uint32_t j = 0u; j < simdSize; ++j )
                     {
-                        const uint32_t localIdx = beginIdx + j;
+                        uint32_t const localIdx = beginIdx + j;
                         if(
                             innerLoopCondition ||
                             localIdx < domainSize

--- a/src/libPMacc/include/mappings/threads/IdxConfig.hpp
+++ b/src/libPMacc/include/mappings/threads/IdxConfig.hpp
@@ -24,6 +24,7 @@
 
 #include "pmacc_types.hpp"
 
+
 namespace PMacc
 {
 namespace mappings
@@ -40,7 +41,7 @@ namespace threads
     template<
         uint32_t T_domainSize,
         uint32_t T_workerSize,
-        uint32_t T_simdSize = 1
+        uint32_t T_simdSize = 1u
     >
     struct IdxConfig
     {
@@ -51,9 +52,9 @@ namespace threads
         /** SMID width */
         static constexpr uint32_t simdSize = T_simdSize;
 
-        /** number of collective iterations needed to address to address all indices */
+        /** number of collective iterations needed to address all indices */
         static constexpr uint32_t numCollIter =
-            (( domainSize + simdSize * workerSize - 1 ) / ( simdSize * workerSize));
+            ( domainSize + simdSize * workerSize - 1u ) / ( simdSize * workerSize);
     };
 
 } // namespace threads

--- a/src/libPMacc/include/mappings/threads/IdxConfig.hpp
+++ b/src/libPMacc/include/mappings/threads/IdxConfig.hpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+
+namespace PMacc
+{
+namespace mappings
+{
+namespace threads
+{
+
+    /** describe a constant index domain
+     *
+     * @tparam T_domainSize number of indices in the domain
+     * @tparam T_workerSize number of worker working on @p T_domainSize
+     * @tparam T_simdSize SMID width
+     */
+    template<
+        uint32_t T_domainSize,
+        uint32_t T_workerSize,
+        uint32_t T_simdSize = 1
+    >
+    struct IdxConfig
+    {
+        /** number of indices within the domain */
+        static constexpr uint32_t domainSize = T_domainSize;
+        /** number of worker (threads) working on @p domainSize */
+        static constexpr uint32_t workerSize = T_workerSize;
+        /** SMID width */
+        static constexpr uint32_t simdSize = T_simdSize;
+
+        /** number of collective iterations needed to address to address all indices */
+        static constexpr uint32_t numCollIter =
+            (( domainSize + simdSize * workerSize - 1 ) / ( simdSize * workerSize));
+    };
+
+} // namespace threads
+} // namespace mappings
+} // namespace PMacc


### PR DESCRIPTION
- add index domain decription class `IdxConfig`
- add for each functor to iterate over a index domain

`ForEachIdx` is the base algorithm to unroll loops for the upcoming lock step programming model for each kernel. This allows to declutch the *supercell* size and the number of worker (threads) to process a supercell or the particles within a *supercell*.

## Example
- old implementation only usable for functor with to parameter
```C++
for (int i = threadId; i < math::CT::volume<FullSuperCellSize>::type::value; i += maxThreads)
{
    const DataSpace<Dim> pos(DataSpaceOperations<Dim>::template map<FullSuperCellSize > (i) - OffsetOrigin::toRT());
    f(p1(pos), p2(pos));
}
```
- new implementation, usable for arbitrary number of functor parameter
```C++
mappings::threads::ForEachIdx<
    mappings::threads::IdxConfig<
        math::CT::volume<FullSuperCellSize>::type::value,
        workerSize
    >
>{ m_workerIdx }(
    [&]( uint32_t const linearIdx, uint32_t const )
    {
        DataSpace< dim > const pos(
            DataSpaceOperations< dim >::template map< FullSuperCellSize >( linearIdx ) -
            OffsetOrigin::toRT( )
        );
        functor( args(pos) ... );
    }
);
```