### PR TITLE
CMake: Boost Target Check

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -155,7 +155,7 @@ endif()
 
 find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options regex filesystem
                                               system math_tr1 serialization)
-if(TARGET Boost::boost)
+if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex
                      Boost::filesystem Boost::system Boost::math_tr1
                      Boost::serialization)

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -61,7 +61,7 @@ add_definitions(${PMacc_DEFINITIONS})
 ###############################################################################
 
 find_package(Boost 1.62.0 COMPONENTS unit_test_framework REQUIRED)
-if(TARGET Boost::boost)
+if(TARGET Boost::unit_test_framework)
     set(LIBS ${LIBS} Boost::boost Boost::unit_test_framework)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -224,7 +224,7 @@ endif(MPI_CXX_FOUND)
 ################################################################################
 
 find_package(Boost 1.62.0 REQUIRED COMPONENTS filesystem system math_tr1)
-if(TARGET Boost::boost)
+if(TARGET Boost::filesystem)
     set(PMacc_LIBRARIES ${PMacc_LIBRARIES} Boost::boost Boost::filesystem
                                            Boost::system Boost::math_tr1)
 else()

--- a/src/mpiInfo/CMakeLists.txt
+++ b/src/mpiInfo/CMakeLists.txt
@@ -81,7 +81,7 @@ endif(MPI_CXX_FOUND)
 ################################################################################
 
 find_package(Boost REQUIRED COMPONENTS program_options)
-if(TARGET Boost::boost)
+if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -83,7 +83,7 @@ endif(NOT RELEASE)
 ################################################################################
 
 find_package(Boost REQUIRED COMPONENTS program_options)
-if(TARGET Boost::boost)
+if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -134,7 +134,7 @@ endif(ADIOS_FOUND)
 ################################################################################
 
 find_package(Boost REQUIRED COMPONENTS program_options regex)
-if(TARGET Boost::boost)
+if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
It turns out, the `Boost::boost` target for the header only libraries is always available, even if the other targets are not, e.g. due to a newer boost version which leads to a `_Boost_IMPORTED_TARGETS FALSE`.

This fixes the detection properly in such a case by testing for the first (or any) of the oder requested targets instead.