### PR TITLE
Docker Update: spack clean & load

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -61,7 +61,7 @@ RUN        git clone --depth 50 https://github.com/llnl/spack.git \
            spack install adios@1.10.0 && \
            spack install isaac@1.3.1 ^boost@1.61.0 && \
            spack install isaac-server@1.3.1 ^boost@1.61.0 && \
-           spack purge --all
+           spack clean -a
 
 # get PIConGPU sources
 RUN        git clone --depth 50 --branch $PICONGPU_BRANCH \

--- a/share/picongpu/dockerfiles/ubuntu-1604/picongpu.profile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/picongpu.profile
@@ -5,23 +5,23 @@
 export MODULEPATH=$HOME/src/spack/share/spack/lmod/linux-ubuntu16-x86_64/Core
 
 # Core Dependencies (based on gcc 5.4.0)
-module load cmake
-module load boost
-module load cuda
-module load openmpi
+spack load cmake
+spack load boost
+spack load cuda
+spack load openmpi
 
 # Plugins (optional)
-module load zlib libpng freetype pngwriter
-module load hdf5 libsplash
-module load libjpeg-turbo jansson icet isaac
-module load isaac-server
+spack load zlib libpng freetype pngwriter
+spack load hdf5 libsplash
+spack load libjpeg-turbo jansson icet isaac
+spack load isaac-server
 
 # either use libSplash or ADIOS for file I/O
-#module load adios
+#spack load adios
 
 # Debug Tools
-#module load gdb
-#module load valgrind
+#spack load gdb
+#spack load valgrind
 
 # Environment #################################################################
 #


### PR DESCRIPTION
Updates the following points in our `Dockerfile`:
- `spack purge` was merged into `spack clean`
- instead of `module load` we can use `spack load` for easier selection syntax of specs