### PR TITLE
TBG Macros: Outdated Comment

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -133,10 +133,10 @@ TBG_<species>_histogram="--<species>_energyHistogram.period 500 --<species>_ener
 
 # Calculate a 2D phase space
 # - requires parallel libSplash for HDF5 output
-# - momentum range in m_e c
+# - momentum range in m_<species> c
 TBG_<species>_PSxpx="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space x --<species>_phaseSpace.momentum px --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
 TBG_<species>_PSxpz="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space x --<species>_phaseSpace.momentum pz --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
-TBG_<species>_ePSypx="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space y --<species>_phaseSpace.momentum px --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
+TBG_<species>_PSypx="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space y --<species>_phaseSpace.momentum px --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
 TBG_<species>_PSypy="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space y --<species>_phaseSpace.momentum py --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
 TBG_<species>_PSypz="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space y --<species>_phaseSpace.momentum pz --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
 


### PR DESCRIPTION
fix an outdated comment in the `docs/TBG_macros.cfg` examples for phase spaces