### PR TITLE
Add Bessel functions to math library

### DIFF
--- a/include/pmacc/algorithms/math.hpp
+++ b/include/pmacc/algorithms/math.hpp
@@ -35,6 +35,7 @@
 #include "pmacc/algorithms/math/defines/pow.hpp"
 #include "pmacc/algorithms/math/defines/modf.hpp"
 #include "pmacc/algorithms/math/defines/fmod.hpp"
+#include "pmacc/algorithms/math/defines/bessel.hpp"
 
 #include "pmacc/algorithms/math/floatMath/abs.tpp"
 #include "pmacc/algorithms/math/floatMath/sqrt.tpp"
@@ -46,6 +47,7 @@
 #include "pmacc/algorithms/math/floatMath/pow.tpp"
 #include "pmacc/algorithms/math/floatMath/modf.tpp"
 #include "pmacc/algorithms/math/floatMath/fmod.tpp"
+#include "pmacc/algorithms/math/floatMath/bessel.tpp"
 
 #include "pmacc/algorithms/math/doubleMath/abs.tpp"
 #include "pmacc/algorithms/math/doubleMath/sqrt.tpp"
@@ -57,4 +59,4 @@
 #include "pmacc/algorithms/math/doubleMath/pow.tpp"
 #include "pmacc/algorithms/math/doubleMath/modf.tpp"
 #include "pmacc/algorithms/math/doubleMath/fmod.tpp"
-
+#include "pmacc/algorithms/math/doubleMath/bessel.tpp"

--- a/include/pmacc/algorithms/math/defines/bessel.hpp
+++ b/include/pmacc/algorithms/math/defines/bessel.hpp
@@ -1,0 +1,208 @@
+/* Copyright 2016-2017 Alexander Debus
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace pmacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+    /* Modified cylindrical Bessel function of order 1 */
+
+    template< typename T_Type >
+    struct Cyl_bessel_i1;
+
+    /**
+     * Calculate the value of the regular modified cylindrical Bessel function
+     * of order 1 for the input argument.
+     * @return float value
+     */
+    template<typename T_Type >
+    HDINLINE typename Cyl_bessel_i1<T_Type>::result cyl_bessel_i1( T_Type x )
+    {
+        return Cyl_bessel_i1< T_Type >( )( x );
+    }
+
+    /* Modified cylindrical Bessel function of order 0 */
+
+    template< typename T_Type >
+    struct Cyl_bessel_i0;
+
+    /**
+     * Calculate the value of the regular modified cylindrical Bessel function
+     * of order 0 for the input argument.
+     * @return float value
+     */
+    template< typename T_Type >
+    HDINLINE typename Cyl_bessel_i0< T_Type >::result cyl_bessel_i0( T_Type x )
+    {
+        return Cyl_bessel_i0< T_Type >( )( x );
+    }
+
+    /* Bessel function of first kind of order 0 */
+
+    template< typename T_Type >
+    struct J0;
+
+    /**
+     * Calculate the value of the Bessel function
+     * of first kind of order 0 for the input argument.
+     * @return float value
+     */
+    template< typename T_Type >
+    HDINLINE typename J0< T_Type >::result j0( T_Type x )
+    {
+        return J0< T_Type >( )( x );
+    }
+
+    /* Bessel function of first kind of order 1 */
+
+    template< typename T_Type >
+    struct J1;
+
+    /**
+     * Calculate the value of the Bessel function
+     * of first kind of order 1 for the input argument.
+     * @return float value
+     */
+    template< typename T_Type >
+    HDINLINE typename J1< T_Type >::result j1( T_Type x )
+    {
+        return J1< T_Type >( )( x );
+    }
+
+    /* Bessel function of first kind of order n */
+
+    template<
+        typename T_IntType,
+        typename T_FloatType
+    >
+    struct Jn;
+
+    /**
+     * Calculate the value of the Bessel function
+     * of first kind of order n for the input argument.
+     * @param n nth order
+     * @param x input argument
+     * @return float value
+     */
+    template<
+        typename T_IntType,
+        typename T_FloatType
+    >
+    HDINLINE
+    typename Jn<
+        T_IntType,
+        T_FloatType
+    >::result
+    jn(
+        T_IntType const & n,
+        T_FloatType const & x
+    )
+    {
+        return Jn<
+            T_IntType,
+            T_FloatType
+        >( )(
+            n,
+            x
+        );
+    }
+
+    /* Bessel function of second kind of order 0 */
+
+    template< typename T_Type >
+    struct Y0;
+
+    /**
+     * Calculate the value of the Bessel function
+     * of first kind of order 0 for the input argument.
+     * @return float value
+     */
+    template< typename T_Type >
+    HDINLINE typename Y0< T_Type >::result y0( T_Type x )
+    {
+        return Y0< T_Type >( )( x );
+    }
+
+    /* Bessel function of second kind of order 1 */
+
+    template< typename T_Type >
+    struct Y1;
+
+    /**
+     * Calculate the value of the Bessel function
+     * of second kind of order 1 for the input argument.
+     * @return float value
+     */
+    template< typename T_Type >
+    HDINLINE typename Y1< T_Type >::result y1( T_Type x )
+    {
+        return Y1< T_Type >( )( x );
+    }
+
+    /** Bessel function of second kind of order n */
+
+    template<
+        typename T_IntType,
+        typename T_FloatType
+    >
+    struct Yn;
+
+    /** Bessel function of second kind of order n
+     *
+     * Calculate the value of the Bessel function
+     * of second kind of order n for the input argument.
+     *
+     * @param n nth order
+     * @param x input argument
+     * @return float value
+     */
+    template<
+        typename T_IntType,
+        typename T_FloatType
+    >
+    HDINLINE
+    typename Yn<
+        T_IntType,
+        T_FloatType
+    >::result
+    yn(
+        T_IntType const & n,
+        T_FloatType const & x
+    )
+    {
+        return Yn<
+            T_IntType,
+            T_FloatType
+        >( )(
+          n,
+          x
+        );
+    }
+
+
+} //namespace math
+} //namespace algorithms
+} //namespace pmacc

--- a/include/pmacc/algorithms/math/defines/bessel.hpp
+++ b/include/pmacc/algorithms/math/defines/bessel.hpp
@@ -27,82 +27,86 @@ namespace algorithms
 {
 namespace math
 {
+namespace bessel
+{
 
-    /* Modified cylindrical Bessel function of order 1 */
-
+    /** Modified cylindrical Bessel function of first kind of order 1
+     */
     template< typename T_Type >
-    struct Cyl_bessel_i1;
+    struct I1;
 
-    /**
-     * Calculate the value of the regular modified cylindrical Bessel function
-     * of order 1 for the input argument.
+    /** Modified cylindrical Bessel function of order 1
+     *
+     * @param x input value
      * @return float value
      */
     template<typename T_Type >
-    HDINLINE typename Cyl_bessel_i1<T_Type>::result cyl_bessel_i1( T_Type x )
+    HDINLINE typename I1<T_Type>::result i1( T_Type const & x )
     {
-        return Cyl_bessel_i1< T_Type >( )( x );
+        return I1< T_Type >( )( x );
     }
 
-    /* Modified cylindrical Bessel function of order 0 */
-
+    /** Modified cylindrical Bessel function of first kind of order 0.
+     */
     template< typename T_Type >
-    struct Cyl_bessel_i0;
+    struct I0;
 
-    /**
-     * Calculate the value of the regular modified cylindrical Bessel function
-     * of order 0 for the input argument.
+    /** Modified cylindrical Bessel function of first kind of order 0.
+     *
+     * @param x input argument
      * @return float value
      */
     template< typename T_Type >
-    HDINLINE typename Cyl_bessel_i0< T_Type >::result cyl_bessel_i0( T_Type x )
+    HDINLINE typename I0< T_Type >::result i0( T_Type const & x )
     {
-        return Cyl_bessel_i0< T_Type >( )( x );
+        return I0< T_Type >( )( x );
     }
 
-    /* Bessel function of first kind of order 0 */
-
+    /** Bessel function of first kind of order 0
+     */
     template< typename T_Type >
     struct J0;
 
-    /**
-     * Calculate the value of the Bessel function
-     * of first kind of order 0 for the input argument.
+    /** Bessel function of first kind of order 0
+     *
+     * @param x input argument
      * @return float value
      */
     template< typename T_Type >
-    HDINLINE typename J0< T_Type >::result j0( T_Type x )
+    HDINLINE typename J0< T_Type >::result j0( T_Type const & x )
     {
         return J0< T_Type >( )( x );
     }
 
-    /* Bessel function of first kind of order 1 */
-
+    /** Bessel function of first kind of order 1
+     */
     template< typename T_Type >
     struct J1;
 
-    /**
-     * Calculate the value of the Bessel function
-     * of first kind of order 1 for the input argument.
+    /** Bessel function of first kind of order 1
+     *
+     * @param x input value
      * @return float value
      */
     template< typename T_Type >
-    HDINLINE typename J1< T_Type >::result j1( T_Type x )
+    HDINLINE typename J1< T_Type >::result j1( T_Type const & x )
     {
         return J1< T_Type >( )( x );
     }
 
-    /* Bessel function of first kind of order n */
-
+    /** Bessel function of first kind of order n
+     */
     template<
         typename T_IntType,
         typename T_FloatType
     >
     struct Jn;
 
-    /**
+    /** Bessel function of first kind of order n
+     *
      * Calculate the value of the Bessel function
      * of first kind of order n for the input argument.
+     *
      * @param n nth order
      * @param x input argument
      * @return float value
@@ -130,40 +134,41 @@ namespace math
         );
     }
 
-    /* Bessel function of second kind of order 0 */
-
+    /** Bessel function of second kind of order 0
+     *
+     */
     template< typename T_Type >
     struct Y0;
 
-    /**
-     * Calculate the value of the Bessel function
-     * of first kind of order 0 for the input argument.
+    /**Bessel function of second kind of order 0
+     *
+     * @param x input argument
      * @return float value
      */
     template< typename T_Type >
-    HDINLINE typename Y0< T_Type >::result y0( T_Type x )
+    HDINLINE typename Y0< T_Type >::result y0( T_Type const & x )
     {
         return Y0< T_Type >( )( x );
     }
 
-    /* Bessel function of second kind of order 1 */
-
+    /* Bessel function of second kind of order 1.
+     */
     template< typename T_Type >
     struct Y1;
 
-    /**
-     * Calculate the value of the Bessel function
-     * of second kind of order 1 for the input argument.
+    /** Bessel function of second kind of order 1
+     *
+     * @param x input argument
      * @return float value
      */
     template< typename T_Type >
-    HDINLINE typename Y1< T_Type >::result y1( T_Type x )
+    HDINLINE typename Y1< T_Type >::result y1( T_Type const & x )
     {
         return Y1< T_Type >( )( x );
     }
 
-    /** Bessel function of second kind of order n */
-
+    /** Bessel function of second kind of order n.
+     */
     template<
         typename T_IntType,
         typename T_FloatType
@@ -202,7 +207,7 @@ namespace math
         );
     }
 
-
+} //namespace bessel
 } //namespace math
 } //namespace algorithms
 } //namespace pmacc

--- a/include/pmacc/algorithms/math/doubleMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/bessel.tpp
@@ -1,0 +1,193 @@
+/* Copyright 2016-2017 Alexander Debus
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+#include <boost/math/special_functions/bessel.hpp>
+
+
+namespace pmacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+    template< >
+    struct Cyl_bessel_i0< double >
+    {
+    typedef double result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::cyl_bessel_i0( x );
+#else
+        return boost::math::cyl_bessel_i(
+            0,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Cyl_bessel_i1< double >
+    {
+    typedef double result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::cyl_bessel_i1( x );
+#else
+        return boost::math::cyl_bessel_i(
+            1,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct J0<double>
+    {
+    typedef double result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::j0( x );
+#else
+        return boost::math::cyl_bessel_j(
+            0,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct J1<double>
+    {
+    typedef double result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::j1( x );
+#else
+        return boost::math::cyl_bessel_j(
+            1,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Jn<int, double>
+    {
+    typedef double result;
+
+    HDINLINE result operator( )(
+        int const & n,
+        result const & x
+    )
+    {
+#if __CUDA_ARCH__
+        return ::jn(
+            n,
+            x
+        );
+#else
+        return boost::math::cyl_bessel_j(
+            n,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Y0<double>
+    {
+    typedef double result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::y0( x );
+#else
+        return boost::math::cyl_neumann(
+            0,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Y1< double >
+    {
+    typedef double result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::y1( x );
+#else
+        return boost::math::cyl_neumann(
+            1,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Yn< int, double >
+    {
+    typedef double result;
+
+    HDINLINE result operator( )(
+        int const & n,
+        result const & x
+    )
+    {
+#if __CUDA_ARCH__
+        return ::yn(
+            n,
+            x
+        );
+#else
+        return boost::math::cyl_neumann(
+            n,
+            x
+        );
+#endif
+    }
+    };
+
+} //namespace math
+} //namespace algorithms
+} //namespace pmacc

--- a/include/pmacc/algorithms/math/doubleMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/bessel.tpp
@@ -31,163 +31,166 @@ namespace algorithms
 {
 namespace math
 {
+namespace bessel
+{
 
     template< >
-    struct Cyl_bessel_i0< double >
+    struct I0< double >
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::cyl_bessel_i0( x );
+            return ::cyl_bessel_i0( x );
 #else
-        return boost::math::cyl_bessel_i(
-            0,
-            x
-        );
+            return boost::math::cyl_bessel_i(
+                0,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
-    struct Cyl_bessel_i1< double >
+    struct I1< double >
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::cyl_bessel_i1( x );
+            return ::cyl_bessel_i1( x );
 #else
-        return boost::math::cyl_bessel_i(
-            1,
-            x
-        );
+            return boost::math::cyl_bessel_i(
+                1,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct J0<double>
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::j0( x );
+            return ::j0( x );
 #else
-        return boost::math::cyl_bessel_j(
-            0,
-            x
-        );
+            return boost::math::cyl_bessel_j(
+                0,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct J1<double>
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::j1( x );
+            return ::j1( x );
 #else
-        return boost::math::cyl_bessel_j(
-            1,
-            x
-        );
+            return boost::math::cyl_bessel_j(
+                1,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Jn<int, double>
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )(
-        int const & n,
-        result const & x
-    )
-    {
+        HDINLINE result operator( )(
+            int const & n,
+            result const & x
+        )
+        {
 #if __CUDA_ARCH__
-        return ::jn(
-            n,
-            x
-        );
+            return ::jn(
+                n,
+                x
+            );
 #else
-        return boost::math::cyl_bessel_j(
-            n,
-            x
-        );
+            return boost::math::cyl_bessel_j(
+                n,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Y0<double>
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::y0( x );
+            return ::y0( x );
 #else
-        return boost::math::cyl_neumann(
-            0,
-            x
-        );
+            return boost::math::cyl_neumann(
+                0,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Y1< double >
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::y1( x );
+            return ::y1( x );
 #else
-        return boost::math::cyl_neumann(
-            1,
-            x
-        );
+            return boost::math::cyl_neumann(
+                1,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Yn< int, double >
     {
-    typedef double result;
+        using result = double;
 
-    HDINLINE result operator( )(
-        int const & n,
-        result const & x
-    )
-    {
+        HDINLINE result operator( )(
+            int const & n,
+            result const & x
+        )
+        {
 #if __CUDA_ARCH__
-        return ::yn(
-            n,
-            x
-        );
+            return ::yn(
+                n,
+                x
+            );
 #else
-        return boost::math::cyl_neumann(
-            n,
-            x
-        );
+            return boost::math::cyl_neumann(
+                n,
+                x
+            );
 #endif
-    }
+        }
     };
 
+} //namespace bessel
 } //namespace math
 } //namespace algorithms
 } //namespace pmacc

--- a/include/pmacc/algorithms/math/doubleMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/bessel.tpp
@@ -71,7 +71,7 @@ namespace bessel
     };
 
     template< >
-    struct J0<double>
+    struct J0< double >
     {
         using result = double;
 
@@ -89,7 +89,7 @@ namespace bessel
     };
 
     template< >
-    struct J1<double>
+    struct J1< double >
     {
         using result = double;
 
@@ -107,7 +107,10 @@ namespace bessel
     };
 
     template< >
-    struct Jn<int, double>
+    struct Jn<
+        int,
+        double
+    >
     {
         using result = double;
 
@@ -131,7 +134,7 @@ namespace bessel
     };
 
     template< >
-    struct Y0<double>
+    struct Y0< double >
     {
         using result = double;
 
@@ -167,7 +170,10 @@ namespace bessel
     };
 
     template< >
-    struct Yn< int, double >
+    struct Yn<
+        int,
+        double
+    >
     {
         using result = double;
 

--- a/include/pmacc/algorithms/math/floatMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/floatMath/bessel.tpp
@@ -31,163 +31,166 @@ namespace algorithms
 {
 namespace math
 {
+namespace bessel
+{
 
     template< >
-    struct Cyl_bessel_i0< float >
+    struct I0< float >
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::cyl_bessel_i0f( x );
+            return ::cyl_bessel_i0f( x );
 #else
-        return boost::math::cyl_bessel_i(
-            0,
-            x
-        );
+            return boost::math::cyl_bessel_i(
+                0,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
-    struct Cyl_bessel_i1< float >
+    struct I1< float >
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::cyl_bessel_i1f( x );
+            return ::cyl_bessel_i1f( x );
 #else
-        return boost::math::cyl_bessel_i(
-            1,
-            x
-        );
+            return boost::math::cyl_bessel_i(
+                1,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct J0<float>
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::j0f( x );
+            return ::j0f( x );
 #else
-        return boost::math::cyl_bessel_j(
-            0,
-            x
-        );
+            return boost::math::cyl_bessel_j(
+                0,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct J1<float>
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::j1f( x );
+            return ::j1f( x );
 #else
-        return boost::math::cyl_bessel_j(
-            1,
-            x
-        );
+            return boost::math::cyl_bessel_j(
+                1,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Jn<int, float>
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )(
-        int const & n,
-        result const & x
-    )
-    {
+        HDINLINE result operator( )(
+            int const & n,
+            result const & x
+        )
+        {
 #if __CUDA_ARCH__
-        return ::jnf(
-            n,
-            x
-        );
+            return ::jnf(
+                n,
+                x
+            );
 #else
-        return boost::math::cyl_bessel_j(
-            n,
-            x
-        );
+            return boost::math::cyl_bessel_j(
+                n,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Y0<float>
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::y0f( x );
+            return ::y0f( x );
 #else
-        return boost::math::cyl_neumann(
-            0,
-            x
-        );
+            return boost::math::cyl_neumann(
+                0,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Y1< float >
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )( result x )
-    {
+        HDINLINE result operator( )( result const & x )
+        {
 #if __CUDA_ARCH__
-        return ::y1f( x );
+            return ::y1f( x );
 #else
-        return boost::math::cyl_neumann(
-            1,
-            x
-        );
+            return boost::math::cyl_neumann(
+                1,
+                x
+            );
 #endif
-    }
+        }
     };
 
     template< >
     struct Yn< int, float >
     {
-    typedef float result;
+        using result = float;
 
-    HDINLINE result operator( )(
-        int const & n,
-        result const & x
-    )
-    {
+        HDINLINE result operator( )(
+            int const & n,
+            result const & x
+        )
+        {
 #if __CUDA_ARCH__
-        return ::ynf(
-            n,
-            x
-        );
+            return ::ynf(
+                n,
+                x
+            );
 #else
-        return boost::math::cyl_neumann(
-            n,
-            x
-        );
+            return boost::math::cyl_neumann(
+                n,
+                x
+            );
 #endif
-    }
+        }
     };
 
+} //namespace bessel
 } //namespace math
 } //namespace algorithms
 } //namespace pmacc

--- a/include/pmacc/algorithms/math/floatMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/floatMath/bessel.tpp
@@ -71,7 +71,7 @@ namespace bessel
     };
 
     template< >
-    struct J0<float>
+    struct J0< float >
     {
         using result = float;
 
@@ -89,7 +89,7 @@ namespace bessel
     };
 
     template< >
-    struct J1<float>
+    struct J1< float >
     {
         using result = float;
 
@@ -107,7 +107,10 @@ namespace bessel
     };
 
     template< >
-    struct Jn<int, float>
+    struct Jn<
+        int,
+        float
+    >
     {
         using result = float;
 
@@ -131,7 +134,7 @@ namespace bessel
     };
 
     template< >
-    struct Y0<float>
+    struct Y0< float >
     {
         using result = float;
 
@@ -167,7 +170,10 @@ namespace bessel
     };
 
     template< >
-    struct Yn< int, float >
+    struct Yn<
+        int,
+        float
+    >
     {
         using result = float;
 

--- a/include/pmacc/algorithms/math/floatMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/floatMath/bessel.tpp
@@ -1,0 +1,193 @@
+/* Copyright 2016-2017 Alexander Debus
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+#include <boost/math/special_functions/bessel.hpp>
+
+
+namespace pmacc
+{
+namespace algorithms
+{
+namespace math
+{
+
+    template< >
+    struct Cyl_bessel_i0< float >
+    {
+    typedef float result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::cyl_bessel_i0f( x );
+#else
+        return boost::math::cyl_bessel_i(
+            0,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Cyl_bessel_i1< float >
+    {
+    typedef float result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::cyl_bessel_i1f( x );
+#else
+        return boost::math::cyl_bessel_i(
+            1,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct J0<float>
+    {
+    typedef float result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::j0f( x );
+#else
+        return boost::math::cyl_bessel_j(
+            0,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct J1<float>
+    {
+    typedef float result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::j1f( x );
+#else
+        return boost::math::cyl_bessel_j(
+            1,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Jn<int, float>
+    {
+    typedef float result;
+
+    HDINLINE result operator( )(
+        int const & n,
+        result const & x
+    )
+    {
+#if __CUDA_ARCH__
+        return ::jnf(
+            n,
+            x
+        );
+#else
+        return boost::math::cyl_bessel_j(
+            n,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Y0<float>
+    {
+    typedef float result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::y0f( x );
+#else
+        return boost::math::cyl_neumann(
+            0,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Y1< float >
+    {
+    typedef float result;
+
+    HDINLINE result operator( )( result x )
+    {
+#if __CUDA_ARCH__
+        return ::y1f( x );
+#else
+        return boost::math::cyl_neumann(
+            1,
+            x
+        );
+#endif
+    }
+    };
+
+    template< >
+    struct Yn< int, float >
+    {
+    typedef float result;
+
+    HDINLINE result operator( )(
+        int const & n,
+        result const & x
+    )
+    {
+#if __CUDA_ARCH__
+        return ::ynf(
+            n,
+            x
+        );
+#else
+        return boost::math::cyl_neumann(
+            n,
+            x
+        );
+#endif
+    }
+    };
+
+} //namespace math
+} //namespace algorithms
+} //namespace pmacc


### PR DESCRIPTION
This pull request adds Bessel-functions from the `CUDA` and `BOOST` libraries to the `PMACC` math implementation. Up to now, there have been no extensive tests, but it seems to compile fine so far.

This contribution does not have any special priority. So, please have a look at the code and give feedback at your leisure. :smiley:
