### PR TITLE
Badge: Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ PIConGPU - A Many GPGPU PIC Code
 
 [![Code Status master](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/master.svg?label=master)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
 [![Code Status dev](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/dev.svg?label=dev)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
-[![Documentation Status](https://readthedocs.org/projects/picongpu/badge/?version=master)](http://picongpu.readthedocs.io/en/master/?badge=master)
-[![Documentation Status](https://readthedocs.org/projects/picongpu/badge/?version=dev)](http://picongpu.readthedocs.io/en/dev/?badge=dev)
+[![Documentation Status](https://readthedocs.org/projects/picongpu/badge/?version=latest)](http://picongpu.readthedocs.io)
 [![Language](https://img.shields.io/badge/language-C%2B%2B11-orange.svg)](https://isocpp.org/)
 [![License PIConGPU](https://img.shields.io/badge/license-GPLv3-blue.svg?label=PIConGPU)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![License PMacc](https://img.shields.io/badge/license-LGPLv3-blue.svg?label=PMacc)](https://www.gnu.org/licenses/lgpl-3.0.html)


### PR DESCRIPTION
Only show the "latest" (dev) badge for the docs. The latest stable would need to be bumped manually.

Renaming does not work properly, so we keep
- tags
- "latest" (for dev)

as to-be-build versions in RTD