### PR TITLE
Fix #2029 MPL Embedded Plots Sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,3 @@ docs/xml/
 docs/doxygen_sqlite3.db
 # sphinx & breathe output
 docs/build/
-
-# generated docs output
-docs/source/models/field_ionization_comparison_c_ii_ionization.svg
-docs/source/models/field_ionization_effective_potentials.svg

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,10 @@ show_authors = True
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax', 'breathe', 'sphinxcontrib.programoutput']
+extensions = ['sphinx.ext.mathjax',
+              'breathe',
+              'sphinxcontrib.programoutput',
+              'matplotlib.sphinxext.plot_directive']
 
 if not on_rtd:
     extensions.append('sphinx.ext.githubpages')
@@ -65,14 +68,6 @@ else:
     import sphinx_rtd_theme
     html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-# generate plots for the docs
-subprocess.call('cd models; ' +
-                'python ./field_ionization_comparison_c_ii_ionization.py',
-                shell=True)
-subprocess.call('cd models; ' +
-                'python ./field_ionization_effective_potentials.py',
-                shell=True)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -113,20 +113,12 @@ In the following comparison one can see the ``ADKLinPol`` ionization rates for t
 For a reference the rates for Hydrogen as well as the barrier suppression field strengths :math:`F_\mathrm{BSI}` have been plotted.
 They mark the transition from the tunneling to the barrier suppression regime.
 
-.. figure:: field_ionization_comparison_c_ii_ionization.svg
-    :name: field_ionization_comparison_c_ii_ionization
-    :alt: Comparison of ADK ionization rates for Carbon-II and Hydrogen
-
-    Comparison of ADK ionization rates for Carbon-II and Hydrogen.
+.. plot:: models/field_ionization_comparison_c_ii_ionization.py
 
 When we account for orbital structure in shielding of the ion charge :math:`Z` according to [ClementiRaimondi1963]_ in ``BSIEffectiveZ`` the barrier suppression field strengths of Hydrogen and Carbon-II are very close to one another.
 One would expect much earlier ionization of Hydrogen due to lower ionization energy. The following image shows how this can be explained by the shape of the ion potential that is assumed in this model.
 
-.. figure:: field_ionization_effective_potentials.svg
-    :name: field_ionization_effective_potentials
-    :alt: Effective atomic potentials of Carbon-II and Hydrogen in homogeneous electric field
-
-    Effective atomic potentials of Carbon-II and Hydrogen in homogeneous electric field :math:`F_\mathrm{BSI}` (C-II).
+.. plot:: models/field_ionization_effective_potentials.py
 
 References
 ----------

--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -22,14 +22,14 @@ PIConGPU features an adaptable ionization framework for arbitrary and combinable
     :widths: auto
     :name: atomic_units
 
-    ================    =====
-     AU                 SI
-    ================    =====
-    length              :math:`5.292 \cdot 10^{-11}\,\mathrm{m}`
-    time                :math:`2.419 \cdot 10^{-17}\,\mathrm{s}`
-    energy              :math:`4.360 \cdot 10^{-18}\,\mathrm{J}\quad` (= 27.21 eV = 1 Rydberg)
-    electrical field    :math:`5.142 \cdot 10^{11}\,\frac{\mathrm{V}}{\mathrm{m}}`
-    ================    =====
+    ================  ======================================================================
+    AU                SI
+    ================  ======================================================================
+    length            :math:`5.292 \cdot 10^{-11}\,\mathrm{m}`
+    time              :math:`2.419 \cdot 10^{-17}\,\mathrm{s}`
+    energy            :math:`4.360 \cdot 10^{-18}\,\mathrm{J}\quad` (= 27.21 eV = 1 Rydberg)
+    electrical field  :math:`5.142 \cdot 10^{11}\,\frac{\mathrm{V}}{\mathrm{m}}`
+    ================  ======================================================================
 
 Overview: Implemented Models
 ----------------------------
@@ -95,6 +95,7 @@ Ammosov-Delone-Krainov (ADK)
 """"""""""""""""""""""""""""
 
 .. math::
+   :nowrap:
 
     \begin{align}
         \Gamma_\mathrm{ADK} &= \underbrace{\sqrt{\frac{3 n^{*3} F}{\pi Z^3}}}_\text{lin. pol.} \frac{F D^2}{8 \pi Z} \exp\left(-\frac{2Z}{3n^{*3}F}\right) \\

--- a/docs/source/models/field_ionization_comparison_c_ii_ionization.py
+++ b/docs/source/models/field_ionization_comparison_c_ii_ionization.py
@@ -92,6 +92,7 @@ if __name__ == "__main__":
                colors="{}".format(p_Ceff[0].get_color()),
                label="$F_\mathrm{BSI}$ C (eff)", linestyles="--")
 
+    plt.title("Comparison of ADK ionization rates for\nCarbon-II and Hydrogen")
     plt.ylim([ymin, ymax])
     plt.xlim([1e-2, 1e1])
     plt.yscale("log")
@@ -100,4 +101,4 @@ if __name__ == "__main__":
     plt.xlabel("field strength $F$ [AU = 5.1422$\cdot 10^{11}$ V/m]")
     plt.legend(loc="best")
 
-    plt.savefig("field_ionization_comparison_c_ii_ionization.svg")
+    plt.show()

--- a/docs/source/models/field_ionization_effective_potentials.py
+++ b/docs/source/models/field_ionization_effective_potentials.py
@@ -77,6 +77,8 @@ if __name__ == "__main__":
     plt.hlines(-E_CII, xmin, xmax)
 
     # add the legend and format the plot
+    plt.title("Effective atomic potentials of Carbon-II and Hydrogen in\n"
+              "homogeneous electric field $F_\mathrm{BSI}$ (C-II)")
     plt.legend(loc="best")
     plt.text(xmin+1, -E_H+.05, r"$E_\mathrm{i}$ H")
     plt.text(xmin+1, -E_CII+.05, r"$E_\mathrm{i}$ C-II (Z_eff)")
@@ -87,4 +89,4 @@ if __name__ == "__main__":
     plt.ylabel("$V_\mathrm{eff}$ [AU = Rydberg]")
     plt.xlabel("$x$ [AU = Bohr radii]")
 
-    plt.savefig("field_ionization_effective_potentials.svg")
+    plt.show()


### PR DESCRIPTION
Fix #2029 by using the official matplotlib (MPL) sphinx extension to embed plots on-the-fly.

Also fixed broken `make latexpdf` compile in usage of own align (use [nowrap](http://stackoverflow.com/questions/24867685/aligned-equations-with-mathjax-and-with-equation-numbers)).

Note:
- this might need regressions after merge, e.g. to set `agg` as backend by hand