### PR TITLE
Profiles for Titan & Taurus

### DIFF
--- a/etc/picongpu/taurus-tud/picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/picongpu.profile.example
@@ -3,8 +3,7 @@ module purge
 # General modules #############################################################
 #
 module load oscar-modules
-echo "WARNING: CMake version is too old! (Need: 3.7.0+)" >&2
-# module load cmake/3.6.2
+module load cmake/3.9.0
 module load git
 module load cuda/8.0.44 # gcc <= 5, intel 15-16
 module load bullxmpi
@@ -13,8 +12,7 @@ module load gnuplot/4.6.1
 # Compilers ###################################################################
 ### GCC
 module load gcc/5.3.0
-echo "WARNING: Boost version is too old! (Need: 1.62.0+)" >&2
-# module load boost/1.60.0-gnu5.3
+module load boost/1.64.0-gnu5.3
 ### ICC
 #module load intel/2015.3.187 boost/1.59.0-intel2015.3.187
 ### PGI

--- a/etc/picongpu/titan-ornl/picongpu.profile.example
+++ b/etc/picongpu/titan-ornl/picongpu.profile.example
@@ -9,7 +9,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 source /opt/modules/3.2.6.7/init/bash
 module load craype-accel-nvidia35
 module swap PrgEnv-pgi PrgEnv-gnu
-# module swap gcc gcc/4.8.2 # default
+module swap gcc gcc/4.9.3
 
 # Compile for CLE nodes
 #   (CMake likes to unwrap the Cray wrappers)
@@ -19,16 +19,17 @@ export FC=$(which ftn)
 #export LD="/sw/xk6/altd/bin/ld"
 
 # symbol bug work around (should not be required)
-#MY_CRAY_LIBS=/opt/gcc/4.8.2/snos/lib64
+#MY_CRAY_LIBS=/opt/gcc/4.9.3/snos/lib64
 #export LD_PRELOAD=$MY_CRAY_LIBS/libstdc++.so.6:$LD_PRELOAD
 #export LD_PRELOAD=$MY_CRAY_LIBS/libgomp.so.1:$LD_PRELOAD
 #export LD_PRELOAD=$MY_CRAY_LIBS/libgfortran.so.3:$LD_PRELOAD
 
 # required tools and libs
 module load git
-echo "WARNING: CMake version is too old! (Need: 3.7.0+)" >&2
-# module load cmake/3.6.1
-module load cudatoolkit
+module load cmake3/3.9.0
+module load cudatoolkit  # 7.5.18
+# might fail to link with missing symbols:
+#   C++11 module rebuild pending [CCS #366279]
 module load boost/1.62.0
 export BOOST_ROOT=$BOOST_DIR
 export MPI_ROOT=$MPICH_DIR
@@ -51,11 +52,11 @@ export MPI_ROOT=$MPICH_DIR
 #     export SCOREP_WRAPPER_INSTRUMENTER_FLAGS="--cuda --mpp=mpi"
 #     make -j
 #     make install
-module load scorep/2.0
+#module load scorep
 
 # plugins (optional) ################################################
 module load cray-hdf5-parallel/1.8.14
-#module load adios/1.10.0 dataspaces/1.4.0
+module load adios/1.10.0
 export HDF5_ROOT=$HDF5_DIR
 #export ADIOS_ROOT=$ADIOS_DIR
 #export DATASPACES_ROOT=$DATASPACES_DIR


### PR DESCRIPTION
Updates for `dev` for running on Titan and Taurus.

- [ ] on ~~both machines~~ Titan, new boost versions are still in the making

note: picongpu builds now officially *too long* to not be killed by the watchdog daemon of Taurus' head nodes.