### PR TITLE
fix class down cast

### DIFF
--- a/include/picongpu/particles/manipulators/generic/Free.hpp
+++ b/include/picongpu/particles/manipulators/generic/Free.hpp
@@ -146,7 +146,7 @@ namespace acc
             T_WorkerCfg const &
         )
         {
-            return acc::Free< Functor >( *reinterpret_cast< Functor * >( this ) );
+            return acc::Free< Functor >( *static_cast< Functor * >( this ) );
         }
     };
 

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -192,7 +192,7 @@ namespace acc
             T_WorkerCfg const & workerCfg
         )
         {
-            RngType< T_Acc > const rng = ( *reinterpret_cast< RngGenerator * >( this ) )(
+            RngType< T_Acc > const rng = ( *static_cast< RngGenerator * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -202,7 +202,7 @@ namespace acc
                 Functor,
                 RngType< T_Acc >
             >(
-                *reinterpret_cast< Functor * >( this ),
+                *static_cast< Functor * >( this ),
                 rng
             );
         }

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -155,7 +155,7 @@ namespace acc
             T_WorkerCfg const &
         )
         {
-            return acc::Free< Functor >( *reinterpret_cast< Functor * >( this ) );
+            return acc::Free< Functor >( *static_cast< Functor * >( this ) );
         }
     };
 

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -199,7 +199,7 @@ namespace acc
             RngType< T_Acc >
         >
         {
-            RngType< T_Acc > const rng = ( *reinterpret_cast< RngGenerator * >( this ) )(
+            RngType< T_Acc > const rng = ( *static_cast< RngGenerator * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -209,7 +209,7 @@ namespace acc
                 Functor,
                 RngType< T_Acc >
             >(
-                *reinterpret_cast< Functor * >( this ),
+                *static_cast< Functor * >( this ),
                 rng
             );
         }

--- a/include/pmacc/functor/Filtered.hpp
+++ b/include/pmacc/functor/Filtered.hpp
@@ -85,11 +85,11 @@ namespace acc
         {
             // call the filter on each argument and combine the results
             bool const combinedResult = T_FilterOperator{ }(
-                ( *reinterpret_cast< Filter * >( this ) )( acc, args ) ...
+                ( *static_cast< Filter * >( this ) )( acc, args ) ...
             );
 
             if( combinedResult )
-                ( *reinterpret_cast< Functor * >( this ) )( acc, args ... );
+                ( *static_cast< Functor * >( this ) )( acc, args ... );
         }
     };
 
@@ -243,12 +243,12 @@ namespace acc
                     )
                 )
             >(
-                ( *reinterpret_cast< Filter * >( this ) )(
+                ( *static_cast< Filter * >( this ) )(
                     acc,
                     domainOffset,
                     workerCfg
                 ),
-                ( *reinterpret_cast< Functor * >( this ) )(
+                ( *static_cast< Functor * >( this ) )(
                     acc,
                     domainOffset,
                     workerCfg

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -125,7 +125,7 @@ namespace detail
                     detail::VoidWrapper< T_ReturnType >
                 >::value
             );
-            return ( *reinterpret_cast< UserFunctor * >( this ) )( acc, args ... );
+            return ( *static_cast< UserFunctor * >( this ) )( acc, args ... );
         }
     };
 
@@ -228,7 +228,7 @@ namespace detail
             T_ReturnType
         >
         {
-            return ( *reinterpret_cast< UserFunctor * >( this ) )(
+            return ( *static_cast< UserFunctor * >( this ) )(
                 acc,
                 domainOffset,
                 workerCfg
@@ -242,7 +242,7 @@ namespace detail
         HINLINE std::string
         getName( ) const
         {
-            return ( *reinterpret_cast< UserFunctor * >( this ) ).getName( );
+            return ( *static_cast< UserFunctor * >( this ) ).getName( );
         }
     };
 


### PR DESCRIPTION
fix #2215

`reinterpret_cast` is used to down cast a class. This is wrong and leads to wrong (not illegal) memory access within the class to the member's.

`static_cast` is used to solve the issue.

The bug was introduced with #2117, #2125 and #2168. 
The result of the bug is that the values within the member's of a class can be wrong, this can result in illegal memory access if the member is an offset within an array or in bad random number as in #2215.

# Tests

- [x] laser wake field default example on GPU