### PR TITLE
Wrong border with current background field

### DIFF
--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -308,7 +308,7 @@ public:
             dc.share( std::shared_ptr< ISimulationData >( newFld ) );
         }
         pushBGField = new cellwiseOperation::CellwiseOperation < CORE + BORDER + GUARD > (*cellDescription);
-        currentBGField = new cellwiseOperation::CellwiseOperation < CORE + BORDER + GUARD > (*cellDescription);
+        currentBGField = new cellwiseOperation::CellwiseOperation < CORE + BORDER > (*cellDescription);
 
         // Initialize random number generator and synchrotron functions, if there are synchrotron or bremsstrahlung Photons
         typedef typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies,
@@ -776,7 +776,7 @@ protected:
     fieldSolver::CurrentInterpolation* myCurrentInterpolation;
 
     cellwiseOperation::CellwiseOperation< CORE + BORDER + GUARD >* pushBGField;
-    cellwiseOperation::CellwiseOperation< CORE + BORDER + GUARD >* currentBGField;
+    cellwiseOperation::CellwiseOperation< CORE + BORDER >* currentBGField;
 
     LaserPhysics *laser;
 


### PR DESCRIPTION
fix #943

If field background is used than the border regions will be wrong.
The field background current is operationg on the local domain regions
`CORE + BORDER + GUARD`. The current is than scattered to the neighboring GPUs
and will create wrong border regions.

- operate background field current only on the region `CORE + BORDER`
- fix `cellwiseOperation` - index passed to the user functor was only correct if `CORE+GUARD + BORDER` was manipulated

With this fix current smoothing is still possible. **Attention** FieldJ is not part of the checkpointing #2325

~~do not merge, there is a wrong index calculation in `cellwiseOperation.hpp`~~

CC-ing: @steindev 