### PR TITLE
add support for CUDA9 `__shfl_snyc, __ballot_sync`

### DIFF
--- a/include/pmacc/nvidia/atomic.hpp
+++ b/include/pmacc/nvidia/atomic.hpp
@@ -89,7 +89,11 @@ namespace nvidia
             operator()(const T_Acc& acc,T_Type* ptr, const T_Hierarchy& hierarchy)
             {
                 /* Get a bitmask with 1 for each thread in the warp, that executes this */
+#if(__CUDACC_VER_MAJOR__ >= 9)
+                const int mask = __ballot_sync(0xFFFFFFFF, 1);
+#else
                 const int mask = __ballot(1);
+#endif
                 /* select the leader */
                 const int leader = __ffs(mask) - 1;
                 T_Type result;
@@ -180,7 +184,11 @@ DINLINE void
 atomicAllExch(const T_Acc& acc, T_Type* ptr, const T_Type value, const T_Hierarchy& hierarchy)
 {
 #if (__CUDA_ARCH__ >= 200)
+#   if(__CUDACC_VER_MAJOR__ >= 9)
+    const int mask = __ballot_sync(0xFFFFFFFF, 1);
+#   else
     const int mask = __ballot(1);
+#   endif
     // select the leader
     const int leader = __ffs(mask) - 1;
     // leader does the update

--- a/include/pmacc/nvidia/warp.hpp
+++ b/include/pmacc/nvidia/warp.hpp
@@ -95,7 +95,11 @@ DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId, c
 //! Broadcast a 32bit float
 DINLINE float warpBroadcast(const float data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
 {
+#if(__CUDACC_VER_MAJOR__ >= 9)
+    return  __shfl_sync(laneMask, data, srcLaneId);
+#else
     return  __shfl(data, srcLaneId);
+#endif
 }
 
 //! Broadcast a 64bit float by using 2 32bit broadcasts


### PR DESCRIPTION
This is a follow up of #2333

- use `__shfl_sync` with CUDA9
- use `__ballot_sync` with CUDA9