### PR TITLE
Hypnos: PNGwriter 0.6.0

### DIFF
--- a/etc/picongpu/hypnos-hzdr/picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/picongpu.profile.example
@@ -15,7 +15,7 @@ then
         module load openmpi/1.8.6.kepler.cuda80
 
         # Plugins (optional)
-        module load pngwriter/0.5.6
+        module load pngwriter/0.6.0
         module load hdf5-parallel/1.8.15 libsplash/1.6.0
 
         # either use libSplash or ADIOS for file I/O


### PR DESCRIPTION
PNGwriter 0.6.0 is now available on Hypnos (HZDR). Using it by default adds some performance improvements for PIConGPU and fulfills the requirement of the png2gas tool.