### PR TITLE
Clang-Tidy

### DIFF
--- a/docs/source/dev/clangtools.rst
+++ b/docs/source/dev/clangtools.rst
@@ -1,0 +1,53 @@
+.. _development-clangtools:
+
+Clang Tools
+===========
+
+.. sectionauthor:: Axel Huebl
+
+We are currently integrating support for Clang Tools [ClangTools]_ such as ``clang-tidy`` and ``clang-format``.
+Clang Tools are fantastic for static source code analysis, e.g. to find defects, automate style formatting or modernize code.
+
+Install
+-------
+
+At least LLVM/Clang 3.9 or newer is required.
+On Debian/Ubuntu, install them via:
+
+
+.. code-block:: bash
+
+   sudo apt-get install clang-tidy-3.9
+
+Usage
+-----
+
+Currently, those tools work only with CPU backends of PIConGPU.
+For example, enable the *OpenMP* backend via:
+
+.. code-block:: bash
+
+   # in an example
+   mkdir .build
+   cd build
+
+   pic-configure -c"-DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON" ..
+
+We try to auto-detect ``clang-tidy``.
+If that fails, you can set a manual hint to an adequate version via ``-DCLANG_TIDY_BIN`` in CMake:
+
+.. code-block:: bash
+
+   pic-configure -c"-DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON -DCLANG_TIDY_BIN=$(which clang-tidy-3.9)" ..
+
+If a proper version of ``clang-tidy`` is found, we add a new ``clang-tidy`` build target:
+
+.. code-block:: bash
+
+   # enable verbose output to see all warnings and errors
+   make VERBOSE=true clang-tidy
+
+
+.. [ClangTools]
+        Online (2017), https://clang.llvm.org/docs/ClangTools.html
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,6 +96,7 @@ Development
    dev/styleguide
    dev/sphinx
    dev/doxygen
+   dev/clangtools
    dev/picongpu
    dev/pmacc
    dev/doxyindex

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -399,6 +399,54 @@ target_link_libraries(picongpu PUBLIC ${LIBS} picongpu-hostonly)
 
 
 ################################################################################
+# Clang-Tidy (3.9+) Target for CI
+################################################################################
+
+find_program(
+    CLANG_TIDY_BIN
+    clang-tidy
+    NAMES clang-tidy clang-tidy-3.9 clang-tidy-4.0
+    DOC "Path to clang-tidy in version 3.9 or newer"
+)
+execute_process(
+    COMMAND ${CLANG_TIDY_BIN} --version
+    RESULT_VARIABLE CLANG_TIDY_RETURN
+    OUTPUT_VARIABLE CLANG_TIDY_OUTPUT
+)
+if(${CLANG_TIDY_RETURN} EQUAL 0)
+    string(REGEX MATCH "[0-9]+(\\.[0-9]+)+"
+           CLANG_TIDY_VERSION ${CLANG_TIDY_OUTPUT})
+
+    if("${CLANG_TIDY_VERSION}" VERSION_GREATER_EQUAL "3.9.0")
+        get_directory_property(ALL_INCLUDES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} INCLUDE_DIRECTORIES)
+        get_directory_property(ALL_DEFINES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPILE_DEFINITIONS)
+        foreach(i ${ALL_INCLUDES})
+            list(APPEND ALL_INCLUDES_STR "-I${i}")
+        endforeach()
+        foreach(d ${ALL_DEFINES})
+            list(APPEND ALL_DEFINES_STR "-D${d}")
+        endforeach()
+
+        add_custom_target(
+            clang-tidy
+            COMMAND ${CLANG_TIDY_BIN}
+            ${SRCFILES} ${ACCSRCFILES}
+            -header-filter='.*'
+            -config=''
+            # -warnings-as-errors='*'
+            # -checks='-*,modernize-use-using'
+            # -fix # -fix-errors
+            --
+            -std=c++11
+            ${OpenMP_CXX_FLAGS}
+            ${ALL_INCLUDES_STR}
+            ${ALL_DEFINES_STR}
+        )
+    endif()
+endif()
+
+
+################################################################################
 # Install PIConGPU
 ################################################################################
 


### PR DESCRIPTION
Add a CMake target for clang-tidy. Can be used to check (or fix) code with e.g.:
```bash
cmake -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON ~/src/picongpu/include/picongpu/
make VERBOSE=true clang-tidy
```

or just any other PIConGPU example in the usual `pic-configure` and `make [install]` workflow.

Needs at least [clang-tidy 3.9](http://releases.llvm.org/3.9.0/tools/clang/tools/extra/docs/clang-tidy/index.html), otherwise it segfaults.

### To Do

- [x] add routines to find clang-tidy itself

also allows to set an explicit newer version in ubuntu/debian via
```bash
cmake -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON  \
      -DCLANG_TIDY_BIN=$(which clang-tidy-3.9) \
      ~/src/picongpu/include/picongpu/
```

### Future

- include in-source files but exclude external headers
- add `.clang-tidy` config file with set of checks we want to add on top of the defaults (see `clang-tidy-3.9 -list-checks -checks='*'`)
- integrate in CI (travis) #2341: https://github.com/ax3l/picongpu/commit/d2273089774a084766ae76bcf476b54a04d6ab83
- [modernization](https://www.kdab.com/clang-tidy-part-1-modernize-source-code-using-c11c14/) of the code (e.g. `typedef` to `using`) works with a relatively low error rate, we should do that (`-fix` and `-fix-errors` flags)
- [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [clang-check](https://clang.llvm.org/docs/ClangTools.html)
- I just [learned](https://www.reddit.com/r/cpp/comments/5b397d/what_c_linter_do_you_use/) that [CMake 3.6+](https://cmake.org/cmake/help/v3.6/release/3.6.html#properties) supports `<LANG>_CLANG_TIDY`. This makes integration a bit shorter but always runs the tool alongside the compiler when not explicitly disabled so we would need at least an option on top of:
```diff
-        add_custom_target(
-            clang-tidy
-            COMMAND ${CLANG_TIDY_BIN}
-            ${SRCFILES} ${ACCSRCFILES}
-            -header-filter='.*'
-            -config=''
-            # -checks='-*,modernize-use-using'
-            -fix # -fix-errors
-            --
-            -std=c++11
-            ${OpenMP_CXX_FLAGS}
-            ${ALL_INCLUDES_STR}
-            ${ALL_DEFINES_STR}
-        )
+        set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_BIN})
```
The var (and a CMake list of `clang-tidy` options) can also be set outside the CMake scripts.