### PR TITLE
Improved the cpuNumaStarter.sh script to support not using all hw threads

### DIFF
--- a/etc/picongpu/cpuNumaStarter.sh
+++ b/etc/picongpu/cpuNumaStarter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017 Rene Widera
+# Copyright 2017 Rene Widera, Alexander Matthes
 #
 # This file is part of PIConGPU.
 #
@@ -20,30 +20,48 @@
 #
 
 # This tool binds a process and main memory to a numa node.
-# OMP_NUM_THREADS is set to the number of threads within the numa node.
-# `numactl` is used to calculate the number and cpu's per numa node.
+# OMP_NUM_THREADS is set to the number of threads within the numa node at
+# default. If not every hardware thread of a core shall be used, the environment
+# variable useHardwareThreadsPerCore can be steered to change OMP_NUM_THREADS
+# accoraccordingly. `numactl` and `/proc/cpuinfo` are used to calculate the
+# number of numa nodes, sockets, and number of cores and hardware threads per
+# numa node or socket.
 #
-# dependencies: numctl, openmpi
+# dependencies: numactl, openmpi
 
 numactl --show &>/dev/null
 
 if [ $? -eq 0 ] ; then
-    numCores=`numactl --show | grep physcpubind | awk '{print $NF}'`
-    let numCores=numCores+1
-    numCPUSockets=`numactl --show | grep nodebind | awk '{print $NF}'`
-    let numCPUSockets=numCPUSockets+1
+    numNumaNodes=`numactl --show | grep nodebind | awk '{print $NF}'`
+    let numNumaNodes=numNumaNodes+1
 
-    let numCoresPerSocket=numCores/numCPUSockets
+    numCoresPerSocket=`cat /proc/cpuinfo | grep "cpu cores" | head -n 1 | awk '{print $NF}'`
+
+    numSockets=`cat /proc/cpuinfo | grep "physical id" | sort -r -V | head -n 1 | awk '{print $NF}'`
+    let numSockets=numSockets+1
+
+    numCoresTotal="$(( numCoresPerSocket * numSockets ))"
+    numCoresPerNumaNode="$(( numCoresTotal / numNumaNodes ))"
+
+    numHardwareThreadsTotal=`cat /proc/cpuinfo | grep "processor" | sort -r -V | head -n 1 | awk '{print $NF}'`
+    let numHardwareThreadsTotal=numHardwareThreadsTotal+1
+
+    numHardwareThreadsPerCore="$(( numHardwareThreadsTotal / numCoresTotal ))"
+    if [ ! -n "$useHardwareThreadsPerCore" ] ; then
+        useHardwareThreadsPerCore="$(( numHardwareThreadsPerCore ))"
+    fi
+
+    useOpenMPNumThreads="$(( useHardwareThreadsPerCore * numCoresPerNumaNode ))"
 
     if [ -n "$OMPI_COMM_WORLD_LOCAL_RANK" ] ; then
 
         let localRank=$OMPI_COMM_WORLD_LOCAL_RANK
-        let cpuSocket=localRank%numCPUSockets
+        let useNumaNode=localRank%numNumaNodes
 
         export MPI_LOCAL_RANK=$localRank
-        export OMP_NUM_THREADS=$numCoresPerSocket
+        export OMP_NUM_THREADS=$useOpenMPNumThreads
 
-        numactl --cpunodebind="$cpuSocket" --preferred="$cpuSocket" $*
+        numactl --cpunodebind="$useNumaNode" --preferred="$useNumaNode" $*
     else
         echo "WARNING: OpenMPI missing, start without thread pinning" >&2
         $*

--- a/etc/picongpu/cpuNumaStarter.sh
+++ b/etc/picongpu/cpuNumaStarter.sh
@@ -22,10 +22,15 @@
 # This tool binds a process and main memory to a numa node.
 # OMP_NUM_THREADS is set to the number of threads within the numa node at
 # default. If not every hardware thread of a core shall be used, the environment
-# variable useHardwareThreadsPerCore can be steered to change OMP_NUM_THREADS
-# accoraccordingly. `numactl` and `/proc/cpuinfo` are used to calculate the
-# number of numa nodes, sockets, and number of cores and hardware threads per
-# numa node or socket.
+# variable NUMA_HW_THREADS_PER_PHYSICAL_CORE can be steered to change
+# OMP_NUM_THREADS accordingly. `numactl` and `/proc/cpuinfo` are used to
+# calculate the number of numa nodes, sockets, and number of cores and hardware
+# threads per numa node or socket.
+#
+# NUMA_HW_THREADS_PER_PHYSICAL_CORE is the number of used hardware threads
+# (read hyperthreads for Intel) per physical core. If hyperthreading shall not
+# be used, use "export NUMA_HW_THREADS_PER_PHYSICAL_CORE=1" before using
+# cpuNumaStarter.sh
 #
 # dependencies: numactl, openmpi
 
@@ -47,11 +52,11 @@ if [ $? -eq 0 ] ; then
     let numHardwareThreadsTotal=numHardwareThreadsTotal+1
 
     numHardwareThreadsPerCore="$(( numHardwareThreadsTotal / numCoresTotal ))"
-    if [ ! -n "$useHardwareThreadsPerCore" ] ; then
-        useHardwareThreadsPerCore="$(( numHardwareThreadsPerCore ))"
+    if [ ! -n "$NUMA_HW_THREADS_PER_PHYSICAL_CORE" ] ; then
+        NUMA_HW_THREADS_PER_PHYSICAL_CORE="$(( numHardwareThreadsPerCore ))"
     fi
 
-    useOpenMPNumThreads="$(( useHardwareThreadsPerCore * numCoresPerNumaNode ))"
+    useOpenMPNumThreads="$(( NUMA_HW_THREADS_PER_PHYSICAL_CORE * numCoresPerNumaNode ))"
 
     if [ -n "$OMPI_COMM_WORLD_LOCAL_RANK" ] ; then
 


### PR DESCRIPTION
cpuNumaStarter always uses all hardware threads of a core, but depending on the
architecture this might not be what the user wants. Using more hardware threads
enables more independend register sets, but reduces the L1 cache per thread,
which might decrease performance.

The number of threads use from OpenMP is now calculated from the number of
cores per numa node and the number of hardware threads which shall be used.
If this number is not set, it is preset to the total amout of hardware threads
establishing the same behaviour as before.

I tested the script on the laser node of hypnos where it showed the same behaviour as before and on the KNLs of taurus where I were able to reduce the used hardware threads per core to achieve a better performance (factor 3!)