### PR TITLE
Travis: Test PMacc Unit Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,54 @@
 language: cpp
 sudo: false
+dist: trusty
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
+      - g++-4.9
+      - gfortran-4.9  # spack OpenMPI dependency
       - python-flake8
+      - environment-modules
+      - openmpi-bin
+      - libopenmpi-dev
 
-script:
+env:
+  global:
+    - SPACK_ROOT: $HOME/.cache/spack
+    - PATH: $PATH:$HOME/.cache/spack/bin
+
+before_install:
+  - export CXX=g++-4.9
+  - export CC=gcc-4.9
+  - export FC=gfortran-4.9
+  - export CXXFLAGS="-std=c++11"
+
+install:
+  #############################################################################
+  # PMacc CPU-only dependencies                                               #
+  #############################################################################
+  - SPACK_FOUND=$(which spack >/dev/null && { echo 0; } || { echo 1; })
+  - if [ $SPACK_FOUND -ne 0 ]; then
+      mkdir -p $SPACK_ROOT &&
+      git clone --depth 50 https://github.com/llnl/spack.git $SPACK_ROOT &&
+      echo -e "config:""\n  build_jobs:"" 2" > $SPACK_ROOT/etc/spack/config.yaml;
+    fi
+  - travis_wait spack install cmake@3.7.2~openssl~ncurses
+  - travis_wait spack install boost@1.62.0~date_time~graph~iostreams~locale~log~random~thread~timer~wave
+  - spack clean -a
+  - source /etc/profile &&
+    source $SPACK_ROOT/share/spack/setup-env.sh
+  - spack load cmake
+  - spack load boost
+
+before_script:
   #############################################################################
   # Disallow PRs to `ComputationalRadiationPhysics/picongpu` branch `master`  #
   # if not an other mainline branch such as `dev` or `release-...`            #
@@ -45,3 +87,14 @@ script:
   # Test Python Files for PEP8 conformance                                    #
   #############################################################################
   - flake8 --exclude=thirdParty .
+
+script:
+  #############################################################################
+  # PMacc CPU-only tests                                                      #
+  #############################################################################
+  - mkdir -p $HOME/build
+  - cd $HOME/build
+  - cmake $TRAVIS_BUILD_DIR/include/pmacc
+          -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON
+  - make -j 2
+  # - make test  # reduce memory and RT costs first


### PR DESCRIPTION
- install dependencies (CPU-only) via spack
- build tests with gcc 4.9.4

Besides a first build-up of the cache (~20min *once*! only 56MB cache!), the `make` of the PMacc unit tests runs quickly. This ensures the tests are not going to be outdated and will always build.

For a RT `make test`, the tests' footprint might be reduced a bit first (maybe to 1 GB mem consumption and <20sec per test).

Actually installing cupla can also save some double-builds.