### PR TITLE
Examples: C++11 Using for Typedef

### DIFF
--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/particle.param
@@ -24,6 +24,7 @@
 #include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
 
+
 namespace picongpu
 {
 
@@ -48,21 +49,22 @@ namespace startPosition
     };
 
     /* definition of random particle start */
-    typedef RandomImpl< RandomParameter > Random;
+    using Random = RandomImpl< RandomParameter >;
 
 
     struct QuietParameter
     {
         /** Count of particles per cell per direction at initial state
          *  unit: none */
-        typedef mCT::shrinkTo<mCT::Int<1, 1, 1>, simDim>::type numParticlesPerDimension;
+        using numParticlesPerDimension = typename mCT::shrinkTo<
+            mCT::Int< 1, 1, 1 >,
+            simDim
+        >::type;
     };
 
     /* definition of quiet particle start*/
-    typedef QuietImpl<QuietParameter> Quiet;
+    using Quiet = QuietImpl<QuietParameter>;
 
-} //namespace startPosition
-
-} //namespace particles
-
-} //namespace picongpu
+} // namespace startPosition
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -81,7 +81,7 @@ namespace particles
  *
  * the functors are called in order (from first to last functor)
  */
-typedef mpl::vector<
+using InitPipeline = mpl::vector<
     CreateDensity<
         densityProfiles::Foil,
         startPosition::Quiet,
@@ -92,7 +92,7 @@ typedef mpl::vector<
         startPosition::Random,
         PIC_Electrons
     >
-> InitPipeline;
+>;
 
 } /* namespace particles */
 } /* namespace picongpu  */

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/density.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/density.param
@@ -79,7 +79,7 @@ namespace densityProfiles
     ); /* struct GaussianCloudParam */
 
     /* definition of cloud profile */
-    typedef GaussianCloudImpl< GaussianCloudParam > GaussianCloud;
+    using GaussianCloud = GaussianCloudImpl< GaussianCloudParam >;
 
 
     struct FreeFormulaFunctor

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/species.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/species.param
@@ -40,12 +40,12 @@ namespace picongpu
  *  - particles::shapes::PCS : 3rd order
  *  - particles::shapes::P4S : 4th order
  *
- *  example:             typedef particles::shapes::CIC CICShape;
+ *  example:             using CICShape = particles::shapes::CIC
  */
-typedef particles::shapes::CIC UsedParticleShape;
+using UsedParticleShape = particles::shapes::CIC;
 
 /* define which interpolation method is used to interpolate fields to particle*/
-typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
+using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
 
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
@@ -57,7 +57,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  *   without optimization (~4x slower and needs more shared memory)
  * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS , P4S (1st to 4th order)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
 
 /*! particle pusher configuration ----------------------------------------------
  *
@@ -74,6 +74,6 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
  * (= free stream model)
  * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
-typedef particles::pusher::Boris UsedParticlePusher;
+using UsedParticlePusher = particles::pusher::Boris;
 
-}//namespace picongpu
+} // namespace picongpu

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -81,7 +81,7 @@ namespace particles
  *
  * the functors are called in order (from first to last functor)
  */
-typedef mpl::vector<
+using InitPipeline = mpl::vector<
 #ifdef PARAM_SINGLE_PARTICLE
     CreateDensity<
         densityProfiles::FreeFormula,
@@ -99,7 +99,7 @@ typedef mpl::vector<
         manipulators::AssignYDriftNegative,
         PIC_Electrons
     >
-> InitPipeline;
+>;
 
 } /* namespace particles */
 } /* namespace picongpu  */

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/density.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/density.param
@@ -41,6 +41,6 @@ namespace SI
 namespace densityProfiles
 {
     /* definition of homogenous profile */
-    typedef HomogenousImpl Homogenous;
+    using Homogenous = HomogenousImpl;
 }
 }

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/memory.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/memory.param
@@ -17,11 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
+
 
 namespace picongpu
 {
@@ -34,15 +34,18 @@ namespace picongpu
 constexpr size_t reservedGpuMemorySize = 400 *1024*1024;
 
 /* short namespace*/
-namespace mCT=pmacc::math::CT;
+namespace mCT = pmacc::math::CT;
 /** size of a superCell
  *
  * volume of a superCell must be <= 1024
  */
-typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+using SuperCellSize = typename mCT::shrinkTo<
+    mCT::Int< 8, 8, 4 >,
+    simDim
+>::type;
 
 /** define the object for mapping superCells to cells*/
-typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
+using MappingDesc = MappingDescription< simDim, SuperCellSize >;
 
 constexpr uint32_t GUARD_SIZE = 1;
 
@@ -76,4 +79,4 @@ constexpr uint32_t fieldTmpNumSlots = 1;
  */
 constexpr bool fieldTmpSupportGatherCommunication = true;
 
-}//namespace picongpu
+} // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
@@ -40,7 +40,7 @@ namespace particles
         {
             /** Count of particles per cell per direction at initial state
              *  unit: none */
-           using numParticlesPerDimension = mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type;
+           using numParticlesPerDimension = typename mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type;
         };
 
         /* definition of quiet particle start */

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/species.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/species.param
@@ -17,8 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/algorithms/FieldToParticleInterpolationNative.hpp"
@@ -39,15 +37,15 @@ namespace picongpu
  *  - particles::shapes::PCS : 3rd order
  *  - particles::shapes::P4S : 4th order
  *
- *  example:             typedef particles::shapes::CIC CICShape;
+ *  example:             using CICShape = particles::shapes::CIC;
  */
 #ifndef PARAM_PARTICLESHAPE
 #define PARAM_PARTICLESHAPE TSC
 #endif
-typedef particles::shapes::PARAM_PARTICLESHAPE UsedParticleShape;
+using UsedParticleShape = particles::shapes::PARAM_PARTICLESHAPE;
 
 /* define which interpolation method is used to interpolate fields to particle*/
-typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
+using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
 
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
@@ -62,7 +60,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 #ifndef PARAM_CURRENTSOLVER
 #define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>
 #endif
-typedef currentSolver::PARAM_CURRENTSOLVER UsedParticleCurrentSolver;
+using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER;
 
 /*! particle pusher configuration ----------------------------------------------
  *
@@ -79,6 +77,6 @@ typedef currentSolver::PARAM_CURRENTSOLVER UsedParticleCurrentSolver;
  * (= free stream model)
  * - particles::pusher::Photon : propagate with c in direction of normalized mom.
  */
-typedef particles::pusher::Boris UsedParticlePusher;
+using UsedParticlePusher = particles::pusher::Boris;
 
-}//namespace picongpu
+} // namespace picongpu

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/density.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/density.param
@@ -79,6 +79,6 @@ namespace densityProfiles
     ); /* struct GaussianParam */
 
     /* definition of density with Gaussian profile */
-    typedef GaussianImpl< GaussianParameter > Gaussian;
+    using Gaussian = GaussianImpl< GaussianParameter >;
 }
 }

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/particle.param
@@ -59,7 +59,10 @@ struct QuietParameter
 {
     /** Count of particles per cell per direction at initial state
      *  unit: none */
-    using numParticlesPerDimension = mCT::shrinkTo<mCT::Int<1, TYPICAL_PARTICLES_PER_CELL, 1>, simDim>::type;
+    using numParticlesPerDimension = typename mCT::shrinkTo<
+        mCT::Int< 1, TYPICAL_PARTICLES_PER_CELL, 1 >,
+        simDim
+    >::type;
 };
 
 /* definition of quiet particle start*/

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/species.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/species.param
@@ -39,15 +39,15 @@ namespace picongpu
  *  - particles::shapes::PCS : 3rd order
  *  - particles::shapes::P4S : 4th order
  *
- *  example:             typedef particles::shapes::CIC CICShape;
+ *  example:             using CICShape = particles::shapes::CIC;
  */
 #ifndef PARAM_PARTICLESHAPE
 #define PARAM_PARTICLESHAPE TSC
 #endif
-typedef particles::shapes::PARAM_PARTICLESHAPE UsedParticleShape;
+using UsedParticleShape = particles::shapes::PARAM_PARTICLESHAPE;
 
 /* define which interpolation method is used to interpolate fields to particle*/
-typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
+using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
 
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
@@ -62,7 +62,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
 #ifndef PARAM_CURRENTSOLVER
 #define PARAM_CURRENTSOLVER Esirkepov
 #endif
-typedef currentSolver::PARAM_CURRENTSOLVER<UsedParticleShape> UsedParticleCurrentSolver;
+using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER< UsedParticleShape >;
 
 /*! particle pusher configuration ----------------------------------------------
  *
@@ -82,6 +82,6 @@ typedef currentSolver::PARAM_CURRENTSOLVER<UsedParticleShape> UsedParticleCurren
 #ifndef PARAM_PARTICLEPUSHER
 #define PARAM_PARTICLEPUSHER Boris
 #endif
-typedef particles::pusher::PARAM_PARTICLEPUSHER UsedParticlePusher;
+using UsedParticlePusher = particles::pusher::PARAM_PARTICLEPUSHER;
 
 }//namespace picongpu

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -81,7 +81,7 @@ namespace particles
  *
  * the functors are called in order (from first to last functor)
  */
-typedef mpl::vector<
+using InitPipeline = mpl::vector<
 #if( PARAM_IONIZATION == 0 )
 
     CreateDensity<densityProfiles::Gaussian, startPosition::Random, PIC_Electrons>
@@ -95,7 +95,7 @@ typedef mpl::vector<
     Manipulate<manipulators::SetBoundElectrons, PIC_Ions>
 
 #endif
-> InitPipeline;
+>;
 
 } /* namespace particles */
 } /* namespace picongpu  */

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/fileOutput.param
@@ -96,7 +96,7 @@ namespace picongpu
     /** FileOutputParticles: Groups all Species that shall be dumped **********
      *
      * hint: to disable particle output set to
-     *   typedef bmpl::vector0< > FileOutputParticles;
+     *   using FileOutputParticles = bmpl::vector0< >;
      */
     using FileOutputParticles = VectorAllSpecies;
 

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/species.param
@@ -40,12 +40,12 @@ namespace picongpu
  *  - particles::shapes::PCS : 3rd order
  *  - particles::shapes::P4S : 4th order
  *
- *  example:             typedef particles::shapes::CIC CICShape;
+ *  example:             using CICShape = particles::shapes::CIC;
  */
-typedef particles::shapes::CIC UsedParticleShape;
+using UsedParticleShape = particles::shapes::CIC;
 
 /* define which interpolation method is used to interpolate fields to particle*/
-typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation> UsedField2Particle;
+using UsedField2Particle = FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation>;
 
 /*! select current solver method -----------------------------------------------
  * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
@@ -57,7 +57,7 @@ typedef FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpo
  *   without optimization (~4x slower and needs more shared memory)
  * - currentSolver::ZigZag<SHAPE>     : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  */
-typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
+using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
 /*! particle pusher configuration ----------------------------------------------
  *
@@ -77,6 +77,6 @@ typedef currentSolver::Esirkepov<UsedParticleShape> UsedParticleCurrentSolver;
 #ifndef PARAM_PARTICLEPUSHER
 #define PARAM_PARTICLEPUSHER Boris
 #endif
-typedef particles::pusher::PARAM_PARTICLEPUSHER UsedParticlePusher;
+using UsedParticlePusher = particles::pusher::PARAM_PARTICLEPUSHER;
 
-}//namespace picongpu
+} // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
@@ -208,8 +208,8 @@ private:
 
     container::HostBuffer<float, 2 >* eField_zt[2];
 
-    typedef pmacc::math::CT::Size_t < 16, 16, 1 > BlockDim;
-    typedef SuperCellSize GuardDim;
+    using BlockDim = pmacc::math::CT::Size_t < 16, 16, 1 >;
+    using GuardDim = SuperCellSize;
 };
 
 } // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/density.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/density.param
@@ -41,6 +41,6 @@ namespace SI
 namespace densityProfiles
 {
     /* definition of homogenous density profile */
-    typedef HomogenousImpl Homogenous;
+    using Homogenous = HomogenousImpl;
 }
 }

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/memory.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/memory.param
@@ -17,11 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
+
 
 namespace picongpu
 {
@@ -34,15 +34,18 @@ namespace picongpu
 constexpr size_t reservedGpuMemorySize = 350 *1024*1024;
 
 /* short namespace*/
-namespace mCT=pmacc::math::CT;
+namespace mCT = pmacc::math::CT;
 /** size of a superCell
  *
  * volume of a superCell must be <= 1024
  */
-typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+using SuperCellSize = typename mCT::shrinkTo<
+    mCT::Int< 8, 8, 4 >,
+    simDim
+>::type;
 
 /** define the object for mapping superCells to cells*/
-typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
+using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 
 constexpr uint32_t GUARD_SIZE = 1;
 
@@ -76,4 +79,4 @@ constexpr uint32_t fieldTmpNumSlots = 1;
  */
 constexpr bool fieldTmpSupportGatherCommunication = true;
 
-}//namespace picongpu
+} // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -81,7 +81,7 @@ namespace particles
  *
  * the functors are called in order (from first to last functor)
  */
-typedef mpl::vector<
+using InitPipeline = mpl::vector<
     CreateDensity<
         densityProfiles::Homogenous,
         startPosition::Random,
@@ -100,7 +100,7 @@ typedef mpl::vector<
         manipulators::AddTemperature,
         PIC_Ions
     >
-> InitPipeline;
+>;
 
 } /* namespace particles */
 } /* namespace picongpu  */

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/unitless/starter.unitless
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/unitless/starter.unitless
@@ -17,8 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/plugins/PluginController.hpp"
@@ -31,14 +29,12 @@ namespace picongpu
 {
     using namespace pmacc;
 
-
     namespace thermalTestStarter
     {
-        typedef ::picongpu::SimulationStarter
-        <
-        ::picongpu::InitialiserController,
-        ::picongpu::PluginController,
-        ::picongpu::ThermalTestSimulation
-        > SimStarter;
+        using SimStarter = ::picongpu::SimulationStarter<
+            ::picongpu::InitialiserController,
+            ::picongpu::PluginController,
+            ::picongpu::ThermalTestSimulation
+        >;
     }
 }

--- a/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/particle.param
@@ -92,17 +92,20 @@ namespace startPosition
         static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
     };
     /* definition of random particle start */
-    typedef RandomImpl< RandomParameter > Random;
+    using Random = RandomImpl< RandomParameter >;
 
     struct QuietParam
     {
         /** Count of particles per cell per direction at initial state
          *  unit: none */
-       typedef mCT::shrinkTo< mCT::Int< 1, TYPICAL_PARTICLES_PER_CELL, 1 >, simDim >::type numParticlesPerDimension;
+        using numParticlesPerDimension = typename mCT::shrinkTo<
+            mCT::Int< 1, TYPICAL_PARTICLES_PER_CELL, 1 >,
+            simDim
+        >::type;
     };
 
     /* definition of quiet particle start */
-    typedef QuietImpl< QuietParam > Quiet;
+    using Quiet = QuietImpl< QuietParam >;
 
 } //namespace startPosition
 } //namespace particles

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/density.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/density.param
@@ -41,6 +41,6 @@ namespace SI
 namespace densityProfiles
 {
     /* definition of homogenous density profile */
-    typedef HomogenousImpl Homogenous;
+    using Homogenous = HomogenousImpl;
 }
 }

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/memory.param
@@ -34,15 +34,18 @@ namespace picongpu
 constexpr size_t reservedGpuMemorySize = 400 *1024*1024;
 
 /* short namespace*/
-namespace mCT=pmacc::math::CT;
+namespace mCT = pmacc::math::CT;
 /** size of a superCell
  *
  * volume of a superCell must be <= 1024
  */
-typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
+using SuperCellSize = typename mCT::shrinkTo<
+    mCT::Int< 8, 8, 4 >,
+    simDim
+>::type;
 
 /** define the object for mapping superCells to cells*/
-typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
+using MappingDesc = MappingDescription< simDim, SuperCellSize >;
 constexpr uint32_t GUARD_SIZE = 1;
 
 /** bytes reserved for species exchange buffer
@@ -75,4 +78,4 @@ constexpr uint32_t fieldTmpNumSlots = 1;
  */
 constexpr bool fieldTmpSupportGatherCommunication = true;
 
-}//namespace picongpu
+} // namespace picongpu

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/particle.param
@@ -54,7 +54,7 @@ namespace manipulators
         const DriftParamElectrons_direction_t direction;
     };
     /* definition of SetDrift start*/
-    using AssignZDriftElectrons = unary::Drift<DriftParamElectrons,nvidia::functors::Assign>;
+    using AssignZDriftElectrons = unary::Drift< DriftParamElectrons,nvidia::functors::Assign >;
 
     CONST_VECTOR(float_X,3,DriftParamIons_direction,0.0,0.0,-1.0);
     struct DriftParamIons
@@ -67,7 +67,7 @@ namespace manipulators
         const DriftParamIons_direction_t direction;
     };
     /* definition of SetDrift start*/
-    using AssignZDriftIons = unary::Drift<DriftParamIons,nvidia::functors::Assign>;
+    using AssignZDriftIons = unary::Drift< DriftParamIons,nvidia::functors::Assign >;
 
     struct TemperatureParam
     {
@@ -89,11 +89,14 @@ namespace startPosition
     {
         /** Count of particles per cell per direction at initial state
          *  unit: none */
-       using numParticlesPerDimension = mCT::shrinkTo<mCT::Int<TYPICAL_PARTICLES_PER_CELL/2, TYPICAL_PARTICLES_PER_CELL/2, 1>, simDim>::type;
+        using numParticlesPerDimension = mCT::shrinkTo<
+            mCT::Int< TYPICAL_PARTICLES_PER_CELL / 2, TYPICAL_PARTICLES_PER_CELL / 2, 1 >,
+            simDim
+        >::type;
     };
 
     /* definition of quiet particle start */
-    using Quiet = QuietImpl<QuietParam>;
+    using Quiet = QuietImpl< QuietParam >;
 
 } //namespace startPosition
 } //namespace particles

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -81,7 +81,7 @@ namespace particles
  *
  * the functors are called in order (from first to last functor)
  */
-typedef mpl::vector<
+using InitPipeline = mpl::vector<
     CreateDensity<
         densityProfiles::Homogenous,
         startPosition::Quiet,
@@ -109,7 +109,7 @@ typedef mpl::vector<
         manipulators::AddTemperature,
         PIC_Electrons
     >
-> InitPipeline;
+>;
 
 } /* namespace particles */
 } /* namespace picongpu  */


### PR DESCRIPTION
replace `typedef` in examples with modern C++11 `using`. Commited as tools user.

Also added missing `typenames` where `::types` are taken from templated classes.