### PR TITLE
Boost 1.62.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -92,15 +92,15 @@ zlib
 
 boost
 """""
-- 1.57.0-1.64.0 (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math``, ``serialization`` and nearly all header-only libs)
-- download from `http://www.boost.org <http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.gz/download>`_
-- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-serialization-dev``
+- 1.62.0-1.64.0 (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``math``, ``serialization`` and header-only libs, optional: ``fiber``, ``context``)
+- download from `http://www.boost.org <http://sourceforge.net/projects/boost/files/boost/1.62.0/boost_1_62_0.tar.gz/download>`_
+- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-serialization-dev # libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
 - *from source:*
 
-  - ``./bootstrap.sh --with-libraries=filesystem,program_options,regex,system,thread,math,serialization --prefix=$HOME/lib/boost``
-  - ``./b2 -j4 && ./b2 install``
+  - ``./bootstrap.sh --with-libraries=context,fiber,filesystem,program_options,regex,system,thread,math,serialization --prefix=$HOME/lib/boost``
+  - ``./b2 cxxflags="-std=c++11" -j4 && ./b2 install``
 - *environment:* (assumes install from source in ``$HOME/lib/boost``)
 
   - ``export BOOST_ROOT=$HOME/lib/boost``

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -93,7 +93,7 @@ touch "$thisDir"runGuard
             # modify compile environment (forwarded to CMake)
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DCUDA_ARCH=35"
             . /etc/profile
-            module load gcc/4.9.4 boost/1.57.0 cmake/3.7.0 cuda/7.5.18 openmpi/1.10.4
+            module load gcc/4.9.4 boost/1.62.0 cmake/3.7.0 cuda/7.5.18 openmpi/1.10.4
             module load libSplash/1.6.0 adios/1.10.0
             module load pngwriter/0.5.6 rivlib/1.0.2
             module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.1.0

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -4,10 +4,10 @@ then
         module purge
 
         # Core Dependencies
-        module load gcc/4.4.7
-        module load cuda/5.5
-        # not yet available, build boost as in `INSTALL.md`
-        #module load boost/1.57.0-gcc
+        module load gcc
+        module load cuda
+        echo "WARNING: Boost version is too old! (Need: 1.62.0+)" >&2
+        # module load boost/1.62.0-gcc
         module load openmpi/1.6.5-gcc
 
         # Core tools

--- a/etc/picongpu/taurus-tud/picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/picongpu.profile.example
@@ -12,7 +12,9 @@ module load gnuplot/4.6.1
 
 # Compilers ###################################################################
 ### GCC
-module load gcc/5.3.0 boost/1.60.0-gnu5.3
+module load gcc/5.3.0
+echo "WARNING: Boost version is too old! (Need: 1.62.0+)" >&2
+# module load boost/1.60.0-gnu5.3
 ### ICC
 #module load intel/2015.3.187 boost/1.59.0-intel2015.3.187
 ### PGI

--- a/etc/picongpu/titan-ornl/picongpu.profile.example
+++ b/etc/picongpu/titan-ornl/picongpu.profile.example
@@ -29,7 +29,7 @@ module load git
 echo "WARNING: CMake version is too old! (Need: 3.7.0+)" >&2
 # module load cmake/3.6.1
 module load cudatoolkit
-module load boost/1.57.0
+module load boost/1.62.0
 export BOOST_ROOT=$BOOST_DIR
 export MPI_ROOT=$MPICH_DIR
 

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -149,7 +149,7 @@ set(LIBS ${LIBS} ${ZLIB_LIBRARIES})
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.57.0 REQUIRED COMPONENTS program_options regex filesystem
+find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options regex filesystem
                                               system thread math_tr1
                                               serialization)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -67,7 +67,7 @@ find_package(CUDA 7.5 REQUIRED)
 # Boost.Test
 ###############################################################################
 
-find_package(Boost 1.57.0 COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost 1.62.0 COMPONENTS unit_test_framework REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -265,7 +265,7 @@ endif(MPI_CXX_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.57.0 REQUIRED COMPONENTS filesystem system math_tr1)
+find_package(Boost 1.62.0 REQUIRED COMPONENTS filesystem system math_tr1)
 set(PMacc_INCLUDE_DIRS ${PMacc_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 set(PMacc_LIBRARIES ${PMacc_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -55,7 +55,7 @@ RUN        git clone --depth 50 https://github.com/llnl/spack.git \
            spack install cuda && \
            spack install openmpi@2.1.1 && \
            spack install zlib@1.2.11 && \
-           spack install boost@1.61.0 && \
+           spack install boost@1.62.0 && \
            spack install pngwriter@0.6.0 && \
            spack install libsplash@1.6.0 ^hdf5~fortran && \
            spack install adios@1.10.0 && \

--- a/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
@@ -98,7 +98,7 @@ endif(GOL_RELEASE)
 # Find Boost
 ###############################################################################
 
-find_package(Boost 1.57.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
Prepares the Boost 1.62.0+ dependency pulled in by alpaka.

Taurus (ZIH) support was informed about our request for newer boost 1.62.0 version with gcc 5.3

### To Do

- [x] rebase after #2181
- [x] add to compile suite