### PR TITLE
tbg: --help exit 0

### DIFF
--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -323,7 +323,7 @@ while true ; do
         -h|--help)
             echo -e "$(help)"
             shift
-            exit 1
+            exit 0
             ;;
         --) shift; break;;
     esac


### PR DESCRIPTION
`-h|--help` should exit with zero return code.