### PR TITLE
PMacc: Set CPU Architecture

### DIFF
--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -147,6 +147,56 @@ endif()
 set(PMacc_LIBRARIES ${PMacc_LIBRARIES} ${cupla_LIBRARIES})
 
 
+###############################################################################
+# CPU Architecture: available instruction sets for e.g. SIMD extensions
+#
+# Conveniently set the architecture for the CPU compiler via this option.
+# For unsupported compilers, ignore this option and set CXXFLAGS.
+###############################################################################
+
+set(PMACC_CPU_ARCH $ENV{PMACC_CPU_ARCH} CACHE STRING
+    "compiler dependent CPU architecture string"
+)
+
+# list of known compiler flags to set the CPU architecture
+# GNU
+if(CMAKE_COMPILER_IS_GNUCXX)
+    if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+        set(PMACC_CPU_ARCH_TEMPLATE "-mcpu={} -mtune={}")
+    else()
+        set(PMACC_CPU_ARCH_TEMPLATE "-march={} -mtune={}")
+    endif()
+# ICC
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+    if("${PMACC_CPU_ARCH}" STREQUAL "native")
+        set(PMACC_CPU_ARCH_TEMPLATE "-march={} -mtune={}")
+    else()
+        set(PMACC_CPU_ARCH_TEMPLATE "-x{}")
+    endif()
+# Clang
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(PMACC_CPU_ARCH_TEMPLATE "-march={} -mtune={}")
+# XL
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "XL")
+    set(PMACC_CPU_ARCH_TEMPLATE "-qarch={}")
+# PGI
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
+    if(NOT "${PMACC_CPU_ARCH}" STREQUAL "native")
+        set(PMACC_CPU_ARCH_TEMPLATE "-tp={}")
+    endif()
+endif()
+
+# architecture is set and compiler is known
+if(PMACC_CPU_ARCH AND PMACC_CPU_ARCH_TEMPLATE)
+    string(REPLACE
+       "{}"
+       "${PMACC_CPU_ARCH}"
+       PMACC_CPU_ARCH_STRING
+       "${PMACC_CPU_ARCH_TEMPLATE}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PMACC_CPU_ARCH_STRING}")
+endif()
+
+
 ################################################################################
 # VampirTrace
 ################################################################################

--- a/pic-configure
+++ b/pic-configure
@@ -40,6 +40,7 @@ help()
     echo "                       supported backends: cuda, omp2b"
     echo "                       (e.g.: \"cuda:20;35;37;52;60\" or \"omp2b:native\" or \"omp2b\")"
     echo "                       default: \"cuda\" if not set via environment variable PIC_BACKEND"
+    echo "                       note: architecture names are compiler dependent"
     echo "-c | --cmake         - overwrite options for cmake"
     echo "                       (e.g.: \"-DPIC_VERBOSE=21 -DCMAKE_BUILD_TYPE=Debug\")"
     echo "-t <presetNumber>    - configure this preset from cmakeFlags"
@@ -62,7 +63,7 @@ get_backend_flags()
     elif [ "${backend_cfg[0]}" == "omp2b" ] ; then
         result+=" -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DCMAKE_CXX_FLAGS=\"$CXXFLAGS -march=${backend_cfg[1]} -mtune=${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi
     else
         echo "unsupported backend given '$1'" >&2


### PR DESCRIPTION
Re-implementation of #2279 in pure CMake.
Easier to maintain a [list of compilers](https://cmake.org/cmake/help/v3.9/variable/CMAKE_LANG_COMPILER_ID.html) in one place and CXX+CXXFLAGS will always match.

## Description

Set the CPU architecture via `PMACC_CPU_ARCH`. Defaults to an environment variable of the same name. Only set if the (host) compiler is known, otherwise use CXXFLAGS if you experiment with more compilers.

Only set as a convinient setter for the user instead of going directly to CXXFLAGS as the user. Helpful in commands such as `pic-configure` to avoid building a compiler lookup list therein.

## Additional Usage Options

For a CUDA backend user, that still wants to set the CPU arch properly, this can be done with `-DPMACC_CPU_ARCH` (`pic-configure -c` or `ccmake`) or `export PMACC_CPU_ARCH`. For CPU backends, it is directly taken from the `[:architecture]`.

## Examples with `pic-build`

(which is actually `pic-configure`)

### OpenMP Backend
```bash
pic-build -b omp2b:native
# [...]
cmake -L .build/ | grep "CPU_ARCH"
# PMACC_CPU_ARCH:STRING=native
```
```bash
pic-build -b omp2b
# [...]
cmake -L .build/ | grep "CPU_ARCH"
# PMACC_CPU_ARCH:STRING=
```

### CUDA Backend
```bash
pic-build -b cuda:35
# [...]
cmake -L .build/ | grep "CPU_ARCH"
# PMACC_CPU_ARCH:STRING=
```

### CUDA Backend + Extra-Fine Tuning of Host Code
```bash
pic-build -b cuda:35 -c"-DPMACC_CPU_ARCH=native"
# [...]
cmake -L .build/ | grep "CPU_ARCH"
# PMACC_CPU_ARCH:STRING=native
```