### PR TITLE
fix possible linker error

### DIFF
--- a/src/picongpu/CMakeLists.txt
+++ b/src/picongpu/CMakeLists.txt
@@ -351,6 +351,7 @@ add_library(picongpu-hostonly
     STATIC
     ${SRCFILES}
 )
+target_link_libraries(picongpu-hostonly ${LIBS} m)
 
 if("${PMACC_CUDA_COMPILER}" STREQUAL "clang")
     add_executable(picongpu


### PR DESCRIPTION
Depending on the the configured environment it could be that the linker
crashes. The reason for that is that the static library `picongpu-hostonly`
is not linked against the dependencies.

fix: link `picongpu-hostonly` with all dependencies.