### PR TITLE
Fix Default Density Ratio Ions

### DIFF
--- a/src/picongpu/include/simulation_defines/param/speciesDefinition.param
+++ b/src/picongpu/include/simulation_defines/param/speciesDefinition.param
@@ -113,7 +113,7 @@ value_identifier( float_X, MassRatioIons, 1836.152672 );
 value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /* ratio relative to BASE_DENSITY */
-value_identifier( float_X, DensityRatioIons, -1.0 );
+value_identifier( float_X, DensityRatioIons, 1.0 );
 
 using ParticleFlagsIons = bmpl::vector<
     particlePusher< UsedParticlePusher >,


### PR DESCRIPTION
In the default density ratio of ions (aka "Empty example") the density ratio is accidentally defined negative. This fixes it (and did cost me some hours to figure out).