### PR TITLE
Rm BSIHydrogenLike, Add BSI with charge Z

### DIFF
--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -63,21 +63,21 @@ namespace ionization
         operator()( const EType eField, ParticleType& parentIon )
         {
 
-            const float_X protonNumber = GetAtomicNumbers<ParticleType>::type::numberOfProtons;
-            float_X chargeState = attribute::getChargeState(parentIon);
+            float_X const protonNumber = GetAtomicNumbers<ParticleType>::type::numberOfProtons;
+            float_X const chargeState = attribute::getChargeState(parentIon);
 
             /* verify that ion is not completely ionized */
             if (chargeState < protonNumber)
             {
-                uint32_t cs = math::float2int_rd(chargeState);
+                uint32_t const cs = math::float2int_rd(chargeState);
                 /* ionization potential in atomic units */
-                const float_X iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
+                float_X const iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
                 /* the charge that attracts the electron that is to be ionized:
- +               * equals `protonNumber - #allInnerElectrons`
+                 * equals `protonNumber - no. allInnerElectrons`
                  */
- +              float_X effectiveCharge = chargeState + float_X(1.0);
+                float_X const effectiveCharge = chargeState + float_X(1.0);
                 /* critical field strength in atomic units */
-                float_X critField = iEnergy*iEnergy / (float_X(4.0) * effectiveCharge);
+                float_X const critField = iEnergy*iEnergy / (float_X(4.0) * effectiveCharge);
                 /* ionization condition */
                 if (math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
                 {

--- a/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -24,7 +24,7 @@
 #include "particles/traits/GetAtomicNumbers.hpp"
 #include "traits/attribute/GetChargeState.hpp"
 
-/** @file AlgorithmBSIHydrogenLike.hpp
+/** @file AlgorithmBSI.hpp
  *
  * IONIZATION ALGORITHM for the BSI model
  *
@@ -42,7 +42,7 @@ namespace ionization
 
     /** Calculation for the Barrier Suppression Ionization model
      */
-    struct AlgorithmBSIHydrogenLike
+    struct AlgorithmBSI
     {
 
         /** Functor implementation
@@ -72,8 +72,12 @@ namespace ionization
                 uint32_t cs = math::float2int_rd(chargeState);
                 /* ionization potential in atomic units */
                 const float_X iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
+                /* the charge that attracts the electron that is to be ionized:
+ +               * equals `protonNumber - #allInnerElectrons`
+                 */
+ +              float_X effectiveCharge = chargeState + float_X(1.0);
                 /* critical field strength in atomic units */
-                float_X critField = iEnergy*iEnergy / (float_X(4.0) * protonNumber);
+                float_X critField = iEnergy*iEnergy / (float_X(4.0) * effectiveCharge);
                 /* ionization condition */
                 if (math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
                 {

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -50,7 +50,7 @@ namespace ionization
      *
      * - This model accounts for naive ion charge shielding by inner electrons
      *   as it assumes that the charge the electron 'feels' is equal to
-     *   `Z - #NumberOfBoundInnerShellElectrons`.
+     *   `proton number - number of inner shell electrons`.
      * - This model neglects the Stark upshift of ionization energies.
      *
      * \tparam T_DestSpecies electron species to be created

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI.def
@@ -27,7 +27,7 @@ namespace particles
 {
 namespace ionization
 {
-    /** arrier Suppression Ionization - Implementation
+    /** Barrier Suppression Ionization - Implementation
      *
      * \tparam T_DestSpecies electron species to be created
      * \tparam T_SrcSpecies particle species that is ionized
@@ -48,9 +48,10 @@ namespace ionization
      *   "Tunneling and barrier-suppression ionization of atoms and ions in a laser radiation field"
      *   doi:10.1070/PU1998v041n05ABEH000393
      *
-     * - This model assumes a hydrogenlike ion configuration,
-     *   neglecting core shielding by other electrons and Stark upshifting
-     *   of ionization energies according to strong external electric fields
+     * - This model accounts for naive ion charge shielding by inner electrons
+     *   as it assumes that the charge the electron 'feels' is equal to
+     *   `Z - #NumberOfBoundInnerShellElectrons`.
+     * - This model neglects the Stark upshift of ionization energies.
      *
      * \tparam T_DestSpecies electron species to be created
      *
@@ -60,18 +61,18 @@ namespace ionization
      * \see speciesDefinition.param
      */
     template<typename T_DestSpecies>
-    struct BSIHydrogenLike
+    struct BSI
     {
-        typedef particles::ionization::AlgorithmBSIHydrogenLike IonizationAlgorithm;
+        typedef particles::ionization::AlgorithmBSI IonizationAlgorithm;
         typedef BSI_Impl<IonizationAlgorithm, T_DestSpecies> type;
     };
 
     /** Barrier Suppression Ionization - Effective Atomic Numbers
      *
-     * - similar to BSIHydrogenLike
+     * - similar to BSI
      *
      * - tries to account for electron shielding by issuing a lookup table of
-     *   effective atomic numbers for each electron shell @see ionizer.param
+     *   effective atomic numbers for each filled electron shell @see ionizer.param
      * - unvalidated and still in development
      *
      * \tparam T_DestSpecies electron species to be created
@@ -85,11 +86,12 @@ namespace ionization
 
     /** Barrier Suppression Ionization - Ion. energies Stark-upshifted
      *
-     * - similar to BSIHydrogenLike
+     * - similar to BSI
      *
      * - developed by Bauer and Mulser (book: High Power Laser Matter Interaction)
      * - accounts for stark upshift of ionization energy but only covers the
      *   hydrogenlike ions originally
+     * - \todo needs to be extrapolated to arbitrary ions
      *
      * \tparam T_DestSpecies electron species to be created
      */

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -25,7 +25,7 @@
 #include "fields/FieldE.hpp"
 
 #include "particles/ionization/byField/BSI/BSI.def"
-#include "particles/ionization/byField/BSI/AlgorithmBSIHydrogenLike.hpp"
+#include "particles/ionization/byField/BSI/AlgorithmBSI.hpp"
 #include "particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp"
 #include "particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp"
 #include "particles/ionization/ionization.hpp"

--- a/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
+++ b/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.def
@@ -40,7 +40,7 @@ namespace ionization
     template<bool T_polarizationType>
     struct AlgorithmADK;
 
-    struct AlgorithmBSIHydrogenLike;
+    struct AlgorithmBSI;
 
     struct AlgorithmBSIEffectiveZ;
 

--- a/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.hpp
+++ b/src/picongpu/include/particles/ionization/byField/fieldIonizationCalc.hpp
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "particles/ionization/byField/ADK/AlgorithmADK.hpp"
-#include "particles/ionization/byField/BSI/AlgorithmBSIHydrogenLike.hpp"
+#include "particles/ionization/byField/BSI/AlgorithmBSI.hpp"
 #include "particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp"
 #include "particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp"
 #include "particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp"

--- a/src/picongpu/include/particles/ionization/byField/ionizers.def
+++ b/src/picongpu/include/particles/ionization/byField/ionizers.def
@@ -30,7 +30,7 @@
  */
 #include "particles/ionization/byField/ADK/ADK.def"
 /** contains definitions for:
- *  - BSIHydrogenLike
+ *  - BSI
  *  - BSIEffectiveZ
  *  - BSIStarkShifted
  */

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -59,7 +59,7 @@ struct KernelIonizeParticles
      * \tparam ParBoxIons container of the ions
      * \tparam ParBoxElectrons container of the electrons
      * \tparam Mapping class containing methods for acquiring info from the block
-     * \tparam FrameIonizer \see e.g. BSIHydrogenLike_Impl in BSIHydrogenLike_Impl.hpp
+     * \tparam FrameIonizer \see e.g. BSI_Impl in BSI_Impl.hpp
      *         instance of the ionization model functor
      */
     template<class ParBoxIons, class ParBoxElectrons, class Mapping, class FrameIonizer>

--- a/src/picongpu/include/simulation_defines/param/ionizer.param
+++ b/src/picongpu/include/simulation_defines/param/ionizer.param
@@ -42,7 +42,7 @@ namespace picongpu
 /** Ionization Model Configuration
  *
  * - None : no particle is ionized
- * - BSIHydrogenLike : simple barrier suppression ionization
+ * - BSI : simple barrier suppression ionization
  * - ADKLinPol : Ammosov-Delone-Krainov tunneling ionization (H-like)
  *               -> linearly polarized lasers
  * - ADKCircPol : Ammosov-Delone-Krainov tunneling ionization (H-like)

--- a/src/picongpu/include/simulation_defines/param/ionizer.param
+++ b/src/picongpu/include/simulation_defines/param/ionizer.param
@@ -43,6 +43,8 @@ namespace picongpu
  *
  * - None : no particle is ionized
  * - BSI : simple barrier suppression ionization
+ * - BSIEffectiveZ : BSI taking electron shielding into account via an effective
+ *                   atomic number Z_eff
  * - ADKLinPol : Ammosov-Delone-Krainov tunneling ionization (H-like)
  *               -> linearly polarized lasers
  * - ADKCircPol : Ammosov-Delone-Krainov tunneling ionization (H-like)
@@ -53,8 +55,6 @@ namespace picongpu
  *                 Attention: requires 2 FieldTmp slots @see memory.param
  *
  * Research and development:
- * - BSIEffectiveZ : BSI taking electron shielding into account via an effective
- *                   atomic number Z_eff
  * - BSIStarkShifted : BSI for hydrogen-like atoms and ions considering the
  *                     Stark upshift of ionization potentials
  *


### PR DESCRIPTION
The `BSIHydrogenLike` model was much too narrow since it was only applicable
to hydrogenlike states, i.e. states that have charge (Z-1)+.
The following replacement was done in

    F_BSI = E_i^2 / (4*Z)

    Z (nuclear charge) --> Z_i (ion residual charge)

That means that in a naive way the inner electrons shield the nuclear charge
from the electron that is to be ionized.