### PR TITLE
call `KernelFillGaps*` from device

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.hpp
+++ b/src/libPMacc/include/particles/ParticlesBase.hpp
@@ -120,12 +120,6 @@ protected:
             PMACC_KERNEL(KernelShiftParticles< numWorkers >{})
                 (mapper.getGridDim(), numWorkers)
                 (pBox, mapper);
-            PMACC_KERNEL(KernelFillGaps< numWorkers >{})
-                (mapper.getGridDim(), numWorkers)
-                (pBox, mapper);
-            PMACC_KERNEL(KernelFillGapsLastFrame< numWorkers >{})
-                (mapper.getGridDim(), numWorkers)
-                (pBox, mapper);
         }
         while (mapper.next());
 
@@ -146,10 +140,6 @@ protected:
         >::value;
 
         PMACC_KERNEL(KernelFillGaps< numWorkers >{})
-            (mapper.getGridDim(), numWorkers)
-            (particlesBuffer->getDeviceParticleBox(), mapper);
-
-        PMACC_KERNEL(KernelFillGapsLastFrame< numWorkers >{})
             (mapper.getGridDim(), numWorkers)
             (particlesBuffer->getDeviceParticleBox(), mapper);
     }

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -231,6 +231,8 @@ struct KernelFillGapsLastFrame
 /** fill particle gaps in all frames
  *
  * Copy all particles from the end to the gaps at the beginning of the frame list.
+ * The functor fulfills the restriction that the last frame must be hold a contiguous
+ * number of valid particles at the beginning and a subsequent, contiguous gap at the end.
  *
  * @tparam T_numWorkers number of workers
  */
@@ -457,14 +459,28 @@ struct KernelFillGaps
             __syncthreads( );
 
         }
+
+        // fill all gaps in the last frame of the supercell
+        KernelFillGapsLastFrame< numWorkers >{ }(
+            pb,
+            mapper
+        );
     }
 };
 
+/** shift particles those leaving the supercell
+ *
+ * The functor fulfills the restriction that all frames expect the last
+ * must be filled with as many particles as can be stored in a frame.
+ *
+ * @tparam T_numWorkers number of workers
+ */
 template< uint32_t T_numWorkers >
 struct KernelShiftParticles
 {
-    /*! This kernel move particles to the next supercell
-     * This kernel can only run with a double checker board
+    /** This kernel move particles to the next supercell
+     *
+     * @warning this kernel can only run with a double checker board
      */
     template<
         class T_ParBox,
@@ -756,6 +772,11 @@ struct KernelShiftParticles
             }
         );
 
+        // fill all gaps in the frame list of the supercell
+        KernelFillGaps< numWorkers >{ }(
+            pb,
+            mapper
+        );
     }
 };
 

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -87,7 +87,7 @@ struct KernelFillGapsLastFrame
         constexpr uint32_t dim = T_Mapping::Dim;
         constexpr uint32_t numWorkers = T_numWorkers;
 
-        typedef typename T_ParBox::FramePtr FramePtr;
+        using FramePtr = typename T_ParBox::FramePtr;
 
         DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim > ( blockIdx ) );
 
@@ -468,17 +468,17 @@ struct KernelFillGaps
     }
 };
 
-/** shift particles those leaving the supercell
+/** shift particles leaving the supercell
  *
- * The functor fulfills the restriction that all frames expect the last
- * must be filled with as many particles as can be stored in a frame.
+ * The functor fulfills the restriction that all frames except the last
+ * must be fully filled with particles as can be stored in a frame.
  *
  * @tparam T_numWorkers number of workers
  */
 template< uint32_t T_numWorkers >
 struct KernelShiftParticles
 {
-    /** This kernel move particles to the next supercell
+    /** This kernel moves particles to the next supercell
      *
      * @warning this kernel can only run with a double checker board
      */
@@ -740,7 +740,7 @@ struct KernelShiftParticles
                     uint32_t const
                 )
                 {
-                    /* if the `low frame` is now full, each master thread removes it and
+                    /* if the `low frame` is full, each master thread
                      * uses the `high frame` (is invalid, if still empty) as the next
                      * `low frame` for the following iteration of the loop
                      */

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -52,304 +52,6 @@ getPreviousFrameAndRemoveLastFrame( const typename T_ParticleBox::FramePtr& fram
     return result;
 }
 
-template< uint32_t T_numWorkers >
-struct KernelShiftParticles
-{
-    /*! This kernel move particles to the next supercell
-     * This kernel can only run with a double checker board
-     */
-    template<
-        class T_ParBox,
-        class Mapping
-    >
-    DINLINE void operator()(
-        T_ParBox pb,
-        Mapping mapper
-    ) const
-    {
-        using ParBox = T_ParBox;
-        using FrameType = typename ParBox::FrameType;
-        using FramePtr = typename ParBox::FramePtr;
-
-        constexpr uint32_t dim = Mapping::Dim;
-        constexpr uint32_t frameSize = math::CT::volume< typename FrameType::SuperCellSize >::type::value;
-        /* number exchanges in 2D=9 and in 3D=27 */
-        constexpr uint32_t numExchanges = traits::NumberOfExchanges< dim >::value;
-        constexpr uint32_t numWorkers = T_numWorkers;
-
-        /* define memory for two times Exchanges
-         * index range [0,numExchanges-1] are being referred to as `low frames`
-         * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
-         */
-        PMACC_SMEM(
-            destFrames,
-            memory::Array<
-                FramePtr,
-                numExchanges * 2
-            >
-        );
-        //count particles per frame
-        PMACC_SMEM(
-            destFramesCounter,
-            memory::Array<
-                int,
-                numExchanges
-            >
-        );
-
-        PMACC_SMEM(
-            frame,
-            FramePtr
-        );
-        PMACC_SMEM(
-            mustShift,
-            bool
-        );
-
-        DataSpace< dim > superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
-        uint32_t const workerIdx = threadIdx.x;
-
-        using namespace mappings::threads;
-
-        ForEachIdx<
-            IdxConfig<
-                1,
-                numWorkers
-            >
-        >{ workerIdx }(
-            [&](
-                uint32_t const,
-                uint32_t const
-            )
-            {
-                mustShift = pb.getSuperCell( superCellIdx ).mustShift( );
-                if ( mustShift )
-                {
-                    pb.getSuperCell( superCellIdx ).setMustShift( false );
-                    frame = pb.getFirstFrame( superCellIdx );
-                }
-            }
-        );
-
-        __syncthreads( );
-        if ( !mustShift || !frame.isValid( ) ) return;
-
-        using ExchangeDomCfg = IdxConfig<
-            numExchanges,
-            numWorkers
-        >;
-
-        memory::CtxArray<
-            uint32_t,
-            ExchangeDomCfg
-        > lastFrameSizeCtx( 0 );
-
-        memory::CtxArray<
-            DataSpace< dim >,
-            ExchangeDomCfg
-        > relativeCtx(
-            workerIdx,
-            [&](
-                uint32_t const linearIdx,
-                uint32_t const
-            )
-            -> DataSpace< dim >
-            {
-                return superCellIdx + Mask::getRelativeDirections< dim > ( linearIdx + 1);
-            }
-        );
-
-        ForEachIdx< ExchangeDomCfg > forEachExchange( workerIdx );
-
-        /* if a partially filled last frame exists for the neighboring supercell,
-         * each master thread (one master per direction) will load it
-         */
-        forEachExchange(
-            [&](
-                uint32_t const linearIdx,
-                uint32_t const idx
-            )
-            {
-                destFramesCounter[ linearIdx ] = 0;
-                destFrames[ linearIdx ] = FramePtr();
-                destFrames[ linearIdx + numExchanges ] = FramePtr();
-                /* load last frame of neighboring supercell */
-                FramePtr tmpFrame( pb.getLastFrame( relativeCtx[ idx ] ) );
-
-                if ( tmpFrame.isValid() )
-                {
-                    lastFrameSizeCtx[ idx ] = pb.getSuperCell( relativeCtx[ idx ] ).getSizeLastFrame( );
-                    // do not use the neighbor's last frame if it is full
-                    if ( lastFrameSizeCtx[ idx ] < frameSize )
-                    {
-                        destFrames[ linearIdx ] = tmpFrame;
-                        destFramesCounter[ linearIdx ] = lastFrameSizeCtx[ idx ];
-                    }
-                }
-            }
-        );
-
-        __syncthreads( );
-
-        /* iterate over the frame list of the current supercell */
-        while ( frame.isValid( ) )
-        {
-            using ParticleDomCfg = IdxConfig<
-                frameSize,
-                numWorkers
-            >;
-
-            ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
-
-            memory::CtxArray<
-                lcellId_t,
-                ParticleDomCfg
-            > destParticleIdxCtx( INV_LOC_IDX );
-            memory::CtxArray<
-                int,
-                ParticleDomCfg
-            > directionCtx;
-
-            forEachParticle(
-                [&](
-                    uint32_t const linearIdx,
-                    uint32_t const idx
-                )
-                {
-                    /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
-                     * -2 is no particle
-                     * -1 is particle but it is not shifted (stays in supercell)
-                     * >=0 particle moves in a certain direction
-                     *     (@see ExchangeType in types.h)
-                     */
-                    directionCtx[ idx ] = frame[ linearIdx ][ multiMask_ ] - 2;
-                    if ( directionCtx[ idx ] >= 0 )
-                    {
-                        destParticleIdxCtx[ idx ] = atomicAdd( &(destFramesCounter[ directionCtx[ idx ] ]), 1 );
-                    }
-                }
-            );
-            __syncthreads( );
-
-            forEachExchange(
-                [&](
-                    uint32_t const linearIdx,
-                    uint32_t const idx
-                )
-                {
-                    /* If the master thread (responsible for a certain direction) did not
-                     * obtain a `low frame` from the neighboring super cell before the loop,
-                     * it will create one now.
-                     *
-                     * In case not all particles that are shifted to the neighboring
-                     * supercell fit into the `low frame`, a second frame is created to
-                     * contain further particles, the `high frame` (default: invalid).
-                     */
-                    if ( destFramesCounter[ linearIdx ] > 0 )
-                    {
-                        lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ];
-                        /* if we had no `low frame` we load a new empty one */
-                        if ( !destFrames[ linearIdx ].isValid( ) )
-                        {
-                            FramePtr tmpFrame( pb.getEmptyFrame( ) );
-                            destFrames[ linearIdx ] = tmpFrame;
-                            pb.setAsLastFrame(
-                                tmpFrame,
-                                relativeCtx[ idx ]
-                            );
-                        }
-                        /* check if a `high frame` is needed */
-                        if ( destFramesCounter[ linearIdx ] > frameSize )
-                        {
-                            lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ] - frameSize;
-                            FramePtr tmpFrame( pb.getEmptyFrame( ) );
-                            destFrames[ linearIdx + numExchanges ] = tmpFrame;
-                            pb.setAsLastFrame(
-                                tmpFrame,
-                                relativeCtx[ idx ]
-                            );
-                        }
-                    }
-                }
-            );
-            __syncthreads( );
-
-            forEachParticle(
-                [&](
-                    uint32_t const linearIdx,
-                    uint32_t const idx
-                )
-                {
-                    /* All threads with a valid index in the neighbor's frame, valid index
-                     * range is [0, frameSize * 2-1], will copy their particle to the new
-                     * frame.
-                     *
-                     * The default value for indexes (in the destination frame) is
-                     * above this range (INV_LOC_IDX) for all particles that are not shifted.
-                     */
-                    if ( destParticleIdxCtx[ idx ] < frameSize * 2 )
-                    {
-                        if ( destParticleIdxCtx[ idx ] >= frameSize )
-                        {
-                            /* use `high frame` */
-                            directionCtx[ idx ] += numExchanges;
-                            destParticleIdxCtx[ idx ] -= frameSize;
-                        }
-                        auto dstParticle = destFrames[ directionCtx[ idx ] ][ destParticleIdxCtx[ idx ] ];
-                        auto srcParticle = frame[ linearIdx ];
-                        dstParticle[ multiMask_ ] = 1;
-                        srcParticle[ multiMask_ ] = 0;
-                        auto dstFilteredParticle =
-                            particles::operations::deselect< multiMask >( dstParticle );
-                        particles::operations::assign(
-                            dstFilteredParticle,
-                            srcParticle
-                        );
-                    }
-                }
-            );
-            __syncthreads( );
-
-            forEachExchange(
-                [&](
-                    uint32_t const linearIdx,
-                    uint32_t const
-                )
-                {
-                    /* if the `low frame` is now full, each master thread removes it and
-                     * uses the `high frame` (is invalid, if still empty) as the next
-                     * `low frame` for the following iteration of the loop
-                     */
-                    if ( destFramesCounter[ linearIdx ] >= frameSize )
-                    {
-                        destFramesCounter[ linearIdx ] -= frameSize;
-                        destFrames[ linearIdx ] = destFrames[ linearIdx + numExchanges ];
-                        destFrames[ linearIdx + numExchanges ] = FramePtr( );
-                    }
-                    if ( linearIdx == 0 )
-                    {
-                        frame = pb.getNextFrame( frame );
-                    }
-                }
-            );
-            __syncthreads( );
-        }
-
-        forEachExchange(
-            [&](
-                uint32_t const,
-                uint32_t const idx
-            )
-            {
-                /* each master thread updates the number of particles in the last frame
-                 * of the neighbors supercell
-                 */
-                pb.getSuperCell( relativeCtx[ idx ] ).setSizeLastFrame( lastFrameSizeCtx[ idx ] );
-            }
-        );
-    }
-};
-
 /** fill particle gaps in the last frame
  *
  * Copy all particles in a frame to the storage places at the frame's beginning.
@@ -755,6 +457,305 @@ struct KernelFillGaps
             __syncthreads( );
 
         }
+    }
+};
+
+template< uint32_t T_numWorkers >
+struct KernelShiftParticles
+{
+    /*! This kernel move particles to the next supercell
+     * This kernel can only run with a double checker board
+     */
+    template<
+        class T_ParBox,
+        class Mapping
+    >
+    DINLINE void operator()(
+        T_ParBox pb,
+        Mapping mapper
+    ) const
+    {
+        using ParBox = T_ParBox;
+        using FrameType = typename ParBox::FrameType;
+        using FramePtr = typename ParBox::FramePtr;
+
+        constexpr uint32_t dim = Mapping::Dim;
+        constexpr uint32_t frameSize = math::CT::volume< typename FrameType::SuperCellSize >::type::value;
+        /* number exchanges in 2D=9 and in 3D=27 */
+        constexpr uint32_t numExchanges = traits::NumberOfExchanges< dim >::value;
+        constexpr uint32_t numWorkers = T_numWorkers;
+
+        /* define memory for two times Exchanges
+         * index range [0,numExchanges-1] are being referred to as `low frames`
+         * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
+         */
+        PMACC_SMEM(
+            destFrames,
+            memory::Array<
+                FramePtr,
+                numExchanges * 2
+            >
+        );
+        //count particles per frame
+        PMACC_SMEM(
+            destFramesCounter,
+            memory::Array<
+                int,
+                numExchanges
+            >
+        );
+
+        PMACC_SMEM(
+            frame,
+            FramePtr
+        );
+        PMACC_SMEM(
+            mustShift,
+            bool
+        );
+
+        DataSpace< dim > superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
+        uint32_t const workerIdx = threadIdx.x;
+
+        using namespace mappings::threads;
+
+        ForEachIdx<
+            IdxConfig<
+                1,
+                numWorkers
+            >
+        >{ workerIdx }(
+            [&](
+                uint32_t const,
+                uint32_t const
+            )
+            {
+                mustShift = pb.getSuperCell( superCellIdx ).mustShift( );
+                if ( mustShift )
+                {
+                    pb.getSuperCell( superCellIdx ).setMustShift( false );
+                    frame = pb.getFirstFrame( superCellIdx );
+                }
+            }
+        );
+
+        __syncthreads( );
+        if ( !mustShift || !frame.isValid( ) ) return;
+
+        using ExchangeDomCfg = IdxConfig<
+            numExchanges,
+            numWorkers
+        >;
+
+        memory::CtxArray<
+            uint32_t,
+            ExchangeDomCfg
+        > lastFrameSizeCtx( 0 );
+
+        memory::CtxArray<
+            DataSpace< dim >,
+            ExchangeDomCfg
+        > relativeCtx(
+            workerIdx,
+            [&](
+                uint32_t const linearIdx,
+                uint32_t const
+            )
+            -> DataSpace< dim >
+            {
+                return superCellIdx + Mask::getRelativeDirections< dim > ( linearIdx + 1);
+            }
+        );
+
+        ForEachIdx< ExchangeDomCfg > forEachExchange( workerIdx );
+
+        /* if a partially filled last frame exists for the neighboring supercell,
+         * each master thread (one master per direction) will load it
+         */
+        forEachExchange(
+            [&](
+                uint32_t const linearIdx,
+                uint32_t const idx
+            )
+            {
+                destFramesCounter[ linearIdx ] = 0;
+                destFrames[ linearIdx ] = FramePtr();
+                destFrames[ linearIdx + numExchanges ] = FramePtr();
+                /* load last frame of neighboring supercell */
+                FramePtr tmpFrame( pb.getLastFrame( relativeCtx[ idx ] ) );
+
+                if ( tmpFrame.isValid() )
+                {
+                    lastFrameSizeCtx[ idx ] = pb.getSuperCell( relativeCtx[ idx ] ).getSizeLastFrame( );
+                    // do not use the neighbor's last frame if it is full
+                    if ( lastFrameSizeCtx[ idx ] < frameSize )
+                    {
+                        destFrames[ linearIdx ] = tmpFrame;
+                        destFramesCounter[ linearIdx ] = lastFrameSizeCtx[ idx ];
+                    }
+                }
+            }
+        );
+
+        __syncthreads( );
+
+        /* iterate over the frame list of the current supercell */
+        while ( frame.isValid( ) )
+        {
+            using ParticleDomCfg = IdxConfig<
+                frameSize,
+                numWorkers
+            >;
+
+            ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
+
+            memory::CtxArray<
+                lcellId_t,
+                ParticleDomCfg
+            > destParticleIdxCtx( INV_LOC_IDX );
+            memory::CtxArray<
+                int,
+                ParticleDomCfg
+            > directionCtx;
+
+            forEachParticle(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
+                {
+                    /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
+                     * -2 is no particle
+                     * -1 is particle but it is not shifted (stays in supercell)
+                     * >=0 particle moves in a certain direction
+                     *     (@see ExchangeType in types.h)
+                     */
+                    directionCtx[ idx ] = frame[ linearIdx ][ multiMask_ ] - 2;
+                    if ( directionCtx[ idx ] >= 0 )
+                    {
+                        destParticleIdxCtx[ idx ] = atomicAdd( &(destFramesCounter[ directionCtx[ idx ] ]), 1 );
+                    }
+                }
+            );
+            __syncthreads( );
+
+            forEachExchange(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
+                {
+                    /* If the master thread (responsible for a certain direction) did not
+                     * obtain a `low frame` from the neighboring super cell before the loop,
+                     * it will create one now.
+                     *
+                     * In case not all particles that are shifted to the neighboring
+                     * supercell fit into the `low frame`, a second frame is created to
+                     * contain further particles, the `high frame` (default: invalid).
+                     */
+                    if ( destFramesCounter[ linearIdx ] > 0 )
+                    {
+                        lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ];
+                        /* if we had no `low frame` we load a new empty one */
+                        if ( !destFrames[ linearIdx ].isValid( ) )
+                        {
+                            FramePtr tmpFrame( pb.getEmptyFrame( ) );
+                            destFrames[ linearIdx ] = tmpFrame;
+                            pb.setAsLastFrame(
+                                tmpFrame,
+                                relativeCtx[ idx ]
+                            );
+                        }
+                        /* check if a `high frame` is needed */
+                        if ( destFramesCounter[ linearIdx ] > frameSize )
+                        {
+                            lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ] - frameSize;
+                            FramePtr tmpFrame( pb.getEmptyFrame( ) );
+                            destFrames[ linearIdx + numExchanges ] = tmpFrame;
+                            pb.setAsLastFrame(
+                                tmpFrame,
+                                relativeCtx[ idx ]
+                            );
+                        }
+                    }
+                }
+            );
+            __syncthreads( );
+
+            forEachParticle(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
+                {
+                    /* All threads with a valid index in the neighbor's frame, valid index
+                     * range is [0, frameSize * 2-1], will copy their particle to the new
+                     * frame.
+                     *
+                     * The default value for indexes (in the destination frame) is
+                     * above this range (INV_LOC_IDX) for all particles that are not shifted.
+                     */
+                    if ( destParticleIdxCtx[ idx ] < frameSize * 2 )
+                    {
+                        if ( destParticleIdxCtx[ idx ] >= frameSize )
+                        {
+                            /* use `high frame` */
+                            directionCtx[ idx ] += numExchanges;
+                            destParticleIdxCtx[ idx ] -= frameSize;
+                        }
+                        auto dstParticle = destFrames[ directionCtx[ idx ] ][ destParticleIdxCtx[ idx ] ];
+                        auto srcParticle = frame[ linearIdx ];
+                        dstParticle[ multiMask_ ] = 1;
+                        srcParticle[ multiMask_ ] = 0;
+                        auto dstFilteredParticle =
+                            particles::operations::deselect< multiMask >( dstParticle );
+                        particles::operations::assign(
+                            dstFilteredParticle,
+                            srcParticle
+                        );
+                    }
+                }
+            );
+            __syncthreads( );
+
+            forEachExchange(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const
+                )
+                {
+                    /* if the `low frame` is now full, each master thread removes it and
+                     * uses the `high frame` (is invalid, if still empty) as the next
+                     * `low frame` for the following iteration of the loop
+                     */
+                    if ( destFramesCounter[ linearIdx ] >= frameSize )
+                    {
+                        destFramesCounter[ linearIdx ] -= frameSize;
+                        destFrames[ linearIdx ] = destFrames[ linearIdx + numExchanges ];
+                        destFrames[ linearIdx + numExchanges ] = FramePtr( );
+                    }
+                    if ( linearIdx == 0 )
+                    {
+                        frame = pb.getNextFrame( frame );
+                    }
+                }
+            );
+            __syncthreads( );
+        }
+
+        forEachExchange(
+            [&](
+                uint32_t const,
+                uint32_t const idx
+            )
+            {
+                /* each master thread updates the number of particles in the last frame
+                 * of the neighbors supercell
+                 */
+                pb.getSuperCell( relativeCtx[ idx ] ).setSizeLastFrame( lastFrameSizeCtx[ idx ] );
+            }
+        );
+
     }
 };
 


### PR DESCRIPTION
- move the source code of the functor `KernelShiftParticles` under `KernelFillGaps` 
- remove host side call of `KernelFillGaps` and `KernelFillGapsLastFrame`
- call `KernelFillGaps` on device from `KernelShiftParticles`
- call `KernelFillGapsLastFrame` on device from `KernelFillGaps`
- add documentation

# Improvements
This PR dramatically  reduces the number of kernels called per time step and therefore improves the performance (~2%) and maybe the scaling.

# Note for the Reviewer
The first commit changes no algorithms, only the source code of the functor `KernelShiftParticles` is moved after `KernelFillGaps`.
The second commit contains all important changes.

# Tests

- [x] default 3D KHI