### PR TITLE
move folder `fields/tasks` to libPMacc

### DIFF
--- a/src/libPMacc/include/fields/tasks/FieldFactory.hpp
+++ b/src/libPMacc/include/fields/tasks/FieldFactory.hpp
@@ -1,19 +1,21 @@
 /* Copyright 2013-2017 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/libPMacc/include/fields/tasks/FieldFactory.tpp
+++ b/src/libPMacc/include/fields/tasks/FieldFactory.tpp
@@ -1,19 +1,21 @@
 /* Copyright 2013-2017 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/libPMacc/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
+++ b/src/libPMacc/include/fields/tasks/TaskFieldReceiveAndInsert.hpp
@@ -1,19 +1,21 @@
 /* Copyright 2013-2017 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/libPMacc/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/src/libPMacc/include/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -1,19 +1,21 @@
 /* Copyright 2013-2017 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/libPMacc/include/fields/tasks/TaskFieldSend.hpp
+++ b/src/libPMacc/include/fields/tasks/TaskFieldSend.hpp
@@ -1,19 +1,21 @@
 /* Copyright 2013-2017 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/libPMacc/include/fields/tasks/TaskFieldSendExchange.hpp
+++ b/src/libPMacc/include/fields/tasks/TaskFieldSendExchange.hpp
@@ -1,19 +1,21 @@
 /* Copyright 2013-2017 Rene Widera
  *
- * This file is part of PIConGPU.
+ * This file is part of libPMacc.
  *
- * PIConGPU is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * PIConGPU is distributed in the hope that it will be useful,
+ * libPMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with PIConGPU.
+ * and the GNU Lesser General Public License along with libPMacc.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 


### PR DESCRIPTION
- move `fields/tasks` to libPMacc
- change PIConGPU license to libPMacc license for the moved files

This is a cosmetic change to simplify a follow up change that the PIConGPU `FieldTmp` and `FieldJ` used the same kernel to `bash`(copy the border of the simulation area to a exchange buffer) and `insert`(copy exchange buffer to the simulation border).
Short: This will become a generic functionality for a N-dimensional GridBuffer.

# Note for the review:
- I have only moved the files
- there is no content/formation change beside the license

# Tests

- [x] default KHI