### PR TITLE
event system: fix illegal memory access

### DIFF
--- a/include/pmacc/eventSystem/tasks/StreamTask.tpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.tpp
@@ -90,7 +90,7 @@ inline cudaStream_t StreamTask::getCudaStream( )
 inline void StreamTask::activate( )
 {
     cudaEvent = Environment<>::get().EventPool( ).pop( );
-    cudaEvent.recordEvent(this->stream->getCudaStream());
+    cudaEvent.recordEvent( getCudaStream( ) );
     hasCudaEventHandle = true;
 }
 


### PR DESCRIPTION
A pointer to a `EventStream` which is by default nullptr is accessed.
The bug is triggered by [TaskSetValue](https://github.com/ComputationalRadiationPhysics/picongpu/blob/05765f45534c0aa210be4a4f039d54051d6ba09c/include/pmacc/eventSystem/tasks/TaskSetValue.hpp#L233), a event task is created without using a stream. 

The bug is **CRITICAL** because unknown memory addresses are overwritten. I think the bug was only triggered during the initialization of the simulation, each time a species is created.