### PR TITLE
fix CUDA9 default constructor warnings

### DIFF
--- a/include/pmacc/memory/Array.hpp
+++ b/include/pmacc/memory/Array.hpp
@@ -80,7 +80,7 @@ namespace memory
          *
          * all members are uninitialized
          */
-        HDINLINE Array() = default;
+        Array() = default;
 
         /** constructor
          *

--- a/include/pmacc/memory/CtxArray.hpp
+++ b/include/pmacc/memory/CtxArray.hpp
@@ -65,7 +65,7 @@ namespace memory
          *
          * data member are uninitialized
          */
-        HDINLINE CtxArray() = default;
+        CtxArray() = default;
 
         /** constructor
          *


### PR DESCRIPTION
fix warning ` warning: __device__ annotation on a defaulted function("Array") is ignored`

- remove `HDINLINE` annotation