### PR TITLE
Doc: $PIC_EXAMPLES

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -115,6 +115,7 @@ PIConGPU Source Code
 - *environment*:
 
   - ``export PICSRC=$PICHOME/src/picongpu``
+  - ``export PIC_EXAMPLES=$PICSRC/share/picongpu/examples``
   - ``export PATH=$PICSRC:$PATH``
   - ``export PATH=$PICSRC/src/tools/bin:$PATH``
   - ``export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH``

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -41,7 +41,7 @@ Step-by-Step
    :emphasize-lines: 2
 
    # clone the LWFA example to $HOME/picInputs/myLWFA
-   pic-create $PICSRC/share/picongpu/examples/LaserWakefield $HOME/picInputs/myLWFA
+   pic-create $PIC_EXAMPLES/LaserWakefield $HOME/picInputs/myLWFA
 
    # switch to your input directory
    cd $HOME/picInputs/myLWFA

--- a/etc/picongpu/draco-mpcdf/picongpu.profile.example
+++ b/etc/picongpu/draco-mpcdf/picongpu.profile.example
@@ -1,5 +1,7 @@
-# User Information ############################################################
-#   - edit those lines!
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
 #   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
@@ -7,12 +9,7 @@ export MY_MAILNOTIFY="ALL"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
-# Name and Path of this Script ################################################
-#   - do NOT change this line!
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-
-# Text Editor for Tools #######################################################
-#   - edit those lines!
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -47,6 +44,7 @@ export CC=$(which gcc)
 # PIConGPU Helper Variables ###################################################
 #
 export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:haswell"
 
 export PATH=$PATH:$PICSRC

--- a/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
+++ b/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
@@ -1,4 +1,14 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me mails on batch system job (b)egin, (e)nd, (a)bortion or (n)o mail
+export MY_MAILNOTIFY="n"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -36,13 +46,8 @@ fi
 alias getNode='qsub -I -q default -lwalltime=00:30:00 -lnodes=1:ppn=32'
 
 export PICSRC=/home/$(whoami)/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:ivybridge"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-export MY_MAILNOTIFY="n"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/splash2txt/build

--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -1,4 +1,14 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me mails on batch system job (b)egin, (e)nd, (a)bortion or (n)o mail
+export MY_MAILNOTIFY="n"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -37,13 +47,8 @@ alias getNode='qsub -I -q k20 -lwalltime=00:30:00 -lnodes=1:ppn=8'
 alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
 export PICSRC=/home/$(whoami)/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:35"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-export MY_MAILNOTIFY="n"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/splash2txt/build

--- a/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
@@ -1,4 +1,14 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me mails on batch system job (b)egin, (e)nd, (a)bortion or (n)o mail
+export MY_MAILNOTIFY="n"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -37,13 +47,8 @@ alias getNode='qsub -I -q k80 -lwalltime=00:30:00 -lnodes=1:ppn=16'
 alias getlaser='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=16'
 
 export PICSRC=/home/$(whoami)/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:37"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-export MY_MAILNOTIFY="n"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/splash2txt/build

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -1,4 +1,14 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me mails on batch system job (b)egin, (e)nd, (a)bortion or (n)o mail
+export MY_MAILNOTIFY="n"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -36,13 +46,8 @@ fi
 alias getNode='qsub -I -q laser -lwalltime=00:30:00 -lnodes=1:ppn=64'
 
 export PICSRC=/home/$(whoami)/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:bdver1"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
-export MY_MAILNOTIFY="n"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/splash2txt/build

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -1,4 +1,15 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -41,8 +52,8 @@ alias allocK20='salloc --time=0:30:00 --nodes=1 --ntasks-per-node=1 --cpus-per-t
 alias allocFermi='salloc --time=0:30:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task=6 --partition mako_manycore'
 
 export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:20"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # fix pic-create: re-enable rsync
 #   ssh lrc-xfer.scs00
@@ -54,12 +65,6 @@ export PATH=$PATH:$PICSRC/src/splash2txt/build
 export PATH=$PATH:$PICSRC/src/tools/bin
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
-
-# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -1,5 +1,7 @@
-# User Information ############################################################
-#   - edit those lines!
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
 #   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
@@ -7,12 +9,7 @@ export MY_MAILNOTIFY="ALL"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
-# Name and Path of this Script ################################################
-#   - do NOT change this line!
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-
-# Text Editor for Tools #######################################################
-#   - edit those lines!
+# Text Editor for Tools #################################### (edit those lines)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 # module load nano
 #export EDITOR="nano"
@@ -65,6 +62,7 @@ export CC=$(which cc)
 export CXX=$(which CC)
 
 export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:60"
 
 export PATH=$PATH:$PICSRC

--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -1,4 +1,15 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -42,19 +53,13 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/pngwriter/lib/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
 
 export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:35"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
-
-# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -1,4 +1,15 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -42,19 +53,13 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/pngwriter/lib/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
 
 export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:37"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
-
-# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -1,10 +1,17 @@
-# Text Editor for Tools #######################################################
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
-
-# "module" commands undefine $BASH_SOURCE on a KNL node for some unknown reason
-# so $PIC_PROFILE needs to be defined before using "module ...".
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 # General modules #############################################################
 #
@@ -16,25 +23,20 @@ module load intelmpi/2017.2.174
 # Compilers ###################################################################
 ### ICC
 module load intel/2017.2.174
-# Boost needs to be build yourself for now!
+# Boost needs to be build by yourself for now!
 # The boost root path needs to be adjusted.
-export BOOST_ROOT=<BOOST_INSTALLATION_DIR>
+export BOOST_ROOT=$HOME/lib/boost-1.62.0
 export LD_LIBRARY_PATH=$BOOST_ROOT:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 
 export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:MIC-AVX512"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
-
-# send me a mail on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
-export MY_MAIL="someone@example.com"
-export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)

--- a/etc/picongpu/titan-ornl/picongpu.profile.example
+++ b/etc/picongpu/titan-ornl/picongpu.profile.example
@@ -1,11 +1,18 @@
-export proj=<yourProject>
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on job (b)egin, (e)nd, (a)bortion or (n)o mail
 export MY_MAILNOTIFY="n"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
-# Text Editor for Tools #######################################################
+# Project Information ######################################## (edit this line)
+#   - project account for computing time
+export proj=<yourProject>
+
+# Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
@@ -86,8 +93,8 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGWRITER_ROOT/lib
 
 # helper variables and tools ##################################################
 export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:35"
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/src/tools/bin


### PR DESCRIPTION
Add a default installed `PIC_EXAMPLES` environment variable that eases to create new input from examples without struggling with long paths.

Also clean up header of profile examples on the way to be more intuitive:
- profile path first (sensitive to some system's module loads)
- name and mail notifications
- optional: computing project on some clusters
- optional: editor
- then all things that the user does not change in normal operation:
  - modules
  - required environment vars
  - defaults in batch system of this file

Also added to [spack package](https://github.com/ComputationalRadiationPhysics/spack-repo) (https://github.com/ComputationalRadiationPhysics/spack-repo/commit/9c05bba8158a31f3f7f233be634345c4cb37fd54) and will be available to users also in simplified docker file #2286.