### PR TITLE
License Docs: Update

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
  PIConGPU - Licenses
 ================================================================================
 
-**Copyright 2009-2016** Florian Berninger, Heiko Burau, Michael Bussmann,
+**Copyright 2009-2017** Florian Berninger, Heiko Burau, Michael Bussmann,
                         Alexander Debus, Robert Dietrich, Carlchristian Eckert,
                         Wen Fu, Marco Garten, Anton Helm, Wolfgang Hoehnig,
                         Axel Huebl, Maximilian Knespel, Remi Lehe,
@@ -21,21 +21,33 @@ following licenses apply:
 The **main simulation** is licensed under the **GPLv3+**. See
 [COPYING](COPYING). If not stated otherwise explicitly, that affects:
  - `buildsystem`
- - `examples`
- - `doc`
- - `inlcude/picongpu`
+ - `etc/picongpu`
+ - `include/picongpu`
+ - `lib/python/picongpu`
+ - `share/picongpu`
  - `src/tools` (without `splash2txt`)
  - `src/mpiInfo`
+ - `test`
 
 
 ### PMacc & splash2txt
  
-All **libraries** are *dual licensed* under the **GLPv3+ and LGPLv3+**. See
-[COPYING](COPYING) and [COPYING.LESSER](COPYING.LESSER).
+All **libraries** are licensed under the **LGPLv3+**. See
+[COPYING.LESSER](COPYING.LESSER).
 If not stated otherwise explicitly, that affects:
- - `inlcude/pmacc`
+ - `include/pmacc`
  - `share/pmacc`
  - `src/tools/splash2txt`
+
+
+### Documentation
+
+Documentation is licensed under CC-BY 4.0.
+See https://creativecommons.org/licenses/by/4.0/ for the license.
+
+If not stated otherwise explicitly, that affects files in:
+
+- `docs`
 
 
 ### Third party software and other licenses
@@ -44,6 +56,14 @@ We include a list of (GPL-) compatible third party software for the sake
 of an easier install of `PIConGPU`. Contributions to these parts of the
 repository should *not* be made in the `thirdParty/` directory but in
 *their according repositories* (that we import).
+
+ - `thirdParty/alpaka`:
+   alpaka is a header-only C++11 abstraction library for parallel
+   kernel development on accelerator hardware. It provides a single-source,
+   performance portable programming model for PIConGPU and PMacc.
+   Please visit
+     https://github.com/ComputationalRadiationPhysics/alpaka
+   for further details and contributions.
 
  - `thirdParty/mallocMC`:
    mallocMC is a fast memory allocator for many core accelerators and was
@@ -70,3 +90,11 @@ repository should *not* be made in the `thirdParty/` directory but in
    and our modified version is hosted at
      https://github.com/ComputationalRadiationPhysics/cuda_memtest
    for further reference.
+
+- `thirdParty/cupla`:
+   cupla is a simple user interface for alpaka. It provides a software layer
+   that follows a similar concept as the Nvidia CUDA API, allowing to write
+   kernels more efficiently.
+   Please visit
+     https://github.com/ComputationalRadiationPhysics/cupla
+   for further details and contributions.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PIConGPU'
-copyright = u'2017, The PIConGPU Community'
+copyright = u'Documentation under CC-BY 4.0, The PIConGPU Community'
 author = u'The PIConGPU Community'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Update the documentation about used licenses to reflect recent changes in the code structure. Also adds infos on alpaka & cupla.

Also adds:
- PMacc: technically LGPLv3+ (which has a GPL fallback already)
- docs: from now on CC-BY 4.0 for images and texts

@ComputationalRadiationPhysics/picongpu-maintainers @ComputationalRadiationPhysics/picongpu-developers This PR proposes to make our manual/documentation/images in `docs/` licensed under a permissive open access license, the [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/), by default. The CC-BY license is the recommended license for open access publishing in Helmholtz and more suited to texts and images then the code licenses we have for the rest of the project. Do you agree to this change?

cc @PrometheusPi @n01r @psychocoderHPC @theZiz @Heikman 