### PR TITLE
fix plasma frequency and remove German comment

### DIFF
--- a/examples/KelvinHelmholtz/include/simulation_defines/param/radiation.param
+++ b/examples/KelvinHelmholtz/include/simulation_defines/param/radiation.param
@@ -51,12 +51,11 @@ namespace rad_log_frequencies
 {
 namespace SI
 {
-//constexpr float_64 omega_min = 1.0e14;
-//constexpr float_64 omega_max = 1.0e17;
-  // plasma omega = sqrt( (Teilchendichte * (1.6e-19)^2) / (8.854e-12 * 9.11e-31) )
-  //              = 2.52e14 Hz
-constexpr float_64 omega_min = 0.1*2.52e14;
-constexpr float_64 omega_max = 200*2.52e14;
+// plasma omega = sqrt( (electron density * (1.6e-19)^2) / (8.854e-12 * 9.11e-31) )
+//              = 1.78e14 1/s
+constexpr float_64 omega_pe = 1.78e14;
+constexpr float_64 omega_min = 0.1 * omega_pe;
+constexpr float_64 omega_max = 200 * omega_pe;
 }
 
 constexpr unsigned int N_omega = 1024; // number of frequencies


### PR DESCRIPTION
This pull request fixes a wrong documentation and implementation of the plasma frequency in the default KHI example `radiation.param`. It exists since the *alpha release*. 

This **does not influence** any publication related to the Gorden Bell competition.
It just avoids confusion if the default parameters are used without checking for consistency between `density.param` and `radiation.param`. Now, they are consistent.  

(I thought I fixed this in 2014 - how did it end up here again.) 
