### PR TITLE
lock step kernel `KernelShiftParticles`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,3 +95,12 @@ Development
    dev/picongpu
    dev/pmacc
    dev/doxyindex
+
+********************
+Programming Patterns
+********************
+.. toctree::
+   :caption: PROGRAMMING PATTERNS
+   :maxdepth: 1
+
+   prgpatterns/lockstep

--- a/docs/source/prgpatterns/lockstep.rst
+++ b/docs/source/prgpatterns/lockstep.rst
@@ -1,0 +1,107 @@
+.. _prgpatterns-lockstep:
+
+Lockstep Programming Model
+==========================
+
+.. sectionauthor:: René Widera
+
+The *lockstep programming model* separates code that is evaluated by workers (threads) collectively and independently.
+A problem is described by index domains. A index domain is **independent** from data but **can** be mapped to a data domain one to one but also with more complex mappings.
+
+Code which is implemented by the *lockstep programming model* is free of any dependencies between the number of worker and processed data elements.
+To simplify the implementation each index within a domain can be seen as a *virtual worker* which is processing one data element (like the common workflow to programming CUDA). Each *worker i* can be executed as N_i *virtual workers* (1:N_i).
+
+PMacc helpers
+-------------
+
+.. doxygenstruct:: PMacc::mappings::threads::IdxConfig
+   :project: PIConGPU
+
+.. doxygenstruct:: PMacc::memory::CtxArray
+   :project: PIConGPU
+
+.. doxygenstruct:: PMacc::mappings::threads::ForEachIdx
+   :project: PIConGPU
+
+Common Pattern
+--------------
+
+Collective Loop
+^^^^^^^^^^^^^^^
+
+* each worker needs to pass a loop N times)
+* in this example, there are more dates then workers that process them
+
+.. code-block:: bash
+
+    // `frame` is a list which must be traversed collectively
+    while ( frame.isValid() )
+    {
+        const uint32_t workerIdx = threadIdx.x;
+        using ParticleDomCfg = IdxConfig<
+            frameSize,
+            numWorker
+        >;
+        ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
+       forEachParticle(
+           [&]( uint32_t const linearIdx, uint32_t const idx )
+           {
+               // independent work
+           }
+       );
+    }
+
+
+Non-Collective Loop
+^^^^^^^^^^^^^^^^^^^
+
+* each *virtual worker* increments a private variable
+
+.. code-block:: cpp
+
+    const uint32_t workerIdx = threadIdx.x;
+    using ParticleDomCfg = IdxConfig<
+        frameSize,
+        numWorker
+    >;
+    ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
+    memory::CtxArray< int, ParticleDomCfg > vWorkerIdx( 0 );
+    forEachParticle(
+        [&]( uint32_t const linearIdx, uint32_t const idx )
+        {
+            vWorkerIdx[ idx ] = linearIdx;
+            for( int i = 0; i < 100; i++ )
+                vWorkerIdx[ idx ]++;
+        }
+    );
+
+
+Create a Context Variable
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ... and initialize with the index of the virtual worker
+
+.. code-block:: cpp
+
+    const uint32_t workerIdx = threadIdx.x;
+    using ParticleDomCfg = IdxConfig<
+        frameSize,
+        numWorker
+    >;
+    memory::CtxArray< int, ParticleDomCfg > vIdx(
+        workerIdx,
+        [&]( uint32_t const linearIdx, uint32_t const ) -> DataSpace<dim>
+        {
+            return linearIdx;
+        }
+    );
+
+    // is equal to
+
+    memory::CtxArray< int, ParticleDomCfg > vIdx;
+    ForEachIdx< ParticleDomCfg > forEachParticle{ workerIdx }(
+        [&]( uint32_t const linearIdx, uint32_t const idx )
+        {
+            vIdx[ idx ] = linearIdx;
+        }
+    );

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -27,6 +27,9 @@
 #include "mappings/kernel/ExchangeMapping.hpp"
 #include "particles/memory/boxes/ExchangePushDataBox.hpp"
 #include "particles/memory/boxes/ExchangePopDataBox.hpp"
+#include "memory/CtxArray.hpp"
+#include "mappings/threads/ForEachIdx.hpp"
+#include "mappings/threads/IdxConfig.hpp"
 
 #include "particles/operations/Assign.hpp"
 #include "particles/operations/Deselect.hpp"
@@ -49,181 +52,301 @@ getPreviousFrameAndRemoveLastFrame( const typename T_ParticleBox::FramePtr& fram
     return result;
 }
 
+template< uint32_t T_numWorkers >
 struct KernelShiftParticles
 {
     /*! This kernel move particles to the next supercell
      * This kernel can only run with a double checker board
      */
-    template<class T_ParBox, class Mapping>
-    DINLINE void operator()( T_ParBox pb, Mapping mapper ) const
+    template<
+        class T_ParBox,
+        class Mapping
+    >
+    DINLINE void operator()(
+        T_ParBox pb,
+        Mapping mapper
+    ) const
     {
-        typedef T_ParBox ParBox;
-        typedef typename ParBox::FrameType FrameType;
-        typedef typename ParBox::FramePtr FramePtr;
+        using ParBox = T_ParBox;
+        using FrameType = typename ParBox::FrameType;
+        using FramePtr = typename ParBox::FramePtr;
 
-        const uint32_t dim = Mapping::Dim;
-        const uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
+        constexpr uint32_t dim = Mapping::Dim;
+        constexpr uint32_t frameSize = math::CT::volume< typename FrameType::SuperCellSize >::type::value;
         /* number exchanges in 2D=9 and in 3D=27 */
-        const uint32_t numExchanges = traits::NumberOfExchanges<dim>::value;
+        constexpr uint32_t numExchanges = traits::NumberOfExchanges< dim >::value;
+        constexpr uint32_t numWorkers = T_numWorkers;
 
         /* define memory for two times Exchanges
          * index range [0,numExchanges-1] are being referred to as `low frames`
          * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
          */
-        PMACC_SMEM( destFrames, memory::Array< FramePtr, numExchanges * 2 > );
+        PMACC_SMEM(
+            destFrames,
+            memory::Array<
+                FramePtr,
+                numExchanges * 2
+            >
+        );
         //count particles per frame
-        PMACC_SMEM( destFramesCounter, memory::Array< int, numExchanges > );
+        PMACC_SMEM(
+            destFramesCounter,
+            memory::Array<
+                int,
+                numExchanges
+            >
+        );
 
-        /* lastFrameSize is only valid for threads with `linearThreadIdx` < numExchanges */
-        uint32_t lastFrameSize = 0;
+        PMACC_SMEM(
+            frame,
+            FramePtr
+        );
+        PMACC_SMEM(
+            mustShift,
+            bool
+        );
 
-        PMACC_SMEM( frame, FramePtr );
-        PMACC_SMEM( mustShift, bool );
+        DataSpace< dim > superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
+        uint32_t const workerIdx = threadIdx.x;
 
-        DataSpace<dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<dim> (blockIdx) );
-        const uint32_t linearThreadIdx = threadIdx.x;
+        using namespace mappings::threads;
 
-        if ( linearThreadIdx == 0 )
-        {
-            mustShift = pb.getSuperCell( superCellIdx ).mustShift( );
-            if ( mustShift )
+        ForEachIdx<
+            IdxConfig<
+                1,
+                numWorkers
+            >
+        >{ workerIdx }(
+            [&](
+                uint32_t const,
+                uint32_t const
+            )
             {
-                pb.getSuperCell( superCellIdx ).setMustShift( false );
-                frame = pb.getFirstFrame( superCellIdx );
+                mustShift = pb.getSuperCell( superCellIdx ).mustShift( );
+                if ( mustShift )
+                {
+                    pb.getSuperCell( superCellIdx ).setMustShift( false );
+                    frame = pb.getFirstFrame( superCellIdx );
+                }
             }
-        }
+        );
 
         __syncthreads( );
         if ( !mustShift || !frame.isValid( ) ) return;
 
-        const DataSpace<dim> relative = superCellIdx + Mask::getRelativeDirections<dim> (linearThreadIdx + 1);
+        using ExchangeDomCfg = IdxConfig<
+            numExchanges,
+            numWorkers
+        >;
+
+        memory::CtxArray<
+            uint32_t,
+            ExchangeDomCfg
+        > lastFrameSizeCtx( 0 );
+
+        memory::CtxArray<
+            DataSpace< dim >,
+            ExchangeDomCfg
+        > relativeCtx(
+            workerIdx,
+            [&](
+                uint32_t const linearIdx,
+                uint32_t const
+            )
+            -> DataSpace< dim >
+            {
+                return superCellIdx + Mask::getRelativeDirections< dim > ( linearIdx + 1);
+            }
+        );
+
+        ForEachIdx< ExchangeDomCfg > forEachExchange( workerIdx );
 
         /* if a partially filled last frame exists for the neighboring supercell,
          * each master thread (one master per direction) will load it
          */
-        if ( linearThreadIdx < numExchanges )
-        {
-            destFramesCounter[linearThreadIdx] = 0;
-            destFrames[linearThreadIdx] = FramePtr();
-            destFrames[linearThreadIdx + numExchanges] = FramePtr();
-            /* load last frame of neighboring supercell */
-            FramePtr tmpFrame(pb.getLastFrame( relative ));
-
-            if ( tmpFrame.isValid() )
+        forEachExchange(
+            [&](
+                uint32_t const linearIdx,
+                uint32_t const idx
+            )
             {
-                lastFrameSize = pb.getSuperCell( relative ).getSizeLastFrame( );
-                // do not use the neighbor's last frame if it is full
-                if ( lastFrameSize < frameSize )
+                destFramesCounter[ linearIdx ] = 0;
+                destFrames[ linearIdx ] = FramePtr();
+                destFrames[ linearIdx + numExchanges ] = FramePtr();
+                /* load last frame of neighboring supercell */
+                FramePtr tmpFrame( pb.getLastFrame( relativeCtx[ idx ] ) );
+
+                if ( tmpFrame.isValid() )
                 {
-                    destFrames[linearThreadIdx] = tmpFrame;
-                    destFramesCounter[linearThreadIdx] = lastFrameSize;
+                    lastFrameSizeCtx[ idx ] = pb.getSuperCell( relativeCtx[ idx ] ).getSizeLastFrame( );
+                    // do not use the neighbor's last frame if it is full
+                    if ( lastFrameSizeCtx[ idx ] < frameSize )
+                    {
+                        destFrames[ linearIdx ] = tmpFrame;
+                        destFramesCounter[ linearIdx ] = lastFrameSizeCtx[ idx ];
+                    }
                 }
             }
-        }
+        );
+
         __syncthreads( );
 
         /* iterate over the frame list of the current supercell */
-        while ( frame.isValid() )
+        while ( frame.isValid( ) )
         {
-            lcellId_t destParticleIdx = INV_LOC_IDX;
+            using ParticleDomCfg = IdxConfig<
+                frameSize,
+                numWorkers
+            >;
 
-            /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
-             * -2 is no particle
-             * -1 is particle but it is not shifted (stays in supercell)
-             * >=0 particle moves in a certain direction
-             *     (@see ExchangeType in types.h)
-             */
-            int direction = frame[linearThreadIdx][multiMask_] - 2;
-            if ( direction >= 0 )
-            {
-                destParticleIdx = atomicAdd( &(destFramesCounter[direction]), 1 );
-            }
-            __syncthreads( );
+            ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
 
-            /* If the master thread (responsible for a certain direction) did not
-             * obtain a `low frame` from the neighboring super cell before the loop,
-             * it will create one now.
-             *
-             * In case not all particles that are shifted to the neighboring
-             * supercell fit into the `low frame`, a second frame is created to
-             * contain further particles, the `high frame` (default: invalid).
-             */
-            if ( linearThreadIdx < numExchanges )
-            {
-                if ( destFramesCounter[linearThreadIdx] > 0 )
+            memory::CtxArray<
+                lcellId_t,
+                ParticleDomCfg
+            > destParticleIdxCtx( INV_LOC_IDX );
+            memory::CtxArray<
+                int,
+                ParticleDomCfg
+            > directionCtx;
+
+            forEachParticle(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
                 {
-                    lastFrameSize = destFramesCounter[linearThreadIdx];
-                    /* if we had no `low frame` we load a new empty one */
-                    if ( !destFrames[linearThreadIdx].isValid() )
+                    /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
+                     * -2 is no particle
+                     * -1 is particle but it is not shifted (stays in supercell)
+                     * >=0 particle moves in a certain direction
+                     *     (@see ExchangeType in types.h)
+                     */
+                    directionCtx[ idx ] = frame[ linearIdx ][ multiMask_ ] - 2;
+                    if ( directionCtx[ idx ] >= 0 )
                     {
-                        FramePtr tmpFrame(pb.getEmptyFrame( ));
-                        destFrames[linearThreadIdx] = tmpFrame;
-                        pb.setAsLastFrame( tmpFrame, relative );
-                    }
-                    /* check if a `high frame` is needed */
-                    if ( destFramesCounter[linearThreadIdx] > frameSize )
-                    {
-                            lastFrameSize = destFramesCounter[linearThreadIdx] - frameSize;
-                            FramePtr tmpFrame(pb.getEmptyFrame( ));
-                            destFrames[linearThreadIdx + numExchanges] = tmpFrame;
-                            pb.setAsLastFrame( tmpFrame, relative );
+                        destParticleIdxCtx[ idx ] = atomicAdd( &(destFramesCounter[ directionCtx[ idx ] ]), 1 );
                     }
                 }
-            }
+            );
             __syncthreads( );
 
-            /* All threads with a valid index in the neighbor's frame, valid index
-             * range is [0, frameSize * 2-1], will copy their particle to the new
-             * frame.
-             *
-             * The default value for indexes (in the destination frame) is
-             * above this range (INV_LOC_IDX) for all particles that are not shifted.
-             */
-            if ( destParticleIdx < frameSize * 2 )
-            {
-                if ( destParticleIdx >= frameSize )
+            forEachExchange(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
                 {
-                    /* use `high frame` */
-                    direction += numExchanges;
-                    destParticleIdx -= frameSize;
+                    /* If the master thread (responsible for a certain direction) did not
+                     * obtain a `low frame` from the neighboring super cell before the loop,
+                     * it will create one now.
+                     *
+                     * In case not all particles that are shifted to the neighboring
+                     * supercell fit into the `low frame`, a second frame is created to
+                     * contain further particles, the `high frame` (default: invalid).
+                     */
+                    if ( destFramesCounter[ linearIdx ] > 0 )
+                    {
+                        lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ];
+                        /* if we had no `low frame` we load a new empty one */
+                        if ( !destFrames[ linearIdx ].isValid( ) )
+                        {
+                            FramePtr tmpFrame( pb.getEmptyFrame( ) );
+                            destFrames[ linearIdx ] = tmpFrame;
+                            pb.setAsLastFrame(
+                                tmpFrame,
+                                relativeCtx[ idx ]
+                            );
+                        }
+                        /* check if a `high frame` is needed */
+                        if ( destFramesCounter[ linearIdx ] > frameSize )
+                        {
+                            lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ] - frameSize;
+                            FramePtr tmpFrame( pb.getEmptyFrame( ) );
+                            destFrames[ linearIdx + numExchanges ] = tmpFrame;
+                            pb.setAsLastFrame(
+                                tmpFrame,
+                                relativeCtx[ idx ]
+                            );
+                        }
+                    }
                 }
-                auto dstParticle = destFrames[direction][destParticleIdx];
-                auto srcParticle = frame[linearThreadIdx];
-                dstParticle[multiMask_] = 1;
-                srcParticle[multiMask_] = 0;
-                auto dstFilteredParticle =
-                            particles::operations::deselect<multiMask>(dstParticle);
-                particles::operations::assign( dstFilteredParticle, srcParticle );
-            }
+            );
             __syncthreads( );
 
-            /* if the `low frame` is now full, each master thread removes it and
-             * uses the `high frame` (is invalid, if still empty) as the next
-             * `low frame` for the following iteration of the loop
-             */
-            if ( linearThreadIdx < numExchanges )
-            {
-                if ( destFramesCounter[linearThreadIdx] >= frameSize )
+            forEachParticle(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
                 {
-                    destFramesCounter[linearThreadIdx] -= frameSize;
-                    destFrames[linearThreadIdx] = destFrames[linearThreadIdx + numExchanges];
-                    destFrames[linearThreadIdx + numExchanges] = FramePtr();
+                    /* All threads with a valid index in the neighbor's frame, valid index
+                     * range is [0, frameSize * 2-1], will copy their particle to the new
+                     * frame.
+                     *
+                     * The default value for indexes (in the destination frame) is
+                     * above this range (INV_LOC_IDX) for all particles that are not shifted.
+                     */
+                    if ( destParticleIdxCtx[ idx ] < frameSize * 2 )
+                    {
+                        if ( destParticleIdxCtx[ idx ] >= frameSize )
+                        {
+                            /* use `high frame` */
+                            directionCtx[ idx ] += numExchanges;
+                            destParticleIdxCtx[ idx ] -= frameSize;
+                        }
+                        auto dstParticle = destFrames[ directionCtx[ idx ] ][ destParticleIdxCtx[ idx ] ];
+                        auto srcParticle = frame[ linearIdx ];
+                        dstParticle[ multiMask_ ] = 1;
+                        srcParticle[ multiMask_ ] = 0;
+                        auto dstFilteredParticle =
+                            particles::operations::deselect< multiMask >( dstParticle );
+                        particles::operations::assign(
+                            dstFilteredParticle,
+                            srcParticle
+                        );
+                    }
                 }
-                if ( linearThreadIdx == 0 )
+            );
+            __syncthreads( );
+
+            forEachExchange(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const
+                )
                 {
-                    frame = pb.getNextFrame( frame );
+                    /* if the `low frame` is now full, each master thread removes it and
+                     * uses the `high frame` (is invalid, if still empty) as the next
+                     * `low frame` for the following iteration of the loop
+                     */
+                    if ( destFramesCounter[ linearIdx ] >= frameSize )
+                    {
+                        destFramesCounter[ linearIdx ] -= frameSize;
+                        destFrames[ linearIdx ] = destFrames[ linearIdx + numExchanges ];
+                        destFrames[ linearIdx + numExchanges ] = FramePtr( );
+                    }
+                    if ( linearIdx == 0 )
+                    {
+                        frame = pb.getNextFrame( frame );
+                    }
                 }
-            }
+            );
             __syncthreads( );
         }
 
-        /* each master thread updates the number of particles in the last frame
-         * of the neighbors supercell
-         */
-        if ( linearThreadIdx < numExchanges )
-        {
-            pb.getSuperCell( relative ).setSizeLastFrame( lastFrameSize );
-        }
+        forEachExchange(
+            [&](
+                uint32_t const,
+                uint32_t const idx
+            )
+            {
+                /* each master thread updates the number of particles in the last frame
+                 * of the neighbors supercell
+                 */
+                pb.getSuperCell( relativeCtx[ idx ] ).setSizeLastFrame( lastFrameSizeCtx[ idx ] );
+            }
+        );
     }
 };
 


### PR DESCRIPTION
- refactor `KernelShiftParticles` (use lockstep description)
- add documentation `lockstep.rst`

# Notes for the reviewer

- each variable which was previously the state of one thread is now a `CtxArray` and got the postfix `Ctx` for *the virtual worker's context* (this avoid side effects during the refactoring and helps to read the code)
- the number of worker per kernel is chosen at compile time and is currently fixed to the size of the supercell but will depend in the future on the alpaka accelerator restrictions.
- I tried not to change the logical flow of the algorithm or add optimizations.
- the changed code is formatted with the new code style

# Lockstep programming model

The *lockstep programming model* separates code those is evaluated by worker (threads) collectively and independently.
A problem is described by index domains. A index domain is **independent** from data but **can** be mapped to a data domain one to one but also with more complex mappings.
Code which is implemented by the *lockstep programming model* is free of any dependencies between the number of worker and processed data elements.
To simplify the implementation each index within a domain can be seen as a *virtual worker* which is processing one data element (like the common workflow to programming CUDA). Each *worker i* can be executed as N_i *virtual workers* (1:N_i).

## PMacc helper

- `mappings::threads::IdxConfig<>`
  - describe the size of the index domain and the number of workers to operate on the domain 
- `memory::CtxArray<>`
  - hold states in a context for each worker
  - the number of states depends on the size of a index domain and the number of worker
- `mappings::threads::ForEachIdx<>`
  - execute a user functor for each index within the index domain

## Common Pattern

- collective loop (each worker needs to pass a loop N times)
  - in this example, there are more dates then workers that process them

```C++
    // `frame` is a list which must be traversed collectively
    while ( frame.isValid() )
    {
        const uint32_t workerIdx = threadIdx.x;
        using ParticleDomCfg = IdxConfig<
            frameSize,
            numWorker
        >;
        ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
       forEachParticle(
           [&]( uint32_t const linearIdx, uint32_t const idx )
           {
               // independent work
           }
       );
    }
````
- non-collective loop (each *virtual worker* increments a private variable)
    ```C++
    const uint32_t workerIdx = threadIdx.x;
    using ParticleDomCfg = IdxConfig<
        frameSize,
        numWorker
    >;
    ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
    memory::CtxArray< int, ParticleDomCfg > vWorkerIdx( 0 );
    forEachParticle(
        [&]( uint32_t const linearIdx, uint32_t const idx )
        {
            vWorkerIdx[ idx ] = linearIdx;
            for( int i = 0; i < 100; i++ )
                vWorkerIdx[ idx ]++;
        }
    );
    ```
- create a context variable and initialize with the index of the virtual worker
    ```C++
    const uint32_t workerIdx = threadIdx.x;
    using ParticleDomCfg = IdxConfig<
        frameSize,
        numWorker
    >;
    memory::CtxArray< int, ParticleDomCfg > vIdx(
        workerIdx,
        [&]( uint32_t const linearIdx, uint32_t const ) -> DataSpace<dim>
        {
            return linearIdx;
        }
    );

    // is equal to

    memory::CtxArray< int, ParticleDomCfg > vIdx;
    ForEachIdx< ParticleDomCfg > forEachParticle{ workerIdx }(
        [&]( uint32_t const linearIdx, uint32_t const idx )
        {
            vIdx[ idx ] = linearIdx;
        }
    );
    ```