### PR TITLE
Isaac plugin using current device instead of the first device

### DIFF
--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -384,9 +384,9 @@ private:
 
             isaac_for_each_params( sources, SourceInitIterator(), cellDescription, movingWindow );
 
-                visualization = new VisualizationType (
-                cupla::manager::Device< cupla::AccHost >::get().device( ),
-                cupla::manager::Device< cupla::AccDev >::get().device( ),
+            visualization = new VisualizationType (
+                cupla::manager::Device< cupla::AccHost >::get().current( ),
+                cupla::manager::Device< cupla::AccDev >::get().current( ),
                 cupla::manager::Stream< cupla::AccDev, cupla::AccStream >::get().stream( ),
                 name,
                 0,


### PR DESCRIPTION
On nodes with more than one GPU, the isaac plugin did always
use the first device, which resulted in "all CUDA-capable devices are
busy or unavailable" errors.