### PR TITLE
Background Fields: Fix Restart GUARD

### DIFF
--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -231,7 +231,6 @@ public:
             TimeIntervall tSimCalculation;
             TimeIntervall tRound;
             double roundAvg = 0.0;
-            Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
 
             /* Since in the main loop movingWindow is called always before the dump, we also call it here for consistency.
              * This becomes only important, if movingWindowCheck does more than merely checking for a slide.
@@ -261,13 +260,14 @@ public:
                 tRound.toggleEnd();
                 roundAvg += tRound.getInterval();
 
+                /* NEXT TIMESTEP STARTS HERE */
                 currentStep++;
                 Environment<>::get().SimulationDescription().setCurrentStep( currentStep );
-                /*output after a round*/
+                /* output times after a round */
                 dumpTimes(tSimCalculation, tRound, roundAvg, currentStep);
 
                 movingWindowCheck(currentStep);
-                /*dump after simulated step*/
+                /* dump at the beginning of the simulated step */
                 dumpOneStep(currentStep);
             }
 


### PR DESCRIPTION
(Trying) to close #2137:
Restart of background fields could cause:
- artificial noise after restart from the outer regions with non-periodic boundary conditions
- if background fields are used (e.g. TWTS pulse)

Simplify the logic of restarting fields:
- do not add the already contained fields in `movingWindowCheck` again
- spares us the substraction we had before
- GUARDS are not part of the checkpoint data, which is cumbersome for the "outer" GUARDS of our global domain
- we need to add the background field ONLY in those to generate a valid restart field