### PR TITLE
Fix undefined device variable in tilted laser pulse

### DIFF
--- a/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
+++ b/src/picongpu/include/fields/laserProfiles/laserPulseFrontTilt.hpp
@@ -102,7 +102,8 @@ namespace picongpu
             constexpr float_X focusPos = FOCUS_POS - laser::initPlaneY * CELL_HEIGHT;
 
             const float_X timeShift = phase / (float_X(2.0) * float_X(PI) * float_X(f)) + focusPos / SPEED_OF_LIGHT;
-            const float_X spaceShift = SPEED_OF_LIGHT * algorithms::math::tan(TILT_X) * timeShift / CELL_HEIGHT;
+            const float_X local_tilt_x = TILT_X;
+            const float_X spaceShift = SPEED_OF_LIGHT * algorithms::math::tan(local_tilt_x) * timeShift / CELL_HEIGHT;
             const float_X r2 = (posX + spaceShift) * (posX + spaceShift) + posZ * posZ;
 
 


### PR DESCRIPTION
This fixes issue #2012. 
For some reasons the `constexp` variable `TITLT_X` is not known on the device side in the `tan()` call. If defined before as `const`, the compile issue is solved. 
@psychocoderHPC Is there a better solution than the work around of this pull request?