### PR TITLE
fix typos found in param files and associated files

### DIFF
--- a/examples/Bremsstrahlung/README.rst
+++ b/examples/Bremsstrahlung/README.rst
@@ -4,13 +4,13 @@ Bremsstrahlung: Emission of Bremsstrahlung from Laser-Foil Interaction
 .. sectionauthor:: Heiko Burau <h.burau (at) hzdr.de>
 .. moduleauthor:: Heiko Burau <h.burau (at) hzdr.de>
 
-This is a simulation of a flat solid density target hit head-on by a high-intensity laser pulse. 
-At the front surface free electrons are accelerated up to ultra relativistic energies and start travelling through the bulk then. 
-Meanwhile, due to ion interaction, the hot electrons lose a small fraction of their kinectic energy in favor of emission of Bremsstrahlung-photons. 
-Passing over the back surface hot electrons are eventually reflected and re-enter the foil in opposite direction. 
+This is a simulation of a flat solid density target hit head-on by a high-intensity laser pulse.
+At the front surface free electrons are accelerated up to ultra relativistic energies and start travelling through the bulk then.
+Meanwhile, due to ion interaction, the hot electrons lose a small fraction of their kinetic energy in favor of emission of Bremsstrahlung-photons.
+Passing over the back surface hot electrons are eventually reflected and re-enter the foil in opposite direction.
 Because of the ultra-relativistic energy Bremsstrahlung (BS) is continuously emitted mainly along the direction of motion of the electron.
-The BS-module models the electron-ion scattering as three single processes, including electron deflection, electron deceleration and photon creation with respect to the emission angle. 
-Details of the implementation and the numerical model can be found in [BurauDipl]_. 
+The BS-module models the electron-ion scattering as three single processes, including electron deflection, electron deceleration and photon creation with respect to the emission angle.
+Details of the implementation and the numerical model can be found in [BurauDipl]_.
 Details of the theoretical description can be found in [Jackson]_ and [Salvat]_.
 
 This 2D test simulates a laser pulse of a_0=40, lambda=0.8µm, w0=1.5µm in head-on collision with a fully pre-ionized gold foil of 2µm thickness.

--- a/examples/Bremsstrahlung/include/simulation_defines/param/bremsstrahlung.param
+++ b/examples/Bremsstrahlung/include/simulation_defines/param/bremsstrahlung.param
@@ -30,7 +30,7 @@ namespace bremsstrahlung
 /** params related to the energy loss and deflection of the incident electron */
 namespace electron
 {
-    /** Minimal kinectic electron energy in MeV for the lookup table.
+    /** Minimal kinetic electron energy in MeV for the lookup table.
      *
      * For electrons below this value Bremsstrahlung is not taken into account.
      */

--- a/examples/FoilLCT/include/simulation_defines/param/fileOutput.param
+++ b/examples/FoilLCT/include/simulation_defines/param/fileOutput.param
@@ -53,7 +53,7 @@ namespace picongpu
      *   - CreateMomentumComponentOperation: ratio between a selected momentum
      *                                       component and the absolute
      *                                       momentum with respect to shape
-     *   - CreateLarmorPowerOperation: radiated larmor power
+     *   - CreateLarmorPowerOperation: radiated Larmor power
      *                                 (species must contain the attribute `momentumPrev1`)
      *
      * for debugging:

--- a/examples/SingleParticleTest/include/simulation_defines/param/fileOutput.param
+++ b/examples/SingleParticleTest/include/simulation_defines/param/fileOutput.param
@@ -53,7 +53,7 @@ namespace picongpu
      *   - CreateMomentumComponentOperation: ratio between a selected momentum
      *                                       component and the absolute
      *                                       momentum with respect to shape
-     *   - CreateLarmorPowerOperation: radiated larmor power
+     *   - CreateLarmorPowerOperation: radiated Larmor power
      *                                 (species must contain the attribute `momentumPrev1`)
      *
      * for debugging:

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -63,7 +63,7 @@ struct LookupTableFunctor
     HDINLINE LookupTableFunctor(LinInterpCursor linInterpCursor);
     /** scaled differential cross section
      *
-     * @param Ekin kinectic energy of the incident electron
+     * @param Ekin kinetic energy of the incident electron
      * @param kappa energy loss normalized to Ekin
      */
     HDINLINE float_X operator()(const float_X Ekin, const float_X kappa) const;

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -46,7 +46,7 @@ HDINLINE LookupTableFunctor::LookupTableFunctor(LinInterpCursor linInterpCursor)
 
 /** scaled differential cross section
  *
- * @param Ekin kinectic energy of the incident electron
+ * @param Ekin kinetic energy of the incident electron
  * @param kappa energy loss normalized to Ekin
  */
 HDINLINE float_X LookupTableFunctor::operator()(const float_X Ekin, const float_X kappa) const

--- a/src/picongpu/include/simulation_defines/param/bremsstrahlung.param
+++ b/src/picongpu/include/simulation_defines/param/bremsstrahlung.param
@@ -30,7 +30,7 @@ namespace bremsstrahlung
  */
 namespace electron
 {
-    /** Minimal kinectic electron energy in MeV for the lookup table.
+    /** Minimal kinetic electron energy in MeV for the lookup table.
      * For electrons below this value Bremsstrahlung is not taken into account.
      */
     constexpr float_64 MIN_ENERGY_MeV = 0.5;

--- a/src/picongpu/include/simulation_defines/param/fileOutput.param
+++ b/src/picongpu/include/simulation_defines/param/fileOutput.param
@@ -53,7 +53,7 @@ namespace picongpu
      *   - CreateMomentumComponentOperation: ratio between a selected momentum
      *                                       component and the absolute
      *                                       momentum with respect to shape
-     *   - CreateLarmorPowerOperation: radiated larmor power
+     *   - CreateLarmorPowerOperation: radiated Larmor power
      *                                 (species must contain the attribute `momentumPrev1`)
      *
      * for debugging:

--- a/src/picongpu/include/simulation_defines/param/particle.param
+++ b/src/picongpu/include/simulation_defines/param/particle.param
@@ -66,7 +66,7 @@ namespace manipulators
         static constexpr float_64 gamma = 1.0;
         const DriftParam_direction_t direction;
     };
-    /** definition of manipulator that assigns a dirft in X */
+    /** definition of manipulator that assigns a drift in X */
     using AssignXDrift = DriftImpl<
         DriftParam,
         nvidia::functors::Assign

--- a/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
+++ b/src/picongpu/include/simulation_defines/param/synchrotronPhotons.param
@@ -26,7 +26,7 @@ namespace particles
 namespace synchrotronPhotons
 {
 
-/** enable synchtrotron photon emission */
+/** enable synchrotron photon emission */
 #ifndef ENABLE_SYNCHROTRON_PHOTONS
 #define ENABLE_SYNCHROTRON_PHOTONS 0
 #endif
@@ -43,8 +43,8 @@ constexpr float_64 SYNC_FUNCS_BESSEL_INTEGRAL_STEPWIDTH = 1.0e-3;
 /** Number of sampling points of the lookup table */
 constexpr uint32_t SYNC_FUNCS_NUM_SAMPLES = 8192;
 
-/** Photons of oszillation periods greater than a timestep are not created since the grid already accounts for them.
- * This cutoff ratio is defined as: photon-oszillation-period / timestep */
+/** Photons of oscillation periods greater than a timestep are not created since the grid already accounts for them.
+ * This cutoff ratio is defined as: photon-oscillation-period / timestep */
 constexpr float_64 SOFT_PHOTONS_CUTOFF_RATIO = 1.0;
 
 /** if the emission probability per timestep is higher than this value and the log level is set to


### PR DESCRIPTION
This pull request fixes some typos discovered in param files during work with PIConGPU this week.  
It also fixes equivalent typos in associated files. 