### PR TITLE
Sphinx: Move Author Macros

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,7 +1,5 @@
 .. _install-dependencies:
 
-.. sectionauthor:: Axel Huebl
-
 .. seealso::
 
    You will need to understand how to use `the terminal <http://www.ks.uiuc.edu/Training/Tutorials/Reference/unixprimer.html>`_, what are `environment variables <http://unix.stackexchange.com/questions/44990/what-is-the-difference-between-path-and-ld-library-path/45106#45106>`_ and please read our :ref:`compiling introduction <install-source>`.
@@ -13,6 +11,8 @@
 
 Dependencies
 ============
+
+.. sectionauthor:: Axel Huebl
 
 Overview
 --------

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -1,13 +1,13 @@
 .. _usage-basics:
 
-.. sectionauthor:: Axel Huebl
-
 .. seealso::
 
    You need to have an :ref:`environment loaded <install-profile>` (``. $HOME/picongpu.profile``) that provides all :ref:`PIConGPU dependencies <install-dependencies>` to complete this chapter.
 
 Basics
 ======
+
+.. sectionauthor:: Axel Huebl
 
 Preparation
 -----------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,8 @@ from recommonmark.parser import CommonMarkParser
 # RTD
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
+show_authors = True
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -1,9 +1,9 @@
 .. _development-sphinx:
 
-.. sectionauthor:: Axel Huebl
-
 Sphinx
 ======
+
+.. sectionauthor:: Axel Huebl
 
 In the following section we explain how to contribute to this documentation.
 

--- a/docs/source/install/compile.rst
+++ b/docs/source/install/compile.rst
@@ -1,7 +1,5 @@
 .. _install-source:
 
-.. sectionauthor:: Axel Huebl
-
 .. seealso::
 
    You will need to understand how to use `the terminal <http://www.ks.uiuc.edu/Training/Tutorials/Reference/unixprimer.html>`_.
@@ -12,6 +10,8 @@
 
 Compiling from Source
 =====================
+
+.. sectionauthor:: Axel Huebl
 
 Don't be afraid young physicist, self-compiling C/C++ projects is easy, fun and profitable!
 

--- a/docs/source/install/path.rst
+++ b/docs/source/install/path.rst
@@ -1,9 +1,9 @@
 .. _install-path:
 
-.. sectionauthor:: Axel Huebl
-
 Installation
 ============
+
+.. sectionauthor:: Axel Huebl
 
 Installing PIConGPU means :ref:`installing C++ libraries <install-dependencies>` that PIConGPU depends on and :ref:`setting environment variables <install-profile>` to find those dependencies.
 The first part is usually the job of a system administrator while the second part needs to be configured on the user-side.

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -1,13 +1,13 @@
 .. _install-profile:
 
-.. sectionauthor:: Axel Huebl
-
 .. seealso::
 
    You need to have all :ref:`dependencies installed <install-dependencies>` to complete this chapter.
 
 picongpu.profile
 ================
+
+.. sectionauthor:: Axel Huebl
 
 Use a ``picongpu.profile`` file to set up your software environment without colliding with other software.
 Ideally, store that file directly in your ``$HOME/`` and source it after connecting to the machine:

--- a/docs/source/models/LL_RR.rst
+++ b/docs/source/models/LL_RR.rst
@@ -3,6 +3,8 @@
 Landau-Lifschitz Radiation Reaction
 ===================================
 
+.. moduleauthor:: Richard Pausch, Marija Vranic
+
 To do
 
 References

--- a/docs/source/models/ionization.rst
+++ b/docs/source/models/ionization.rst
@@ -1,6 +1,8 @@
 Ionization
 ==========
 
+.. moduleauthor:: Marco Garten
+
 Field Ionization
 ----------------
 

--- a/docs/source/models/photons.rst
+++ b/docs/source/models/photons.rst
@@ -1,6 +1,9 @@
 Photons
 =======
 
+.. sectionauthor:: Axel Huebl
+.. moduleauthor:: Heiko Burau
+
 Radiation reaction and (hard) photons: why and when are they needed.
 Models we implemented and verified:
 

--- a/docs/source/models/pic.rst
+++ b/docs/source/models/pic.rst
@@ -1,9 +1,9 @@
 .. _model-pic:
 
-.. sectionauthor:: Axel Huebl
-
 The Particle-in-Cell Algorithm
 ==============================
+
+.. sectionauthor:: Axel Huebl
 
 For now, please refer to the textbooks [BirdsallLangdon]_, [HockneyEastwood]_, our :ref:`latest paper on PIConGPU <usage-reference>` and [Huebl2014]_ (chapters 2.3, 3.1 and 3.4).
 

--- a/docs/source/postprocessing/openPMD.rst
+++ b/docs/source/postprocessing/openPMD.rst
@@ -1,8 +1,9 @@
 .. _pp-openPMD:
 
-.. sectionauthor:: Axel Huebl
-
 openPMD
 =======
+
+.. sectionauthor:: Axel Huebl
+.. moduleauthor:: Axel Huebl
 
 Please see https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Post-processing-and-Visualization for now.

--- a/docs/source/postprocessing/paraview.rst
+++ b/docs/source/postprocessing/paraview.rst
@@ -1,8 +1,9 @@
 .. _pp-paraview:
 
-.. sectionauthor:: Axel Huebl
-
 ParaView
 ========
+
+.. sectionauthor:: Axel Huebl
+.. moduleauthor:: Axel Huebl
 
 Please see https://github.com/ComputationalRadiationPhysics/picongpu/wiki/ParaView for now.

--- a/docs/source/postprocessing/python.rst
+++ b/docs/source/postprocessing/python.rst
@@ -1,9 +1,9 @@
 .. _pp-python:
 
-.. sectionauthor:: Axel Huebl
-
 Python
 ======
+
+.. sectionauthor:: Axel Huebl
 
 If you are new to python, get your hands on the tutorials of the following important libraries to get started.
 

--- a/docs/source/usage/reference.rst
+++ b/docs/source/usage/reference.rst
@@ -1,9 +1,9 @@
 .. _usage-reference:
 
-.. sectionauthor:: Axel Huebl
-
 Reference
 =========
+
+.. sectionauthor:: Axel Huebl
 
 PIConGPU is a year-long, scientific project with many people contributing to it.
 In order to credit the work of others, we expect you to cite our latest paper describing PIConGPU when publishing and/or presenting scientific results.

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -1,9 +1,10 @@
 .. _usage-tbg:
 
-.. sectionauthor:: René Widera, Axel Huebl
-
 TBG
 ===
+
+.. sectionauthor:: Axel Huebl, Richard Pausch
+.. moduleauthor:: René Widera
 
 todo: explain idea and use case
 
@@ -18,14 +19,6 @@ Usage
 
 .. program-output:: ../../src/tools/bin/tbg --help
 
-
-Example with Slurm
-^^^^^^^^^^^^^^^^^^
-
-.. include:: ../install/submit/taurus-tud/Slurm_Tutorial.rst
-   :start-line: 3
-
-
 .. _usage-cfg:
 
 .cfg File Macros
@@ -35,3 +28,23 @@ Feel free to copy & paste sections of the files below into your `.cfg`, e.g. to 
 
 .. literalinclude:: ../../TBG_macros.cfg
    :language: bash
+
+Batch System Examples
+^^^^^^^^^^^^^^^^^^^^^
+
+Slurm
+"""""
+
+Slurm is a modern batch system, e.g. installed on the Taurus cluster at TU Dresden.
+
+.. include:: ../install/submit/taurus-tud/Slurm_Tutorial.rst
+   :start-line: 3
+
+PBS
+"""
+
+PBS (for *Portable Batch System*) is a widely distributed batch system that comes in several implementations (open, professional, etc.).
+It is used, e.g. on Hypnos at HZDR.
+
+.. note::
+   Please contribute an example.

--- a/docs/source/usage/workflows/laserPeakOnTarget.rst
+++ b/docs/source/usage/workflows/laserPeakOnTarget.rst
@@ -3,6 +3,8 @@
 Setting the Laser Initialization Cut-Off
 ----------------------------------------
 
+.. sectionauthor:: Axel Huebl
+
 Laser profiles for simulation are modeled with a temporal envelope.
 A common model assumes a Gaussian intensity distribution over time which by definition never sets to zero, so it needs to be cut-off to a reasonable range.
 

--- a/docs/source/usage/workflows/numberOfCells.rst
+++ b/docs/source/usage/workflows/numberOfCells.rst
@@ -3,6 +3,8 @@
 Setting the Number of Cells
 ---------------------------
 
+.. sectionauthor:: Axel Huebl
+
 Together with the grid resolution in :ref:`grid.param <usage-params-core>`, the number of cells in our :ref:`.cfg files <usage-tbg>` determine the overall size of a simulation (box).
 The following rules need to be applied when setting the number of cells:
 

--- a/docs/source/usage/workflows/resolution.rst
+++ b/docs/source/usage/workflows/resolution.rst
@@ -3,6 +3,8 @@
 Changing the Resolution with a Fixed Target
 -------------------------------------------
 
+.. sectionauthor:: Axel Huebl
+
 One often wants to refine an already existing resolution in order to model a setup more precisely or to be able to model a higher density.
 
 #. change cell sizes and time step in :ref:`grid.param <usage-params-core>`

--- a/examples/Bremsstrahlung/README.rst
+++ b/examples/Bremsstrahlung/README.rst
@@ -1,8 +1,8 @@
 Bremsstrahlung: Emission of Bremsstrahlung from Laser-Foil Interaction
 ======================================================================
 
-* author:      Heiko Burau <h.burau (at) hzdr.de>
-* maintainer:  Heiko Burau <h.burau (at) hzdr.de>
+.. sectionauthor:: Heiko Burau <h.burau (at) hzdr.de>
+.. moduleauthor:: Heiko Burau <h.burau (at) hzdr.de>
 
 This is a simulation of a flat solid density target hit head-on by a high-intensity laser pulse. 
 At the front surface free electrons are accelerated up to ultra relativistic energies and start travelling through the bulk then. 

--- a/examples/Bunch/README.rst
+++ b/examples/Bunch/README.rst
@@ -1,8 +1,8 @@
 Bunch: Thomson scattering from laser electron-bunch interaction
 ===============================================================
 
-* author:      Richard Pausch <r.pausch (at) hzdr.de>, Rene Widera <r.widera (at) hzdr.de>
-* maintainer:  Richard Pausch <r.pausch (at) hzdr.de>
+.. sectionauthor:: Richard Pausch <r.pausch (at) hzdr.de>
+.. moduleauthor:: Richard Pausch <r.pausch (at) hzdr.de>, Rene Widera <r.widera (at) hzdr.de>
 
 This is a simulation of an electron bunch that collides head-on with a laser pulse.
 Depending on the number of electrons in the bunch, their momentum and their distribution and depending on the laser wavelength and intensity, the emitted radiation differs.

--- a/examples/Empty/README.rst
+++ b/examples/Empty/README.rst
@@ -1,8 +1,7 @@
 Empty: Default PIC Algorithm
 ============================
 
-* author:      Axel Huebl <a.huebl (at) hzdr.de>
-* maintainer:  Axel Huebl <a.huebl (at) hzdr.de>
+.. sectionauthor:: Axel Huebl <a.huebl (at) hzdr.de>
 
 This is an "empty" example, initializing a default particle-in-cell cycle with default algorithms [BirdsallLangdon]_ [HockneyEastwood]_ but without a specific test case.
 When run, it iterates a particle-in-cell algorithm on a vacuum without particles or electro-magnetic fields initialized, which are the default `.param` files in `src/picongpu/include/simulation_defines/param/`.

--- a/examples/KelvinHelmholtz/README.rst
+++ b/examples/KelvinHelmholtz/README.rst
@@ -1,8 +1,8 @@
 KelvinHelmholtz: Kelvin-Helmholtz Instability
 =============================================
 
-* author:      Axel Huebl <a.huebl (at) hzdr.de>, E. Paulo Alves, Thomas Grismayer
-* maintainer:  Axel Huebl <a.huebl (at) hzdr.de>
+.. sectionauthor:: Axel Huebl <a.huebl (at) hzdr.de>
+.. moduleauthor:: Axel Huebl <a.huebl (at) hzdr.de>, E. Paulo Alves, Thomas Grismayer
 
 This example simulates a shear-flow instability known as the Kelvin-Helmholtz Instability in a near-relativistic setup as studied in [Alves12]_, [Grismayer13]_, [Bussmann13]_.
 The default setup uses a pre-ionized quasi-neutral hydrogen plasma.

--- a/examples/LaserWakefield/README.rst
+++ b/examples/LaserWakefield/README.rst
@@ -1,8 +1,8 @@
 LaserWakefield: Laser Electron Acceleration
 ===========================================
 
-* author:      Axel Huebl <a.huebl (at) hzdr.de>, René Widera, Heiko Burau, Richard Pausch, Marco Garten
-* maintainer:  Axel Huebl <a.huebl (at) hzdr.de>
+.. sectionauthor:: Axel Huebl <a.huebl (at) hzdr.de>
+.. moduleauthor:: Axel Huebl <a.huebl (at) hzdr.de>, René Widera, Heiko Burau, Richard Pausch, Marco Garten
 
 Setup for a laser-driven electron accelerator [TajimaDawson]_ in the blowout regime of an underdense plasma [Modena]_ [PukhovMeyerterVehn]_.
 A short (fs) laser beam with ultra-high intensity (a_0 >> 1), modeled as a finite Gaussian beam is focussed in a hydrogen gas target.

--- a/examples/WarmCopper/README.rst
+++ b/examples/WarmCopper/README.rst
@@ -1,8 +1,8 @@
 WarmCopper: Average Charge State Evolution of Copper Irradiated by a Laser
 ==========================================================================
 
-* author:      Axel Huebl <a.huebl (at) hzdr.de>, Hyun-Kyung Chung
-* maintainer:  Axel Huebl <a.huebl (at) hzdr.de>
+.. sectionauthor:: Axel Huebl <a.huebl (at) hzdr.de>
+.. moduleauthor:: Axel Huebl <a.huebl (at) hzdr.de>, Hyun-Kyung Chung
 
 This setup initializes a homogenous, non-moving, copper block irradiated by a laser with 10^18 W/cm^3 as a benchmark for [SCFLY]_ [#FLYlite]_ atomic population dynamics.
 We follow the setup from [FLYCHK]_ page 10, figure 4 assuming a quasi 0D setup with homogenous density of a 1+ ionized copper target.

--- a/src/picongpu/submit/taurus-tud/Slurm_Tutorial.rst
+++ b/src/picongpu/submit/taurus-tud/Slurm_Tutorial.rst
@@ -2,7 +2,7 @@ Slurm examples
 ==============
 
 Job Submission
-""""""""""""""
+''''''''''''''
 
 PIConGPU job submission on the *Taurus* cluster at *TU Dresden*:
 
@@ -10,7 +10,7 @@ PIConGPU job submission on the *Taurus* cluster at *TU Dresden*:
 
 
 Job Control
-"""""""""""
+'''''''''''
 
 * interactive job:
 


### PR DESCRIPTION
Moves author macros to the right position and enables printing them.

- `sectionauthor`: author(s) of the doc
- `moduleauthor`: original author and maintainer(s) of the implementation (nor everyone that touched or formatted a file but relevant contributions to that section in modeling and implementing; scope: BA/MA/PhD thesis or sub-project lead)