### PR TITLE
New Tool: pic-edit

### DIFF
--- a/docs/source/usage/param.rst
+++ b/docs/source/usage/param.rst
@@ -8,13 +8,31 @@
 Parameter files, ``*.param`` placed in ``include/picongpu/simulation_defines/param/`` are used to set all **compile-time options** for a PIConGPU simulation.
 This includes most fundamental options such as numerical solvers, floating precision, memory usage due to attributes and super-cell based algorithms, density profiles, initial conditions etc.
 
+Editing
+-------
+
+For convenience, we provide a tool ``pic-edit`` to edit the compile-time input by its name.
+For example, if you want to edit the *grid* and time step resolution, *file output* and add a *laser* to the simulation, open the according files via:
+
+.. code-block:: bash
+   :emphasize-lines: 4
+
+   # first switch to your input directory
+   cd $HOME/picInputs/myLWFA
+
+   pic-edit grid fileOutput laser
+
+See ``pic-edit --help`` for all available files:
+
+.. program-output:: ../../pic-edit --help
+
 Rationale
 ---------
 
 High-performance hardware comes with a lot of restrictions on how to use it, mainly memory, control flow and register limits.
 In order to create an efficient simulation, PIConGPU compiles to **exactly** the numerical solvers (kernels) and physical attributes (fields, species) for the setup you need to run, which will furthermore be specialized for a specific hardware.
 
-This comes at a small cost: when one of those settings is changed, you need to recompile.
+This comes at a small cost: when **even one of those settings is changed, you need to recompile**.
 Nevertheless, wasting about 5 minutes compiling on a single node is nothing compared to the time you save *at scale*!
 
 All options that are less or non-critical for runtime performance, such as specific ranges observables in :ref:`plugins <usage-plugins>` or how many nodes shall be used, can be set in :ref:`run time configuration files (*.cfg) <usage-tbg>` and do not need a recompile when changed.

--- a/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
+++ b/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
@@ -1,6 +1,9 @@
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
 # Modules #####################################################################
 #
-
 if [ -f /etc/profile.modules ]
 then
         . /etc/profile.modules

--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -1,6 +1,9 @@
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
 # Modules #####################################################################
 #
-
 if [ -f /etc/profile.modules ]
 then
         . /etc/profile.modules

--- a/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
@@ -1,6 +1,9 @@
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
 # Modules #####################################################################
 #
-
 if [ -f /etc/profile.modules ]
 then
         . /etc/profile.modules

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -1,6 +1,9 @@
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
 # Modules #####################################################################
 #
-
 if [ -f /etc/profile.modules ]
 then
         . /etc/profile.modules
@@ -32,7 +35,7 @@ fi
 #
 alias getNode='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=64'
 
-export PICSRC=/home/`whoami`/src/picongpu
+export PICSRC=/home/$(whoami)/src/picongpu
 export PIC_BACKEND="omp2b:bdver1"
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -1,3 +1,9 @@
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# Modules #####################################################################
+#
 if [ -f /etc/profile.d/modules.sh ]
 then
         . /etc/profile.d/modules.sh

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -1,8 +1,8 @@
-# this file is loaded from all PIConGPU template *.tpl files, therefore please
-# copy this file to $SCRATCH/picongpu.profile
-#
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
 
-# General modules #############################################################
+# General Modules #############################################################
 #
 # if the wrong environment is loaded we switch to the gnu environment
 module li 2>&1 | grep "PrgEnv-cray" > /dev/null

--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -1,7 +1,10 @@
-module purge
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
 
 # General modules #############################################################
 #
+module purge
 module load oscar-modules
 module load cmake/3.9.0
 module load git

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -1,7 +1,10 @@
-module purge
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
 
 # General modules #############################################################
 #
+module purge
 module load oscar-modules
 module load cmake/3.9.0
 module load git

--- a/etc/picongpu/titan-ornl/picongpu.profile.example
+++ b/etc/picongpu/titan-ornl/picongpu.profile.example
@@ -5,7 +5,11 @@ export MY_MAILNOTIFY="n"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
-# basic environment #################################################
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# basic environment ###########################################################
 source /opt/modules/3.2.6.7/init/bash
 module load craype-accel-nvidia35
 module swap PrgEnv-pgi PrgEnv-gnu
@@ -34,14 +38,14 @@ module load boost/1.62.0
 export BOOST_ROOT=$BOOST_DIR
 export MPI_ROOT=$MPICH_DIR
 
-# vampirtrace (optional) ############################################
+# vampirtrace (optional) ######################################################
 #   pic-configure with -c "-DVAMPIR_ENABLE=ON"
 #   e.g.:
 #     pic-configure -c "-DVAMPIR_ENABLE=ON" ~/picInputs/case001
 #module load vampirtrace/5.14.4
 #export VT_ROOT=$VAMPIRTRACE_DIR
 
-# scorep (optional) #################################################
+# scorep (optional) ###########################################################
 #   pic-configure with -c "-DCMAKE_CXX_COMPILER=$(which scorep-CC) \
 #                          -DCUDA_NVCC_EXECUTABLE=$(which scorep-nvcc)"
 #   e.g.:
@@ -54,7 +58,7 @@ export MPI_ROOT=$MPICH_DIR
 #     make install
 #module load scorep
 
-# plugins (optional) ################################################
+# plugins (optional) ##########################################################
 module load cray-hdf5-parallel/1.8.14
 module load adios/1.10.0
 export HDF5_ROOT=$HDF5_DIR
@@ -80,7 +84,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBPNG_ROOT/lib
 export PNGWRITER_ROOT=$PROJWORK/$proj/lib/pngwriter
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGWRITER_ROOT/lib
 
-# helper variables and tools ########################################
+# helper variables and tools ##################################################
 export PICSRC=$HOME/src/picongpu
 export PIC_BACKEND="cuda:35"
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
@@ -90,7 +94,7 @@ export PATH=$PATH:$PICSRC/src/tools/bin
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
-alias getInteractive="qsub -I -A $proj -q debug -l nodes=1,walltime=30:00"
+alias getNode="qsub -I -A $proj -q debug -l nodes=1,walltime=30:00"
 
 # "tbg" default options #######################################################
 export TBG_SUBMIT="qsub"

--- a/etc/picongpu/titan-ornl/pythonOnRhea.profile.example
+++ b/etc/picongpu/titan-ornl/pythonOnRhea.profile.example
@@ -1,5 +1,11 @@
 export proj=<yourProject>
 
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# Modules######################################################################
+#
 module unload intel
 module swap PE-intel PE-gnu
 

--- a/pic-create
+++ b/pic-create
@@ -21,9 +21,9 @@
 
 this_dir=$(cd $(dirname $0) && pwd)
 
-# only copy submit and params if we clone from default pic folder
-default_folder_to_copy="etc/picongpu include/picongpu/simulation_defines/param include/picongpu/simulation_defines/unitless lib"
-# if we clone a project we copy full include
+# files always cloned from defaults, can be overwritten by input set
+default_folder_to_copy="etc/picongpu lib"
+# if we clone an input set we copy from it
 folder_to_clone="etc/picongpu bin include/picongpu lib"
 files_to_copy="cmakeFlags executeOnClone"
 

--- a/pic-edit
+++ b/pic-edit
@@ -67,7 +67,7 @@ help()
 {
     echo "Edit compile-time options for a PIConGPU input set"
     echo ""
-    echo 'Opens .param files in an input set with the default "$EDITOR".'
+    echo 'Opens .param files in an input set with the default "EDITOR".'
     echo "If a .param file is not yet part of the input set but exists in the"
     echo "defaults, it will be transparently added to the input set."
     echo ""
@@ -79,7 +79,7 @@ help()
         test_editor="NOT FOUND"
     fi
     echo "The currently selected editor is: $test_editor"
-    echo 'You can change it via the "$EDITOR" environment variable.'
+    echo 'You can change it via the "EDITOR" environment variable.'
     echo ""
     echo "usage: pic-edit <input>"
     echo ""
@@ -148,9 +148,15 @@ use_editor="$(find_editor)"
 if [ $? -ne 0 ]
 then
     echo 'ERROR: Could not find a working text editor!' >&2
-    echo '       You might want to set the "$EDITOR" environment variable.' >&2
+    echo '       You might want to set the "EDITOR" environment variable.' >&2
     exit 3
 fi
 
 # open the files for editing
 $use_editor $file_paths
+editor_exit=$?
+
+# remove new files that are unchanged
+# TODO: grep -Fxvf file1 file2
+
+exit $editor_exit

--- a/pic-edit
+++ b/pic-edit
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+this_dir=$(cd $(dirname $0) && pwd)
+known_editors=( 'nano' 'vim' 'vi' 'emacs' )
+file_prefix="include/picongpu/simulation_defines/param"
+
+find_inputs()
+{
+    if [ -d "$file_prefix" ]
+    then
+        files_local=$(cd $file_prefix && ls *.param 2>/dev/null)
+    fi
+    if [ -d "$this_dir/$file_prefix" ]
+    then
+        files_defaults=$(cd $this_dir/$file_prefix && ls *.param 2>/dev/null)
+    fi
+    # only basename of the files
+    echo "${files_local//\.param/} ${files_defaults//\.param/}" | sort -u
+}
+
+find_editor()
+{
+    if [ ! -z "$EDITOR" ]
+    then
+        echo "$EDITOR"
+        return 0
+    fi
+    # fallback to system default
+    if which editor >/dev/null
+    then
+        echo "$(readlink -f $(which editor))"
+        return 0
+    fi
+    # fallback to know editors if they exist
+    for ke in "${known_editors[@]}"
+    do
+        if ! which $ke >/dev/null
+        then
+            echo "$(which $ke)"
+            return 0
+        fi
+    done
+    # none found
+    return 3
+}
+
+help()
+{
+    echo "Edit compile-time options for a PIConGPU input set"
+    echo ""
+    echo 'Opens .param files in an input set with the default "$EDITOR".'
+    echo "If a .param file is not yet part of the input set but exists in the"
+    echo "defaults, it will be transparently added to the input set."
+    echo ""
+    echo "You must run this command inside an input directory."
+    echo ""
+    test_editor="$(find_editor)"
+    if [ -z "$test_editor" ]
+    then
+        test_editor="NOT FOUND"
+    fi
+    echo "The currently selected editor is: $test_editor"
+    echo 'You can change it via the "$EDITOR" environment variable.'
+    echo ""
+    echo "usage: pic-edit <input>"
+    echo ""
+    echo "Available <input>s:"
+    inputs=($(find_inputs))
+    echo "${inputs[@]}"
+}
+
+# save cmd line args (names of inputs)
+cmd_line_args=("$@")
+
+if [ $# -eq 0 ]
+then
+    echo -e "$(help)"
+    exit 2
+fi
+
+# show help
+while [[ $# -gt 0 ]] ; do
+    case "$1" in
+        -h|--help)
+            echo -e "$(help)"
+            exit 0
+            ;;
+        *)
+            # just ignore other options
+            ;;
+    esac
+    shift # next token
+done
+
+# check if we are in an input directory
+if [ ! -d "include/picongpu/simulation_defines/param" ]
+then
+    echo "ERROR: Could not find directory" >&2
+    echo "       'include/picongpu/simulation_defines/param'!" >&2
+    echo "       Are you in a PIConGPU input directory?" >&2
+    exit 1
+fi
+
+for input in "${cmd_line_args[@]}"
+do
+    # check if the file exists locally (even if it does not exist in defaults)
+    file_name="$input.param"
+    file_path="$file_prefix/$file_name"
+    file_paths="$file_path $file_paths"
+    if [ ! -f "$file_path" ]
+    then
+        # if the file is missing, but does exist in the defaults, add it from defaults
+        defaults_path="$this_dir/$file_prefix/$file_name"
+        if [ -f "$defaults_path" ]
+        then
+            cp $defaults_path $file_path
+        else
+            echo "ERROR: input '$input' does not exist!" >&2
+            echo "Available inputs:" >&2
+            inputs=($(find_inputs))
+            echo "${inputs[@]}"
+            exit 4
+        fi
+    fi
+done
+
+# get editor
+use_editor="$(find_editor)"
+if [ $? -ne 0 ]
+then
+    echo 'ERROR: Could not find a working text editor!' >&2
+    echo '       You might want to set the "$EDITOR" environment variable.' >&2
+    exit 3
+fi
+
+# open the files for editing
+$use_editor $file_paths

--- a/share/picongpu/dockerfiles/ubuntu-1604/picongpu.profile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/picongpu.profile
@@ -1,3 +1,7 @@
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
 # Modules #####################################################################
 #
 . /usr/share/lmod/5.8/init/bash


### PR DESCRIPTION
For easier forward-compatibility, we should not fill-up all default `.param` and `.unitless` files during pic-create. This also makes version control of input easier.

Our defaults are sane (basic PIC cycle without any density or lasers) for a PIC simulation and will only cause unnecessary conflicts when the defaults change.

Instead, we can clone only the files that are changed in input on `pic-create` and add the others automatically when needed.

The workflow possible with `pic-edit` editing `.param` files is:

```bash
  pic-create $PICSRC/share/picongpu/LaserWakefield lwfa
  cd lwfa

  # edit compile time options
  pic-edit grid laser isaac
  # will copy in a default isaac.param
  # will open the already existing grid.param and laser.param plus
  #   the added isaac.param inside the simulation_defines/param/
  #   directory

  pic-build

  # edit run time options in .cfg files
  nano etc/picongpu/0001gpus.cfg
  # submit
  tbg ...
```

This also solves the issue of telling users "where to get additional files from" when they change inputs, because they do not need to know anymore.

`.unitless` files are not able to be opened with `pic-edit` since they are for power-users only anyway.

See also the help of this tool:
```
$ pic-edit -h
Edit compile-time options for a PIConGPU input set

Opens .param files in an input set with the default "$EDITOR".
If a .param file is not yet part of the input set but exists in the
defaults, it will be transparently added to the input set.

You must run this command inside an input directory.

The currently selected editor is: /bin/nano
You can change it via the "$EDITOR" environment variable.

usage: pic-edit <input>

Available <input>s:
components density dimension fieldBackground fieldSolver fileOutput flylite grid ionizationEnergies ionizer isaac laser mallocMC memory particle particleCalorimeter particleMerger physicalConstants precision pusher radiation radiationObserver seed species speciesAttributes speciesConstants speciesDefinition speciesInitialization starter synchrotronPhotons visColorScales visualization visualization bremsstrahlung
```

### To Do

- feedback? @ComputationalRadiationPhysics/picongpu-developers 
- [x] add `.rst` docs
- [x] change `pic-create`
- [x] `$EDITOR` in `picongpu.profile.example`s

### Future Ideas

- [ ] do not copy-in an input file if it is unchanged to defaults (try to *avoid* adding a new third-party dependency such as `diff`/`cmp`/...?) -> `grep -Fxvf file1 file2`