### PR TITLE
Png Plugin: Boost to std Thread

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -76,7 +76,7 @@ zlib
 
 boost
 """""
-- 1.62.0-1.64.0 (``program options``, ``regex`` , ``filesystem``, ``system``, ``thread``, ``chrono``, ``atomic``, ``date_time``, ``math``, ``serialization`` and header-only libs, optional: ``fiber``, ``context``)
+- 1.62.0-1.64.0 (``program_options``, ``regex`` , ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
 - download from `http://www.boost.org <http://sourceforge.net/projects/boost/files/boost/1.62.0/boost_1_62_0.tar.gz/download>`_
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -153,13 +153,11 @@ endif()
 ################################################################################
 
 find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options regex filesystem
-                                              system thread math_tr1 date_time
-                                              serialization chrono atomic)
+                                              system math_tr1 serialization)
 if(TARGET Boost::boost)
     set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex
-                     Boost::filesystem Boost::system Boost::thread
-                     Boost::math_tr1 Boost::date_time Boost::serialization
-                     Boost::chrono Boost::atomic)
+                     Boost::filesystem Boost::system Boost::math_tr1
+                     Boost::serialization)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
     set(LIBS ${LIBS} ${Boost_LIBRARIES})

--- a/include/picongpu/plugins/output/images/PngCreator.hpp
+++ b/include/picongpu/plugins/output/images/PngCreator.hpp
@@ -22,15 +22,14 @@
 #include <pmacc/types.hpp>
 #include "picongpu/simulation_defines.hpp"
 
+#include <pmacc/memory/boxes/DataBox.hpp>
+#include "picongpu/plugins/output/header/MessageHeader.hpp"
+
 #include <string>
 #include <iostream>
 #include <sstream>
 #include <iomanip>
-
-#include <pmacc/memory/boxes/DataBox.hpp>
-#include "picongpu/plugins/output/header/MessageHeader.hpp"
-
-#include <boost/thread.hpp>
+#include <thread>
 
 
 namespace picongpu
@@ -104,7 +103,7 @@ namespace picongpu
                 workerThread.join();
             }
             m_isThreadActive = true;
-            workerThread = boost::thread(&PngCreator::createImage<Box>, this, data, size, header);
+            workerThread = std::thread(&PngCreator::createImage<Box>, this, data, size, header);
         }
 
     private:
@@ -117,10 +116,7 @@ namespace picongpu
         std::string m_name;
         std::string m_folder;
         bool m_createFolder;
-        /* boost::thread is not copy able,
-         * therefore we must define an own copy constructor
-         */
-        boost::thread workerThread;
+        std::thread workerThread;
         /* status whether a thread is currently active */
         bool m_isThreadActive;
 


### PR DESCRIPTION
Close #2196

Remove the direct Boost.Thread dependency of PIConGPU. In its default configuration, we now require less transient non-headeronly libraries from Boost.

Note: the alpaka fiber backend pulls in context & thread and with them chrono, date_time and atomic again, if enabled.

### To Do

- [x] rebase against #2195 
- [x] rebase against #2193
- [x] update `CMakeLists.txt` (-thread -chrono -date_time -atomic)
- [x] update `INSTALL.md` (with fiber: the libs from above)
- [x] repeat RT test (k80 & laser)