### PR TITLE
fix shadowed member variable

### DIFF
--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -56,14 +56,14 @@ public:
         //create size on device before any use of setCurrentSize
         if (useVectorAsBase)
         {
-            sizeOnDevice = false;
-            createSizeOnDevice(sizeOnDevice);
+            this->sizeOnDevice = false;
+            createSizeOnDevice(this->sizeOnDevice);
             createFakeData();
             this->data1D = true;
         }
         else
         {
-            createSizeOnDevice(sizeOnDevice);
+            createSizeOnDevice(this->sizeOnDevice);
             createData();
             this->data1D = false;
         }


### PR DESCRIPTION
Remove usage of local instead of the member variable.

The result of the bug is that more buffer than needed have stored the buffer size on the device.
This results in more memory copies from/to the device.
This could be negative for the strong scaling.