### PR TITLE
use fast `atomicAllExch` in `KernelFillGridWithParticles`

### DIFF
--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -331,10 +331,12 @@ namespace picongpu
 
                             numParsPerCellCtx[ idx ]--;
                             if( numParsPerCellCtx[ idx ] > 0 )
-                                atomicExch(
+                                nvidia::atomicAllExch(
+                                    acc,
                                     &finished,
-                                    0
-                                ); //one or more cell has particles to create
+                                    0,
+                                    ::alpaka::hierarchy::Threads{}
+                                ); // one or more cells have particles to create
                         }
                     }
                 );


### PR DESCRIPTION
use fast `atomicAllExch` instead of slow `atomicExch`

All threads within the kernel reducing it's value to the same pointer, tehrefore the faster version of `atomicExch` can be used.