### PR TITLE
pic-configure: cmakeFlags return code

### DIFF
--- a/pic-configure
+++ b/pic-configure
@@ -134,6 +134,11 @@ fi
 # check for cmakeFlags file (interprete with sh)
 if [ -f "$extension_param/cmakeFlags" ] ; then
     cmake_flags=$($extension_param/cmakeFlags $cmakeFlagsNr)
+    if [ $? -ne 0 ] ; then
+        echo "ERROR: Executing '$extension_param/cmakeFlags' failed!" >&2
+        echo "       Is the file executable? (chmod u+x cmakeFlags)" >&2
+        exit 2
+    fi
 fi
 
 # set default install path if no path is set by paramater


### PR DESCRIPTION
Cleanly abort if `cmakeFlags` exist but could not be successfully executed. Error will properly be forwarded to `pic-build`.

This can e.g. happen due to
- a wrongly selected case
- a newly created file with missing +x rights

Example (return-code 4):
```bash
$ pic-build
build directory: .build
/home/axel/src/picongpu/pic-configure: line 136: ../cmakeFlags: Permission denied
ERROR: Executing '../cmakeFlags' failed!
       Is the file executable? (chmod u+x cmakeFlags)
```

first noted by @n01r 