### PR TITLE
LWFA Example: Improve Ranges

### DIFF
--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -66,7 +66,7 @@ The easiest way is to load the data in Python:
 
    # plotting
    plt.imshow(
-       np.abs(e_ps) * e_ps_meta.dV,
+       np.abs(e_ps).T * e_ps_meta.dV,
        extent = e_ps_meta.extent * [mu, mu, e_mc_r, e_mc_r],
        interpolation = 'nearest',
        aspect = 'auto',
@@ -79,7 +79,7 @@ The easiest way is to load the data in Python:
    cbar.set_label(r'$Q / \mathrm{d}r \mathrm{d}p$ [$\mathrm{C s kg^{-1} m^{-2}}$]')
 
    ax = plt.gca()
-   ax.set_xlabel(r'${0}$ [$\mathrm{\mu m}$]'.format(e_ps_meta.r))
+   ax.set_xlabel(r'${0}$'.format(e_ps_meta.r) + r' [$\mathrm{\mu m}$]')
    ax.set_ylabel(r'$p_{0}$ [$\beta\gamma$]'.format(e_ps_meta.p))
 
    plt.show()

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0004gpus_gui.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0004gpus_gui.cfg
@@ -36,7 +36,7 @@ TBG_gpu_x=1
 TBG_gpu_y=4
 TBG_gpu_z=1
 
-TBG_gridSize="128 512 128"
+TBG_gridSize="128 2048 128"
 TBG_steps="10000"
 TBG_movingWindow="-m"
 
@@ -58,7 +58,7 @@ TBG_e_histogram="--e_energyHistogram.period !TBG_plugin_period --e_energyHistogr
 # - requires parallel libSplash for HDF5 output
 # - momentum range in m_<species> c
 TBG_e_PSxpx="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space x --e_phaseSpace.momentum px --e_phaseSpace.min -8.0 --e_phaseSpace.max 8.0"
-TBG_e_PSypy="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space y --e_phaseSpace.momentum py --e_phaseSpace.min  0.0 --e_phaseSpace.max 1.0"
+TBG_e_PSypy="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space y --e_phaseSpace.momentum py --e_phaseSpace.min -0.5 --e_phaseSpace.max 3.0"
 TBG_e_PSzpz="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space z --e_phaseSpace.momentum pz --e_phaseSpace.min -2.0 --e_phaseSpace.max 2.0"
 
 TBG_plugins="!TBG_pngYX                    \

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0004gpus_gui.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0004gpus_gui.cfg
@@ -58,7 +58,7 @@ TBG_e_histogram="--e_energyHistogram.period !TBG_plugin_period --e_energyHistogr
 # - requires parallel libSplash for HDF5 output
 # - momentum range in m_<species> c
 TBG_e_PSxpx="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space x --e_phaseSpace.momentum px --e_phaseSpace.min -8.0 --e_phaseSpace.max 8.0"
-TBG_e_PSypy="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space y --e_phaseSpace.momentum py --e_phaseSpace.min -0.5 --e_phaseSpace.max 3.0"
+TBG_e_PSypy="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space y --e_phaseSpace.momentum py --e_phaseSpace.min -1.5 --e_phaseSpace.max 5.0"
 TBG_e_PSzpz="--e_phaseSpace.period !TBG_plugin_period --e_phaseSpace.space z --e_phaseSpace.momentum pz --e_phaseSpace.min -2.0 --e_phaseSpace.max 2.0"
 
 TBG_plugins="!TBG_pngYX                    \


### PR DESCRIPTION
Improve ranges for LWFA GUI example and fix typos in example of phase space python analysis plot.

**Energy Histogram (step=4000)**
![screenshot from 2017-11-07 11-40-21](https://user-images.githubusercontent.com/1353258/32489830-7690a356-c3b1-11e7-8dbd-e33a3ffe3463.png)


**Phase space: ypy (step=2000)**

![figure_1](https://user-images.githubusercontent.com/1353258/32489529-a1b24ad6-c3b0-11e7-9bd4-59b6c820693d.png)

(note: increased momentum range now even a bit more)


ccing @codingS3b 