### PR TITLE
picongpu --version

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -72,6 +72,10 @@ TBG_projectPath
 TBG_dstPath
 
 
+# version information on startup
+TBG_verson="--versionOnce"
+
+
 # Regex to describe the static distribution of the cells for each GPU
 # default: equal distribution over all GPUs
 # example for -d 2 4 1 -g 128 192 12

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -73,7 +73,7 @@ TBG_dstPath
 
 
 # version information on startup
-TBG_verson="--versionOnce"
+TBG_version="--versionOnce"
 
 
 # Regex to describe the static distribution of the cells for each GPU

--- a/include/picongpu/ArgsParser.cpp
+++ b/include/picongpu/ArgsParser.cpp
@@ -18,16 +18,18 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <iostream>
-#include <sstream>
-#include <fstream>
-
 #include "picongpu/ArgsParser.hpp"
+#include "picongpu/versionFormat.hpp"
 
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/cmdline.hpp>
 #include <boost/program_options/variables_map.hpp>
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+
 
 namespace picongpu
 {
@@ -77,6 +79,7 @@ namespace picongpu
             desc.add_options()
                     ( "help,h", "print help message and exit" )
                     ( "validate", "validate command line parameters and exit" )
+                    ( "version,v", "print version information and exit" )
                     ( "config,c", po::value<std::vector<std::string> > ( &config_files )->multitoken( ), "Config file(s)" )
                     ;
 
@@ -109,6 +112,12 @@ namespace picongpu
             if ( vm.count( "help" ) )
             {
                 std::cerr << desc << "\n";
+                return SUCCESS_EXIT;
+            }
+            // print versions of dependent software
+            if ( vm.count( "version" ) )
+            {
+                void( getSoftwareVersions( std::cout ) );
                 return SUCCESS_EXIT;
             }
             // no parameters set: required parameters (e.g., -g) will be missing

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -230,6 +230,24 @@ endif(ADIOS_FOUND)
 
 
 ################################################################################
+# Additional defines for PIConGPU outputs
+################################################################################
+
+# CMake
+add_definitions(-DCMAKE_VERSION=${CMAKE_VERSION})
+add_definitions(-DCMAKE_GENERATOR=${CMAKE_GENERATOR})
+add_definitions(-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+
+# OS & Host Architecture
+add_definitions(-DCMAKE_SYSTEM=${CMAKE_SYSTEM})
+add_definitions(-DCMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR})
+
+# Compiler
+add_definitions(-DCMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID})
+add_definitions(-DCMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION})
+
+
+################################################################################
 # Warnings
 ################################################################################
 

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -235,7 +235,6 @@ endif(ADIOS_FOUND)
 
 # CMake
 add_definitions(-DCMAKE_VERSION=${CMAKE_VERSION})
-add_definitions(-DCMAKE_GENERATOR=${CMAKE_GENERATOR})
 add_definitions(-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
 # OS & Host Architecture

--- a/include/picongpu/versionFormat.cu
+++ b/include/picongpu/versionFormat.cu
@@ -1,0 +1,177 @@
+/* Copyright 2015-2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picongpu/versionFormat.hpp"
+
+#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/cmdline.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <boost/preprocessor/stringize.hpp>
+
+#include <cuda.h>
+#include <mallocMC/mallocMC.hpp>
+#include <mpi.h>
+#if( ENABLE_HDF5 == 1 )
+#   include <splash/splash.h>
+#endif
+#if( ENABLE_ADIOS == 1 )
+#   include <adios.h>
+#endif
+#if( PIC_ENABLE_PNG == 1 )
+#   include <pngwriter.h>
+#endif
+
+#include <sstream>
+
+
+namespace picongpu
+{
+    std::list< std::string >
+    getSoftwareVersions( std::ostream & cliText )
+    {
+        std::string const versionNotFound( "NOTFOUND" );
+
+        std::stringstream picongpu;
+        picongpu << PICONGPU_VERSION_MAJOR << "."
+                 << PICONGPU_VERSION_MINOR << "."
+                 << PICONGPU_VERSION_PATCH;
+        if( std::string( PICONGPU_VERSION_LABEL ).size() > 0 )
+            picongpu << "-" << PICONGPU_VERSION_LABEL;
+
+        std::stringstream buildType;
+        buildType << BOOST_PP_STRINGIZE(CMAKE_BUILD_TYPE);
+
+        std::stringstream os;
+        os << BOOST_PP_STRINGIZE(CMAKE_SYSTEM);
+        std::stringstream arch;
+        arch << BOOST_PP_STRINGIZE(CMAKE_SYSTEM_PROCESSOR);
+
+        std::stringstream cxx;
+        std::stringstream cxxVersion;
+        cxx << BOOST_PP_STRINGIZE(CMAKE_CXX_COMPILER_ID);
+        cxxVersion << BOOST_PP_STRINGIZE(CMAKE_CXX_COMPILER_VERSION);
+
+        std::stringstream cmake;
+        cmake << BOOST_PP_STRINGIZE(CMAKE_VERSION);
+        std::stringstream cmakeGenerator;
+        cmakeGenerator << BOOST_PP_STRINGIZE(CMAKE_GENERATOR);
+
+        std::stringstream cuda;
+        cuda << CUDA_VERSION;
+
+        std::stringstream mallocMC;
+        mallocMC << MALLOCMC_VERSION_MAJOR << "."
+                 << MALLOCMC_VERSION_MINOR << "."
+                 << MALLOCMC_VERSION_PATCH;
+
+        std::stringstream boost;
+        boost << BOOST_PP_STRINGIZE(BOOST_VERSION);
+
+        std::stringstream mpiStandard;
+        std::stringstream mpiFlavor;
+        std::stringstream mpiFlavorVersion;
+        mpiStandard << MPI_VERSION << "." << MPI_SUBVERSION;
+#if defined( OMPI_MAJOR_VERSION )
+        // includes derivates such as Bullx MPI, Sun, ...
+        mpiFlavor << "OpenMPI";
+        mpiFlavorVersion << OMPI_MAJOR_VERSION << "."
+                         << OMPI_MINOR_VERSION << "."
+                         << OMPI_RELEASE_VERSION;
+#elif defined( MPICH_VERSION )
+        /* includes MPICH2 and MPICH3 and
+         * derivates such as IBM, Cray, MS, Intel, MVAPICH(2), ... */
+        mpiFlavor << "MPICH";
+        mpiFlavorVersion << MPICH_VERSION;
+#else
+        mpiFlavor << "unknown";
+        mpiFlavorVersion << "unknown";
+#endif
+
+        std::stringstream pngwriter;
+#if( PIC_ENABLE_PNG == 1 )
+        pngwriter << PNGWRITER_VERSION_MAJOR << "."
+                  << PNGWRITER_VERSION_MINOR << "."
+                  << PNGWRITER_VERSION_PATCH;
+#else
+        pngwriter << versionNotFound;
+#endif
+
+        std::stringstream splash;
+        std::stringstream splashFormat;
+#if( ENABLE_HDF5 == 1 )
+        splash << SPLASH_VERSION_MAJOR << "."
+               << SPLASH_VERSION_MINOR << "."
+               << SPLASH_VERSION_PATCH;
+        splashFormat << SPLASH_FILE_FORMAT_MAJOR << "."
+                     << SPLASH_FILE_FORMAT_MINOR;
+#else
+        splash << versionNotFound;
+        splashFormat << versionNotFound;
+#endif
+
+        std::stringstream adios;
+#if( ENABLE_ADIOS == 1 )
+        adios << ADIOS_VERSION;
+#else
+        adios << versionNotFound;
+#endif
+
+        // CLI Formatting
+        cliText << "PIConGPU: " << picongpu.str() << std::endl;
+        cliText << "  Build-Type: " << buildType.str() << std::endl
+                << std::endl;
+        cliText << "Third party:" << std::endl;
+        cliText << "  OS:         " << os.str() << std::endl;
+        cliText << "  arch:       " << arch.str() << std::endl;
+        cliText << "  CXX:        " << cxx.str()
+                << " (" << cxxVersion.str() << ")" << std::endl;
+        cliText << "  CMake:      " << cmake.str()
+                << " (" << cmakeGenerator.str() << ")" << std::endl;
+        cliText << "  CUDA:       " << cuda.str() << std::endl;
+        cliText << "  mallocMC:   " << mallocMC.str() << std::endl;
+        cliText << "  Boost:      " << boost.str() << std::endl;
+        cliText << "  MPI:        " << std::endl
+                << "    standard: " << mpiStandard.str() << std::endl
+                << "    flavor:   " << mpiFlavor.str()
+                << " (" << mpiFlavorVersion.str() << ")" << std::endl;
+        cliText << "  PNGwriter:  " << pngwriter.str() << std::endl;
+        cliText << "  libSplash:  " << splash.str()
+                << " (Format " << splashFormat.str() << ")" << std::endl;
+        cliText << "  ADIOS:      " << adios.str() << std::endl;
+
+        // Module-like formatting of software only
+        std::list< std::string > software;
+        software.push_back( std::string( "PIConGPU/" ) + picongpu.str() );
+        software.push_back( cxx.str() + std::string( "/" ) + cxxVersion.str() );
+        software.push_back( std::string( "CMake/" ) + cmake.str() );
+        software.push_back( std::string( "CUDA/" ) + cuda.str() );
+        software.push_back( std::string( "Boost/" ) + boost.str() );
+        software.push_back( mpiFlavor.str() + std::string( "/" ) + mpiFlavorVersion.str() );
+        software.push_back( std::string( "mallocMC/" ) + mallocMC.str() );
+        if( pngwriter.str().compare( versionNotFound ) != 0 )
+            software.push_back( std::string( "PNGwriter/" ) + pngwriter.str() );
+        if( splash.str().compare( versionNotFound ) != 0 )
+            software.push_back( std::string( "libSplash/" ) + splash.str() );
+        if( adios.str().compare( versionNotFound ) != 0 )
+            software.push_back( std::string( "ADIOS/" ) + adios.str() );
+
+        return software;
+    }
+} // namespace picongpu

--- a/include/picongpu/versionFormat.cu
+++ b/include/picongpu/versionFormat.cu
@@ -19,10 +19,9 @@
 
 #include "picongpu/versionFormat.hpp"
 
-#include <boost/program_options.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/cmdline.hpp>
-#include <boost/program_options/variables_map.hpp>
+#include <boost/version.hpp>
+// work-around: mallocMC PR #142
+#include <boost/config.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
 #include <cuda.h>

--- a/include/picongpu/versionFormat.cu
+++ b/include/picongpu/versionFormat.cu
@@ -70,8 +70,6 @@ namespace picongpu
 
         std::stringstream cmake;
         cmake << BOOST_PP_STRINGIZE(CMAKE_VERSION);
-        std::stringstream cmakeGenerator;
-        cmakeGenerator << BOOST_PP_STRINGIZE(CMAKE_GENERATOR);
 
         std::stringstream cuda;
         cuda << CUDA_VERSION;
@@ -142,8 +140,7 @@ namespace picongpu
         cliText << "  arch:       " << arch.str() << std::endl;
         cliText << "  CXX:        " << cxx.str()
                 << " (" << cxxVersion.str() << ")" << std::endl;
-        cliText << "  CMake:      " << cmake.str()
-                << " (" << cmakeGenerator.str() << ")" << std::endl;
+        cliText << "  CMake:      " << cmake.str() << std::endl;
         cliText << "  CUDA:       " << cuda.str() << std::endl;
         cliText << "  mallocMC:   " << mallocMC.str() << std::endl;
         cliText << "  Boost:      " << boost.str() << std::endl;

--- a/include/picongpu/versionFormat.hpp
+++ b/include/picongpu/versionFormat.hpp
@@ -1,0 +1,40 @@
+/* Copyright 2015-2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "picongpu/version.hpp"
+
+#include <ostream>
+#include <string>
+#include <list>
+
+
+namespace picongpu
+{
+    /** Collect software dependencies of PIConGPU
+     *
+     * Collect the versions of dependent software in PIConGPU
+     * for output and reproducibility.
+     *
+     * @param[out] cliText formatted table for output to a command line
+     * @return a list of strings in the form software/version
+     */
+    std::list< std::string >
+    getSoftwareVersions( std::ostream & cliText );
+} // namespace picongpu

--- a/share/picongpu/examples/Bremsstrahlung/etc/picongpu/0008gpus.cfg
+++ b/share/picongpu/examples/Bremsstrahlung/etc/picongpu/0008gpus.cfg
@@ -68,7 +68,8 @@ TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
 TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/Bunch/etc/picongpu/bunch_0032.cfg
+++ b/share/picongpu/examples/Bunch/etc/picongpu/bunch_0032.cfg
@@ -70,7 +70,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/Empty/etc/picongpu/1gpu.cfg
+++ b/share/picongpu/examples/Empty/etc/picongpu/1gpu.cfg
@@ -59,7 +59,8 @@ TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
 TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
@@ -84,7 +84,8 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_periodic     \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0004gpus.cfg
@@ -75,7 +75,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
@@ -81,7 +81,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus.cfg
@@ -59,7 +59,8 @@ TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
 TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus_isaac.cfg
@@ -61,7 +61,8 @@ TBG_programParams="!TBG_devices      \
                    !TBG_steps        \
                    !TBG_periodic     \
                    !TBG_softRestarts \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0008gpus.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0008gpus.cfg
@@ -64,7 +64,8 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_movingWindow \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0016gpus.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0016gpus.cfg
@@ -66,7 +66,8 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_movingWindow \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0032gpus.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0032gpus.cfg
@@ -64,7 +64,8 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_movingWindow \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/SingleParticleTest/etc/picongpu/0001gpu.cfg
+++ b/share/picongpu/examples/SingleParticleTest/etc/picongpu/0001gpu.cfg
@@ -62,7 +62,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/0001gpu.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/0001gpu.cfg
@@ -64,7 +64,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/0004gpus.cfg
@@ -64,7 +64,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/0008gpus.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/0008gpus.cfg
@@ -64,7 +64,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/0032gpus.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/0032gpus.cfg
@@ -64,7 +64,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/0064gpus.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/0064gpus.cfg
@@ -64,7 +64,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/WarmCopper/etc/picongpu/1gpu.cfg
+++ b/share/picongpu/examples/WarmCopper/etc/picongpu/1gpu.cfg
@@ -67,7 +67,8 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_period       \
-                   !TBG_plugins"
+                   !TBG_plugins      \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"

--- a/share/picongpu/examples/WeibelTransverse/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/WeibelTransverse/etc/picongpu/0004gpus.cfg
@@ -78,7 +78,8 @@ TBG_programParams="!TBG_devices     \
                    !TBG_gridSize    \
                    !TBG_steps       \
                    !TBG_periodic    \
-                   !TBG_plugins"
+                   !TBG_plugins     \
+                   --versionOnce"
 
 # TOTAL number of GPUs
 TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"


### PR DESCRIPTION
Supersedes PR #867, Output version information and exit with zero return state.

### Without MPI Init

```bash
$ ./bin/picongpu --version
```
```
PIConGPU: 0.4.0-dev
  Build-Type: Release

Third party:
  OS:         Linux-4.4.0-38-generic
  arch:       x86_64
  CXX:        GNU (4.9.2)
  CMake:      3.7.2 (Unix Makefiles)
  CUDA:       8000
  mallocMC:   2.2.0
  Boost:      106200
  MPI:        
    standard: 3.0
    flavor:   OpenMPI (1.8.6)
  PNGwriter:  0.5.6
  libSplash:  1.6.0 (Format 4.0)
  ADIOS:      1.10.0
```
(returns with 0 exit status)

### During Run

```bash
$ mpirun -n 2 ./bin/picongpu --versionOnce -g 64 32 32 --periodic 1 1 1 -d 2 1 1 -s 10
```
```
PIConGPU: 0.4.0-dev
  Build-Type: Release

Third party:
  OS:         Linux-4.4.0-38-generic
  arch:       x86_64
  CXX:        GNU (4.9.2)
  CMake:      3.7.2 (Unix Makefiles)
  CUDA:       8000
  mallocMC:   2.2.0
  Boost:      106200
  MPI:        
    standard: 3.0
    flavor:   OpenMPI (1.8.6)
  PNGwriter:  0.5.6
  libSplash:  1.6.0 (Format 4.0)
  ADIOS:      1.10.0
PIConGPUVerbose PHYSICS(1) | Sliding Window is OFF
PIConGPUVerbose PHYSICS(1) | Courant c*dt <= 1.00229 ? 1
PIConGPUVerbose PHYSICS(1) | species e: omega_p * dt <= 0.1 ? 0.0247974
PIConGPUVerbose PHYSICS(1) | y-cells per wavelength: 18.0587
PIConGPUVerbose PHYSICS(1) | macro particles per gpu: 65536
PIConGPUVerbose PHYSICS(1) | typical macro particle weighting: 6955.06
PIConGPUVerbose PHYSICS(1) | UNIT_SPEED 2.99792e+08
PIConGPUVerbose PHYSICS(1) | UNIT_TIME 1.39e-16
PIConGPUVerbose PHYSICS(1) | UNIT_LENGTH 4.16712e-08
PIConGPUVerbose PHYSICS(1) | UNIT_MASS 6.33563e-27
PIConGPUVerbose PHYSICS(1) | UNIT_CHARGE 1.11432e-15
PIConGPUVerbose PHYSICS(1) | UNIT_EFIELD 1.22627e+13
PIConGPUVerbose PHYSICS(1) | UNIT_BFIELD 40903.8
PIConGPUVerbose PHYSICS(1) | UNIT_ENERGY 5.69418e-10
initialization time:  6sec 370msec = 6 sec
  0 % =        0 | time elapsed:                    0msec | avg time per step:   0msec
 10 % =        1 | time elapsed:                   15msec | avg time per step:  15msec
 20 % =        2 | time elapsed:                   29msec | avg time per step:  13msec
 30 % =        3 | time elapsed:                   43msec | avg time per step:  14msec
 40 % =        4 | time elapsed:                   57msec | avg time per step:  14msec
 50 % =        5 | time elapsed:                   70msec | avg time per step:  13msec
 60 % =        6 | time elapsed:                   84msec | avg time per step:  14msec
 70 % =        7 | time elapsed:                   99msec | avg time per step:  14msec
 80 % =        8 | time elapsed:                  113msec | avg time per step:  14msec
 90 % =        9 | time elapsed:                  126msec | avg time per step:  13msec
100 % =       10 | time elapsed:                  140msec | avg time per step:  13msec
calculation  simulation time: 140msec = 0 sec
full simulation time:  6sec 553msec = 6 sec
```
(only printed once by rank zero and continues normal execution)