### PR TITLE
fix typo causing no absorber in 3D

### DIFF
--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -103,7 +103,7 @@ struct KernelAbsorbBorder
             absorb < 0 > (field, thickness, absorber_strength, mapper, direction);
         else if (direction.y() != 0)
             absorb < 1 > (field, thickness, absorber_strength, mapper, direction);
-#if( SDIMDIM==DIM3 )
+#if( SIMDIM==DIM3 )
         else if (direction.z() != 0)
             absorb < 2 > (field, thickness, absorber_strength, mapper, direction);
 #endif


### PR DESCRIPTION
This fixes a bug introduces **3 years ago** with #212.

The typo `SDIMDIM` in the precompiler if-clause evaluates as false, thus causing **no absorber in z**. 

This effects all 3D simulations with absorbers. 

The field along z-are not absorbed, see here:
![absorber_issue](https://cloud.githubusercontent.com/assets/5121158/25998700/88c674ae-3722-11e7-8b6c-7141b4a82a74.png)

- [x] check if this pull request fixes the missing absorber