### PR TITLE
Fix Dead Code

### DIFF
--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -174,8 +174,6 @@ GridLayout< simDim> FieldE::getGridLayout( )
 
 void FieldE::laserManipulation( uint32_t currentStep )
 {
-    const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(currentStep);
-
     /* initialize the laser not in the first cell is equal to a negative shift
      * in time
      */
@@ -185,11 +183,16 @@ void FieldE::laserManipulation( uint32_t currentStep )
      * - we have periodic boundaries in Y direction or
      * - we already performed a slide
      */
-    if (
+    if(
         laserProfile::INIT_TIME == float_X(0.0) || /* laser is disabled e.g. laserNone */
         ( currentStep * DELTA_T  - laserTimeShift ) >= laserProfile::INIT_TIME ||
-        Environment<simDim>::get().GridController().getCommunicationMask( ).isSet( TOP ) || numSlides != 0
+        Environment<simDim>::get().GridController().getCommunicationMask( ).isSet( TOP )
     )
+    {
+        return;
+    }
+    const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(currentStep);
+    if( numSlides != 0 )
     {
         return;
     }

--- a/include/picongpu/fields/laserProfiles/laserGaussianBeam.hpp
+++ b/include/picongpu/fields/laserProfiles/laserGaussianBeam.hpp
@@ -187,7 +187,8 @@ namespace picongpu
                               / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * PULSE_LENGTH ) / ( float_X(2.0) * PULSE_LENGTH ) );
                 }
                 elong.z() *= etrans / etrans_norm;
-                phase -= float_X( PI / 2.0 );
+                // reminder: if you want to use phase below, substract pi/2
+                // phase -= float_X( PI / 2.0 );
             }
 
             return elong;

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -392,6 +392,7 @@ public:
             throw std::runtime_error(msg.str());
         }
 
+#if( PMACC_CUDA_ENABLED == 1 )
         size_t heapSize = freeGpuMem - reservedGpuMemorySize;
 
         if( Environment<>::get().MemoryInfo().isSharedMemoryPool() )
@@ -402,7 +403,6 @@ public:
         else
             log<picLog::MEMORY > ("RAM is NOT shared between GPU and host.");
 
-#if( PMACC_CUDA_ENABLED == 1 )
         // initializing the heap for particles
         deviceHeap->destructiveResize(heapSize);
         MallocMCBuffer<DeviceHeap>* mallocMCBuffer = new MallocMCBuffer<DeviceHeap>(deviceHeap);


### PR DESCRIPTION
Fix dead code and unused variables in scenarios such as:
- no laser or
- CPU only

found with clang-tidy, fixed manually.