### PR TITLE
New Tool: pic-build

### DIFF
--- a/pic-build
+++ b/pic-build
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+this_dir=`dirname $0`
+build_dir=".build"
+
+help()
+{
+    echo "Build new binaries for a PIConGPU input set"
+    echo ""
+    echo "Creates or updates the binaries in an input set. This step needs to"
+    echo "be performed every time a .param file is changed."
+    echo ""
+    echo "This tools creates a temporary build directory, configures and"
+    echo "compiles current input set in it and installs the resulting"
+    echo "binaries."
+    echo "This is just a short-hand tool for switching to a temporary build"
+    echo "directory and running 'pic-configure ..' and 'make install'"
+    echo "manually."
+    echo ""
+    echo "You must run this command inside an input directory."
+    echo ""
+    echo "usage: pic-build [OPTIONS]"
+    echo ""
+    # lend the rest of the options from pic-configure
+    echo "$($this_dir/pic-configure --help | tail -n +12)"
+}
+
+# save cmd line args
+cmd_line_args="$@"
+
+# show help
+while [[ $# -gt 0 ]] ; do
+    case "$1" in
+        -h|--help)
+            echo -e "$(help)"
+            exit 0
+            ;;
+        *)
+            # just ignore other options
+            ;;
+    esac
+    shift # next token
+done
+
+# check if we are in an input directory
+if [ ! -d "include/picongpu/" ]
+then
+    echo "ERROR: Could not find directory 'include/picongpu'!" >&2
+    echo "       Are you in a PIConGPU input directory?" >&2
+    exit 1
+fi
+
+# diagnostics
+echo -e "\033[32mbuild directory:\033[0m $build_dir"
+
+# create or re-use an existing build directory
+mkdir -p $build_dir
+if [ $? -ne 0 ]
+then
+    echo "ERROR: Could not create temporary build directory in:" >&2
+    echo "       $build_dir" >&2
+    exit 2
+fi
+
+# switch to build directory
+cd $build_dir
+if [ $? -ne 0 ]
+then
+    echo "ERROR: Could not switch to build directory in:" >&2
+    echo "       $build_dir" >&2
+    exit 3
+fi
+
+# cmake call
+$this_dir/pic-configure $cmd_line_args ..
+if [ $? -ne 0 ]
+then
+    # let pic-configure errors speak for themselves
+    exit 4
+fi
+
+# make and install
+make -j install
+if [ $? -ne 0 ]
+then
+    echo ""
+    echo "ERROR: Could not successfully run make install in build directory:" >&2
+    echo "       $build_dir" >&2
+    exit 5
+fi
+
+# switch back
+cd -

--- a/pic-configure
+++ b/pic-configure
@@ -24,11 +24,17 @@ this_dir=`dirname $0`
 
 help()
 {
-    echo "configure create a cmake call for picongpu \nand get fast access to selected picongpu cmake options"
+    echo "Configure PIConGPU with CMake"
     echo ""
-    echo "usage: configure [OPTIONS] <parameterDirectory>"
+    echo "Generates a call to CMake and provides short-hand access to selected"
+    echo "PIConGPU CMake options."
+    echo "Advanced users can always run 'ccmake .' after this call for further"
+    echo "compilation options."
     echo ""
-    echo "-i | --install       - path were picongpu shall be installed (default is <parameterDirectory>)"
+    echo "usage: pic-configure [OPTIONS] <inputDirectory>"
+    echo ""
+    echo "-i | --install       - path were picongpu shall be installed"
+    echo "                       (default is <inputDirectory>)"
     echo "-a | --arch          - set compute backend and optionally the architecture"
     echo "                       syntax: backend[:architecture]"
     echo "                       supported backends: cuda, omp2b"

--- a/pic-create
+++ b/pic-create
@@ -21,9 +21,9 @@
 
 this_dir=`dirname $0`
 
-#only copy submit and params if we clone from default pic folder
+# only copy submit and params if we clone from default pic folder
 default_folder_to_copy="etc/picongpu include/picongpu/simulation_defines/param include/picongpu/simulation_defines/unitless"
-#if we clone a project we copy full include 
+# if we clone a project we copy full include
 folder_to_clone="etc/picongpu bin include/picongpu lib"
 files_to_copy="cmakeFlags executeOnClone"
 
@@ -55,7 +55,7 @@ eval set -- "$OPTS"
 while true ; do
     case "$1" in
         -f|--force)
-            force_param=1                       
+            force_param=1
             ;;
         -h|--help)
             echo -e "$(help)"


### PR DESCRIPTION
Just run `pic-build` inside a input directory.

This updates the binaries for a `tbg` call with the latest options in an input's param sets.

Just short-hand for

```bash
mkdir .build
cd .build
pic-configure ..
make -j install
cd -
```

Avoids confusion for users that are not used to out-of-source builds.

cc'ing @ComputationalRadiationPhysics/picls-developer @ComputationalRadiationPhysics/picls-maintainer please provide feedback and give this new tool in `dev` a try! You will never have to switch directories during input design again 💃 