### PR TITLE
Profile Preparations

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -119,8 +119,11 @@ rsync
 - *Arch Linux:* ``sudo pacman --sync rsync``
 - *Spack:* ``spack install rsync``
 
-PIConGPU source code
-""""""""""""""""""""
+.. _install-dependencies-picongpu:
+
+PIConGPU Source Code
+^^^^^^^^^^^^^^^^^^^^
+
 - ``git clone https://github.com/ComputationalRadiationPhysics/picongpu.git $HOME/src/picongpu``
 
   - *optional:* update the source code with ``cd $HOME/src/picongpu && git fetch && git pull``

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -16,10 +16,12 @@ Ideally, store that file directly in your ``$HOME/`` and source it after connect
 
    . $HOME/picongpu.profile
 
-We listed some example `picongpu.profile` files below which can be used to set up PIConGPU's dependencies on various HPC systems.
+We listed some example ``picongpu.profile`` files below which can be used to set up PIConGPU's dependencies on various HPC systems.
 
 Hypnos (HZDR)
 -------------
+
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` manually.
 
 .. literalinclude:: submit/hypnos-hzdr/picongpu.profile.example
    :language: bash
@@ -27,11 +29,15 @@ Hypnos (HZDR)
 Titan (ORNL)
 ------------
 
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`libSplash, libpng and PNGwriter <install-dependencies>` manually.
+
 .. literalinclude:: submit/titan-ornl/picongpu.profile.example
    :language: bash
 
 Piz Daint (CSCS)
 ----------------
+
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`boost, PNGwriter and ADIOS <install-dependencies>` manually.
 
 .. literalinclude:: submit/pizdaint-cscs/picongpu.profile.example
    :language: bash
@@ -39,11 +45,16 @@ Piz Daint (CSCS)
 Taurus (TU Dresden)
 -------------------
 
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter and libSplash <install-dependencies>` manually.
+
 .. literalinclude:: submit/taurus-tud/picongpu.profile.example
    :language: bash
 
 Lawrencium (LBNL)
 -----------------
+
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`boost, PNGwriter and libSplash <install-dependencies>` manually.
+Additionally, you need to make the ``rsync`` command available as written below.
 
 .. literalinclude:: submit/lawrencium-lbnl/picongpu.profile.example
    :language: bash


### PR DESCRIPTION
For the `picongpu.profile` files already listed, note which preparations are necessary to be installed. (See comment in #2093, report in #2092)

In the future #1969, PIConGPU's source will be a module on HPC systems, too. (Alternatively, a `spack install` command or similar.)