### PR TITLE
pic-compile: make cmakeFlags optional

### DIFF
--- a/pic-compile
+++ b/pic-compile
@@ -99,7 +99,8 @@ do
         example_name=`basename $examples_path`
     fi
 
-    testFlag_cnt=0
+    # the default is 1 to allow examples without the file `cmakeFlags`
+    testFlag_cnt=1
     if [ -f "$examples_path/$i/cmakeFlags" ]; then
         testFlag_cnt=`$examples_path/$i/cmakeFlags -l`
     fi

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/memory.param
@@ -45,12 +45,22 @@ typedef mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type SuperCellSize;
 typedef MappingDescription<simDim, SuperCellSize> MappingDesc;
 constexpr uint32_t GUARD_SIZE = 1;
 
-//! how many bytes for buffer is reserved to communication in one direction
-constexpr uint32_t BYTES_EXCHANGE_X = 8 * 256 * 1024; //8 MiB
-constexpr uint32_t BYTES_EXCHANGE_Y = 12 * 512 * 1024; //12 MiB
-constexpr uint32_t BYTES_EXCHANGE_Z = 256 * 256 * 1024; //256 MiB
-constexpr uint32_t BYTES_CORNER = 2 * 256 * 1024; //2 MiB
-constexpr uint32_t BYTES_EDGES = 8 * 256 * 1024; //8 MiB
+/** bytes reserved for species exchange buffer
+ *
+ * This is the default configuration for species exchanges buffer sizes.
+ * The default exchange buffer sizes can be changed per species by adding
+ * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
+ * to its flag list.
+ */
+struct DefaultExchangeMemCfg
+{
+    // memory used for a direction
+    static constexpr uint32_t BYTES_EXCHANGE_X = 4 * 1024 * 1024; // 4 MiB
+    static constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 1024 * 1024; // 6 MiB
+    static constexpr uint32_t BYTES_EXCHANGE_Z = 64 * 1024 * 1024; // 64 MiB
+    static constexpr uint32_t BYTES_EDGES = 2 * 1024 * 1024; // 2 MiB
+    static constexpr uint32_t BYTES_CORNER = 512 * 1024; // 512 kiB
+};
 
 /** number of scalar fields that are reserved as temporary fields */
 constexpr uint32_t fieldTmpNumSlots = 1;


### PR DESCRIPTION
Since #2243 the cmakeFlags file for examples without user params is removed.
`pic-compile` used the wrong default value and assumed that `cmakeFlags` is always setting the correct number of test cases within an example.

- fix pic-compile
- `WeibelTransverse` test: add `DefaultExchangeMemCfg` to `memory.param`