### PR TITLE
pic-create: derived sim lib/

### DIFF
--- a/pic-create
+++ b/pic-create
@@ -118,7 +118,7 @@ do
     if [ ! -d "$dir_dst" ] ; then
         mkdir -p "$dir_dst"
     fi
-    rsync --inplace -q -avc --exclude=".*" $dir_src/* $dir_dst
+    rsync --inplace -q -avc --exclude=".*" $dir_src/ $dir_dst
 done
 
 #copy all data from src_path if path is not picongpu default param path
@@ -129,7 +129,7 @@ if [ "$src_path" != "$this_dir/src/picongpu" ] ; then
         dir_src="$src_path/$d"
         if [ -d "$dir_src" ] ; then
             mkdir -p "$dir_dst"
-            rsync --inplace -q -avc --exclude=".*" $dir_src/* $dir_dst
+            rsync --inplace -q -avc --exclude=".*" $dir_src/ $dir_dst
         fi
     done
 fi


### PR DESCRIPTION
If libraries (or python modules) are present in a simulation's `picongpu/` directory (inside `lib/`), `pic-create` did fail to derive a new input parameter set.

This changes it (only a problem in `dev` since #2058).

Tested on both a creation from an example and a creation from a run simulation's `picongpu/` directory via:
```bash
$ pic-create $PICSRC/examples/LaserWakefield ~/paramSets/lwfa-dev1
# and
$ pic-create /bigdata/hplsim/scratch/huebl/lwfa-dev-018/picongpu ~/paramSets/lwfa-dev2
```