### PR TITLE
Tools: Allow Call With Relative Path

### DIFF
--- a/pic-build
+++ b/pic-build
@@ -19,7 +19,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-this_dir=`dirname $0`
+this_dir=$(cd $(dirname $0) && pwd)
 build_dir=".build"
 
 help()

--- a/pic-configure
+++ b/pic-configure
@@ -19,7 +19,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-this_dir=`dirname $0`
+this_dir=$(cd $(dirname $0) && pwd)
 
 
 help()

--- a/pic-create
+++ b/pic-create
@@ -19,7 +19,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-this_dir=`dirname $0`
+this_dir=$(cd $(dirname $0) && pwd)
 
 # only copy submit and params if we clone from default pic folder
 default_folder_to_copy="etc/picongpu include/picongpu/simulation_defines/param include/picongpu/simulation_defines/unitless lib"


### PR DESCRIPTION
This fixed the bug reported in issue #2221.
 
Allows to call the scripts `pic-create`, `pic-build`, `pic-configure` even with relative paths to the scripts instead of relying on the `$PATH` environment var. 