### PR TITLE
Fixes for python parameters 

### DIFF
--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -143,7 +143,7 @@ class UiParameter(Parameter):
         """
         Returns
         -------
-        A float cointaining the 'value' attribute.
+        A float containing the 'value' attribute.
         """
         return self.value
 
@@ -184,7 +184,7 @@ class LinearScaledParameter(UiParameter):
 
         Returns
         -------
-        A float cointaining the internal 'value' attribute after adjustment.
+        A float containing the internal 'value' attribute after adjustment.
         """
         self.value = x * self.scale_factor
         return self.value
@@ -237,7 +237,7 @@ class LogScaledParameter(Parameter):
 
         Returns
         -------
-        A float cointaining the internal 'value' attribute after adjustment.
+        A float containing the internal 'value' attribute after adjustment.
         """
 
         self.value = self.base ** x

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -30,9 +30,9 @@ PARAMETER_LIST = [
         slider_step=0.1),
 
     LinearScaledParameter(
-        name="Wave_Length_SI", ptype="compile", unit="m",
-        default=0.8, slider_min=0.4, slider_max=1400.1,
-        slider_step=0.1, scale_factor=1.e-6),
+        name="Wave_Length_SI", ptype="compile", unit="nm",
+        default=800, slider_min=400, slider_max=1400,
+        slider_step=1, scale_factor=1.e-9),
 
     LinearScaledParameter(
         name="Pulse_Length_SI", ptype="compile", unit="s",

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -35,7 +35,7 @@ PARAMETER_LIST = [
         slider_step=1, scale_factor=1.e-9),
 
     LinearScaledParameter(
-        name="Pulse_Length_SI", ptype="compile", unit="s",
+        name="Pulse_Length_SI", ptype="compile", unit="fs",
         default=5, slider_min=1, slider_max=150,
         slider_step=1, scale_factor=1.e-15),
 ]

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -30,12 +30,12 @@ PARAMETER_LIST = [
         slider_step=0.1),
 
     LinearScaledParameter(
-        name="Wave_Length_SI", ptype="compile", unit="nm",
+        name="Wave_Length_SI", ptype="compile", unit="m",
         default=800, slider_min=400, slider_max=1400,
         slider_step=1, scale_factor=1.e-9),
 
     LinearScaledParameter(
-        name="Pulse_Length_SI", ptype="compile", unit="fs",
+        name="Pulse_Length_SI", ptype="compile", unit="s",
         default=5, slider_min=1, slider_max=150,
         slider_step=1, scale_factor=1.e-15),
 ]


### PR DESCRIPTION
Just minor fixes of typos in documentation of parameter classes and the parameter range of Wave_Length_SI parameter of the LaserWakefield example.