### PR TITLE
CMake: Same Boost Min for Tools

### DIFF
--- a/src/mpiInfo/CMakeLists.txt
+++ b/src/mpiInfo/CMakeLists.txt
@@ -80,7 +80,7 @@ endif(MPI_CXX_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost REQUIRED COMPONENTS program_options)
+find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
 if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -82,7 +82,7 @@ endif(NOT RELEASE)
 # Find Boost
 ################################################################################
 
-find_package(Boost REQUIRED COMPONENTS program_options)
+find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
 if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -133,7 +133,7 @@ endif(ADIOS_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost REQUIRED COMPONENTS program_options regex)
+find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options regex)
 if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex)
 else()


### PR DESCRIPTION
Introduce the same minimal boost version as a requirement for tools as we use for the main project.

Helps a little to avoid picking up parallel installs of (system) boost versions, which are usually older.

- [x] needs rebase after #2292 was merged