### PR TITLE
Docs: Streamline Install

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,7 +40,7 @@ Installation
    :maxdepth: 1
 
    install/path
-   install/compile
+   install/instructions
    install/dependencies
    install/profile
 

--- a/docs/source/install/instructions.rst
+++ b/docs/source/install/instructions.rst
@@ -1,0 +1,19 @@
+.. _install-instructions:
+
+Instructions
+============
+
+.. sectionauthor:: Axel Huebl
+
+As explained in the previous section, select and **follow exactly one** of the following install options.
+
+.. toctree::
+   :maxdepth: 1
+
+   instructions/spack
+   instructions/docker
+   instructions/source
+
+If anything goes wrong, an overview of the full list of PIConGPU dependencies is provided in :ref:`section Dependencies <install-dependencies>`.
+
+After installing, the last step is the setup of a :ref:`profile <install-profile>`.

--- a/docs/source/install/instructions/docker.rst
+++ b/docs/source/install/instructions/docker.rst
@@ -1,0 +1,49 @@
+.. _install-spack:
+
+.. seealso::
+
+   You will need to understand how to use `the terminal <http://www.ks.uiuc.edu/Training/Tutorials/Reference/unixprimer.html>`_.
+
+.. warning::
+
+   Docker images are experimental and not yet fully automated or integrated.
+
+Docker
+------
+
+.. sectionauthor:: Axel Huebl
+
+Preparation
+^^^^^^^^^^^
+
+First `install nvidia-docker <https://github.com/NVIDIA/nvidia-docker>`_ for your distribution.
+
+Install
+^^^^^^^
+
+The download of a pre-configured image with the latest version of PIConGPU is now as easy as:
+
+.. code-block:: bash
+
+   nvidia-docker pull ax3l/picongpu
+
+Use PIConGPU
+^^^^^^^^^^^^
+
+Start a pre-configured LWFA live-simulation with
+
+.. code-block:: bash
+
+   nvidia-docker run -p 2459:2459 -t ax3l/picongpu:0.3.0 /bin/bash -lc start_lwfa
+   # open firefox and isaac client
+
+or just open the container and run your own:
+
+.. code-block:: bash
+
+   nvidia-docker run -it ax3l/picongpu
+
+.. note::
+
+   PIConGPU can also run *without a GPU*!
+   We will provide more image variants in the future.

--- a/docs/source/install/instructions/source.rst
+++ b/docs/source/install/instructions/source.rst
@@ -8,8 +8,8 @@
 
    This section is a short introduction in case you are missing a few software packages, want to try out a cutting edge development version of a software or have no system administrator or software package manager to build and install software for you.
 
-Compiling from Source
-=====================
+From Source
+-----------
 
 .. sectionauthor:: Axel Huebl
 
@@ -24,7 +24,7 @@ Compiling a project from source essentially requires three steps:
 All of the above steps can be performed without administrative rights ("root" or "superuser") as long as the install is not targeted at a system directory (such as ``/usr``) but inside a user-writable directory (such as ``$HOME`` or a project directory).
 
 Preparation
------------
+^^^^^^^^^^^
 
 In order to compile projects from source, we assume you have individual directories created to store *source code*, *build temporary files* and *install* the projects to:
 
@@ -41,7 +41,7 @@ Note that on some supercomputing systems, you might need to install the final so
 Use a different path for the last directory then.
 
 Step-by-Step
-------------
+^^^^^^^^^^^^
 
 Compling can differ in two principle ways: building *inside* the source directory ("in-source") and in a *temporary directory* ("out-of-source").
 Modern projects prefer the latter and use a build system such as [CMake]_.
@@ -76,10 +76,10 @@ The syntax is still very similar:
    make install
 
 That's all!
-Continue with the following chapter to build our dependencies.
+Continue with the following section to build our dependencies.
 
 References
-----------
+^^^^^^^^^^
 
 .. [CMake]
         Kitware Inc.

--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -1,0 +1,65 @@
+.. _install-spack:
+
+.. seealso::
+
+   You will need to understand how to use `the terminal <http://www.ks.uiuc.edu/Training/Tutorials/Reference/unixprimer.html>`_.
+
+Spack
+-----
+
+.. sectionauthor:: Axel Huebl
+
+Preparation
+^^^^^^^^^^^
+
+First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html>`_ itself via:
+
+.. code-block:: bash
+
+   # get spack
+   git clone https://github.com/llnl/spack.git $HOME/src/spack
+   $HOME/src/spack/bin/spack bootstrap
+
+   # activate the spack environment
+   # note: add this to your $HOME/.profile - otherwise you have to
+   #       do this every time you open a new terminal
+   . $HOME/src/spack/share/spack/setup-env.sh
+
+   # install a supported compiler
+   spack install gcc@5.4.0
+   spack load gcc@5.4.0
+   spack compiler add
+
+   # add the PIConGPU repository
+   git clone https://github.com/ComputationalRadiationPhysics/spack-repo.git $HOME/src/spack-repo
+   spack repo add $HOME/src/spack-repo
+
+Install
+^^^^^^^
+
+The installation of the latest version of PIConGPU is now as easy as:
+
+.. code-block:: bash
+
+   spack install picongpu %gcc@5.4.0
+
+Use PIConGPU
+^^^^^^^^^^^^
+
+PIConGPU can now be loaded with
+
+.. code-block:: bash
+
+   spack load picongpu %gcc@5.4.0
+
+For more information on *variants* of the ``picongpu`` package in spack run ``spack info picongpu`` and refer to the `official spack documentation <https://spack.readthedocs.io/>`_.
+
+.. note::
+
+   PIConGPU can also run *without a GPU*!
+   For example for our OpenMP backend, just specify the backend with ``backend=omp2b`` for the two commands above:
+   
+   .. code-block:: bash
+
+      spack install picongpu backend=omp2b %gcc@5.4.0
+      spack load picongpu backend=omp2b %gcc@5.4.0

--- a/docs/source/install/path.rst
+++ b/docs/source/install/path.rst
@@ -1,6 +1,6 @@
 .. _install-path:
 
-Installation
+Introduction
 ============
 
 .. sectionauthor:: Axel Huebl
@@ -11,23 +11,31 @@ The first part is usually the job of a system administrator while the second par
 Depending on your experience, role, computing environment and expectations for optimal hardware utilization, you have several ways to install and select PIConGPU's dependencies.
 Choose your favorite *install and environment management method* below, young padavan, and follow the corresponding sections of the next chapters.
 
+Before you Start
+----------------
+
+.. important::
+
+   For many HPC systems we already prepared and maintain an environment for you which will run out-of-the-box.
+   See if yours is :ref:`in the list <install-profile>` so you can skip the installation completely!
+
 Ways to Install
 ---------------
+
+Spack
+^^^^^
+
+[Spack]_ is a flexible package manager that can build and organize software dependencies for you.
+It can be configured once for your hardware architecture to create optimally tuned binaries and provides modulefile support (e.g. [modules]_, [Lmod]_).
+Those auto-build modules manage your environment variables and allow easy switching between versions, configurations and compilers.
 
 Build from Source
 ^^^^^^^^^^^^^^^^^
 
 You choose a supported C++ compiler and configure, compile and install all missing dependencies from source.
 You are responsible to manage the right versions and configurations.
-Performance can be near-ideal if architecture is choosen correctly (and/or if build directly on your hardware).
+Performance will be ideal if architecture is chosen correctly (and/or if build directly on your hardware).
 You then set environment variables to find those installs.
-
-Spack
-^^^^^
-
-[Spack]_ is a flexible package manager for HPC systems that can organize versions and dependencies for you.
-It can be configured once for your hardware architecture to create optimally tuned binaries and provides modulefile support (e.g. [modules]_, [Lmod]_).
-Those auto-build modules manage your environment variables and allow easy switching between versions, configurations and compilers.
 
 Conda
 ^^^^^
@@ -39,74 +47,10 @@ Useful for small desktop or single-node runs.
 Nvidia-Docker
 ^^^^^^^^^^^^^
 
-Not yet officially supported but we already provide a `dockerfile <https://github.com/ComputationalRadiationPhysics/picongpu/issues/829>`_ to get started.
+Not yet officially supported but we already provide a ``Dockerfile`` to get started.
 Performance might be sub-ideal if the image is not build for the specific local hardware again.
 Useful for small desktop or single-node runs.
-
-Compute Environments
---------------------
-
-HPC Cluster
-^^^^^^^^^^^
-
-SysAdmin
-""""""""
-
-- use [Spack]_ and auto-build modules, ideally via [Lmod]_
-- or build from source, manage binary and version incompatibilities and provide modules
-
-User
-""""
-
-As a user, you ideally start with a configured compiler and MPI version for your HPC system (at least).
-Those and further dependencies can be set up by:
-
-- loading modules (e.g. via [Lmod]_ or [modules]_)
-
-or self-adding them:
-
-- build from source
-- or use [Spack]_
-
-Desktop
-^^^^^^^
-
-Root/Admin
-""""""""""
-
-Use your package manager to install drivers and core dependencies, e.g. via `apt-get install` as far as possible.
-Build further dependencies from source.
-
-Alternately, use [Spack]_ for all dependencies.
-
-User
-""""
-
-If drivers are already installed:
-
-- use [Spack]_
-- or use [nvidia-docker]_ (`dockerfile <https://github.com/ComputationalRadiationPhysics/picongpu/issues/829>`_)
-- or build from source
-
-Cloud
-^^^^^
-
-For single nodes, essentially the same as working via SSH on any other machine.
-We did not investigate deeper into multi-node cloud setups yet.
-
-AWS
-"""
-
-- use [Spack]_
-- or use [nvidia-docker]_ (`dockerfile <https://github.com/ComputationalRadiationPhysics/picongpu/issues/829>`_)
-- or build from source
-
-Google Cloud
-""""""""""""
-
-- use [Spack]_
-- or use [nvidia-docker]_ (`dockerfile <https://github.com/ComputationalRadiationPhysics/picongpu/issues/829>`_)
-- or build from source
+We are also working on `Singularity <http://singularity.lbl.gov/>`_ images.
 
 References
 ----------


### PR DESCRIPTION
Streamlines the install instructions.

Organizes the install instructions to make them more clear.

Also adresses commonly seen user problems:
- only select *one* install path
- remove confusing recommendations for systems
- prefer [spack](https://github.com/LLNL/spack) over self-build in order of appearance