### PR TITLE
fix wrong used hierarchy for atomic operation

### DIFF
--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
@@ -274,7 +274,7 @@ namespace helperFields
                         atomicAdd(
                             &( localEnergyHistogram[ i ] ),
                             shLocalEnergyHistogram[ i ],
-                            ::alpaka::hierarchy::Threads{}
+                            ::alpaka::hierarchy::Blocks{}
                         );
                 }
             );


### PR DESCRIPTION
The shared memory histogram is reduced with the hierarchy `Threads`
to the global memory. This will produce raceconditions between blocks of a grid.

- use hierarchy `Blocks` instead of `Threads`

This bug was introduced with #2178.