### PR TITLE
fix `KernelLaserE`

### DIFF
--- a/src/picongpu/include/fields/FieldE.kernel
+++ b/src/picongpu/include/fields/FieldE.kernel
@@ -78,7 +78,7 @@ struct KernelLaserE
                 DataSpace< simDim > const cellIdxInSuperCell = DataSpaceOperations<simDim>::template map< LaserPlaneSizeInSuperCell >( linearIdx );
                 /* cell index (relative to the local origin of the border)*/
                 auto cellIdx = superCellOffset + cellIdxInSuperCell;
-                cellIdx.y() += cell + laser::initPlaneY;
+                cellIdx.y() += laser::initPlaneY;
 
                 auto const eField = lMan.getManipulation( cellIdx );
                 if( laser::initPlaneY != 0 ) // compile time if


### PR DESCRIPTION
remove usage of the undefined variable `cell`

This bug was introduced with #2056.

thx @n01r for the bug [report](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2056#pullrequestreview-40011823)