### PR TITLE
remove micro meters usage in default background field

### DIFF
--- a/include/picongpu/simulation_defines/param/fieldBackground.param
+++ b/include/picongpu/simulation_defines/param/fieldBackground.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2017 Axel Huebl, Alexander Debus
+/* Copyright 2014-2017 Axel Huebl, Alexander Debus, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -49,8 +49,8 @@ namespace picongpu
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */
             constexpr float_64 period_SI(20.0e-6);
-            /* calculate cells -> SI -> m to microns*/
-            const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI * 1.0e6;
+            /* calculate cells -> SI [m] */
+            const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI;
             /* note: you can also transform the time step to seconds by
              *       multiplying with DELTA_T_SI */
 
@@ -82,8 +82,8 @@ namespace picongpu
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */
             constexpr float_64 period_SI(20.0e-6);
-            /* calculate cells -> SI -> m to microns*/
-            const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI * 1.0e6;
+            /* calculate cells -> SI -> [m] */
+            const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI;
             /* note: you can also transform the time step to seconds by
              *       multiplying with DELTA_T_SI */
 


### PR DESCRIPTION
This pull request fixes the mixed unit usage of wavelength `period_SI` (in meter) and position `y_SI` (in micro meters) to meter.

With the current setup this would be a period/wavelength of 0.02 nm - which is way below the grid resolution. 


