### PR TITLE
New Laser Profile: Exp. Ramps with Prepulse

### DIFF
--- a/include/picongpu/fields/laserProfiles/laserExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/laserProfiles/laserExpRampWithPrepulse.hpp
@@ -1,0 +1,204 @@
+/* Copyright 2013-2017 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Stefan Tietze
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+/** Wavepacket with spatial Gaussian envelope and adjustable temporal shape.
+ * Allows defining a prepulse and two regions of exponential preramp with
+ * independent slopes. The definition works by specifying three (t, intensity)-
+ * points, where time is counted from the very beginning in SI and the
+ * intensity (yes, intensity, not amplitude) is given in multiples of the main
+ * peak.
+ *
+ * Be careful - problematic for few cycle pulses. Thought the rest is cloned
+ * from laserWavepacket, the correctionFactor is not included (this made a
+ * correction to the laser phase, which is necessary for very short pulses,
+ * since otherwise the field is not a solution to the the free Maxwell Eq.; so
+ * that in particular a test particle is, after the laser pulse has passed,
+ * not returned to immobility, as it should. Since the analytical solution is
+ * only implemented for the Gaussian regime, and we have mostly exponential
+ * regimes here, it was not retained here.
+ */
+
+namespace laserExpRampWithPrepulse
+{
+    constexpr float_X laserTimeShift = laser::initPlaneY * CELL_HEIGHT /
+        SPEED_OF_LIGHT;
+    constexpr float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+    constexpr float_64 w = 2.0 * PI * f;
+
+    /** takes time t relative to the center of the Gaussian and returns value
+     * between 0 and 1, i.e. as multiple of the max value.
+     * use as: amp_t = amp_0 * gauss( t - t_0 )
+     */
+    HDINLINE float_X
+    gauss( float_X const t )
+    {
+        float_X const exponent = t / float_X( PULSE_LENGTH );
+        return math::exp( float_X( -0.25 ) * exponent * exponent );
+    }
+
+    /** get value of exponential curve through two points at given t
+     * t/t1/t2 given as float_X, since the envelope doesn't need the accuracy
+     */
+    HDINLINE float_X
+    extrapolate_expo(
+        float_X const t1,
+        float_X const a1,
+        float_X const t2,
+        float_X const a2,
+        float_X const t
+    )
+    {
+        const float_X log1 = ( t2 - t ) * math::log( a1 );
+        const float_X log2 = ( t - t1 ) * math::log( a2 );
+        return math::exp( ( log1 + log2 )/( t2 - t1 ) );
+    }
+
+    HINLINE float_X
+    get_envelope(float_X runTime)
+    {
+        float_X env = 0.0;
+        const bool before_preupramp = ( float_X( -0.5 * RAMP_INIT *
+            PULSE_LENGTH ) > runTime );
+        const bool before_start = runTime < 0.;
+        const bool before_peakpulse = runTime < endUpramp;
+        const bool during_first_exp = ( TIME_1 < runTime ) &&
+            ( runTime < TIME_2 );
+        const bool after_peakpulse = startDownramp <= runTime;
+
+        if ( !before_preupramp && before_start )
+        {
+            env = AMP_1 * gauss( runTime ) +
+                AMP_PREPULSE * gauss( runTime - TIME_PREPULSE );
+        }
+        else if ( before_peakpulse )
+        {
+            const float_X ramp_when_peakpulse = extrapolate_expo(
+                TIME_2,
+                AMP_2,
+                TIME_3,
+                AMP_3,
+                endUpramp
+            ) / AMPLITUDE;
+
+            if ( ramp_when_peakpulse > 0.5 )
+            {
+                log< picLog::PHYSICS >(
+                    "Attention, the intensities of the ramp are very large!\n"
+                    "The extrapolation of the last exponential to the time of "
+                    "the peakpulse gives more than half of the amplitude of "
+                    "the peak Gaussian. This is not a Gaussian at all anymore, "
+                    "and physically very unplausible, check the params for misunderstandings!"
+                );
+            }
+
+            env += AMPLITUDE * ( float_X( 1. ) - ramp_when_peakpulse ) *
+                gauss( runTime - endUpramp );
+            env += AMP_PREPULSE * gauss( runTime - TIME_PREPULSE );
+            if ( during_first_exp )
+                env += extrapolate_expo(
+                    TIME_1,
+                    AMP_1,
+                    TIME_2,
+                    AMP_2,
+                    runTime
+                );
+            else
+                env += extrapolate_expo(
+                    TIME_2,
+                    AMP_2,
+                    TIME_3,
+                    AMP_3,
+                    runTime
+                );
+        }
+        else if ( !after_peakpulse )
+            env = AMPLITUDE;
+    else // after startDownramp
+            env = AMPLITUDE * gauss( runTime - startDownramp );
+        return env;
+    }
+
+    HINLINE float3_X laserLongitudinal(uint32_t currentStep, float_X& phase)
+    {
+        float_X envelope;
+        float3_X elong( float3_X::create( 0.0 ) );
+
+        // a symmetric pulse will be initialized at position z=0 for
+        // a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
+        // we shift the complete pulse for the half of this time to start with
+        // the front of the laser pulse.
+
+        /* initialize the laser not in the first cell is equal to a negative shift
+         * in time
+         */
+        const float_64 runTime = (DELTA_T * currentStep - laserTimeShift -
+            0.5 * RAMP_INIT * PULSE_LENGTH );
+
+        phase += float_X( w * runTime ) + LASER_PHASE ;
+
+        envelope = get_envelope( runTime );
+
+
+        if( Polarisation == LINEAR_X )
+        {
+            elong.x() = float_X( envelope * ( math::sin( phase ) ) );
+        }
+        else if( Polarisation == LINEAR_Z )
+        {
+            elong.z() = float_X( envelope * ( math::sin( phase ) ) );
+        }
+        else if( Polarisation == CIRCULAR )
+        {
+            elong.x() = float_X( envelope / sqrt( 2.0 ) * ( math::sin( phase ) ) );
+            elong.z() = float_X( envelope / sqrt( 2.0 ) * ( math::cos( phase ) ) );
+        }
+
+        return elong;
+    }
+
+    /**
+     * takes the 3-component-vector elong of the E-field (computed for the
+     * current timestep), and the x- and z-position and returns this elong
+     * modulated by an isotropic Gaussian in transversal direction.
+     * @param elong
+     * @param phase
+     * @param posX
+     * @param posZ
+     * @return
+     */
+    HDINLINE float3_X laserTransversal(float3_X elong, const float_X, const float_X posX, const float_X posZ)
+    {
+
+        const float_X exp_x = posX * posX / (W0_X * W0_X);
+        const float_X exp_z = posZ * posZ / (W0_Z * W0_Z);
+
+        return elong * math::exp( float_X( -1.0 ) * ( exp_x + exp_z ) );
+
+    }
+
+}
+}
+

--- a/include/picongpu/fields/laserProfiles/laserExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/laserProfiles/laserExpRampWithPrepulse.hpp
@@ -34,9 +34,8 @@ namespace picongpu
  * Be careful - problematic for few cycle pulses. Thought the rest is cloned
  * from laserWavepacket, the correctionFactor is not included (this made a
  * correction to the laser phase, which is necessary for very short pulses,
- * since otherwise the field is not a solution to the the free Maxwell Eq.; so
- * that in particular a test particle is, after the laser pulse has passed,
- * not returned to immobility, as it should. Since the analytical solution is
+ * since otherwise a test particle is, after the laser pulse has passed, not
+ * returned to immobility, as it should). Since the analytical solution is
  * only implemented for the Gaussian regime, and we have mostly exponential
  * regimes here, it was not retained here.
  */
@@ -106,7 +105,7 @@ namespace laserExpRampWithPrepulse
             if ( ramp_when_peakpulse > 0.5 )
             {
                 log< picLog::PHYSICS >(
-                    "Attention, the intensities of the ramp are very large!\n"
+                    "Attention, the intensities of the laser upramp are very large! "
                     "The extrapolation of the last exponential to the time of "
                     "the peakpulse gives more than half of the amplitude of "
                     "the peak Gaussian. This is not a Gaussian at all anymore, "

--- a/include/picongpu/simulation_defines/param/components.param
+++ b/include/picongpu/simulation_defines/param/components.param
@@ -40,13 +40,16 @@ namespace simulation_starter = defaultPIConGPU;
 /** @namespace laserProfile
  *
  * Laser Profile Selection:
- *  - laserNone             : no laser init
- *  - laserGaussianBeam     : Gaussian beam (focusing)
- *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
- *                            in 'x' direction
- *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
- *  - laserPlaneWave        : a plane wave (Gaussian in time)
- *  - laserPolynom          : a polynomial laser envelope
+ *  - laserNone                : no laser init
+ *  - laserGaussianBeam        : Gaussian beam (focusing)
+ *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+ *                               in 'x' direction
+ *  - laserPlaneWave           : a plane wave (Gaussian in time)
+ *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                 focusing)
+ *  - laserPolynom             : a polynomial laser envelope
+ *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                 and prepulse in time
  *
  * Adjust the settings of the selected profile in laser.param
  */

--- a/include/picongpu/simulation_defines/param/laser.param
+++ b/include/picongpu/simulation_defines/param/laser.param
@@ -206,7 +206,7 @@ namespace picongpu
             //constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
             /** The profile of the test Lasers 0 and 2 can be stretched by a
-             *      constexprant area between the up and downramp
+             *      constant area between the up and downramp
              *  unit: seconds */
             constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
 
@@ -269,7 +269,7 @@ namespace picongpu
         constexpr float_64 AMPLITUDE_SI = 1.738e13;
 
         /** The profile of the test Lasers 0 and 2 can be stretched by a
-         *      constexprant area between the up and downramp
+         *      constant area between the up and downramp
          *  unit: seconds */
         constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
@@ -368,6 +368,114 @@ namespace picongpu
          */
         constexpr float_X LASER_PHASE = 0.0;
     }
+
+
+    namespace laserExpRampWithPrepulse
+    {
+        /* Laser profile with Gaussian spatial envelope and the following
+         * temporal shape:
+         * A Gaussian peak (optionally lengthened by a plateau) is preceded by
+         * two pieces of exponential preramps, defined by 3 (time, intensity)-
+         * -points.
+         * The first two points get connected by an exponential, the 2nd and
+         * 3rd point are connected by another exponential, which is then
+         * extrapolated to the peak. The Gaussian is added everywhere, but
+         * typically contributes significantly only near the peak.
+         * It is advisable to set the third point far enough from the plateau
+         * (approx 3*FWHM), then the contribution from the Gaussian is
+         * negligible there, and the intensity can be set as measured from the
+         * laser profile.
+         * Optionally a Gaussian prepulse can be added, given by the parameters
+         * of the relative intersity and time point.
+         * The time of the prepulse and the three preramp points are given in
+         * SI, the intensities are given as multiples of the peak intensity.
+         */
+
+        // Intensities of prepulse and exponential preramp
+        constexpr float_X INT_RATIO_PREPULSE = 0.;
+        constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
+        constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
+        constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
+
+        namespace SI
+        {
+            // time-positions of prepulse and preramps points
+            constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
+            constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
+            constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
+            constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
+            constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
+
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0  = 20.;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt /meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** The profile of the test Lasers 0 and 2 can be stretched by a
+             *      constant area between the up and downramp
+             *  unit: seconds */
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 3.0e-14 / 2.35482; // half of the time in which E falls to half its initial value (then I falls to half its value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              WO_X_SI is this distance in x-direction
+             *              W0_Z_SI is this distance in z-direction
+             *              if both values are equal, the laser has a circular shape in x-z
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
+            constexpr float_64 W0_Z_SI = W0_X_SI;
+
+        }
+
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+        and half at the end of the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 16.0;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
 
     namespace laserNone
     {

--- a/include/picongpu/simulation_defines/unitless/laser.unitless
+++ b/include/picongpu/simulation_defines/unitless/laser.unitless
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <pmacc/static_assert.hpp>
 
 
 namespace picongpu
@@ -90,9 +91,70 @@ namespace picongpu
         constexpr float_X INIT_TIME = 0.0; //no inizialisation of laser
     }
 
+    namespace laserExpRampWithPrepulse
+    {
+        //normed laser parameter
+        constexpr float_X WAVE_LENGTH = float_X (SI::WAVE_LENGTH_SI / UNIT_LENGTH); //unit: meter
+        constexpr float_X PULSE_LENGTH = float_X (SI::PULSE_LENGTH_SI / UNIT_TIME); //unit: seconds (1 sigma)
+        constexpr float_X LASER_NOFOCUS_CONSTANT = float_X (SI::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); //unit: seconds
+        constexpr float_X AMPLITUDE = float_X (SI::AMPLITUDE_SI / UNIT_EFIELD); //unit: Volt /meter
+        constexpr float_X W0_X = float_X(SI::W0_X_SI / UNIT_LENGTH); // unit: meter
+        constexpr float_X W0_Z = float_X(SI::W0_Z_SI / UNIT_LENGTH); // unit: meter
+
+        constexpr float_64 TIME_PREPULSE = float_64 (SI::TIME_PREPULSE_SI / UNIT_TIME);
+        constexpr float_64 TIME_PEAKPULSE = float_64 (SI::TIME_PEAKPULSE_SI / UNIT_TIME);
+        constexpr float_64 TIME_1 = float_64 (SI::TIME_POINT_1_SI / UNIT_TIME);
+        constexpr float_64 TIME_2 = float_64 (SI::TIME_POINT_2_SI / UNIT_TIME);
+        constexpr float_64 TIME_3 = float_64 (SI::TIME_POINT_3_SI / UNIT_TIME);
+        constexpr float_X endUpramp = TIME_PEAKPULSE -
+            0.5 * LASER_NOFOCUS_CONSTANT;
+        constexpr float_X startDownramp = TIME_PEAKPULSE +
+            0.5 * LASER_NOFOCUS_CONSTANT;
+
+        constexpr float_X INIT_TIME = float_X ((TIME_PEAKPULSE + RAMP_INIT * PULSE_LENGTH) / UNIT_TIME);
+
+        const float_X AMP_PREPULSE = float_X (math::sqrt(INT_RATIO_PREPULSE) * AMPLITUDE);
+        const float_X AMP_1 = float_X (math::sqrt(INT_RATIO_POINT_1) * AMPLITUDE);
+        const float_X AMP_2 = float_X (math::sqrt(INT_RATIO_POINT_2) * AMPLITUDE);
+        const float_X AMP_3 = float_X (math::sqrt(INT_RATIO_POINT_3) * AMPLITUDE);
+
+        // compile-time checks for physical sanity:
+        static_assert(
+            ( TIME_1 < TIME_2 ) && ( TIME_2 < TIME_3 ) && ( TIME_3 < endUpramp ),
+            "The times in the parameters TIME_POINT_1/2/3 and the beginning of the plateau (which is at TIME_PEAKPULSE - 0.5*RAMP_INIT*PULSE_LENGTH) should be in ascending order"
+        );
+        // some prerequisites for check of intensities (approximate check, because I can't use exp and log)
+        constexpr float ratio_dt = ( endUpramp - TIME_3 ) / ( TIME_3 - TIME_2 ); // ratio of time intervals
+        constexpr float ri1 = INT_RATIO_POINT_3 / INT_RATIO_POINT_2; // first intensity ratio
+        constexpr float ri2 = 0.2 / INT_RATIO_POINT_3; // secont intensity ratio (0.2 is an arbitrary upper border for the intensity of the exp ramp)
+        /* Approximate check, if ri1 ^ ratio_dt > ri2. That would mean, that the exponential curve through (time2, int2) and (time3, int3) lies above (endUpramp, 0.2)
+         * the power function is emulated by "rounding" the exponent to a rational number and expanding both sides by the common denominator, to get integer powers, see below
+         * for this, the range for ratio_dt is split into parts; the checked condition is "rounded down", i.e. it's weaker in every point of those ranges except one.
+         */
+        constexpr bool intensity_too_big =
+            ( ratio_dt >= 3.   && ri1 * ri1 * ri1 > ri2) ||
+            ( ratio_dt >= 2.   && ri1 * ri1 > ri2) ||
+            ( ratio_dt >= 1.5  && ri1 * ri1 * ri1 > ri2 * ri2) ||
+            ( ratio_dt >= 1.   && ri1 > ri2) ||
+            ( ratio_dt >= 0.8  && ri1 * ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.75 && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.67 && ri1 * ri1 > ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.6  && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.5  && ri1 > ri2 * ri2 ) ||
+            ( ratio_dt >= 0.4  && ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.33 && ri1 > ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.25 && ri1 > ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.2  && ri1 > ri2 * ri2 * ri2 * ri2 * ri2 );
+        static_assert(
+            !intensity_too_big,
+            "The intensities of the ramp are very large - the extrapolation to the time of the main pulse would give more than half of the pulse amplitude. This is not a Gaussian pulse at all anymore - probably some of the parameters are different from what you think!?"
+        );
+    }
+
 }
 
     /* include implemented laser profiles */
+#include "picongpu/fields/laserProfiles/laserExpRampWithPrepulse.hpp"
 #include "picongpu/fields/laserProfiles/laserPulseFrontTilt.hpp"
 #include "picongpu/fields/laserProfiles/laserGaussianBeam.hpp"
 #include "picongpu/fields/laserProfiles/laserWavepacket.hpp"

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/components.param
@@ -26,14 +26,21 @@ namespace picongpu
  */
 namespace simulation_starter = defaultPIConGPU;
 
-/*! Laser Configuration --------------------------------------------------
- *  - laserNone             : no laser init
- *  - laserGaussianBeam     : Gaussian beam (focusing)
- *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
- *                            in 'x' direction
- *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
- *  - laserPlaneWave        : a plane wave (Gaussian in time)
- *  - laserPolynom          : a polynomial laser envelope
+/** @namespace laserProfile
+ *
+ * Laser Profile Selection:
+ *  - laserNone                : no laser init
+ *  - laserGaussianBeam        : Gaussian beam (focusing)
+ *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+ *                               in 'x' direction
+ *  - laserPlaneWave           : a plane wave (Gaussian in time)
+ *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                 focusing)
+ *  - laserPolynom             : a polynomial laser envelope
+ *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                 and prepulse in time
+ *
+ * Adjust the settings of the selected profile in laser.param
  */
 namespace laserProfile = laserGaussianBeam;
 

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/laser.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/laser.param
@@ -319,6 +319,114 @@ namespace laser
         constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
     }
 
+
+    namespace laserExpRampWithPrepulse
+    {
+        /* Laser profile with Gaussian spatial envelope and the following
+         * temporal shape:
+         * A Gaussian peak (optionally lengthened by a plateau) is preceded by
+         * two pieces of exponential preramps, defined by 3 (time, intensity)-
+         * -points.
+         * The first two points get connected by an exponential, the 2nd and
+         * 3rd point are connected by another exponential, which is then
+         * extrapolated to the peak. The Gaussian is added everywhere, but
+         * typically contributes significantly only near the peak.
+         * It is advisable to set the third point far enough from the plateau
+         * (approx 3*FWHM), then the contribution from the Gaussian is
+         * negligible there, and the intensity can be set as measured from the
+         * laser profile.
+         * Optionally a Gaussian prepulse can be added, given by the parameters
+         * of the relative intersity and time point.
+         * The time of the prepulse and the three preramp points are given in
+         * SI, the intensities are given as multiples of the peak intensity.
+         */
+
+        // Intensities of prepulse and exponential preramp
+        constexpr float_X INT_RATIO_PREPULSE = 0.;
+        constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
+        constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
+        constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
+
+        namespace SI
+        {
+            // time-positions of prepulse and preramps points
+            constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
+            constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
+            constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
+            constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
+            constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
+
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0  = 20.;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt /meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** The profile of the test Lasers 0 and 2 can be stretched by a
+             *      constant area between the up and downramp
+             *  unit: seconds */
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 3.0e-14 / 2.35482; // half of the time in which E falls to half its initial value (then I falls to half its value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              WO_X_SI is this distance in x-direction
+             *              W0_Z_SI is this distance in z-direction
+             *              if both values are equal, the laser has a circular shape in x-z
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
+            constexpr float_64 W0_Z_SI = W0_X_SI;
+
+        }
+
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+        and half at the end of the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 16.0;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+
     namespace laserNone
     {
         namespace SI

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/components.param
@@ -28,14 +28,21 @@ namespace picongpu
  */
 namespace simulation_starter = defaultPIConGPU;
 
-/*! Laser Configuration --------------------------------------------------
- *  - laserNone             : no laser init
- *  - laserGaussianBeam     : Gaussian beam (focusing)
- *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
- *                            in 'x' direction
- *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
- *  - laserPlaneWave        : a plane wave (Gaussian in time)
- *  - laserPolynom          : a polynomial laser envelope
+/** @namespace laserProfile
+ *
+ * Laser Profile Selection:
+ *  - laserNone                : no laser init
+ *  - laserGaussianBeam        : Gaussian beam (focusing)
+ *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+ *                               in 'x' direction
+ *  - laserPlaneWave           : a plane wave (Gaussian in time)
+ *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                 focusing)
+ *  - laserPolynom             : a polynomial laser envelope
+ *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                 and prepulse in time
+ *
+ * Adjust the settings of the selected profile in laser.param
  */
 namespace laserProfile = laserPlaneWave;
 

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/laser.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/laser.param
@@ -319,6 +319,114 @@ constexpr float_64 W0z_SI = W0x_SI; // waist in z-direction
 constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
 }
 
+
+namespace laserExpRampWithPrepulse
+{
+/* Laser profile with Gaussian spatial envelope and the following
+ * temporal shape:
+ * A Gaussian peak (optionally lengthened by a plateau) is preceded by
+ * two pieces of exponential preramps, defined by 3 (time, intensity)-
+ * -points.
+ * The first two points get connected by an exponential, the 2nd and
+ * 3rd point are connected by another exponential, which is then
+ * extrapolated to the peak. The Gaussian is added everywhere, but
+ * typically contributes significantly only near the peak.
+ * It is advisable to set the third point far enough from the plateau
+ * (approx 3*FWHM), then the contribution from the Gaussian is
+ * negligible there, and the intensity can be set as measured from the
+ * laser profile.
+ * Optionally a Gaussian prepulse can be added, given by the parameters
+ * of the relative intersity and time point.
+ * The time of the prepulse and the three preramp points are given in
+ * SI, the intensities are given as multiples of the peak intensity.
+ */
+
+// Intensities of prepulse and exponential preramp
+constexpr float_X INT_RATIO_PREPULSE = 0.;
+constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
+constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
+constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
+
+namespace SI
+{
+    // time-positions of prepulse and preramps points
+    constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
+    constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
+    constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
+    constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
+    constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
+
+    /** unit: meter */
+    constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+    /** UNITCONV */
+    constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+    /** unit: W / m^2 */
+    // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+    /** unit: none */
+    constexpr float_64 _A0  = 20.;
+
+    /** unit: Volt /meter */
+    constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+    /** unit: Volt /meter */
+    //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+    /** The profile of the test Lasers 0 and 2 can be stretched by a
+     *      constant area between the up and downramp
+     *  unit: seconds */
+    constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+    /** Pulse length: sigma of std. gauss for intensity (E^2)
+     *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+     *                                          [    2.354820045     ]
+     *  Info:             FWHM_of_Intensity = FWHM_Illumination
+     *                      = what a experimentalist calls "pulse duration"
+     *  unit: seconds (1 sigma) */
+    constexpr float_64 PULSE_LENGTH_SI = 3.0e-14 / 2.35482; // half of the time in which E falls to half its initial value (then I falls to half its value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
+
+    /** beam waist: distance from the axis where the pulse intensity (E^2)
+     *              decreases to its 1/e^2-th part,
+     *              WO_X_SI is this distance in x-direction
+     *              W0_Z_SI is this distance in z-direction
+     *              if both values are equal, the laser has a circular shape in x-z
+     * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+     *                             [   1.17741    ]
+     *  unit: meter */
+    constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
+    constexpr float_64 W0_Z_SI = W0_X_SI;
+
+}
+
+/** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+and half at the end of the plateau
+ *  unit: none */
+constexpr float_64 RAMP_INIT = 16.0;
+
+/** laser phase shift (no shift: 0.0)
+ *
+ * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+ *
+ * unit: rad, periodic in 2*pi
+ */
+constexpr float_X LASER_PHASE = 0.0;
+
+/** Available polarisation types
+ */
+enum PolarisationType
+{
+    LINEAR_X = 1u,
+    LINEAR_Z = 2u,
+    CIRCULAR = 4u,
+};
+/** Polarization selection
+ */
+constexpr PolarisationType Polarisation = LINEAR_X;
+}
+
+
 namespace laserNone
 {
 namespace SI

--- a/share/picongpu/examples/FoilLCT/cmakeFlags
+++ b/share/picongpu/examples/FoilLCT/cmakeFlags
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2018 Axel Huebl, Rene Widera, Richard Pausch
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+
+flags[0]=""
+flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_LASERPROFILE=laserExpRampWithPrepulse'"
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/components.param
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#ifndef PARAM_LASERPROFILE
+#define PARAM_LASERPROFILE laserPlaneWave
+#endif
+
 
 namespace picongpu
 {
@@ -40,17 +44,20 @@ namespace picongpu
     /** @namespace laserProfile
      *
      * Laser Profile Selection:
-     *  - laserNone             : no laser init
-     *  - laserGaussianBeam     : Gaussian beam (focusing)
-     *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
-     *                            in 'x' direction
-     *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
-     *  - laserPlaneWave        : a plane wave (Gaussian in time)
-     *  - laserPolynom          : a polynomial laser envelope
+     *  - laserNone                : no laser init
+     *  - laserGaussianBeam        : Gaussian beam (focusing)
+     *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+     *                               in 'x' direction
+     *  - laserPlaneWave           : a plane wave (Gaussian in time)
+     *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                     focusing)
+     *  - laserPolynom             : a polynomial laser envelope
+     *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                     and prepulse in time
      *
      * Adjust the settings of the selected profile in laser.param
      */
-    namespace laserProfile = laserPlaneWave;
+    namespace laserProfile = PARAM_LASERPROFILE;
 
     /** @namespace fieldSolver
      *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/laser.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/laser.param
@@ -369,6 +369,114 @@ namespace picongpu
         constexpr float_X LASER_PHASE = 0.0;
     }
 
+
+    namespace laserExpRampWithPrepulse
+    {
+        /* Laser profile with Gaussian spatial envelope and the following
+         * temporal shape:
+         * A Gaussian peak (optionally lengthened by a plateau) is preceded by
+         * two pieces of exponential preramps, defined by 3 (time, intensity)-
+         * -points.
+         * The first two points get connected by an exponential, the 2nd and
+         * 3rd point are connected by another exponential, which is then
+         * extrapolated to the peak. The Gaussian is added everywhere, but
+         * typically contributes significantly only near the peak.
+         * It is advisable to set the third point far enough from the plateau
+         * (approx 3*FWHM), then the contribution from the Gaussian is
+         * negligible there, and the intensity can be set as measured from the
+         * laser profile.
+         * Optionally a Gaussian prepulse can be added, given by the parameters
+         * of the relative intersity and time point.
+         * The time of the prepulse and the three preramp points are given in
+         * SI, the intensities are given as multiples of the peak intensity.
+         */
+
+        // Intensities of prepulse and exponential preramp
+        constexpr float_X INT_RATIO_PREPULSE = 0.;
+        constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
+        constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
+        constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
+
+        namespace SI
+        {
+            // time-positions of prepulse and preramps points
+            constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
+            constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
+            constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
+            constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
+            constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
+
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0  = 20.;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt /meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** The profile of the test Lasers 0 and 2 can be stretched by a
+             *      constant area between the up and downramp
+             *  unit: seconds */
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 3.0e-14 / 2.35482; // half of the time in which E falls to half its initial value (then I falls to half its value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              WO_X_SI is this distance in x-direction
+             *              W0_Z_SI is this distance in z-direction
+             *              if both values are equal, the laser has a circular shape in x-z
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
+            constexpr float_64 W0_Z_SI = W0_X_SI;
+
+        }
+
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+        and half at the end of the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 16.0;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+
     namespace laserNone
     {
         namespace SI

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/components.param
@@ -28,14 +28,21 @@ namespace picongpu
      */
     namespace simulation_starter = defaultPIConGPU;
 
-    /*! Laser Configuration --------------------------------------------------
-     *  - laserNone             : no laser init
-     *  - laserGaussianBeam     : Gaussian beam (focusing)
-     *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
-     *                            in 'x' direction
-     *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
-     *  - laserPlaneWave        : a plane wave (Gaussian in time)
-     *  - laserPolynom          : a polynomial laser envelope
+    /** @namespace laserProfile
+     *
+     * Laser Profile Selection:
+     *  - laserNone                : no laser init
+     *  - laserGaussianBeam        : Gaussian beam (focusing)
+     *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+     *                               in 'x' direction
+     *  - laserPlaneWave           : a plane wave (Gaussian in time)
+     *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                     focusing)
+     *  - laserPolynom             : a polynomial laser envelope
+     *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                     and prepulse in time
+     *
+     * Adjust the settings of the selected profile in laser.param
      */
     namespace laserProfile = laserNone;
 

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/components.param
@@ -29,14 +29,21 @@ namespace picongpu
  */
 namespace simulation_starter = defaultPIConGPU;
 
-/*! Laser Configuration --------------------------------------------------
- *  - laserNone             : no laser init
- *  - laserGaussianBeam     : Gaussian beam (focusing)
- *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
- *                            in 'x' direction
- *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
- *  - laserPlaneWave        : a plane wave (Gaussian in time)
- *  - laserPolynom          : a polynomial laser envelope
+/** @namespace laserProfile
+ *
+ * Laser Profile Selection:
+ *  - laserNone                : no laser init
+ *  - laserGaussianBeam        : Gaussian beam (focusing)
+ *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+ *                               in 'x' direction
+ *  - laserPlaneWave           : a plane wave (Gaussian in time)
+ *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                 focusing)
+ *  - laserPolynom             : a polynomial laser envelope
+ *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                 and prepulse in time
+ *
+ * Adjust the settings of the selected profile in laser.param
  */
 namespace laserProfile = laserGaussianBeam;
 

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/laser.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/laser.param
@@ -331,6 +331,114 @@ namespace picongpu
         constexpr float_X LASER_PHASE = 0.0; /* unit: rad, periodic in 2*pi */
     }
 
+
+    namespace laserExpRampWithPrepulse
+    {
+        /* Laser profile with Gaussian spatial envelope and the following
+         * temporal shape:
+         * A Gaussian peak (optionally lengthened by a plateau) is preceded by
+         * two pieces of exponential preramps, defined by 3 (time, intensity)-
+         * -points.
+         * The first two points get connected by an exponential, the 2nd and
+         * 3rd point are connected by another exponential, which is then
+         * extrapolated to the peak. The Gaussian is added everywhere, but
+         * typically contributes significantly only near the peak.
+         * It is advisable to set the third point far enough from the plateau
+         * (approx 3*FWHM), then the contribution from the Gaussian is
+         * negligible there, and the intensity can be set as measured from the
+         * laser profile.
+         * Optionally a Gaussian prepulse can be added, given by the parameters
+         * of the relative intersity and time point.
+         * The time of the prepulse and the three preramp points are given in
+         * SI, the intensities are given as multiples of the peak intensity.
+         */
+
+        // Intensities of prepulse and exponential preramp
+        constexpr float_X INT_RATIO_PREPULSE = 0.;
+        constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
+        constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
+        constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
+
+        namespace SI
+        {
+            // time-positions of prepulse and preramps points
+            constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
+            constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
+            constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
+            constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
+            constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
+
+            /** unit: meter */
+            constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+            /** UNITCONV */
+            constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+            /** unit: W / m^2 */
+            // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+            /** unit: none */
+            constexpr float_64 _A0  = 20.;
+
+            /** unit: Volt /meter */
+            constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+            /** unit: Volt /meter */
+            //constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+            /** The profile of the test Lasers 0 and 2 can be stretched by a
+             *      constant area between the up and downramp
+             *  unit: seconds */
+            constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+            /** Pulse length: sigma of std. gauss for intensity (E^2)
+             *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+             *                                          [    2.354820045     ]
+             *  Info:             FWHM_of_Intensity = FWHM_Illumination
+             *                      = what a experimentalist calls "pulse duration"
+             *  unit: seconds (1 sigma) */
+            constexpr float_64 PULSE_LENGTH_SI = 3.0e-14 / 2.35482; // half of the time in which E falls to half its initial value (then I falls to half its value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
+
+            /** beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              WO_X_SI is this distance in x-direction
+             *              W0_Z_SI is this distance in z-direction
+             *              if both values are equal, the laser has a circular shape in x-z
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *  unit: meter */
+            constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
+            constexpr float_64 W0_Z_SI = W0_X_SI;
+
+        }
+
+        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+        and half at the end of the plateau
+         *  unit: none */
+        constexpr float_64 RAMP_INIT = 16.0;
+
+        /** laser phase shift (no shift: 0.0)
+         *
+         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+         *
+         * unit: rad, periodic in 2*pi
+         */
+        constexpr float_X LASER_PHASE = 0.0;
+
+        /** Available polarisation types
+         */
+        enum PolarisationType
+        {
+            LINEAR_X = 1u,
+            LINEAR_Z = 2u,
+            CIRCULAR = 4u,
+        };
+        /** Polarization selection
+         */
+        constexpr PolarisationType Polarisation = LINEAR_X;
+    }
+
+
     namespace laserNone
     {
         namespace SI

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/components.param
@@ -28,14 +28,21 @@ namespace picongpu
  */
 namespace simulation_starter = defaultPIConGPU;
 
-/*! Laser Configuration --------------------------------------------------
- *  - laserNone             : no laser init
- *  - laserGaussianBeam     : Gaussian beam (focusing)
- *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
- *                            in 'x' direction
- *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
- *  - laserPlaneWave        : a plane wave (Gaussian in time)
- *  - laserPolynom          : a polynomial laser envelope
+/** @namespace laserProfile
+ *
+ * Laser Profile Selection:
+ *  - laserNone                : no laser init
+ *  - laserGaussianBeam        : Gaussian beam (focusing)
+ *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+ *                               in 'x' direction
+ *  - laserPlaneWave           : a plane wave (Gaussian in time)
+ *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                 focusing)
+ *  - laserPolynom             : a polynomial laser envelope
+ *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                 and prepulse in time
+ *
+ * Adjust the settings of the selected profile in laser.param
  */
 namespace laserProfile = laserNone;
 

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/components.param
@@ -29,14 +29,21 @@ namespace picongpu
  */
 namespace simulation_starter = thermalTestStarter;
 
-/*! Laser Configuration --------------------------------------------------
- *  - laserNone             : no laser init
- *  - laserGaussianBeam     : Gaussian beam (focusing)
- *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
- *                            in 'x' direction
- *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
- *  - laserPlaneWave        : a plane wave (Gaussian in time)
- *  - laserPolynom          : a polynomial laser envelope
+/** @namespace laserProfile
+ *
+ * Laser Profile Selection:
+ *  - laserNone                : no laser init
+ *  - laserGaussianBeam        : Gaussian beam (focusing)
+ *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+ *                               in 'x' direction
+ *  - laserPlaneWave           : a plane wave (Gaussian in time)
+ *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                 focusing)
+ *  - laserPolynom             : a polynomial laser envelope
+ *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                 and prepulse in time
+ *
+ * Adjust the settings of the selected profile in laser.param
  */
 namespace laserProfile = laserNone;
 

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/components.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/components.param
@@ -28,14 +28,21 @@ namespace picongpu
      */
     namespace simulation_starter = defaultPIConGPU;
 
-    /*! Laser Configuration --------------------------------------------------
-     *  - laserNone             : no laser init
-     *  - laserGaussianBeam     : Gaussian beam (focusing)
-     *  - laserPulseFrontTilt   : Gaussian beam with a tilted pulse envelope
-     *                            in 'x' direction
-     *  - laserWavepacket       : wavepacket (Gaussian in time and space, not focusing)
-     *  - laserPlaneWave        : a plane wave (Gaussian in time)
-     *  - laserPolynom          : a polynomial laser envelope
+    /** @namespace laserProfile
+     *
+     * Laser Profile Selection:
+     *  - laserNone                : no laser init
+     *  - laserGaussianBeam        : Gaussian beam (focusing)
+     *  - laserPulseFrontTilt      : Gaussian beam with a tilted pulse envelope
+     *                               in 'x' direction
+     *  - laserPlaneWave           : a plane wave (Gaussian in time)
+     *  - laserWavepacket          : wavepacket (Gaussian in time and space, not
+                                     focusing)
+     *  - laserPolynom             : a polynomial laser envelope
+     *  - laserExpRampWithPrepulse : gaussian in space, with exponential upramps
+                                     and prepulse in time
+     *
+     * Adjust the settings of the selected profile in laser.param
      */
     namespace laserProfile = laserNone;
 


### PR DESCRIPTION
### Summary:
This PR introduces enhancements to the laser-time-profile.
Based on the laserWavepacket-profile, the intensity before the main pulse is modified. 
Like in the following picture: 
![laser scetch](https://user-images.githubusercontent.com/23503115/32611743-b12eb294-c566-11e7-89c4-10eff2009864.png)
the user can specify three (time-intensity)-points, according to which the laser is initialized. Additionally, a gaussian prepulse can be added.

### Syntax/Parameters 
 - additionally to the parameters of the laserWavepacket-profile:
float_64 WAVE_LENGTH_SI = 0.8e-6;
float_64 AMPLITUDE_SI = 1.738e13;
float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0
float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
float_64 W0_X_SI = 4.246e-6;
float_64 W0_Z_SI = W0_X_SI;
float_64 RAMP_INIT = 20.0;
float_X LASER_PHASE = 0.0;
PolarisationType Polarisation = LINEAR_X;

 - the following new parameters are introduced:
float_X INT_RATIO_PREPULSE = 0.;
float_X INT_RATIO_POINT_1 = 1.e-8;
float_X INT_RATIO_POINT_2 = 1.e-4;
float_X INT_RATIO_POINT_3 = 1.e-4;
float_64 TIME_PREPULSE_SI = 50.0e-15;
float_64 TIME_PEAKPULSE_SI = 1000.0e-15;
float_64 TIME_POINT_1_SI = 0.0;
float_64 TIME_POINT_2_SI = 700.0e-15;
float_64 TIME_POINT_3_SI = 900.0e-15;

 - the new parameters should be self-explanatory, I hope. The specified points of the envelope are connected with exponential pieces; after the last point the extrapolated exponential is added to the gaussian, and the gaussian is scaled accordingly (such that the net intensity at the peak is unity). All old parameters keep their meaning, especially: 
 - before the (TIME/INT)-POINT_1 and after the peakpulse, there is a gaussian ramp of the length PULSE_LENGHT * RAMP_INIT / 2
 - the peakpulse can be stretched by a plateau of length LASER_NOFOCUS_CONSTANT
 - the transversal geometry, phase, and polarisation can be set
 - the correction_factor, that was meant to correct the phase of the gaussian, is not implemented; this could be done at least for the predominantly gaussian regime; with much more effort maybe even everywhere.

### Open Question
 -  new profile vs updating laserWavepacket? - pro new: the correction factor is not yet implemented; and it's hard to provide defaults such that the old behaviour is reproduced. All other arguments I see are contra a new profile.  
 - are my sanity-checks appropriate? I throw an error, if the exponential extrapolated from the last piece to the time of the peakpulse is more intense than half of the peakpulse - which would be (I hope) _far_ beyond physical meaningfullness and _has_ to be a mistake of the user. 
 - any more? :)