### PR TITLE
add interfaces for functor and filter

### DIFF
--- a/src/libPMacc/include/filter/Interface.hpp
+++ b/src/libPMacc/include/filter/Interface.hpp
@@ -1,0 +1,49 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "functor/Interface.hpp"
+
+
+namespace PMacc
+{
+namespace filter
+{
+
+    /** Interface for a filter
+     *
+     * @tparam T_UserFunctor PMacc::functor::Interface, type of the functor
+     * @tparam T_numArguments number which must be supported by T_UserFunctor
+     */
+    template<
+        typename T_UserFunctor,
+        uint32_t T_numArguments
+    >
+    using Interface = PMacc::functor::Interface<
+        T_UserFunctor,
+        T_numArguments,
+        bool
+    >;
+
+} // namespace filter
+} // namespace PMacc

--- a/src/libPMacc/include/filter/Interface.hpp
+++ b/src/libPMacc/include/filter/Interface.hpp
@@ -32,8 +32,13 @@ namespace filter
 
     /** Interface for a filter
      *
-     * @tparam T_UserFunctor PMacc::functor::Interface, type of the functor
-     * @tparam T_numArguments number which must be supported by T_UserFunctor
+     * A filter is a functor which is evaluated to true or false depending
+     * on the input parameters.
+     * A filter can be used to decide e.g. if a particle is located in a user
+     * defined area or if an attribute is above a threshold.
+     *
+     * @tparam T_UserFunctor PMacc::functor::Interface, type of the functor (filter rule)
+     * @tparam T_numArguments number of arguments which must be supported by T_UserFunctor
      */
     template<
         typename T_UserFunctor,

--- a/src/libPMacc/include/filter/operators/And.hpp
+++ b/src/libPMacc/include/filter/operators/And.hpp
@@ -47,7 +47,7 @@ namespace operators
         /** get AND combined result
          *
          * @param args arguments to combine
-         * @return the input argument
+         * @return AND combination of all arguments
          */
         template<
             typename T_Arg1,

--- a/src/libPMacc/include/filter/operators/And.hpp
+++ b/src/libPMacc/include/filter/operators/And.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace PMacc
+{
+namespace filter
+{
+namespace operators
+{
+
+    //! combine all arguments by AND `&&`
+    struct And
+    {
+        /** return a
+         *
+         * @param a a boolean value
+         * @return the input argument
+         */
+        template< typename T_Arg >
+        DINLINE bool
+        operator()( T_Arg const a ) const
+        {
+            return a;
+        }
+
+        /** get AND combined result
+         *
+         * @param args arguments to combine
+         * @return the input argument
+         */
+        template<
+            typename T_Arg1,
+            typename ... T_Args
+        >
+        DINLINE bool
+        operator()( T_Arg1 const a, T_Args const ... args ) const
+        {
+            return a && And{}( args ... );
+        }
+    };
+
+} // namespace operators
+} // namespace filter
+} // namespace PMacc

--- a/src/libPMacc/include/filter/operators/Or.hpp
+++ b/src/libPMacc/include/filter/operators/Or.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace PMacc
+{
+namespace filter
+{
+namespace operators
+{
+
+    //! combine all arguments by OR `||`
+    struct Or
+    {
+        /** return a
+         *
+         * @param a a boolean value
+         * @return the input argument
+         */
+        template< typename T_Arg >
+        DINLINE bool
+        operator()( T_Arg const a ) const
+        {
+            return a;
+        }
+
+        /** get OR combined result
+         *
+         * @param args arguments to combine
+         * @return the input argument
+         */
+        template<
+            typename T_Arg1,
+            typename ... T_Args
+        >
+        DINLINE bool
+        operator()( T_Arg1 const a, T_Args const ... args ) const
+        {
+            return a || Or{}( args ... );
+        }
+    };
+
+} // namespace operators
+} // namespace filter
+} // namespace PMacc

--- a/src/libPMacc/include/filter/operators/Or.hpp
+++ b/src/libPMacc/include/filter/operators/Or.hpp
@@ -47,7 +47,7 @@ namespace operators
         /** get OR combined result
          *
          * @param args arguments to combine
-         * @return the input argument
+         * @return OR combination of all arguments
          */
         template<
             typename T_Arg1,

--- a/src/libPMacc/include/functor/Filtered.hpp
+++ b/src/libPMacc/include/functor/Filtered.hpp
@@ -1,0 +1,255 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "filter/Interface.hpp"
+#include "mappings/threads/WorkerCfg.hpp"
+
+#include <string>
+
+
+namespace PMacc
+{
+namespace functor
+{
+namespace acc
+{
+
+
+    /** interface to combine a filter and a functor on the accelerator
+     *
+     *
+     * @tparam T_FilterOperator PMacc::filter::operators, type concatenate the
+     *                          results of the filter
+     * @tparam T_Filter PMacc::filter::Interface, type of the filter
+     * @tparam T_Functor PMacc::functor::Interface, type of the functor
+     */
+    template<
+        typename T_FilterOperator,
+        typename T_Filter,
+        typename T_Functor
+    >
+    struct Filtered :
+        private T_Filter,
+        private T_Functor
+    {
+        using Filter = T_Filter;
+        using Functor = T_Functor;
+
+        DINLINE Filtered(
+            Filter const & filter,
+            Functor const & functor
+        ) :
+            Filter( filter ),
+            Functor( functor )
+        {
+
+        }
+
+        /** execute the functor depending of the filter result
+         *
+         * Call the filter for each argument and if the combined result is true
+         * the user functor is called.
+         *
+         * @param args arguments passed to the functor
+         *             - the filter is executed for each argument
+         *             - the functor get passed all arguments
+         */
+        template< typename ... T_Args >
+        DINLINE auto operator( )(  T_Args && ... args )
+        -> void
+        {
+            if(
+                T_FilterOperator{ }(
+                    ( *reinterpret_cast< Filter * >( this ) )( args ) ...
+                )
+            )
+                ( *reinterpret_cast< Functor * >( this ) )( args ... );
+        }
+    };
+
+} // namespace acc
+
+    /** combine a filter and a functor
+     *
+     * Creates a functor where each argument which is passed to
+     * the accelerator instance is evaluated by the filter and if the
+     * combined result is true the functor is executed.
+     *
+     * @tparam T_FilterOperator PMacc::filter::operators, type concatenate the
+     *                          results of the filter
+     * @tparam T_Filter PMacc::filter::Interface, type of the filter
+     * @tparam T_Functor PMacc::functor::Interface, type of the functor
+     */
+    template<
+        typename T_FilterOperator,
+        typename T_Filter,
+        typename T_Functor
+    >
+    struct Filtered;
+
+    /** specialization of Filtered (with unary filter)
+     *
+     * This specialization can only used if T_Filter is of the type PMacc::filter::Interface
+     * and T_Functor is of the type PMacc::filter::Interface
+     */
+    template<
+        typename T_FilterOperator,
+        typename T_Filter,
+        typename T_Functor,
+        uint32_t T_numFunctorArguments
+
+    >
+    struct Filtered<
+        T_FilterOperator,
+        filter::Interface<
+            T_Filter,
+            1u
+        >,
+        Interface<
+            T_Functor,
+            T_numFunctorArguments,
+            void
+        >
+    > :
+        private filter::Interface<
+            T_Filter,
+            1u
+        >,
+        Interface<
+            T_Functor,
+            T_numFunctorArguments,
+            void
+        >
+    {
+
+        template< typename ... T_Params >
+        struct apply
+        {
+            using type = Filtered<
+                T_FilterOperator,
+                typename boost::mpl::apply<
+                    T_Filter,
+                    T_Params ...
+                >::type,
+                typename boost::mpl::apply<
+                    T_Functor,
+                    T_Params ...
+                >::type
+            >;
+        };
+
+        using Filter = filter::Interface<
+            T_Filter,
+            1u
+        >;
+        using Functor = Interface<
+            T_Functor,
+            T_numFunctorArguments,
+            void
+        >;
+
+        template< typename DeferFunctor = Functor >
+        HINLINE Filtered( uint32_t const currentStep ) :
+            Filter( currentStep ),
+            Functor( currentStep )
+        {
+        }
+
+
+        /** create a filtered functor which can be used on the accelerator
+         *
+         * @tparam T_OffsetType type to describe the size of a domain
+         * @tparam T_numWorkers number of workers
+         *
+         * @param domainOffset offset to the origin of the local domain
+         *                     This can be e.g a supercell or cell offset and depends
+         *                     of the context where the interface is specialized.
+         * @param workerCfg configuration of the worker
+         * @return accelerator instance of the filtered functor
+         */
+        template<
+            typename T_OffsetType,
+            uint32_t T_numWorkers
+        >
+        DINLINE auto
+        operator( )(
+            T_OffsetType const & domainOffset,
+            mappings::threads::WorkerCfg< T_numWorkers > const & workerCfg
+        )
+        -> acc::Filtered<
+            T_FilterOperator,
+            decltype(
+                std::declval< Filter >( )(
+                    domainOffset,
+                    workerCfg
+                )
+            ),
+            decltype(
+                std::declval< Functor >( )(
+                    domainOffset,
+                    workerCfg
+                )
+            )
+        >
+        {
+            return acc::Filtered<
+                T_FilterOperator,
+                decltype(
+                    std::declval< Filter >( )(
+                        domainOffset,
+                        workerCfg
+                    )
+                ),
+                decltype(
+                    std::declval< Functor >( )(
+                        domainOffset,
+                        workerCfg
+                    )
+                )
+            >(
+                ( *reinterpret_cast< Filter * >( this ) )(
+                    domainOffset,
+                    workerCfg
+                ),
+                ( *reinterpret_cast< Functor * >( this ) )(
+                    domainOffset,
+                    workerCfg
+                )
+            );
+        }
+
+        /** get the of the filtered functor
+         *
+         * @return combination of the filter and functor name, the names are
+         *         separated by an underscore `_`
+         */
+        HINLINE std::string
+        getName( ) const
+        {
+            return Filter::getName( ) + std::string("_") + Functor::getName( );
+        }
+    };
+
+} // namespace functor
+} // namespace PMacc

--- a/src/libPMacc/include/functor/Filtered.hpp
+++ b/src/libPMacc/include/functor/Filtered.hpp
@@ -38,7 +38,6 @@ namespace acc
 
     /** interface to combine a filter and a functor on the accelerator
      *
-     *
      * @tparam T_FilterOperator PMacc::filter::operators, type concatenate the
      *                          results of the filter
      * @tparam T_Filter PMacc::filter::Interface, type of the filter
@@ -68,22 +67,22 @@ namespace acc
 
         /** execute the functor depending of the filter result
          *
-         * Call the filter for each argument and if the combined result is true
+         * Call the filter for each argument. If the combined result is true
          * the user functor is called.
          *
-         * @param args arguments passed to the functor
-         *             - the filter is executed for each argument
-         *             - the functor get passed all arguments
+         * @param args arguments passed to the functor if the filter results of
+         *             each argument evaluate to true when combined
          */
         template< typename ... T_Args >
         DINLINE auto operator( )(  T_Args && ... args )
         -> void
         {
-            if(
-                T_FilterOperator{ }(
-                    ( *reinterpret_cast< Filter * >( this ) )( args ) ...
-                )
-            )
+            // call the filter on each argument and combine the results
+            bool const combinedResult = T_FilterOperator{ }(
+                ( *reinterpret_cast< Filter * >( this ) )( args ) ...
+            );
+
+            if( combinedResult )
                 ( *reinterpret_cast< Functor * >( this ) )( args ... );
         }
     };
@@ -110,8 +109,10 @@ namespace acc
 
     /** specialization of Filtered (with unary filter)
      *
-     * This specialization can only used if T_Filter is of the type PMacc::filter::Interface
-     * and T_Functor is of the type PMacc::filter::Interface
+     * This specialization can only be used if T_Filter is of the type PMacc::filter::Interface
+     * and T_Functor is of the type PMacc::functor::Interface.
+     * A unary filters means that each argument can only pass the same filter
+     * check before its results are combined.
      */
     template<
         typename T_FilterOperator,
@@ -239,7 +240,7 @@ namespace acc
             );
         }
 
-        /** get the of the filtered functor
+        /** get name the of the filtered functor
          *
          * @return combination of the filter and functor name, the names are
          *         separated by an underscore `_`

--- a/src/libPMacc/include/functor/Interface.hpp
+++ b/src/libPMacc/include/functor/Interface.hpp
@@ -1,0 +1,239 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of libPMacc.
+ *
+ * libPMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libPMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libPMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc_types.hpp"
+#include "mappings/threads/WorkerCfg.hpp"
+
+#include <boost/core/ignore_unused.hpp>
+#include <string>
+#include <type_traits> // std::is_same
+
+
+namespace PMacc
+{
+namespace functor
+{
+namespace acc
+{
+namespace detail
+{
+    /** Helper class to compare void with void
+     *
+     * std::is_same not allows use void as type, by wrapping the type before
+     * compare we can workaround this limitation.
+     *
+     * @tparam T_Type type to be wrapped
+     */
+    template< typename T_Type >
+    struct VoidWrapper
+    {
+
+    };
+} // namespace detail
+
+    /** functor interface used on the accelerator side
+     *
+     * The user functor of the type T_UserFunctor must contain
+     * - the `operator()` with T_numArguments arguments and a return type T_ReturnType.
+     * - a copy constructor
+     * This interface is used to wrap the user functor to make sure that
+     * the required interface is fulfilled.
+     *
+     * @tparam T_UserFunctor user functor type
+     * @tparam T_numArguments number which must be supported by T_UserFunctor
+     * @tparam T_ReturnType required return type of T_UserFunctor
+     */
+    template<
+        typename T_UserFunctor,
+        uint32_t T_numArguments,
+        typename T_ReturnType
+    >
+    struct Interface : private T_UserFunctor
+    {
+        //! type of the user functor
+        using UserFunctor = T_UserFunctor;
+
+        /** constructor
+         *
+         * @param functor user functor instance
+         */
+        DINLINE Interface( UserFunctor const & functor ) :
+            UserFunctor( functor )
+        {
+        }
+
+        /** execute the functor
+         *
+         * The number of arguments and the return type of the user functor are
+         * evaluated at compile-time and must be equal to the interface description.
+         *
+         * @tparam T_Args type of the arguments passed to the user functor
+         *
+         * @param args arguments passed to the user functor
+         * @return T_ReturnType
+         */
+        template< typename ... T_Args >
+        DINLINE auto operator( )(  T_Args && ... args )
+        -> decltype(
+            std::declval< UserFunctor >( )( args ... )
+        )
+        {
+            /* check if the current used number of arguments to execute the
+             * functor is equal to the interface requirements
+             */
+            PMACC_CASSERT_MSG_TYPE(
+                __user_functor_has_wrong_number_of_arguments,
+                UserFunctor,
+                T_numArguments == sizeof...( args )
+            );
+
+            // get the return type of the user functor
+            using UserFunctorReturnType = decltype(
+                std::declval< UserFunctor >( )( args ... )
+            );
+
+            // compare user functor return type with the interface requirements
+            PMACC_CASSERT_MSG(
+                __wrong_user_functor_return_type,
+                std::is_same<
+                    detail::VoidWrapper< UserFunctorReturnType >,
+                    detail::VoidWrapper< T_ReturnType >
+                >::value
+            );
+            return ( *reinterpret_cast< UserFunctor * >( this ) )( args ... );
+        }
+    };
+
+} // namespace acc
+
+    /** Interface for a user functor
+     *
+     * @tparam T_UserFunctor user functor type
+     * @tparam T_numArguments number which must be supported by T_UserFunctor
+     * @tparam T_ReturnType required return type of T_UserFunctor
+     */
+    template<
+        typename T_UserFunctor,
+        uint32_t T_numArguments,
+        typename T_ReturnType
+    >
+    struct Interface : private T_UserFunctor
+    {
+
+        //! type of the user functor
+        using UserFunctor = T_UserFunctor;
+
+        /** constructor
+         *
+         * This constructor is only compiled if the user functor has
+         * a host side constructor with one (uint32_t) argument.
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                      the constructor
+         * @param currentStep current simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = UserFunctor >
+        HINLINE Interface(
+            uint32_t const currentStep,
+            typename std::enable_if<
+                std::is_constructible<
+                    DeferFunctor,
+                    uint32_t
+                >::value
+            >::type* = 0
+        ) : UserFunctor( currentStep )
+        {
+        }
+
+        /** constructor
+         *
+         * This constructor is only compiled if the user functor has a default constructor.
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                      the constructor
+         * @param currentStep simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = UserFunctor >
+        HINLINE Interface(
+            uint32_t const currentStep,
+            typename std::enable_if<
+                std::is_constructible< DeferFunctor >::value
+            >::type* = 0
+        ) : UserFunctor( )
+        {
+            boost::ignore_unused( currentStep );
+        }
+
+        /** create a functor which can be used on the accelerator
+         *
+         * @tparam T_OffsetType type to describe the size of a domain
+         * @tparam T_numWorkers number of workers
+         *
+         * @param domainOffset offset to the origin of the local domain
+         *                     This can be e.g a supercell or cell offset and depends
+         *                     of the context where the interface is specialized.
+         * @param workerCfg configuration of the worker
+         * @return a instance of the user functor wrapped by the accelerator
+         *         functor interface
+         */
+        template<
+            typename T_OffsetType,
+            uint32_t T_numWorkers
+        >
+        DINLINE auto
+        operator( )(
+            T_OffsetType const & domainOffset,
+            mappings::threads::WorkerCfg< T_numWorkers > const & workerCfg
+        )
+        -> acc::Interface<
+            decltype(
+                std::declval< UserFunctor >( )(
+                    domainOffset,
+                    workerCfg
+                )
+            ),
+            T_numArguments,
+            T_ReturnType
+        >
+        {
+            return ( *reinterpret_cast< UserFunctor * >( this ) )(
+                domainOffset,
+                workerCfg
+            );
+        }
+
+        /** get the user functor name
+         *
+         * @return name to identify the functor
+         */
+        HINLINE std::string
+        getName( ) const
+        {
+            return ( *reinterpret_cast< UserFunctor * >( this ) ).getName( );
+        }
+    };
+
+} // namespace functor
+} // namespace PMacc

--- a/src/libPMacc/include/functor/Interface.hpp
+++ b/src/libPMacc/include/functor/Interface.hpp
@@ -39,8 +39,8 @@ namespace detail
 {
     /** Helper class to compare void with void
      *
-     * std::is_same not allows use void as type, by wrapping the type before
-     * compare we can workaround this limitation.
+     * std::is_same does not allow to use void as type. By wrapping the type before
+     * comparing, we can workaround this limitation.
      *
      * @tparam T_Type type to be wrapped
      */
@@ -129,7 +129,7 @@ namespace detail
     /** Interface for a user functor
      *
      * @tparam T_UserFunctor user functor type
-     * @tparam T_numArguments number which must be supported by T_UserFunctor
+     * @tparam T_numArguments number of arguments which must be supported by T_UserFunctor
      * @tparam T_ReturnType required return type of T_UserFunctor
      */
     template<
@@ -195,7 +195,7 @@ namespace detail
          *                     This can be e.g a supercell or cell offset and depends
          *                     of the context where the interface is specialized.
          * @param workerCfg configuration of the worker
-         * @return a instance of the user functor wrapped by the accelerator
+         * @return an instance of the user functor wrapped by the accelerator
          *         functor interface
          */
         template<
@@ -224,7 +224,7 @@ namespace detail
             );
         }
 
-        /** get the user functor name
+        /** get name of the user functor
          *
          * @return name to identify the functor
          */


### PR DESCRIPTION
Introduce a generic implementation for a functor. The functor is instantiated on the host side then passed to the kernel and on the device/accelerator a device instance is created.

This workflow allows to pass a generic functor to the device without defining a fixed interface for the `operator()` but keeps the possibility that the user can embed container or other members into the functor even if there is a strong dependency to the accelerator. A example is the random number generator in alpaka, the generator depends on the accelerator but the accelerator is not known before the kernel is executed on the device.

At runtime, the following logic happens, for a binary filtered functor (`PMacc::functor::Filtered`):
- call filter for the two arguments (`PMacc::filter::Interface`)
- combine both results via the filter operator (`PMacc::filter::operators`)
- call the functor if this combined filter result is true (`PMacc::functor::Interface`)

For unary functors, the typical filter operator is just a pass-through of the one argument (as long as one does not negate its result).

# Features

- add generic functor interface
- add define a filter interface
- add a filtered functor interface (confitional functor)
- add operators to combine filter results

# Examples

```C++
    // definition for a unary filtered functor
    template<
        typename T_UnaryFunctor,
        typename T_UnaryFilter = filter::IsValid
    >
    using IUnary = PMacc::functor::Filtered<
        PMacc::filter::operators::And,
        PMacc::filter::Interface<
            T_UnaryFilter,
            1u
        >,
        PMacc::functor::Interface<
            T_UnaryFunctor,
            1u,
            void
        >
    >;

    // definition for a binary filtered functor
    template<
        typename T_BinaryFunctor,
        typename T_UnaryFilter = filter::IsValid
    >
    using IBinary = PMacc::functor::Filtered<
        PMacc::filter::operators::And,
        PMacc::filter::Interface<
            T_UnaryFilter,
            1u
        >,
        PMacc::functor::Interface<
            T_BinaryFunctor,
            2u,
            void
        >
    >;
```