### PR TITLE
Bash Subshells: `cmd` to $(cmd)

### DIFF
--- a/etc/picongpu/hypnos-hzdr/picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/picongpu.profile.example
@@ -33,7 +33,7 @@ fi
 alias getk20='qsub -I -q k20 -lwalltime=00:30:00 -lnodes=1:ppn=8'
 alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
-export PICSRC=/home/`whoami`/src/picongpu
+export PICSRC=/home/$(whoami)/src/picongpu
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
@@ -51,7 +51,7 @@ export PYTHONPATH=$PICSRC/src/tools/lib/python:$PYTHONPATH
 #
 #function make
 #{
-#  real_make=`which make`
+#  real_make=$(which make)
 #  $real_make $* 2>&1 | $HOME/grcat/usr/bin/grcat conf.gcc
 #}
 

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -1,5 +1,5 @@
-# this file is loaded from all PIConGPU template files `*.tpl` therefore please
-# copy this file to `$SCRATCH/picongpu.profile`
+# this file is loaded from all PIConGPU template *.tpl files, therefore please
+# copy this file to $SCRATCH/picongpu.profile
 #
 
 # General modules #############################################################
@@ -37,14 +37,14 @@ export MPI_ROOT=$MPICH_DIR
 export HDF5_ROOT=$HDF5_DIR
 
 # define cray compiler target architecture
-# if not defined the linker crashed because wrong from `*/lib` instead
-# of `*/lib64` are used
+# if not defined the linker crashed because wrong from */lib instead
+# of */lib64 are used
 export CRAY_CPU_TARGET=x86-64
 
 # Compile for cluster nodes
 #   (CMake likes to unwrap the Cray wrappers)
-export CC=`which cc`
-export CXX=`which CC`
+export CC=$(which cc)
+export CXX=$(which CC)
 
 export PICSRC=$HOME/src/picongpu
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
@@ -69,13 +69,13 @@ export TBG_TPLFILE="etc/picongpu/pizdaint-cscs/normal_profile.tpl"
 # helper tools ################################################################
 
 # allocate an interactive shell for one hour
-# `getInteractive 2` # allocates to interactive nodes (default: 1)
+#   getInteractive 2  # allocates to interactive nodes (default: 1)
 getInteractive() {
     if [ -z "$1" ] ; then
         numNodes=1
     else
         numNodes=$1
     fi
-    # `--ntasks-per-core=2` activates intel hyper threading
+    # --ntasks-per-core=2  # activates intel hyper threading
     salloc --time=1:00:00 --nodes="$numNodes" --ntasks-per-node=12 --ntasks-per-core=2 --partition normal --gres=gpu:1 --constraint=gpu
 }

--- a/etc/picongpu/taurus-tud/Slurm_Tutorial.rst
+++ b/etc/picongpu/taurus-tud/Slurm_Tutorial.rst
@@ -21,7 +21,7 @@ Job Control
 * details for my jobs:
 
   * ``scontrol -d show job 12345`` all details for job with <job id> ``12345``
-  * ``squeue -u `whoami` -l`` all jobs under my user name
+  * ``squeue -u $(whoami) -l`` all jobs under my user name
 
 * details for queues:
 

--- a/etc/picongpu/taurus-tud/picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/picongpu.profile.example
@@ -21,7 +21,7 @@ echo "WARNING: Boost version is too old! (Need: 1.62.0+)" >&2
 #export BOOST_ROOT=$HOME/lib/boost_1_57_pgi_14_9
 #export BOOST_INC=$BOOST_ROOT/include
 #export BOOST_LIB=$BOOST_ROOT/lib
-# must be set in `which <pgiDir>/bin/localrc`:
+# must be set in $(which <pgiDir>/bin/localrc):
 #   set NOSWITCHERROR=YES;
 #module load pgi/14.9 boost/<noneBuildYet>
 

--- a/etc/picongpu/titan-ornl/picongpu.profile.example
+++ b/etc/picongpu/titan-ornl/picongpu.profile.example
@@ -13,9 +13,9 @@ module swap PrgEnv-pgi PrgEnv-gnu
 
 # Compile for CLE nodes
 #   (CMake likes to unwrap the Cray wrappers)
-export CC=`which cc`
-export CXX=`which CC`
-export FC=`which ftn`
+export CC=$(which cc)
+export CXX=$(which CC)
+export FC=$(which ftn)
 #export LD="/sw/xk6/altd/bin/ld"
 
 # symbol bug work around (should not be required)
@@ -41,12 +41,12 @@ export MPI_ROOT=$MPICH_DIR
 #export VT_ROOT=$VAMPIRTRACE_DIR
 
 # scorep (optional) #################################################
-#   pic-configure with -c "-DCMAKE_CXX_COMPILER=`which scorep-CC` \
-#                          -DCUDA_NVCC_EXECUTABLE=`which scorep-nvcc`"
+#   pic-configure with -c "-DCMAKE_CXX_COMPILER=$(which scorep-CC) \
+#                          -DCUDA_NVCC_EXECUTABLE=$(which scorep-nvcc)"
 #   e.g.:
 #     SCOREP_WRAPPER=OFF pic-configure -a "cuda:35" \
-#         -c "-DCMAKE_CXX_COMPILER=`which scorep-CC` \
-#         -DCUDA_NVCC_EXECUTABLE=`which scorep-nvcc`" \
+#         -c "-DCMAKE_CXX_COMPILER=$(which scorep-CC) \
+#         -DCUDA_NVCC_EXECUTABLE=$(which scorep-nvcc)" \
 #         ~/picInputs/case001
 #     export SCOREP_WRAPPER_INSTRUMENTER_FLAGS="--cuda --mpp=mpi"
 #     make -j

--- a/share/picongpu/dockerfiles/ubuntu-1604/picongpu.profile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/picongpu.profile
@@ -25,7 +25,7 @@ module load isaac-server
 
 # Environment #################################################################
 #
-export PICSRC=/home/`whoami`/src/picongpu
+export PICSRC=/home/$(whoami)/src/picongpu
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail


### PR DESCRIPTION
Generally, prefer this style in call bash scripts.

It can be:
- nested,
- is a tiny bit more portable and
- is not prune to be [mismatched with '](https://github.com/ComputationalRadiationPhysics/picongpu/issues/1984#issuecomment-321235872)

and has no difference in meaning.

For more information, see e.g.
  https://github.com/azet/community_bash_style_guide#common-mistakes-and-useful-tricks