### PR TITLE
Examples: Collisional Ionization Include

### DIFF
--- a/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
@@ -28,9 +28,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 namespace picongpu
 {

--- a/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/speciesDefinition.param
@@ -29,6 +29,8 @@
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
+#include "particles/ionization/byCollision/ionizers.def"
+
 
 namespace picongpu
 {

--- a/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
@@ -28,9 +28,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 namespace picongpu
 {

--- a/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesDefinition.param
@@ -17,8 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "simulation_defines.hpp"
@@ -31,6 +29,8 @@
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
+#include "particles/ionization/byCollision/ionizers.def"
+
 
 namespace picongpu
 {

--- a/examples/FoilLCT/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/FoilLCT/include/simulation_defines/param/speciesDefinition.param
@@ -41,9 +41,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 namespace picongpu
 {

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
@@ -28,9 +28,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 #ifndef PARAM_RADIATION
     /* disable radiation calculation */

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/speciesDefinition.param
@@ -17,7 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "simulation_defines.hpp"
@@ -37,6 +36,7 @@
     /* disable radiation calculation */
 #   define PARAM_RADIATION 0
 #endif
+
 
 namespace picongpu
 {

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -28,9 +28,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 namespace picongpu
 {

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesDefinition.param
@@ -18,8 +18,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "simulation_defines.hpp"
@@ -32,6 +30,7 @@
 
 #include "particles/ionization/byField/ionizers.def"
 #include "particles/ionization/byCollision/ionizers.def"
+
 
 namespace picongpu
 {

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -29,9 +29,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 namespace picongpu
 {

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesDefinition.param
@@ -29,6 +29,10 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
+#include "particles/ionization/byField/ionizers.def"
+#include "particles/ionization/byCollision/ionizers.def"
+
+
 namespace picongpu
 {
 

--- a/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
@@ -27,9 +27,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 namespace picongpu
 {

--- a/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
@@ -28,6 +28,7 @@
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
+#include "particles/ionization/byCollision/ionizers.def"
 
 
 namespace picongpu

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -27,9 +27,6 @@
 #include "particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#include "particles/ionization/byField/ionizers.def"
-#include "particles/ionization/byCollision/ionizers.def"
-
 
 namespace picongpu
 {

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesDefinition.param
@@ -17,8 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "simulation_defines.hpp"
@@ -30,6 +28,8 @@
 #include <boost/mpl/string.hpp>
 
 #include "particles/ionization/byField/ionizers.def"
+#include "particles/ionization/byCollision/ionizers.def"
+
 
 namespace picongpu
 {

--- a/src/picongpu/include/simulation_defines/param/ionizer.param
+++ b/src/picongpu/include/simulation_defines/param/ionizer.param
@@ -35,7 +35,8 @@
 
 #include "particles/ionization/byField/fieldIonizationCalc.def"
 #include "particles/ionization/byCollision/collisionalIonizationCalc.def"
-
+#include "particles/ionization/byField/ionizers.def"
+#include "particles/ionization/byCollision/ionizers.def"
 
 namespace picongpu
 {


### PR DESCRIPTION
Adds the include in `speciesDefiniton.param` to examples where it was still missing. Otherwise Thomas-Fermi ionization could not be used in the `ionizers< ... >` sequence.