### PR TITLE
Docs: Fix broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,21 +29,20 @@ If you are familiar with git, feel free to jump to our [github workflow](#github
 **Debian/Ubuntu**:
 - `sudo apt-get install git`
 - make sure `git --version` is at least at version
-  [1.7.9.5](https://help.github.com/articles/https-cloning-errors)
+  [1.7.10](https://help.github.com/articles/https-cloning-errors)
 
 Optional *one* of these. There are nice GUI tools available to get an overview
 on your repository.
 - `gitk git-gui qgit gitg`
 
 **Mac**:
-- see [here](https://help.github.com/articles/set-up-git#platform-mac)
-- you may like to visit http://mac.github.com/
+- see [here](https://help.github.com/articles/set-up-git)
 
 **Windows**:
 - see [here](http://lmgtfy.com/?q=debian+-+or+how+to+download+a+real+operating+system)
-- just kidding, it's [this link](https://help.github.com/articles/set-up-git#platform-windows)
-- please use UTF8 for your files and take care of
-  [line endings](https://help.github.com/articles/dealing-with-line-endings#platform-windows)
+- just kidding, it's [this link](https://help.github.com/articles/set-up-git)
+- please use ASCII for your files and take care of
+  [line endings](https://help.github.com/articles/dealing-with-line-endings)
 
 **Configure** your global git settings:
 - `git config --global user.name NAME`
@@ -59,7 +58,7 @@ You may even improve your level of awesomeness by:
 - `git config --global alias.l "log --oneline --graph --decorate --first-parent"` (single branch history)
 - `git config --global alias.la "log --oneline --graph --decorate --all"` (full branch history)
 - `git config --global rerere.enable 1`
-  (see [git rerere](http://git-scm.com/blog/2010/03/08/rerere.html))
+  (see [git rerere](https://git-scm.com/blog/2010/03/08/rerere.html))
 - More `alias` tricks:
   - `git config --get-regexp alias` (show all aliases)
   - `git config --global --unset alias.<Name>` (unset alias `<Name>`)
@@ -76,28 +75,28 @@ the *same project*. Examples:
 - Everything is wrong now, why did this happen and when?
 - What parts of the code changed since I went on vacation
   (to a conference, phd seminar,
-   [mate](http://en.wikipedia.org/wiki/Club-Mate) fridge, ...)?
+   [mate](https://en.wikipedia.org/wiki/Club-Mate) fridge, ...)?
 
 If *version control* is totally **new** to you (that's good, because you are not
-[spoiled](http://www.youtube.com/watch?v=4XpnKHJAok8)) - please refer to a
+[spoiled](https://www.youtube.com/watch?v=4XpnKHJAok8)) - please refer to a
 beginners guide first.
 - [git - the simple guide](http://rogerdudler.github.io/git-guide/)
-- 15 minutes guide at [try.github.io](http://try.github.io)
+- 15 minutes guide at [try.github.io](https://try.github.io)
 
 Since git is *distributed*, no one really needs a server or services like
 github.com to *use git*. Actually, there are even very good reasons why one should
 use git even for **local** data, e.g. a master thesis (or your collection of ascii art
 dwarf hamster pictures).
 
-Btw, **fun fact warning**: [Linus Torvalds](http://en.wikipedia.org/wiki/Linus_Torvalds),
+Btw, **fun fact warning**: [Linus Torvalds](https://en.wikipedia.org/wiki/Linus_Torvalds),
 yes the nice guy with the pinguin stuff and all that, developed git to maintain
 the **Linux kernel**. So that's cool, by definition.
 
 A nice overview about the *humongous* number of tutorials can be found at
-[stackoverflow.com](http://stackoverflow.com/questions/315911/git-for-beginners-the-definitive-practical-guide)
+[stackoverflow.com](https://stackoverflow.com/questions/315911/git-for-beginners-the-definitive-practical-guide)
 ... but we may like to start with a git **cheat sheet** (is there anyone out there who knows more
 than 1% of all git commands available?)
-- [git-tower.com](http://www.git-tower.com/files/cheatsheet/Git_Cheat_Sheet_grey.pdf) (print the 1st page)
+- [git-tower.com](https://www.git-tower.com/blog/git-cheat-sheet/) (print the 1st page)
 - [github.com - "cheat git" gem](https://help.github.com/articles/git-cheatsheet) (a cheat sheet for the console)
 - [kernel.org](https://www.kernel.org/pub/software/scm/git/docs/everyday.html) *Everyday GIT with 20 commands or so*
 - [an other interactive, huge cheat sheet](http://ndpsoftware.com/git-cheatsheet.html)
@@ -177,9 +176,9 @@ your work from our **dev** (development)
 branch in your private repository. Simply click the *Fork* button above to do so.
 
 Afterwards, `git clone` **your** repository to your
-[local machine](https://help.github.com/articles/fork-a-repo#step-2-clone-your-fork).
+[local machine](https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork).
 But that is not it! To keep track of the original **dev** repository, add
-it as another [remote](https://help.github.com/articles/fork-a-repo#step-3-configure-remotes).
+it as another [remote](https://help.github.com/articles/fork-a-repo/#step-3-configure-git-to-sync-your-fork-with-the-original-spoon-knife-repository).
 - `git remote add mainline https://github.com/ComputationalRadiationPhysics/picongpu.git`
 - `git checkout dev` (go to branch **dev**)
 
@@ -223,13 +222,10 @@ Now solve your conflicts, if there are any, and you got it! Well done!
 How to propose that **your awesome feature** (we know it will be awesome!) should be
 included in the **mainline PIConGPU** version?
 
-Due to the so called
-[pull requests](https://help.github.com/articles/using-pull-requests)
-in *GitHub*, this quite easy (yeah, sure). We start again with a
-*forked repository* of our own. You already created a **new feature branch**
-starting from our **dev** branch and commited your changes. Finally, you
-[pushed](http://www.mariopareja.com/blog/archive/2010/01/11/how-to-push-a-new-local-branch-to-a-remote.aspx)
-your local branch to *your* GitHub repository: `git push -u origin <yourLocalBranchName>`
+Due to the so called [pull requests](https://help.github.com/articles/using-pull-requests) in *GitHub*, this quite easy (yeah, sure).
+We start again with a *forked repository* of our own.
+You already created a **new feature branch** starting from our **dev** branch and commited your changes.
+Finally, you publish you local branch via a *push* to *your* GitHub repository: `git push -u origin <yourLocalBranchName>`
 
 Now let's start a *review*. Open the *GitHub* homepage, go to your repository and
 switch to your *pushed feature branch*. Select the green **compare & review**

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -2,7 +2,7 @@
 
 .. seealso::
 
-   You will need to understand how to use `the terminal <http://www.ks.uiuc.edu/Training/Tutorials/Reference/unixprimer.html>`_, what are `environment variables <http://unix.stackexchange.com/questions/44990/what-is-the-difference-between-path-and-ld-library-path/45106#45106>`_ and please read our :ref:`compiling introduction <install-source>`.
+   You will need to understand how to use `the terminal <http://www.ks.uiuc.edu/Training/Tutorials/Reference/unixprimer.html>`_, what are `environment variables <https://unix.stackexchange.com/questions/44990/what-is-the-difference-between-path-and-ld-library-path/45106#45106>`_ and please read our :ref:`compiling introduction <install-source>`.
 
 .. note::
 
@@ -234,7 +234,7 @@ png2gas
 
 ADIOS
 """""
-- 1.10.0+ (requires *MPI*, *zlib* and `mxml <http://www.msweet.org/projects.php?Z3>`_)
+- 1.10.0+ (requires *MPI* and *zlib*)
 - *Debian/Ubuntu:* ``sudo apt-get install libadios-dev libadios-bin``
 - *Arch Linux* using an `AUR helper <https://wiki.archlinux.org/index.php/AUR_helpers>`_: ``pacaur --sync libadios``
 - *Arch Linux* using the `AUR <https://wiki.archlinux.org/index.php/Arch_User_Repository>`_ manually:

--- a/docs/source/install/compile.rst
+++ b/docs/source/install/compile.rst
@@ -84,4 +84,4 @@ References
 .. [CMake]
         Kitware Inc.
         *CMake: Cross-platform build management tool*,
-        http://cmake.org/
+        https://cmake.org/

--- a/docs/source/postprocessing/python.rst
+++ b/docs/source/postprocessing/python.rst
@@ -60,4 +60,4 @@ pyDive (experimental)
 pyDive provides numpy-style array and file processing on distributed memory systems ("numpy on MPI" for data sets that are much larger than your local RAM).
 pyDive is currently not ready to interpret openPMD directly, but can work on generated raw ADIOS and HDF5 files.
 
-https://github.com/ComputationalRadiationPhysics/pyDive#documentation
+https://github.com/ComputationalRadiationPhysics/pyDive

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -5,7 +5,7 @@ Radiation
 
 The spectrally resolved far field radiation of charged macro particles.
 
-Our simulation computes the `Lienard Wiechert potentials <http://en.wikipedia.org/wiki/Li%C3%A9nard%E2%80%93Wiechert_potential>`_ to calculate the emitted electromagnetic spectra for different observation directions using the far field approximation.
+Our simulation computes the `Lienard Wiechert potentials <https://en.wikipedia.org/wiki/Li%C3%A9nard%E2%80%93Wiechert_potential>`_ to calculate the emitted electromagnetic spectra for different observation directions using the far field approximation.
 
 .. math::
 
@@ -90,7 +90,7 @@ Nyquist limit
 """""""""""""
 
 A major limitation of discrete Fourier transform is the limited frequency resolution due to the discrete time steps of the temporal signal.
-(see `Nyquist-Shannon sampling theorem <http://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem>`_)
+(see `Nyquist-Shannon sampling theorem <https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem>`_)
 Due to the consideration of relativistic delays, the sampling of the emitted radiation is not equidistantly sampled. 
 The plugin has the option to ignore any frequency contributions that lies above the frequency resolution given by the Nyquist-Shannon sampling theorem. 
 Because performing this check costs computation time, it can be switched off. 
@@ -201,7 +201,7 @@ sets the flag to true is a particle fulfills the gamma condition.
 Window function filter
 """"""""""""""""""""""
 
-A window function can be added to the simulation area to reduce `ringing artifacts <http://en.wikipedia.org/wiki/Ringing_artifacts>`_ due to sharp transition from radiating regions to non-radiating regions at the boundaries of the simulation box.
+A window function can be added to the simulation area to reduce `ringing artifacts <https://en.wikipedia.org/wiki/Ringing_artifacts>`_ due to sharp transition from radiating regions to non-radiating regions at the boundaries of the simulation box.
 This should be applied to simulation setups where the entire volume simulated is radiating (e.g. Kelvin-Helmholtz Instability).
 
 In ``radiationConfig.param`` the precompiler variable ``PIC_RADWINDOWFUNCTION`` defines if the window function filter should be used or not.
@@ -322,7 +322,7 @@ The plugin supports multiple radiation species but spectra (frequencies and obse
 References
 ^^^^^^^^^^
 
-- [Electromagnetic Radiation from Relativistic Electrons as Characteristic Signature of their Dynamics](http://www.hzdr.de/db/Cms?pOid=38997) <br>
+- `Electromagnetic Radiation from Relativistic Electrons as Characteristic Signature of their Dynamics <https://www.hzdr.de/db/Cms?pOid=38997>`_,
   Diploma thesis on the radiation plugin
-- [How to test and verify radiation diagnostics simulations within particle-in-cell frameworks](http://dx.doi.org/10.1016/j.nima.2013.10.073 ) <br>
+- `How to test and verify radiation diagnostics simulations within particle-in-cell frameworks <http://dx.doi.org/10.1016/j.nima.2013.10.073>`_,
   Some tests that have been performed to validate the code

--- a/share/picongpu/examples/Bremsstrahlung/README.rst
+++ b/share/picongpu/examples/Bremsstrahlung/README.rst
@@ -28,13 +28,13 @@ References
     H. Burau.
     *Entwicklung und Überprüfung eines Photonenmodells für die Abstrahlung durch hochenergetische Elektronen*,
     Diploma Thesis TU Dresden (2016),
-    https://doi.org/10.5281/zenodo.192116
+    https://dx.doi.org/10.5281/zenodo.192116
 
 .. [Jackson]
     J.D. Jackson.
     *Electrodynamics*,
     Wiley-VCH Verlag GmbH & Co. KGaA (1975),
-    http://onlinelibrary.wiley.com/doi/10.1002/9783527600441.oe014
+    https://dx.doi.org/10.1002/9783527600441.oe014
 
 .. [Salvat]
     F. Salvat, J. Fernández-Varea, J. Sempau, X. Llovet.

--- a/share/picongpu/examples/Bunch/README.rst
+++ b/share/picongpu/examples/Bunch/README.rst
@@ -20,7 +20,7 @@ References
         Richard Pausch.
         *Electromagnetic Radiation from Relativistic Electrons as Characteristic Signature of their Dynamics*,
         Diploma Thesis TU Dresden (2012),
-        http://www.hzdr.de/db/Cms?pOid=38997
+        https://www.hzdr.de/db/Cms?pOid=38997
 
 .. [Pausch13]
         R. Pausch, A. Debus, R. Widera, K. Steiniger, A. Huebl, H. Burau, M. Bussmann, U. Schramm.


### PR DESCRIPTION
Fix all broken links in the sphinx docs. Found via `make linkcheck` and fixed manually.

Upgraded to https where appropriate and redirected.