### PR TITLE
 Parameter Order in Manual

### DIFF
--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -3,20 +3,20 @@
 PIC Core
 --------
 
-grid.param
-^^^^^^^^^^
-
-.. doxygenfile:: grid.param
-   :project: PIConGPU
-   :path: src/picongpu/include/simulation_defines/param/grid.param
-   :no-link:
-
 dimension.param
 ^^^^^^^^^^^^^^^
 
 .. doxygenfile:: dimension.param
    :project: PIConGPU
    :path: src/picongpu/include/simulation_defines/param/dimension.param
+   :no-link:
+
+grid.param
+^^^^^^^^^^
+
+.. doxygenfile:: grid.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/grid.param
    :no-link:
 
 components.param
@@ -35,12 +35,12 @@ fieldSolver.param
    :path: src/picongpu/include/simulation_defines/param/fieldSolver.param
    :no-link:
 
-density.param
-^^^^^^^^^^^^^
+laser.param
+^^^^^^^^^^^
 
-.. doxygenfile:: density.param
+.. doxygenfile:: laser.param
    :project: PIConGPU
-   :path: src/picongpu/include/simulation_defines/param/density.param
+   :path: src/picongpu/include/simulation_defines/param/laser.param
    :no-link:
 
 pusher.param
@@ -51,28 +51,12 @@ pusher.param
    :path: src/picongpu/include/simulation_defines/param/pusher.param
    :no-link:
 
-laser.param
-^^^^^^^^^^^
-
-.. doxygenfile:: laser.param
-   :project: PIConGPU
-   :path: src/picongpu/include/simulation_defines/param/laser.param
-   :no-link:
-
-particle.param
-^^^^^^^^^^^^^^
-
-.. doxygenfile:: particle.param
-   :project: PIConGPU
-   :path: src/picongpu/include/simulation_defines/param/particle.param
-   :no-link:
-
-species.param
+density.param
 ^^^^^^^^^^^^^
 
-.. doxygenfile:: species.param
+.. doxygenfile:: density.param
    :project: PIConGPU
-   :path: src/picongpu/include/simulation_defines/param/species.param
+   :path: src/picongpu/include/simulation_defines/param/density.param
    :no-link:
 
 speciesAttributes.param
@@ -91,12 +75,28 @@ speciesConstants.param
    :path: src/picongpu/include/simulation_defines/param/speciesConstants.param
    :no-link:
 
+species.param
+^^^^^^^^^^^^^
+
+.. doxygenfile:: species.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/species.param
+   :no-link:
+
 speciesDefinition.param
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. doxygenfile:: speciesDefinition.param
    :project: PIConGPU
    :path: src/picongpu/include/simulation_defines/param/speciesDefinition.param
+   :no-link:
+
+particle.param
+^^^^^^^^^^^^^^
+
+.. doxygenfile:: particle.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/particle.param
    :no-link:
 
 speciesInitialization.param

--- a/docs/source/usage/plugin.rst
+++ b/docs/source/usage/plugin.rst
@@ -3,6 +3,10 @@
 Plugins
 =======
 
+Please refer to
+https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-Plugins
+for now.
+
 .. toctree::
    :glob:
    :maxdepth: 1


### PR DESCRIPTION
Updates the order in the usage chapter of our docs to be more intuitive.
Also adds a link to the wiki for plugins.

I would propose the following re-namings for our species files:
- `species.params`:
  - just contains general defines, two ways to go:
    - move `speciesDefinitions` headers like `DefaultAttributes` and
      `DefaultFlags` to same file and rename to `speciesDefaults` or
    - merge into header of `speciesDefinition.param`
- `particles.param`: rename to either `speciesFunctors.param` or
  `speciesManipulation.param`/`speciesManipulators.param`