### PR TITLE
LWFA: GUI .cfg & Additional Parameters

### DIFF
--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -7,6 +7,7 @@ License: GPLv3+
 """
 
 import numpy as np
+import inspect
 
 
 class Parameter(object):
@@ -68,8 +69,16 @@ class Parameter(object):
         --------
         A dictionary with the member variables as (key, value) pairs.
         """
+        d = dict(
+            cls=type(self).__name__,
+            name=self.name,
+            type=self.type,
+            unit=self.unit,
+            default=self.default,
+            value=self.value,
+            dtype=self.dtype.__name__)
 
-        return self.__dict__
+        return d
 
     def macro_name(self):
         """
@@ -175,8 +184,10 @@ class UiParameter(Parameter):
         """
 
         members = super(UiParameter, self).as_dict()
-        del members["formatter"]
-        del members["dtype"]
+        members["label"] = self.label
+        members["formatter"] = str(inspect.getsourcelines(self.formatter)[
+                                   0]).strip("['\\n']").split(" = ")[1]
+
         return members
 
 

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -6,7 +6,7 @@ Authors: Sebastian Starke, Jeffrey Kelling
 License: GPLv3+
 """
 
-from numpy import log10
+import numpy as np
 
 
 class Parameter(object):
@@ -14,7 +14,7 @@ class Parameter(object):
     Base class for exposable parameters.
     """
 
-    def __init__(self, name, ptype, unit, default, value=None):
+    def __init__(self, name, ptype, unit, default, value=None, dtype=None):
         """
         Parameters
         ----------
@@ -31,6 +31,9 @@ class Parameter(object):
         value: float (optional)
             The value of the parameter object. If it is not provided, the value
             of the 'default' argument is used.
+        dtype: type (optional)
+            The data type of the parameter value. If it is not provided, the
+            type of the 'default' argument is used.
         """
         self.name = name
         self.type = ptype  # decides if compile time or runtime parameter
@@ -38,6 +41,7 @@ class Parameter(object):
         self.default = default
 
         self.value = value if value is not None else default
+        self.dtype = dtype if dtype is not None else type(default)
 
     def __str__(self):
         """
@@ -101,7 +105,8 @@ class UiParameter(Parameter):
     """
 
     def __init__(self, name, ptype, unit, default, slider_min, slider_max,
-                 slider_step, value=None):
+                 slider_step, label=None, formatter=None,
+                 value=None, dtype=None):
         """
         Parameters
         ----------
@@ -113,14 +118,27 @@ class UiParameter(Parameter):
             The maximal value of the slider widget
         slider_step: float
             The stepsize when adjusting the slider
+        label: string [optional]
+            Overwrite the name for UI
+        formatter: function or lambda of form f(x) -> string [optional]
+            representation of the current value for UI
 
         """
-        Parameter.__init__(self, name, ptype, unit, default, value)
+        Parameter.__init__(self, name, ptype, unit, default, value, dtype)
 
         # for slider widget creation
         self.min = slider_min
         self.max = slider_max
         self.step = slider_step
+
+        if label is None:
+            self.label = name
+        else:
+            self.label = label
+        if formatter is None:
+            self.formatter = lambda x: str(x)
+        else:
+            self.formatter = formatter
 
     def set_value(self, x):
         """
@@ -136,8 +154,8 @@ class UiParameter(Parameter):
         A float containing the updated 'value' attribute. Is printed
         below the slider-widget for user-feedback.
         """
-        self.value = x
-        return self.value
+        self.value = self.dtype(x)
+        return self.formatter(self.value)
 
     def get_value(self):
         """
@@ -147,6 +165,20 @@ class UiParameter(Parameter):
         """
         return self.value
 
+    def as_dict(self):
+        """
+        Convert Parameter object into a plain dictionary
+
+        Returns
+        --------
+        A dictionary with the member variables as (key, value) pairs.
+        """
+
+        members = super(UiParameter, self).as_dict()
+        del members["formatter"]
+        del members["dtype"]
+        return members
+
 
 class LinearScaledParameter(UiParameter):
     """
@@ -155,7 +187,8 @@ class LinearScaledParameter(UiParameter):
     """
 
     def __init__(self, name, ptype, unit, default, slider_min, slider_max,
-                 slider_step, scale_factor=1.0, value=None):
+                 slider_step, scale_factor=1.0, label=None, formatter=None,
+                 value=None, dtype=None):
         """
         Parameters
         ----------
@@ -166,7 +199,8 @@ class LinearScaledParameter(UiParameter):
             internal value.
         """
         UiParameter.__init__(self, name, ptype, unit, default,
-                             slider_min, slider_max, slider_step, value)
+                             slider_min, slider_max, slider_step,
+                             label, formatter, value, dtype)
 
         self.scale_factor = scale_factor
 
@@ -186,8 +220,8 @@ class LinearScaledParameter(UiParameter):
         -------
         A float containing the internal 'value' attribute after adjustment.
         """
-        self.value = x * self.scale_factor
-        return self.value
+        self.value = self.dtype(x * self.scale_factor)
+        return self.formatter(self.value)
 
     def get_value(self):
         """
@@ -198,17 +232,18 @@ class LinearScaledParameter(UiParameter):
         This is the inverse computation of the linear scaling procedure.
         Overrides the base class method.
         """
-        return self.value / self.scale_factor
+        return float(self.value) / self.scale_factor
 
 
-class LogScaledParameter(Parameter):
+class LogScaledParameter(UiParameter):
     """
     Parameter that can be displayed in jupyter notebooks but whose internal
     'value' is computed from a power transformation of the slider values.
     """
 
     def __init__(self, name, ptype, unit, default, slider_min, slider_max,
-                 slider_step, base, value=None):
+                 slider_step, base, label=None, formatter=None,
+                 value=None, dtype=None):
         """
         Parameters
         ----------
@@ -219,7 +254,8 @@ class LogScaledParameter(Parameter):
             the internal 'value'.
         """
         UiParameter.__init__(self, name, ptype, unit, default,
-                             slider_min, slider_max, slider_step, value)
+                             slider_min, slider_max, slider_step,
+                             label, formatter, value, dtype)
 
         self.base = float(base)
 
@@ -240,8 +276,8 @@ class LogScaledParameter(Parameter):
         A float containing the internal 'value' attribute after adjustment.
         """
 
-        self.value = self.base ** x
-        return self.value
+        self.value = self.dtype(self.base ** x)
+        return self.formatter(self.value)
 
     def get_value(self):
         """
@@ -255,4 +291,4 @@ class LogScaledParameter(Parameter):
         # want to return log_b(v)
         # which is identical to log_10(v) / log_10(b)
         # by logarithmic law.
-        return log10(self.value) / log10(self.base)
+        return np.log10(float(self.value)) / np.log10(self.base)

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0004gpus_gui.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0004gpus_gui.cfg
@@ -1,0 +1,86 @@
+# Copyright 2013-2017 Axel Huebl, Rene Widera, Felix Schmitt
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="1:00:00"
+
+TBG_gpu_x=1
+TBG_gpu_y=4
+TBG_gpu_z=1
+
+TBG_gridSize="128 512 128"
+TBG_steps="10000"
+TBG_movingWindow="-m"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+TBG_plugin_period="100"
+
+# png image output (electron density)
+TBG_pngYX="--e_png.period !TBG_plugin_period --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+TBG_pngYZ="--e_png.period !TBG_plugin_period --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
+
+# Create a particle-energy histogram [in keV] per species for every .period steps
+TBG_e_histogram="--e_energyHistogram.period !TBG_plugin_period --e_energyHistogram.binCount 1024 \
+                 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 100000"
+
+# Calculate a 2D phase space
+# - requires parallel libSplash for HDF5 output
+# - momentum range in m_<species> c
+TBG_e_PSxpx="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space x --e_phaseSpace.momentum px --e_phaseSpace.min -8.0 --e_phaseSpace.max 8.0"
+TBG_e_PSypy="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space y --e_phaseSpace.momentum py --e_phaseSpace.min  0.0 --e_phaseSpace.max 1.0"
+TBG_e_PSzpz="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space z --e_phaseSpace.momentum pz --e_phaseSpace.min -2.0 --e_phaseSpace.max 2.0"
+
+TBG_plugins="!TBG_pngYX                    \
+             !TBG_pngYZ                    \
+             !TBG_e_histogram              \
+             !TBG_e_PSxpx !TBG_e_PSypy !TBG_e_PSzpz"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_devices="!TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+
+TBG_programParams="-d !TBG_devices   \
+                   -g !TBG_gridSize  \
+                   -s !TBG_steps     \
+                   !TBG_movingWindow \
+                   !TBG_plugins      \
+                   --versionOnce"
+
+# TOTAL number of GPUs
+TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+
+"$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -18,12 +18,13 @@ they need to be at least of class UiParameter (or inherited).
 
 from picongpu.input.parameters import LogScaledParameter, LinearScaledParameter
 
-dt=1.39e-4
+pico = 1.e-12
+dt_r = 1. / 1.39e-16 * pico
 
 PARAMETER_LIST = [
     LogScaledParameter(
         name="Base_Density_SI", ptype="compile", unit="1/m^3",
-        default=25, slider_min=20, slider_max=26,
+        default=25.0, slider_min=20.0, slider_max=26.0,
         slider_step=1, base=10),
 
     LinearScaledParameter(
@@ -32,17 +33,18 @@ PARAMETER_LIST = [
         slider_step=0.1),
 
     LinearScaledParameter(
-        name="Wave_Length_SI", ptype="compile", unit="m",
-        default=800, slider_min=400, slider_max=1400,
+        name="Wave_Length_SI", ptype="compile", unit="nm",
+        default=800.0, slider_min=400.0, slider_max=1400.0,
         slider_step=1, scale_factor=1.e-9),
 
     LinearScaledParameter(
-        name="Pulse_Length_SI", ptype="compile", unit="s",
-        default=5, slider_min=1, slider_max=150,
+        name="Pulse_Length_SI", ptype="compile", unit="fs",
+        default=5.0, slider_min=1.0, slider_max=150.0,
         slider_step=1, scale_factor=1.e-15),
 
     LinearScaledParameter(
-        name="TBG_steps", ptype="run", unit="",
-        default=10000, slider_min=1000, slider_max=50000,
-        slider_step=1000, scale_factor=1.0),
+        name="TBG_steps", ptype="run", unit="ps",
+        default=1.0, slider_min=0.1, slider_max=10.0,
+        slider_step=0.1, scale_factor=dt_r, dtype=int,
+        label="simulation time")
 ]

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -18,6 +18,8 @@ they need to be at least of class UiParameter (or inherited).
 
 from picongpu.input.parameters import LogScaledParameter, LinearScaledParameter
 
+dt=1.39e-4
+
 PARAMETER_LIST = [
     LogScaledParameter(
         name="Base_Density_SI", ptype="compile", unit="1/m^3",
@@ -38,4 +40,9 @@ PARAMETER_LIST = [
         name="Pulse_Length_SI", ptype="compile", unit="s",
         default=5, slider_min=1, slider_max=150,
         slider_step=1, scale_factor=1.e-15),
+
+    LinearScaledParameter(
+        name="TBG_steps", ptype="run", unit="",
+        default=10000, slider_min=1000, slider_max=50000,
+        slider_step=1000, scale_factor=1.0),
 ]


### PR DESCRIPTION
#### Add to python input `Parameter` class

- dtype: data type of the PIConGPU value
- label: UI label instead of name
- formatter: UI value label instead of name

### New cfg for GUI: `0004gpus_gui.cfg`

 - make more easily modifiable with `tbg -o`:
   - steps
   - grid size
   - devices
- expose TBG_steps properly as integers.
- all plugins dump in same interval: `TBG_plugin_period`
- add histogram, second cut in PNG and phase space