### PR TITLE
Const POD Default Constructor

### DIFF
--- a/include/picongpu/algorithms/DifferenceToLower.hpp
+++ b/include/picongpu/algorithms/DifferenceToLower.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -17,11 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include <pmacc/types.hpp>
 #include <pmacc/math/Vector.hpp>
+
 
 namespace picongpu
 {
@@ -54,6 +54,10 @@ struct DifferenceToLower
     {
         static constexpr uint32_t direction = T_direction;
 
+        HDINLINE GetDifference()
+        {
+        }
+
         /** get difference to lower value
          * @return difference divided by cell size of the given direction
          */
@@ -75,6 +79,10 @@ struct DifferenceToLower
     template<uint32_t T_direction>
     struct GetDifference<T_direction, false>
     {
+
+        HDINLINE GetDifference()
+        {
+        }
 
         /** @return always a zeroed value
          */

--- a/include/picongpu/algorithms/DifferenceToUpper.hpp
+++ b/include/picongpu/algorithms/DifferenceToUpper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2017 Heiko Burau, Rene Widera
+/* Copyright 2013-2017 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -17,12 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include <pmacc/types.hpp>
 #include <pmacc/math/Vector.hpp>
+
 
 namespace picongpu
 {
@@ -52,6 +51,10 @@ struct DifferenceToUpper
     {
         static constexpr uint32_t direction = T_direction;
 
+        HDINLINE GetDifference()
+        {
+        }
+
         /** get difference to lower value
          * @return difference divided by cell size of the given direction
          */
@@ -73,6 +76,9 @@ struct DifferenceToUpper
     template<uint32_t T_direction>
     struct GetDifference<T_direction, false>
     {
+        HDINLINE GetDifference()
+        {
+        }
 
         /** @return always a zeroed value
          */

--- a/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -82,6 +82,10 @@ namespace detail
         static constexpr uint32_t dim = T_simDim;
         static constexpr uint32_t dir = T_direction;
 
+        HDINLINE ShiftMeIfYouCan()
+        {
+        }
+
         template<class T_DataBox >
         HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
         {
@@ -94,6 +98,10 @@ namespace detail
     template<uint32_t T_simDim, uint32_t T_direction>
     struct ShiftMeIfYouCan<T_simDim, T_direction, false>
     {
+        HDINLINE ShiftMeIfYouCan()
+        {
+        }
+
         template<class T_DataBox >
         HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
         {

--- a/include/picongpu/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/include/picongpu/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -17,13 +17,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/Fields.def"
 #include <pmacc/math/Vector.hpp>
+
 
 namespace picongpu
 {
@@ -57,6 +56,10 @@ namespace traits
             typedef ReturnType type;
         };
 
+        HDINLINE FieldPosition()
+        {
+        }
+
         HDINLINE ReturnType operator()() const
         {
             const auto center = PosType::create( 0.5 );
@@ -89,6 +92,10 @@ namespace traits
             typedef VectorVector2D3V type;
         };
 
+        HDINLINE FieldPosition()
+        {
+        }
+
         HDINLINE VectorVector2D3V operator()() const
         {
             const float2_X posJ_x( 0.5, 0.0 );
@@ -111,6 +118,10 @@ namespace traits
         struct result<F()> {
             typedef VectorVector3D3V type;
         };
+
+        HDINLINE FieldPosition()
+        {
+        }
 
         HDINLINE VectorVector3D3V operator()() const
         {
@@ -139,6 +150,10 @@ namespace traits
         struct result<F()> {
             typedef ReturnType type;
         };
+
+        HDINLINE FieldPosition()
+        {
+        }
 
         HDINLINE ReturnType operator()() const
         {

--- a/include/picongpu/fields/numericalCellTypes/YeeCell.hpp
+++ b/include/picongpu/fields/numericalCellTypes/YeeCell.hpp
@@ -17,12 +17,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/Fields.def"
 #include <pmacc/math/Vector.hpp>
+
 
 namespace picongpu
 {
@@ -52,6 +52,10 @@ namespace traits
             typedef VectorVector2D3V type;
         };
 
+        HDINLINE FieldPosition()
+        {
+        }
+
         HDINLINE VectorVector2D3V operator()() const
         {
             const float2_X posE_x( 0.5, 0.0 );
@@ -74,6 +78,10 @@ namespace traits
         struct result<F()> {
             typedef VectorVector3D3V type;
         };
+
+        HDINLINE FieldPosition()
+        {
+        }
 
         HDINLINE VectorVector3D3V operator()() const
         {
@@ -98,6 +106,10 @@ namespace traits
             typedef VectorVector2D3V type;
         };
 
+        HDINLINE FieldPosition()
+        {
+        }
+
         HDINLINE VectorVector2D3V operator()() const
         {
             const float2_X posB_x( 0.0, 0.5 );
@@ -120,6 +132,10 @@ namespace traits
         struct result<F()> {
             typedef VectorVector3D3V type;
         };
+
+        HDINLINE FieldPosition()
+        {
+        }
 
         HDINLINE VectorVector3D3V operator()() const
         {
@@ -160,6 +176,10 @@ namespace traits
         struct result<F()> {
             typedef ReturnType type;
         };
+
+        HDINLINE FieldPosition()
+        {
+        }
 
         HDINLINE ReturnType operator()() const
         {


### PR DESCRIPTION
Fixes clang(-tidy) errors of the kind [clang-diagnostic-error]:
"default initialization of an object of const type '...' without a user-provided default constructor":

First approach before discussion:
```C++
const typename Difference::template GetDifference<0> Dx;
// to
const typename Difference::template GetDifference<0> Dx{};
```

Final approach: add explicit constructors to POD classes that are used as `const`:
```C++
    struct GetDifference
    {
        static constexpr uint32_t direction = T_direction;

        HDINLINE GetDifference()
        {
        }
        // ...
    };
```