### PR TITLE
enable cuSTL CartBuffer on CPU

### DIFF
--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -22,10 +22,9 @@
 
 #pragma once
 
-#if (PMACC_CUDA_ENABLED == 1)
-#   include "pmacc/cuSTL/container/view/View.hpp"
-#   include "pmacc/cuSTL/container/DeviceBuffer.hpp"
-#endif
+
+#include "pmacc/cuSTL/container/view/View.hpp"
+#include "pmacc/cuSTL/container/DeviceBuffer.hpp"
 #include "pmacc/math/vector/Int.hpp"
 #include "pmacc/math/vector/Size_t.hpp"
 #include "pmacc/memory/buffers/Buffer.hpp"
@@ -81,7 +80,6 @@ namespace pmacc
         {
         };
 
-#if (PMACC_CUDA_ENABLED == 1)
         HINLINE
         container::CartBuffer<TYPE, DIM, allocator::DeviceMemAllocator<TYPE, DIM>,
                                 copier::D2DCopier<DIM>,
@@ -97,7 +95,6 @@ namespace pmacc
             container::DeviceBuffer<TYPE, DIM> result((TYPE*)cudaData.ptr, this->getDataSpace(), false, pitch);
             return result;
         }
-#endif
 
         /**
          * Returns offset of elements in every dimension.

--- a/include/pmacc/memory/buffers/HostBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostBuffer.hpp
@@ -21,9 +21,8 @@
 
 #pragma once
 
-#if (PMACC_CUDA_ENABLED == 1)
-#   include "pmacc/cuSTL/container/HostBuffer.hpp"
-#endif
+
+#include "pmacc/cuSTL/container/HostBuffer.hpp"
 #include "pmacc/memory/buffers/Buffer.hpp"
 #include "pmacc/dimensions/DataSpace.hpp"
 
@@ -72,7 +71,7 @@ namespace pmacc
         virtual ~HostBuffer()
         {
         };
-#if (PMACC_CUDA_ENABLED == 1)
+
         HINLINE
         container::HostBuffer<TYPE, DIM>
         cartBuffer()
@@ -85,7 +84,7 @@ namespace pmacc
             container::HostBuffer<TYPE, DIM> result(this->getBasePointer(), this->getDataSpace(), false, pitch);
             return result;
         }
-#endif
+
     protected:
 
         /** Constructor.


### PR DESCRIPTION
allow usage of cuSTL `container::CartBuffer` with CPU back-end

This feature was disabled for the CPU back-end with #2178 to avoid side effects during the porting.