### PR TITLE
Assign: missing check for valid particles

### DIFF
--- a/src/picongpu/include/particles/manipulators/AssignImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/AssignImpl.hpp
@@ -46,9 +46,10 @@ struct AssignImpl
     template<typename T_Particle1, typename T_Particle2>
     DINLINE void operator()(const DataSpace<simDim>&,
                             T_Particle1& particleDest, T_Particle2& particleSrc,
-                            const bool, const bool)
+                            const bool isDesParticle, const bool isSrcParticle)
     {
-        PMacc::particles::operations::assign(particleDest, particleSrc);
+        if (isDesParticle && isSrcParticle)
+            PMacc::particles::operations::assign(particleDest, particleSrc);
     }
 
 };


### PR DESCRIPTION
add missing check if source and destination particle is valid

# possible side effects

- overhead because a non existent particle memory is copied
- particle ids are wasted

As I can see this bug is not producing any invalid memory access.