### PR TITLE
Travis: Stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-language: cpp
+language: none
 sudo: false
 dist: trusty
 
 cache:
   apt: true
   directories:
-    - $HOME/.cache
+    - $HOME/.cache/spack
+  pip: true
 
 addons:
   apt:
@@ -14,21 +15,18 @@ addons:
     packages:
       - g++-4.9
       - gfortran-4.9  # spack OpenMPI dependency
-      - python-flake8
       - environment-modules
       - openmpi-bin
       - libopenmpi-dev
+      # clang 3.9.0 is pre-installed
+      # - clang-3.9  # 3.9.1-4ubuntu3~14.04.3
+      # - clang-tidy-3.9
 
 env:
   global:
     - SPACK_ROOT: $HOME/.cache/spack
     - PATH: $PATH:$HOME/.cache/spack/bin
-
-before_install:
-  - export CXX=g++-4.9
-  - export CC=gcc-4.9
-  - export FC=gfortran-4.9
-  - export CXXFLAGS="-std=c++11"
+    - CXXFLAGS: "-std=c++11"
 
 install:
   #############################################################################
@@ -40,61 +38,96 @@ install:
       git clone --depth 50 https://github.com/llnl/spack.git $SPACK_ROOT &&
       echo -e "config:""\n  build_jobs:"" 2" > $SPACK_ROOT/etc/spack/config.yaml;
     fi
-  - travis_wait spack install cmake@3.7.2~openssl~ncurses
-  - travis_wait spack install boost@1.62.0~date_time~graph~iostreams~locale~log~random~thread~timer~wave
+  - spack compiler add
+  - travis_wait spack install
+      cmake@3.7.2~openssl~ncurses
+      $COMPILERSPEC
+  - travis_wait spack install
+      boost@1.62.0~date_time~graph~iostreams~locale~log~random~thread~timer~wave
+      $COMPILERSPEC
   - spack clean -a
   - source /etc/profile &&
     source $SPACK_ROOT/share/spack/setup-env.sh
-  - spack load cmake
-  - spack load boost
+  - spack load cmake $COMPILERSPEC
+  - spack load boost $COMPILERSPEC
 
-before_script:
-  #############################################################################
-  # Disallow PRs to `ComputationalRadiationPhysics/picongpu` branch `master`  #
-  # if not an other mainline branch such as `dev` or `release-...`            #
-  #############################################################################
-  - . test/correctBranchPR
+jobs:
+  fast_finish: true
+  include:
+    - stage: 'Target Branch'
+      install: skip
+      script:
+        #############################################################################
+        # Disallow PRs to `ComputationalRadiationPhysics/picongpu` branch `master`  #
+        # if not an other mainline branch such as `dev` or `release-...`            #
+        #############################################################################
+        - . test/correctBranchPR
+    - &style-python
+      stage: 'Style'
+      language: python
+      python: "2.7"
+      install: pip install -U flake8
+      script:
+        #############################################################################
+        # Test Python Files for PEP8 conformance                                    #
+        #############################################################################
+        - flake8 --exclude=thirdParty .
+    - <<: *style-python
+      python: "3.6"
+    - install: skip
+      language: cpp
+      script:
+        #############################################################################
+        # Conformance with Alpaka: Do not write __global__ CUDA kernels directly    #
+        #############################################################################
+        - test/hasCudaGlobalKeyword include/pmacc
+        - test/hasCudaGlobalKeyword share/pmacc/examples
+        - test/hasCudaGlobalKeyword include/picongpu
+        - test/hasCudaGlobalKeyword share/picongpu/examples
 
-  #############################################################################
-  # Conformance with Alpaka: Do not write __global__ CUDA kernels directly    #
-  #############################################################################
-  - test/hasCudaGlobalKeyword include/pmacc
-  - test/hasCudaGlobalKeyword share/pmacc/examples
-  - test/hasCudaGlobalKeyword include/picongpu
-  - test/hasCudaGlobalKeyword share/picongpu/examples
+        #############################################################################
+        # Disallow end-of-line (EOL) white spaces                                   #
+        #############################################################################
+        - test/hasEOLwhiteSpace
 
-  #############################################################################
-  # Disallow end-of-line (EOL) white spaces                                   #
-  #############################################################################
-  - test/hasEOLwhiteSpace
+        #############################################################################
+        # Disallow TABs, use white spaces                                           #
+        #############################################################################
+        - test/hasTabs
 
-  #############################################################################
-  # Disallow TABs, use white spaces                                           #
-  #############################################################################
-  - test/hasTabs
+        #############################################################################
+        # Disallow non-ASCII in source files and scripts                            #
+        #############################################################################
+        - test/hasNonASCII
 
-  #############################################################################
-  # Disallow non-ASCII in source files and scripts                            #
-  #############################################################################
-  - test/hasNonASCII
-
-  #############################################################################
-  # Disallow spaces before pre-compiler macros                                #
-  #############################################################################
-  - test/hasSpaceBeforePrecompiler
-
-  #############################################################################
-  # Test Python Files for PEP8 conformance                                    #
-  #############################################################################
-  - flake8 --exclude=thirdParty .
-
-script:
-  #############################################################################
-  # PMacc CPU-only tests                                                      #
-  #############################################################################
-  - mkdir -p $HOME/build
-  - cd $HOME/build
-  - cmake $TRAVIS_BUILD_DIR/include/pmacc
-          -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON
-  - make -j 2
-  # - make test  # reduce memory and RT costs first
+        #############################################################################
+        # Disallow spaces before pre-compiler macros                                #
+        #############################################################################
+        - test/hasSpaceBeforePrecompiler
+    - &test-cpp-unit
+      stage: 'C++ Unit Tests'
+      language: cpp
+      env: [ COMPILERSPEC='%gcc@4.9.4' ]
+      before_install:
+        - export CXX=g++-4.9
+        - export CC=gcc-4.9
+        - export FC=gfortran-4.9
+      script:
+        - $CXX --version
+        - $CC --version
+        - $FC --version
+        #############################################################################
+        # PMacc CPU-only tests                                                      #
+        #############################################################################
+        - mkdir -p $HOME/build
+        - cd $HOME/build
+        - cmake $TRAVIS_BUILD_DIR/include/pmacc
+                -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON
+        - make -j 2
+        # - make test  # reduce memory and RT costs first
+    - <<: *test-cpp-unit
+      env: [ COMPILERSPEC='%clang@3.9.0' ]
+      before_install:
+        - export CXX=clang++
+        - export CC=clang-3.9
+        - export FC=gfortran-4.9


### PR DESCRIPTION
Use [build stages](https://docs.travis-ci.com/user/build-stages/) for individual steps of the tests. Each stage is an independent job that does not share artifacts but will only run if the previous stages were successful.

### New Features

- add clang-3.9 unit testing for PMacc.
- add flake8 test in both Python 2.7 & 3.6

![travis_stages_picongpu](https://user-images.githubusercontent.com/1353258/32103251-df3b218c-bb1f-11e7-82f7-99792f463a70.png)

### Prepares

- upcoming `clang-tidy` #2303, `clang-check` and `clang-format` tests

### Depends On

- [x] #2340 