### PR TITLE
Update cuda_memtest

### DIFF
--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -159,6 +159,8 @@ namespace kernel
                 }
             );
 
+            __syncthreads();
+
             using ParticleDomCfg = IdxConfig<
                 particlesPerFrame,
                 numWorkers

--- a/thirdParty/cuda_memtest/.travis.yml
+++ b/thirdParty/cuda_memtest/.travis.yml
@@ -27,6 +27,7 @@ addons:
 
 env:
   global:
+    - CXXFLAGS="-Wall -Wextra -Werror"
     - INSTALL_DIR=~/mylibs
     - NVML_FILE=cuda_346.46_gdk_linux.run
     - NVML_LINK=http://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers/

--- a/thirdParty/cuda_memtest/cuda_memtest.cu
+++ b/thirdParty/cuda_memtest/cuda_memtest.cu
@@ -40,12 +40,12 @@
 
 #include "misc.h"
 #include <pthread.h>
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <signal.h>
+#include <csignal>
 
 #define MAX_NUM_GPUS 8
 bool useMappedMemory;

--- a/thirdParty/cuda_memtest/cuda_memtest.h
+++ b/thirdParty/cuda_memtest/cuda_memtest.h
@@ -41,7 +41,7 @@
 #ifndef __MEMTEST_H__
 #define __MEMTEST_H__
 
-#include <stdio.h>
+#include <cstdio>
 #include <stdint.h>
 #include <pthread.h>
 #include <iostream>

--- a/thirdParty/cuda_memtest/misc.cpp
+++ b/thirdParty/cuda_memtest/misc.cpp
@@ -31,6 +31,9 @@ void get_serial_number(unsigned int devIdx, char* serial)
 
     unsigned int serialLength = NVML_DEVICE_SERIAL_BUFFER_SIZE;
     NVML_CHECK(nvmlDeviceGetSerial( devHandle, serial, serialLength ));
+#else
+    (void)(devIdx);
+    (void)(serial);
 #endif
 }
 

--- a/thirdParty/cuda_memtest/misc.h
+++ b/thirdParty/cuda_memtest/misc.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cassert>
 #include "cuda_memtest.h"
 
 void update_temperature(void);

--- a/thirdParty/cuda_memtest/ocl_memtest.cpp
+++ b/thirdParty/cuda_memtest/ocl_memtest.cpp
@@ -3,10 +3,10 @@
 #include <CL/cl_gl.h>
 #include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <sys/time.h>
-#include <string.h>
+#include <cstring>
 #include <pthread.h>
 #include <unistd.h>
 

--- a/thirdParty/cuda_memtest/ocl_tests.cpp
+++ b/thirdParty/cuda_memtest/ocl_tests.cpp
@@ -3,10 +3,10 @@
 #include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
 #include <sys/time.h>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 #include <unistd.h>
 #include <pthread.h>
 

--- a/thirdParty/cuda_memtest/sanity_check.sh
+++ b/thirdParty/cuda_memtest/sanity_check.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # This script do a quick check if one GPU or all GPUs are in good health.
 # usage: ./sanity_check.sh 0   //check GPU 0
 #        ./sanity_check.sh 1   //check GPU 1

--- a/thirdParty/cuda_memtest/tests.cu
+++ b/thirdParty/cuda_memtest/tests.cu
@@ -38,7 +38,7 @@
  * DEALINGS WITH THE SOFTWARE.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include "misc.h"
 #include <cuda.h>
 #include <sys/time.h>
@@ -175,7 +175,10 @@ error_checking(const char* msg, unsigned int blockidx)
 		error_msg[ERR_MSG_LENGTH -1] = 0;
 		snprintf(cmd, CMD_LENGTH, "echo \"%s cuda_memtest errors found in %s[%d]\n%s\" |%s -s \" cuda_memtest errors found in %s[%d]\" %s",
 			 time_string(), hostname,gpu_idx, error_msg, MAILFILE, hostname,gpu_idx, emails );
-		system(cmd);
+		int sendMailResult = system(cmd);
+		if(sendMailResult != 0){
+			FPRINTF("ERROR: can not send the error report via mail to %s, '%s' returned an error\n", emails, MAILFILE);
+		}
 
 		firsttime = 0;
 		unreported_errors = 0;


### PR DESCRIPTION
Updates cuda_memtest:
- Travis: -Werror [#13](https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/13)
- fix warning `result of call is not used` [#12](https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/12)
- includes: C includes in C++ [#8](cuda_memtest/pull/12)

From
- `cuda_memtest@dev` (https://github.com/ComputationalRadiationPhysics/cuda_memtest/commit/9bddbdf73f33759b82e1ac3094a1d002f7dae76f) to
- `cuda_memtest@dev` (https://github.com/ComputationalRadiationPhysics/cuda_memtest/commit/8a0e21bea7be98a1d0f0f9fc48ae90f87c3ecb81)

```bash
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git subtree pull --prefix thirdParty/cuda_memtest \
  git@github.com:ComputationalRadiationPhysics/cuda_memtest.git dev --squash
```