### PR TITLE
restart: fix illegal memory access

### DIFF
--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -159,6 +159,8 @@ namespace kernel
                 }
             );
 
+            __syncthreads();
+
             using ParticleDomCfg = IdxConfig<
                 particlesPerFrame,
                 numWorkers


### PR DESCRIPTION
A racecondition triggered by a missing synchronization results in an illegal memory access.

- add missing `__syncthreads()`

Bug was introduced with #2163