### PR TITLE
splash2txt: C++98

### DIFF
--- a/src/tools/splash2txt/splash2txt.cpp
+++ b/src/tools/splash2txt/splash2txt.cpp
@@ -218,7 +218,7 @@ int main( int argc, char** argv )
         return 1;
     }
 
-    ITools *tools = nullptr;
+    ITools *tools = NULL;
     switch ( options.fileMode)
     {
         case FM_SPLASH: tools = new ToolsSplashParallel( options, mpi_topology, *outStream );

--- a/src/tools/splash2txt/tools_adios_parallel.cpp
+++ b/src/tools/splash2txt/tools_adios_parallel.cpp
@@ -61,7 +61,7 @@ void ToolsAdiosParallel::convertToText()
 
         pVarInfo = adios_inq_var(pFile, nodeName.c_str());
 
-        varTypeSize = adios_type_size(pVarInfo->type, nullptr);
+        varTypeSize = adios_type_size(pVarInfo->type, NULL);
 
         // get number of elements combined in a dataset
         for(int j = 0; j < pVarInfo->ndim; j++)
@@ -71,7 +71,7 @@ void ToolsAdiosParallel::convertToText()
         // allocate memory
         P = (uint8_t*) malloc (sizeof(uint8_t) * varTypeSize * varElement);
 
-        adios_schedule_read(pFile, nullptr, nodeName.c_str(), 0, 1, P);
+        adios_schedule_read(pFile, NULL, nodeName.c_str(), 0, 1, P);
 
         adios_perform_reads(pFile, 1);
 

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -132,7 +132,7 @@ void ToolsSplashParallel::printParticles(std::vector<ExDataContainer> fileData)
                 }
 
                 void* element = container->getElement(i);
-                assert(element != nullptr);
+                assert(element != NULL);
 
                 printElement(data_type, element, iter->unit, m_options.delimiter);
                 numElementsProcessed[container]++;
@@ -196,7 +196,7 @@ void ToolsSplashParallel::printFields(std::vector<ExDataContainer> fileData)
                             iter->container->getIndex(0)->getDataType();
 
                     void* element = iter->container->getElement(index);
-                    assert(element != nullptr);
+                    assert(element != NULL);
 
                     printElement(data_type, element, iter->unit, m_options.delimiter);
                 }
@@ -233,7 +233,7 @@ void ToolsSplashParallel::convertToText()
     try
     {
         dc.readAttribute(m_options.step, m_options.data[0].c_str(), DOMCOL_ATTR_CLASS,
-                &ref_data_class, nullptr);
+                &ref_data_class, NULL);
     } catch (const DCException&)
     {
         errorStream << "Error: No domain information for dataset '" << m_options.data[0] << "' available." << std::endl;
@@ -266,7 +266,7 @@ void ToolsSplashParallel::convertToText()
 
         DomainCollector::DomDataClass data_class = DomainCollector::UndefinedType;
         dc.readAttribute(m_options.step, iter->c_str(), DOMCOL_ATTR_CLASS,
-                &data_class, nullptr);
+                &data_class, NULL);
         if (data_class != ref_data_class)
             throw std::runtime_error("All requested datasets must be of the same data class");
 
@@ -282,7 +282,7 @@ void ToolsSplashParallel::convertToText()
             // poly type
 
             excontainer.container = dc.readDomain(m_options.step, iter->c_str(),
-                    Domain(total_domain.getOffset(), total_domain.getSize()), nullptr, true);
+                    Domain(total_domain.getOffset(), total_domain.getSize()), NULL, true);
         } else
         {
             // grid type
@@ -302,7 +302,7 @@ void ToolsSplashParallel::convertToText()
                 }
 
             excontainer.container = dc.readDomain(m_options.step, iter->c_str(),
-                    Domain(offset, domain_size), nullptr);
+                    Domain(offset, domain_size), NULL);
         }
 
         // read unit
@@ -312,7 +312,7 @@ void ToolsSplashParallel::convertToText()
             try
             {
                 dc.readAttribute(m_options.step, iter->c_str(), "unitSI",
-                        &(excontainer.unit), nullptr);
+                        &(excontainer.unit), NULL);
             } catch (const DCException&)
             {
                 if (m_options.verbose)
@@ -333,7 +333,7 @@ void ToolsSplashParallel::convertToText()
         file_data.push_back(excontainer);
     }
 
-    assert(file_data[0].container->get(0)->getData() != nullptr);
+    assert(file_data[0].container->get(0)->getData() != NULL);
 
     // write to file
     //
@@ -391,7 +391,7 @@ void ToolsSplashParallel::listAvailableDatasets()
 {
     // number of timesteps in this file
     size_t num_entries = 0;
-    dc.getEntryIDs(nullptr, &num_entries);
+    dc.getEntryIDs(NULL, &num_entries);
     if (num_entries == 0)
     {
         m_outStream << "no entries in file" << std::endl;
@@ -399,7 +399,7 @@ void ToolsSplashParallel::listAvailableDatasets()
     }
 
     int32_t *entries = new int32_t[num_entries];
-    dc.getEntryIDs(entries, nullptr);
+    dc.getEntryIDs(entries, NULL);
     std::sort(entries, entries + num_entries);
 
     m_outStream << std::endl
@@ -418,9 +418,9 @@ void ToolsSplashParallel::listAvailableDatasets()
     // available data sets in this file
     std::vector<DataCollector::DCEntry> dataTypeNames;
     size_t numDataTypes = 0;
-    dc.getEntriesForID(entries[0], nullptr, &numDataTypes);
+    dc.getEntriesForID(entries[0], NULL, &numDataTypes);
     dataTypeNames.resize(numDataTypes);
-    dc.getEntriesForID(entries[0], &(dataTypeNames.front()), nullptr);
+    dc.getEntriesForID(entries[0], &(dataTypeNames.front()), NULL);
 
     // parse dataTypeNames vector in a nice way for stdout
     m_outStream << "Available data field names:";


### PR DESCRIPTION
Keep splash2txt in C++98 so we do not need to artificially push up it's CMakeLists.txt requirements to C++11.


**Or:** also make it require C++11 (the main project that ships it does so anyway). I might prefer the second option (patch below).

Fixes an issue reported in https://github.com/ComputationalRadiationPhysics/picongpu/issues/1984#issuecomment-313293471 (compile fail with, e.g. gcc 4.9 that still defaults to C++98 but supports C++11)