### PR TITLE
SliceField Plugin: Option .frequency to .period

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -140,6 +140,10 @@ TBG_<species>_PSypx="--<species>_phaseSpace.period 10 --<species>_phaseSpace.spa
 TBG_<species>_PSypy="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space y --<species>_phaseSpace.momentum py --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
 TBG_<species>_PSypz="--<species>_phaseSpace.period 10 --<species>_phaseSpace.space y --<species>_phaseSpace.momentum pz --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
 
+# Write out slices of field data for every .period step
+TBG_EField_slice="--E_slice.period 100 --E_slice.fileName sliceE --E_slice.plane 2 --E_slice.slicePoint 0.5"
+TBG_BField_slice="--B_slice.period 100 --B_slice.fileName sliceB --B_slice.plane 2 --B_slice.slicePoint 0.5"
+TBG_JField_slice="--J_slice.period 100 --J_slice.fileName sliceJ --J_slice.plane 2 --J_slice.slicePoint 0.5"
 
 # Sum up total energy every .period steps for
 # - species   (--<species>_energy)

--- a/src/picongpu/include/plugins/SliceFieldPrinter.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.hpp
@@ -40,7 +40,7 @@ template<typename Field>
 class SliceFieldPrinter : public ILightweightPlugin
 {
 private:
-    uint32_t notifyFrequency;
+    uint32_t notifyPeriod;
     bool sliceIsOK;
     std::string fileName;
     int plane;

--- a/src/picongpu/include/plugins/SliceFieldPrinter.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinter.tpp
@@ -65,7 +65,7 @@ void SliceFieldPrinter<Field>::pluginLoad()
       {
         /* in case the slice point is inside of [0.0,1.0] */
         sliceIsOK = true;
-        Environment<>::get().PluginConnector().setNotificationPeriod(this, this->notifyFrequency);
+        Environment<>::get().PluginConnector().setNotificationPeriod(this, this->notifyPeriod);
         namespace vec = ::PMacc::math;
         typedef SuperCellSize BlockDim;
 

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.hpp
@@ -39,7 +39,7 @@ class SliceFieldPrinterMulti : public ILightweightPlugin
 private:
     std::string name;
     std::string prefix;
-    std::vector<uint32_t> notifyFrequency;
+    std::vector<uint32_t> notifyPeriod;
     std::vector<std::string> fileName;
     std::vector<int> plane;
     std::vector<float_X> slicePoint;

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
@@ -52,8 +52,8 @@ template<typename Field>
 void SliceFieldPrinterMulti<Field>::pluginRegisterHelp(po::options_description& desc)
 {
     desc.add_options()
-        ((this->prefix + ".frequency").c_str(),
-        po::value<std::vector<uint32_t> > (&this->notifyFrequency)->multitoken(), "notify frequency");
+        ((this->prefix + ".period").c_str(),
+        po::value<std::vector<uint32_t> > (&this->notifyFrequency)->multitoken(), "notify period");
     desc.add_options()
         ((this->prefix + ".fileName").c_str(),
         po::value<std::vector<std::string> > (&this->fileName)->multitoken(), "file name to store slices in");

--- a/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
+++ b/src/picongpu/include/plugins/SliceFieldPrinterMulti.tpp
@@ -53,7 +53,7 @@ void SliceFieldPrinterMulti<Field>::pluginRegisterHelp(po::options_description& 
 {
     desc.add_options()
         ((this->prefix + ".period").c_str(),
-        po::value<std::vector<uint32_t> > (&this->notifyFrequency)->multitoken(), "notify period");
+        po::value<std::vector<uint32_t> > (&this->notifyPeriod)->multitoken(), "notify period");
     desc.add_options()
         ((this->prefix + ".fileName").c_str(),
         po::value<std::vector<std::string> > (&this->fileName)->multitoken(), "file name to store slices in");
@@ -71,11 +71,11 @@ std::string SliceFieldPrinterMulti<Field>::pluginGetName() const {return this->n
 template<typename Field>
 void SliceFieldPrinterMulti<Field>::pluginLoad()
 {
-    this->childs.resize(this->notifyFrequency.size());
+    this->childs.resize(this->notifyPeriod.size());
     for(uint32_t i = 0; i < this->childs.size(); i++)
     {
         this->childs[i].setMappingDescription(this->cellDescription);
-        this->childs[i].notifyFrequency = this->notifyFrequency[i];
+        this->childs[i].notifyPeriod = this->notifyPeriod[i];
         this->childs[i].fileName = this->fileName[i];
         this->childs[i].plane = this->plane[i];
         this->childs[i].slicePoint = this->slicePoint[i];


### PR DESCRIPTION
This pull request changes for all sliceField plugins the `.frequency` call to `.period` (as used in all other plugins). This makes the interface of the plugin more coherent.

Thanks @steindev for pointing out this issue *offline*. 

### To Do

- [x] please also adjust the private vars such as `notifyFrequency` accordingly
- [x] please also adjust the `docs/TBG_macros.cfg` example
- [x] please also adjust the [wiki article](https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-SliceFieldPrinter)
