### PR TITLE
fix plugin energy field reduce

### DIFF
--- a/src/picongpu/include/plugins/EnergyFields.hpp
+++ b/src/picongpu/include/plugins/EnergyFields.hpp
@@ -217,8 +217,8 @@ private:
         localReducedFieldEnergy[1] = reduceField(fieldE);
 
         mpiReduce(nvidia::functors::Add(),
-                  &globalFieldEnergy,
-                  &localReducedFieldEnergy,
+                  globalFieldEnergy,
+                  localReducedFieldEnergy,
                   2,
                   mpi::reduceMethods::Reduce());
 


### PR DESCRIPTION
This pull request fixes a wrong MPI reduce in the field energy plugin.
It caused wrong field values (f.e. in TWTS runs)  because the mpi reduce reduces over two `float3_X[2]` instead of over just one `float3_X[2]` (which is equal two 2 `float3_X` - which was probably the intention of the developer).

**Thanks @psychocoderHPC for spotting this!**

Run time test show taht this solves the wrong output we see during TWTS runs. 
(This effects **all** heating tests)

**Effects so far:**
So far this caused mostly some massively increased `Ez` values. 
This **does not** effect the physics - just the output. 

## Test

- [x] test field energy with TWTS enabled

CC-ing: @steindev, @BeyondEspresso 