### PR TITLE
Hypnos & Taurus: Profile Examples Per Queue

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -21,9 +21,24 @@ We listed some example ``picongpu.profile`` files below which can be used to set
 Hypnos (HZDR)
 -------------
 
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` manually.
+For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` manually.
 
-.. literalinclude:: profiles/hypnos-hzdr/picongpu.profile.example
+Queue: laser (AMD Opteron 6276 CPUs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/hypnos-hzdr/laser_picongpu.profile.example
+   :language: bash
+
+Queue: k20 (Nvidia K20 GPUs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/hypnos-hzdr/k20_picongpu.profile.example
+   :language: bash
+
+Queue: k80 (Nvidia K80 GPUs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/hypnos-hzdr/k80_picongpu.profile.example
    :language: bash
 
 Titan (ORNL)
@@ -45,10 +60,24 @@ For this profile to work, you need to download the :ref:`PIConGPU source code <i
 Taurus (TU Dresden)
 -------------------
 
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter and libSplash <install-dependencies>` manually.
+For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter and libSplash <install-dependencies>` manually.
 
-.. literalinclude:: profiles/taurus-tud/picongpu.profile.example
+Queue: gpu1 (Nvidia K20x GPUs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/taurus-tud/k20x_picongpu.profile.example
    :language: bash
+
+Queue: gpu2 (Nvidia K80 GPUs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/taurus-tud/k80_picongpu.profile.example
+   :language: bash
+
+Queue: knl (Intel  Intel Xeon Phi - Knights Landing)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(example missing)
 
 Lawrencium (LBNL)
 -----------------

--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -11,8 +11,8 @@ then
         module load gcc/4.9.2
         module load cmake/3.7.2
         module load boost/1.62.0
-        module load openmpi/1.8.6
-        module load numactl
+        module load cuda/8.0
+        module load openmpi/1.8.6.kepler.cuda80
 
         # Plugins (optional)
         module load pngwriter/0.6.0
@@ -30,10 +30,11 @@ fi
 
 # Environment #################################################################
 #
-alias getNode='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=64'
+alias getNode='qsub -I -q k20 -lwalltime=00:30:00 -lnodes=1:ppn=8'
+alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
-export PICSRC=/home/`whoami`/src/picongpu
-export PIC_BACKEND="omp2b:bdver1"
+export PICSRC=/home/$(whoami)/src/picongpu
+export PIC_BACKEND="cuda:35"
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
@@ -49,6 +50,6 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
 # "tbg" default options #######################################################
 #   - PBS/Torque (qsub)
-#   - "laser" queue
+#   - "k20" queue
 export TBG_SUBMIT="qsub"
-export TBG_TPLFILE="etc/picongpu/hypnos-hzdr/laser.tpl"
+export TBG_TPLFILE="etc/picongpu/hypnos-hzdr/k20.tpl"

--- a/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
@@ -30,11 +30,11 @@ fi
 
 # Environment #################################################################
 #
-alias getk20='qsub -I -q k20 -lwalltime=00:30:00 -lnodes=1:ppn=8'
+alias getNode='qsub -I -q k80 -lwalltime=00:30:00 -lnodes=1:ppn=16'
 alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
 export PICSRC=/home/$(whoami)/src/picongpu
-export PIC_BACKEND="cuda:35"
+export PIC_BACKEND="cuda:37"
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
@@ -48,16 +48,8 @@ export PATH=$PATH:$PICSRC/src/tools/bin
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
-# Development #################################################################
-#
-#function make
-#{
-#  real_make=$(which make)
-#  $real_make $* 2>&1 | $HOME/grcat/usr/bin/grcat conf.gcc
-#}
-
 # "tbg" default options #######################################################
 #   - PBS/Torque (qsub)
-#   - "k20" queue
+#   - "k80" queue
 export TBG_SUBMIT="qsub"
-export TBG_TPLFILE="etc/picongpu/hypnos-hzdr/k20.tpl"
+export TBG_TPLFILE="etc/picongpu/hypnos-hzdr/k80.tpl"

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -35,7 +35,7 @@ alias allocK20='salloc --time=0:30:00 --nodes=1 --ntasks-per-node=1 --cpus-per-t
 alias allocFermi='salloc --time=0:30:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task=6 --partition mako_manycore'
 
 export PICSRC=$HOME/src/picongpu
-export PIC_BACKEND="cuda:35"
+export PIC_BACKEND="cuda:20"
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # fix pic-create: re-enable rsync

--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -55,6 +55,6 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)
-#   - "gpu" queue
+#   - "gpu1" queue
 export TBG_SUBMIT="sbatch"
-export TBG_TPLFILE="etc/picongpu/taurus-tud/k80.tpl"
+export TBG_TPLFILE="etc/picongpu/taurus-tud/k20x.tpl"

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -1,0 +1,60 @@
+module purge
+
+# General modules #############################################################
+#
+module load oscar-modules
+module load cmake/3.9.0
+module load git
+module load cuda/8.0.44 # gcc <= 5, intel 15-16
+module load bullxmpi
+module load gnuplot/4.6.1
+
+# Compilers ###################################################################
+### GCC
+module load gcc/5.3.0
+module load boost/1.64.0-gnu5.3
+### ICC
+#module load intel/2015.3.187 boost/1.59.0-intel2015.3.187
+### PGI
+#export BOOST_ROOT=$HOME/lib/boost_1_57_pgi_14_9
+#export BOOST_INC=$BOOST_ROOT/include
+#export BOOST_LIB=$BOOST_ROOT/lib
+# must be set in $(which <pgiDir>/bin/localrc):
+#   set NOSWITCHERROR=YES;
+#module load pgi/14.9 boost/<noneBuildYet>
+
+# Other Software ##############################################################
+#
+module load hdf5/1.8.18-gcc-5.3.0-xmpi
+module load zlib/1.2.8
+
+# Environment #################################################################
+#
+#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_LIB
+
+export PNGWRITER_ROOT=$HOME/lib/pngwriter
+export SPLASH_ROOT=$HOME/lib/splash
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/pngwriter/lib/
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
+
+export PICSRC=$HOME/src/picongpu
+export PIC_BACKEND="cuda:37"
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "gpu2" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/taurus-tud/k80.tpl"


### PR DESCRIPTION
Add a profile example per queue for Hypnos (HZDR) and Taurus (TU Dresden).

Allows to optimize the compile for the exact right architecture by default and cleans up confusion, e.g. for upcoming KNL profiles, and requires less user interaction.