### PR TITLE
remove `ParticlesBuffer::createParticleBuffer()`

### DIFF
--- a/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/src/libPMacc/include/particles/memory/buffers/ParticlesBuffer.hpp
@@ -189,10 +189,6 @@ public:
 
         superCells = new GridBuffer<SuperCellType, DIM > (superCellsCount);
 
-    }
-
-    void createParticleBuffer()
-    {
         reset();
     }
 

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -91,7 +91,7 @@ struct CreateSpecies
 };
 
 template<typename T_SpeciesType>
-struct CallCreateParticleBuffer
+struct LogMemoryStatisticsForSpecies
 {
     using SpeciesType = T_SpeciesType;
     using FrameType = typename SpeciesType::FrameType;
@@ -105,11 +105,6 @@ struct CallCreateParticleBuffer
             deviceHeap->getAvailableSlots(sizeof (FrameType)) %
             sizeof (FrameType) %
             FrameType::getName();
-
-        DataConnector &dc = Environment<>::get().DataConnector();
-        auto species = dc.get< SpeciesType >( FrameType::getName(), true );
-        species->createParticleBuffer();
-        dc.releaseData( FrameType::getName() );
     }
 };
 

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -373,8 +373,8 @@ public:
         MallocMCBuffer<DeviceHeap>* mallocMCBuffer = new MallocMCBuffer<DeviceHeap>(deviceHeap);
         dc.share( std::shared_ptr< ISimulationData >( mallocMCBuffer ) );
 
-        ForEach< VectorAllSpecies, particles::CallCreateParticleBuffer<bmpl::_1> > createParticleBuffer;
-        createParticleBuffer( deviceHeap );
+        ForEach< VectorAllSpecies, particles::LogMemoryStatisticsForSpecies<bmpl::_1> > logMemoryStatisticsForSpecies;
+        logMemoryStatisticsForSpecies( deviceHeap );
 
         Environment<>::get().MemoryInfo().getMemoryInfo(&freeGpuMem);
         log<picLog::MEMORY > ("free mem after all mem is allocated %1% MiB") % (freeGpuMem / 1024 / 1024);


### PR DESCRIPTION
- remove method `createParticleBuffer()`
- call member method `reset()` within the constructor to have a valid object after creation
- `CallCreateParticleBuffer` 
  - rename to `LogMemoryStatisticsForSpecies`
  - remove call to `createParticleBuffer()`
- `MySimulation.hpp: call `LogMemoryStatisticsForSpecies` for each species

Note: This pull request contains two changes but a splitting it into two pull request make no sense.

## Test

- [x] default KHI