### PR TITLE
fix boost 1.64.0 odeint integrate bug

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -92,14 +92,14 @@ zlib
 
 boost
 """""
-- 1.57.0+ (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math`` and nearly all header-only libs)
+- 1.57.0+ (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math``, ``serialization`` and nearly all header-only libs)
 - download from `http://www.boost.org <http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.gz/download>`_
-- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-math-dev``
+- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-serialization-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
 - *from source:*
 
-  - ``./bootstrap.sh --with-libraries=filesystem,program_options,regex,system,thread,math --prefix=$HOME/lib/boost``
+  - ``./bootstrap.sh --with-libraries=filesystem,program_options,regex,system,thread,math,serialization --prefix=$HOME/lib/boost``
   - ``./b2 -j4 && ./b2 install``
 - *environment:* (assumes install from source in ``$HOME/lib/boost``)
 

--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -153,7 +153,8 @@ set(LIBS ${LIBS} ${ZLIB_LIBRARIES})
 ################################################################################
 
 find_package(Boost 1.57.0 REQUIRED COMPONENTS program_options regex filesystem
-                                              system thread math_tr1)
+                                              system thread math_tr1
+                                              serialization)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 

--- a/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -27,6 +27,13 @@
 #include "algorithms/math.hpp"
 #include <boost/array.hpp>
 #include <boost/shared_ptr.hpp>
+/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
+ * the error
+ * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
+ * in boost 1.64.0
+ * see boost issue https://svn.boost.org/trac/boost/ticket/12516
+ */
+#include <boost/serialization/array_wrapper.hpp>
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 #include <boost/math/tools/minima.hpp>
 #include <limits>

--- a/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -27,13 +27,15 @@
 #include "algorithms/math.hpp"
 #include <boost/array.hpp>
 #include <boost/shared_ptr.hpp>
-/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
- * the error
- * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
- * in boost 1.64.0
- * see boost issue https://svn.boost.org/trac/boost/ticket/12516
- */
-#include <boost/serialization/array_wrapper.hpp>
+#if( BOOST_VERSION == 106400 )
+    /* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
+     * the error
+     * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
+     * in boost 1.64.0
+     * see boost issue https://svn.boost.org/trac/boost/ticket/12516
+     */
+#   include <boost/serialization/array_wrapper.hpp>
+#endif
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 #include <boost/math/tools/minima.hpp>
 #include <limits>

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -27,13 +27,15 @@
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include "algorithms/math.hpp"
 #include <boost/array.hpp>
-/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
- * the error
- * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
- * in boost 1.64.0
- * see boost issue https://svn.boost.org/trac/boost/ticket/12516
- */
-#include <boost/serialization/array_wrapper.hpp>
+#if( BOOST_VERSION == 106400 )
+    /* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
+     * the error
+     * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
+     * in boost 1.64.0
+     * see boost issue https://svn.boost.org/trac/boost/ticket/12516
+     */
+#   include <boost/serialization/array_wrapper.hpp>
+#endif
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 #include <boost/shared_ptr.hpp>
 #include <limits>

--- a/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/src/picongpu/include/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -27,6 +27,13 @@
 #include "cuSTL/cursor/BufferCursor.hpp"
 #include "algorithms/math.hpp"
 #include <boost/array.hpp>
+/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
+ * the error
+ * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
+ * in boost 1.64.0
+ * see boost issue https://svn.boost.org/trac/boost/ticket/12516
+ */
+#include <boost/serialization/array_wrapper.hpp>
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 #include <boost/shared_ptr.hpp>
 #include <limits>

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -22,13 +22,15 @@
 #include "particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 #include "simulation_defines.hpp"
 #include <boost/array.hpp>
-/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
- * the error
- * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
- * in boost 1.64.0
- * see boost issue https://svn.boost.org/trac/boost/ticket/12516
- */
-#include <boost/serialization/array_wrapper.hpp>
+#if( BOOST_VERSION == 106400 )
+    /* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
+     * the error
+     * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
+     * in boost 1.64.0
+     * see boost issue https://svn.boost.org/trac/boost/ticket/12516
+     */
+#   include <boost/serialization/array_wrapper.hpp>
+#endif
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 
 

--- a/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -22,6 +22,13 @@
 #include "particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 #include "simulation_defines.hpp"
 #include <boost/array.hpp>
+/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
+ * the error
+ * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
+ * in boost 1.64.0
+ * see boost issue https://svn.boost.org/trac/boost/ticket/12516
+ */
+#include <boost/serialization/array_wrapper.hpp>
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 
 


### PR DESCRIPTION
Fix error 
```boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"```
This bug is introduced with boost 1.64.0.

boost issue [12516](https://svn.boost.org/trac/boost/ticket/12516).

This fix allows to compile PIConGPU with boost 1.64.0 and cuda 7.5.
This fix is **not solving** #2048 for CUDA 8.0.

- [x] 1.64.0 include guard: [`BOOST_VERSION` as `106400`](https://github.com/boostorg/config/blob/boost-1.64.0/include/boost/version.hpp#L22) (not a string!)