### PR TITLE
check cells needed for stencils

### DIFF
--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -51,6 +51,12 @@ struct FieldToParticleInterpolation
     typedef typename pmacc::math::CT::make_Int<simDim,lowerMargin>::type LowerMargin;
     typedef typename pmacc::math::CT::make_Int<simDim,upperMargin>::type UpperMargin;
 
+    PMACC_CASSERT_MSG(
+        __FieldToParticleInterpolation_supercell_is_to_small_for_stencil,
+        pmacc::math::CT::min< SuperCellSize >::type::value >= lowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value >= upperMargin
+    );
+
     /*(supp + 1) % 2 is 1 for even supports else 0*/
     static constexpr int begin = -supp / 2 + (supp + 1) % 2;
     static constexpr int end = begin+supp-1;

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -44,6 +44,12 @@ struct EmZ
     typedef typename pmacc::math::CT::make_Int<simDim, currentLowerMargin>::type LowerMargin;
     typedef typename pmacc::math::CT::make_Int<simDim, currentUpperMargin>::type UpperMargin;
 
+    PMACC_CASSERT_MSG(
+        __EmZ_supercell_is_to_small_for_stencil,
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+    );
+
 
     static constexpr int begin = -currentLowerMargin + 1;
     static constexpr int end = begin + supp;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -48,6 +48,12 @@ struct Esirkepov<T_ParticleShape, DIM3>
     typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
     typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
 
+    PMACC_CASSERT_MSG(
+        __Esirkepov_supercell_is_to_small_for_stencil,
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+    );
+
     float_X charge;
 
     /* At the moment Esirkepov only support YeeCell were W is defined at origin (0,0,0)

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -55,6 +55,12 @@ struct Esirkepov<T_ParticleShape, DIM2>
     typedef typename pmacc::math::CT::make_Int<DIM2, currentLowerMargin>::type LowerMargin;
     typedef typename pmacc::math::CT::make_Int<DIM2, currentUpperMargin>::type UpperMargin;
 
+    PMACC_CASSERT_MSG(
+        __Esirkepov2D_supercell_is_to_small_for_stencil,
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+    );
+
     static constexpr int begin = -currentLowerMargin + 1;
     static constexpr int end = begin + supp;
 

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -55,6 +55,11 @@ struct EsirkepovNative
     typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
     typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
 
+    PMACC_CASSERT_MSG(
+        __EsirkepovNative_supercell_is_to_small_for_stencil,
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+    );
 
     /* iterate over all grid points */
     static constexpr int begin = -currentLowerMargin;

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -271,6 +271,11 @@ struct GetMargin<picongpu::currentSolver::VillaBune<T_ParticleShape> >
 {
     typedef ::pmacc::math::CT::Int < 1, 1, 1 > LowerMargin;
     typedef ::pmacc::math::CT::Int < 2, 2, 2 > UpperMargin;
+
+    PMACC_CASSERT_MSG(
+        __VillaBune_supercell_is_to_small_for_stencil,
+        pmacc::math::CT::min< SuperCellSize >::type::value >= 2
+    );
 };
 
 } //namespace traits

--- a/include/picongpu/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/include/picongpu/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -155,6 +155,12 @@ struct ZigZag
     typedef typename pmacc::math::CT::make_Int<simDim, currentLowerMargin>::type LowerMargin;
     typedef typename pmacc::math::CT::make_Int<simDim, currentUpperMargin>::type UpperMargin;
 
+    PMACC_CASSERT_MSG(
+        __ZigZag_supercell_is_to_small_for_stencil,
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+    );
+
     /* calculate grid point where we calculate the assigned values
      * grid points are independent of particle position if we use
      * @see ShiftCoordinateSystem

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -244,13 +244,29 @@ struct max
 
 //________________________M I N____________________________
 
-template<typename Lhs, typename Rhs>
+template<typename Lhs, typename Rhs = void>
 struct min
 {
     typedef typename applyOperator<
     typename Lhs::vector_type,
     typename Rhs::vector_type,
     mpl::min<mpl::_1, mpl::_2> >::type type;
+};
+
+template<typename T_Vec>
+struct min<
+    T_Vec,
+    void
+>
+{
+    typedef typename mpl::accumulate<
+        typename T_Vec::mplVector,
+        typename T_Vec::x,
+        mpl::min<
+            mpl::_1,
+            mpl::_2
+        >
+    >::type type;
 };
 
 //________________________D O T____________________________


### PR DESCRIPTION
- PIConGPU: add static assert to check if a stencil fits into a supercell
- PMacc: add specialization to get the minimum component of a compile time vector