### PR TITLE
Sphinx: PDF Radiation 

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -251,7 +251,7 @@ Command line option                       Description
                                           Using `1` calculates the radiation constantly. Any value ``>=2`` is currently producing nonsense.
 ``--radiation_<species>.dump``            Period, after which the calculated radiation data should be dumped to the file system.
                                           Default is ``0``, therefor never.
-                                          In order to store the radiation data, a value `≥1` should be used.
+                                          In order to store the radiation data, a value `>=1` should be used.
 ``--radiation_<species>.lastRadiation``   If set, the radiation spectra summed between the last and the current dump-time-step are stored.
                                           Used for a better evaluation of the temporal evolution of the emitted radiation.
 ``--radiation_<species>.folderLastRad``   Name of the folder, in which the summed spectra for the simulation time between the last dump and the current dump are stored.

--- a/test/hasNonASCII
+++ b/test/hasNonASCII
@@ -35,7 +35,7 @@ for i in $(find . \
                 -type f | \
            egrep "\.def$|\.h$|\.cpp$|\.cu$|\.hpp$|\.tpp$|\.kernel$|\.loader$|\
                   \.param$|\.unitless$|\.sh$|\.bash$|\.cfg$|\.tpl$|\.conf$|\
-                  \.awk$|\.gnuplot$|\.cmake$|\.profile$|\.example$\.py$")
+                  \.awk$|\.gnuplot$|\.cmake$|\.profile$|\.example$|\.py$")
 do
   # non-ASCII test regex via jerrymouse at stackoverflow under CC-By-SA 3.0:
   #   http://stackoverflow.com/questions/3001177/how-do-i-grep-for-all-non-ascii-characters-in-unix/9395552#9395552


### PR DESCRIPTION
Remove latex unexpected character so sphinx pdf builds.

Also fix a typo in the nonACII test:
- fix typo in selection of .py files