### PR TITLE
tbg: Add -f | --force

### DIFF
--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -236,7 +236,7 @@ help()
     echo "create a new folder for a batch job and copy in all important files"
     echo ""
     echo "usage: tbg -c [cfgFile] [-s [submitsystem]] [-t [templateFile]]"
-    echo "          [-o \"VARNAME1=10 VARNAME2=5\"] [-h]"
+    echo "          [-o \"VARNAME1=10 VARNAME2=5\"] [-f] [-h]"
     echo "          [projectPath] destinationPath"
     echo ""
     echo "-c | --cfg      [file]         - Configuration file to set up batch file."
@@ -250,7 +250,7 @@ help()
     echo "                                 spaces within the right side of assign are not allowed"
     echo "                                 e.g. -o \"VARNAME1=10 VARNAME2=5\""
     echo "                                 Overwriting is done after cfg file was executed"
-    echo "-f | --force                   - Start new job even if TBG_dstPath exists."
+    echo "-f | --force                   - Override if TBG_dstPath exists."
     echo "-h | --help                    - Shows help (this output)."
     echo ""
     echo "[projectPath]                  - Project directory containing source code and"
@@ -427,12 +427,12 @@ fi
 start_dir=`dirname $0`
 
 if [ -d "$job_outDir" ] ; then
-	if [ "$force" = "true" ] ; then
-		echo "Warning: using existing folder for job on user-request ( -f )"
-	else
-		echo "job name already in use, can't create new folder"
-		exit 1
-	fi
+    if [ "$force" == "true" ] ; then
+        echo "Warning: using existing folder on user-request [-f]"
+    else
+        echo "destination path already in use, can't create new folder"
+        exit 1
+    fi
 fi
 
 #set TBG variables which can used in cfg and tpl file

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -250,6 +250,7 @@ help()
     echo "                                 spaces within the right side of assign are not allowed"
     echo "                                 e.g. -o \"VARNAME1=10 VARNAME2=5\""
     echo "                                 Overwriting is done after cfg file was executed"
+    echo "-f | --force                   - Start new job even if TBG_dstPath exists."
     echo "-h | --help                    - Shows help (this output)."
     echo ""
     echo "[projectPath]                  - Project directory containing source code and"
@@ -289,7 +290,7 @@ fi
 # options may be followed by
 # - one colon to indicate they has a required argument
 # - two colons to indicate they has a optional argument
-OPTS=`$egetoptTool -o t::c::s::o:h -l tpl::,cfg::,submit::,help -n tbg ++ "$@"`
+OPTS=`$egetoptTool -o t::c::s::o:fh -l tpl::,cfg::,submit::,force,help -n tbg ++ "$@"`
 if [ $? != 0 ] ; then
     # something went wrong, egetopt will put out an error message for us
     exit 1
@@ -315,6 +316,9 @@ while true ; do
        -o)
             tooltpl_overwrite="$2"
             shift
+            ;;
+       -f|--force)
+            force="true"
             ;;
        -t|--tpl)
             tooltpl_file=${2:-$TBG_TPLFILE}
@@ -423,8 +427,12 @@ fi
 start_dir=`dirname $0`
 
 if [ -d "$job_outDir" ] ; then
-    echo "job name already in use, can't create new folder"
-    exit 1
+	if [ "$force" = "true" ] ; then
+		echo "Warning: using existing folder for job on user-request ( -f )"
+	else
+		echo "job name already in use, can't create new folder"
+		exit 1
+	fi
 fi
 
 #set TBG variables which can used in cfg and tpl file

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -250,7 +250,7 @@ help()
     echo "                                 spaces within the right side of assign are not allowed"
     echo "                                 e.g. -o \"VARNAME1=10 VARNAME2=5\""
     echo "                                 Overwriting is done after cfg file was executed"
-    echo "-f | --force                   - Override if TBG_dstPath exists."
+    echo "-f | --force                   - Override if 'destinationPath' exists."
     echo "-h | --help                    - Shows help (this output)."
     echo ""
     echo "[projectPath]                  - Project directory containing source code and"


### PR DESCRIPTION
This change provides the option to force tbg to accept an already existing directory for a new job. This is useful when tbg is used in other workflows, where tbg is only used to submit the job, but the working directory is prepared by the workflow prior to the invocation of tbg.

The changed code also produces a warning when the '-f' option causes tbg to actually use an existing folder.