### PR TITLE
fix usage of uninitialized variable

### DIFF
--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -63,7 +63,7 @@ struct CalorimeterFunctor
                        const float3_X calorimeterFrameVecX,
                        const float3_X calorimeterFrameVecY,
                        const float3_X calorimeterFrameVecZ) :
-        calorimeterCur(nullptr, pmacc::math::Size_t<DIM2>()),
+        calorimeterCur(nullptr, pmacc::math::Size_t<DIM2>::create(0)),
         maxYaw(maxYaw),
         maxPitch(maxPitch),
         numBinsYaw(numBinsYaw),


### PR DESCRIPTION
fix #2307

`CalorimeterFunctor`: set pitch size to zero to initilize the BufferCursor

I can't reproduce #2307 but this PR should fix it