### PR TITLE
`FieldTmp` gather support

### DIFF
--- a/examples/Bunch/include/simulation_defines/param/memory.param
+++ b/examples/Bunch/include/simulation_defines/param/memory.param
@@ -56,4 +56,14 @@ constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
 /** number of scalar fields that are reserved as temporary fields */
 constexpr uint32_t fieldTmpNumSlots = 1;
 
+/** can `FieldTmp` gather neighbor information
+ *
+ * If `true` it is possible to call the method `asyncCommunicationGather()`
+ * to copy data from the border of neighboring GPU into the local guard.
+ * This is also known as building up a "ghost" or "halo" region in domain
+ * decomposition and only necessary for specific algorithms that extend
+ * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+ */
+constexpr bool fieldTmpSupportGatherCommunication = true;
+
 }//namespace picongpu

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/memory.param
@@ -56,4 +56,14 @@ constexpr uint32_t BYTES_EDGES = 64 * 1024; //64 kiB;
 /** number of scalar fields that are reserved as temporary fields */
 constexpr uint32_t fieldTmpNumSlots = 1;
 
+/** can `FieldTmp` gather neighbor information
+ *
+ * If `true` it is possible to call the method `asyncCommunicationGather()`
+ * to copy data from the border of neighboring GPU into the local guard.
+ * This is also known as building up a "ghost" or "halo" region in domain
+ * decomposition and only necessary for specific algorithms that extend
+ * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+ */
+constexpr bool fieldTmpSupportGatherCommunication = true;
+
 }//namespace picongpu

--- a/examples/LaserWakefield/include/simulation_defines/param/memory.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/memory.param
@@ -56,4 +56,14 @@ constexpr uint32_t BYTES_EDGES = 32 * 1024; //32 kiB;
 /** number of scalar fields that are reserved as temporary fields */
 constexpr uint32_t fieldTmpNumSlots = 1;
 
+/** can `FieldTmp` gather neighbor information
+ *
+ * If `true` it is possible to call the method `asyncCommunicationGather()`
+ * to copy data from the border of neighboring GPU into the local guard.
+ * This is also known as building up a "ghost" or "halo" region in domain
+ * decomposition and only necessary for specific algorithms that extend
+ * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+ */
+constexpr bool fieldTmpSupportGatherCommunication = true;
+
 }//namespace picongpu

--- a/examples/ThermalTest/include/simulation_defines/param/memory.param
+++ b/examples/ThermalTest/include/simulation_defines/param/memory.param
@@ -56,4 +56,14 @@ constexpr uint32_t BYTES_EDGES = 3200 * 1024; //32 kiB;
 /** number of scalar fields that are reserved as temporary fields */
 constexpr uint32_t fieldTmpNumSlots = 1;
 
+/** can `FieldTmp` gather neighbor information
+ *
+ * If `true` it is possible to call the method `asyncCommunicationGather()`
+ * to copy data from the border of neighboring GPU into the local guard.
+ * This is also known as building up a "ghost" or "halo" region in domain
+ * decomposition and only necessary for specific algorithms that extend
+ * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+ */
+constexpr bool fieldTmpSupportGatherCommunication = true;
+
 }//namespace picongpu

--- a/examples/WeibelTransverse/include/simulation_defines/param/memory.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/memory.param
@@ -55,4 +55,14 @@ constexpr uint32_t BYTES_EDGES = 8 * 256 * 1024; //8 MiB
 /** number of scalar fields that are reserved as temporary fields */
 constexpr uint32_t fieldTmpNumSlots = 1;
 
+/** can `FieldTmp` gather neighbor information
+ *
+ * If `true` it is possible to call the method `asyncCommunicationGather()`
+ * to copy data from the border of neighboring GPU into the local guard.
+ * This is also known as building up a "ghost" or "halo" region in domain
+ * decomposition and only necessary for specific algorithms that extend
+ * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+ */
+constexpr bool fieldTmpSupportGatherCommunication = true;
+
 }//namespace picongpu

--- a/src/picongpu/include/fields/FieldTmp.hpp
+++ b/src/picongpu/include/fields/FieldTmp.hpp
@@ -26,9 +26,7 @@
 #include <vector>
 
 /*pic default*/
-#include "pmacc_types.hpp"
 #include "simulation_defines.hpp"
-#include "simulation_classTypes.hpp"
 
 #include "fields/Fields.def"
 #include "fields/SimulationFieldHelper.hpp"
@@ -88,9 +86,21 @@ namespace picongpu
 
         static std::string getName();
 
-        uint32_t getCommTag();
-
+        /** scatter data to neighboring GPUs
+         *
+         * Add data from the local guard of the GPU to the border of the neighboring GPUs.
+         * This method can be called before or after asyncCommunicationGather without
+         * explicit handling to avoid race conditions between both methods.
+         */
         virtual EventTask asyncCommunication( EventTask serialEvent );
+
+        /** gather data from neighboring GPUs
+         *
+         * Copy data from the border of neighboring GPUs into the local guard.
+         * This method can be called before or after asyncCommunication without
+         * explicit handling to avoid race conditions between both methods.
+         */
+        EventTask asyncCommunicationGather( EventTask serialEvent );
 
         void init( );
 
@@ -125,10 +135,14 @@ namespace picongpu
     private:
 
         GridBuffer<ValueType, simDim> *fieldTmp;
+        GridBuffer<ValueType, simDim>* fieldTmpRecv;
 
         uint32_t m_slotId;
 
-        uint32_t m_commTag;
+        EventTask m_scatterEv;
+        uint32_t m_commTagScatter;
+        EventTask m_gatherEv;
+        uint32_t m_commTagGather;
     };
 
 

--- a/src/picongpu/include/fields/FieldTmp.tpp
+++ b/src/picongpu/include/fields/FieldTmp.tpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "memory/buffers/GridBuffer.hpp"
 #include "mappings/simulation/GridController.hpp"
 
@@ -61,13 +61,19 @@ namespace picongpu
     ) :
         SimulationFieldHelper<MappingDesc>( cellDescription ),
         fieldTmp( nullptr ),
+        fieldTmpRecv( nullptr ),
         m_slotId( slotId )
     {
-        m_commTag =
+        m_commTagScatter =
             ++PMacc::traits::detail::GetUniqueTypeId< uint8_t >::counter +
             SPECIES_FIRSTTAG;
+        m_commTagGather = ++PMacc::traits::detail::GetUniqueTypeId< uint8_t >::counter +
+            SPECIES_FIRSTTAG;
 
-        fieldTmp = new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) );
+        fieldTmp = new GridBuffer <ValueType, simDim >( cellDescription.getGridLayout( ) );
+
+        if( fieldTmpSupportGatherCommunication )
+            fieldTmpRecv = new GridBuffer< ValueType, simDim >( fieldTmp->getDeviceBuffer(), cellDescription.getGridLayout( ) );
 
         /** \todo The exchange has to be resetted and set again regarding the
          *  temporary "Fill-"Functor we want to use.
@@ -165,9 +171,21 @@ namespace picongpu
                 };
 
             }
-            // std::cout << "ex " << i << " x=" << guardingCells[0] << " y=" << guardingCells[1] << " z=" << guardingCells[2] << std::endl;
-            fieldTmp->addExchangeBuffer( i, guardingCells, m_commTag );
+
+            fieldTmp->addExchangeBuffer( i, guardingCells, m_commTagScatter );
+
+            if( fieldTmpRecv )
+            {
+                /* guarding cells depend on direction
+                 * for negative direction use originGuard else endGuard (relative direction ZERO is ignored)
+                 * don't switch end and origin because this is a read buffer and not send buffer
+                 */
+                for ( uint32_t d = 0; d < simDim; ++d )
+                    guardingCells[d] = ( relativMask[d] == -1 ? originGuard[d] : endGuard[d] );
+                fieldTmpRecv->addExchange( GUARD, i, guardingCells, m_commTagGather );
+            }
         }
+
     }
 
     FieldTmp::~FieldTmp( )
@@ -224,14 +242,27 @@ namespace picongpu
     EventTask FieldTmp::asyncCommunication( EventTask serialEvent )
     {
         EventTask ret;
-        __startTransaction( serialEvent );
+        __startTransaction( serialEvent + m_gatherEv + m_scatterEv );
         FieldFactory::getInstance( ).createTaskFieldReceiveAndInsert( *this );
         ret = __endTransaction( );
 
-        __startTransaction( serialEvent );
+        __startTransaction( serialEvent + m_gatherEv + m_scatterEv);
         FieldFactory::getInstance( ).createTaskFieldSend( *this );
         ret += __endTransaction( );
+        m_scatterEv = ret;
         return ret;
+    }
+
+    EventTask FieldTmp::asyncCommunicationGather( EventTask serialEvent )
+    {
+        PMACC_VERIFY_MSG(
+            fieldTmpSupportGatherCommunication == true,
+            "fieldTmpSupportGatherCommunication in memory.param must be set to true"
+        );
+
+        if( fieldTmpRecv != nullptr )
+            m_gatherEv = fieldTmpRecv->asyncCommunication( serialEvent + m_scatterEv + m_gatherEv );
+        return m_gatherEv;
     }
 
     void FieldTmp::bashField( uint32_t exchangeType )
@@ -313,12 +344,6 @@ namespace picongpu
     FieldTmp::getName( )
     {
         return "FieldTmp";
-    }
-
-    uint32_t
-    FieldTmp::getCommTag( )
-    {
-        return m_commTag;
     }
 
 } // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/memory.param
+++ b/src/picongpu/include/simulation_defines/param/memory.param
@@ -56,4 +56,14 @@ namespace picongpu
     /** number of scalar fields that are reserved as temporary fields */
     constexpr uint32_t fieldTmpNumSlots = 1;
 
+    /** can `FieldTmp` gather neighbor information
+     *
+     * If `true` it is possible to call the method `asyncCommunicationGather()`
+     * to copy data from the border of neighboring GPU into the local guard.
+     * This is also known as building up a "ghost" or "halo" region in domain
+     * decomposition and only necessary for specific algorithms that extend
+     * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+     */
+    constexpr bool fieldTmpSupportGatherCommunication = true;
+
 } //namespace picongpu


### PR DESCRIPTION
Add an explicit method to trigger that border data from the neighbor is gathered into the local guard of the GPU.

- add method `asyncCommunicationGather()` (gather neighbor's border data)
- add buffer for gather communication
- define `fieldTmpSupportGatherCommunication` variable in `memory.param` to activate gather support for `FieldTmp`
- remove method `getCommTag()`

## Note
Currently the new method `asyncCommunicationGather()` is only available in `FieldTmp` but should be later also be ported to all other buffers like `FieldE` and `FieldB`. The best way to do is is to extent the PMacc `GridBuffer` to support `asyncCommunicationScatter()` and `asyncCommunicationGather()`.
This is a bigger refactoring and should not be part of this pull request to allow a backport to the current release candidate `0.3.0`.
