### PR TITLE
improve speed to calculate number of ppc

### DIFF
--- a/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
+++ b/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
@@ -59,21 +59,20 @@ namespace detail
             float_X & weighting
         ) const
         {
+            PMACC_CASSERT_MSG(
+                __MIN_WEIGHTING_must_be_greater_than_zero,
+                MIN_WEIGHTING > float_X( 0.0 )
+            );
             weighting = float_X( 0.0 );
+            float_X const maxParPerCell = realParticlesPerCell / MIN_WEIGHTING;
+            numMacroParticles = math::float2int_rd(
+                math::min(
+                    float_X( numMacroParticles ),
+                    maxParPerCell
+                )
+            );
             if( numMacroParticles > 0u )
                 weighting = realParticlesPerCell / float_X( numMacroParticles );
-
-            while(
-                weighting < MIN_WEIGHTING &&
-                numMacroParticles > 0u
-            )
-            {
-                --numMacroParticles;
-                if( numMacroParticles > 0u )
-                    weighting = realParticlesPerCell / float_X( numMacroParticles );
-                else
-                    weighting = float_X( 0.0 );
-            }
 
             return numMacroParticles;
         }


### PR DESCRIPTION
Remove loop to calculate number of particles per cell with respect to `MIN_WEIGHTING`.
This improves the speed for the initialization of heterogeneous gas profiles e.g. laser wake field.

# Test

- [x] LWFA (dev 60 sec vs PR 50 sec init time)

thx @wmles for pointing me to it