### PR TITLE
ADIOS: allow usage with accelerator `omp2b`

### DIFF
--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -38,6 +38,10 @@
  */
 #include "picongpu/plugins/PngPlugin.hpp"
 
+#if (ENABLE_ADIOS == 1)
+#   include "picongpu/plugins/adios/ADIOSWriter.hpp"
+#endif
+
 #if( PMACC_CUDA_ENABLED == 1 )
 #   include "picongpu/plugins/PositionsParticles.hpp"
 #   include "picongpu/plugins/ChargeConservation.hpp"
@@ -58,10 +62,6 @@
 #   include "picongpu/plugins/SliceFieldPrinterMulti.hpp"
 #   if(SIMDIM==DIM3)
 #       include "picongpu/plugins/IntensityPlugin.hpp"
-#   endif
-
-#   if (ENABLE_ADIOS == 1)
-#       include "picongpu/plugins/adios/ADIOSWriter.hpp"
 #   endif
 
 #   if (ENABLE_ISAAC == 1) && (SIMDIM==DIM3)
@@ -122,7 +122,11 @@ private:
 
     /* define stand alone plugins*/
     typedef bmpl::vector<
-        EnergyFields
+        EnergyFields,
+#if (ENABLE_ADIOS == 1)
+        adios::ADIOSWriter
+#endif
+
 #if( PMACC_CUDA_ENABLED == 1 )
         , SumCurrents
         , ChargeConservation
@@ -131,9 +135,6 @@ private:
 #   endif
 #   if (ENABLE_INSITU_VOLVIS == 1)
         , InSituVolumeRenderer
-#   endif
-#   if (ENABLE_ADIOS == 1)
-        , adios::ADIOSWriter
 #   endif
 #   if (ENABLE_ISAAC == 1) && (SIMDIM==DIM3)
         , isaacP::IsaacPlugin

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -41,7 +41,9 @@
 #include <pmacc/pluginSystem/PluginConnector.hpp>
 #include "picongpu/simulationControl/MovingWindow.hpp"
 #include <pmacc/math/Vector.hpp>
-#include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
+#if( PMACC_CUDA_ENABLED == 1 )
+#   include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
+#endif
 #include <pmacc/traits/Limits.hpp>
 
 #include "picongpu/plugins/ILightweightPlugin.hpp"
@@ -815,9 +817,10 @@ private:
         {
             DataConnector &dc = Environment<>::get().DataConnector();
 
+#if( PMACC_CUDA_ENABLED == 1 )
             /* synchronizes the MallocMCBuffer to the host side */
             dc.get< MallocMCBuffer< DeviceHeap > >( MallocMCBuffer< DeviceHeap >::getName() );
-
+#endif
             /* here we are copying all species to the host side since we
              * can not say at this point if this time step will need all of them
              * for sure (checkpoint) or just some user-defined species (dump)
@@ -825,7 +828,9 @@ private:
             ForEach<FileCheckpointParticles, CopySpeciesToHost<bmpl::_1> > copySpeciesToHost;
             copySpeciesToHost();
             lastSpeciesSyncStep = currentStep;
+#if( PMACC_CUDA_ENABLED == 1 )
             dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
+#endif
         }
 
         beginAdios(mThreadParams.adiosFilename);


### PR DESCRIPTION
- disable usage of `MallocMCBuffer` if accelerator `omp2b` is used
- with `omp2b`: access the device memory directly without copying particles before to host

# Tests

- [x] LWFA (check adios derived fields)