### PR TITLE
Copy pymodules from examples to run directory

### DIFF
--- a/pic-create
+++ b/pic-create
@@ -23,8 +23,13 @@ this_dir=`dirname $0`
 
 #only copy submit and params if we clone from default pic folder
 default_folder_to_copy="submit include/simulation_defines/param include/simulation_defines/unitless"
-#if we clone a project we copy full include 
-folder_to_clone="submit include"
+#if we clone a project we copy full include
+if [ -d "$1/pymodules" ] ; then
+    folder_to_clone="submit include pymodules"
+else
+    folder_to_clone="submit include"
+fi
+
 files_to_copy="cmakeFlags executeOnClone"
 
 help()

--- a/src/picongpu/submit/submitAction.sh
+++ b/src/picongpu/submit/submitAction.sh
@@ -24,6 +24,10 @@ mkdir picongpu
 cp -r $TBG_projectPath/bin picongpu
 cp -r $TBG_projectPath/include picongpu
 cp -r $TBG_projectPath/submit picongpu
+if [ -d $TBG_projectPath/pymodules ]
+then
+  cp -r $TBG_projectPath/pymodules picongpu
+fi
 if [ -f $TBG_projectPath/cmakeFlags ]
 then
   cp $TBG_projectPath/cmakeFlags picongpu


### PR DESCRIPTION
This pull request modifies `pic-create` in order to copy analysis tools from
the examples in source to the parameter set.

Additionally `submitAction.sh` was modified to copy these tools to the run
directory.

This is a follow-up to #1979 .