### PR TITLE
Added an example profile and tpl file for taurus' KNL

### DIFF
--- a/etc/picongpu/taurus-tud/knl.tpl
+++ b/etc/picongpu/taurus-tud/knl.tpl
@@ -84,4 +84,4 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 
 # Run PIConGPU
-useHardwareThreadsPerCore=!TBG_hardwareThreadsPerCore mpirun !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+NUMA_HW_THREADS_PER_PHYSICAL_CORE=!TBG_hardwareThreadsPerCore mpirun !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output

--- a/etc/picongpu/taurus-tud/knl.tpl
+++ b/etc/picongpu/taurus-tud/knl.tpl
@@ -22,6 +22,7 @@
 # PIConGPU batch script for taurus' SLURM batch system
 
 #SBATCH -p !TBG_queue
+#SBATCH --constraint="Quadrant&Cache"
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName
@@ -48,7 +49,7 @@
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # number of hardware threads used per core (hyperthreading)
-.TBG_hardwareThreadsPerCore=3
+.TBG_hardwareThreadsPerCore=1
 
 # 1 accelerator per node
 .TBG_accPerNode=1
@@ -57,10 +58,10 @@
 .TBG_coresPerAcc=64
 
 # We only start 1 MPI task per Node
-.TBG_mpiTasksPerNode="$(( TBG_accPerNode ))"
+.TBG_mpiTasksPerNode=!TBG_accPerNode
 
 # use ceil to caculate nodes
-.TBG_nodes="$(( TBG_tasks ))"
+.TBG_nodes=!TBG_tasks
 
 ## end calculations ##
 
@@ -82,7 +83,5 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  useHardwareThreadsPerCore=!TBG_hardwareThreadsPerCore mpirun !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
-fi
+# Run PIConGPU
+useHardwareThreadsPerCore=!TBG_hardwareThreadsPerCore mpirun !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output

--- a/etc/picongpu/taurus-tud/knl.tpl
+++ b/etc/picongpu/taurus-tud/knl.tpl
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2013-2017 Axel Huebl, Richard Pausch, Alexander Matthes
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for taurus' SLURM batch system
+
+#SBATCH -p !TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH -N !TBG_nodes
+#SBATCH -c !TBG_coresPerAcc
+#SBATCH --mem=90000
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="knl"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of hardware threads used per core (hyperthreading)
+.TBG_hardwareThreadsPerCore=3
+
+# 1 accelerator per node
+.TBG_accPerNode=1
+
+# number of cores to block per KNL - we got 64 cores per node
+.TBG_coresPerAcc=64
+
+# We only start 1 MPI task per Node
+.TBG_mpiTasksPerNode="$(( TBG_accPerNode ))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$(( TBG_tasks ))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  useHardwareThreadsPerCore=!TBG_hardwareThreadsPerCore mpirun !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi

--- a/etc/picongpu/taurus-tud/knl.tpl
+++ b/etc/picongpu/taurus-tud/knl.tpl
@@ -84,4 +84,4 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 
 # Run PIConGPU
-NUMA_HW_THREADS_PER_PHYSICAL_CORE=!TBG_hardwareThreadsPerCore mpirun !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+NUMA_HW_THREADS_PER_PHYSICAL_CORE=!TBG_hardwareThreadsPerCore mpiexec !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -23,7 +23,7 @@ export LD_LIBRARY_PATH=$BOOST_ROOT:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 
 export PICSRC=$HOME/src/picongpu
-export PIC_BACKEND="omp2b:native"
+export PIC_BACKEND="omp2b:MIC-AVX512"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -13,10 +13,10 @@ module load intelmpi/2017.2.174
 ### ICC
 module load intel/2017.2.174
 # Boost needs to be build yourself for now!
-# These paths need to be adjusted.
-export LD_LIBRARY_PATH=<BOOST_INSTALLATION_DIR>:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=<BOOST_INSTALLATION_DIR>/lib:$LD_LIBRARY_PATH
+# The boost root path needs to be adjusted.
 export BOOST_ROOT=<BOOST_INSTALLATION_DIR>
+export LD_LIBRARY_PATH=$BOOST_ROOT:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 
 export PICSRC=$HOME/src/picongpu
 export PIC_BACKEND="omp2b:native"

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -1,0 +1,40 @@
+# Text Editor for Tools #######################################################
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# General modules #############################################################
+#
+module purge
+module load cmake/3.9.0
+module load git
+module load openmpi/2.1.0-intel
+
+# Compilers ###################################################################
+### ICC
+module load intel/2017.2.174
+# Boost needs to be build yourself for now!
+# These paths need to be adjusted.
+export LD_LIBRARY_PATH=<BOOST_INSTALLATION_DIR>:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=<BOOST_INSTALLATION_DIR>/lib:$LD_LIBRARY_PATH
+export BOOST_ROOT=<BOOST_INSTALLATION_DIR>
+
+export PICSRC=$HOME/src/picongpu
+export PIC_BACKEND="comp2b:native"
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "gpu1" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/taurus-tud/knl.tpl"

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -38,3 +38,5 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #   - "gpu1" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/knl.tpl"
+
+alias getNode='srun -p knl -N 1 -c 64 --mem=90000 --constraint="Quadrant&Cache" --pty bash'

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -19,7 +19,7 @@ export LD_LIBRARY_PATH=<BOOST_INSTALLATION_DIR>/lib:$LD_LIBRARY_PATH
 export BOOST_ROOT=<BOOST_INSTALLATION_DIR>
 
 export PICSRC=$HOME/src/picongpu
-export PIC_BACKEND="comp2b:native"
+export PIC_BACKEND="omp2b:native"
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 export PATH=$PATH:$PICSRC

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -7,7 +7,7 @@
 module purge
 module load cmake/3.9.0
 module load git
-module load openmpi/2.1.0-intel
+module load intelmpi/2017.2.174
 
 # Compilers ###################################################################
 ### ICC
@@ -35,7 +35,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)
-#   - "gpu1" queue
+#   - "knl" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/knl.tpl"
 

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -2,6 +2,10 @@
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
+# "module" commands undefine $BASH_SOURCE on a KNL node for some unknown reason
+# so $PIC_PROFILE needs to be defined before using "module ...".
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
 # General modules #############################################################
 #
 module purge
@@ -20,7 +24,6 @@ export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 
 export PICSRC=$HOME/src/picongpu
 export PIC_BACKEND="omp2b:native"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin


### PR DESCRIPTION
The knl.tpl uses the new useHardwareThreadsPerCore feature of
PR https://github.com/ComputationalRadiationPhysics/picongpu/pull/2269
to set the number of used hardware threads per core to 1 at default.

Related to issue https://github.com/ComputationalRadiationPhysics/picongpu/issues/2210