### PR TITLE
FLYlite: Interface & Helper Fields

### DIFF
--- a/docs/source/usage/param/extensions.rst
+++ b/docs/source/usage/param/extensions.rst
@@ -43,3 +43,10 @@ ionizationEnergies.param
    :path: src/picongpu/include/simulation_defines/param/ionizationEnergies.param
    :no-link:
 
+flylite.param
+^^^^^^^^^^^^^
+
+.. doxygenfile:: flylite.param
+   :project: PIConGPU
+   :path: src/picongpu/include/simulation_defines/param/flylite.param
+   :no-link:

--- a/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
@@ -147,7 +147,17 @@ using ParticleFlagsCopper = bmpl::vector<
     massRatio< MassRatioCopper >,
     chargeRatio< ChargeRatioCopper >,
     densityRatio< DensityRatioCopper >,
-    atomicNumbers< ionization::atomicNumbers::Copper_t >
+    atomicNumbers< ionization::atomicNumbers::Copper_t >,
+    // note: this method is not yet fully implemented
+    populationKinetics<
+        particles::flylite::NonLTE<
+            MakeSeq_t<
+                BulkElectrons,
+                PromptElectrons
+            >,
+            MakeSeq_t< Photons >
+        >
+    >
 >;
 
 /* define species ions */

--- a/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
+++ b/examples/WarmCopper/include/simulation_defines/param/speciesDefinition.param
@@ -155,11 +155,9 @@ using CopperIons = Particles<
     bmpl::string< 'C', 'u' >,
     ParticleFlagsCopper,
     MakeSeq_t<
-        position< position_pic >,
-        momentum,
-        weighting,
-        particleId,
-        boundElectrons
+        DefaultParticleAttributes,
+        boundElectrons,
+        superconfig
     >
 >;
 

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -175,12 +175,14 @@ struct CallPopulationKineticsInit
 
 /** Calculate FLYlite population kinetics evolving one time step
  *
- * @tparam T_SpeciesName name of ion species
+ * @tparam T_SpeciesName name of ion species as PMacc::TypeAsIdentifier
  */
 template< typename T_SpeciesName >
 struct CallPopulationKinetics
 {
+    //! PMacc::TypeAsIdentifier for the particle species
     using SpeciesName = T_SpeciesName;
+    //! expects a picongpu::Particles class
     using SpeciesType = typename SpeciesName::type;
     using FrameType = typename SpeciesType::FrameType;
 
@@ -194,7 +196,7 @@ struct CallPopulationKinetics
     HINLINE void operator()( uint32_t currentStep ) const
     {
         PopulationKineticsSolver flylite{};
-        flylite.template update< SpeciesName >(
+        flylite.template update< SpeciesType >(
             FrameType::getName(),
             currentStep
         );

--- a/src/picongpu/include/particles/flylite/IFlyLite.hpp
+++ b/src/picongpu/include/particles/flylite/IFlyLite.hpp
@@ -25,6 +25,7 @@
 // PMacc
 #include "static_assert.hpp"
 
+#include <boost/core/ignore_unused.hpp>
 #include <string>
 
 
@@ -46,10 +47,10 @@ namespace flylite
          */
         virtual void init(
             PMacc::DataSpace< simDim > const & gridSizeLocal,
-            std::string const ionSpeciesName
+            std::string const & ionSpeciesName
         ) = 0;
 
-        /** Calculate evolution of populations for one time step
+        /** Calculate Evolution of Populations for One Time Step
          *
          * Interface for the update of the atomic populations during the PIC
          * cycle.
@@ -61,13 +62,16 @@ namespace flylite
             typename T_IonSpecies
         >
         void update(
-            std::string const ionSpeciesName,
+            std::string const & ionSpeciesName,
             uint32_t currentStep
         )
         {
+            boost::ignore_unused( ionSpeciesName, currentStep );
+
             PMACC_STATIC_ASSERT_MSG(
                 false,
-                FLYlite_the_update_method_for_ion_population_kinetics_is_not_implemented);
+                FLYlite_the_update_method_for_ion_population_kinetics_is_not_implemented
+            );
         }
 
     };

--- a/src/picongpu/include/particles/flylite/IFlyLite.hpp
+++ b/src/picongpu/include/particles/flylite/IFlyLite.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2017 Axel Huebl
+ *
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+// PMacc
+#include "static_assert.hpp"
+
+#include <string>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+    /** Interface for a method of solving population kinetics
+     */
+    class IFlyLite
+    {
+    public:
+        /** Allocate & Initialize Memory Buffers for Algorithms
+         *
+         * @param gridSizeLocal local size of electro-magnetic fields on the cells
+         * @param ionSpeciesName unique name for the ion species
+         */
+        virtual void init(
+            PMacc::DataSpace< simDim > const & gridSizeLocal,
+            std::string const ionSpeciesName
+        ) = 0;
+
+        /** Calculate evolution of populations for one time step
+         *
+         * Interface for the update of the atomic populations during the PIC
+         * cycle.
+         *
+         * @param ionSpeciesName unique name for the ion species
+         * @param currentStep the current time step of the simulation
+         */
+        template<
+            typename T_IonSpecies
+        >
+        void update(
+            std::string const ionSpeciesName,
+            uint32_t currentStep
+        )
+        {
+            PMACC_STATIC_ASSERT_MSG(
+                false,
+                FLYlite_the_update_method_for_ion_population_kinetics_is_not_implemented);
+        }
+
+    };
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/NonLTE.def
+++ b/src/picongpu/include/particles/flylite/NonLTE.def
@@ -1,0 +1,54 @@
+/* Copyright 2017 Axel Huebl
+ *
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+    /** Non-LTE Steady-State
+     *
+     * Implementation of non-LTE ionization dynamics.
+     * @todo later on, add references on the overall model here.
+     *
+     * @todo add T_OtherIonsList for multi ion species IPD
+     *
+     * @tparam T_ElectronsList A mpl sequence of picongpu::Particles with a list
+     *                         of electron species for local density and energy
+     *                         histogram binning
+     *
+     * @tparam T_PhotonsList A mpl sequence of picongpu::Particles with a list
+     *                       of photon species for local energy histogram
+     *                       binning
+     */
+    template<
+        /* typename T_OtherIonsList, */
+        typename T_ElectronsList,
+        typename T_PhotonsList
+    >
+    class NonLTE;
+
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/NonLTE.hpp
+++ b/src/picongpu/include/particles/flylite/NonLTE.hpp
@@ -52,13 +52,13 @@ namespace flylite
         void
         init(
             PMacc::DataSpace< simDim > const & gridSizeLocal,
-            std::string const ionSpeciesName
+            std::string const & ionSpeciesName
         );
 
         /** Update atomic configurations
          *
          * Prepares auxiliary fields for the non-LTE atomic physics model and
-         * updates the configurations & charge state of an ion species.
+         * updates the configurations & charge states of an ion species.
          *
          * @tparam T_IonSpeciesType a picongpu::Particles class with an ion
          *                          species
@@ -71,7 +71,7 @@ namespace flylite
         >
         void
         update(
-            std::string const ionSpeciesName,
+            std::string const & ionSpeciesName,
             uint32_t currentStep
         );
 
@@ -89,7 +89,7 @@ namespace flylite
         >
         void
         fillHelpers(
-            std::string const ionSpeciesName,
+            std::string const & ionSpeciesName,
             uint32_t currentStep
         );
 

--- a/src/picongpu/include/particles/flylite/NonLTE.hpp
+++ b/src/picongpu/include/particles/flylite/NonLTE.hpp
@@ -1,0 +1,100 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/flylite/NonLTE.def"
+#include "simulation_defines.hpp"
+#include "particles/flylite/IFlyLite.hpp"
+
+/* PMacc */
+#include "dimensions/DataSpace.hpp"
+
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+    template<
+        //! @todo for multi ion species IPD: typename T_OtherIonsList,
+        typename T_ElectronsList,
+        typename T_PhotonsList
+    >
+    class NonLTE : public IFlyLite
+    {
+    public:
+        //! @todo for multi ion species IPD: using OtherIonsList = T_OtherIonsList;
+
+        using ElectronsList = T_ElectronsList;
+        using PhotonsList = T_PhotonsList;
+
+        virtual
+        void
+        init(
+            PMacc::DataSpace< simDim > const & gridSizeLocal,
+            std::string const ionSpeciesName
+        );
+
+        /** Update atomic configurations
+         *
+         * Prepares auxiliary fields for the non-LTE atomic physics model and
+         * updates the configurations & charge state of an ion species.
+         *
+         * @tparam T_IonSpeciesType a picongpu::Particles class with an ion
+         *                          species
+         *
+         * @param ionSpeciesName unique name of the ion species in T_IonSpeciesType
+         * @param currentStep the current time step
+         */
+        template<
+            typename T_IonSpeciesType
+        >
+        void
+        update(
+            std::string const ionSpeciesName,
+            uint32_t currentStep
+        );
+
+    private:
+        /** Calculate new values in helper fields
+         *
+         * Prepares helper fields by calculating local densities and energy
+         * histograms.
+         *
+         * @param ionSpeciesName unique name of the ion species in T_IonSpeciesType
+         * @param currentStep the current time step
+         */
+        template<
+            typename T_IonSpeciesType
+        >
+        void
+        fillHelpers(
+            std::string const ionSpeciesName,
+            uint32_t currentStep
+        );
+
+    };
+
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/NonLTE.tpp
+++ b/src/picongpu/include/particles/flylite/NonLTE.tpp
@@ -53,7 +53,7 @@ namespace flylite
         T_PhotonsList
     >::init(
         PMacc::DataSpace< simDim > const & gridSizeLocal,
-        std::string const ionSpeciesName
+        std::string const & ionSpeciesName
     )
     {
         //! GPU-local number of cells in regular resolution (like FieldE & B)
@@ -63,7 +63,7 @@ namespace flylite
 
         DataConnector &dc = Environment<>::get().DataConnector();
 
-        /* once allocated for all ion species to share */
+        // once allocated for all ion species to share
         if( ! dc.hasId( helperFields::LocalEnergyHistogram::getName( "electrons" ) ) )
             dc.share(
                 std::shared_ptr< ISimulationData >(
@@ -94,7 +94,7 @@ namespace flylite
                 )
             );
 
-        /* for each ion species */
+        // for each ion species
         if( ! dc.hasId( helperFields::LocalRateMatrix::getName( ionSpeciesName ) ) )
             dc.share(
                 std::shared_ptr< ISimulationData >(
@@ -132,7 +132,7 @@ namespace flylite
         T_ElectronsList,
         T_PhotonsList
     >::update(
-        std::string const ionSpeciesName,
+        std::string const & ionSpeciesName,
         uint32_t currentStep
     )
     {
@@ -164,7 +164,7 @@ namespace flylite
         T_ElectronsList,
         T_PhotonsList
     >::fillHelpers(
-        std::string const ionSpeciesName,
+        std::string const & ionSpeciesName,
         uint32_t currentStep
     )
     {

--- a/src/picongpu/include/particles/flylite/helperFields/LocalDensity.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalDensity.hpp
@@ -1,0 +1,110 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+// PMacc
+#include "dataManagement/ISimulationData.hpp"
+#include "dimensions/GridLayout.hpp"
+#include "memory/buffers/GridBuffer.hpp"
+#include "memory/Array.hpp"
+
+#include <string>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+namespace helperFields
+{
+    class LocalDensity :
+        public ISimulationData
+    {
+    public:
+        using ValueType = float_X;
+
+    private:
+        GridBuffer< ValueType, simDim >* m_density;
+        std::string m_speciesGroup;
+
+    public:
+        /** Allocate and initialize local (number) density
+         *
+         * @param speciesGroup unique naming for the species inside this density,
+         *                     e.g. a collection of electron species or ions
+         * @param sizeLocal spatial size of the local density value
+         */
+        LocalDensity(
+            std::string const speciesGroup,
+            DataSpace< simDim > const & sizeLocal
+        ) :
+            m_density( nullptr ),
+            m_speciesGroup( speciesGroup )
+        {
+            // without guards
+            m_density = new GridBuffer< ValueType, simDim >( sizeLocal );
+        }
+
+        ~LocalDensity()
+        {
+            __delete( m_density );
+        }
+
+        static std::string
+        getName( std::string const speciesGroup )
+        {
+            return speciesGroup + "_LocalDensity";
+        }
+
+        std::string
+        getName( )
+        {
+            return getName( m_speciesGroup );
+        }
+
+        GridBuffer< ValueType, simDim >&
+        getGridBuffer( )
+        {
+            return *m_density;
+        }
+
+        /* implement ISimulationData members */
+        void
+        synchronize()
+        {
+            m_density->deviceToHost( );
+        }
+
+        SimulationDataId
+        getUniqueId()
+        {
+            return getName();
+        }
+    };
+
+} // namespace helperFields
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/helperFields/LocalDensity.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalDensity.hpp
@@ -57,7 +57,7 @@ namespace helperFields
          * @param sizeLocal spatial size of the local density value
          */
         LocalDensity(
-            std::string const speciesGroup,
+            std::string const & speciesGroup,
             DataSpace< simDim > const & sizeLocal
         ) :
             m_density( nullptr ),
@@ -73,7 +73,7 @@ namespace helperFields
         }
 
         static std::string
-        getName( std::string const speciesGroup )
+        getName( std::string const & speciesGroup )
         {
             return speciesGroup + "_LocalDensity";
         }

--- a/src/picongpu/include/particles/flylite/helperFields/LocalDensity.kernel
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalDensity.kernel
@@ -1,0 +1,150 @@
+/* Copyright 2017 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+// PMacc
+#include "dataManagement/ISimulationData.hpp"
+#include "dimensions/GridLayout.hpp"
+#include "nvidia/reduce/Reduce.hpp"
+#include "nvidia/functors/Add.hpp"
+#include "memory/buffers/GridBuffer.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
+
+#include <string>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+namespace helperFields
+{
+    /** Average a FieldTmp density to a smaller resolution
+     *
+     * Average a FieldTmp density to a smaller (per-supercell) resolution and
+     * add it to a local density field.
+     *
+     * @tparam T_numWorkers number of workers for lockstep execution per block,
+     *                      arbitrary for reduce since it will loop over the
+     *                      source size when necessary
+     */
+    template<
+        uint32_t T_numWorkers
+    >
+    struct KernelAverageDensity
+    {
+        /** Functor
+         *
+         * @tparam T_TmpBox PMacc::DataBox with full-resolution density
+         * @tparam T_LocalDensityBox PMacc::DataBox local density with less
+         *                           resolution
+         *
+         * @param fieldTmp PMacc::DataBox with FieldTmp density scalar field
+         * @param localDensity PMacc::DataBox with global memory, e.g. for each
+         *                     supercell's density
+         */
+        template<
+            typename T_TmpBox,
+            typename T_LocalDensityBox
+        >
+        DINLINE void operator()(
+            T_TmpBox fieldTmp,
+            T_LocalDensityBox localDensity
+        ) const
+        {
+            using picongpu::flylite::spatialAverageBox;
+            using ValueType = typename T_TmpBox::ValueType;
+            constexpr uint32_t numWorkers = T_numWorkers;
+
+            // cell index in the average box in reduced resolution
+            const DataSpace< simDim > avgBoxCell( blockIdx );
+            // first cell index inside FieldTmp (originating from BORDER) for block
+            const DataSpace< simDim > fieldTmpBlockOriginCell = avgBoxCell * spatialAverageBox::toRT();
+            // our workers per block are started 1D
+            const uint32_t linearThreadIdx( threadIdx.x );
+
+            // shift the fieldTmp to the start of average box
+            auto fieldTmpBlock = fieldTmp.shift( fieldTmpBlockOriginCell );
+
+            // shared memory for reduce
+            PMACC_SMEM(
+                shReduceBuffer,
+                memory::Array<
+                    ValueType,
+                    numWorkers
+                >
+            );
+
+            // re-map access indices to local average view
+            using D1Box = DataBoxDim1Access< T_TmpBox >;
+            D1Box d1access(
+                fieldTmpBlock,
+                spatialAverageBox::toRT()
+            );
+
+            __syncthreads();
+
+            nvidia::reduce::kernel::Reduce< ValueType > reduce{};
+
+            const uint32_t numAvgCells = PMacc::math::CT::volume< spatialAverageBox >::type::value;
+            reduce(
+                linearThreadIdx,
+                numWorkers,
+                /* block-wise reduce, every worker participates */
+                linearThreadIdx,
+                numWorkers,
+                /* access inside local average view */
+                d1access,
+                numAvgCells,
+                nvidia::functors::Add(),
+                shReduceBuffer
+            );
+
+            /* continue with master
+             *
+             * - before working with this field, multiply by
+             *   particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
+             * - divide by for average by numAvgCells
+             * - write back to global
+             *
+             * - change those lines if you want to re-use this kernel for a vector field
+             */
+            if( linearThreadIdx == 0 )
+            {
+                ValueType localAverageResult = shReduceBuffer[ 0 ] *
+                    particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE /
+                    float_X( numAvgCells );
+
+                localDensity( avgBoxCell ) =
+                    static_cast< typename T_LocalDensityBox::ValueType >( localAverageResult );
+            }
+        }
+    };
+
+} // namespace helperFields
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/helperFields/LocalDensity.kernel
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalDensity.kernel
@@ -30,9 +30,6 @@
 #include "memory/shared/Allocate.hpp"
 #include "memory/Array.hpp"
 
-#include <string>
-#include <memory>
-
 
 namespace picongpu
 {
@@ -80,11 +77,11 @@ namespace helperFields
             constexpr uint32_t numWorkers = T_numWorkers;
 
             // cell index in the average box in reduced resolution
-            const DataSpace< simDim > avgBoxCell( blockIdx );
+            DataSpace< simDim > const avgBoxCell( blockIdx );
             // first cell index inside FieldTmp (originating from BORDER) for block
-            const DataSpace< simDim > fieldTmpBlockOriginCell = avgBoxCell * spatialAverageBox::toRT();
+            DataSpace< simDim > const fieldTmpBlockOriginCell = avgBoxCell * spatialAverageBox::toRT();
             // our workers per block are started 1D
-            const uint32_t linearThreadIdx( threadIdx.x );
+            uint32_t const linearThreadIdx( threadIdx.x );
 
             // shift the fieldTmp to the start of average box
             auto fieldTmpBlock = fieldTmp.shift( fieldTmpBlockOriginCell );
@@ -109,7 +106,7 @@ namespace helperFields
 
             nvidia::reduce::kernel::Reduce< ValueType > reduce{};
 
-            const uint32_t numAvgCells = PMacc::math::CT::volume< spatialAverageBox >::type::value;
+            uint32_t const numAvgCells = PMacc::math::CT::volume< spatialAverageBox >::type::value;
             reduce(
                 linearThreadIdx,
                 numWorkers,

--- a/src/picongpu/include/particles/flylite/helperFields/LocalDensityFunctors.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalDensityFunctors.hpp
@@ -1,0 +1,169 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "particles/flylite/helperFields/LocalDensity.hpp"
+#include "particles/flylite/helperFields/LocalDensity.kernel"
+
+// PMacc
+#include "pmacc_types.hpp"
+#include "static_assert.hpp"
+#include "Environment.hpp"
+#include "algorithms/ForEach.hpp"
+
+#include <string>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+namespace helperFields
+{
+namespace detail
+{
+    /** Average a group of species to a local density
+     *
+     * Takes a single species and fills the LocalDensity with it.
+     *
+     * @tparam T_SpeciesType a picongpu::Particles class with a particle species
+     */
+    template<
+        typename T_SpeciesType
+    >
+    struct AddSingleDensity
+    {
+        using SpeciesType = T_SpeciesType;
+        using FrameType = typename SpeciesType::FrameType;
+        using ShapeType = typename GetShape< SpeciesType >::type;
+        using Density = ComputeGridValuePerFrame<
+            ShapeType,
+            particleToGrid::derivedAttributes::Density
+        >;
+
+        /** Functor
+         *
+         * @param currentStep the current time step
+         * @param fieldTmp a slot of FieldTmp to add a density to
+         */
+        void operator()(
+            uint32_t currentStep,
+            std::shared_ptr< FieldTmp > fieldTmp
+        )
+        {
+            DataConnector &dc = Environment<>::get().DataConnector();
+
+            // load particle without copy particle data to host
+            auto speciesTmp = dc.get< SpeciesType >( FrameType::getName(), true );
+
+            fieldTmp->template computeValue< CORE + BORDER, Density >( *speciesTmp, currentStep );
+
+            dc.releaseData( FrameType::getName() );
+        }
+    };
+}
+    /** Average a group of species to a local density
+     *
+     * Takes a list of species and fills the LocalDensity with it.
+     * Ideally executed for a list of electron species or an ion species.
+     *
+     * @tparam T_SpeciesList sequence of picongpu::Particles to create a
+     *                       local density from
+     */
+    template<
+        typename T_SpeciesList
+    >
+    struct FillLocalDensity
+    {
+        using SpeciesList = T_SpeciesList;
+
+        /** Functor
+         *
+         * @param currentStep the current time step
+         * @param speciesGroup naming for the group of species in T_SpeciesList
+         */
+        void operator()(
+            uint32_t currentStep,
+            std::string const speciesGroup
+        )
+        {
+            // generating a density requires at least one slot in FieldTmp
+            PMACC_CASSERT_MSG(
+                _please_allocate_at_least_one_FieldTmp_in_memory_param,
+                fieldTmpNumSlots > 0
+            );
+
+            DataConnector &dc = Environment<>::get().DataConnector();
+
+            // load FieldTmp without copy data to host and zero it
+            auto fieldTmp = dc.get< FieldTmp >(
+                FieldTmp::getUniqueId( 0 ),
+                true
+            );
+            using DensityValueType = typename FieldTmp::ValueType;
+            fieldTmp->getGridBuffer().getDeviceBuffer().setValue( DensityValueType::create(0.0) );
+
+            // add density of each species in list to FieldTmp
+            ForEach< SpeciesList, detail::AddSingleDensity< bmpl::_1 > > addSingleDensity;
+            addSingleDensity( currentStep, fieldTmp );
+
+            /* create valid density in the BORDER region
+             * note: for average != supercell multiples the GUARD of fieldTmp
+             *       also needs to be filled in the communication above
+             */
+            EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
+            __setTransactionEvent(fieldTmpEvent);
+
+            /* average summed density in FieldTmp down to local resolution and
+             * write in new field
+             */
+            auto nlocal = dc.get< LocalDensity >(
+                helperFields::LocalDensity::getName( speciesGroup ),
+                true
+            );
+            constexpr uint32_t numWorkers = PMacc::traits::GetNumWorkers<
+                PMacc::math::CT::volume< SuperCellSize >::type::value
+            >::value;
+            PMACC_KERNEL( helperFields::KernelAverageDensity< numWorkers >{ } )
+            (
+                // one block per averaged density value
+                nlocal->getGridBuffer().getGridLayout().getDataSpaceWithoutGuarding(),
+                numWorkers
+            )
+            (
+                // start in border (jump over GUARD area)
+                fieldTmp->getDeviceDataBox().shift( SuperCellSize::toRT() * GUARD_SIZE ),
+                // start in border (has no GUARD area)
+                nlocal->getGridBuffer().getDeviceBuffer( ).getDataBox( )
+            );
+
+            // release fields
+            dc.releaseData( FieldTmp::getUniqueId( 0 ) );
+            dc.releaseData( helperFields::LocalDensity::getName( speciesGroup ) );
+        }
+    };
+
+} // namespace helperFields
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/helperFields/LocalDensityFunctors.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalDensityFunctors.hpp
@@ -27,6 +27,7 @@
 #include "static_assert.hpp"
 #include "Environment.hpp"
 #include "algorithms/ForEach.hpp"
+#include "forward.hpp"
 
 #include <string>
 #include <memory>
@@ -68,7 +69,7 @@ namespace detail
          */
         void operator()(
             uint32_t currentStep,
-            std::shared_ptr< FieldTmp > fieldTmp
+            std::shared_ptr< FieldTmp > & fieldTmp
         )
         {
             DataConnector &dc = Environment<>::get().DataConnector();
@@ -104,7 +105,7 @@ namespace detail
          */
         void operator()(
             uint32_t currentStep,
-            std::string const speciesGroup
+            std::string const & speciesGroup
         )
         {
             // generating a density requires at least one slot in FieldTmp
@@ -125,7 +126,7 @@ namespace detail
 
             // add density of each species in list to FieldTmp
             ForEach< SpeciesList, detail::AddSingleDensity< bmpl::_1 > > addSingleDensity;
-            addSingleDensity( currentStep, fieldTmp );
+            addSingleDensity( currentStep, forward( fieldTmp ) );
 
             /* create valid density in the BORDER region
              * note: for average != supercell multiples the GUARD of fieldTmp

--- a/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.hpp
@@ -1,0 +1,114 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+// PMacc
+#include "dataManagement/ISimulationData.hpp"
+#include "dimensions/GridLayout.hpp"
+#include "memory/buffers/GridBuffer.hpp"
+#include "memory/Array.hpp"
+
+#include <string>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+namespace helperFields
+{
+    using namespace PMacc;
+
+    class LocalEnergyHistogram :
+        public ISimulationData
+    {
+    private:
+        using EnergyHistogram =
+            memory::Array<
+                float_X,
+                picongpu::flylite::energies
+            >;
+        GridBuffer< EnergyHistogram, simDim >* m_energyHistogram;
+        std::string m_speciesGroup;
+
+    public:
+        /** Allocate and Initialize local Energy Histogram
+         *
+         * @param speciesGroup unique naming for the species inside this histogram,
+         *                     e.g. a collection of electron species or photon species
+         * @param histSizeLocal spatial size of the local energy histogram
+         */
+        LocalEnergyHistogram(
+            std::string const speciesGroup,
+            DataSpace< simDim > const & histSizeLocal
+        ) :
+            m_energyHistogram( nullptr ),
+            m_speciesGroup( speciesGroup )
+        {
+            m_energyHistogram =
+                new GridBuffer< EnergyHistogram, simDim >( histSizeLocal );
+        }
+
+        ~LocalEnergyHistogram()
+        {
+            __delete( m_energyHistogram );
+        }
+
+        static std::string
+        getName( std::string const speciesGroup )
+        {
+            return speciesGroup + "_LocalEnergyHistogram";
+        }
+
+        std::string
+        getName( )
+        {
+            return getName( m_speciesGroup );
+        }
+
+        GridBuffer< EnergyHistogram, simDim >&
+        getGridBuffer( )
+        {
+            return *m_energyHistogram;
+        }
+
+        /* implement ISimulationData members */
+        void
+        synchronize()
+        {
+            m_energyHistogram->deviceToHost( );
+        }
+
+        SimulationDataId
+        getUniqueId()
+        {
+            return getName();
+        }
+    };
+
+} // namespace helperFields
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.hpp
@@ -28,7 +28,6 @@
 #include "memory/Array.hpp"
 
 #include <string>
-#include <memory>
 
 
 namespace picongpu
@@ -50,7 +49,10 @@ namespace helperFields
                 float_X,
                 picongpu::flylite::energies
             >;
-        GridBuffer< EnergyHistogram, simDim >* m_energyHistogram;
+        GridBuffer<
+            EnergyHistogram,
+            simDim
+        > * m_energyHistogram;
         std::string m_speciesGroup;
 
     public:
@@ -61,14 +63,17 @@ namespace helperFields
          * @param histSizeLocal spatial size of the local energy histogram
          */
         LocalEnergyHistogram(
-            std::string const speciesGroup,
+            std::string const & speciesGroup,
             DataSpace< simDim > const & histSizeLocal
         ) :
             m_energyHistogram( nullptr ),
             m_speciesGroup( speciesGroup )
         {
             m_energyHistogram =
-                new GridBuffer< EnergyHistogram, simDim >( histSizeLocal );
+                new GridBuffer<
+                    EnergyHistogram,
+                    simDim
+                >( histSizeLocal );
         }
 
         ~LocalEnergyHistogram()
@@ -77,7 +82,7 @@ namespace helperFields
         }
 
         static std::string
-        getName( std::string const speciesGroup )
+        getName( std::string const & speciesGroup )
         {
             return speciesGroup + "_LocalEnergyHistogram";
         }
@@ -88,7 +93,10 @@ namespace helperFields
             return getName( m_speciesGroup );
         }
 
-        GridBuffer< EnergyHistogram, simDim >&
+        GridBuffer<
+            EnergyHistogram,
+            simDim
+        > &
         getGridBuffer( )
         {
             return *m_energyHistogram;

--- a/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.kernel
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.kernel
@@ -1,0 +1,280 @@
+/* Copyright 2017 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+// PMacc
+#include "dataManagement/ISimulationData.hpp"
+#include "dimensions/GridLayout.hpp"
+#include "nvidia/functors/Add.hpp"
+#include "memory/buffers/GridBuffer.hpp"
+#include "memory/shared/Allocate.hpp"
+#include "memory/Array.hpp"
+#include "mappings/threads/ForEachIdx.hpp"
+#include "mappings/threads/IdxConfig.hpp"
+
+#include <string>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+namespace helperFields
+{
+    /** Generate and add a local energy histogram
+     *
+     * Generate a (per-supercell) energy histogram and add it to global memory.
+     *
+     * @tparam T_numWorkers number of workers for lockstep execution per block,
+     *                      usually equal to the number of particles per frame
+     *                      (which is equal to the supercell size)
+     */
+    template< uint32_t T_numWorkers >
+    struct KernelAddLocalEnergyHistogram
+    {
+        /** Functor
+         *
+         * The functor is executed frame-list wise, meaning locally per
+         * supercell. All particles of a supercell generate a shared memory
+         * histogram and write that back into global memory. Particles outside
+         * of the range of the histogram are ignored and not counted.
+         *
+         * @todo In case the local averging in flylite shall be larger then a
+         * supercell (in integer multiples), the results need to be merged.
+         *
+         * @tparam T_ParBox PMacc::ParticlesBox, particle box type
+         * @tparam T_LocalEnergyHistogramBox PMacc::DataBox, local energy histograms,
+         *                                   e.g. for each supercell
+         *
+         * @param pb particles of a species
+         * @param energyHistogramBox box with global memory for each supercell's histogram
+         * @param minEnergy minimum energy to account for (eV)
+         * @param maxEnergy maximum energy to account for (eV)
+         */
+        template<
+            typename T_ParBox,
+            typename T_LocalEnergyHistogramBox,
+            typename T_Mapping
+        >
+        DINLINE void operator()(
+            T_ParBox & pb,
+            T_LocalEnergyHistogramBox & energyHistogramBox,
+            float_X const minEnergy,
+            float_X const maxEnergy,
+            T_Mapping const mapper
+        ) const
+        {
+            using picongpu::flylite::spatialAverageBox;
+            constexpr uint16_t numBins = picongpu::flylite::energies;
+            constexpr uint32_t numWorkers = T_numWorkers;
+
+            using namespace PMacc::mappings::threads;
+            using SuperCellSize = typename MappingDesc::SuperCellSize;
+            using FramePtr = typename T_ParBox::FramePtr;
+            constexpr uint32_t maxParticlesPerFrame = PMacc::math::CT::volume< SuperCellSize >::type::value;
+
+            PMACC_SMEM(
+                frame,
+                FramePtr
+            );
+            PMACC_SMEM(
+                particlesInSuperCell,
+                lcellId_t
+            );
+
+            // our workers per block are started 1D
+            uint32_t const workerIdx = threadIdx.x;
+
+            // supercell index of current (frame-wise) supercell including GUARD
+            DataSpace< simDim > const superCellIdx(
+                mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
+            );
+            /* index inside local energy histogram in averaged space (has no GUARD)
+             * integer division: of we average over multiples of supercells
+             *                   this will select the right local energy
+             *                   histogram in global RAM
+             */
+            DataSpace< simDim > const localEnergyBlock =
+                ( superCellIdx - DataSpace< simDim >::create( GUARD_SIZE ) ) *
+                SuperCellSize::toRT() / spatialAverageBox::toRT();
+
+            /* shift the energyHistogramBox to the local spatial average box and
+             * get a reference on the histogram
+             */
+            auto & localEnergyHistogram = *energyHistogramBox.shift( localEnergyBlock );
+
+            // shared memory for local energy histogram
+            PMACC_SMEM(
+                shLocalEnergyHistogram,
+                memory::Array<
+                    float_X,
+                    numBins
+                >
+            );
+
+            using MasterOnly = IdxConfig<
+                1,
+                numWorkers
+            >;
+
+            // get frame lists of this supercell
+            ForEachIdx< MasterOnly >{ workerIdx }(
+                [&](
+                    uint32_t const,
+                    uint32_t const
+                )
+                {
+                    frame = pb.getLastFrame( superCellIdx );
+                    particlesInSuperCell = pb.getSuperCell( superCellIdx ).getSizeLastFrame( );
+                }
+            );
+
+            // empty the histogram to contain only zeroes
+            ForEachIdx<
+                IdxConfig<
+                    numWorkers,
+                    numWorkers
+                >
+            >{ workerIdx }(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const
+                )
+                {
+                    /* set all bins to 0 */
+                    for( int i = linearIdx; i < numBins; i += numWorkers )
+                        shLocalEnergyHistogram[ i ] = float_X( 0. );
+                }
+            );
+
+            __syncthreads();
+
+            // return if the supercell has no particles
+            if( !frame.isValid( ) )
+                return;
+
+            // iterate the frame list
+            while( frame.isValid() )
+            {
+                // move over all particles in a frame
+                ForEachIdx<
+                    IdxConfig<
+                        maxParticlesPerFrame,
+                        numWorkers
+                    >
+                >{ workerIdx }(
+                    [&](
+                        uint32_t const linearIdx,
+                        uint32_t const
+                    )
+                    {
+                        if( linearIdx < particlesInSuperCell )
+                        {
+                            auto const particle = frame[ linearIdx ];
+                            /* kinetic Energy for Particles: E^2 = p^2*c^2 + m^2*c^4
+                             *                                   = c^2 * [p^2 + m^2*c^2]
+                             */
+                            float3_X const mom = particle[ momentum_ ];
+
+                            float_X const weighting = particle[ weighting_ ];
+                            float_X const mass = attribute::getMass(
+                                weighting,
+                                particle
+                            );
+
+                            // calculate kinetic energy of the macro particle
+                            float_X particleEnergy = KinEnergy< >( )(
+                                mom,
+                                mass
+                            );
+
+                            particleEnergy /= weighting;
+
+                            // calculate bin number
+                            int binNumber = math::floor(
+                                ( particleEnergy - minEnergy ) /
+                                ( maxEnergy - minEnergy ) * static_cast< float_X >( numBins )
+                            );
+
+                            /* all entries larger than maxEnergy or smaller
+                             * than minEnergy are ignored
+                             */
+                            if( binNumber >= 0 and binNumber < numBins )
+                            {
+                                // artifical norm for reduce
+                                float_X const normedWeighting = weighting /
+                                    float_X( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE );
+
+                                atomicAddWrapper(
+                                    &( shLocalEnergyHistogram[ binNumber ] ),
+                                    normedWeighting
+                                );
+                            }
+                        }
+                    }
+                );
+
+                __syncthreads();
+
+                // go to next frame
+                ForEachIdx< MasterOnly >{ workerIdx }(
+                    [&](
+                        uint32_t const,
+                        uint32_t const
+                    )
+                    {
+                        frame = pb.getPreviousFrame( frame );
+                        particlesInSuperCell = maxParticlesPerFrame;
+                    }
+                );
+                __syncthreads();
+            }
+
+            // write histogram back to global memory (add)
+            ForEachIdx<
+                IdxConfig<
+                    numWorkers,
+                    numWorkers
+                >
+            >{ workerIdx }(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const
+                )
+                {
+                    for( int i = linearIdx; i < numBins; i += numWorkers )
+                        atomicAddWrapper(
+                            &( localEnergyHistogram[ i ] ),
+                            shLocalEnergyHistogram[ i ]
+                        );
+                }
+            );
+        }
+    };
+
+} // namespace helperFields
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.kernel
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogram.kernel
@@ -31,9 +31,6 @@
 #include "mappings/threads/ForEachIdx.hpp"
 #include "mappings/threads/IdxConfig.hpp"
 
-#include <string>
-#include <memory>
-
 
 namespace picongpu
 {
@@ -62,7 +59,7 @@ namespace helperFields
          * of the range of the histogram are ignored and not counted.
          *
          * @todo In case the local averging in flylite shall be larger then a
-         * supercell (in integer multiples), the results need to be merged.
+         * supercell (in multiples of integers), the results need to be merged.
          *
          * @tparam T_ParBox PMacc::ParticlesBox, particle box type
          * @tparam T_LocalEnergyHistogramBox PMacc::DataBox, local energy histograms,
@@ -112,8 +109,8 @@ namespace helperFields
                 mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
             );
             /* index inside local energy histogram in averaged space (has no GUARD)
-             * integer division: of we average over multiples of supercells
-             *                   this will select the right local energy
+             * integer division: we average over multiples of supercells;
+             *                   this index selects the according local energy
              *                   histogram in global RAM
              */
             DataSpace< simDim > const localEnergyBlock =

--- a/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
@@ -1,0 +1,169 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+#include "particles/flylite/helperFields/LocalEnergyHistogram.hpp"
+#include "particles/flylite/helperFields/LocalEnergyHistogram.kernel"
+
+// PMacc
+#include "static_assert.hpp"
+#include "Environment.hpp"
+#include "algorithms/ForEach.hpp"
+
+#include <string>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+namespace helperFields
+{
+namespace detail
+{
+    /** Takes a single species and adds it to a LocalEnergyHistogram
+     *
+     * @tparam T_SpeciesType a picongpu::Particles class with a particle species
+     */
+    template<
+        typename T_SpeciesType
+    >
+    struct AddSingleEnergyHistogram
+    {
+        using SpeciesType = T_SpeciesType;
+        using FrameType = typename SpeciesType::FrameType;
+
+        /** Functor
+         *
+         * @param currentStep the current time step
+         * @param eneHistLocal the GridBuffer for local energy histograms
+         * @param minEnergy minimum energy to account for (eV)
+         * @param maxEnergy maximum energy to account for (eV)
+         */
+        void operator()(
+            uint32_t currentStep,
+            std::shared_ptr< LocalEnergyHistogram > eneHistLocal,
+            float_X const minEnergy,
+            float_X const maxEnergy
+        )
+        {
+            DataConnector &dc = Environment<>::get().DataConnector();
+
+            // load particle without copy particle data to host
+            auto speciesTmp = dc.get< SpeciesType >( FrameType::getName(), true );
+
+            // mapper to access species in CORE & BORDER only
+            MappingDesc cellDescription(
+                speciesTmp->getParticlesBuffer().getSuperCellsLayout().getDataSpace() * SuperCellSize::toRT(),
+                GUARD_SIZE,
+                GUARD_SIZE
+            );
+            AreaMapping<
+                CORE + BORDER,
+                MappingDesc
+            > mapper( cellDescription );
+
+            // add energy histogram on top of existing data
+            constexpr uint32_t numWorkers = PMacc::traits::GetNumWorkers<
+                PMacc::math::CT::volume< SuperCellSize >::type::value
+            >::value;
+            PMACC_KERNEL( helperFields::KernelAddLocalEnergyHistogram< numWorkers >{ } )
+            (
+                // one block per local energy histogram
+                mapper.getGridDim(),
+                numWorkers
+            )
+            (
+                // start in border (jump over GUARD area)
+                speciesTmp->getDeviceParticlesBox(),
+                // start in border (has no GUARD area)
+                eneHistLocal->getGridBuffer().getDeviceBuffer( ).getDataBox( ),
+                minEnergy,
+                maxEnergy,
+                mapper
+            );
+
+            dc.releaseData( FrameType::getName() );
+        }
+    };
+}
+    /** Add a group of species to a local energy histogram
+     *
+     * Takes a list of species and fills the LocalEnergyHistogram with it.
+     * Ideally executed for a list of electron species or an photon species.
+     *
+     * @tparam T_SpeciesList sequence of picongpu::Particles to create a
+     *                       local energy histogram from
+     */
+    template<
+        typename T_SpeciesList
+    >
+    struct FillLocalEnergyHistogram
+    {
+        using SpeciesList = T_SpeciesList;
+
+        /** Functor
+         *
+         * @param currentStep the current time step
+         * @param speciesGroup naming for the group of species in T_SpeciesList
+         * @param minEnergy minimum energy to account for (eV)
+         * @param maxEnergy maximum energy to account for (eV)
+         */
+        void operator()(
+            uint32_t currentStep,
+            std::string const speciesGroup,
+            float_X const minEnergy,
+            float_X const maxEnergy
+        )
+        {
+            DataConnector &dc = Environment<>::get().DataConnector();
+
+            /* load local energy histogram field without copy data to host and
+             * zero it
+             */
+            auto eneHistLocal = dc.get< LocalEnergyHistogram >(
+                helperFields::LocalEnergyHistogram::getName( speciesGroup ),
+                true
+            );
+
+            // reset local energy histograms
+            eneHistLocal->getGridBuffer().getDeviceBuffer().setValue( float_X( 0.0 ) );
+
+            // add local energy histogram of each species in list
+            ForEach< SpeciesList, detail::AddSingleEnergyHistogram< bmpl::_1 > > addSingleEnergyHistogram;
+            addSingleEnergyHistogram( currentStep, eneHistLocal, minEnergy, maxEnergy );
+
+            /* note: for average != supercell the BORDER region would need to be
+             *       build up via communication accordingly
+             */
+
+            // release fields
+            dc.releaseData( helperFields::LocalEnergyHistogram::getName( speciesGroup ) );
+        }
+    };
+
+} // namespace helperFields
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
@@ -27,6 +27,7 @@
 #include "static_assert.hpp"
 #include "Environment.hpp"
 #include "algorithms/ForEach.hpp"
+#include "forward.hpp"
 
 #include <string>
 #include <memory>
@@ -63,7 +64,7 @@ namespace detail
          */
         void operator()(
             uint32_t currentStep,
-            std::shared_ptr< LocalEnergyHistogram > eneHistLocal,
+            std::shared_ptr< LocalEnergyHistogram > & eneHistLocal,
             float_X const minEnergy,
             float_X const maxEnergy
         )
@@ -132,7 +133,7 @@ namespace detail
          */
         void operator()(
             uint32_t currentStep,
-            std::string const speciesGroup,
+            std::string const & speciesGroup,
             float_X const minEnergy,
             float_X const maxEnergy
         )
@@ -152,7 +153,7 @@ namespace detail
 
             // add local energy histogram of each species in list
             ForEach< SpeciesList, detail::AddSingleEnergyHistogram< bmpl::_1 > > addSingleEnergyHistogram;
-            addSingleEnergyHistogram( currentStep, eneHistLocal, minEnergy, maxEnergy );
+            addSingleEnergyHistogram( currentStep, forward( eneHistLocal ), minEnergy, maxEnergy );
 
             /* note: for average != supercell the BORDER region would need to be
              *       build up via communication accordingly

--- a/src/picongpu/include/particles/flylite/helperFields/LocalRateMatrix.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalRateMatrix.hpp
@@ -28,7 +28,6 @@
 #include "memory/Array.hpp"
 
 #include <string>
-#include <memory>
 
 
 namespace picongpu
@@ -65,7 +64,7 @@ namespace helperFields
          * @param histSizeLocal spatial size of the local energy histogram
          */
         LocalRateMatrix(
-            std::string const ionSpeciesName,
+            std::string const & ionSpeciesName,
             DataSpace< simDim > const & histSizeLocal
         ) :
             m_rateMatrix( nullptr ),
@@ -81,7 +80,7 @@ namespace helperFields
         }
 
         static std::string
-        getName( std::string const speciesGroup )
+        getName( std::string const & speciesGroup )
         {
             return speciesGroup + "_RateMatrix";
         }

--- a/src/picongpu/include/particles/flylite/helperFields/LocalRateMatrix.hpp
+++ b/src/picongpu/include/particles/flylite/helperFields/LocalRateMatrix.hpp
@@ -1,0 +1,118 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "simulation_defines.hpp"
+
+// PMacc
+#include "dataManagement/ISimulationData.hpp"
+#include "dimensions/GridLayout.hpp"
+#include "memory/buffers/GridBuffer.hpp"
+#include "memory/Array.hpp"
+
+#include <string>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace flylite
+{
+namespace helperFields
+{
+    using namespace PMacc;
+
+    class LocalRateMatrix :
+        public ISimulationData
+    {
+    private:
+        /** A[iz, numpop, numpop] */
+        using RateMatrix = memory::Array<
+                memory::Array<
+                    memory::Array<
+                        float_X,
+                        picongpu::flylite::populations
+                    >,
+                    picongpu::flylite::populations
+                >,
+                picongpu::flylite::ionizationStates
+        >;
+         GridBuffer< RateMatrix, simDim >* m_rateMatrix;
+        std::string m_speciesName;
+
+    public:
+        /** Allocate and initialize local rate matrix for ion state transitions
+         *
+         * @param histSizeLocal spatial size of the local energy histogram
+         */
+        LocalRateMatrix(
+            std::string const ionSpeciesName,
+            DataSpace< simDim > const & histSizeLocal
+        ) :
+            m_rateMatrix( nullptr ),
+            m_speciesName( ionSpeciesName )
+        {
+            m_rateMatrix =
+                new GridBuffer< RateMatrix, simDim >( histSizeLocal );
+        }
+
+        ~LocalRateMatrix()
+        {
+            __delete( m_rateMatrix );
+        }
+
+        static std::string
+        getName( std::string const speciesGroup )
+        {
+            return speciesGroup + "_RateMatrix";
+        }
+
+        std::string
+        getName( )
+        {
+            return getName( m_speciesName );
+        }
+
+        GridBuffer< RateMatrix, simDim >&
+        getGridBuffer( )
+        {
+            return *m_rateMatrix;
+        }
+
+        /* implement ISimulationData members */
+        void
+        synchronize()
+        {
+            m_rateMatrix->deviceToHost( );
+        }
+
+        SimulationDataId
+        getUniqueId()
+        {
+            return getName();
+        }
+    };
+
+} // namespace helperFields
+} // namespace flylite
+} // namespace particles
+} // namespace picongpu

--- a/src/picongpu/include/particles/flylite/types/Superconfig.hpp
+++ b/src/picongpu/include/particles/flylite/types/Superconfig.hpp
@@ -31,7 +31,15 @@ namespace types
 {
     /** Ion Superconfiguration
      *
-     * This is the attribute type for an ion's hydrogenic superconfiguration.
+     * This is the attribute type for an ion's screened hydrogenic
+     * superconfiguration.
+     *
+     * See for details on screened hydrogenic levels:
+     *   H.-K. Chung, S.H. Hansen, H.A. Scott.
+     *   *Generalized Collisional Radiative Model Using*
+     *   *Screened Hydrogenic Levels*,
+     *   in Modern Methods in Collisional-Radiative Modeling of Plasmas,
+     *   edited by Y. Ralchenko (Springer, 2016) pp.51-79
      *
      * @tparam T_Type the float type to use, e.g. float_64
      * @tparam T_populations the number of populations to store for each ion,

--- a/src/picongpu/include/particles/flylite/types/Superconfig.hpp
+++ b/src/picongpu/include/particles/flylite/types/Superconfig.hpp
@@ -1,0 +1,50 @@
+/** Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "math/Vector.hpp"
+
+
+namespace picongpu
+{
+namespace flylite
+{
+namespace types
+{
+    /** Ion Superconfiguration
+     *
+     * This is the attribute type for an ion's hydrogenic superconfiguration.
+     *
+     * @tparam T_Type the float type to use, e.g. float_64
+     * @tparam T_populations the number of populations to store for each ion,
+     *                       range: [0, 255]
+     */
+    template<
+        typename T_Type,
+        uint8_t T_populations
+    >
+    using Superconfig = PMacc::math::Vector<
+        T_Type,
+        T_populations
+    >;
+} // namespace types
+} // namespace flylite
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/_defaultParam.loader
+++ b/src/picongpu/include/simulation_defines/_defaultParam.loader
@@ -30,6 +30,7 @@
 #include "simulation_defines/param/seed.param"
 #include "simulation_defines/param/precision.param"
 #include "simulation_defines/param/physicalConstants.param"
+#include "simulation_defines/param/flylite.param"
 #include "simulation_defines/param/speciesConstants.param"
 #include "simulation_defines/param/speciesAttributes.param"
 #include "simulation_defines/param/synchrotronPhotons.param"

--- a/src/picongpu/include/simulation_defines/param/flylite.param
+++ b/src/picongpu/include/simulation_defines/param/flylite.param
@@ -19,9 +19,10 @@
 
 /** @file
  *
- * Configuration file for the atomic particle population kinetics model FLYlite.
+ * This is the configuration file for the atomic particle population kinetics
+ * model FLYlite.
  * Its main purpose is non-LTE collisional-radiative modeling for transient
- * plasmas in high densities and/or interaction with (X-Ray) photon fields.
+ * plasmas at high densities and/or interaction with (X-Ray) photon fields.
  *
  * In simpler words, one can also use this module to simulate collisional
  * ionization processes without the assumption of a local thermal equilibrium
@@ -55,7 +56,7 @@ namespace flylite
         populations
     >;
 
-    /** ionization states of the atom (iz?)
+    /** ionization states of the atom (iz)
      *
      * range: [0, 255]
      */
@@ -64,8 +65,8 @@ namespace flylite
     /** number of energy bins
      *
      * energy steps used for local energy histograms
-     * @note: the actual number of bins will be 3 bins less:
-     *        we also need an overflow-, underflow- and sum-bin
+     * @note: no overflow- or underflow-bins are used, particles with energies
+     *        outside the range (see below) are ignored
      */
     constexpr uint16_t energies = 512u;
 
@@ -73,7 +74,7 @@ namespace flylite
      *
      * electron and photon histograms f(e) f(ph) are currently
      * calculated in a linearly binned histogram while particles with
-     * energies outside are ignored
+     * energies outside the ranges below are ignored
      *
      * unit: eV
      */
@@ -86,7 +87,7 @@ namespace flylite
      *
      * no seriously, per-supercell is the quickest way to average particle
      * quantities such as density, energy histogram, etc. and I won't implement
-     * an other size until needed
+     * another size until needed
      */
     using spatialAverageBox = SuperCellSize;
 } // namespace flylite

--- a/src/picongpu/include/simulation_defines/param/flylite.param
+++ b/src/picongpu/include/simulation_defines/param/flylite.param
@@ -1,0 +1,93 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configuration file for the atomic particle population kinetics model FLYlite.
+ * Its main purpose is non-LTE collisional-radiative modeling for transient
+ * plasmas in high densities and/or interaction with (X-Ray) photon fields.
+ *
+ * In simpler words, one can also use this module to simulate collisional
+ * ionization processes without the assumption of a local thermal equilibrium
+ * (LTE), contrary to popular collisional ionization models such as the
+ * Thomas-Fermi ionization model.
+ *
+ * This file configures the number of modeled populations for ions, spatial and
+ * spectral binning of non-LTE density and energy histograms.
+ *
+ * @todo this model is not yet fully complete
+ */
+#pragma once
+
+#include "particles/flylite/types/Superconfig.hpp"
+
+
+namespace picongpu
+{
+namespace flylite
+{
+    /** number of populations (numpop)
+     *
+     * this number defines how many configurations make up a superconfiguration
+     *
+     * range: [0, 255]
+     */
+    constexpr uint8_t populations = 3u; // example Cu data set: 32u
+
+    using Superconfig = types::Superconfig<
+        float_64,
+        populations
+    >;
+
+    /** ionization states of the atom (iz?)
+     *
+     * range: [0, 255]
+     */
+    constexpr uint8_t ionizationStates = 29u;
+
+    /** number of energy bins
+     *
+     * energy steps used for local energy histograms
+     * @note: the actual number of bins will be 3 bins less:
+     *        we also need an overflow-, underflow- and sum-bin
+     */
+    constexpr uint16_t energies = 512u;
+
+    /** energy range for electron and photon histograms
+     *
+     * electron and photon histograms f(e) f(ph) are currently
+     * calculated in a linearly binned histogram while particles with
+     * energies outside are ignored
+     *
+     * unit: eV
+     */
+    constexpr float_X electronMinEnergy = 0.0;
+    constexpr float_X electronMaxEnergy = 100.e3;
+    constexpr float_X photonMinEnergy = 0.0;
+    constexpr float_X photonMaxEnergy = 100.e3;
+
+    /** you better not change this line, the wooooorld depends on it!
+     *
+     * no seriously, per-supercell is the quickest way to average particle
+     * quantities such as density, energy histogram, etc. and I won't implement
+     * an other size until needed
+     */
+    using spatialAverageBox = SuperCellSize;
+} // namespace flylite
+} // namespace picongpu

--- a/src/picongpu/include/simulation_defines/param/species.param
+++ b/src/picongpu/include/simulation_defines/param/species.param
@@ -34,6 +34,7 @@
 #include "fields/currentDeposition/Solver.def"
 
 #include "particles/InitFunctors.hpp"
+#include "particles/flylite/NonLTE.def"
 #include "particles/manipulators/manipulators.def"
 
 

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -82,6 +82,18 @@ value_identifier(bool, radiationMask, false);
  */
 value_identifier(float_X,boundElectrons,float_X(0.0));
 
+/** atomic superconfiguration
+ *
+ * atomic configuration of an ion for collisional-radiative modeling
+ *
+ * \see flylite.param
+ */
+value_identifier(
+    flylite::Superconfig,
+    superconfig,
+    flylite::Superconfig::create( 0. )
+);
+
 /** Total cell index of a particle.
  *
  *  The total cell index is a

--- a/src/picongpu/include/simulation_defines/param/speciesAttributes.param
+++ b/src/picongpu/include/simulation_defines/param/speciesAttributes.param
@@ -140,6 +140,11 @@ alias(atomicNumbers);
  */
 alias(effectiveNuclearCharge);
 
+/*! alias for particle population kinetics model, e.g. FLYlite
+ * @see flylite.param
+ */
+alias(populationKinetics);
+
 /*! alias for particle mass ratio
  *
  * mass ratio between base particle @see `speciesConstants.param` SI::BASE_MASS_SI

--- a/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
+++ b/src/picongpu/include/simulation_defines/unitless/speciesAttributes.unitless
@@ -416,5 +416,43 @@ struct WeightingPower<boundElectrons>
     }
 };
 
+template<>
+struct Unit<superconfig>
+{
+    // unitless and not scaled by a factor: 1.0
+    static std::vector<double> get()
+    {
+        return std::vector<double>( picongpu::flylite::populations, 1.0 );
+    }
+};
+template<>
+struct UnitDimension<superconfig>
+{
+    static std::vector<float_64> get()
+    {
+        // superconfig is unitless
+        std::vector<float_64> unitDimension( NUnitDimension, 0.0 );
+
+        return unitDimension;
+    }
+};
+template<>
+struct MacroWeighted<superconfig>
+{
+    // represented by (1) or (weighted) ions???
+    static bool get()
+    {
+        return false;
+    }
+};
+template<>
+struct WeightingPower<superconfig>
+{
+    static float_64 get()
+    {
+        return 1.0;
+    }
+};
+
 } // namespace traits
 } // namespace picongpu


### PR DESCRIPTION
This PR adds the interface for FLYlite non-LTE collisional-radiative modeling for ions.

Read it commit-wise. Implements:

- ion attribute `superconfig` (not used yet, but already initialized when used)
- ion alias/flag `populationKinetics` to enable non-LTE calculations for an ion species
- adds FLYlite API
- adds particle functors and implements all RT interfaces in `MySimulation`
- creates helper fields and fills them with proper values (histograms and densities)
- updates the WarmCopper example to use the `populationKinetics` algorithms (so the compile-suite catches it), RT tests on K80 were successful

The actual population kinetics is not part of this PR and still in development.