### PR TITLE
Density: Param Gaussian Density

### DIFF
--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -53,7 +53,7 @@ struct GaussianImpl : public T_ParamClass
         const float_X gas_center_left = ParamClass::gasCenterLeft_SI / UNIT_LENGTH;
         const float_X gas_center_right = ParamClass::gasCenterRight_SI / UNIT_LENGTH;
         const float_X gas_sigma_left = ParamClass::gasSigmaLeft_SI / UNIT_LENGTH;
-        const float_X gas_sigma_right = ParamClass::gasCenterRight_SI / UNIT_LENGTH;
+        const float_X gas_sigma_right = ParamClass::gasSigmaRight_SI / UNIT_LENGTH;
 
         const floatD_X globalCellPos(
                                      precisionCast<float_X>(totalCellOffset) *


### PR DESCRIPTION
Fix wrong parameter usage in `Gaussian` density profile:
Instead of `gasSigmaRight` the `gasCenterRight` parameter was taken for the scale-length of the downramp.

Bug since the 0.2.x release series: 7b451c01304a228895d00fbe27507859c1e93569