### PR TITLE
Particle Pusher: Clean-Up Interface

### DIFF
--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -584,7 +584,6 @@ struct PushParticlePerFrame
         typedef typename BoxE::ValueType EType;
 
         auto particle = frame[localIdx];
-        const float_X weighting = particle[weighting_];
 
         floatD_X pos = particle[position_];
         const int particleCellIdx = particle[localCellIdx_];
@@ -597,22 +596,17 @@ struct PushParticlePerFrame
         auto functorEfield = CreateInterpolationForPusher<Field2ParticleInterpolation>()( eBox.shift(localCell).toCursor(), fieldPosE() );
         auto functorBfield = CreateInterpolationForPusher<Field2ParticleInterpolation>()( bBox.shift(localCell).toCursor(), fieldPosB() );
 
-        float3_X mom = particle[momentum_];
-        const float_X mass = attribute::getMass(weighting,particle);
-
+        /** @todo this functor should only manipulate the momentum and all changes
+         *        in position and cell below need to go into a separate kernel
+         */
         PushAlgo push;
         push(
              functorBfield,
              functorEfield,
+             particle,
              pos,
-             mom,
-             mass,
-             attribute::getCharge(weighting,particle),
-             weighting,
              currentStep
         );
-        particle[momentum_] = mom;
-
 
         DataSpace<simDim> dir;
         for (uint32_t i = 0; i < simDim; ++i)

--- a/include/picongpu/particles/pusher/particlePusherFree.hpp
+++ b/include/picongpu/particles/pusher/particlePusherFree.hpp
@@ -18,10 +18,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <pmacc/types.hpp>
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/attribute/GetMass.hpp"
+
 
 namespace picongpu
 {
@@ -36,20 +37,20 @@ namespace picongpu
             typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
             typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
-            template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
-            typename T_Charge, typename T_Weighting>
+            template< typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Particle, typename T_Pos >
             HDINLINE void operator()(
-                const T_FunctorFieldB,
-                const T_FunctorFieldE,
-                T_Pos& pos,
-                T_Mom& mom,
-                const T_Mass mass,
-                const T_Charge,
-                const T_Weighting,
+                const T_FunctorFieldB functorBField,
+                const T_FunctorFieldE functorEField,
+                T_Particle & particle,
+                T_Pos & pos,
                 const uint32_t
             )
             {
-                typedef T_Mom MomType;
+                float_X const weighting = particle[ weighting_ ];
+                float_X const mass = attribute::getMass( weighting, particle );
+
+                using MomType = momentum::type;
+                MomType const mom = particle[ momentum_ ];
 
                 Velocity velocity;
                 const MomType vel = velocity(mom, mass);

--- a/include/picongpu/particles/pusher/particlePusherPhoton.hpp
+++ b/include/picongpu/particles/pusher/particlePusherPhoton.hpp
@@ -18,10 +18,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <pmacc/types.hpp>
+#include "picongpu/simulation_defines.hpp"
+
 
 namespace picongpu
 {
@@ -36,20 +36,17 @@ namespace picongpu
             typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
             typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
 
-            template<typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Pos, typename T_Mom, typename T_Mass,
-            typename T_Charge,  typename T_Weighting>
+            template< typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Particle, typename T_Pos >
             HDINLINE void operator()(
-                const T_FunctorFieldB,
-                const T_FunctorFieldE,
-                T_Pos& pos,
-                T_Mom& mom,
-                const T_Mass,
-                const T_Charge,
-                const T_Weighting,
+                const T_FunctorFieldB functorBField,
+                const T_FunctorFieldE functorEField,
+                T_Particle & particle,
+                T_Pos & pos,
                 const uint32_t
             )
             {
-                typedef T_Mom MomType;
+                using MomType = momentum::type;
+                MomType const mom = particle[ momentum_ ];
 
                 const float_X mom_abs = math::abs( mom );
                 const MomType vel = mom * ( SPEED_OF_LIGHT / mom_abs );


### PR DESCRIPTION
Clean up the particle pusher interface. Only passes the particle handle directly, making the overall API more clearly.

In the future, the main pusher will only manipulate the momentum and the particle change (usually linear step) will follow in a separate kernel together with the cell and memory management changes.

This is a preparation for particle probes.