### PR TITLE
Remove ToDo from ionizationEnergies.param

### DIFF
--- a/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
+++ b/src/picongpu/include/simulation_defines/param/ionizationEnergies.param
@@ -29,11 +29,6 @@
 
 #pragma once
 
-/** \todo Make compatible for multiple atom species
- * - Probably do some calculation from energy to required field strength (or do that model dependent)
- * - Introduce some clever way of storage, like matrices for different charge states of the same species
- * - future: even different states of excitation should be possible
- */
 
 namespace picongpu
 {


### PR DESCRIPTION
The `\todo` section was outdated since there is currently no need for either
better storage of ionization energies or field strengths calculated from
them. (The latter is done by the BSI model itself.)
One of the remaining issues is that the ionization energy vectors take up
constant memory of the GPU even if they are not used. An improvement on that
should be requested in a GitHub issue, though.

This is a follow-up to #1983 .