### PR TITLE
--help to stdout

### DIFF
--- a/include/picongpu/ArgsParser.cpp
+++ b/include/picongpu/ArgsParser.cpp
@@ -108,7 +108,7 @@ namespace picongpu
             // print help message and quit simulation
             if ( vm.count( "help" ) )
             {
-                std::cerr << desc << "\n";
+                std::cout << desc << "\n";
                 return SUCCESS_EXIT;
             }
             // no parameters set: required parameters (e.g., -g) will be missing


### PR DESCRIPTION
`--help|-h` should write to stdout when explicitly requested, as it returns with a zero (success) state.

When triggered from invalid arguments, e.g. no arguments, the program-triggered help output stays with write to stderr