### PR TITLE
Add upper energy cut-off to ThomasFermi model

### DIFF
--- a/docs/source/models/collisional_ionization.rst
+++ b/docs/source/models/collisional_ionization.rst
@@ -14,7 +14,7 @@ Get started here https://github.com/ComputationalRadiationPhysics/picongpu/wiki/
 
 The implementation of the Thomas-Fermi model takes the following input quantities.
 
-- Ion proton number :math:`Z`
+- ion proton number :math:`Z`
 - ion species mass density :math:`\rho`
 - electron "temperature" :math:`T`
 

--- a/docs/source/models/collisional_ionization.rst
+++ b/docs/source/models/collisional_ionization.rst
@@ -12,15 +12,28 @@ Implemented LTE Model: Thomas-Fermi Ionization according to [More1985]_
 
 Get started here https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Ionization-in-PIConGPU
 
+The implementation of the Thomas-Fermi model takes the following input quantities.
+
+- Ion proton number :math:`Z`
+- ion species mass density :math:`\rho`
+- electron "temperature" :math:`T`
+
+Due to the nature of our simulated setups it is also used in non-equilibrium situations.
+We therefore implemented additional conditions to mediate unphysical behavior but introduce arbitrariness.
+
+1. Super-thermal electron cutoff
+
+    We calculate the temperature according to :math:`T_\mathrm{e} = \frac{2}{3} E_\mathrm{kin, e}` in units of electron volts.
+    We thereby assume an *ideal electron gas*.
+    Via the variable ``CUTOFF_MAX_ENERGY_KEV`` in ``ionizer.param`` the user can exclude electrons with kinetic energy above this value from average energy calculation.
+    That is motivated by a lower interaction cross section of particles with high relative velocities.
+
 NLTE Models
 -----------
 
 .. moduleauthor:: Axel Huebl
 
 in development
-
-References
-----------
 
 .. [More1985]
         R. M. More.

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -98,6 +98,13 @@ namespace ionization
 
         BlockArea BlockDescription;
 
+        /* parameter class containing the energy cutoff parameter for electron temperature calculation */
+        struct CutoffMaxEnergy
+        {
+            static constexpr float_X cutoff_max_energy =
+                particles::ionization::thomasFermi::CUTOFF_MAX_ENERGY;
+        };
+
         private:
 
             /* define ionization ALGORITHM (calculation) for ionization MODEL */
@@ -129,12 +136,15 @@ namespace ionization
              */
             using DensitySolver = typename particleToGrid::CreateDensityOperation<T_SrcSpecies>::type::Solver;
 
-            /** Solver for energy density of the electron species with energy cutoff
+            /** Solver for energy density of the electron species with maximum energy cutoff
              *
              *  @todo Include all electron species with a ForEach<VectorallSpecies,...>
              * instead of just the destination species
              */
-            using EnergyDensitySolver = typename particleToGrid::CreateEnergyDensityCutoffOperation<T_DestSpecies>::type::Solver;
+            using EnergyDensitySolver = typename particleToGrid::CreateEnergyDensityCutoffOperation<
+                T_DestSpecies,
+                CutoffMaxEnergy
+            >::type::Solver;
 
 
 

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -129,12 +129,12 @@ namespace ionization
              */
             using DensitySolver = typename particleToGrid::CreateDensityOperation<T_SrcSpecies>::type::Solver;
 
-            /** Solver for energy density of the electron species
+            /** Solver for energy density of the electron species with energy cutoff
              *
              *  @todo Include all electron species with a ForEach<VectorallSpecies,...>
              * instead of just the destination species
              */
-            using EnergyDensitySolver = typename particleToGrid::CreateEnergyDensityOperation<T_DestSpecies>::type::Solver;
+            using EnergyDensitySolver = typename particleToGrid::CreateEnergyDensityCutoffOperation<T_DestSpecies>::type::Solver;
 
 
 

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -101,7 +101,7 @@ namespace ionization
         /* parameter class containing the energy cutoff parameter for electron temperature calculation */
         struct CutoffMaxEnergy
         {
-            static constexpr float_X cutoff_max_energy =
+            static constexpr float_X cutoffMaxEnergy =
                 particles::ionization::thomasFermi::CUTOFF_MAX_ENERGY;
         };
 

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -1,4 +1,5 @@
-/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -259,6 +260,34 @@ struct CreateEnergyDensityOperation
     > ParticleEnergyDensity;
 
     typedef FieldTmpOperation< ParticleEnergyDensity, T_Species > type;
+};
+
+/** Energy Density Operation with Energy Cut-Off for Particle to Grid Projections
+ *
+ * Derives a scalar field for average kinetic particle energy per cell times the
+ * particle density from a particle species at runtime.
+ * Each value is mapped per cell according to the species' spatial shape.
+ *
+ * @note Only energies below a user-definable cut-off energy are taken for
+ *       calculation!
+ *
+ * @tparam T_Species a @see picongpu::Particles class with a species definition,
+ *                   see @see speciesDefinition.param
+ *
+ * @typedef CreateEnergyDensityOperation< T_Species >::type
+ *          a field that can be used in @see fileOutput.param
+ *          @see picongpu::FileOutputFields
+ */
+template<typename T_Species>
+struct CreateEnergyDensityCutoffOperation
+{
+    typedef typename GetShape<T_Species>::type shapeType;
+    typedef ComputeGridValuePerFrame<
+        shapeType,
+        particleToGrid::derivedAttributes::EnergyDensityCutoff
+    > ParticleEnergyDensityCutoff;
+
+    typedef FieldTmpOperation< ParticleEnergyDensityCutoff, T_Species > type;
 };
 
 /** Kinetic Energy Operation for Particle to Grid Projections

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -262,7 +262,7 @@ struct CreateEnergyDensityOperation
     typedef FieldTmpOperation< ParticleEnergyDensity, T_Species > type;
 };
 
-/** Energy Density Operation with Energy Cut-Off for Particle to Grid Projections
+/** Energy Density Operation with Maxmimum Energy Cut-Off for Particle to Grid Projections
  *
  * Derives a scalar field for average kinetic particle energy per cell times the
  * particle density from a particle species at runtime.
@@ -274,17 +274,17 @@ struct CreateEnergyDensityOperation
  * @tparam T_Species a @see picongpu::Particles class with a species definition,
  *                   see @see speciesDefinition.param
  *
- * @typedef CreateEnergyDensityOperation< T_Species >::type
+ * @typedef CreateEnergyDensityCutoffOperation< T_Species >::type
  *          a field that can be used in @see fileOutput.param
  *          @see picongpu::FileOutputFields
  */
-template<typename T_Species>
+template<typename T_Species, typename T_ParamClass>
 struct CreateEnergyDensityCutoffOperation
 {
     typedef typename GetShape<T_Species>::type shapeType;
     typedef ComputeGridValuePerFrame<
         shapeType,
-        particleToGrid::derivedAttributes::EnergyDensityCutoff
+        particleToGrid::derivedAttributes::EnergyDensityCutoff< T_ParamClass >
     > ParticleEnergyDensityCutoff;
 
     typedef FieldTmpOperation< ParticleEnergyDensityCutoff, T_Species > type;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -25,6 +25,7 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/Energy.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def"

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -25,6 +25,7 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/Energy.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp"

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
@@ -1,0 +1,80 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
+#include <vector>
+
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    struct EnergyDensityCutoff
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::vector<float_64>
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * EnergyDensityCutoff is in Joule / cubic meter: J / m^3 = kg * m^2 / s^2 / m^3
+            *                                                  = kg / (s^2 * m)
+            *   -> L^-1 * M * T^-2
+            */
+           std::vector<float_64> unitDimension( 7, 0.0 );
+           unitDimension.at(SIBaseUnits::length) = -1.0;
+           unitDimension.at(SIBaseUnits::mass)   =  1.0;
+           unitDimension.at(SIBaseUnits::time)   = -2.0;
+
+           return unitDimension;
+        }
+
+        HINLINE std::string
+        getName() const
+        {
+            return "energyDensityCutoff";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * \tparam T_Particle particle in the frame
+         * \param particle particle in the frame
+         *
+         * \return new attribute for the particle (type \see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
@@ -36,7 +36,7 @@ namespace derivedAttributes
      *
      * @tparam T_ParamClass parameter class containing the maximum energy cutoff
      *
-     * Note: `T_ParamClass` requires the member `float_X constexpr cutoffMaxEnergy`.
+     * Note: `T_ParamClass` requires the member `constexpr float_X cutoffMaxEnergy`.
      */
     template< typename T_ParamClass >
     struct EnergyDensityCutoff : public EnergyDensity

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
@@ -23,6 +23,8 @@
 #include "picongpu/traits/SIBaseUnits.hpp"
 #include <vector>
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def"
+
 
 namespace picongpu
 {
@@ -30,28 +32,13 @@ namespace particleToGrid
 {
 namespace derivedAttributes
 {
-    struct EnergyDensityCutoff
+    /* Inherits from the `EnergyDensity` derived attribute
+     *
+     * \tparam T_ParamClass parameter class containing the maximum energy cutoff
+     */
+    template< typename T_ParamClass >
+    struct EnergyDensityCutoff : public EnergyDensity
     {
-
-        HDINLINE float1_64
-        getUnit() const;
-
-        HINLINE std::vector<float_64>
-        getUnitDimension() const
-        {
-           /* L, M, T, I, theta, N, J
-            *
-            * EnergyDensityCutoff is in Joule / cubic meter: J / m^3 = kg * m^2 / s^2 / m^3
-            *                                                  = kg / (s^2 * m)
-            *   -> L^-1 * M * T^-2
-            */
-           std::vector<float_64> unitDimension( 7, 0.0 );
-           unitDimension.at(SIBaseUnits::length) = -1.0;
-           unitDimension.at(SIBaseUnits::mass)   =  1.0;
-           unitDimension.at(SIBaseUnits::time)   = -2.0;
-
-           return unitDimension;
-        }
 
         HINLINE std::string
         getName() const

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
@@ -32,9 +32,11 @@ namespace particleToGrid
 {
 namespace derivedAttributes
 {
-    /* Inherits from the `EnergyDensity` derived attribute
+    /** Inherits from the `EnergyDensity` derived attribute
      *
-     * \tparam T_ParamClass parameter class containing the maximum energy cutoff
+     * @tparam T_ParamClass parameter class containing the maximum energy cutoff
+     *
+     * Note: `T_ParamClass` requires the member `float_X constexpr cutoffMaxEnergy`.
      */
     template< typename T_ParamClass >
     struct EnergyDensityCutoff : public EnergyDensity
@@ -53,15 +55,15 @@ namespace derivedAttributes
          * This method is called on a per-thread basis (each thread of a block
          * handles a particle of a frame).
          *
-         * \tparam T_Particle particle in the frame
-         * \param particle particle in the frame
+         * @tparam T_Particle particle in the frame
+         * @param particle particle in the frame
          *
-         * \return new attribute for the particle (type \see T_AttributeType)
+         * @return new attribute for the particle (type @see T_AttributeType)
          */
         template< class T_Particle >
         DINLINE float_X
         operator()( T_Particle& particle ) const;
     };
-} /* namespace derivedAttributes */
-} /* namespace particleToGrid */
-} /* namespace picongpu */
+} // namespace derivedAttributes
+} // namespace particleToGrid
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
@@ -57,10 +57,11 @@ namespace derivedAttributes
             mass
         );
 
+        float_X result( 0. );
         if( kinEnergy < cutoff )
-            return kinEnergy * INV_CELL_VOLUME;
+            result =  kinEnergy * INV_CELL_VOLUME;
 
-        return float_X( 0. );
+        return result;
     }
 } /* namespace derivedAttributes */
 } /* namespace particleToGrid */

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2013-2017 Axel Huebl, Rene Widera, Heiko Burau, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def"
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/algorithms/KinEnergy.hpp"
+
+namespace picongpu
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    EnergyDensityCutoff::getUnit() const
+    {
+        constexpr float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
+        return UNIT_ENERGY / UNIT_VOLUME;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    EnergyDensityCutoff::operator()( T_Particle& particle ) const
+    {
+        /* read existing attributes */
+        const float_X weighting = particle[weighting_];
+        const float3_X mom = particle[momentum_];
+        const float_X mass = attribute::getMass( weighting, particle );
+
+        constexpr float_X INV_CELL_VOLUME = float_X(1.0) / CELL_VOLUME;
+
+        /* value for energy cut-off */
+        constexpr float_X cutoff_energy = particles::ionization::thomasFermi::TF_CUTOFF_ENERGY;
+        float_X const cutoff = cutoff_energy / UNIT_ENERGY * weighting;
+
+        float_X const kinEnergy = KinEnergy<>()( mom, mass );
+
+        if (kinEnergy < cutoff)
+            return kinEnergy * INV_CELL_VOLUME;
+
+        return float_X(0.);
+    }
+} /* namespace derivedAttributes */
+} /* namespace particleToGrid */
+} /* namespace picongpu */

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
@@ -31,17 +31,13 @@ namespace particleToGrid
 namespace derivedAttributes
 {
 
-    HDINLINE float1_64
-    EnergyDensityCutoff::getUnit() const
-    {
-        constexpr float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
-        return UNIT_ENERGY / UNIT_VOLUME;
-    }
-
+    template< class T_ParamClass >
     template< class T_Particle >
     DINLINE float_X
-    EnergyDensityCutoff::operator()( T_Particle& particle ) const
+    EnergyDensityCutoff< T_ParamClass >::operator()( T_Particle& particle ) const
     {
+        using ParamClass =  T_ParamClass;
+
         /* read existing attributes */
         const float_X weighting = particle[weighting_];
         const float3_X mom = particle[momentum_];
@@ -50,8 +46,8 @@ namespace derivedAttributes
         constexpr float_X INV_CELL_VOLUME = float_X(1.0) / CELL_VOLUME;
 
         /* value for energy cut-off */
-        constexpr float_X cutoff_energy = particles::ionization::thomasFermi::TF_CUTOFF_ENERGY;
-        float_X const cutoff = cutoff_energy / UNIT_ENERGY * weighting;
+        float_X const cutoff_max_energy = ParamClass::cutoff_max_energy;
+        float_X const cutoff = cutoff_max_energy / UNIT_ENERGY * weighting;
 
         float_X const kinEnergy = KinEnergy<>()( mom, mass );
 

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
@@ -39,22 +39,28 @@ namespace derivedAttributes
         using ParamClass =  T_ParamClass;
 
         /* read existing attributes */
-        const float_X weighting = particle[weighting_];
-        const float3_X mom = particle[momentum_];
-        const float_X mass = attribute::getMass( weighting, particle );
+        float_X const weighting = particle[ weighting_ ];
+        float3_X const mom = particle[ momentum_ ];
+        float_X const mass = attribute::getMass(
+            weighting,
+            particle
+        );
 
-        constexpr float_X INV_CELL_VOLUME = float_X(1.0) / CELL_VOLUME;
+        constexpr float_X INV_CELL_VOLUME = float_X( 1.0 ) / CELL_VOLUME;
 
         /* value for energy cut-off */
-        float_X const cutoff_max_energy = ParamClass::cutoff_max_energy;
-        float_X const cutoff = cutoff_max_energy / UNIT_ENERGY * weighting;
+        float_X const cutoffMaxEnergy = ParamClass::cutoffMaxEnergy;
+        float_X const cutoff = cutoffMaxEnergy / UNIT_ENERGY * weighting;
 
-        float_X const kinEnergy = KinEnergy<>()( mom, mass );
+        float_X const kinEnergy = KinEnergy< >( )(
+            mom,
+            mass
+        );
 
-        if (kinEnergy < cutoff)
+        if( kinEnergy < cutoff )
             return kinEnergy * INV_CELL_VOLUME;
 
-        return float_X(0.);
+        return float_X( 0. );
     }
 } /* namespace derivedAttributes */
 } /* namespace particleToGrid */

--- a/include/picongpu/simulation_defines/param/ionizer.param
+++ b/include/picongpu/simulation_defines/param/ionizer.param
@@ -423,6 +423,20 @@ namespace thomasFermi
     constexpr float_X TFC1    = -0.366667;
     constexpr float_X TFC2    =  0.983333;
 
+    /** cutoff energy for electron "temperature" calculation
+     *
+     * In laser produced plasmas we can have different, well-separable groups
+     * of electrons. For the Thomas-Fermi ionization model we only want the
+     * thermalized "bulk" electrons. Including the high-energy "prompt"
+     * is physically questionable since they do not have a large cross section
+     * for collisional ionization.
+     *
+     * unit: keV
+     */
+    constexpr float_X CUTOFF_ENERGY_KEV = 50;
+    /** cutoff energy for electron "temperature" calculation in SI units*/
+    constexpr float_X TF_CUTOFF_ENERGY = CUTOFF_ENERGY_KEV * UNITCONV_keV_to_Joule;
+
 } // namespace thomasFermi
 } // namespace ionization
 } // namespace particles

--- a/include/picongpu/simulation_defines/param/ionizer.param
+++ b/include/picongpu/simulation_defines/param/ionizer.param
@@ -428,14 +428,14 @@ namespace thomasFermi
      * In laser produced plasmas we can have different, well-separable groups
      * of electrons. For the Thomas-Fermi ionization model we only want the
      * thermalized "bulk" electrons. Including the high-energy "prompt"
-     * is physically questionable since they do not have a large cross section
-     * for collisional ionization.
+     * electrons is physically questionable since they do not have a large
+     * cross section for collisional ionization.
      *
      * unit: keV
      */
-    constexpr float_X CUTOFF_ENERGY_KEV = 50;
+    constexpr float_X CUTOFF_MAX_ENERGY_KEV = 50.0;
     /** cutoff energy for electron "temperature" calculation in SI units*/
-    constexpr float_X TF_CUTOFF_ENERGY = CUTOFF_ENERGY_KEV * UNITCONV_keV_to_Joule;
+    constexpr float_X CUTOFF_MAX_ENERGY = CUTOFF_MAX_ENERGY_KEV * UNITCONV_keV_to_Joule;
 
 } // namespace thomasFermi
 } // namespace ionization


### PR DESCRIPTION
Separate bulk from prompt electrons by defining an energy cut-off.
Above this threshold value electrons are classified as "prompt" electrons
and are therefore neglected in the calculation of electron temperature.

The actual cut-off value is highly debated, see [Kemp, Sentoku](http://link.aps.org/doi/10.1103/PhysRevLett.116.159501).

This is one of 4 planned improvements of the `ThomasFermi` implementation.

A test with a directed stream of electrons has shown that if the electrons have energies higher than the cut-off they will not be considered for the "temperature" calculation.
The test features a 2-dimensional 256 x 256 grid with period boundaries in every direction and about 6 copper ions distributed in every cell.
The ions are preionized once and electrons are derived from them.
There are three test setups:
1. electron temperature of 0 eV
2. electron temperature of 100 eV
3. electron temperature of 0 eV and drift of 200 keV
An energy cut-off of 50 keV has been configured.

The results show that in case 1 and 2 the predicted charge state matches the one reached in the simulation.
The TF model predicts an initial charge state for copper at density 8.92 g/cm³ and T_e = 0 eV of 4+.
Case 3 performs exactly as case 1 until the fast electrons distribute some of their energy to the cold electrons and TF ionization continues.

~~- [ ] Perform a more advanced test with disabled current deposition and a velocity gradient that depends on the cell index perpendicular to the stream direction   
Thereby redistribution of electron energies is avoided and we should see the cut-off spatially in a jump of ion charge state / electron density~~
**update 2017-11-07**   
A simple test has been done and it shows that the implementation works *BUT* a more detailed test will be relocated to the issue #1967.

Expectation:
 
![04_high_energy_cutoff_gradient_test_expectation](https://user-images.githubusercontent.com/5416860/32005476-ac7e575e-b9a4-11e7-9bae-66361864ce46.png)

- [x] Add documentation to the `/docs` in the TF section

cc'ing @HighIander 

This PR closes #1967 .