### PR TITLE
lockstep refactoring of `KernelBashParticles`

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -179,10 +179,11 @@ public:
     template<uint32_t T_area>
     void deleteParticlesInArea();
 
-    /* Bash particles in a direction.
-     * Copy all particles from the guard of a direction to the device exchange buffer
+    /** copy gard particles to intermediate exchange buffer
+     *
+     * Copy all particles from the guard of a direction to the device exchange buffer.
      */
-    void bashParticles(uint32_t exchangeType);
+    void copyGuardToExchange(uint32_t exchangeType);
 
     /* Insert all particles which are in device exchange buffer
      */

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -920,8 +920,9 @@ struct KernelCopyGuardToExchange
         DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
         uint32_t const workerIdx = threadIdx.x;
 
+        // number of particles in the current handled frame
         PMACC_SMEM(
-            numBashedParticles,
+            numParticles,
             int
         );
         PMACC_SMEM(
@@ -930,7 +931,7 @@ struct KernelCopyGuardToExchange
         );
 
         /* `exchangeChunk` is a view to a chunk of the memory in the exchange-
-         * The chunk contains between 0 and `numBashedParticles` particles
+         * The chunk contains between 0 and `numParticles` particles
          * and is updated for each frame.
          */
         PMACC_SMEM(
@@ -975,11 +976,14 @@ struct KernelCopyGuardToExchange
                 numWorkers
             >;
 
+            /* the index of the gap in the exchange box where the particle
+             * is copied to
+             */
             memory::CtxArray<
                 lcellId_t,
                 ParticleDomCfg
             >
-            bashIdxCtx( INV_LOC_IDX );
+            exchangeGapIdxCtx( INV_LOC_IDX );
 
             onlyMaster(
                 [&](
@@ -987,7 +991,7 @@ struct KernelCopyGuardToExchange
                     uint32_t const
                 )
                 {
-                    numBashedParticles = 0;
+                    numParticles = 0;
                 }
             );
 
@@ -1004,13 +1008,13 @@ struct KernelCopyGuardToExchange
                 {
                     if ( frame[ linearIdx ][ multiMask_ ] == 1 )
                     {
-                        bashIdxCtx[ idx ] = nvidia::atomicAllInc( &numBashedParticles );
+                        exchangeGapIdxCtx[ idx ] = nvidia::atomicAllInc( &numParticles );
                     }
                 }
             );
             __syncthreads( );
 
-            if( numBashedParticles > 0 )
+            if( numParticles > 0 )
             {
 
                 onlyMaster(
@@ -1021,14 +1025,14 @@ struct KernelCopyGuardToExchange
                     {
                         // try to get as many memory as particles in the current frame
                         exchangeChunk = exchangeBox.pushN(
-                            numBashedParticles,
+                            numParticles,
                             // Compute the target supercell depending on the exchangeType
                             DataSpaceOperations< dim >::reduce(
                                 superCellIdx,
                                 mapper.getExchangeType( )
                             )
                         );
-                        if( exchangeChunk.getSize( ) < numBashParticles )
+                        if( exchangeChunk.getSize( ) < numParticles )
                             allParticlesCopied = false;
                     }
                 );
@@ -1041,9 +1045,9 @@ struct KernelCopyGuardToExchange
                         uint32_t const idx
                     )
                     {
-                        if( bashIdxCtx[ idx ] != INV_LOC_IDX && bashIdxCtx[ idx ] < borderChunk.getSize( ) )
+                        if( exchangeGapIdxCtx[ idx ] != INV_LOC_IDX && exchangeGapIdxCtx[ idx ] < exchangeChunk.getSize( ) )
                         {
-                            auto parDest = exchangeChunk[ bashIdxCtx[ idx ] ][ 0 ];
+                            auto parDest = exchangeChunk[ exchangeGapIdxCtx[ idx ] ][ 0 ];
                             auto parSrc = frame[ linearIdx ];
                             assign( parDest, parSrc );
                             parSrc[ multiMask_ ] = 0;

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -876,21 +876,21 @@ struct KernelDeleteParticles
     }
 };
 
-/** copy particle from the border to a exchange buffer
+/** copy particles from the guard to an exchange buffer
  *
  * @tparam T_numWorkers number of workers
  */
 template< uint32_t T_numWorkers >
-struct KernelBashParticles
+struct KernelCopyGuardToExchange
 {
-    /** copy border particle to a exchange buffer
+    /** copy guard particles to an exchange buffer
      *
      * @tparam T_ParBox PMacc::ParticlesBox, particle box type
      * @tparam T_ExchangeValueType frame type of the exchange buffer
      * @tparam T_Mapping mapper functor type
      *
      * @param pb particle memory
-     * @param border exchange buffer for particles
+     * @param exchangeBox exchange buffer for particles
      * @param mapper functor to map a block to a supercell
      */
     template<
@@ -899,13 +899,13 @@ struct KernelBashParticles
         typename T_Mapping
     >
     DINLINE void operator()(
-        T_ParBox pb,
+        T_ParBox & pb,
         ExchangePushDataBox<
             vint_t,
             T_ExchangeValueType,
             T_Mapping::Dim - 1
-        > border,
-        T_Mapping mapper
+        > & exchangeBox,
+        T_Mapping const & mapper
     ) const
     {
         using namespace particles::operations;
@@ -928,13 +928,24 @@ struct KernelBashParticles
             frame,
             FramePtr
         );
+
+        /* `exchangeChunk` is a view to a chunk of the memory in the exchange-
+         * The chunk contains between 0 and `numBashedParticles` particles
+         * and is updated for each frame.
+         */
         PMACC_SMEM(
-            hasMemory,
-            bool
-        );
-        PMACC_SMEM(
-            tmpBorder,
+            exchangeChunk,
             TileDataBox< T_ExchangeValueType >
+        );
+
+        /* flag: define if all particles from the current frame are copied to the
+         * exchange buffer
+         *
+         * `true` if all particles are copied, else `false`
+         */
+        PMACC_SMEM(
+            allParticlesCopied,
+            bool
         );
 
         ForEachIdx<
@@ -950,14 +961,14 @@ struct KernelBashParticles
                 uint32_t const
             )
             {
-                hasMemory = true;
+                allParticlesCopied = true;
                 frame = pb.getLastFrame( superCellIdx );
             }
         );
 
         __syncthreads( );
 
-        while ( frame.isValid( ) && hasMemory )
+        while ( frame.isValid( ) && allParticlesCopied )
         {
             using ParticleDomCfg = IdxConfig<
                 frameSize,
@@ -1008,7 +1019,8 @@ struct KernelBashParticles
                         uint32_t const
                     )
                     {
-                        tmpBorder = border.pushN(
+                        // try to get as many memory as particles in the current frame
+                        exchangeChunk = exchangeBox.pushN(
                             numBashedParticles,
                             // Compute the target supercell depending on the exchangeType
                             DataSpaceOperations< dim >::reduce(
@@ -1016,8 +1028,8 @@ struct KernelBashParticles
                                 mapper.getExchangeType( )
                             )
                         );
-                        if( tmpBorder.getSize( ) < numBashedParticles )
-                            hasMemory = false;
+                        if( exchangeChunk.getSize( ) < numBashParticles )
+                            allParticlesCopied = false;
                     }
                 );
 
@@ -1029,9 +1041,9 @@ struct KernelBashParticles
                         uint32_t const idx
                     )
                     {
-                        if( bashIdxCtx[ idx ] != INV_LOC_IDX && bashIdxCtx[ idx ] < tmpBorder.getSize( ) )
+                        if( bashIdxCtx[ idx ] != INV_LOC_IDX && bashIdxCtx[ idx ] < borderChunk.getSize( ) )
                         {
-                            auto parDest = tmpBorder[ bashIdxCtx[ idx ] ][ 0 ];
+                            auto parDest = exchangeChunk[ bashIdxCtx[ idx ] ][ 0 ];
                             auto parSrc = frame[ linearIdx ];
                             assign( parDest, parSrc );
                             parSrc[ multiMask_ ] = 0;
@@ -1047,10 +1059,10 @@ struct KernelBashParticles
                     uint32_t const
                 )
                 {
-                    /* do not remove the frame if we had not enough memory for
-                     * all particles in the tmpBorder buffer
+                    /* do not remove the frame if we had not copied
+                     * all particles from the current frame to the exchange buffer
                      */
-                    if ( hasMemory )
+                    if ( allParticlesCopied )
                         frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
                 }
             );

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -876,92 +876,196 @@ struct KernelDeleteParticles
     }
 };
 
+/** copy particle from the border to a exchange buffer
+ *
+ * @tparam T_numWorkers number of workers
+ */
+template< uint32_t T_numWorkers >
 struct KernelBashParticles
 {
-    template< class ParBox, class BORDER, class Mapping>
+    /** copy border particle to a exchange buffer
+     *
+     * @tparam T_ParBox PMacc::ParticlesBox, particle box type
+     * @tparam T_ExchangeValueType frame type of the exchange buffer
+     * @tparam T_Mapping mapper functor type
+     *
+     * @param pb particle memory
+     * @param border exchange buffer for particles
+     * @param mapper functor to map a block to a supercell
+     */
+    template<
+        typename T_ParBox,
+        typename T_ExchangeValueType,
+        typename T_Mapping
+    >
     DINLINE void operator()(
-        ParBox pb,
-        ExchangePushDataBox<vint_t, BORDER, Mapping::Dim - 1 > border,
-        Mapping mapper ) const
+        T_ParBox pb,
+        ExchangePushDataBox<
+            vint_t,
+            T_ExchangeValueType,
+            T_Mapping::Dim - 1
+        > border,
+        T_Mapping mapper
+    ) const
     {
         using namespace particles::operations;
+        using namespace mappings::threads;
 
-        enum
-        {
-            TileSize = math::CT::volume<typename Mapping::SuperCellSize>::type::value,
-            Dim = Mapping::Dim
-        };
-        typedef typename ParBox::FramePtr FramePtr;
+        constexpr uint32_t dim = T_Mapping::Dim;
+        constexpr uint32_t frameSize = math::CT::volume< typename T_ParBox::FrameType::SuperCellSize >::type::value;
+        constexpr uint32_t numWorkers = T_numWorkers;
 
-        DataSpace<Dim> superCellIdx = mapper.getSuperCellIndex( DataSpace<Dim > (blockIdx) );
+        using FramePtr = typename T_ParBox::FramePtr;
 
-        PMACC_SMEM( numBashedParticles, int );
-        PMACC_SMEM( frame, FramePtr );
-        PMACC_SMEM( hasMemory, bool );
-        PMACC_SMEM( tmpBorder, TileDataBox<BORDER> );
+        DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
+        uint32_t const workerIdx = threadIdx.x;
 
-        if ( threadIdx.x == 0 )
-        {
-            hasMemory = true;
-            frame = pb.getLastFrame( superCellIdx );
-        }
-        //\todo: eventuell ist es schneller, parallelen und seriellen Code zu trennen
+        PMACC_SMEM(
+            numBashedParticles,
+            int
+        );
+        PMACC_SMEM(
+            frame,
+            FramePtr
+        );
+        PMACC_SMEM(
+            hasMemory,
+            bool
+        );
+        PMACC_SMEM(
+            tmpBorder,
+            TileDataBox< T_ExchangeValueType >
+        );
+
+        ForEachIdx<
+            IdxConfig<
+                1,
+                numWorkers
+            >
+        > onlyMaster{ workerIdx };
+
+        onlyMaster(
+            [&](
+                uint32_t const,
+                uint32_t const
+            )
+            {
+                hasMemory = true;
+                frame = pb.getLastFrame( superCellIdx );
+            }
+        );
+
         __syncthreads( );
+
         while ( frame.isValid( ) && hasMemory )
         {
-            lcellId_t bashIdx = INV_LOC_IDX;
-            if ( threadIdx.x == 0 )
-                numBashedParticles = 0;
+            using ParticleDomCfg = IdxConfig<
+                frameSize,
+                numWorkers
+            >;
+
+            memory::CtxArray<
+                lcellId_t,
+                ParticleDomCfg
+            >
+            bashIdxCtx( INV_LOC_IDX );
+
+            onlyMaster(
+                [&](
+                    uint32_t const,
+                    uint32_t const
+                )
+                {
+                    numBashedParticles = 0;
+                }
+            );
+
             __syncthreads( );
 
-            if ( frame[threadIdx.x][multiMask_] == 1 )
-            {
-                bashIdx = nvidia::atomicAllInc( &numBashedParticles );
-            }
+             // loop over all particles in the frame
+            ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
+
+            forEachParticle(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
+                {
+                    if ( frame[ linearIdx ][ multiMask_ ] == 1 )
+                    {
+                        bashIdxCtx[ idx ] = nvidia::atomicAllInc( &numBashedParticles );
+                    }
+                }
+            );
             __syncthreads( );
 
-            if ( numBashedParticles > 0 )
+            if( numBashedParticles > 0 )
             {
 
-                if ( threadIdx.x == 0 )
-                {
-                    // DataSpaceOperations<DIM2>::reduce computes target position for domainTile and exchangeType
-                    tmpBorder = border.pushN( numBashedParticles,
-                                              DataSpaceOperations<Dim>::reduce(
-                                                                                superCellIdx,
-                                                                                mapper.getExchangeType( ) ) );
-                    if ( tmpBorder.getSize( ) < numBashedParticles )
-                        hasMemory = false;
-                }
+                onlyMaster(
+                    [&](
+                        uint32_t const,
+                        uint32_t const
+                    )
+                    {
+                        tmpBorder = border.pushN(
+                            numBashedParticles,
+                            // Compute the target supercell depending on the exchangeType
+                            DataSpaceOperations< dim >::reduce(
+                                superCellIdx,
+                                mapper.getExchangeType( )
+                            )
+                        );
+                        if( tmpBorder.getSize( ) < numBashedParticles )
+                            hasMemory = false;
+                    }
+                );
+
                 __syncthreads( );
 
-                if ( bashIdx != INV_LOC_IDX && bashIdx < tmpBorder.getSize( ) )
-                {
-                    auto parDest = tmpBorder[bashIdx][0];
-                    auto parSrc = (frame[threadIdx.x]);
-                    assign( parDest, parSrc );
-                    parSrc[multiMask_] = 0;
-                }
+                forEachParticle(
+                    [&](
+                        uint32_t const linearIdx,
+                        uint32_t const idx
+                    )
+                    {
+                        if( bashIdxCtx[ idx ] != INV_LOC_IDX && bashIdxCtx[ idx ] < tmpBorder.getSize( ) )
+                        {
+                            auto parDest = tmpBorder[ bashIdxCtx[ idx ] ][ 0 ];
+                            auto parSrc = frame[ linearIdx ];
+                            assign( parDest, parSrc );
+                            parSrc[ multiMask_ ] = 0;
+                        }
+                    }
+                );
                 __syncthreads( );
+            }
 
-                if ( threadIdx.x == 0 && hasMemory )
+            onlyMaster(
+                [&](
+                    uint32_t const,
+                    uint32_t const
+                )
                 {
-                    //always remove the last frame
-                    frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
+                    /* do not remove the frame if we had not enough memory for
+                     * all particles in the tmpBorder buffer
+                     */
+                    if ( hasMemory )
+                        frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
                 }
-            }
-            else
-            {
-                //if we had no particles to copy than we are the last and only frame
-                if ( threadIdx.x == 0 )
-                {
-                    frame = getPreviousFrameAndRemoveLastFrame( frame, pb, superCellIdx );
-                }
-            }
+            );
+
             __syncthreads( );
         }
-        if ( threadIdx.x == 0 )
-            pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
+        onlyMaster(
+            [&](
+                uint32_t const,
+                uint32_t const
+            )
+            {
+                pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
+            }
+        );
 
     }
 };

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -81,7 +81,7 @@ namespace PMacc
     }
 
     template<typename T_ParticleDescription, class MappingDesc, typename T_DeviceHeap>
-    void ParticlesBase<T_ParticleDescription, MappingDesc, T_DeviceHeap>::bashParticles( uint32_t exchangeType )
+    void ParticlesBase<T_ParticleDescription, MappingDesc, T_DeviceHeap>::copyGuardToExchange( uint32_t exchangeType )
     {
         if( particlesBuffer->hasSendExchange( exchangeType ) )
         {

--- a/src/libPMacc/include/particles/ParticlesBase.tpp
+++ b/src/libPMacc/include/particles/ParticlesBase.tpp
@@ -99,7 +99,7 @@ namespace PMacc
                 math::CT::volume< typename FrameType::SuperCellSize >::type::value
             >::value;
 
-            PMACC_KERNEL( KernelBashParticles< numWorkers >{ } )(
+            PMACC_KERNEL( KernelCopyGuardToExchange< numWorkers >{ } )(
                 mapper.getGridDim( ),
                 numWorkers
             )(

--- a/src/libPMacc/include/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/src/libPMacc/include/particles/tasks/TaskSendParticlesExchange.hpp
@@ -50,7 +50,7 @@ namespace PMacc
         {
             state = Init;
             __startTransaction(initDependency);
-            parBase.bashParticles(exchange);
+            parBase.copyGuardToExchange(exchange);
             tmpEvent = __endTransaction();
             state = WaitForBash;
         }


### PR DESCRIPTION
- rewrite kernel with the lockstep programming model
- add documentation
- rename `KernelBashParticles` to `KernelCopyGuardToExchange`
- rename `ParticlesBase::bashParticles` to `ParticlesBase::copyGuardToExchange`

[HowTo lockstep programming](http://picongpu.readthedocs.io/en/dev/prgpatterns/lockstep.html)

## Tests

- [x] default KHI
- [x] change name of the variable`hasMemory`