### PR TITLE
fix comma in `PluginController`

### DIFF
--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -118,9 +118,9 @@ private:
 
     /* define stand alone plugins*/
     typedef bmpl::vector<
-        EnergyFields,
+        EnergyFields
 #if (ENABLE_ADIOS == 1)
-        adios::ADIOSWriter
+        , adios::ADIOSWriter
 #endif
 
 #if( PMACC_CUDA_ENABLED == 1 )


### PR DESCRIPTION
- move comma into the pre compiler guards

Bug was introduced with #2236 and is triggered if adios is not available.