### PR TITLE
remove extra typename in documentation of manipulators

### DIFF
--- a/examples/Bremsstrahlung/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/FoilLCT/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/FoilLCT/include/simulation_defines/param/speciesInitialization.param
@@ -43,7 +43,7 @@
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/SingleParticleTest/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/WarmCopper/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesInitialization.param
@@ -43,7 +43,7 @@
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/src/picongpu/include/simulation_defines/param/speciesInitialization.param
+++ b/src/picongpu/include/simulation_defines/param/speciesInitialization.param
@@ -43,7 +43,7 @@
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)


### PR DESCRIPTION
This pull request removes a wrong `typename` in the documentation of the particle manipulators. 

Adding this `typename` will lead to a compile time error. 