### PR TITLE
enable ionization for CPU backend

### DIFF
--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -27,13 +27,13 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/communication/AsyncCommunication.hpp>
+#include "picongpu/particles/traits/GetIonizerList.hpp"
 #if( PMACC_CUDA_ENABLED == 1 )
-#   include "picongpu/particles/traits/GetIonizerList.hpp"
 #   include "picongpu/particles/traits/GetPhotonCreator.hpp"
 #   include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 #   include "picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp"
-#   include "picongpu/particles/creation/creation.hpp"
 #endif
+#include "picongpu/particles/creation/creation.hpp"
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/particles/traits/ResolveAliasFromSpecies.hpp>
 #include "picongpu/particles/flylite/IFlyLite.hpp"
@@ -298,7 +298,6 @@ struct PushAllSpecies
     }
 };
 
-#if( PMACC_CUDA_ENABLED == 1 )
 /** Call an ionization method upon an ion species
  *
  * \tparam T_SpeciesType type of particle species that is going to be ionized with
@@ -393,6 +392,8 @@ struct CallIonization
     }
 
 };
+
+#if( PMACC_CUDA_ENABLED == 1 )
 
 /** Handles the bremsstrahlung effect for electrons on ions.
  *

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -130,6 +130,27 @@ public:
         const DataSpace<simDim>& localCellOffset
     );
 
+    /** cache fields used by this functor
+     *
+     * @warning this is a collective method and calls synchronize
+     *
+     * @tparam T_Acc alpaka accelerator type
+     * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+     *
+     * @param acc alpaka accelerator
+     * @param blockCell relative offset (in cells) to the local domain plus the guarding cells
+     * @param workerCfg configuration of the worker
+     */
+    template<
+        typename T_Acc ,
+        typename T_WorkerCfg
+    >
+    DINLINE void collectiveInit(
+        const T_Acc & acc,
+        const DataSpace<simDim>& blockCell,
+        const T_WorkerCfg & workerCfg
+    );
+
     /** Rotates a vector to a given polar angle and a random azimuthal angle.
      *
      * @param vec vector to be rotated

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -78,7 +78,7 @@ template<
     typename T_PhotonSpecies
 >
 template<
-    typename T_Acc ,
+    typename T_Acc,
     typename T_WorkerCfg
 >
 DINLINE void Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::collectiveInit(

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -85,6 +85,8 @@ namespace creation
 
         /** Goes over all frames and calls `ParticleCreator`
          *
+         * @tparam T_Acc alpaka accelerator type
+         *
          * @param blockCell n-dim. block offset (in cells) relative to the origin
          *                  of the local domain plus guarding cells
          */
@@ -356,12 +358,12 @@ namespace creation
                         {
                             if( 0 <= targetParIdCtx[ idx ] &&  targetParIdCtx[ idx ] < maxParticlesInFrame )
                             {
-                                // each thread makes the attributes of its source particle accessible
+                                // each virtual worker makes the attributes of its source particle accessible
                                 auto sourceParticle = sourceFrame[ linearIdx ];
-                                // each thread initializes an target particle if one should be created
+                                // each virtual worker initializes a target particle if one should be created
                                 auto targetParticle = targetFrame[ targetParIdCtx[ idx ] ];
 
-                                // create an target particle in the new target particle frame:
+                                // create a target particle in the new target particle frame:
                                 particleCreatorCtx[ idx ](
                                     acc,
                                     sourceParticle,
@@ -402,7 +404,7 @@ namespace creation
                     __syncthreads( );
 
                     /* < CREATE 2 >
-                     * - the thread writes an target particle to the new frame
+                     * - the thread writes a target particle to the new frame
                      * - the internal counter is decremented by 1
                      */
                     forEachParticle(
@@ -417,10 +419,10 @@ namespace creation
 
                                 // each thread makes the attributes of its source particle accessible
                                 auto sourceParticle = sourceFrame[ linearIdx ];
-                                // each thread initializes an target particle if one should be created
+                                // each thread initializes a target particle if one should be created
                                 auto targetParticle = targetFrame[ targetParIdCtx[ idx ] ];
 
-                                // create an target particle in the new target particle frame:
+                                // create a target particle in the new target particle frame:
                                 particleCreatorCtx[ idx ](
                                     acc,
                                     sourceParticle,

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -30,7 +30,12 @@
 #include <pmacc/math/vector/Int.hpp>
 #include <pmacc/nvidia/atomic.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/mappings/threads/ForEachIdx.hpp>
+#include <pmacc/mappings/threads/IdxConfig.hpp>
+#include <pmacc/mappings/threads/WorkerCfg.hpp>
+
 #include <iostream>
+
 
 namespace picongpu
 {
@@ -39,273 +44,444 @@ namespace particles
 namespace creation
 {
 
-using namespace pmacc;
-
-/** Functor with main kernel for particle creation
- *
- * \tparam T_ParBoxSource container of the source species
- * \tparam T_ParBoxTarget container of the target species
- * \tparam T_ParticleCreator type of the particle creation functor
- *
- * - maps the frame dimensions and gathers the particle boxes
- * - contains / calls the Creator
- */
-template<class T_ParBoxSource, class T_ParBoxTarget, class T_ParticleCreator>
-struct CreateParticlesKernel
-{
-    typedef T_ParBoxSource ParBoxSource;
-    typedef T_ParBoxTarget ParBoxTarget;
-    typedef T_ParticleCreator ParticleCreator;
-
-    ParBoxSource sourceBox;
-    ParBoxTarget targetBox;
-    ParticleCreator particleCreator;
-    uint32_t guardSuperCells;
-
-    CreateParticlesKernel(
-        ParBoxSource sourceBox,
-        ParBoxTarget targetBox,
-        ParticleCreator particleCreator,
-        const uint32_t guardSuperCells) :
-            sourceBox(sourceBox),
-            targetBox(targetBox),
-            particleCreator(particleCreator),
-            guardSuperCells(guardSuperCells)
-    {}
-
-    /** Goes over all frames and calls `ParticleCreator`
+    /** Functor with main kernel for particle creation
      *
-     * @param cellIndex n-dim. cell index from the origin of the local domain
+     * - maps the frame dimensions and gathers the particle boxes
+     * - contains / calls the Creator
+     *
+     * @tparam T_numWorkers number of workers
+     * @tparam T_ParBoxSource container of the source species
+     * @tparam T_ParBoxTarget container of the target species
+     * @tparam T_ParticleCreator type of the particle creation functor
      */
-    template< typename T_Acc >
-    DINLINE void operator()(
-        T_Acc const & acc,
-        const pmacc::math::Int<simDim>& cellIndex
-    )
+    template<
+        uint32_t T_numWorkers,
+        typename T_ParBoxSource,
+        typename T_ParBoxTarget,
+        typename T_ParticleCreator
+    >
+    struct CreateParticlesKernel
     {
-        /* definitions for domain variables, like indices of blocks and threads */
-        typedef typename MappingDesc::SuperCellSize SuperCellSize;
+        using ParBoxSource = T_ParBoxSource;
+        using ParBoxTarget = T_ParBoxTarget;
+        using ParticleCreator = T_ParticleCreator;
 
-        /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
-        const pmacc::math::Int<simDim> block = cellIndex / SuperCellSize::toRT();
+        ParBoxSource sourceBox;
+        ParBoxTarget targetBox;
+        ParticleCreator particleCreator;
+        uint32_t const guardSuperCells;
 
-        /* multi-dim offset from the origin of the local domain on GPU
-         * to the origin of the block of the in unit of cells
+        CreateParticlesKernel(
+            ParBoxSource const & sourceBox,
+            ParBoxTarget const & targetBox,
+            ParticleCreator const & particleCreator,
+            uint32_t const guardSuperCells
+        ) :
+            sourceBox( sourceBox ),
+            targetBox( targetBox ),
+            particleCreator( particleCreator ),
+            guardSuperCells( guardSuperCells )
+        { }
+
+        /** Goes over all frames and calls `ParticleCreator`
+         *
+         * @param blockCell n-dim. block offset (in cells) relative to the origin
+         *                  of the local domain plus guarding cells
          */
-        const pmacc::math::Int<simDim> blockCell = block * SuperCellSize::toRT();
-
-        /* multi-dim vector from origin of the block to a cell in units of cells */
-        const pmacc::math::Int<simDim> threadIndex = cellIndex % SuperCellSize::toRT();
-
-        /* conversion from a multi-dim cell coordinate to a linear coordinate of the cell in its super cell */
-        const int linearThreadIdx = pmacc::math::linearize(
-            pmacc::math::CT::shrinkTo<SuperCellSize, simDim-1>::type::toRT(),
-            threadIndex);
-
-        /* "particle box" : container/iterator where the particles live in
-         * and where one can get the frame in a super cell from
-         */
-        typedef typename ParBoxSource::FramePtr SourceFramePtr;
-        typedef typename ParBoxTarget::FramePtr TargetFramePtr;
-
-        /* for not mixing operations::assign up with the nvidia functor assign */
-        namespace partOp = pmacc::particles::operations;
-
-        PMACC_SMEM( acc, sourceFrame, SourceFramePtr );
-        PMACC_SMEM( acc, targetFrame, TargetFramePtr );
-        const lcellId_t maxParticlesInFrame = pmacc::math::CT::volume<SuperCellSize>::type::value;
-
-        /* find last frame in super cell
-         */
-        if (linearThreadIdx == 0)
+        template< typename T_Acc >
+        DINLINE void operator( )(
+            T_Acc const & acc,
+            pmacc::math::Int< simDim > const & blockCell
+        )
         {
-            sourceFrame = sourceBox.getLastFrame(block);
-        }
 
-        __syncthreads();
-        if (!sourceFrame.isValid())
-            return; // end method if we have no frames
+            using namespace mappings::threads;
 
-        const pmacc::math::Int<simDim> localCellIndex = cellIndex - this->guardSuperCells * SuperCellSize::toRT();
+            constexpr uint32_t numWorkers = T_numWorkers;
 
-        /* init particle creator functor     */
-        particleCreator.init(acc, blockCell, linearThreadIdx, localCellIndex);
+            uint32_t const workerIdx = threadIdx.x;
 
-        /* Declare counter in shared memory that will later tell the current fill level or
-         * occupation of the newly created target frames.
-         */
-        PMACC_SMEM( acc, newFrameFillLvl, int );
+            /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+            pmacc::math::Int< simDim > const block = blockCell / SuperCellSize::toRT( );
 
-        /* Declare local variable oldFrameFillLvl for each thread */
-        int oldFrameFillLvl;
+            // relative offset to the origin of the local domain (without any guarding cells)
+            pmacc::math::Int<simDim> const supercellCellOffset = blockCell - this->guardSuperCells * SuperCellSize::toRT( );
 
-        /* Initialize local (register) counter for each thread
-         * - describes how many new macro target particles should be created
-         */
-        unsigned int numNewParticles = 0;
-
-        /* Declare local target particle ID
-         * - describes at which position in the new frame the new target particle is to be created
-         */
-        int targetParId;
-
-        /* Master initializes the frame fill level with 0 */
-        if (linearThreadIdx == 0)
-        {
-            newFrameFillLvl = 0;
-            targetFrame = nullptr;
-        }
-        __syncthreads();
-
-        /* move over source species frames and call particleCreator
-         * frames are worked on in backwards order to avoid asking if there is another frame
-         * --> performance
-         * Because all frames are completely filled except the last and apart from that last frame
-         * one wants to make sure that all threads are working and every frame is worked on.
-         */
-        while (sourceFrame.isValid())
-        {
-            /* casting uint8_t multiMask to boolean */
-            const bool isParticle = sourceFrame[linearThreadIdx][multiMask_];
-
-            if (isParticle)
-                /* ask the particle creator functor how many new particles to create. */
-                numNewParticles = particleCreator.numNewParticles(acc, *sourceFrame, linearThreadIdx);
-
-            __syncthreads();
-            /* always true while-loop over all particles inside source frame until each thread breaks out individually
-             *
-             * **Attention**: Speaking of 1st and 2nd frame only may seem odd.
-             * The question might arise what happens if more target particles are created than would fit into two frames.
-             * Well, multi-particle creation during a time step is accounted for. The number of new target particles is
-             * determined inside the outer loop over the valid frames while in the inner loop each thread can create only ONE
-             * new macro target particle. But the loop repeats until each thread has created all the target particles needed in the time step.
+            /* "particle box" : container/iterator where the particles live in
+             * and where one can get the frame in a super cell from
              */
-            while (true)
+            using SourceFramePtr = typename ParBoxSource::FramePtr;
+            using TargetFramePtr = typename ParBoxTarget::FramePtr;
+
+            /* for not mixing operations::assign up with the nvidia functor assign */
+            namespace partOp = pmacc::particles::operations;
+
+            constexpr lcellId_t maxParticlesInFrame = pmacc::math::CT::volume< SuperCellSize >::type::value;
+
+            PMACC_SMEM(
+                acc,
+                targetFrame,
+                TargetFramePtr
+            );
+
+            // find last frame in super cell
+            SourceFramePtr sourceFrame( sourceBox.getLastFrame( block ) );
+
+            // end method if we have no frames
+            if( !sourceFrame.isValid( ) )
+                return;
+
+            using ParticleDomCfg = IdxConfig<
+                maxParticlesInFrame,
+                numWorkers
+            >;
+
+            ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
+
+            // initialize the collective part of the functor (e.g. field caching)
+            particleCreator.collectiveInit(
+                acc,
+                blockCell,
+                WorkerCfg< numWorkers >{ workerIdx }
+            );
+
+            memory::CtxArray<
+                ParticleCreator,
+                ParticleDomCfg
+            >
+            particleCreatorCtx{ };
+
+            forEachParticle(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const idx
+                )
+                {
+                    // cell index within the superCell
+                    DataSpace< simDim > const cellIdx = DataSpaceOperations< simDim >::template map< SuperCellSize >( linearIdx );
+
+                    // cell offset with respect to the local domain origin (without any guarding cells
+                    pmacc::math::Int<simDim> const localCellIndex = supercellCellOffset + cellIdx;
+
+                    // create a copy of the functor for each virtual worker
+                    particleCreatorCtx[ idx ] = particleCreator;
+
+                    // init particle creator functor for each virtual worker
+                    particleCreatorCtx[ idx ].init(
+                        acc,
+                        blockCell,
+                        linearIdx,
+                        localCellIndex
+                    );
+                }
+            );
+
+            /* Declare counter in shared memory that will later tell the current fill level or
+             * occupation of the newly created target frames.
+             */
+            PMACC_SMEM(
+                acc,
+                newFrameFillLvl,
+                int
+            );
+
+            ForEachIdx<
+                IdxConfig<
+                    1,
+                    numWorkers
+                >
+            > onlyMaster{ workerIdx };
+
+            // Declare local variable oldFrameFillLvl for each thread
+            int oldFrameFillLvl;
+
+            /* Initialize local (register) counter for each thread
+             * - describes how many new macro target particles should be created
+             */
+            memory::CtxArray<
+                uint32_t,
+                ParticleDomCfg
+            >
+            numNewParticlesCtx( 0 );
+
+            // Master initializes the frame fill level with 0
+            onlyMaster(
+                [&](
+                    uint32_t const,
+                    uint32_t const
+                )
+                {
+                    newFrameFillLvl = 0;
+                    targetFrame = nullptr;
+                }
+            );
+
+            __syncthreads( );
+
+            /* move over source species frames and call particleCreator
+             * frames are worked on in backwards order to avoid asking if there is another frame
+             * --> performance
+             * Because all frames are completely filled except the last and apart from that last frame
+             * one wants to make sure that all threads are working and every frame is worked on.
+             */
+            while( sourceFrame.isValid( ) )
             {
-                /* < INIT >
-                 * - targetParId is initialized as -1 (meaning: invalid)
-                 * - (local) oldFrameFillLvl set equal to (shared) newFrameFillLvl for each thread
-                 * --> each thread remembers the old "counter"
-                 * - then sync
-                 */
-                targetParId = -1;
-                oldFrameFillLvl = newFrameFillLvl;
-                __syncthreads();
-                /* < CHECK & ADD >
-                 * - if a thread wants to create target particles in each cycle it can do that only once
-                 * and before that it atomically adds to the shared counter and uses the current
-                 * value as targetParId in the new frame
-                 * - then sync
-                 */
-                if (numNewParticles > 0)
-                    targetParId = nvidia::atomicAllInc(acc, &newFrameFillLvl, ::alpaka::hierarchy::Threads{});
 
-                __syncthreads();
-                /* < EXIT? >
-                 * - if the counter hasn't changed all threads break out of the loop */
-                if (oldFrameFillLvl == newFrameFillLvl)
-                    break;
-
-                __syncthreads();
-                /* < FIRST NEW FRAME >
-                 * - if there is no frame, yet, the master will create a new target particle frame
-                 * and attach it to the back of the frame list
-                 * - sync all threads again for them to know which frame to use
-                 */
-                if (linearThreadIdx == 0)
-                {
-                    if (!targetFrame.isValid())
+                memory::CtxArray<
+                    bool,
+                    ParticleDomCfg
+                >
+                isParticleCtx(
+                    workerIdx,
+                    [&](
+                        uint32_t const linearIdx,
+                        uint32_t const
+                    )
                     {
-                        targetFrame = targetBox.getEmptyFrame();
-                        targetBox.setAsLastFrame(acc, targetFrame, block);
+                        return static_cast< bool >( sourceFrame[ linearIdx ][ multiMask_ ] );
                     }
-                }
-                __syncthreads();
-                /* < CREATE 1 >
-                 * - all target particles fitting into the current frame are created there
-                 * - internal particle creation counter is decremented by 1
-                 * - sync
-                 */
-                if ((0 <= targetParId) && (targetParId < maxParticlesInFrame))
-                {
-                    /* each thread makes the attributes of its source particle accessible */
-                    auto sourceParticle = (sourceFrame[linearThreadIdx]);
-                    /* each thread initializes an target particle if one should be created */
-                    auto targetParticle = (targetFrame[targetParId]);
-
-                    /* create an target particle in the new target particle frame: */
-                    particleCreator(acc, sourceParticle, targetParticle);
-
-                    numNewParticles -= 1;
-                }
-                __syncthreads();
-                /* < SECOND NEW FRAME >
-                 * - if the shared counter is larger than the frame size a new target particle frame is reserved
-                 * and attached to the back of the frame list
-                 * - then the shared counter is set back by one frame size
-                 * - sync so that every thread knows about the new frame
-                 */
-                if (linearThreadIdx == 0)
-                {
-                    if (newFrameFillLvl >= maxParticlesInFrame)
+                );
+                forEachParticle(
+                    [&](
+                        uint32_t const linearIdx,
+                        uint32_t const idx
+                    )
                     {
-                        targetFrame = targetBox.getEmptyFrame();
-                        targetBox.setAsLastFrame(acc, targetFrame, block);
-                        newFrameFillLvl -= maxParticlesInFrame;
+                        bool const isParticle = static_cast< bool >( sourceFrame[ linearIdx ][ multiMask_ ] );
+                        numNewParticlesCtx[ idx ] = 0u;
+                        if( isParticle )
+                            /* ask the particle creator functor how many new particles to create. */
+                            numNewParticlesCtx[ idx ] = particleCreatorCtx[ idx ].numNewParticles(
+                                acc,
+                                *sourceFrame,
+                                linearIdx
+                            );
                     }
-                }
-                __syncthreads();
-                /* < CREATE 2 >
-                 * - the thread writes an target particle to the new frame
-                 * - the internal counter is decremented by 1
+                );
+
+                __syncthreads( );
+
+                /* always true while-loop over all particles inside source frame until each thread breaks out individually
+                 *
+                 * **Attention**: Speaking of 1st and 2nd frame only may seem odd.
+                 * The question might arise what happens if more target particles are created than would fit into two frames.
+                 * Well, multi-particle creation during a time step is accounted for. The number of new target particles is
+                 * determined inside the outer loop over the valid frames while in the inner loop each thread can create only ONE
+                 * new macro target particle. But the loop repeats until each thread has created all the target particles needed in the time step.
                  */
-                if (targetParId >= maxParticlesInFrame)
+                while( true )
                 {
-                    targetParId -= maxParticlesInFrame;
+                    /* < INIT >
+                     * - targetParId is initialized as -1 (meaning: invalid)
+                     * - (local) oldFrameFillLvl set equal to (shared) newFrameFillLvl for each thread
+                     * --> each thread remembers the old "counter"
+                     */
 
-                    /* each thread makes the attributes of its source particle accessible */
-                    auto sourceParticle = (sourceFrame[linearThreadIdx]);
-                    /* each thread initializes an target particle if one should be created */
-                    auto targetParticle = (targetFrame[targetParId]);
+                    /* Declare local target particle ID
+                     * - describes at which position in the new frame the new target particle is to be created
+                     */
+                    memory::CtxArray<
+                        int,
+                        ParticleDomCfg
+                    >
+                    targetParIdCtx( -1 );
 
-                    /* create an target particle in the new target particle frame: */
-                    particleCreator(acc, sourceParticle, targetParticle);
+                    oldFrameFillLvl = newFrameFillLvl;
 
-                    numNewParticles -= 1;
+                    __syncthreads( );
+
+                    /* < CHECK & ADD >
+                     * - if a thread wants to create target particles in each cycle it can do that only once
+                     * and before that it atomically adds to the shared counter and uses the current
+                     * value as targetParId in the new frame
+                     */
+                    forEachParticle(
+                        [&](
+                            uint32_t const linearIdx,
+                            uint32_t const idx
+                        )
+                        {
+                            if( numNewParticlesCtx[ idx ] > 0u )
+                                targetParIdCtx[ idx ] = nvidia::atomicAllInc(
+                                    acc,
+                                    &newFrameFillLvl,
+                                    ::alpaka::hierarchy::Threads{}
+                                );
+                        }
+                    );
+
+                    __syncthreads( );
+
+                    /* < EXIT? >
+                     * - if the counter hasn't changed all threads break out of the loop
+                     */
+                    if( oldFrameFillLvl == newFrameFillLvl )
+                        break;
+
+                    __syncthreads( );
+
+                    /* < FIRST NEW FRAME >
+                     * - if there is no frame, yet, the master will create a new target particle frame
+                     * and attach it to the back of the frame list
+                     */
+                    onlyMaster(
+                        [&](
+                            uint32_t const,
+                            uint32_t const
+                        )
+                        {
+                            if( !targetFrame.isValid( ) )
+                            {
+                                targetFrame = targetBox.getEmptyFrame( );
+                                targetBox.setAsLastFrame(
+                                    acc,
+                                    targetFrame,
+                                    block
+                                );
+                            }
+                        }
+                    );
+
+                    __syncthreads( );
+
+                    /* < CREATE 1 >
+                     * - all target particles fitting into the current frame are created there
+                     * - internal particle creation counter is decremented by 1
+                     */
+                    forEachParticle(
+                        [&](
+                            uint32_t const linearIdx,
+                            uint32_t const idx
+                        )
+                        {
+                            if( 0 <= targetParIdCtx[ idx ] &&  targetParIdCtx[ idx ] < maxParticlesInFrame )
+                            {
+                                // each thread makes the attributes of its source particle accessible
+                                auto sourceParticle = sourceFrame[ linearIdx ];
+                                // each thread initializes an target particle if one should be created
+                                auto targetParticle = targetFrame[ targetParIdCtx[ idx ] ];
+
+                                // create an target particle in the new target particle frame:
+                                particleCreatorCtx[ idx ](
+                                    acc,
+                                    sourceParticle,
+                                    targetParticle
+                                );
+
+                                    numNewParticlesCtx[ idx ] -= 1;
+                                }
+                        }
+                    );
+
+                    __syncthreads( );
+                    /* < SECOND NEW FRAME >
+                     * - if the shared counter is larger than the frame size a new target particle frame is reserved
+                     * and attached to the back of the frame list
+                     * - then the shared counter is set back by one frame size
+                     * - sync so that every thread knows about the new frame
+                     */
+                    onlyMaster(
+                        [&](
+                            uint32_t const,
+                            uint32_t const
+                        )
+                        {
+                            if( newFrameFillLvl >= maxParticlesInFrame )
+                            {
+                                targetFrame = targetBox.getEmptyFrame( );
+                                targetBox.setAsLastFrame(
+                                    acc,
+                                    targetFrame,
+                                    block
+                                );
+                                newFrameFillLvl -= maxParticlesInFrame;
+                            }
+                        }
+                    );
+
+                    __syncthreads( );
+
+                    /* < CREATE 2 >
+                     * - the thread writes an target particle to the new frame
+                     * - the internal counter is decremented by 1
+                     */
+                    forEachParticle(
+                        [&](
+                            uint32_t const linearIdx,
+                            uint32_t const idx
+                        )
+                        {
+                            if( targetParIdCtx[ idx ] >= maxParticlesInFrame )
+                            {
+                                targetParIdCtx[ idx ] -= maxParticlesInFrame;
+
+                                // each thread makes the attributes of its source particle accessible
+                                auto sourceParticle = sourceFrame[ linearIdx ];
+                                // each thread initializes an target particle if one should be created
+                                auto targetParticle = targetFrame[ targetParIdCtx[ idx ] ];
+
+                                // create an target particle in the new target particle frame:
+                                particleCreatorCtx[ idx ](
+                                    acc,
+                                    sourceParticle,
+                                    targetParticle
+                                );
+
+                                numNewParticlesCtx[ idx ] -= 1;
+                            }
+                        }
+                    );
+                    __syncthreads( );
                 }
-                __syncthreads();
-            }
-            __syncthreads();
 
-            if (linearThreadIdx == 0)
-            {
-                sourceFrame = sourceBox.getPreviousFrame(sourceFrame);
+                __syncthreads( );
+
+                sourceFrame = sourceBox.getPreviousFrame( sourceFrame );
+
             }
-            __syncthreads();
         }
-    }
-};
+    };
 
-/** Convenient function to create a `CreateParticlesKernel` instance
- *
- * @param parBoxSource particle box of the source species
- * @param parBoxTarget particle box of the target species
- * @param particleCreator particle creation functor
- * @param guardSuperCells number of guard cells
- * @return new `CreateParticlesKernel` instance
- */
-template<class T_ParBoxSource, class T_ParBoxTarget, class T_ParticleCreator>
-CreateParticlesKernel<T_ParBoxSource, T_ParBoxTarget, T_ParticleCreator>
-make_CreateParticlesKernel(
-    T_ParBoxSource parBoxSource,
-    T_ParBoxTarget parBoxTarget,
-    T_ParticleCreator particleCreator,
-    const uint32_t guardSuperCells)
-{
-    return CreateParticlesKernel<T_ParBoxSource, T_ParBoxTarget, T_ParticleCreator>(
-        parBoxSource, parBoxTarget, particleCreator, guardSuperCells);
-}
+    /** Convenient function to create a `CreateParticlesKernel` instance
+     *
+     * @tparam T_numWorkers number of workers
+     *
+     * @param parBoxSource particle box of the source species
+     * @param parBoxTarget particle box of the target species
+     * @param particleCreator particle creation functor
+     * @param guardSuperCells number of guard cells
+     * @return new `CreateParticlesKernel` instance
+     */
+    template<
+        uint32_t T_numWorkers,
+        typename T_ParBoxSource,
+        typename T_ParBoxTarget,
+        typename T_ParticleCreator
+    >
+    CreateParticlesKernel<
+        T_numWorkers,
+        T_ParBoxSource,
+        T_ParBoxTarget,
+        T_ParticleCreator
+    >
+    make_CreateParticlesKernel(
+        T_ParBoxSource const & parBoxSource,
+        T_ParBoxTarget const & parBoxTarget,
+        T_ParticleCreator const & particleCreator,
+        uint32_t const guardSuperCells)
+    {
+        return CreateParticlesKernel<
+            T_numWorkers,
+            T_ParBoxSource,
+            T_ParBoxTarget,
+            T_ParticleCreator
+        >(
+            parBoxSource,
+            parBoxTarget,
+            particleCreator,
+            guardSuperCells
+        );
+    }
 
 } // namespace creation
 } // namespace particles

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -36,6 +36,7 @@
 #include <pmacc/compileTime/conversion/TypeToPointerPair.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/mappings/threads/WorkerCfg.hpp>
 
 #include <boost/type_traits/integral_constant.hpp>
 
@@ -130,24 +131,27 @@ namespace ionization
 
             }
 
-            /** Initialization function on device
+            /** cache fields used by this functor
              *
-             * \brief Cache EM-fields on device
-             *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+             * @warning this is a collective method and calls synchronize
              *
-             * This function will be called inline on the device which must happen BEFORE threads diverge
-             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
-             * initializing the E-/B-field shared boxes in shared memory.
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+             *
+             * @param acc alpaka accelerator
+             * @param blockCell relative offset (in cells) to the local domain plus the guarding cells
+             * @param workerCfg configuration of the worker
              */
-            template< typename T_Acc >
-            DINLINE void init(
-                T_Acc const & acc,
+            template<
+                typename T_Acc ,
+                typename T_WorkerCfg
+            >
+            DINLINE void collectiveInit(
+                const T_Acc & acc,
                 const DataSpace<simDim>& blockCell,
-                const int& linearThreadIdx,
-                const DataSpace<simDim>& localCellOffset
+                const T_WorkerCfg & workerCfg
             )
             {
-
                 /* caching of E and B fields */
                 cachedB = CachedBox::create<
                     0,
@@ -170,8 +174,8 @@ namespace ionization
                 auto fieldBBlock = bBox.shift(blockCell);
                 ThreadCollective<
                     BlockArea,
-                    pmacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
-                > collective( linearThreadIdx );
+                    T_WorkerCfg::numWorkers
+                > collective( workerCfg.getWorkerIdx( ) );
                 collective(
                           acc,
                           assign,
@@ -189,7 +193,25 @@ namespace ionization
 
                 /* wait for shared memory to be initialized */
                 __syncthreads();
+            }
 
+            /** Initialization function on device
+             *
+             * \brief Cache EM-fields on device
+             *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+             *
+             * This function will be called inline on the device which must happen BEFORE threads diverge
+             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+             * initializing the E-/B-field shared boxes in shared memory.
+             */
+            template< typename T_Acc >
+            DINLINE void init(
+                T_Acc const & acc,
+                const DataSpace<simDim>& blockCell,
+                const int& linearThreadIdx,
+                const DataSpace<simDim>& localCellOffset
+            )
+            {
                 /* initialize random number generator with the local cell index in the simulation */
                 this->randomGen.init(localCellOffset);
             }

--- a/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -78,7 +78,7 @@ namespace ionization
             if( chargeState < protonNumber )
             {
                 uint32_t const cs = math::float2int_rd(chargeState);
-                float_X const iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
+                float_X const iEnergy = typename GetIonizationEnergies<ParticleType>::type{ }[cs];
 
                 float_X const pi = precisionCast< float_X >( M_PI );
                 /* electric field in atomic units - only absolute value */

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -71,7 +71,7 @@ namespace ionization
             {
                 uint32_t const cs = math::float2int_rd(chargeState);
                 /* ionization potential in atomic units */
-                float_X const iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
+                float_X const iEnergy = typename GetIonizationEnergies<ParticleType>::type{ }[cs];
                 /* the charge that attracts the electron that is to be ionized:
                  * equals `protonNumber - no. allInnerElectrons`
                  */

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
@@ -72,8 +72,8 @@ namespace ionization
             {
                 uint32_t cs = math::float2int_rd(chargeState);
                 /* ionization potential in atomic units */
-                const float_X iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
-                const float_X ZEff = GetEffectiveNuclearCharge<ParticleType>::type()[cs];
+                const float_X iEnergy = typename GetIonizationEnergies<ParticleType>::type{ }[cs];
+                const float_X ZEff = typename GetEffectiveNuclearCharge<ParticleType>::type{ }[cs];
                 /* critical field strength in atomic units */
                 float_X critField = iEnergy*iEnergy / (float_X(4.0) * ZEff);
 

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
@@ -71,7 +71,7 @@ namespace ionization
             {
                 uint32_t cs = math::float2int_rd(chargeState);
                 /* ionization potential in atomic units */
-                const float_X iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
+                const float_X iEnergy = typename GetIonizationEnergies<ParticleType>::type{ }[cs];
                 /* critical field strength in atomic units */
                 float_X critField = (math::sqrt(float_X(2.))-float_X(1.)) * math::pow(iEnergy,float_X(3./2.));
 

--- a/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -70,7 +70,7 @@ namespace ionization
             if ( chargeState < protonNumber )
             {
                 uint32_t const cs = math::float2int_rd(chargeState);
-                const float_X iEnergy = GetIonizationEnergies<ParticleType>::type()[cs];
+                const float_X iEnergy = typename GetIonizationEnergies<ParticleType>::type{ }[cs];
 
                 const float_X pi = precisionCast<float_X>(M_PI);
                 /* electric field in atomic units - only absolute value */

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -37,6 +37,7 @@
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/traits/Resolve.hpp>
+#include <pmacc/mappings/threads/WorkerCfg.hpp>
 
 #include <boost/type_traits/integral_constant.hpp>
 
@@ -131,24 +132,27 @@ namespace ionization
 
             }
 
-            /** Initialization function on device
+            /** cache fields used by this functor
              *
-             * \brief Cache EM-fields on device
-             *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+             * @warning this is a collective method and calls synchronize
              *
-             * This function will be called inline on the device which must happen BEFORE threads diverge
-             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
-             * initializing the E-/B-field shared boxes in shared memory.
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+             *
+             * @param acc alpaka accelerator
+             * @param blockCell relative offset (in cells) to the local domain plus the guarding cells
+             * @param workerCfg configuration of the worker
              */
-            template< typename T_Acc >
-            DINLINE void init(
-                T_Acc const & acc,
+            template<
+                typename T_Acc ,
+                typename T_WorkerCfg
+            >
+            DINLINE void collectiveInit(
+                const T_Acc & acc,
                 const DataSpace<simDim>& blockCell,
-                const int& linearThreadIdx,
-                const DataSpace<simDim>& localCellOffset
+                const T_WorkerCfg & workerCfg
             )
             {
-
                 /* caching of E and B fields */
                 cachedB = CachedBox::create<
                     0,
@@ -171,8 +175,8 @@ namespace ionization
                 auto fieldBBlock = bBox.shift(blockCell);
                 ThreadCollective<
                     BlockArea,
-                    pmacc::math::CT::volume< typename BlockArea::SuperCellSize >::type::value
-                > collective( linearThreadIdx );
+                    T_WorkerCfg::numWorkers
+                > collective( workerCfg.getWorkerIdx( ) );
                 collective(
                           acc,
                           assign,
@@ -190,7 +194,25 @@ namespace ionization
 
                 /* wait for shared memory to be initialized */
                 __syncthreads();
+            }
 
+            /** Initialization function on device
+             *
+             * \brief Cache EM-fields on device
+             *         and initialize possible prerequisites for ionization, like e.g. random number generator.
+             *
+             * This function will be called inline on the device which must happen BEFORE threads diverge
+             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+             * initializing the E-/B-field shared boxes in shared memory.
+             */
+            template< typename T_Acc >
+            DINLINE void init(
+                T_Acc const & acc,
+                const DataSpace<simDim>& blockCell,
+                const int& linearThreadIdx,
+                const DataSpace<simDim>& localCellOffset
+            )
+            {
                 /* initialize random number generator with the local cell index in the simulation */
                 this->randomGen.init(localCellOffset);
             }

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -534,7 +534,7 @@ public:
         copyMomentumPrev1( currentStep );
 
         DataConnector &dc = Environment<>::get().DataConnector();
-#if( PMACC_CUDA_ENABLED == 1 )
+
         /* Initialize ionization routine for each species with the flag `ionizers<>` */
         using VectorSpeciesWithIonizers = typename pmacc::particles::traits::FilterByFlag<
             VectorAllSpecies,
@@ -542,7 +542,7 @@ public:
         >::type;
         ForEach< VectorSpeciesWithIonizers, particles::CallIonization< bmpl::_1 > > particleIonization;
         particleIonization( cellDescription, currentStep );
-#endif
+
         /* FLYlite population kinetics for atomic physics */
         using AllFlyLiteIons = typename pmacc::particles::traits::FilterByFlag<
             VectorAllSpecies,

--- a/include/picongpu/simulation_defines/_defaultUnitless.loader
+++ b/include/picongpu/simulation_defines/_defaultUnitless.loader
@@ -33,9 +33,7 @@
 #include "picongpu/simulation_defines/unitless/particle.unitless"
 #include "picongpu/simulation_defines/unitless/fieldSolver.unitless"
 #include "picongpu/simulation_defines/unitless/pusher.unitless"
-#if( PMACC_CUDA_ENABLED == 1 )
-#   include "picongpu/simulation_defines/unitless/ionizer.unitless"
-#endif
+#include "picongpu/simulation_defines/unitless/ionizer.unitless"
 #include "picongpu/simulation_defines/unitless/speciesAttributes.unitless"
 #include "picongpu/simulation_defines/unitless/speciesDefinition.unitless"
 #include "picongpu/simulation_defines/unitless/speciesInitialization.unitless"

--- a/include/picongpu/simulation_defines/param/speciesDefinition.param
+++ b/include/picongpu/simulation_defines/param/speciesDefinition.param
@@ -41,11 +41,6 @@
 #include "picongpu/particles/Particles.hpp"
 #include <boost/mpl/string.hpp>
 
-#if( PMACC_CUDA_ENABLED == 1 )
-#   include "picongpu/particles/ionization/byField/ionizers.def"
-#   include "picongpu/particles/ionization/byCollision/ionizers.def"
-#endif
-
 namespace picongpu
 {
 

--- a/include/picongpu/simulation_defines/unitless/speciesDefinition.unitless
+++ b/include/picongpu/simulation_defines/unitless/speciesDefinition.unitless
@@ -27,10 +27,8 @@
 #include "picongpu/traits/attribute/GetMass.hpp"
 #include "picongpu/fields/currentDeposition/Solver.hpp"
 #include "picongpu/particles/Particles.tpp"
-#if( PMACC_CUDA_ENABLED == 1 )
-#   include "picongpu/particles/ionization/byField/ionizers.hpp"
-#   include "picongpu/particles/ionization/byCollision/ionizers.hpp"
-#endif
+#include "picongpu/particles/ionization/byField/ionizers.hpp"
+#include "picongpu/particles/ionization/byCollision/ionizers.hpp"
 
 
 namespace picongpu


### PR DESCRIPTION
- remove define which disabled the ionization code on CPU
- rewrite kernel with the lockstep programming model
- add documentation
- use new functor interface with `collectiveInit`
- use a source frame for each worker (instead of all worker in the block)
- extend interface of all functors used together with `CreateParticlesKernel` (add method `collectiveInit()`)

# Review

Please check the changes commit wise!

# Tests

- [x] LWFA test case 10 (CPU/GPU vs GPU 0.3.X)
- [x] rebase against #2233