### PR TITLE
option for CMake build type

### DIFF
--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -46,6 +46,18 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 
 
 ###############################################################################
+# Build Flags
+###############################################################################
+
+set(PMACC_BUILD_TYPE "Release;Debug")
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the build type for the project" FORCE)
+endif()
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${PMACC_BUILD_TYPE}")
+unset(PMACC_BUILD_TYPE)
+
+
+###############################################################################
 # Language Flags
 ###############################################################################
 

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -72,21 +72,6 @@ find_package(CUDA 7.5 REQUIRED)
 
 
 ################################################################################
-# Build type (debug, release)
-################################################################################
-
-option(PIC_RELEASE "Build release version, disables all runtime asserts" OFF)
-if(PIC_RELEASE)
-    message(STATUS "Release version")
-    set(CMAKE_BUILD_TYPE Release)
-    add_definitions(-DNDEBUG)
-else(PIC_RELEASE)
-    message(STATUS "Debug version")
-    set(CMAKE_BUILD_TYPE Debug)
-endif(PIC_RELEASE)
-
-
-################################################################################
 # Find MPI
 ################################################################################
 


### PR DESCRIPTION
The issue with the old implementation is that the variable `CMAKE_BUILD_TYPE` was always empty and therefore we build everything as `debug`. This should be avoided and is since #1662 not necessary.

- PMacc
  - change default behavior from build in debug mode to build as release
  - allow user to switch `CMAKE_BUILD_TYPE` between `Release` and `Debug`
- PIConGPU
  - remove CMake option `PIC_RELEASE`

This changes the build type default to `Release`.

## Tests

- [x] compile debug
- [x] compile release

@ax3l Should we port this the the `0.3.0-rc`?
