### PR TITLE
fix wrong time step in reduction of field background after restart

### DIFF
--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -466,10 +466,13 @@ public:
         {
             namespace nvfct = PMacc::nvidia::functors;
 
+            /* subtract the background field as it has been stored in the
+             * checkpoint: at its iteration step = currentStep - 1
+             */
             (*pushBGField)( fieldE, nvfct::Sub(), FieldBackgroundE(fieldE->getUnit()),
-                            step, FieldBackgroundE::InfluenceParticlePusher);
+                            step - 1u, FieldBackgroundE::InfluenceParticlePusher);
             (*pushBGField)( fieldB, nvfct::Sub(), FieldBackgroundB(fieldB->getUnit()),
-                            step, FieldBackgroundB::InfluenceParticlePusher);
+                            step - 1u, FieldBackgroundB::InfluenceParticlePusher);
         }
 
         // communicate all fields


### PR DESCRIPTION
This pull request fixes a wrong background field reduction during restart. The checkpoints contains the background field of `currentStep -1` but we subtract the background field of `currentStep` and than add the background field of `currentStep -1`. This leads to a wrong field if the background field is not constant over time. 
**Thanks @psychocoderHPC for spotting this.**

I will check the results on TWTS as soon as possible.

Please wait with merging till the test are finished. 

CC-ing: @steindev, @BeyondEspresso 