### PR TITLE
LWFA Example: Restore a0=8.0

### DIFF
--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/laser.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/laser.param
@@ -22,7 +22,7 @@
 #pragma once
 
 #ifndef PARAM_A0
-#   define PARAM_A0 1.5
+#   define PARAM_A0 8.0
 #endif
 
 #ifndef PARAM_WAVE_LENGTH_SI


### PR DESCRIPTION
restore the default laser strength of 8.0 in the LWFA example. Follow-up to the unintentional change introduced in #2289.

ccing @codingS3b @theZiz 