### PR TITLE
Spack: Own GitHub Org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - SPACK_FOUND=$(which spack >/dev/null && { echo 0; } || { echo 1; })
   - if [ $SPACK_FOUND -ne 0 ]; then
       mkdir -p $SPACK_ROOT &&
-      git clone --depth 50 https://github.com/llnl/spack.git $SPACK_ROOT &&
+      git clone --depth 50 https://github.com/spack/spack.git $SPACK_ROOT &&
       echo -e "config:""\n  build_jobs:"" 2" > $SPACK_ROOT/etc/spack/config.yaml;
     fi
   - spack compiler add

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -20,7 +20,7 @@ Overview
 .. figure:: libraryDependencies.png
    :alt: overview of PIConGPU library dependencies
 
-   Overview of inter-library dependencies for parallel execution of PIConGPU on a typical HPC system. Due to common binary incompatibilities between compilers, MPI and boost versions, we recommend to organize software with a version-aware package manager such as `spack <https://github.com/LLNL/spack>`_ and to deploy a hierarchical module system such as `lmod <https://github.com/TACC/Lmod>`_.
+   Overview of inter-library dependencies for parallel execution of PIConGPU on a typical HPC system. Due to common binary incompatibilities between compilers, MPI and boost versions, we recommend to organize software with a version-aware package manager such as `spack <https://github.com/spack/spack>`_ and to deploy a hierarchical module system such as `lmod <https://github.com/TACC/Lmod>`_.
    A Lmod example setup can be found `here <https://github.com/ComputationalRadiationPhysics/compileNode>`_.
 
 Requirements

--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -17,7 +17,7 @@ First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html
 .. code-block:: bash
 
    # get spack
-   git clone https://github.com/llnl/spack.git $HOME/src/spack
+   git clone https://github.com/spack/spack.git $HOME/src/spack
    $HOME/src/spack/bin/spack bootstrap
 
    # activate the spack environment

--- a/docs/source/install/path.rst
+++ b/docs/source/install/path.rst
@@ -60,7 +60,7 @@ References
         *A flexible package manager that supports multiple versions, configurations, platforms, and compilers*,
         SC '15 Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis (2015),
         `DOI:10.1145/2807591.2807623 <https://dx.doi.org/10.1145/2807591.2807623>`_,
-        https://github.com/LLNL/spack
+        https://github.com/spack/spack
 
 .. [modules]
         J.L. Furlani, P.W. Osel.

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -49,7 +49,7 @@ RUN        mkdir build src paramSets && \
 
 # install spack && PIConGPU dependencies
 # todo: fix to a specific spack SHA or tag
-RUN        git clone --depth 50 https://github.com/llnl/spack.git \
+RUN        git clone --depth 50 https://github.com/spack/spack.git \
            $HOME/src/spack/ && \
            spack install cmake@3.7.2 && \
            spack install cuda && \


### PR DESCRIPTION
Spack has its own GitHub organization now 🚀 ✨ 

This changes all links from LLNL to it.