### PR TITLE
fix FillAllGaps

### DIFF
--- a/src/picongpu/include/particles/InitFunctors.hpp
+++ b/src/picongpu/include/particles/InitFunctors.hpp
@@ -165,7 +165,6 @@ struct FillAllGaps
     using SpeciesType = T_SpeciesType;
     using FrameType = typename SpeciesType::FrameType;
 
-    template<typename T_StorageTuple>
     HINLINE void operator()( const uint32_t currentStep )
     {
         DataConnector &dc = Environment<>::get().DataConnector();


### PR DESCRIPTION
This pull request removes a not-needed template in `FillAllGaps` that prevents using `FillAllGaps` in the init pipeline. 

Thanks @psychocoderHPC for finding this bug. 