### PR TITLE
fix clang compile

### DIFF
--- a/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
+++ b/src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
@@ -43,7 +43,7 @@ namespace derivedAttributes
     LarmorPower::operator()( T_Particle& particle ) const
     {
 
-        static constexpr bool hasMomentumPrev1 = PMacc::traits::HasIdentifier<
+        constexpr bool hasMomentumPrev1 = PMacc::traits::HasIdentifier<
             typename T_Particle::FrameType,
             momentumPrev1
         >::type::value;


### PR DESCRIPTION
It is not allowed to use `static constexpr` within device functions.

Bug was introduced with #1931

## Example
This snippet within a device function
```
static constexpr bool hasMomentumPrev1 = PMacc::traits::HasIdentifier<
    typename T_Particle::FrameType,
    momentumPrev1
>::type::value;
PMACC_CASSERT_MSG_TYPE( species_must_have_the_attribute_momentumPrev1, T_Particle, hasMomentumPrev1 );
```
creates the error
```
src/picongpu/include/particles/particleToGrid/derivedAttributes/LarmorPower.hpp:46:31: error: within a __device__ function, only __shared__ variables may be marked 'static'
        static constexpr bool hasMomentumPrev1 = PMacc::traits::HasIdentifier<
```