### PR TITLE
optimize particle shape implementation

### DIFF
--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -58,9 +58,14 @@ struct CIC : public shared_CIC::CIC
              */
             float_X abs_x = algorithms::math::abs(x);
 
-            const bool below_1 = (abs_x < float_X(1.0));
+            const bool below_1 = abs_x < float_X(1.0);
+            const float_X onSupport = float_X(1.0) - abs_x;
 
-            return float_X(below_1) * (float_X(1.0) - abs_x);
+            float_X result(0.0);
+            if(below_1)
+                result = onSupport;
+
+            return result;
         }
     };
 

--- a/include/picongpu/particles/shapes/P4S.hpp
+++ b/include/picongpu/particles/shapes/P4S.hpp
@@ -103,17 +103,20 @@ struct P4S : public shared_P4S::P4S
              */
             float_X abs_x = algorithms::math::abs(x);
 
-            const bool below_3rd_radius = (abs_x < float_X(1.5));
-            if (below_3rd_radius)
-            {
-                const bool below_2rd_radius = (abs_x < float_X(0.5));
-                if (below_2rd_radius)
-                    return ff_1st_radius(abs_x);
-                else
-                    return ff_2nd_radius(abs_x);
-            }
-            else
-                return ff_3rd_radius(abs_x);
+            const bool below_2nd_radius = abs_x < float_X(1.5);
+            const bool below_1st_radius = abs_x < float_X(0.5);
+
+            const float_X rad1 = ff_1st_radius(abs_x);
+            const float_X rad2 = ff_2nd_radius(abs_x);
+            const float_X rad3 = ff_3rd_radius(abs_x);
+
+            float_X result = rad3;
+            if(below_1st_radius)
+                result = rad1;
+            else if(below_2nd_radius)
+                result = rad2;
+
+            return result;
         }
 
     };
@@ -136,12 +139,15 @@ struct P4S : public shared_P4S::P4S
              */
             float_X abs_x = algorithms::math::abs(x);
 
-            const bool below_max = (abs_x < float_X(2.5));
+            const bool below_max = abs_x < float_X(2.5);
 
-            if (below_max)
-                return ChargeAssignmentOnSupport()(abs_x);
-            else
-                return float_X(0.);
+            const float_X onSupport = ChargeAssignmentOnSupport()(abs_x);
+
+            float_X result(0.0);
+            if(below_max)
+                result = onSupport;
+
+            return result;
         }
     };
 };

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -75,11 +75,19 @@ struct PCS : public shared_PCS::PCS
              */
             float_X abs_x = algorithms::math::abs(x);
 
-            const bool below_1 = (abs_x < float_X(1.0));
-            const bool below_2 = (abs_x < float_X(2.0));
+            const bool below_1 = abs_x < float_X(1.0);
+            const bool below_2 = abs_x < float_X(2.0);
 
-            return float_X(below_1) * ff_1st_radius(abs_x) +
-                float_X(below_2 && !below_1) * ff_2nd_radius(abs_x);
+            const float_X rad1 = ff_1st_radius(abs_x);
+            const float_X rad2 = ff_2nd_radius(abs_x);
+
+            float_X result(0.0);
+            if(below_1)
+                result = rad1;
+            else if(below_2)
+                result = rad2;
+
+            return result;
         }
     };
 
@@ -96,10 +104,15 @@ struct PCS : public shared_PCS::PCS
              */
             float_X abs_x = algorithms::math::abs(x);
 
-            const bool below_1 = (abs_x < float_X(1.0));
+            const bool below_1 = abs_x < float_X(1.0);
+            const float_X rad1 = ff_1st_radius(abs_x);
+            const float_X rad2 = ff_2nd_radius(abs_x);
 
-            return float_X(below_1) * ff_1st_radius(abs_x) +
-                float_X(!below_1) * ff_2nd_radius(abs_x);
+            float_X result = rad2;
+            if(below_1)
+                result = rad1;
+
+            return result;
 
             /* Semantix:
             if (abs_x < float_X(1.0))

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -80,11 +80,19 @@ struct TSC : public shared_TSC::TSC
              */
             float_X abs_x = algorithms::math::abs(x);
 
-            const bool below_05 = (abs_x < float_X(0.5));
-            const float_X fbelow_05 = float_X(below_05);
+            const bool below_05 = abs_x < float_X(0.5);
+            const bool below_1_5 = abs_x < float_X(1.5);
 
-            return fbelow_05 * ff_1st_radius(abs_x) +
-                float_X(abs_x < float_X(1.5) && !below_05) * ff_2nd_radius(abs_x);
+            const float_X rad1 = ff_1st_radius(abs_x);
+            const float_X rad2 = ff_2nd_radius(abs_x);
+
+            float_X result(0.0);
+            if(below_05)
+                result = rad1;
+            else if(below_1_5)
+                result = rad2;
+
+            return result;
 
         }
     };
@@ -105,11 +113,16 @@ struct TSC : public shared_TSC::TSC
              */
             float_X abs_x = algorithms::math::abs(x);
 
-            const bool below_05 = (abs_x < float_X(0.5));
-            const float_X fbelow_05 = float_X(below_05);
+            const bool below_05 = abs_x < float_X(0.5);
 
-            return fbelow_05 * ff_1st_radius(abs_x) +
-                float_X(!below_05) * ff_2nd_radius(abs_x);
+            const float_X rad1 = ff_1st_radius(abs_x);
+            const float_X rad2 = ff_2nd_radius(abs_x);
+
+            float_X result = rad2;
+            if(below_05)
+                result = rad1;
+
+            return result;
         }
 
     };


### PR DESCRIPTION
Optimize the implementation of the particle shapes to help the compiler
to create optimized vector code.
Use easy if patterns to give the compiler the freedom to transform the if statements.

# Background

Currently we using something like arithmetic ifs to avoid branch differences during the particle shape evaluation. This will force the compiler to calculate all branches of the if. By refactoring the if conditions we can help the compiler to optimize the code much better. That allows the compiler to use masked assignments, to use branch differences or any other architecture specific optimizations.

thx to INTEL(R) for the [A Guide to
Vectorization with
Intel® C++ Compilers](https://d3f8ykwhia686p.cloudfront.net/1live/intel/CompilerAutovectorizationGuide.pdf)

# Test

- [x] KHI heating
- [x] KHI speed