### PR TITLE
Backports for 0.2.5-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log / Release Log for PIConGPU
 
 0.2.5
 -----
-**Date:** 2017-05-..
+**Date:** 2017-05-24
 
 Absorber in z in 3D3V, effective charge in ADK ionization
 
@@ -20,8 +20,13 @@ elements but Hydrogen.
  - ADK ionization: effective principal quantum number nEff #2011
  - 3D3V: missing absorber in z #2042
 
-Thanks to Marco Garten and Richard Pausch for spotting the issues and
-providing fixes!
+**Misc:**
+ - compile-time warning in 2D live plugin #2063
+ - DeviceBufferIntern: fix shadowed member variable #2051
+ - speciesInitialization: remove extra typename in doc #2044
+
+Thanks to Marco Garten, Richard Pausch, René Widera and Axel Huebl
+for spotting the issues and providing fixes!
 
 
 0.2.4

--- a/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/Bunch/include/simulation_defines/param/speciesInitialization.param
@@ -51,7 +51,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/KelvinHelmholtz/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/speciesInitialization.param
@@ -51,7 +51,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/speciesInitialization.param
@@ -51,7 +51,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/ThermalTest/include/simulation_defines/param/speciesInitialization.param
@@ -51,7 +51,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
+++ b/examples/WeibelTransverse/include/simulation_defines/param/speciesInitialization.param
@@ -51,7 +51,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)

--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -58,14 +58,14 @@ public:
         //create size on device before any use of setCurrentSize
         if (useVectorAsBase)
         {
-            sizeOnDevice = false;
-            createSizeOnDevice(sizeOnDevice);
+            this->sizeOnDevice = false;
+            createSizeOnDevice(this->sizeOnDevice);
             createFakeData();
             this->data1D = true;
         }
         else
         {
-            createSizeOnDevice(sizeOnDevice);
+            createSizeOnDevice(this->sizeOnDevice);
             createData();
             this->data1D = false;
         }

--- a/src/picongpu/include/plugins/output/sockets/SocketConnector.hpp
+++ b/src/picongpu/include/plugins/output/sockets/SocketConnector.hpp
@@ -110,7 +110,9 @@ public:
             size_t zipedSize = zip.compress(tmp + MessageHeader::bytes, ((char*) array) + MessageHeader::bytes, size - MessageHeader::bytes, 6);
             MessageHeader* header = (MessageHeader*) tmp;
             header->data.byte = (uint32_t) zipedSize;
-            write(SocketFD, tmp, zipedSize + MessageHeader::bytes);
+            int nbytes = write(SocketFD, tmp, zipedSize + MessageHeader::bytes);
+            if (nbytes < 0)
+                perror("a socket write error occured");
             __deleteArray(tmp);
         }
     }

--- a/src/picongpu/include/simulation_defines/param/speciesInitialization.param
+++ b/src/picongpu/include/simulation_defines/param/speciesInitialization.param
@@ -51,7 +51,7 @@ namespace particles
  *     @tparam T_SrcSpeciesType  source species
  *     @tparam T_DestSpeciesType destination species
  *
- * - Manipulate<T_Functor, typename T_SpeciesType>
+ * - Manipulate<T_Functor, T_SpeciesType>
  *     Run a user defined functor for every particle.
  *     \warning does not call `fillAllGaps()` if one removes or
  *              adds particles with it (\see FillAllGaps below)


### PR DESCRIPTION
Further backports for the 0.2.5 release (C++98):

**Bug Fixes:** (already in)
 - ADK ionization: effective principal quantum number nEff #2011
 - 3D3V: missing absorber in z #2042

**Misc:** (added in this PR)
 - compile-time warning in 2D live plugin #2063
 - DeviceBufferIntern: fix shadowed member variable #2051
 - speciesInitialization: remove extra typename in doc #2044