### PR TITLE
CMake: Use Imported Targets Zlib, Boost

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -129,13 +129,23 @@ if(ALPAKA_ACC_GPU_CUDA_ENABLE)
     set(LIBS ${LIBS} ${mallocMC_LIBRARIES})
 endif()
 
+
 ################################################################################
 # Find zlib
 ################################################################################
 
 find_package(ZLIB REQUIRED)
-include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${ZLIB_LIBRARIES})
+set(LIBS ${LIBS} ZLIB::ZLIB)
+
+
+################################################################################
+# Find math from stdlib
+################################################################################
+
+if(NOT WIN32)
+    # automatically added on windows
+    set(LIBS ${LIBS} m)
+endif()
 
 
 ################################################################################
@@ -145,8 +155,15 @@ set(LIBS ${LIBS} ${ZLIB_LIBRARIES})
 find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options regex filesystem
                                               system thread math_tr1 date_time
                                               serialization chrono atomic)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
+if(TARGET Boost::boost)
+    set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex
+                     Boost::filesystem Boost::system Boost::thread
+                     Boost::math_tr1 Boost::date_time Boost::serialization
+                     Boost::chrono Boost::atomic)
+else()
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${Boost_LIBRARIES})
+endif()
 
 
 ################################################################################
@@ -365,14 +382,14 @@ add_library(picongpu-hostonly
     STATIC
     ${SRCFILES}
 )
-target_link_libraries(picongpu-hostonly ${LIBS} m)
+target_link_libraries(picongpu-hostonly ${LIBS})
 
 
 cupla_add_executable(picongpu
     ${SRCFILES}
 )
 
-target_link_libraries(picongpu ${LIBS} picongpu-hostonly m)
+target_link_libraries(picongpu ${LIBS} picongpu-hostonly)
 
 
 ################################################################################

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -61,8 +61,12 @@ add_definitions(${PMacc_DEFINITIONS})
 ###############################################################################
 
 find_package(Boost 1.62.0 COMPONENTS unit_test_framework REQUIRED)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
+if(TARGET Boost::boost)
+    set(LIBS ${LIBS} Boost::boost Boost::unit_test_framework)
+else()
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${Boost_LIBRARIES})
+endif()
 
 
 ################################################################################

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -224,8 +224,13 @@ endif(MPI_CXX_FOUND)
 ################################################################################
 
 find_package(Boost 1.62.0 REQUIRED COMPONENTS filesystem system math_tr1)
-set(PMacc_INCLUDE_DIRS ${PMacc_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
-set(PMacc_LIBRARIES ${PMacc_LIBRARIES} ${Boost_LIBRARIES})
+if(TARGET Boost::boost)
+    set(PMacc_LIBRARIES ${PMacc_LIBRARIES} Boost::boost Boost::filesystem
+                                           Boost::system Boost::math_tr1)
+else()
+    set(PMacc_INCLUDE_DIRS ${PMacc_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+    set(PMacc_LIBRARIES ${PMacc_LIBRARIES} ${Boost_LIBRARIES})
+endif()
 
 # Boost 1.55 added support for a define that makes result_of look for
 # the result<> template and falls back to decltype if none is found. This is

--- a/src/mpiInfo/CMakeLists.txt
+++ b/src/mpiInfo/CMakeLists.txt
@@ -71,8 +71,12 @@ endif(MPI_CXX_FOUND)
 ################################################################################
 
 find_package(Boost REQUIRED COMPONENTS program_options)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
+if(TARGET Boost::boost)
+    set(LIBS ${LIBS} Boost::boost Boost::program_options)
+else()
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${Boost_LIBRARIES})
+endif()
 
 
 ################################################################################

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -73,8 +73,12 @@ endif(NOT RELEASE)
 ################################################################################
 
 find_package(Boost REQUIRED COMPONENTS program_options)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
+if(TARGET Boost::boost)
+    set(LIBS ${LIBS} Boost::boost Boost::program_options)
+else()
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${Boost_LIBRARIES})
+endif()
 
 
 ################################################################################

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -124,10 +124,12 @@ endif(ADIOS_FOUND)
 ################################################################################
 
 find_package(Boost REQUIRED COMPONENTS program_options regex)
-
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIR})
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
+if(TARGET Boost::boost)
+    set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex)
+else()
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${Boost_LIBRARIES})
+endif()
 
 
 ################################################################################


### PR DESCRIPTION
Use imported targets for Zlib and Boost. This makes linking with existing libraries in system paths more robust, e.g. on centos, and spares the need to add include paths.

Do not add math on windows machines.

With our CMake requirement (version) we can rely on targets for all dependencies.
All dependencies, but Boost, where we need a fallback:

> Since the boost transient dependencies are updated via a manual list currently, we explicitly request all transient libraries for now (instead of letting the cmake script find and add them). This helps users with a newer boost version but an older CMake that does not know the latest boost releases (yet).

Since boost targets are not available in the same situation either, we add the `include_directories` + `${Boost_LIBRARIES}` fallbacks until boost has a forward-compatible CMake build chain.

### To Do

- [x] rebase against #2195 
- [x] rebase against #2198 (last commit migrated there)
- [x] Boost: evaluate and react on `if(TARGET Boost::boost)`
- [x] Boost: also include `Boost::boost` for *explicit* request of header-only dependencies?