### PR TITLE
add support for CUDA9 `__shfl_snyc`

### DIFF
--- a/include/pmacc/nvidia/atomic.hpp
+++ b/include/pmacc/nvidia/atomic.hpp
@@ -97,7 +97,7 @@ namespace nvidia
                 /* Get the start value for this warp */
                 if (laneId == leader)
                     result = ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc,ptr, static_cast<T_Type>(__popc(mask)), hierarchy);
-                result = warpBroadcast(result, leader);
+                result = warpBroadcast(result, leader, static_cast< uint32_t >(mask));
                 /* Add offset per thread */
                 return result + static_cast<T_Type>(__popc(mask & ((1 << laneId) - 1)));
             }

--- a/include/pmacc/nvidia/warp.hpp
+++ b/include/pmacc/nvidia/warp.hpp
@@ -44,63 +44,69 @@ DINLINE uint32_t getLaneId()
 }
 #endif
 
-/** broadcast data within a thread
+
+#if (__CUDA_ARCH__ >= 300)
+/** broadcast data within a warp
  *
  * required PTX ISA >=3.0
+ *
+ * @param data value to broadcast
+ * @param srcLaneId lane id of the source thread
+ * @param laneMask lane mask with participating thread
+ * @return value send by the source thread
+ *
+ * \{
  */
-#if (__CUDA_ARCH__ >= 300)
-DINLINE int32_t warpBroadcast(const int32_t data, const int32_t srcLaneId)
+//! broadcast a 32bit integer
+DINLINE int32_t warpBroadcast(const int32_t data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
 {
+#if(__CUDACC_VER_MAJOR__ >= 9)
+    return  __shfl_sync(laneMask, data, srcLaneId);
+#else
     return  __shfl(data, srcLaneId);
+#endif
 }
-/**
- * Broadcast a 64bit integer by using 2 32bit broadcasts
- */
-DINLINE int64_cu warpBroadcast(int64_cu data, const int32_t srcLaneId)
+
+//! Broadcast a 64bit integer by using 2 32bit broadcasts
+DINLINE int64_cu warpBroadcast(int64_cu data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
 {
     int32_t* const pData = reinterpret_cast<int32_t*>(&data);
     pData[0] = warpBroadcast(pData[0], srcLaneId);
     pData[1] = warpBroadcast(pData[1], srcLaneId);
     return data;
 }
-/**
- * Broadcast a 32bit unsigned int
- * Maps to signed int function with no additional overhead
- */
-DINLINE uint32_t warpBroadcast(const uint32_t data, const int32_t srcLaneId)
+
+//! Broadcast a 32bit unsigned int
+DINLINE uint32_t warpBroadcast(const uint32_t data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
 {
     return static_cast<uint32_t>(
-            warpBroadcast(static_cast<int32_t>(data), srcLaneId)
-            );
-}
-/**
- * Broadcast a 64bit unsigned int
- * Maps to signed int function with no additional overhead
- */
-DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId)
-{
-    return static_cast<uint64_cu>(
-            warpBroadcast(static_cast<int64_cu>(data), srcLaneId)
-            );
+        warpBroadcast(static_cast<int32_t>(data), srcLaneId)
+    );
 }
 
-/**
- * Broadcast a 32bit float
- */
-DINLINE float warpBroadcast(const float data, const int32_t srcLaneId)
+//!Broadcast a 64bit unsigned int
+DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
+{
+    return static_cast<uint64_cu>(
+        warpBroadcast(static_cast<int64_cu>(data), srcLaneId)
+    );
+}
+
+//! Broadcast a 32bit float
+DINLINE float warpBroadcast(const float data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
 {
     return  __shfl(data, srcLaneId);
 }
-/**
- * Broadcast a 64bit float by using 2 32bit broadcasts
- */
-DINLINE double warpBroadcast(double data, const int32_t srcLaneId)
+
+//! Broadcast a 64bit float by using 2 32bit broadcasts
+DINLINE double warpBroadcast(double data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
 {
     float* const pData = reinterpret_cast<float*>(&data);
     pData[0] = warpBroadcast(pData[0], srcLaneId);
     pData[1] = warpBroadcast(pData[1], srcLaneId);
     return data;
 }
+//! @}
 #endif
 
 } //namespace nvidia


### PR DESCRIPTION
With CUDA9 the function `__shfl` should not be used anymore, instead function `__shfl_sync` should be used.

- use `__shfl_sync` with CUDA9
- add parameter `laneMask` to `warpBroadcast`
- add documentation to `warpBroadcastwarpBroadcast`

This PR removes the CUDA9 warning `cuda_9_0/include/sm_30_intrinsics.hpp(152): here was declared deprecated ("__shfl() is not valid on compute_70 and above, and should be replaced with __shfl_sync().To continue using __shfl(), specify virtual architecture compute_60 when targe`