### PR TITLE
Radiation: fix wrong python formatting

### DIFF
--- a/lib/python/picongpu/plugins/radiation.py
+++ b/lib/python/picongpu/plugins/radiation.py
@@ -41,8 +41,8 @@ class radiationHDF5:
         self.timestep = self.get_timestep()
 
         # Amplitude
-        detectorAmplitude = self.h5_file["/data/{}/DetectorMesh/" +
-                                         "Amplitude".format(self.timestep)]
+        detectorAmplitude = self.h5_file[("/data/{}/DetectorMesh/" +
+                                          "Amplitude").format(self.timestep)]
         # A_x
         self.h5_Ax_Re = detectorAmplitude["x_Re"]
         self.h5_Ax_Im = detectorAmplitude["x_Im"]

--- a/src/tools/bin/smooth.py
+++ b/src/tools/bin/smooth.py
@@ -74,8 +74,8 @@ def makeOddNumber(number, larger=True):
         else:
             return number - 1
     else:
-        error_msg = "ERROR: number (= {}) neather odd " + \
-                    "nor even".format(number)
+        error_msg = ("ERROR: number (= {}) neither odd " +
+                     "nor even").format(number)
         raise Exception(error_msg)
 
 


### PR DESCRIPTION
This pull request  solves issue #2264.

With #2028 there were several strings separated to make their length agree with PEP8. Due to this several formatting processes were broken. 
This pull request fixes these where it is necessary. 