### PR TITLE
Abort on CUDA8 + Boost 1.64.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -92,7 +92,7 @@ zlib
 
 boost
 """""
-- 1.57.0+ (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math``, ``serialization`` and nearly all header-only libs)
+- 1.57.0-1.63.0 (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math``, ``serialization`` and nearly all header-only libs)
 - download from `http://www.boost.org <http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.gz/download>`_
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-serialization-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``

--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -295,6 +295,16 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_SMART_PTR")
 endif()
 
+# Boost 1.64.0 is broken with CUDA 8.0 and C++11
+#   https://github.com/ComputationalRadiationPhysics/picongpu/issues/2048
+#   fixed in CUDA 9.0 (ticket 1928813)
+if( (Boost_VERSION EQUAL 106400) AND
+    (CUDA_VERSION VERSION_EQUAL 8.0) )
+    message(FATAL_ERROR "Boost 1.64.0 and CUDA 8.0 are incompatible due to "
+                        "a bug in the CUDA compiler. Please use, e.g. Boost "
+                        "1.63.0 instead.")
+endif()
+
 
 ################################################################################
 # Find OpenMP


### PR DESCRIPTION
Until we find a fix for Boost 1.64.0 and CUDA 8.0, we throw a clean abort at configure time to inform the user.

See #2048