### PR TITLE
Push with currentStep

### DIFF
--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -96,7 +96,7 @@ public:
 
     void createParticleBuffer();
 
-    void update(uint32_t currentStep);
+    void update( uint32_t const currentStep );
 
     template<typename T_DensityFunctor, typename T_PositionFunctor>
     void initDensityProfile(T_DensityFunctor& densityFunctor, T_PositionFunctor& positionFunctor, const uint32_t currentStep);

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -408,6 +408,7 @@ struct KernelMoveAndMarkParticles
         T_ParBox pb,
         T_EBox fieldE,
         T_BBox fieldB,
+        uint32_t const currentStep,
         T_ParticleFunctor particleFunctor,
         T_Mapping mapper
     ) const
@@ -527,6 +528,7 @@ struct KernelMoveAndMarkParticles
                             linearIdx,
                             cachedB,
                             cachedE,
+                            currentStep,
                             mustShift
                         );
                     }
@@ -564,7 +566,15 @@ struct PushParticlePerFrame
 {
 
     template<class FrameType, class BoxB, class BoxE, typename T_Acc >
-    DINLINE void operator()(T_Acc const & acc, FrameType& frame, int localIdx, BoxB& bBox, BoxE& eBox, int& mustShift)
+    DINLINE void operator()(
+        T_Acc const & acc,
+        FrameType& frame,
+        int localIdx,
+        BoxB& bBox,
+        BoxE& eBox,
+        uint32_t const currentStep,
+        int& mustShift
+    )
     {
 
         typedef TVec Block;
@@ -598,8 +608,9 @@ struct PushParticlePerFrame
              mom,
              mass,
              attribute::getCharge(weighting,particle),
-             weighting
-             );
+             weighting,
+             currentStep
+        );
         particle[momentum_] = mom;
 
 

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -217,7 +217,7 @@ Particles<
     T_Name,
     T_Flags,
     T_Attributes
->::update(uint32_t )
+>::update( uint32_t const currentStep )
 {
     using PusherAlias = typename GetFlagType<FrameType,particlePusher<> >::type;
     using ParticlePush = typename pmacc::traits::Resolve<PusherAlias>::type;
@@ -271,6 +271,7 @@ Particles<
         this->getDeviceParticlesBox( ),
         fieldE->getDeviceDataBox( ),
         fieldB->getDeviceDataBox( ),
+        currentStep,
         FrameSolver( ),
         mapper
     );

--- a/include/picongpu/particles/pusher/particlePusherAxel.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAxel.hpp
@@ -69,7 +69,8 @@ namespace picongpu
                 T_Mom& mom, /* at t=-1/2 */
                 const T_Mass mass,
                 const T_Charge charge,
-                const T_Weighting
+                const T_Weighting,
+                const uint32_t
             )
             {
                 typedef T_Mom MomType;

--- a/include/picongpu/particles/pusher/particlePusherBoris.hpp
+++ b/include/picongpu/particles/pusher/particlePusherBoris.hpp
@@ -46,7 +46,8 @@ struct Push
         T_Mom& mom,
         const T_Mass mass,
         const T_Charge charge,
-        const T_Weighting
+        const T_Weighting,
+        const uint32_t
     )
     {
         typedef T_Mom MomType;

--- a/include/picongpu/particles/pusher/particlePusherFree.hpp
+++ b/include/picongpu/particles/pusher/particlePusherFree.hpp
@@ -45,7 +45,8 @@ namespace picongpu
                 T_Mom& mom,
                 const T_Mass mass,
                 const T_Charge,
-                const T_Weighting
+                const T_Weighting,
+                const uint32_t
             )
             {
                 typedef T_Mom MomType;

--- a/include/picongpu/particles/pusher/particlePusherPhoton.hpp
+++ b/include/picongpu/particles/pusher/particlePusherPhoton.hpp
@@ -45,7 +45,8 @@ namespace picongpu
                 T_Mom& mom,
                 const T_Mass,
                 const T_Charge,
-                const T_Weighting
+                const T_Weighting,
+                const uint32_t
             )
             {
                 typedef T_Mom MomType;

--- a/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -59,7 +59,8 @@ struct Push
     T_Mom& mom, /* at t=-1/2 */
     const T_Mass mass,
     const T_Charge charge,
-    const T_Weighting weighting
+    const T_Weighting weighting,
+    const uint32_t
   )
   {
     typedef T_FunctorFieldB TypeBFieldFunctor;

--- a/include/picongpu/particles/pusher/particlePusherVay.hpp
+++ b/include/picongpu/particles/pusher/particlePusherVay.hpp
@@ -46,7 +46,8 @@ struct Push
         T_Mom& mom, /* at t=-1/2 */
         const T_Mass mass,
         const T_Charge charge,
-        const  T_Weighting
+        const  T_Weighting,
+        const uint32_t
     )
     {
         typedef T_Mom MomType;


### PR DESCRIPTION
Forward the current step for the species update through `KernelMoveAndMarkParticles` and `PushParticlePerFrame` to the particle pushers.

### Performance Implications

- in most pushers, a useless parameter for the current time step will be moved to the device on kernel start (latency that can be hidden)
- according to k3diff, the unused parameter was optimized out by the compiler (tested with CUDA 8) and no additional registers or cmem is used compared to the current `dev`

[compile_dev.txt](https://github.com/ComputationalRadiationPhysics/picongpu/files/1402600/compile_dev.txt)
[compile_PR.txt](https://github.com/ComputationalRadiationPhysics/picongpu/files/1402601/compile_PR.txt)

cc @steindev @PrometheusPi 