### PR TITLE
ionization: speedup particle creation

### DIFF
--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -30,6 +30,7 @@
 #include <pmacc/math/vector/Int.hpp>
 #include <pmacc/nvidia/atomic.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/memory/Array.hpp>
 #include <pmacc/mappings/threads/ForEachIdx.hpp>
 #include <pmacc/mappings/threads/IdxConfig.hpp>
 #include <pmacc/mappings/threads/WorkerCfg.hpp>
@@ -120,10 +121,18 @@ namespace creation
 
             constexpr lcellId_t maxParticlesInFrame = pmacc::math::CT::volume< SuperCellSize >::type::value;
 
+            /* use two frames to allow that all virtual workers can create new particles
+             * even if newFrameFillLvl is not zero.
+             */
+            using FrameArray = memory::Array<
+                TargetFramePtr,
+                2
+            >;
+
             PMACC_SMEM(
                 acc,
-                targetFrame,
-                TargetFramePtr
+                targetFrames,
+                FrameArray
             );
 
             // find last frame in super cell
@@ -163,7 +172,7 @@ namespace creation
                     DataSpace< simDim > const cellIdx = DataSpaceOperations< simDim >::template map< SuperCellSize >( linearIdx );
 
                     // cell offset with respect to the local domain origin (without any guarding cells
-                    pmacc::math::Int<simDim> const localCellIndex = supercellCellOffset + cellIdx;
+                    pmacc::math::Int< simDim > const localCellIndex = supercellCellOffset + cellIdx;
 
                     // create a copy of the functor for each virtual worker
                     particleCreatorCtx[ idx ] = particleCreator;
@@ -189,10 +198,10 @@ namespace creation
 
             ForEachIdx<
                 IdxConfig<
-                    1,
+                    2,
                     numWorkers
                 >
-            > onlyMaster{ workerIdx };
+            > onlyMasters{ workerIdx };
 
             // Declare local variable oldFrameFillLvl for each thread
             int oldFrameFillLvl;
@@ -207,14 +216,15 @@ namespace creation
             numNewParticlesCtx( 0 );
 
             // Master initializes the frame fill level with 0
-            onlyMaster(
+            onlyMasters(
                 [&](
-                    uint32_t const,
+                    uint32_t const linearIdx,
                     uint32_t const
                 )
                 {
-                    newFrameFillLvl = 0;
-                    targetFrame = nullptr;
+                    if( linearIdx == 0 )
+                        newFrameFillLvl = 0;
+                    targetFrames[ linearIdx ] = nullptr;
                 }
             );
 
@@ -322,22 +332,23 @@ namespace creation
 
                     __syncthreads( );
 
-                    /* < FIRST NEW FRAME >
+                    /* < NEW FRAME >
                      * - if there is no frame, yet, the master will create a new target particle frame
                      * and attach it to the back of the frame list
                      */
-                    onlyMaster(
+                    onlyMasters(
                         [&](
-                            uint32_t const,
+                            uint32_t const linearIdx,
                             uint32_t const
                         )
                         {
-                            if( !targetFrame.isValid( ) )
+                            uint32_t const numFramesNeeded = ( newFrameFillLvl + maxParticlesInFrame - 1u ) / maxParticlesInFrame;
+                            if( linearIdx < numFramesNeeded && !targetFrames[ linearIdx ].isValid( ) )
                             {
-                                targetFrame = targetBox.getEmptyFrame( );
+                                targetFrames[ linearIdx ] = targetBox.getEmptyFrame( );
                                 targetBox.setAsLastFrame(
                                     acc,
-                                    targetFrame,
+                                    targetFrames[ linearIdx ],
                                     block
                                 );
                             }
@@ -346,8 +357,8 @@ namespace creation
 
                     __syncthreads( );
 
-                    /* < CREATE 1 >
-                     * - all target particles fitting into the current frame are created there
+                    /* < CREATE >
+                     * - all target particles were created
                      * - internal particle creation counter is decremented by 1
                      */
                     forEachParticle(
@@ -356,12 +367,18 @@ namespace creation
                             uint32_t const idx
                         )
                         {
-                            if( 0 <= targetParIdCtx[ idx ] &&  targetParIdCtx[ idx ] < maxParticlesInFrame )
+                            uint32_t targetFrameIdx = 0;
+                            if( targetParIdCtx[ idx ] >= maxParticlesInFrame )
+                            {
+                                targetFrameIdx = 1;
+                                targetParIdCtx[ idx ] -= maxParticlesInFrame;
+                            }
+                            if( 0 <= targetParIdCtx[ idx ] )
                             {
                                 // each virtual worker makes the attributes of its source particle accessible
                                 auto sourceParticle = sourceFrame[ linearIdx ];
                                 // each virtual worker initializes a target particle if one should be created
-                                auto targetParticle = targetFrame[ targetParIdCtx[ idx ] ];
+                                auto targetParticle = targetFrames[ targetFrameIdx ][ targetParIdCtx[ idx ] ];
 
                                 // create a target particle in the new target particle frame:
                                 particleCreatorCtx[ idx ](
@@ -376,63 +393,24 @@ namespace creation
                     );
 
                     __syncthreads( );
-                    /* < SECOND NEW FRAME >
-                     * - if the shared counter is larger than the frame size a new target particle frame is reserved
-                     * and attached to the back of the frame list
-                     * - then the shared counter is set back by one frame size
-                     * - sync so that every thread knows about the new frame
-                     */
-                    onlyMaster(
+
+                    onlyMasters(
                         [&](
-                            uint32_t const,
+                            uint32_t const linearIdx,
                             uint32_t const
                         )
                         {
-                            if( newFrameFillLvl >= maxParticlesInFrame )
+                            if( linearIdx == 0  && newFrameFillLvl >= maxParticlesInFrame )
                             {
-                                targetFrame = targetBox.getEmptyFrame( );
-                                targetBox.setAsLastFrame(
-                                    acc,
-                                    targetFrame,
-                                    block
-                                );
-                                newFrameFillLvl -= maxParticlesInFrame;
+                                 newFrameFillLvl -= maxParticlesInFrame;
+                                 // copy the not filled frame pointer to the beginning
+                                 targetFrames[ 0 ] = targetFrames[ 1 ];
+                                 // reset second frame
+                                 targetFrames[ 1 ] = nullptr;
                             }
                         }
                     );
 
-                    __syncthreads( );
-
-                    /* < CREATE 2 >
-                     * - the thread writes a target particle to the new frame
-                     * - the internal counter is decremented by 1
-                     */
-                    forEachParticle(
-                        [&](
-                            uint32_t const linearIdx,
-                            uint32_t const idx
-                        )
-                        {
-                            if( targetParIdCtx[ idx ] >= maxParticlesInFrame )
-                            {
-                                targetParIdCtx[ idx ] -= maxParticlesInFrame;
-
-                                // each thread makes the attributes of its source particle accessible
-                                auto sourceParticle = sourceFrame[ linearIdx ];
-                                // each thread initializes a target particle if one should be created
-                                auto targetParticle = targetFrame[ targetParIdCtx[ idx ] ];
-
-                                // create a target particle in the new target particle frame:
-                                particleCreatorCtx[ idx ](
-                                    acc,
-                                    sourceParticle,
-                                    targetParticle
-                                );
-
-                                numNewParticlesCtx[ idx ] -= 1;
-                            }
-                        }
-                    );
                     __syncthreads( );
                 }
 


### PR DESCRIPTION
Avoid that electrons are created within two independent steps.
This will increase the concurrency and increase the bandwidth utilization.

# Tests

- [x] default foil example