### PR TITLE
png2gas: C++98

### DIFF
--- a/src/tools/png2gas/png2gas.cpp
+++ b/src/tools/png2gas/png2gas.cpp
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
     if (!parseCmdLine(argc, argv, options))
         return -1;
 
-    MPI_Init(nullptr, nullptr);
+    MPI_Init(NULL, NULL);
 
     Dimensions data_size(options.dataSize);
     std::cout << "Creating density data with size " << data_size.toString() << std::endl;


### PR DESCRIPTION
Close #2159: Keep `png2gas` in C++98 so we do not need to artificially push up it's `CMakeLists.txt` requirements to C++11.