### PR TITLE
Doxygen: Fix Headers

### DIFF
--- a/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
+++ b/src/libPMacc/include/cuSTL/algorithm/mpi/Reduce.hpp
@@ -1,6 +1,4 @@
-
-/**
- * Copyright 2013-2017 Heiko Burau
+/* Copyright 2013-2017 Heiko Burau
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/threads/ForEachIdx.hpp
+++ b/src/libPMacc/include/mappings/threads/ForEachIdx.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2017 Rene Widera
+/* Copyright 2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/mappings/threads/IdxConfig.hpp
+++ b/src/libPMacc/include/mappings/threads/IdxConfig.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2017 Rene Widera
+/* Copyright 2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/memory/CtxArray.hpp
+++ b/src/libPMacc/include/memory/CtxArray.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2017 Rene Widera
+/* Copyright 2017 Rene Widera
  *
  * This file is part of libPMacc.
  *

--- a/src/libPMacc/include/traits/GetNumWorkers.hpp
+++ b/src/libPMacc/include/traits/GetNumWorkers.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2017 Rene Widera
+/* Copyright 2017 Rene Widera
  *
  * This file is part of libPMacc.
  *


### PR DESCRIPTION
Fix falsely placed doxygen comments in file headers which show up at unexpected places in the sphinx docs.