### PR TITLE
activate synchrotron for CPU back-end

### DIFF
--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -29,10 +29,10 @@
 #include <pmacc/communication/AsyncCommunication.hpp>
 #include "picongpu/particles/traits/GetIonizerList.hpp"
 #if( PMACC_CUDA_ENABLED == 1 )
-#   include "picongpu/particles/traits/GetPhotonCreator.hpp"
-#   include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 #   include "picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp"
 #endif
+#include "picongpu/particles/traits/GetPhotonCreator.hpp"
+#include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 #include "picongpu/particles/creation/creation.hpp"
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/particles/traits/ResolveAliasFromSpecies.hpp>
@@ -458,6 +458,7 @@ struct CallBremsstrahlung
     }
 
 };
+#endif
 
 /** Handles the synchrotron radiation emission of photons from electrons
  *
@@ -508,6 +509,6 @@ struct CallSynchrotronPhotons
     }
 
 };
-#endif
+
 } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include <pmacc/cuSTL/container/HostBuffer.hpp>
+#include <pmacc/cuSTL/container/DeviceBuffer.hpp>
 #include <pmacc/cuSTL/cursor/Cursor.hpp>
 #include <pmacc/cuSTL/cursor/navigator/PlusNavigator.hpp>
 #include <pmacc/cuSTL/cursor/tools/LinearInterp.hpp>

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -61,8 +61,9 @@
 #if( PMACC_CUDA_ENABLED == 1 )
 #   include "picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp"
 #   include "picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp"
-#   include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 #endif
+
+#include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 
 #include <pmacc/nvidia/reduce/Reduce.hpp>
 #include <pmacc/memory/boxes/DataBoxDim1Access.hpp>
@@ -333,13 +334,13 @@ public:
             rngFactory->init( gridCon.getScalarPosition() );
             dc.share( std::shared_ptr< ISimulationData >( rngFactory ) );
         }
-#if( PMACC_CUDA_ENABLED == 1 )
+
         // Initialize synchrotron functions, if there are synchrotron photon species
         if(!bmpl::empty<AllSynchrotronPhotonsSpecies>::value)
         {
             this->synchrotronFunctions.init();
         }
-
+#if( PMACC_CUDA_ENABLED == 1 )
         // Initialize bremsstrahlung lookup tables, if there are species containing bremsstrahlung photons
         if(!bmpl::empty<AllBremsstrahlungPhotonsSpecies>::value)
         {
@@ -556,7 +557,6 @@ public:
         > populationKinetics;
         populationKinetics( currentStep );
 
-#if( PMACC_CUDA_ENABLED == 1 )
         /* call the synchrotron radiation module for each radiating species (normally electrons) */
         typedef typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies,
                                                                 synchrotronPhotons<> >::type AllSynchrotronPhotonsSpecies;
@@ -567,6 +567,7 @@ public:
         > synchrotronRadiation;
         synchrotronRadiation( cellDescription, currentStep, this->synchrotronFunctions );
 
+#if( PMACC_CUDA_ENABLED == 1 )
         /* Bremsstrahlung */
         typedef typename pmacc::particles::traits::FilterByFlag
         <
@@ -784,10 +785,11 @@ protected:
     // map<atomic number, scaled bremsstrahlung spectrum>
     std::map<float_X, particles::bremsstrahlung::ScaledSpectrum> scaledBremsstrahlungSpectrumMap;
     particles::bremsstrahlung::GetPhotonAngle bremsstrahlungPhotonAngle;
+#endif
 
     // Synchrotron functions (used in synchrotronPhotons module)
     particles::synchrotronPhotons::SynchrotronFunctions synchrotronFunctions;
-#endif
+
     // output classes
 
     IInitPlugin* initialiserController;
@@ -811,8 +813,9 @@ protected:
 } /* namespace picongpu */
 
 #include "picongpu/fields/Fields.tpp"
+#include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp"
+
 #if( PMACC_CUDA_ENABLED == 1 )
-#   include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp"
 #   include "picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp"
 #   include "picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp"
 #endif

--- a/include/picongpu/simulation_defines/_defaultParam.loader
+++ b/include/picongpu/simulation_defines/_defaultParam.loader
@@ -35,9 +35,7 @@
 #include "picongpu/simulation_defines/param/flylite.param"
 #include "picongpu/simulation_defines/param/speciesConstants.param"
 #include "picongpu/simulation_defines/param/speciesAttributes.param"
-#if( PMACC_CUDA_ENABLED == 1 )
-#   include "picongpu/simulation_defines/param/synchrotronPhotons.param"
-#endif
+#include "picongpu/simulation_defines/param/synchrotronPhotons.param"
 #include "picongpu/simulation_defines/param/grid.param"
 #include "picongpu/simulation_defines/param/pusher.param"
 #include "picongpu/simulation_defines/param/ionizer.param"

--- a/include/picongpu/simulation_defines/_defaultUnitless.loader
+++ b/include/picongpu/simulation_defines/_defaultUnitless.loader
@@ -38,8 +38,8 @@
 #include "picongpu/simulation_defines/unitless/speciesDefinition.unitless"
 #include "picongpu/simulation_defines/unitless/speciesInitialization.unitless"
 #include "picongpu/simulation_defines/unitless/fieldBackground.unitless"
+#include "picongpu/simulation_defines/unitless/synchrotronPhotons.unitless"
 #if( PMACC_CUDA_ENABLED == 1 )
-#    include "picongpu/simulation_defines/unitless/synchrotronPhotons.unitless"
 #    include "picongpu/simulation_defines/unitless/bremsstrahlung.unitless"
 #endif
 


### PR DESCRIPTION
allow using synchrotron solver with the CPU back-end

# Tests

- [x] CPU runtime test (bunch example case 4)
- [x] GPU runtime test (bunch example case 4)

I can't verify the solver because we have no useful preset to verify the correctness #2283