### PR TITLE
add missing linestyle to ionization plot for documentation

### DIFF
--- a/docs/source/models/field_ionization_comparison_c_ii_ionization.py
+++ b/docs/source/models/field_ionization_comparison_c_ii_ionization.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
                       label="ADK C (eff) $ \quad Z = 3.136 = Z_\mathrm{eff}$")
     plt.vlines(E_H**2./(4*1), ymin, ymax,
                colors="{}".format(p_H[0].get_color()),
-               label="$F_\mathrm{BSI}$ H")
+               label="$F_\mathrm{BSI}$ H", linestyles="--")
 
     plt.vlines(E_C[1]**2. / (4*2), ymin, ymax,
                colors="{}".format(p_Csimple[0].get_color()),


### PR DESCRIPTION
This is a follow up pull request to #2031 and #2011. It adds a missing `linestyle` in `field_ionization_comparison_c_ii_ionization.py`. 

(I missed this in the review of #2011.)