### PR TITLE
add peridoic boundary conditions to the bremsstrahlungs example

### DIFF
--- a/examples/Bremsstrahlung/submit/0008gpus.cfg
+++ b/examples/Bremsstrahlung/submit/0008gpus.cfg
@@ -40,7 +40,7 @@ TBG_gpu_z=1
 TBG_gridSize="-g 2048 2048 1"
 TBG_steps="-s 5000"
 
-TBG_periodic="--periodic 0 0 0"
+TBG_periodic="--periodic 1 0 1"
 
 #################################
 ## Section: Optional Variables ##


### PR DESCRIPTION
The `Bremsstrahlung` example was missing periodic boundary conditions. 

This leads to false results on the borders. 

@ax3l and @Heikman Do you think this is necessary? 