### PR TITLE
`GetIonizerList` fix missing include

### DIFF
--- a/src/picongpu/include/particles/traits/GetIonizerList.hpp
+++ b/src/picongpu/include/particles/traits/GetIonizerList.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "pmacc_types.hpp"
+#include "simulation_defines.hpp"
 #include "traits/Resolve.hpp"
 #include "traits/GetFlagType.hpp"
 #include "compileTime/accessors/Type.hpp"


### PR DESCRIPTION
The alias `ionizers<>` is defined in `speciesAttributes.param` therefore `simulation_defines.hpp` must be
 included.
No definition from `macc_types.hpp` is used.
Remove `#include "pmacc_types.hpp"` with `#include "simulation_defines.hpp"`.

The effect of the missing include should be a non compile able version of PIConGPU, This is not the case because the definition is included somewhere else in another file and therefore hides the error.