### PR TITLE
extend particle handle

### DIFF
--- a/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
@@ -81,7 +81,31 @@ struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
      * ATTENTION: The pointer must be the last member to avoid local memory usage
      *            https://github.com/ComputationalRadiationPhysics/picongpu/pull/762
      */
-    PMACC_ALIGN(frame, FrameType* const);
+    PMACC_ALIGN(frame, FrameType*);
+
+    /** set particle handle to invalid
+     *
+     * This method set the particle handle to invalid. It is possible to proof with
+     * the method isHandleValid if the particle is valid.
+     * If the particle is set to invalid it is not allowed to call any method other
+     * than isHandleValid or setHandleInvalid.
+     */
+    HDINLINE void setHandleInvalid()
+    {
+        frame = nullptr;
+    }
+
+    /** check if particle handle is valid
+     *
+     * A valid particle handle means that the memory behind the handle can be used
+     * save, it not means that the particle multiMask is `>= 1`.
+     *
+     * @return true if the particle handle is valid, else false
+     */
+    HDINLINE bool isHandleValid() const
+    {
+        return frame != nullptr;
+    }
 
     /** create particle
      *

--- a/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
+++ b/src/libPMacc/include/particles/memory/dataTypes/Particle.hpp
@@ -85,10 +85,11 @@ struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
 
     /** set particle handle to invalid
      *
-     * This method set the particle handle to invalid. It is possible to proof with
+     * This method sets the particle handle to invalid. It is possible to test with
      * the method isHandleValid if the particle is valid.
      * If the particle is set to invalid it is not allowed to call any method other
-     * than isHandleValid or setHandleInvalid.
+     * than isHandleValid or setHandleInvalid, but it does not mean the particle is
+     * deactivated outside of this instance.
      */
     HDINLINE void setHandleInvalid()
     {
@@ -98,7 +99,7 @@ struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
     /** check if particle handle is valid
      *
      * A valid particle handle means that the memory behind the handle can be used
-     * save, it not means that the particle multiMask is `>= 1`.
+     * savely. A valid handle does not mean that the particle's multiMask is valid (>=1).
      *
      * @return true if the particle handle is valid, else false
      */


### PR DESCRIPTION
- add method `setHandleInvalid()`
- add method `isHandleValid()`
- set internal point to non `const` to allow the state change to invalid

This is a pre work to support the new filter functors. The new functor concepts are needed to use the PIConGPU manipulator together with the lock step programming model and alpaka.