### PR TITLE
fix `ParticlesBox::setAsLastFrame()`

### DIFF
--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -282,7 +282,7 @@ public:
             (FrameType*) atomicExch(
                 (unsigned long long int*) lastFrameNativPtr,
                 (unsigned long long int) frame.ptr,
-                ::alpaka::hierarchy::Threads{}
+                ::alpaka::hierarchy::Grids{}
             )
         );
 


### PR DESCRIPTION
fix #2228

The function `setAsLAstFrame()` must be atomic between different grids.
With #2178 [this line](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2178/files#diff-82ce98f3d12c8577e81d5cc7c1a6245cR285) the function was wrongly changed to be atomic only between threads within a block.

- use `::alpaka::hierarchy::Threads{}` to `::alpaka::hierarchy::Grids{}`


# Tests

- [x] LWFA with `omp2b`