### PR TITLE
KHI: Fix Build

### DIFF
--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
@@ -51,9 +51,9 @@ namespace particles
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
      *  unit: none */
-    const float_X MIN_WEIGHTING = 10.0;
+    constexpr float_X MIN_WEIGHTING = 10.0;
 
-    const uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
         startPosition::QuietParam::numParticlesPerDimension
     >::type::value;
 


### PR DESCRIPTION
Fix a missing constexpr in `particle.param`. Did fail to build on CPU builds (compile suite tests CUDA builds). Found last week with @psychocoderHPC 

Note: already exists in `0.3.0` but due to CUDA only, this is not problematic therein. Still, we can fix it there as well.