### PR TITLE
fix restart with background fields enabled

### DIFF
--- a/src/libPMacc/include/simulationControl/SimulationHelper.hpp
+++ b/src/libPMacc/include/simulationControl/SimulationHelper.hpp
@@ -231,21 +231,18 @@ public:
             TimeIntervall tSimCalculation;
             TimeIntervall tRound;
             double roundAvg = 0.0;
+            Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
+
+            /* Since in the main loop movingWindow is called always before the dump, we also call it here for consistency.
+             * This becomes only important, if movingWindowCheck does more than merely checking for a slide.
+             * TO DO in a new feature: Turn this into a general hook for pre-checks (window slides are just one possible action).
+             */
+            movingWindowCheck(currentStep);
 
             /* dump initial step if simulation starts without restart */
-            if (currentStep == 0)
+            if (!restartRequested)
             {
-                /* Since in the main loop movingWindow is called always before the dump, we also call it here for consistency.
-                This becomes only important, if movingWindowCheck does more than merely checking for a slide.
-                TO DO in a new feature: Turn this into a general hook for pre-checks (window slides are just one possible action). */
-                movingWindowCheck(currentStep);
                 dumpOneStep(currentStep);
-            }
-            else
-            {
-                currentStep--; //We dump before calculation, thus we must go one step back when doing a restart.
-                Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
-                movingWindowCheck(currentStep); //If we restart at any step check if we must slide.
             }
 
             /* dump 0% output */

--- a/src/picongpu/include/simulationControl/MySimulation.hpp
+++ b/src/picongpu/include/simulationControl/MySimulation.hpp
@@ -440,7 +440,7 @@ public:
                 }
 
                 initialiserController->restart((uint32_t)this->restartStep, this->restartDirectory);
-                step = this->restartStep + 1;
+                step = this->restartStep;
             }
             else
             {
@@ -462,7 +462,7 @@ public:
         auto fieldE = dc.get< FieldE >( FieldE::getName(), true );
         auto fieldB = dc.get< FieldB >( FieldB::getName(), true );
 
-        if( step != 0 )
+        if( this->restartRequested )
         {
             namespace nvfct = PMacc::nvidia::functors;
 


### PR DESCRIPTION
This PR replace #2111 and solves the issue by removing dirty detection of a restart by checking the simulation time step.

- PIConGPU: remove magic time step increase to detect restarts
- PMacc (SimulationHelper): use class member `restartRequested` to  detect a restart


## Tests
- [x] field background restart from step 0 and X, `background = currentStep + 1`

Cc-ing: @PrometheusPi, @steindev, @BeyondEspresso 