### PR TITLE
lockstep refactoring of `ThreadCollective`

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -26,7 +26,7 @@
 #include "nvidia/functors/Assign.hpp"
 #include "memory/boxes/CachedBox.hpp"
 #include "memory/dataTypes/Mask.hpp"
-
+#include "dimensions/DataSpaceOperations.hpp"
 #include "nvidia/rng/RNG.hpp"
 #include "nvidia/rng/methods/Xor.hpp"
 #include "nvidia/rng/distributions/Uniform_float.hpp"
@@ -58,7 +58,14 @@ namespace gol
                 const Space threadIndex(threadIdx);
                 auto buffRead_shifted = buffRead.shift(blockCell);
 
-                ThreadCollective<BlockArea> collective(threadIndex);
+                ThreadCollective<
+                    BlockArea,
+                    PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+                > collective(
+                    DataSpaceOperations< BlockArea::Dim >::template map<
+                        typename BlockArea::SuperCellSize
+                    >( threadIndex )
+                );
 
                 nvidia::functors::Assign assign;
                 collective(

--- a/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
+++ b/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
@@ -49,7 +49,7 @@ class ThreadCollective
 private:
     // size of the CORE (in elements per dimension)
     using CoreDomainSize = typename T_DataDomain::SuperCellSize;
-    // full size if the domain including the GUARD (in elements per dimension)
+    // full size of the domain including the GUARD (in elements per dimension)
     using DomainSize = typename T_DataDomain::FullSuperCellSize;
     // offset (in elements per dimension) from the GUARD origin to the CORE
     using OffsetOrigin = typename T_DataDomain::OffsetOrigin;
@@ -77,12 +77,12 @@ public:
      *
      * @tparam T_Functor type of the user functor, must have a `void operator()`
      *                   with as many arguments as args contains
-     * @tapram  T_Args type of the arguments, each type must implement an operator
-     *                 `template<typename T, typnme R> R operator(T)`
+     * @tparam T_Args type of the arguments, each type must implement an operator
+     *                 `template<typename T, typename R> R operator(T)`
      *
      * @param functor user defined functor
      * @param args arguments passed to the functor
-     *             The method `template<typename T, typnme R> R operator(T)`
+     *             The method `template<typename T, typename R> R operator(T)`
      *             is called for each argument, the result is passed to the
      *             functor `functor::operator()`.
      *             `T` is a N-dimensional vector of an index relative to the origin
@@ -109,11 +109,14 @@ public:
                 uint32_t const
             )
             {
-                DataSpace< dim > const pos(
+                /* offset (in elements) of the current processed element relative
+                 * to the origin of the core domain
+                 */
+                DataSpace< dim > const offset(
                     DataSpaceOperations< dim >::template map< DomainSize >( linearIdx ) -
                     OffsetOrigin::toRT( )
                 );
-                functor( args(pos) ... );
+                functor( args( offset ) ... );
             }
         );
     }

--- a/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
+++ b/src/libPMacc/include/mappings/threads/ThreadCollective.hpp
@@ -32,72 +32,61 @@
 namespace PMacc
 {
 
-/** execute a functor on a domain
+/** execute a functor for each cell of a domain
  *
- * For each argument passed to the functor the `operator()` is called.
- * This is a **collective** functor and needs to be called by all worker within a block.
+ * the user functor is executed on each elements of the full domain (GUARD +CORE)
  *
- * @tparam T_BlockDomain domain description, type mist contain the definitions `SuperCellSize`,
- *                       `FullSuperCellSize`, `OffsetOrigin` and `Dim`
- * @tparam T_numWorkers number of workers which are used to execute this functor
+ * @tparam T_DataDomain PMacc::SuperCellDescription, compile time data domain
+ *                      description with a CORE and GUARD
+ * @tparam T_numWorkers number of workers
  */
 template<
-    typename T_BlockDomain,
-    uint32_t T_numWorkers = math::CT::volume<typename T_BlockDomain::SuperCellSize>::type::value
+    typename T_DataDomain,
+    uint32_t T_numWorkers
 >
 class ThreadCollective
 {
 private:
-    /** size of the inner domain */
-    using SuperCellSize = typename T_BlockDomain::SuperCellSize;
+    // size of the CORE (in elements per dimension)
+    using CoreDomainSize = typename T_DataDomain::SuperCellSize;
+    // full size if the domain including the GUARD (in elements per dimension)
+    using DomainSize = typename T_DataDomain::FullSuperCellSize;
+    // offset (in elements per dimension) from the GUARD origin to the CORE
+    using OffsetOrigin = typename T_DataDomain::OffsetOrigin;
 
-    /** full size of the domain including the guards around SuperCellSize */
-    using FullSuperCellSize = typename T_BlockDomain::FullSuperCellSize;
-
-    /** size of the negative guard */
-    using OffsetOrigin = typename T_BlockDomain::OffsetOrigin;
-
-    /** number of worker performing the functior */
     static constexpr uint32_t numWorkers = T_numWorkers;
+    static constexpr uint32_t dim = T_DataDomain::Dim;
 
-    /** dimensionality of the index domain */
-    static constexpr uint32_t dim = T_BlockDomain::Dim;
-
-    /** index of the worker: range [0;numWorkers) */
-    PMACC_ALIGN( m_workerIdx, uint32_t const );
+    const PMACC_ALIGN(
+        m_workerIdx,
+        uint32_t
+    );
 
 public:
 
     /** constructor
      *
-     * @param workerIdx worker index
+     * @param workerIdx index of the worker
      */
     DINLINE ThreadCollective( uint32_t const workerIdx ) :
         m_workerIdx( workerIdx )
-    { }
+    {
+    }
 
-    /** constructor
+    /** execute the user functor for each element in the full domain
      *
-     * @warning this constructor is **deprecated** (assuming that the index domain
-     *          and the number of workers needs to be euqal is not good and avoid the
-     *          usage of alpaka)
+     * @tparam T_Functor type of the user functor, must have a `void operator()`
+     *                   with as many arguments as args contains
+     * @tapram  T_Args type of the arguments, each type must implement an operator
+     *                 `template<typename T, typnme R> R operator(T)`
      *
-     * @param nDimWorkerIdx n dimensional worker index
-     */
-    DINLINE ThreadCollective( DataSpace< dim > const nDimWorkerIdx ) :
-        m_workerIdx( DataSpaceOperations< dim >::template map< SuperCellSize >( nDimWorkerIdx ) )
-    { }
-
-    /** execute a functor for each data point
-     *
-     * @tparam T_Functor type of the functor
-     * @tparam T_Args type of arguments given to the functor
-     *
-     * @param functor functor which is called for each data element in the domain
-     *                spanned by T_BlockDomain
-     * @param args the result of each argument of the `operator( relativeNDimensionalIdx )` call
-     *             with the relative index inside `T_BlockDomain` based on
-     *             the origin `T_BlockDomain::OffsetOrigin` is passed to the functor
+     * @param functor user defined functor
+     * @param args arguments passed to the functor
+     *             The method `template<typename T, typnme R> R operator(T)`
+     *             is called for each argument, the result is passed to the
+     *             functor `functor::operator()`.
+     *             `T` is a N-dimensional vector of an index relative to the origin
+     *             of data domain GUARD
      */
     template<
         typename T_Functor,
@@ -108,19 +97,23 @@ public:
         T_Args && ... args
     )
     {
-        mappings::threads::ForEachIdx<
-            mappings::threads::IdxConfig<
-                math::CT::volume<FullSuperCellSize>::type::value,
+        using namespace mappings::threads;
+        ForEachIdx<
+            IdxConfig<
+                math::CT::volume< DomainSize >::type::value,
                 numWorkers
             >
         >{ m_workerIdx }(
-            [&]( uint32_t const linearIdx, uint32_t const )
+            [&](
+                uint32_t const linearIdx,
+                uint32_t const
+            )
             {
-                DataSpace< dim > const relativeIdx(
-                    DataSpaceOperations< dim >::template map< FullSuperCellSize >( linearIdx ) -
+                DataSpace< dim > const pos(
+                    DataSpaceOperations< dim >::template map< DomainSize >( linearIdx ) -
                     OffsetOrigin::toRT( )
                 );
-                functor( args( relativeIdx ) ... );
+                functor( args(pos) ... );
             }
         );
     }

--- a/src/picongpu/include/fields/FieldJ.kernel
+++ b/src/picongpu/include/fields/FieldJ.kernel
@@ -342,7 +342,14 @@ struct KernelAddCurrentToEMF
         const DataSpace<simDim > threadIndex(threadIdx);
         auto fieldJBlock = fieldJ.shift(blockCell);
 
-        ThreadCollective<BlockArea> collective(threadIndex);
+        ThreadCollective<
+            BlockArea,
+            PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+        > collective(
+            DataSpaceOperations< BlockArea::Dim >::template map<
+                typename BlockArea::SuperCellSize
+            >( threadIndex )
+        );
         collective(
                   assign,
                   cachedJ,

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -75,7 +75,10 @@ namespace picongpu
             auto cachedVal = CachedBox::create < 0, typename TmpBox::ValueType > ( BlockDescription_( ) );
             Set<typename TmpBox::ValueType > set( float_X( 0.0 ) );
 
-            ThreadCollective<BlockDescription_> collective( linearThreadIdx );
+            ThreadCollective<
+                BlockDescription_,
+                PMacc::math::CT::volume< typename BlockDescription_::SuperCellSize >::type::value
+            > collective( linearThreadIdx );
             collective( set, cachedVal );
 
             __syncthreads( );

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -225,7 +225,10 @@ struct KernelMoveAndMarkParticles
        auto fieldBBlock = fieldB.shift(blockCell);
 
        nvidia::functors::Assign assign;
-       ThreadCollective<BlockDescription_> collective(linearThreadIdx);
+       ThreadCollective<
+           BlockDescription_,
+           PMacc::math::CT::volume< typename BlockDescription_::SuperCellSize >::type::value
+       > collective( linearThreadIdx );
        collective(
                  assign,
                  cachedB,

--- a/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/src/picongpu/include/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -83,7 +83,11 @@ void Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::init
     nvidia::functors::Assign assign;
     /* copy fields from global to shared */
     const auto fieldIonDensityBlock = ionDensityBox.shift(blockCell);
-    ThreadCollective<BlockArea> collective(linearThreadIdx);
+
+    ThreadCollective<
+        BlockArea,
+        PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+    > collective( linearThreadIdx );
     collective(
               assign,
               cachedIonDensity,

--- a/src/picongpu/include/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -221,7 +221,10 @@ namespace ionization
                 nvidia::functors::Assign assign;
                 /* copy fields from global to shared */
                 auto fieldRhoBlock = rhoBox.shift(blockCell);
-                ThreadCollective<BlockArea> collective(linearThreadIdx);
+                ThreadCollective<
+                    BlockArea,
+                    PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+                > collective( linearThreadIdx );
                 collective(
                           assign,
                           cachedRho,

--- a/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -152,7 +152,10 @@ namespace ionization
                 nvidia::functors::Assign assign;
                 /* copy fields from global to shared */
                 auto fieldBBlock = bBox.shift(blockCell);
-                ThreadCollective<BlockArea> collective(linearThreadIdx);
+                ThreadCollective<
+                    BlockArea,
+                    PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+                > collective( linearThreadIdx );
                 collective(
                           assign,
                           cachedB,

--- a/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -129,7 +129,10 @@ namespace ionization
                 /* instance of nvidia assignment operator */
                 nvidia::functors::Assign assign;
 
-                ThreadCollective<BlockArea> collective(linearThreadIdx);
+                ThreadCollective<
+                    BlockArea,
+                    PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+                > collective( linearThreadIdx );
                 /* copy fields from global to shared */
                 auto fieldEBlock = eBox.shift(blockCell);
                 collective(

--- a/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/src/picongpu/include/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -153,7 +153,10 @@ namespace ionization
                 nvidia::functors::Assign assign;
                 /* copy fields from global to shared */
                 auto fieldBBlock = bBox.shift(blockCell);
-                ThreadCollective<BlockArea> collective(linearThreadIdx);
+                ThreadCollective<
+                    BlockArea,
+                    PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+                > collective( linearThreadIdx );
                 collective(
                           assign,
                           cachedB,

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -159,11 +159,7 @@ public:
         ThreadCollective<
             BlockArea,
             PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
-        > collective(
-            DataSpaceOperations< BlockArea::Dim >::template map<
-                typename BlockArea::SuperCellSize
-            >( linearThreadIdx )
-        );
+        > collective( linearThreadIdx );
         collective(
                   assign,
                   cachedB,

--- a/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/src/picongpu/include/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -44,6 +44,7 @@
 
 #include "compileTime/conversion/TypeToPointerPair.hpp"
 #include "memory/boxes/DataBox.hpp"
+#include "dimensions/DataSpaceOperations.hpp"
 
 
 namespace picongpu
@@ -155,7 +156,14 @@ public:
         nvidia::functors::Assign assign;
         /* copy fields from global to shared */
         auto fieldBBlock = bBox.shift(blockCell);
-        ThreadCollective<BlockArea> collective(linearThreadIdx);
+        ThreadCollective<
+            BlockArea,
+            PMacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
+        > collective(
+            DataSpaceOperations< BlockArea::Dim >::template map<
+                typename BlockArea::SuperCellSize
+            >( linearThreadIdx )
+        );
         collective(
                   assign,
                   cachedB,


### PR DESCRIPTION
This pull request move the restriction out of PMacc that `ThreadCollective` must be called with the same number of worker than a supercell contains.

- remove the constructor with the N-dimensional worker index
- rename private type definitions
- add documentation
- update all call to the old constructor

# Review
Please check the changes commit wise

# Tests

- [x] game of life 
- [x] default 3D KHI