### PR TITLE
CompileTime Accessor: Type (::type)

### DIFF
--- a/src/libPMacc/include/compileTime/accessors/Type.hpp
+++ b/src/libPMacc/include/compileTime/accessors/Type.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include <boost/mpl/placeholders.hpp>
+
+
+namespace PMacc
+{
+namespace compileTime
+{
+namespace accessors
+{
+    /** Get ::type member of the given type
+     *
+     * @tparam T type from which we return the type held in ::type
+     *
+     * T must have defined ::type
+     */
+    template< typename T = bmpl::_1 >
+    struct Type
+    {
+        using type = typename T::type;
+    };
+
+} // namespace accessors
+} // namespace compileTime
+} // namespace PMacc


### PR DESCRIPTION
The most ridiculous doxygen string I have ever written, enjoy:
```C++
/** Get ::type member of the given type
 *
 * @tparam T type from which we return the type held in ::type
 *
 * T must have defined ::type
 */
```

Can be used in conjunction with, e.g. `boost::mpl::transform` or `PMacc::OperateOnSeq`. Needed for multi-ionizer per species support.