### PR TITLE
Reduce # photons in Bremsstrahlung example

### DIFF
--- a/examples/Bremsstrahlung/bin/plot_energy_histogram.py
+++ b/examples/Bremsstrahlung/bin/plot_energy_histogram.py
@@ -1,0 +1,67 @@
+"""
+This file is part of PIConGPU.
+
+PIConGPU is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PIConGPU is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PIConGPU.
+If not, see <http://www.gnu.org/licenses/>.
+
+Example script for analyzing data from the *energyHistogram* plugin.
+If the file is just executed in place it will plot the photon energy
+histogram of the default Bremsstrahlung example.
+There will be 5 datasets for the 5 different output iterations. The plots
+will also not contain the outliers.
+
+Copyright 2017 Marco Garten, Axel Huebl
+Authors: Axel Huebl
+License: GPLv3+
+"""
+import matplotlib as mpl
+from energy_histogram import EnergyHistogram
+
+
+# custom matplotlib settings
+params = {
+    'font.size': 20,
+    'xtick.labelsize': 20,
+    'ytick.labelsize': 20,
+    'figure.figsize': [12, 8],
+    'legend.fontsize': 20,
+    'legend.frameon': "False",
+    'legend.markerscale': 2,
+    'legend.numpoints': 1,
+    'lines.linestyle': '',
+    'lines.marker': "+",
+    'lines.markeredgewidth': 2,
+    'lines.markersize': 6
+}
+
+# overwrite matplotlib defaults
+mpl.rcParams.update(params)
+
+
+# simulation time steps
+times = np.linspace(1e3, 5e3, 5)
+hist = EnergyHistogram(
+    species_name="ph",
+    sim="../",
+    period=1000,
+    bin_count=1024,
+    min_energy=10,
+    max_energy=10000,
+    distance_to_detector=0,
+    slit_detector_x=None,
+    slit_detector_z=None
+)
+
+for i in times:
+    hist.plot(time=int(i))

--- a/examples/Bremsstrahlung/bin/plot_particle_calorimeter.py
+++ b/examples/Bremsstrahlung/bin/plot_particle_calorimeter.py
@@ -1,0 +1,73 @@
+"""
+This file is part of PIConGPU.
+
+PIConGPU is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PIConGPU is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PIConGPU.
+If not, see <http://www.gnu.org/licenses/>.
+
+Example script for analyzing data from the *particleCalorimeter* plugin.
+If the file is just executed in place it will plot the photon energy
+histogram of the default Bremsstrahlung example.
+There will be 5 datasets for the 5 different output iterations. The plots
+will also not contain the outliers.
+
+Copyright 2017 Marco Garten, Axel Huebl
+Authors: Axel Huebl
+License: GPLv3+
+"""
+import matplotlib as mpl
+from particle_calorimeter import ParticleCalorimeter
+
+
+# custom matplotlib settings
+params = {
+    'font.size': 20,
+    'xtick.labelsize': 20,
+    'ytick.labelsize': 20,
+    'figure.figsize': [12, 8],
+    'legend.fontsize': 20,
+    'legend.frameon': "False",
+    'legend.markerscale': 2,
+    'legend.numpoints': 1,
+    'lines.linestyle': '',
+    'lines.marker': "+",
+    'lines.markeredgewidth': 2,
+    'lines.markersize': 6
+}
+
+# overwrite matplotlib defaults
+mpl.rcParams.update(params)
+
+times = np.linspace(1e3, 5e3, 5)
+PC = ParticleCalorimeter(
+    species_name="ph",
+    sim="../",
+    period=1000,
+    num_bins_yaw=64,
+    num_bins_pitch=64,
+    num_bins_energy=1024,
+    min_energy=10,
+    max_energy=10000,
+    logscale=False,
+    opening_yaw=360,
+    opening_pitch=180,
+    pos_yaw=0,
+    pos_pitch=0
+)
+
+for i in times:
+    PC.load_step(step=i)
+    PC.energy_histogram()
+    PC.plot_histogram(norm=False)
+
+PC.plot_calorimeter()

--- a/examples/Bremsstrahlung/include/simulation_defines/param/bremsstrahlung.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/bremsstrahlung.param
@@ -124,7 +124,7 @@ namespace photon
      *
      * The emission probability is proportional to this parameter.
      */
-    constexpr float_64 WEIGHTING_RATIO = 100;
+    constexpr float_64 WEIGHTING_RATIO = 5;
 } // namespace photon
 
 } // namespace bremsstrahlung

--- a/examples/Bremsstrahlung/submit/0008gpus.cfg
+++ b/examples/Bremsstrahlung/submit/0008gpus.cfg
@@ -46,11 +46,17 @@ TBG_periodic="--periodic 0 0 0"
 ## Section: Optional Variables ##
 #################################
 
+TBG_ph_calorimeter="--ph_calorimeter.period 1000 --ph_calorimeter.openingYaw 360 --ph_calorimeter.openingPitch 180 \
+                    --ph_calorimeter.numBinsEnergy 1024 --ph_calorimeter.minEnergy 10 --ph_calorimeter.maxEnergy 10000"
+
+TBG_ph_energyHistogram="--ph_energyHistogram.period 1000  --ph_energyHistogram.minEnergy 10 --ph_energyHistogram.maxEnergy 10000"
 
 TBG_plugins="--hdf5.period 1000  \
              --e_macroParticlesCount.period 1000 \
              --i_macroParticlesCount.period 1000 \
-             --ph_macroParticlesCount.period 1000"
+             --ph_macroParticlesCount.period 1000 \
+             !TBG_ph_calorimeter \
+             !TBG_ph_energyHistogram"
 
 
 #################################


### PR DESCRIPTION
In the `Bremsstrahlung` example we have typically 100 macro electrons per cell.
Initially the photon weighting was 100 times less than the electron weighting.
This would lead to good photon statistics but created a memory overflow.
Therefore the photon weighting was increased 20 times.
Now the default example runs on k20 in 21 minutes and does not use too much
memory.

The influence of the parameter `WEIGHTING_RATIO` from `bremsstrahlung.param` is two-fold:   
From `Bremsstrahlung.tpp`:   
directly proportional to the **photon emission probability**
```
const float_X emissionProb = photon::WEIGHTING_RATIO * scalingFactor * ionDensity * c * DELTA_T * this->scaledSpectrumFunctor(Ekin, kappa);
```   
inversely proportional to the spawned **photons' weighting**
```
if(this->randomGen() < emissionProb)
{
    const float_X photonEnergy = kappa * Ekin;
    this->photonMom = mom_norm * weighting / photon::WEIGHTING_RATIO * photonEnergy / c;
    return 1;
}
```

**update 2017-04-20**
Merging this closes #1961.

- [x] add pymodule(s)
- [ ] depends on #2060