### PR TITLE
Example: Foil (LCT) TNSA

### DIFF
--- a/docs/source/usage/workflows.rst
+++ b/docs/source/usage/workflows.rst
@@ -11,3 +11,5 @@ This section contains typical user workflows and best practices.
    workflows/numberOfCells
    workflows/resolution
    workflows/laserPeakOnTarget
+   workflows/compositeMaterials
+   workflows/quasiNeutrality

--- a/docs/source/usage/workflows/compositeMaterials.rst
+++ b/docs/source/usage/workflows/compositeMaterials.rst
@@ -1,0 +1,19 @@
+.. _usage-workflows-compositeMaterials:
+
+Definition of Composite Materials
+---------------------------------
+
+.. sectionauthor:: Axel Huebl
+
+The easiest way to define a composite material in PIConGPU is starting relative to an idealized full-ionized electron density.
+As an example, lets use :math:`\text{C}_{21}\text{H}_{25}\text{N}` (*"8CB"*) with a plasma density of :math:`n_\text{e,max} = 192\,n_\text{c}` contributed by the individual ions relatively as:
+
+* Carbon: :math:`21 \cdot 6 / N_{\Sigma \text{e-}}`
+* Hydrogen: :math:`25 \cdot 1 / N_{\Sigma \text{e-}}`
+* Nitrogen: :math:`1 \cdot 7 / N_{\Sigma \text{e-}}`
+
+and :math:`N_{\Sigma \text{e-}} = 21_\text{C} \cdot 6_{\text{C}^{6+}} + 25_\text{H} \cdot 1_{\text{H}^+} + 1_\text{N} \cdot 7_{\text{N}^{7+}} = 158`.
+
+Set the idealized electron density in :ref:`density.param <usage-params-core>` as a reference and each species' relative ``densityRatio`` from the list above accordingly in :ref:`speciesDefinition.param <usage-params-core>` (see the input files in the :ref:`FoilLCT example <usage-examples-foilLCT>` for details).
+
+In order to initialize the electro-magnetic fields self-consistently, read :ref:`quasi-neutral initialization <usage-workflows-quasiNeutrality>`.

--- a/docs/source/usage/workflows/quasiNeutrality.rst
+++ b/docs/source/usage/workflows/quasiNeutrality.rst
@@ -1,0 +1,70 @@
+.. _usage-workflows-quasiNeutrality:
+
+Quasi-Neutral Initialization
+----------------------------
+
+.. sectionauthor:: Axel Huebl
+
+In order to initialize the electro-magnetic fields self-consistently, one needs to fulfill Gauss's law :math:`\vec \nabla \cdot \vec E = \frac{\rho}{\epsilon_0}` (and :math:`\vec \nabla \cdot \vec B = 0`).
+The trivial solution to this equation is to start *field neutral* by microscopically placing a charge-compensating amount of free electrons on the same position as according ions.
+
+Fully Ionized Ions
+""""""""""""""""""
+
+For fully ionized ions, just use ``ManipulateDeriveSpecies`` in :ref:`speciesInitialization.param <usage-params-core>` and derive macro-electrons :math:`1:1` from macro-ions but increase their weighting by :math:`1:Z` of the ion.
+
+.. code-block:: cpp
+
+   using InitPipeline = mpl::vector<
+       // density profile from density.param and
+       //     start position from particle.param
+       CreateDensity<
+           densityProfiles::YourSelectedProfile,
+           startPosition::YourStartPosition,
+           Carbon
+       >,
+       // create a macro electron for each macro carbon but increase its
+       //     weighting by the ion's proton number so it represents all its
+       //     electrons after an instantanous ionization
+       ManipulateDeriveSpecies<
+           manipulators::ProtonTimesWeighting,
+           Carbon,
+           Electrons
+       >
+   >;
+
+Partly Ionized Ions
+"""""""""""""""""""
+
+For partial pre-ionization, the :ref:`FoilLCT example <usage-examples-foilLCT>` shows a detailed setup.
+First, define a functor that manipulates the number of bound electrons in :ref:`particle.param <usage-params-core>`, e.g. to *once ionized*.
+Then again in :ref:`speciesInitialization.param <usage-params-core>` set your initialization routines to:
+
+.. code-block:: cpp
+
+   using InitPipeline = mpl::vector<
+       // density profile from density.param and
+       //     start position from particle.param
+       CreateDensity<
+           densityProfiles::YourSelectedProfile,
+           startPosition::YourStartPosition,
+           Carbon
+       >,
+       // partially pre-ionize the carbons by manipulating the carbon's
+       //     `boundElectrons` attribute,
+       //     functor defined in particle.param: set to C1+
+       Manipulate<
+           manipulators::OnceIonized,
+           Carbon
+       >,
+       // does not manipulate the weighting while deriving the electrons
+       //     ("once pre-ionized") since we set carbon as C1+
+       DeriveSpecies<
+           Carbon,
+           Electrons
+       >
+   >;
+
+If you want to initialize an arbitrary ionization state, just add your own weighting manipulating functor in :ref:`particle.param <usage-params-core>` for the electrons and use it with ``ManipulateDeriveSpecies`` as in the first example.
+
+In the first example, which does not manipulate the ``boundElectrons`` attribute of the carbon species (optional, see :ref:`speciesAttributes.param <usage-params-core>`), the default is used (zero bound electrons, fully ionized).

--- a/examples/FoilLCT/README.rst
+++ b/examples/FoilLCT/README.rst
@@ -1,0 +1,34 @@
+.. _usage-examples-foilLCT:
+
+FoilLCT: Ion Acceleration from a Liquid-Crystal Target
+======================================================
+
+.. sectionauthor:: Axel Huebl
+.. moduleauthor:: Axel Huebl, T. Kluge
+
+The following example models a laser-ion accelerator in the [TNSA]_ regime.
+An optically over-dense target (:math:`n_\text{max} = 192 n_\text{c}`) consisting of a liquid-crystal material *8CB* (4-octyl-4'-cyanobiphenyl) :math:`C_{21}H_{25}N` is used.
+
+Irradiated with a high-power laser pulse with :math:`a_0 = 5` the target is assumed to be once pre-ionized due to realistic laser contrast and pre-pulses to :math:`C^+`, :math:`H^+` and :math:`N^+` while being slightly expanded on its surfaces (modeled as exponential density slope).
+The overall target is assumed to be initially quasi-neutral and the *8CB* ion components are are not demixed in the surface regions.
+Surface contamination with, e.g. water vapor is neglected.
+
+The laser is assumed to be in-focus and approximated as a plane wave with temporally Gaussian intensity envelope of :math:`\tau^\text{FWHM}_I = 25` fs.
+
+This example is used to demonstrate:
+
+* an ion acceleration setup with
+* :ref:`composite, multi ion-species target material <usage-workflows-compositeMaterials>`
+* :ref:`quasi-neutral initial conditions <usage-workflows-quasiNeutrality>`
+* ionization models for :ref:`field ionization <model-fieldIonization>` and :ref:`collisional ionization <model-collisionalIonization>`
+
+with PIConGPU.
+
+References
+----------
+
+.. [TNSA]
+       S.C. Wilks, A.B. Langdon, T.E. Cowan, M. Roth, M. Singh, S. Hatchett, M.H. Key, D. Pennington, A. MacKinnon, and R.A. Snavely.
+       *Energetic proton generation in ultra-intense laser-solid interactions*,
+       Physics of Plasmas **8**, 542 (2001),
+       https://dx.doi.org/10.1063/1.1333697

--- a/examples/FoilLCT/cmakeFlags
+++ b/examples/FoilLCT/cmakeFlags
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+
+flags[0]="-DCUDA_ARCH=20"
+
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/examples/FoilLCT/include/simulation_defines/param/components.param
+++ b/examples/FoilLCT/include/simulation_defines/param/components.param
@@ -1,0 +1,74 @@
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Anton Helm,
+ *                     Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Select the laser profile and the field solver here.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    /** @namespace simulation_starter
+     *
+     * Simulation Starter Selection:
+     * This value does usually not need to be changed. Change only if you want to
+     * implement your own `SimulationHelper` (e.g. `MySimulation`) class.
+     *  - defaultPIConGPU         : default PIConGPU configuration
+     */
+    namespace simulation_starter = defaultPIConGPU;
+
+    /** @namespace laserProfile
+     *
+     * Laser Profile Selection:
+     *  - laserNone             : no laser init
+     *  - laserGaussianBeam     : Gaussian beam (focusing)
+     *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
+     *                            in 'x' direction
+     *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
+     *  - laserPlaneWave        : a plane wave (Gaussian in time)
+     *  - laserPolynom          : a polynomial laser envelope
+     *
+     * Adjust the settings of the selected profile in laser.param
+     */
+    namespace laserProfile = laserPlaneWave;
+
+    /** @namespace fieldSolver
+     *
+     * Field Solver Selection:
+     *  - fieldSolverYee : standard Yee solver
+     *  - fieldSolverLehe: Num. Cherenkov free field solver in a chosen direction
+     *  - fieldSolverDirSplitting: Sentoku's Directional Splitting Method
+     *  - fieldSolverNone: disable the vacuum update of E and B
+     *
+     * For development purposes:
+     *  - fieldSolverYeeNative : generic version of fieldSolverYee
+     *    (need more shared memory per GPU and is slow)
+     *
+     * Adjust the settings of the selected field solver in fieldSolver.param
+     */
+    namespace fieldSolver = fieldSolverYee;
+
+/** enable (1) or disable (0) current calculation (deprecated) */
+#define ENABLE_CURRENT 1
+
+}

--- a/examples/FoilLCT/include/simulation_defines/param/density.param
+++ b/examples/FoilLCT/include/simulation_defines/param/density.param
@@ -1,0 +1,106 @@
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure existing or define new normalized density profiles here.
+ * During particle species creation in speciesInitialization.param,
+ * those profiles can be translated to spatial particle distributions.
+ */
+
+#pragma once
+
+#include "particles/densityProfiles/profiles.def"
+/* preprocessor struct generator */
+#include "preprocessor/struct.hpp"
+
+
+namespace picongpu
+{
+namespace SI
+{
+    /** Base density in particles per m^3 in the density profiles.
+     *
+     * This is often taken as reference maximum density in normalized profiles.
+     * Individual particle species can define a `densityRatio` flag relative
+     * to this value.
+     *
+     * unit: ELEMENTS/m^3
+     *
+     * We take n_e ("fully ionized") as reference density.
+     * Our target material (see speciesDefinition) is a liquid crystal called
+     * 8CB (4'-octyl-4-cyanobiphenyl).
+     */
+     constexpr float_64 nc = 1.11485e21 * 1.e6 / 0.8 / 0.8;
+     constexpr float_64 BASE_DENSITY_SI = 192. * nc;
+
+} // namespace SI
+
+namespace densityProfiles
+{
+    struct FlatFoilWithRampFunctor
+    {
+        /** This formula uses SI quantities only.
+         *  The profile will be multiplied by BASE_DENSITY_SI.
+         *
+         * @param position_SI total offset including all slides [meter]
+         * @param cellSize_SI cell sizes [meter]
+         *
+         * @return float_X density [normalized to 1.0]
+         */
+        HDINLINE float_X
+        operator()(
+            const floatD_64& position_SI,
+            const float3_64& cellSize_SI
+        )
+        {
+            // m -> mu
+            const float_64 y( position_SI.y() * 1.e6 );
+
+            // target begin & end (plateau)
+            constexpr float_64 y0( 0.5 );
+            constexpr float_64 y1( y0 + 1.0 );
+            // exponential pre-expanded density
+            constexpr float_64 L( 10.e-3 );
+            constexpr float_64 L_cutoff( 4. * L );
+
+            float_64 dens = 0.0;
+
+            // upramp
+            if( y < y0 && (y0 - y) < L_cutoff )
+                dens = math::exp( ( y - y0 ) / L );
+            // downramp
+            if( y > y1 && (y - y1) < L_cutoff )
+                dens = math::exp( ( y1 - y ) / L );
+            // plateau
+            if( y >= y0 && y <= y1 )
+                dens = 1.0;
+
+            // safety check: all parts of the function MUST be > 0
+            dens *= float_64( dens >= 0.0 );
+            return dens;
+        }
+    };
+
+    /* definition of free formula profile */
+    using FlatFoilWithRamp = FreeFormulaImpl< FlatFoilWithRampFunctor >;
+
+} // namespace densityProfiles
+} // namespace picongpu

--- a/examples/FoilLCT/include/simulation_defines/param/dimension.param
+++ b/examples/FoilLCT/include/simulation_defines/param/dimension.param
@@ -1,0 +1,35 @@
+/* Copyright 2014-2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * The spatial dimensionality of the simulation.
+ */
+
+#pragma once
+
+
+/** Possible values: DIM3 for 3D3V and DIM2 for 2D3V.
+ */
+#define SIMDIM DIM2
+
+namespace picongpu
+{
+    constexpr uint32_t simDim = SIMDIM;
+} // namespace picongpu

--- a/examples/FoilLCT/include/simulation_defines/param/fileOutput.param
+++ b/examples/FoilLCT/include/simulation_defines/param/fileOutput.param
@@ -1,0 +1,119 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt,
+ * Benjamin Worpitz, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/int.hpp>
+
+#include "compileTime/conversion/MakeSeq.hpp"
+
+/* some forward declarations we need */
+#include "fields/Fields.def"
+#include "particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+
+namespace picongpu
+{
+    /** FieldTmp output (calculated at runtime) *******************************
+     *
+     * Those operations derive scalar field quantities from particle species
+     * at runtime. Each value is mapped per cell. Some operations are identical
+     * up to a constant, so avoid writing those twice to save storage.
+     *
+     * you can choose any of these particle to grid projections:
+     *   - CreateDensityOperation: particle position + shape on the grid
+     *   - CreateChargeDensityOperation: density * charge
+     *       note: for species that do not change their charge state, this is
+     *             the same as the density times a constant for the charge
+     *   - CreateEnergyOperation: sum of kinetic particle energy per cell with
+     *                            respect to shape
+     *   - CreateEnergyDensityOperation: average kinetic particle energy per
+     *                                   cell times the particle density
+     *       note: this is the same as the sum of kinetic particle energy
+     *             divided by a constant for the cell volume
+     *   - CreateMomentumComponentOperation: ratio between a selected momentum
+     *                                       component and the absolute
+     *                                       momentum with respect to shape
+     *   - CreateLarmorPowerOperation: radiated larmor power
+     *                                 (species must contain the attribute `momentumPrev1`)
+     *
+     * for debugging:
+     *   - CreateMidCurrentDensityComponentOperation:
+     *       density * charge * velocity_component
+     *   - CreateCounterOperation: counts point like particles per cell
+     *   - CreateMacroCounterOperation: counts point like macro particles per cell
+     */
+    using namespace particleToGrid;
+
+    /* Density section for Hydrogen */
+    using Density_Seq = bmpl::transform<
+        MakeSeq_t< Hydrogen >,
+        CreateDensityOperation< bmpl::_1 >
+    >::type;
+
+    /* ChargeDensity section */
+    using ChargeDensity_Seq = bmpl::transform<
+        VectorAllSpecies,
+        CreateChargeDensityOperation< bmpl::_1 >
+    >::type;
+
+    /* EnergyDensity section */
+    using EnergyDensity_Seq = bmpl::transform<
+        VectorAllSpecies,
+        CreateEnergyDensityOperation< bmpl::_1 >
+    >::type;
+
+    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
+     *
+     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
+     */
+    using FieldTmpSolvers = MakeSeq_t<
+        Density_Seq,
+        ChargeDensity_Seq,
+        EnergyDensity_Seq
+    >;
+
+
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
+
+    /** Possible native fields: FieldE, FieldB, FieldJ
+     */
+    using NativeFileOutputFields = MakeSeq_t<
+        FieldE,
+        FieldB,
+        FieldJ
+    >;
+
+    using FileOutputFields = MakeSeq_t<
+        NativeFileOutputFields,
+        FieldTmpSolvers
+    >;
+
+
+    /** FileOutputParticles: Groups all Species that shall be dumped **********
+     *
+     * hint: to enable particle output set to
+     *   using FileOutputParticles = VectorAllSpecies;
+     */
+    using FileOutputParticles = bmpl::vector0<>;
+
+}

--- a/examples/FoilLCT/include/simulation_defines/param/grid.param
+++ b/examples/FoilLCT/include/simulation_defines/param/grid.param
@@ -1,0 +1,103 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Definition of cell sizes and time step. Our cells are defining a regular,
+ * cartesian grid. Our explicit FDTD field solvers define an upper bound for
+ * the time step value in relation to the cell size for convergence. Make
+ * sure to resolve important wavelengths of your simulation, e.g. shortest
+ * plasma wavelength and central laser wavelength both spatially and
+ * temporarily.
+ *
+ * **Units in reduced dimensions**
+ *
+ * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+ * is still used for normalization of densities, etc..
+ *
+ * A 2D3V simulation in a cartesian PIC simulation such as
+ * ours only changes the degrees of freedom in motion for
+ * (macro) particles and all (field) information in z
+ * travels instantaneous, making the 2D3V simulation
+ * behave like the interaction of infinite "wire particles"
+ * in fields with perfect symmetry in Z.
+ *
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace SI
+    {
+        /** equals X
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = 0.8e-6 / 384.;
+        /** equals Y - the laser & moving window propagation direction
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Duration of one timestep
+         *  unit: seconds                       CFL criteria for Yee MW Solver
+         *                                             2D: sqrt(2)
+         *                                             3D: sqrt(3)   */
+        constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / ( 1.4143 * SPEED_OF_LIGHT_SI );
+
+    } // namespace SI
+
+    /** Defines the size of the absorbing zone (in cells)
+     *
+     *  unit: none
+     */
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
+        {64, 64},  /*x direction [negative,positive]*/
+        {64, 64},  /*y direction [negative,positive]*/
+        {64, 64}   /*z direction [negative,positive]*/
+    };
+
+    /** Define the strength of the absorber for any direction
+     *
+     *  unit: none
+     */
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
+        {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
+    };
+
+    /** When to start moving the co-moving window
+     *
+     *  Slide point model: A virtual photon starts at t=0 at the lower end
+     *  of the global simulation box in y-direction of the simulation.
+     *  When it reaches movePoint % of the global simulation box,
+     *  the co-moving window starts to move with the speed of light.
+     *
+     *  @note global simulation area: there is one additional "hidden" row
+     *        of gpus at the y-front, when you use the co-moving window.
+     *        1.0 would correspond to: start moving exactly when the above
+     *        described "virtual photon" from the lower end of the box' Y-axis
+     *        reaches the beginning of this "hidden" row of GPUs.
+     */
+    constexpr float_64 movePoint = 0.9;
+
+} // namespace picongpu

--- a/examples/FoilLCT/include/simulation_defines/param/laser.param
+++ b/examples/FoilLCT/include/simulation_defines/param/laser.param
@@ -1,0 +1,386 @@
+/* Copyright 2013-2017 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
+ *                     Alexander Debus
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure laser profiles.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace laser
+    {
+        /** cell from top where the laser is initialized
+         *
+         * if `initPlaneY == 0` than the absorber are disabled.
+         * if `initPlaneY > absorbercells negative Y` the negative absorber in y
+         * direction is enabled
+         *
+         * valid ranges:
+         *   - initPlaneY == 0
+         *   - absorber cells negative Y < initPlaneY < cells in y direction of the top gpu
+        */
+        constexpr uint32_t initPlaneY = 80;
+    }
+
+    namespace laserGaussianBeam
+    {
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** Convert the normalized laser strength parameter a0 to Volt per meter */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0  = 5.0;
+
+            /** unit: Volt / meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt / meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 25.0e-15 / 2.354820045;
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *
+             *  unit: meter */
+            constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
+            /** the distance to the laser focus in y-direction
+             *  unit: meter */
+            constexpr float_64 FOCUS_POS_SI = 2.0e-6;
+        }
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+         *
+         *  unit: none */
+        constexpr float_64 PULSE_INIT = 3. * 2.354820045;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Use only the 0th Laguerremode for a standard Gaussian */
+        constexpr uint32_t MODENUMBER = 0;
+        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+        /* This is just an example for a more complicated set of Laguerre modes. */
+        //constexpr uint32_t MODENUMBER = 12;
+        //PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321, -0.0160788);
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+    namespace laserPulseFrontTilt
+    {
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: Volt / meter */
+            constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+                *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                *                                          [   2.354820045      ]
+                *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                *                      = what a experimentalist calls "pulse duration"
+                *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 25.0e-15 / 2.354820045;
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
+
+            /** the distance to the laser focus in y-direction
+                *  unit: meter */
+            constexpr float_64 FOCUS_POS_SI = 2.0e-6;
+
+            /** the tilt angle between laser propagation in y-direction and laser axis in
+                *  x-direction (0 degree == no tilt)
+                *  unit: degree */
+            constexpr float_64 TILT_X_SI = 0;
+        }
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+        *  unit: none */
+        constexpr float_64 PULSE_INIT = 3. * 2.354820045;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+    namespace laserPlaneWave
+    {
+        // NOT-symetric sinus used: starts with phase=0 --> E-field=0
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0  = 5.0;
+
+            /** unit: Volt / meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt / meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** The profile of the test Lasers 0 and 2 can be stretched by a
+             *      constexprant area between the up and downramp
+             *  unit: seconds */
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 25.0e-15 / 2.354820045;
+
+        }
+
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 3. * 2.354820045;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+    namespace laserWavepacket
+    {
+    // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+    namespace SI
+    {
+        /** unit: meter */
+        constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+        /** UNITCONV */
+        constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+        /** unit: W / m^2 */
+        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+        /** unit: none */
+        constexpr float_64 _A0  = 5.0;
+
+        /** unit: Volt / meter */
+        constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+        /** unit: Volt / meter */
+        //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+        /** The profile of the test Lasers 0 and 2 can be stretched by a
+         *      constexprant area between the up and downramp
+         *  unit: seconds */
+        constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0;
+
+        /** Pulse length: sigma of std. gauss for intensity (E^2)
+         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+         *                                          [    2.354820045     ]
+         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+         *                      = what a experimentalist calls "pulse duration"
+         *  unit: seconds (1 sigma) */
+        constexpr float_64 PULSE_LENGTH_SI = 25.0e-15 / 2.354820045;
+
+        /** beam waist: distance from the axis where the pulse intensity (E^2)
+         *              decreases to its 1/e^2-th part,
+         *              WO_X_SI is this distance in x-direction
+         *              W0_Z_SI is this distance in z-direction
+         *              if both values are equal, the laser has a circular shape in x-z
+         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+         *                             [   1.17741    ]
+         *  unit: meter */
+        constexpr float_64 W0_X_SI = 5.0e-6 / 1.17741;
+        constexpr float_64 W0_Z_SI = W0_X_SI;
+
+    }
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+        and half at the end of the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 3. * 2.354820045;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+
+    namespace laserPolynom
+    {
+        // Asymetric sinus used: starts with phase=0 at center --> E-field=0 at center
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0  = 5.0;
+
+            /** unit: Volt / meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt / meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+
+            /** Pulse length:
+             *  PULSE_LENGTH_SI = total length of polynamial laser pulse
+             *  Rise time = 0.5 * PULSE_LENGTH_SI
+             *  Fall time = 0.5 * PULSE_LENGTH_SI
+             *  in order to compare to a gaussian pulse: rise  time = sqrt{2} * T_{FWHM}
+             *  unit: seconds  */
+            constexpr float_64 PULSE_LENGTH_SI = 25.0e-15 / 2.354820045;
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             *  unit: meter */
+            constexpr float_64 W0x_SI = 4.246e-6; // waist in x-direction
+            constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
+        }
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+    }
+
+    namespace laserNone
+    {
+        namespace SI
+        {
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.0;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = 0.0;
+
+            constexpr float_64 PULSE_LENGTH_SI = 0.0;
+        }
+    }
+
+}

--- a/examples/FoilLCT/include/simulation_defines/param/memory.param
+++ b/examples/FoilLCT/include/simulation_defines/param/memory.param
@@ -1,0 +1,69 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "math/Vector.hpp"
+#include "mappings/kernel/MappingDescription.hpp"
+
+
+namespace picongpu
+{
+
+    /* We have to hold back 350MiB for gpu-internal operations:
+     *   - random number generator
+     *   - reduces
+     *   - ...
+     */
+    constexpr size_t reservedGpuMemorySize = 350 * 1024 * 1024;
+
+    /* short namespace*/
+    namespace mCT = PMacc::math::CT;
+    /** size of a superCell
+     *
+     * volume of a superCell must be <= 1024
+     */
+    using SuperCellSize = mCT::Int< 16, 16 >;
+
+    /** define mapper which is used for kernel call mappings */
+    using MappingDesc = MappingDescription< simDim, SuperCellSize >;
+
+    constexpr uint32_t GUARD_SIZE = 1;
+
+    //! how many bytes for buffer is reserved to communication in one direction
+    constexpr uint32_t BYTES_EXCHANGE_X = 3 * 1024 * 1024; // 3 MiB
+    constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 1024 * 1024; // 6 MiB
+    constexpr uint32_t BYTES_EXCHANGE_Z = 3 * 1024 * 1024; // 3 MiB
+    constexpr uint32_t BYTES_CORNER = 32 * 1024; // 32 kiB;
+    constexpr uint32_t BYTES_EDGES = 128 * 1024; // 128 kiB;
+
+    /** number of scalar fields that are reserved as temporary fields */
+    constexpr uint32_t fieldTmpNumSlots = 2;
+
+    /** can `FieldTmp` gather neighbor information
+     *
+     * If `true` it is possible to call the method `asyncCommunicationGather()`
+     * to copy data from the border of neighboring GPU into the local guard.
+     * This is also known as building up a "ghost" or "halo" region in domain
+     * decomposition and only necessary for specific algorithms that extend
+     * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+     */
+    constexpr bool fieldTmpSupportGatherCommunication = true;
+
+} // namespace picongpu

--- a/examples/FoilLCT/include/simulation_defines/param/particle.param
+++ b/examples/FoilLCT/include/simulation_defines/param/particle.param
@@ -1,0 +1,110 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configurations for particle manipulators. Set up and declare functors that
+ * can be used in speciesInitalization.param for particle species
+ * initialization and manipulation, such as temperature distributions, drifts,
+ * pre-ionization and in-cell position.
+ */
+
+#pragma once
+
+#include "particles/startPosition/functors.def"
+#include "particles/manipulators/manipulators.def"
+#include "nvidia/functors/Add.hpp"
+#include "nvidia/functors/Assign.hpp"
+#include "nvidia/rng/distributions/Uniform_float.hpp"
+#include "particles/traits/GetAtomicNumbers.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+
+    /** a particle with a weighting below MIN_WEIGHTING will not
+     *      be created / will be deleted
+     *
+     *  unit: none
+     *
+     * here we essentially allow any weighting since it has no real meaning in 2D3V
+     */
+    constexpr float_X MIN_WEIGHTING = 0.0000001;
+
+    /** Number of maximum particles per cell during density profile evaluation.
+     *
+     * Determines the weighting of a macro particle and with it, the number of
+     * particles "sampling" dynamics in phase space.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 6;
+
+namespace manipulators
+{
+    //! ionize ions once
+    struct OnceIonizedImpl
+    {
+        template< typename T_Particle >
+        DINLINE void operator()(
+            T_Particle& particle,
+            T_Particle&
+        )
+        {
+            constexpr float_X protonNumber = GetAtomicNumbers< T_Particle >::type::numberOfProtons;
+            particle[boundElectrons_] = protonNumber - 1;
+        }
+    };
+
+    //! definition of OnceIonized manipulator
+    using OnceIonized = FreeImpl< OnceIonizedImpl >;
+
+    //! changes the in-cell position of each particle of a species
+    using RandomPosition = RandomPositionImpl<>;
+
+} // namespace manipulators
+
+
+namespace startPosition
+{
+    struct RandomParameter
+    {
+        /** Count of particles per cell at initial state
+         *
+         *  unit: none */
+        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+    };
+    /** definition of random particle start */
+    using Random = RandomImpl< RandomParameter >;
+
+    struct QuietParam
+    {
+        /** Count of particles per cell per direction at initial state
+         *
+         *  unit: none */
+        using numParticlesPerDimension = mCT::Int< 2, 3 >;
+    };
+
+    /** definition of quiet particle start */
+    using Quiet = QuietImpl< QuietParam >;
+
+} // namespace startPosition
+} // namespace particles
+} // namespace picongpu

--- a/examples/FoilLCT/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/FoilLCT/include/simulation_defines/param/speciesDefinition.param
@@ -1,0 +1,214 @@
+/* Copyright 2013-2017 Rene Widera, Benjamin Worpitz, Heiko Burau, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define particle species.
+ *
+ * This file collects all previous declarations of base (reference) quantities
+ * and configured solvers for species and defines particle species. This
+ * includes "attributes" (lvalues to store with each species) and "flags"
+ * (rvalues & aliases for solvers to perform with the species for each timestep
+ * and ratios to base quantities). With those information, a `Particles` class
+ * is defined for each species and then collected in the list
+ * `VectorAllSpecies`.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "particles/Identifier.hpp"
+#include "compileTime/conversion/MakeSeq.hpp"
+#include "identifier/value_identifier.hpp"
+
+#include "particles/traits/FilterByFlag.hpp"
+#include "particles/Particles.hpp"
+#include <boost/mpl/string.hpp>
+
+#include "particles/ionization/byField/ionizers.def"
+#include "particles/ionization/byCollision/ionizers.def"
+
+
+namespace picongpu
+{
+
+/*########################### define particle attributes #####################*/
+
+//! describe attributes of a particle
+using DefaultParticleAttributes = MakeSeq_t<
+    position< position_pic >,
+    momentum,
+    weighting
+>;
+
+//! ions also need to have a boundElectrons attribute for ionization
+using IonParticleAttributes = MakeSeq_t<
+    DefaultParticleAttributes,
+    boundElectrons
+>;
+
+/*########################### end particle attributes ########################*/
+
+/*########################### define species #################################*/
+
+/*--------------------------- electrons --------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+
+using ParticleFlagsElectrons = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioElectrons >,
+    chargeRatio< ChargeRatioElectrons >
+>;
+
+/* define species electrons */
+using Electrons = Particles<
+    bmpl::string< 'e' >,
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
+>;
+
+/*--------------------------- H+ --------------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioHydrogen, 1836.152672 );
+value_identifier( float_X, ChargeRatioHydrogen, -1.0 );
+
+/* ratio relative to BASE_DENSITY (n_e) */
+value_identifier( float_X, DensityRatioHydrogen, 25. / 158. );
+
+using ParticleFlagsHydrogen = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioHydrogen >,
+    chargeRatio< ChargeRatioHydrogen >,
+    densityRatio< DensityRatioHydrogen >,
+    atomicNumbers< ionization::atomicNumbers::Hydrogen_t >,
+    ionizationEnergies< ionization::energies::AU::Hydrogen_t >,
+    effectiveNuclearCharge< ionization::effectiveNuclearCharge::Hydrogen_t >,
+    ionizers<
+        MakeSeq_t<
+            particles::ionization::BSIEffectiveZ< Electrons >,
+            particles::ionization::ADKLinPol< Electrons >,
+            particles::ionization::ThomasFermi< Electrons >
+        >
+    >
+>;
+
+/* define species Hydrogen */
+using Hydrogen = Particles<
+    bmpl::string< 'H' >,
+    ParticleFlagsHydrogen,
+    IonParticleAttributes
+>;
+
+/*--------------------------- C ---------------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioCarbon, 22032.0 );
+value_identifier( float_X, ChargeRatioCarbon, -6.0 );
+
+/* ratio relative to BASE_DENSITY (n_e) */
+value_identifier( float_X, DensityRatioCarbon, 21. / 158. );
+
+using ParticleFlagsCarbon = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioCarbon >,
+    chargeRatio< ChargeRatioCarbon >,
+    densityRatio< DensityRatioCarbon >,
+    atomicNumbers< ionization::atomicNumbers::Carbon_t >,
+    ionizationEnergies< ionization::energies::AU::Carbon_t >,
+    effectiveNuclearCharge< ionization::effectiveNuclearCharge::Carbon_t >,
+    ionizers<
+        MakeSeq_t<
+            particles::ionization::BSIEffectiveZ< Electrons >,
+            particles::ionization::ADKLinPol< Electrons >,
+            particles::ionization::ThomasFermi< Electrons >
+        >
+    >
+>;
+
+/* define species Carbon */
+using Carbon = Particles<
+    bmpl::string< 'C' >,
+    ParticleFlagsCarbon,
+    IonParticleAttributes
+>;
+
+/*--------------------------- N ---------------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioNitrogen, 25716.852 );
+value_identifier( float_X, ChargeRatioNitrogen, -7.0 );
+
+/* ratio relative to BASE_DENSITY (n_e) */
+value_identifier( float_X, DensityRatioNitrogen, 1. / 158. );
+
+using ParticleFlagsNitrogen = bmpl::vector<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioNitrogen >,
+    chargeRatio< ChargeRatioNitrogen >,
+    densityRatio< DensityRatioNitrogen >,
+    atomicNumbers< ionization::atomicNumbers::Nitrogen_t >,
+    ionizationEnergies< ionization::energies::AU::Nitrogen_t >,
+    effectiveNuclearCharge< ionization::effectiveNuclearCharge::Nitrogen_t >,
+    ionizers<
+        MakeSeq_t<
+            particles::ionization::BSIEffectiveZ< Electrons >,
+            particles::ionization::ADKLinPol< Electrons >,
+            particles::ionization::ThomasFermi< Electrons >
+        >
+    >
+>;
+
+/* define species Nitrogen */
+using Nitrogen = Particles<
+    bmpl::string< 'N' >,
+    ParticleFlagsNitrogen,
+    IonParticleAttributes
+>;
+
+/*########################### end species ####################################*/
+
+/** All known particle species of the simulation
+ *
+ * List all defined particle species from above in this list
+ * to make them available to the PIC algorithm.
+ */
+using VectorAllSpecies = MakeSeq_t<
+    Electrons,
+    Hydrogen,
+    Carbon,
+    Nitrogen
+>;
+
+} // namespace picongpu

--- a/examples/FoilLCT/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/FoilLCT/include/simulation_defines/param/speciesInitialization.param
@@ -1,0 +1,139 @@
+/* Copyright 2015-2017 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Available species functors
+ *   in src/picongpu/include/particles/InitFunctors.hpp
+ *
+ * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
+ *     Create particle distribution based on a density profile and an in-cell
+ *     positioning.
+ *     Fills a particle species (`fillAllGaps()` is called).
+ *     @tparam T_DensityFunctor  unary lambda functor with density description,
+ *                               \see density.param
+ *                               \example densityProfiles::Homogenous,
+ *     @tparam T_PositionFunctor unary lambda functor with position description,
+ *                               \see particles.param
+ *                               \example startPosition::Quiet
+ *                                        startPosition::Random
+ *     @tparam T_SpeciesType type of the used species,
+ *                               \see speciesDefinition.param
+ *                               \example PIC_Electrons
+ *
+ * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
+ *     Create a particle species by copying all matching attributes from an
+ *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
+ *     @tparam T_SrcSpeciesType  source species
+ *     @tparam T_DestSpeciesType destination species
+ *
+ * - Manipulate<T_Functor, typename T_SpeciesType>
+ *     Run a user defined functor for every particle.
+ *     \warning does not call `fillAllGaps()` if one removes or
+ *              adds particles with it (\see FillAllGaps below)
+ *     @tparam T_Functor     unary lambda functor,
+ *                           \see particle.param
+ *     @tparam T_SpeciesType type of the used species
+ *
+ * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
+ *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
+ *     after deriving to manipulate the two particles that took part
+ *     in the deriving (e.g., assign and increase an attribute such as weighting).
+ *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
+ *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
+ *                                 species: destination and source,
+ *                                 \see particle.param
+ *     @tparam T_SrcSpeciesType    source species
+ *     @tparam T_DestSpeciesType   destination species
+ *
+ * - FillAllGaps<T_SpeciesType>
+ *     The manipulate functor does not call `fillAllGaps` on
+ *     the particle list of frames. For user-defined functors
+ *     that are called via Manipulate and create/remove
+ *     particles into/from frame lists, this must be called
+ *     afterward to create a valid data structure.
+ */
+
+#pragma once
+
+#include "particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+
+    /** InitPipeline defines in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        CreateDensity<
+            densityProfiles::FlatFoilWithRamp,
+            startPosition::Random,
+            Hydrogen
+        >,
+        /* derive the other two ion species and adjust their weighting to have always all
+         * three of macro ions present in a cell, even in cut-off regions of the density profile */
+        ManipulateDeriveSpecies<
+            manipulators::DensityWeighting,
+            Hydrogen,
+            Carbon
+        >,
+        ManipulateDeriveSpecies<
+            manipulators::DensityWeighting,
+            Hydrogen,
+            Nitrogen
+        >,
+        // randomize C & N in-cell
+        Manipulate<
+            manipulators::RandomPosition,
+            Carbon
+        >,
+        Manipulate<
+            manipulators::RandomPosition,
+            Nitrogen
+        >,
+        // partial pre-ionization: set bound electrons for C & N
+        Manipulate<
+            manipulators::OnceIonized,
+            Carbon
+        >,
+        Manipulate<
+            manipulators::OnceIonized,
+            Nitrogen
+        >,
+        // partial pre-ionization: create free electrons
+        DeriveSpecies<
+            Hydrogen,
+            Electrons
+        >,
+        DeriveSpecies<
+            Carbon,
+            Electrons
+        >,
+        DeriveSpecies<
+            Nitrogen,
+            Electrons
+        >
+    >;
+
+} // namespace particles
+} // namespace picongpu

--- a/examples/FoilLCT/submit/0004gpus.cfg
+++ b/examples/FoilLCT/submit/0004gpus.cfg
@@ -1,0 +1,92 @@
+# Copyright 2017 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="2:00:00"
+
+TBG_gpu_x=2
+TBG_gpu_y=2
+TBG_gpu_z=1
+
+TBG_gridSize="-g 256 1280"
+TBG_steps="-s 2000"
+
+TBG_periodic="--periodic 1 0"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+# Create a particle-energy histogram [in keV]
+TBG_e_histogram="--e_energyHistogram.period 100 --e_energyHistogram.binCount 1024    \
+                 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 2000"
+TBG_H_histogram="--H_energyHistogram.period 100 --H_energyHistogram.binCount 1024    \
+                 --H_energyHistogram.minEnergy 0 --H_energyHistogram.maxEnergy 2000"
+TBG_C_histogram="--C_energyHistogram.period 100 --C_energyHistogram.binCount 1024    \
+                 --C_energyHistogram.minEnergy 0 --C_energyHistogram.maxEnergy 2000"
+TBG_N_histogram="--N_energyHistogram.period 100 --N_energyHistogram.binCount 1024    \
+                 --N_energyHistogram.minEnergy 0 --N_energyHistogram.maxEnergy 2000"
+
+# longitudinal phase space: in m_<species> c
+TBG_e_PSypy="--e_phaseSpace.period 250 --e_phaseSpace.space y --e_phaseSpace.momentum py --e_phaseSpace.min -2.0 --e_phaseSpace.max 2.0"
+TBG_H_PSypy="--H_phaseSpace.period 250 --H_phaseSpace.space y --H_phaseSpace.momentum py --H_phaseSpace.min -0.04 --H_phaseSpace.max 0.04"
+TBG_C_PSypy="--C_phaseSpace.period 250 --C_phaseSpace.space y --C_phaseSpace.momentum py --C_phaseSpace.min -0.02 --C_phaseSpace.max 0.02"
+TBG_N_PSypy="--N_phaseSpace.period 250 --N_phaseSpace.space y --N_phaseSpace.momentum py --N_phaseSpace.min -0.02 --N_phaseSpace.max 0.02"
+
+# useful for heating tests
+TBG_sumEnergy="--fields_energy.period 100 --e_energy.period 100 --H_energy.period 100 --C_energy.period 100 --N_energy.period 100"
+TBG_chargeConservation="--chargeConservation.period 100"
+
+# regular output
+TBG_hdf5="--hdf5.period 250"
+
+TBG_plugins="!TBG_e_histogram !TBG_H_histogram !TBG_C_histogram !TBG_N_histogram \
+             !TBG_e_PSypy !TBG_H_PSypy !TBG_C_PSypy !TBG_N_PSypy                 \
+             !TBG_sumEnergy !TBG_chargeConservation                              \
+             !TBG_hdf5"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+
+TBG_programParams="!TBG_devices      \
+                   !TBG_gridSize     \
+                   !TBG_steps        \
+                   !TBG_periodic     \
+                   !TBG_plugins"
+
+# TOTAL number of GPUs
+TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+
+"$TBG_cfgPath"/submitAction.sh


### PR DESCRIPTION
This example models a laser-ion accelerator in the TNSA regime. An optically over-dense target n_max = 192 n_c consisting of a liquid-crystal material is used. Irradiated with a high-power laser pulse with a_0 = 5 the *8CB* ([4-octyl-4'-cyanobiphenyl](http://www.chemspider.com/Chemical-Structure.94149.html)) C_{21} H_{25} N target is assumed to be once pre-ionized due to realistic laser contrast and pre-pulses to C^+, H^+ and N^+ while being slightly expanded on its surfaces (modeled as exponential density slope).

The laser is assumed to be in-focus and approximated as a plane wave with temporally Gaussian intensity envelope of tau^{FWHM}_I = 25 fs.

This example is used to demonstrate:

* an ion acceleration setup with
* non-trivial initial conditions
* composite materials
* ionization models (compile test for ADK lin., close #1962)

with PIConGPU.

It fits on 4 K20m GPUs (with ECC enabled) with reasonable resolution.

## To Do

- [x] rename cfg file to `0004gpus.cfg`
- [x] depends on #1999
- [x] add comparisons for ionization models (depends on #2007 #2011)

## Comparisons

(laser from bottom plane)

### Quiet Start

**n_e**
![quietstart](https://cloud.githubusercontent.com/assets/1353258/25794098/c9fe85b6-33cf-11e7-8594-461265ec1eaf.png)

**n_Z,C**
![quietstart_c](https://cloud.githubusercontent.com/assets/1353258/25794104/cd7b472e-33cf-11e7-9e79-1b74cc153f25.png)

**sum(n_Z)**
![quietstart_sum](https://cloud.githubusercontent.com/assets/1353258/25794300/98c9f2ae-33d0-11e7-8bc9-abd21d215a3c.png)

### Random Start

**n_e**
![randomstart](https://cloud.githubusercontent.com/assets/1353258/25755757/767f206a-31c4-11e7-88cc-4654fffdb8f5.png)

**n_Z,C**
![randomstart_c](https://cloud.githubusercontent.com/assets/1353258/25755758/7901153c-31c4-11e7-9404-2bccfdf05e99.png)

**sum(n_Z)**
![randomstart_sum](https://cloud.githubusercontent.com/assets/1353258/25794296/93b3b034-33d0-11e7-8140-c2412c0a3f49.png)
