### PR TITLE
Using ISAAC for CUDA and CPU build if available

### DIFF
--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -55,10 +55,10 @@
 #   if(SIMDIM==DIM3)
 #       include "picongpu/plugins/IntensityPlugin.hpp"
 #   endif
+#endif
 
-#   if (ENABLE_ISAAC == 1) && (SIMDIM==DIM3)
-#       include "picongpu/plugins/IsaacPlugin.hpp"
-#   endif
+#if (ENABLE_ISAAC == 1) && (SIMDIM==DIM3)
+#    include "picongpu/plugins/IsaacPlugin.hpp"
 #endif
 
 #if (ENABLE_HDF5 == 1)
@@ -128,11 +128,12 @@ private:
 #   if(SIMDIM==DIM3)
         , IntensityPlugin
 #   endif
-
-#   if (ENABLE_ISAAC == 1) && (SIMDIM==DIM3)
-        , isaacP::IsaacPlugin
-#   endif
 #endif
+
+#if (ENABLE_ISAAC == 1) && (SIMDIM==DIM3)
+        , isaacP::IsaacPlugin
+#endif
+
 #if (ENABLE_HDF5 == 1)
         , hdf5::HDF5Writer
 #endif


### PR DESCRIPTION
I somehow forgot to activate ISAAC for CPU builds if it is available although I tested it on CPU architectures...