### PR TITLE
PMacc: Fix IdProvider Test

### DIFF
--- a/include/pmacc/test/particles/IdProvider.hpp
+++ b/include/pmacc/test/particles/IdProvider.hpp
@@ -51,7 +51,7 @@ namespace
     struct GenerateIds
     {
         template<class T_Box, typename T_Acc>
-        DINLINE void operator()(const T_Acc & acc, T_Box outputbox, uint32_t numThreads, uint32_t numIdsPerThread) const
+        HDINLINE void operator()(const T_Acc & acc, T_Box outputbox, uint32_t numThreads, uint32_t numIdsPerThread) const
         {
             using namespace pmacc::mappings::threads;
             constexpr uint32_t numWorkers = T_numWorkers;


### PR DESCRIPTION
Related to #2202

Add missing `HDINLINE` on CUDA backend.
```bash
cmake -DALPAKA_ACC_GPU_CUDA_ENABLE=ON -DALPAKA_ACC_GPU_CUDA_ONLY_MODE=ON /bigdata/hplsim/development/huebl/picsrc/include/pmacc/
```

- [x] RT test with OMP2 backend
- [x] RT test with CUDA backend