### PR TITLE
fix nvcc compile with boost 1.64.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -92,7 +92,7 @@ zlib
 
 boost
 """""
-- 1.57.0-1.63.0 (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math``, ``serialization`` and nearly all header-only libs)
+- 1.57.0-1.64.0 (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math``, ``serialization`` and nearly all header-only libs)
 - download from `http://www.boost.org <http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.gz/download>`_
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-serialization-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``

--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -295,14 +295,13 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_SMART_PTR")
 endif()
 
-# Boost 1.64.0 is broken with CUDA 8.0 and C++11
+# Boost 1.64.0 is broken with CUDA 8.0 (nvcc) and C++11
 #   https://github.com/ComputationalRadiationPhysics/picongpu/issues/2048
 #   fixed in CUDA 9.0 (ticket 1928813)
-if( (Boost_VERSION EQUAL 106400) AND
+if( ("${PMACC_CUDA_COMPILER}" STREQUAL "nvcc") AND
+    (Boost_VERSION EQUAL 106400) AND
     (CUDA_VERSION VERSION_EQUAL 8.0) )
-    message(FATAL_ERROR "Boost 1.64.0 and CUDA 8.0 are incompatible due to "
-                        "a bug in the CUDA compiler. Please use, e.g. Boost "
-                        "1.63.0 instead.")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_NOEXCEPT")
 endif()
 
 


### PR DESCRIPTION
fix #2048 follow-up to #2069

disable boost noexept if nvcc with (CUDA 8.0) is the device compiler and boost 1.64.0 is used

# Tests

- [x] nvcc compile with boost 1.64.0
- [x] clang compile with boost 1.64.0