### PR TITLE
Tools: All C++11

### DIFF
--- a/src/mpiInfo/CMakeLists.txt
+++ b/src/mpiInfo/CMakeLists.txt
@@ -45,6 +45,16 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 list(APPEND "/usr/lib/x86_64-linux-gnu/")
 
 
+###############################################################################
+# Language Flags
+###############################################################################
+
+# enforce C++11
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
+
+
 ################################################################################
 # Warnings
 ################################################################################

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -52,6 +52,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../thirdParty/cmake-modules/)
 
 
+###############################################################################
+# Language Flags
+###############################################################################
+
+# enforce C++11
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
+
+
 ################################################################################
 # Build type (debug, release)
 ################################################################################

--- a/src/tools/png2gas/png2gas.cpp
+++ b/src/tools/png2gas/png2gas.cpp
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
     if (!parseCmdLine(argc, argv, options))
         return -1;
 
-    MPI_Init(NULL, NULL);
+    MPI_Init(nullptr, nullptr);
 
     Dimensions data_size(options.dataSize);
     std::cout << "Creating density data with size " << data_size.toString() << std::endl;

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -48,6 +48,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 include_directories(include)
 
 
+###############################################################################
+# Language Flags
+###############################################################################
+
+# enforce C++11
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
+
+
 ################################################################################
 # Build type (debug, release, relwithdebinfo)
 ################################################################################

--- a/src/tools/splash2txt/splash2txt.cpp
+++ b/src/tools/splash2txt/splash2txt.cpp
@@ -218,7 +218,7 @@ int main( int argc, char** argv )
         return 1;
     }
 
-    ITools *tools = NULL;
+    ITools *tools = nullptr;
     switch ( options.fileMode)
     {
         case FM_SPLASH: tools = new ToolsSplashParallel( options, mpi_topology, *outStream );

--- a/src/tools/splash2txt/tools_adios_parallel.cpp
+++ b/src/tools/splash2txt/tools_adios_parallel.cpp
@@ -61,7 +61,7 @@ void ToolsAdiosParallel::convertToText()
 
         pVarInfo = adios_inq_var(pFile, nodeName.c_str());
 
-        varTypeSize = adios_type_size(pVarInfo->type, NULL);
+        varTypeSize = adios_type_size(pVarInfo->type, nullptr);
 
         // get number of elements combined in a dataset
         for(int j = 0; j < pVarInfo->ndim; j++)
@@ -71,7 +71,7 @@ void ToolsAdiosParallel::convertToText()
         // allocate memory
         P = (uint8_t*) malloc (sizeof(uint8_t) * varTypeSize * varElement);
 
-        adios_schedule_read(pFile, NULL, nodeName.c_str(), 0, 1, P);
+        adios_schedule_read(pFile, nullptr, nodeName.c_str(), 0, 1, P);
 
         adios_perform_reads(pFile, 1);
 

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -132,7 +132,7 @@ void ToolsSplashParallel::printParticles(std::vector<ExDataContainer> fileData)
                 }
 
                 void* element = container->getElement(i);
-                assert(element != NULL);
+                assert(element != nullptr);
 
                 printElement(data_type, element, iter->unit, m_options.delimiter);
                 numElementsProcessed[container]++;
@@ -196,7 +196,7 @@ void ToolsSplashParallel::printFields(std::vector<ExDataContainer> fileData)
                             iter->container->getIndex(0)->getDataType();
 
                     void* element = iter->container->getElement(index);
-                    assert(element != NULL);
+                    assert(element != nullptr);
 
                     printElement(data_type, element, iter->unit, m_options.delimiter);
                 }
@@ -233,7 +233,7 @@ void ToolsSplashParallel::convertToText()
     try
     {
         dc.readAttribute(m_options.step, m_options.data[0].c_str(), DOMCOL_ATTR_CLASS,
-                &ref_data_class, NULL);
+                &ref_data_class, nullptr);
     } catch (const DCException&)
     {
         errorStream << "Error: No domain information for dataset '" << m_options.data[0] << "' available." << std::endl;
@@ -266,7 +266,7 @@ void ToolsSplashParallel::convertToText()
 
         DomainCollector::DomDataClass data_class = DomainCollector::UndefinedType;
         dc.readAttribute(m_options.step, iter->c_str(), DOMCOL_ATTR_CLASS,
-                &data_class, NULL);
+                &data_class, nullptr);
         if (data_class != ref_data_class)
             throw std::runtime_error("All requested datasets must be of the same data class");
 
@@ -282,7 +282,7 @@ void ToolsSplashParallel::convertToText()
             // poly type
 
             excontainer.container = dc.readDomain(m_options.step, iter->c_str(),
-                    Domain(total_domain.getOffset(), total_domain.getSize()), NULL, true);
+                    Domain(total_domain.getOffset(), total_domain.getSize()), nullptr, true);
         } else
         {
             // grid type
@@ -302,7 +302,7 @@ void ToolsSplashParallel::convertToText()
                 }
 
             excontainer.container = dc.readDomain(m_options.step, iter->c_str(),
-                    Domain(offset, domain_size), NULL);
+                    Domain(offset, domain_size), nullptr);
         }
 
         // read unit
@@ -312,7 +312,7 @@ void ToolsSplashParallel::convertToText()
             try
             {
                 dc.readAttribute(m_options.step, iter->c_str(), "unitSI",
-                        &(excontainer.unit), NULL);
+                        &(excontainer.unit), nullptr);
             } catch (const DCException&)
             {
                 if (m_options.verbose)
@@ -333,7 +333,7 @@ void ToolsSplashParallel::convertToText()
         file_data.push_back(excontainer);
     }
 
-    assert(file_data[0].container->get(0)->getData() != NULL);
+    assert(file_data[0].container->get(0)->getData() != nullptr);
 
     // write to file
     //
@@ -391,7 +391,7 @@ void ToolsSplashParallel::listAvailableDatasets()
 {
     // number of timesteps in this file
     size_t num_entries = 0;
-    dc.getEntryIDs(NULL, &num_entries);
+    dc.getEntryIDs(nullptr, &num_entries);
     if (num_entries == 0)
     {
         m_outStream << "no entries in file" << std::endl;
@@ -399,7 +399,7 @@ void ToolsSplashParallel::listAvailableDatasets()
     }
 
     int32_t *entries = new int32_t[num_entries];
-    dc.getEntryIDs(entries, NULL);
+    dc.getEntryIDs(entries, nullptr);
     std::sort(entries, entries + num_entries);
 
     m_outStream << std::endl
@@ -418,9 +418,9 @@ void ToolsSplashParallel::listAvailableDatasets()
     // available data sets in this file
     std::vector<DataCollector::DCEntry> dataTypeNames;
     size_t numDataTypes = 0;
-    dc.getEntriesForID(entries[0], NULL, &numDataTypes);
+    dc.getEntriesForID(entries[0], nullptr, &numDataTypes);
     dataTypeNames.resize(numDataTypes);
-    dc.getEntriesForID(entries[0], &(dataTypeNames.front()), NULL);
+    dc.getEntriesForID(entries[0], &(dataTypeNames.front()), nullptr);
 
     // parse dataTypeNames vector in a nice way for stdout
     m_outStream << "Available data field names:";


### PR DESCRIPTION
Close #2188: for building against a common set of C++ dependencies, it is easier to always depend on the same language version (C++11 right now) to avoid requiring that all dependencies are build with C++98/C++11 ABI compatibility.