### PR TITLE
lockstep refactoring `KernelLaserE`

### DIFF
--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -30,79 +30,78 @@ namespace picongpu
 {
 using namespace PMacc;
 
+/** compute the electric field of the laser
+ *
+ * @tparam T_numWorkers number of workers
+ * @tparam T_LaserPlaneSizeInSuperCell number of cells per dimension which
+ *  initialize the laser (size must be less or equal than the supercell size)
+ */
+template<
+    uint32_t T_numWorkers,
+    typename T_LaserPlaneSizeInSuperCell
+>
 struct KernelLaserE
 {
-    template<class EBox>
-    DINLINE void operator()(EBox fieldE, LaserManipulator lMan) const
+    template< typename EBox >
+    DINLINE void operator()(
+        EBox fieldE,
+        LaserManipulator lMan
+    ) const
     {
-        DataSpace<simDim> cellOffset;
+        using LaserPlaneSizeInSuperCell = T_LaserPlaneSizeInSuperCell;
 
-        cellOffset.x() = (blockIdx.x * blockDim.x) + threadIdx.x;
-        DataSpace<simDim> EFieldOffset;
-        EFieldOffset.x() = cellOffset.x() + (MappingDesc::SuperCellSize::x::value * GUARD_SIZE);
-        EFieldOffset.y() = MappingDesc::SuperCellSize::y::value*GUARD_SIZE;
+        PMACC_CASSERT_MSG(
+            __LaserPlaneSizeInSuperCell_y_must_be_less_or_equal_than_SuperCellSize_y,
+            LaserPlaneSizeInSuperCell::y::value <= SuperCellSize::y::value
+        );
 
-#if( SIMDIM==DIM3 )
-        cellOffset.z() = (blockIdx.y * blockDim.y) + threadIdx.y;
-        EFieldOffset.z() = cellOffset.z() + (MappingDesc::SuperCellSize::z::value * GUARD_SIZE);
-#endif
-        // shift offsets to the laser initialization plane
-        cellOffset.y() += laser::initPlaneY;
-        EFieldOffset.y() += laser::initPlaneY;
+        constexpr uint32_t planeSize = PMacc::math::CT::volume< LaserPlaneSizeInSuperCell >::type::value;
+        constexpr uint32_t numWorkers = T_numWorkers;
 
-        /** Calculate how many neighbors to the left we have
-         * to initialize the laser in the E-Field
-         *
-         * Example: Yee needs one neighbor to perform dB = curlE
-         *            -> initialize in y=0 plane
-         *          A second order solver could need 2 neighbors left:
-         *            -> initialize in y=0 and y=1 plane
-         *
-         * Question: Why do other codes initialize the B-Field instead?
-         * Answer:   Because our fields are defined on the lower cell side
-         *           (C-Style ftw). Therefore, our curls (for example Yee)
-         *           are shifted nabla+ <-> nabla- compared to Fortran codes
-         *           (in other words: curlLeft <-> curlRight)
-         *           for E and B.
-         *           For this reason, we have to initialize E instead of B.
-         *
-         * Problem: that's still not our case. For example our Yee does a
-         *          dE = curlLeft(B) - therefor, we should init B, too.
-         *
-         *
-         *  @todo: might also lack temporal offset since our formulas are E(x,z,t) instead of E(x,y,z,t)
-         *  `const int max_y_neighbors = Get<fieldSolver::FieldSolver::OffsetOrigin_E, 1 >::value;`
-         */
-        const int max_y_neighbors = 1;
+        const uint32_t workerIdx = threadIdx.x;
 
-        for (int totalOffsetY = 0; totalOffsetY < max_y_neighbors; ++totalOffsetY)
-        {
-            /** \todo Right now, the phase could be wrong ( == is cloned)
-             *        \see LaserPhysics.hpp
-             *
-             *  \todo What about the B-Field in the second plane?
-             */
-            if (laser::initPlaneY != 0) // compile time if
+        /* offset in cells to the superCell of the local GPU (relative from the local origin of the border) */
+        DataSpace< simDim > const superCellOffset = DataSpace< simDim >( blockIdx ) * SuperCellSize::toRT();
+
+        mappings::threads::ForEachIdx<
+            mappings::threads::IdxConfig<
+                planeSize,
+                numWorkers
+            >
+        > { workerIdx }(
+            [&](
+                uint32_t const linearIdx,
+                uint32_t const
+            )
             {
-                /* If the laser is not initialized in the first cell we emit a
-                 * negatively and positively propagating wave. Therefore we need to multiply the
-                 * amplitude with a correction factor depending of the cell size in
-                 * propagation direction.
-                 * The negatively propagating wave is damped by the absorber.
-                 *
-                 * The `correctionFactor` assume that the wave is moving in y direction.
-                 */
-                auto correctionFactor = (SPEED_OF_LIGHT * DELTA_T) / CELL_HEIGHT * float_X(2.);
-                fieldE(EFieldOffset) +=  correctionFactor * lMan.getManipulation(cellOffset);
+                /* cell index within the superCell */
+                DataSpace< simDim > const cellIdxInSuperCell = DataSpaceOperations<simDim>::template map< LaserPlaneSizeInSuperCell >( linearIdx );
+                /* cell index (relative to the local origin of the border)*/
+                auto cellIdx = superCellOffset + cellIdxInSuperCell;
+                cellIdx.y() += cell + laser::initPlaneY;
+
+                auto const eField = lMan.getManipulation( cellIdx );
+                if( laser::initPlaneY != 0 ) // compile time if
+                {
+                    /* If the laser is not initialized in the first cell we emit a
+                     * negatively and positively propagating wave. Therefore we need to multiply the
+                     * amplitude with a correction factor depending of the cell size in
+                     * propagation direction.
+                     * The negatively propagating wave is damped by the absorber.
+                     *
+                     * The `correctionFactor` assume that the wave is moving in y direction.
+                     */
+                    auto correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * float_X( 2. );
+                    /* jump over the guard of the electric field */
+                    fieldE( cellIdx + SuperCellSize::toRT() * GUARD_SIZE ) +=  correctionFactor * eField;
+                }
+                else
+                {
+                    /* jump over the guard of the electric field */
+                    fieldE( cellIdx + SuperCellSize::toRT() * GUARD_SIZE ) = eField;
+                }
             }
-            else
-            {
-                fieldE(EFieldOffset) = lMan.getManipulation(cellOffset);
-            }
-            /* move to next cell @see max_y_neighbors */
-            cellOffset.y() += 1;
-            EFieldOffset.y() += 1;
-        }
+        );
     }
 };
 


### PR DESCRIPTION
- rewrite kernel with the lockstep programming model
- add documentation

[HowTo lockstep programming](http://picongpu.readthedocs.io/en/dev/prgpatterns/lockstep.html)

## Tests (set `traits::GetNumWorkers<>` to `143`)

- [x] default LWFA
- [x] default LWFA example without particle and `laser::initPlaneY = 65`