### PR TITLE
Inefficient CMake Compile

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -378,7 +378,6 @@ include_directories(BEFORE ${PIC_EXTENSION_PATH}/include)
 list(APPEND ACCSRCFILES
     "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/versionFormat.cpp"
-    #"${CMAKE_CURRENT_SOURCE_DIR}/plugins/common/particlePatches.cpp"
 )
 
 # host-only sources

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -374,7 +374,16 @@ include_directories(BEFORE ${PIC_EXTENSION_PATH}/include)
 # Compile & Link PIConGPU
 ################################################################################
 
+# files with accelerator code (kernel and API calls)
+list(APPEND ACCSRCFILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/versionFormat.cpp"
+    #"${CMAKE_CURRENT_SOURCE_DIR}/plugins/common/particlePatches.cpp"
+)
+
+# host-only sources
 file(GLOB_RECURSE SRCFILES "*.cpp")
+list(REMOVE_ITEM SRCFILES ${ACCSRCFILES})
 
 add_library(picongpu-hostonly
     STATIC
@@ -382,9 +391,8 @@ add_library(picongpu-hostonly
 )
 target_link_libraries(picongpu-hostonly PUBLIC ${LIBS})
 
-
 cupla_add_executable(picongpu
-    ${SRCFILES}
+     ${ACCSRCFILES}
 )
 
 target_link_libraries(picongpu PUBLIC ${LIBS} picongpu-hostonly)

--- a/include/picongpu/plugins/common/particlePatches.hpp
+++ b/include/picongpu/plugins/common/particlePatches.hpp
@@ -19,11 +19,10 @@
 
 #pragma once
 
-#include <pmacc/types.hpp>
-
 #include <vector>
 #include <list>
 #include <iostream>
+#include <cstdint>
 
 namespace picongpu
 {

--- a/include/picongpu/plugins/hdf5/openPMD/patchReader.cpp
+++ b/include/picongpu/plugins/hdf5/openPMD/patchReader.cpp
@@ -55,7 +55,8 @@ namespace openPMD
         assert( typeid(*colType) == typeid(splash::ColTypeUInt64) );
 
         // free collections
-        __delete( colType );
+        delete( colType );
+        colType = nullptr;
     }
 
     void PatchReader::readPatchAttribute(


### PR DESCRIPTION
The PIConGPU CmakeLists.txt is separating host only and accelerator source files.
In the current implementation the host only and accelarator code is compiled twice (with host and device compiler).
The result of this bug is that compiling takes up to a factor of two longer than needed and all symboles are defined twice which can lead in linker issues.
This bug was introduced with #2178.

Fix: compile `main.cpp` with the device compiler and all other files with the host compiler