### PR TITLE
create separate plugin for checkpointing

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -195,12 +195,12 @@ TBG_restart="--checkpoint.restart"
 # To restart in a new run directory point to the old run where to start from
 #   --checkpoint.restart.directory /path/to/simOutput/checkpoints
 
-# Presentation mode: loop a simulation via soft restart
+# Presentation mode: loop a simulation via restarts
 #   does either start from 0 again or from the checkpoint specified with
 #   --checkpoint.restart.step as soon as the simulation reached the last time step;
 #   in the example below, the simulation is run 5000 times before it shuts down
 # Note: does currently not work with `Radiation` plugin
-TBG_softRestarts="--checkpoint.restart.soft 5000"
+TBG_restartLoop="--checkpoint.restart.loop 5000"
 
 # Live in situ visualization using ISAAC
 #   Initial period in which a image shall be rendered

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -184,23 +184,23 @@ TBG_adios="--adios.period 100 --adios.file simData"
 #                      (FS chooses OST;user chooses striping factor)
 #   --adios.transport-params "semicolon_separated_list"
 
-# Create a checkpoint that is restartable every --checkpoints steps
+# Create a checkpoint that is restartable every --checkpoint.period steps
 #   http://git.io/PToFYg
-TBG_checkpoints="--checkpoints 1000"
+TBG_checkpoint="--checkpoint.period 1000"
 
-# Restart the simulation from checkpoints created using TBG_checkpoints
-TBG_restart="--restart"
+# Restart the simulation from checkpoint created using TBG_checkpoint
+TBG_restart="--checkpoint.restart"
 # By default, the last checkpoint is restarted if not specified via
-#   --restart-step 1000
+#   --checkpoint.restart.step 1000
 # To restart in a new run directory point to the old run where to start from
-#   --restart-directory /path/to/simOutput/checkpoints
+#   --checkpoint.restart.directory /path/to/simOutput/checkpoints
 
 # Presentation mode: loop a simulation via soft restart
 #   does either start from 0 again or from the checkpoint specified with
-#   --restart-step as soon as the simulation reached the last time step;
+#   --checkpoint.restart.step as soon as the simulation reached the last time step;
 #   in the example below, the simulation is run 5000 times before it shuts down
 # Note: does currently not work with `Radiation` plugin
-TBG_softRestarts="--softRestarts 5000"
+TBG_softRestarts="--checkpoint.restart.soft 5000"
 
 # Live in situ visualization using ISAAC
 #   Initial period in which a image shall be rendered

--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -9,6 +9,7 @@ Plugin name                                                                   sh
 :ref:`ADIOS <usage-plugins-ADIOS>` [#f2]_                                     stores simulation data as ADIOS files
 :ref:`energy histogram <usage-plugins-energyHistogram>`                       energy histograms for electrons and ions
 :ref:`charge conservation <usage-plugins-chargeConservation>`                 maximum difference between electron charge density and div E
+:ref:`checkpoint <usage-plugins-checkpoint>` [#f2]_                           stores the primary data of the simulation for restarts.
 :ref:`count particles <usage-plugins-countParticles>`                         count total number of macro particles
 :ref:`count per supercell <usage-plugins-countPerSupercell>` [#f3]_           count macro particles *per supercell*
 :ref:`energy fields <usage-plugins-energyFields>`                             electromagnetic field energy per time step

--- a/docs/source/usage/plugins/checkpoint.rst
+++ b/docs/source/usage/plugins/checkpoint.rst
@@ -1,0 +1,61 @@
+.. _usage-plugins-checkpoint:
+
+Checkpoint
+----
+
+Stores the primary data of the simulation for restarts.
+Primary data includes:
+
+* electro-magnetic fields
+* particle attributes
+* state of random number generators and particle ID generator
+* ...
+
+.. note::
+
+   Some plugins have their onw internal state.
+   They will be notified on checkpoints to store their state themselves.
+
+What is the format of the created files?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We write our fields and particles in an open markup called **openPMD**.
+You can investigate your files via a large collection of `tools and frameworks <https://github.com/openPMD/openPMD-projects>`_ or your use the native HDF5 bindings of your `favourite programming language <https://en.wikipedia.org/wiki/Hierarchical_Data_Format#Interfaces>`_.
+
+**Resources for a quick-start:**
+
+* `online tutorial <http://www.openPMD.org>`_
+* `example files <https://github.com/openPMD/openPMD-example-datasets>`_
+* `written standard <https://github.com/openPMD/openPMD-standard>`_ of the openPMD standard
+* `list of projects <https://github.com/openPMD/openPMD-projects>`_ supporting openPMD files
+
+External Dependencies
+^^^^^^^^^^^^^^^^^^^^^
+
+The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <install-dependencies>` are compiled in.
+
+.cfg file
+^^^^^^^^^
+
+You can use ``--checkpoint.period`` to specify the output period of the created checkpoints.
+Note that this plugin will only be available if ``libSplash and HDF5`` or Adios is found during compile configuration.
+
+================================== ======================================================================================
+PIConGPU command line option       Description
+================================== ======================================================================================
+``--checkpoint.backend``           IO-backend used to create the checkpoint.
+``--checkpoint.file``              Relative or absolute fileset prefix for writing checkpoints.
+                                   If relative, checkpoint files are stored under ``simOutput/<checkpoint-directory>``.
+                                   Default depends on the selected IO-backend.
+``--checkpoint.restart.backend``   IO-backend used to load a existent checkpoint.
+``--checkpoint.restart.file``      Relative or absolute fileset prefix for reading checkpoints.
+                                   If relative, checkpoint files are searched under ``simOutput/<checkpoint-directory>``.
+                                   Default depends on the selected IO-backend``.
+``--checkpoint.restart.chunkSize`` Number of particles processed in one kernel call during restart to prevent frame count blowup.
+``--checkpoint.<IO-backend>.*      Additional options to control the IO-bakend
+================================== ======================================================================================
+
+Additional Tools
+^^^^^^^^^^^^^^^^
+
+See our :ref:`openPMD <pp-openPMD>` chapter.

--- a/docs/source/usage/plugins/checkpoint.rst
+++ b/docs/source/usage/plugins/checkpoint.rst
@@ -1,7 +1,7 @@
 .. _usage-plugins-checkpoint:
 
 Checkpoint
-----
+----------
 
 Stores the primary data of the simulation for restarts.
 Primary data includes:
@@ -13,32 +13,26 @@ Primary data includes:
 
 .. note::
 
-   Some plugins have their onw internal state.
+   Some plugins have their own internal state.
    They will be notified on checkpoints to store their state themselves.
 
 What is the format of the created files?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We write our fields and particles in an open markup called **openPMD**.
-You can investigate your files via a large collection of `tools and frameworks <https://github.com/openPMD/openPMD-projects>`_ or your use the native HDF5 bindings of your `favourite programming language <https://en.wikipedia.org/wiki/Hierarchical_Data_Format#Interfaces>`_.
+We write our fields and particles in an open markup called :ref:`openPMD <pp-openPMD>`.
 
-**Resources for a quick-start:**
-
-* `online tutorial <http://www.openPMD.org>`_
-* `example files <https://github.com/openPMD/openPMD-example-datasets>`_
-* `written standard <https://github.com/openPMD/openPMD-standard>`_ of the openPMD standard
-* `list of projects <https://github.com/openPMD/openPMD-projects>`_ supporting openPMD files
+For further details, see the according sections in :ref:`HDF5 <usage-plugins-HDF5>` and :ref:`ADIOS <usage-plugins-ADIOS>`.
 
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
-The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <install-dependencies>` are compiled in.
+The plugin is available as soon as the :ref:`libSplash (HDF5) or ADIOS libraries <install-dependencies>` are compiled in.
 
 .cfg file
 ^^^^^^^^^
 
 You can use ``--checkpoint.period`` to specify the output period of the created checkpoints.
-Note that this plugin will only be available if ``libSplash and HDF5`` or Adios is found during compile configuration.
+Note that this plugin will only be available if libSplash (HDF5) or ADIOS is found during compile configuration.
 
 ================================== ======================================================================================
 PIConGPU command line option       Description
@@ -55,7 +49,12 @@ PIConGPU command line option       Description
 ``--checkpoint.<IO-backend>.*      Additional options to control the IO-bakend
 ================================== ======================================================================================
 
-Additional Tools
-^^^^^^^^^^^^^^^^
+Interacting Manually with Checkpoint Data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See our :ref:`openPMD <pp-openPMD>` chapter.
+.. note::
+
+   Interacting with the *raw data of checkpoints* for manual manipulation is considered an advanced feature for experienced users.
+
+Contrary to regular output, checkpoints contain additional data which might be confusing on the first glance.
+For example, some comments might be missing, all data from our concept of `slides for moving window simulations <https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-domain-definitions>`_ will be visible, additional data for internal states of helper classes is stored as well and index tables such as openPMD particle patches are essential for parallel restarts.

--- a/docs/source/usage/plugins/hdf5.rst
+++ b/docs/source/usage/plugins/hdf5.rst
@@ -55,12 +55,6 @@ PIConGPU command line option Description
 ``--hdf5.file``              Relative or absolute fileset prefix for simulation data.
                              If relative, files are stored under ``simOutput/``.
                              Default is ``h5``.
-``--hdf5.checkpoint-file``   Relative or absolute fileset prefix for writing checkpoints.
-                             If relative, checkpoint files are stored under ``simOutput/<checkpoint-directory>``.
-                             Default is ``h5_checkpoint``.
-``--hdf5.restart-file``      Relative or absolute fileset prefix for reading checkpoints.
-                             If relative, checkpoint files are searched under ``simOutput/<checkpoint-directory>``.
-                             Default is ``<checkpoint-file>``.
 ============================ ======================================================================================
 
 Additional Tools

--- a/etc/picongpu/hypnos-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k80_restart.tpl
@@ -104,9 +104,9 @@ done
 finalStep=`echo !TBG_programParams | sed 's/.*-s[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
 echo "final step      = " $finalStep | tee -a output
 #this sed call extracts the -s and --checkpoint flags
-programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoints[[:blank:]]\+[0-9]\+[^\s]//g'`
+programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9]\+[^\s]//g'`
 #extract restart period
-restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoints[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
+restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
 echo  "restart period = " $restartPeriod | tee -a output
 
 if [ "" != "$file" ]
@@ -117,11 +117,11 @@ then
     endTime="$(($cptimestep + $restartPeriod ))"
     echo "end time        = " $endTime | tee -a output
 
-    stepSetup=$(echo -s $endTime "--restart --restart-step" $cptimestep "--checkpoints" $restartPeriod )
+    stepSetup=$(echo -s $endTime "--checkpoint.restart --checkpoint.restart.step" $cptimestep "--checkpoint.period" $restartPeriod )
 else
     echo "no checkpoint found" | tee -a output
     endTime=$restartPeriod
-    stepSetup=$(echo " -s " $endTime "--checkpoints" $restartPeriod )
+    stepSetup=$(echo " -s " $endTime "--checkpoint.period" $restartPeriod )
 fi
 
 echo "--- end automated restart routine ---" | tee -a output

--- a/include/picongpu/plugins/Checkpoint.hpp
+++ b/include/picongpu/plugins/Checkpoint.hpp
@@ -1,5 +1,4 @@
-/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Alexander Grund
+/* Copyright 2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -32,11 +31,11 @@
 #endif
 #include <pmacc/pluginSystem/PluginConnector.hpp>
 
-
 #include <string>
 #include <map>
 #include <memory>
 #include <stdexcept>
+
 
 namespace picongpu
 {
@@ -180,7 +179,7 @@ namespace picongpu
             if( !ioBackends.empty( ) && cBackend == ioBackends.end( ) )
                 throw std::runtime_error( std::string( "IO-backend " ) +
                     checkpointBackendName +
-                    " not found, possible backends " +
+                    " for checkpoints not found, possible backends: " +
                     activeBackends
                 );
 
@@ -188,11 +187,11 @@ namespace picongpu
             if( !ioBackends.empty( ) && rBackend == ioBackends.end( ) )
                 throw std::runtime_error( std::string( "IO-backend " ) +
                     restartBackendName +
-                    " not found, possible backends " +
+                    " for restarts not found, possible backends: " +
                     activeBackends
                 );
 
-            if (restartFilename == "")
+            if( restartFilename.empty( ) )
             {
                 restartFilename = checkpointFilename;
             }

--- a/include/picongpu/plugins/Checkpoint.hpp
+++ b/include/picongpu/plugins/Checkpoint.hpp
@@ -1,0 +1,236 @@
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Alexander Grund
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/plugins/output/IIOBackend.hpp"
+#include "picongpu/plugins/ISimulationPlugin.hpp"
+
+#if(ENABLE_ADIOS == 1)
+#   include "picongpu/plugins/adios/ADIOSWriter.hpp"
+#endif
+#if(ENABLE_HDF5 == 1)
+#   include "picongpu/plugins/hdf5/HDF5Writer.hpp"
+#endif
+#include <pmacc/pluginSystem/PluginConnector.hpp>
+
+
+#include <string>
+#include <map>
+#include <memory>
+#include <stdexcept>
+
+namespace picongpu
+{
+    /** Checkpoint creation and load
+     *
+     *  Plugin is handling different IO-backends to create and load simulation checkpoints
+     */
+    class Checkpoint : public ISimulationPlugin
+    {
+    public:
+
+        Checkpoint( ) :
+            checkpointFilename( "checkpoint" ),
+            restartChunkSize( 0u )
+        {
+#if(ENABLE_ADIOS == 1)
+            ioBackends[ "adios" ] = IIOBackend::create< adios::ADIOSWriter >( false );
+#endif
+#if(ENABLE_HDF5 == 1)
+            ioBackends[ "hdf5" ] = IIOBackend::create< hdf5::HDF5Writer >( false );
+#endif
+            // if adios is enabled the default is adios
+            if( !ioBackends.empty( ) )
+            {
+                checkpointBackendName = ioBackends.begin( )->first;
+                restartBackendName = ioBackends.begin( )->first;
+            }
+
+            uint32_t backendCount = 0u;
+            for( auto & backend : ioBackends )
+            {
+                if( backendCount >= 1u )
+                    activeBackends += ", ";
+                activeBackends += backend.first;
+                ++backendCount;
+            }
+
+            Environment<>::get( ).PluginConnector( ).registerPlugin( this );
+        }
+
+        virtual ~Checkpoint( )
+        {
+
+        }
+
+        void pluginRegisterHelp(boost::program_options::options_description & desc)
+        {
+
+            namespace po = boost::program_options;
+            if( ioBackends.empty( ) )
+                desc.add_options( )(
+                    "checkpoint",
+                    "plugin disabled [compiled without dependency HDF5 or Adios]"
+                );
+            else
+                desc.add_options( )
+                    (
+                        "checkpoint.backend",
+                        po::value <std::string >( &checkpointBackendName ),
+                        ( std::string( "Optional backend for checkpointing [" ) + activeBackends + "] default: " + checkpointBackendName ).c_str( )
+                    )(
+                        "checkpoint.file",
+                        po::value< std::string >( &checkpointFilename ),
+                        "Optional checkpoint filename (prefix)"
+                    )(
+                        "checkpoint.restart.backend",
+                        po::value< std::string >( &restartBackendName ),
+                        ( std::string( "Optional backend for restarting [" ) + activeBackends + "] default: " + restartBackendName ).c_str( )
+                    )(
+                        "checkpoint.restart.file",
+                        po::value< std::string >( &restartFilename ),
+                        "checkpoint restart filename (prefix)"
+                    )(
+                        /* 1,000,000 particles are around 3900 frames at 256 particles per frame
+                         * and match ~30MiB with typical picongpu particles.
+                         * The only reason why we use 1M particles per chunk is that we can get a
+                         * frame overflow in our memory manager if we process all particles in one kernel.
+                         **/
+                        "checkpoint.restart.chunkSize",
+                        po::value< uint32_t >(&restartChunkSize)->default_value( 1000000u ),
+                        "Number of particles processed in one kernel call during restart to prevent frame count blowup"
+                    );
+
+                for( auto & backend : ioBackends )
+                    backend.second->expandHelp(
+                        "checkpoint.",
+                        desc
+                    );
+
+        }
+
+        std::string pluginGetName( ) const
+        {
+            return "Checkpoint";
+        }
+
+        void notify( uint32_t )
+        {
+        }
+
+        void setMappingDescription(MappingDesc *cellDescription)
+        {
+            for( auto & backend : ioBackends )
+                backend.second->setMappingDescription( cellDescription );
+        }
+
+        void checkpoint(
+            uint32_t currentStep,
+            const std::string checkpointDirectory
+        )
+        {
+            auto cBackend = ioBackends.find( checkpointBackendName );
+            if( cBackend != ioBackends.end( ) )
+            {
+                cBackend->second->dumpCheckpoint(
+                    currentStep,
+                    checkpointDirectory,
+                    checkpointFilename
+                );
+            }
+        }
+
+        void restart(uint32_t restartStep, const std::string restartDirectory)
+        {
+            auto rBackend = ioBackends.find( restartBackendName );
+            if( rBackend != ioBackends.end( ) )
+            {
+                rBackend->second->doRestart(
+                    restartStep,
+                    restartDirectory,
+                    restartFilename,
+                    restartChunkSize
+                );
+            }
+        }
+
+    private:
+        void pluginLoad( )
+        {
+            auto cBackend = ioBackends.find( checkpointBackendName );
+            if( !ioBackends.empty( ) && cBackend == ioBackends.end( ) )
+                throw std::runtime_error( std::string( "IO-backend " ) +
+                    checkpointBackendName +
+                    " not found, possible backends " +
+                    activeBackends
+                );
+
+            auto rBackend = ioBackends.find( restartBackendName );
+            if( !ioBackends.empty( ) && rBackend == ioBackends.end( ) )
+                throw std::runtime_error( std::string( "IO-backend " ) +
+                    restartBackendName +
+                    " not found, possible backends " +
+                    activeBackends
+                );
+
+            if (restartFilename == "")
+            {
+                restartFilename = checkpointFilename;
+            }
+
+            for( auto & backend : ioBackends )
+                backend.second->load( );
+        }
+
+        virtual void pluginUnload( )
+        {
+            for( auto & backend : ioBackends )
+                backend.second->unload( );
+        }
+
+        //! string list with all possible IO-backends
+        std::string activeBackends;
+
+        //! name of the IO-backend to create checkpoints
+        std::string checkpointBackendName;
+        //! prefix of the checkpoint file
+        std::string checkpointFilename;
+
+        //! name of the IO-backend to restart from a checkpoint
+        std::string restartBackendName;
+        //! prefix of the restart file
+        std::string restartFilename;
+        /** number of particles processed in one kernel
+         *
+         * Load particles in chunks avoid that the accelerator backend is
+         * running out of frame memory.
+         */
+        uint32_t restartChunkSize;
+
+        // can be "adios" and "hdf5"
+        std::map<
+            std::string,
+            std::shared_ptr< IIOBackend >
+        > ioBackends;
+    };
+
+} // namespace picongpu

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -68,6 +68,7 @@
 #   include "picongpu/plugins/hdf5/HDF5Writer.hpp"
 #endif
 
+#include "picongpu/plugins/Checkpoint.hpp"
 #include "picongpu/plugins/ResourceLog.hpp"
 
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
@@ -137,6 +138,7 @@ private:
 #if (ENABLE_HDF5 == 1)
         , hdf5::HDF5Writer
 #endif
+        , Checkpoint
         , ResourceLog
     > StandAlonePlugins;
 

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -118,6 +118,7 @@ private:
 
     /* define stand alone plugins*/
     typedef bmpl::vector<
+        Checkpoint,
         EnergyFields
 #if (ENABLE_ADIOS == 1)
         , adios::ADIOSWriter
@@ -138,7 +139,6 @@ private:
 #if (ENABLE_HDF5 == 1)
         , hdf5::HDF5Writer
 #endif
-        , Checkpoint
         , ResourceLog
     > StandAlonePlugins;
 

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -524,6 +524,10 @@ private:
 
 public:
 
+    /** constructor
+     *
+     * @param isIndependent if `true`: class register itself to PluginConnector
+     */
     ADIOSWriter(bool isIndependent = true) :
     filename("simData"),
     outputDirectory("bp"),

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -46,7 +46,7 @@
 #endif
 #include <pmacc/traits/Limits.hpp>
 
-#include "picongpu/plugins/ILightweightPlugin.hpp"
+#include "picongpu/plugins/output/IIOBackend.hpp"
 
 #include "picongpu/plugins/adios/WriteMeta.hpp"
 #include "picongpu/plugins/adios/WriteSpecies.hpp"
@@ -137,11 +137,11 @@ int64_t defineAdiosVar(int64_t group_id,
     return var_id;
 }
 
-/**
- * Writes simulation data to adios files.
- * Implements the ILightweightPlugin interface.
+/** Writes simulation data to adios files.
+ *
+ * Implements the IIOBackend interface.
  */
-class ADIOSWriter : public ILightweightPlugin
+class ADIOSWriter : public IIOBackend
 {
 private:
 
@@ -524,17 +524,17 @@ private:
 
 public:
 
-    ADIOSWriter() :
+    ADIOSWriter(bool isIndependent = true) :
     filename("simData"),
     outputDirectory("bp"),
-    checkpointFilename("checkpoint"),
-    restartFilename(""), /* set to checkpointFilename by default */
     /* select MPI method, #OSTs and #aggregators */
     mpiTransportParams(""),
     notifyPeriod(0),
     lastSpeciesSyncStep(pmacc::traits::limits::Max<uint32_t>::value)
     {
-        Environment<>::get().PluginConnector().registerPlugin(this);
+        // only register if plugin is not maintained by an wrapper
+        if(isIndependent)
+            Environment<>::get().PluginConnector().registerPlugin(this);
     }
 
     virtual ~ADIOSWriter()
@@ -547,28 +547,28 @@ public:
         desc.add_options()
             ("adios.period", po::value<uint32_t > (&notifyPeriod)->default_value(0),
              "enable ADIOS IO [for each n-th step]")
-            ("adios.aggregators", po::value<uint32_t >
-             (&mThreadParams.adiosAggregators)->default_value(0), "Number of aggregators [0 == number of MPI processes]")
-            ("adios.ost", po::value<uint32_t > (&mThreadParams.adiosOST)->default_value(1),
-             "Number of OST")
-            ("adios.disable-meta", po::bool_switch (&mThreadParams.adiosDisableMeta)->default_value(false),
-             "Disable online gather and write of a global meta file, can be time consuming (use `bpmeta` post-mortem)")
-            ("adios.transport-params", po::value<std::string > (&mThreadParams.adiosTransportParams),
-             "additional transport parameters, see ADIOS manual chapter 6.1.5, e.g., 'random_offset=1;stripe_count=4'")
-            ("adios.compression", po::value<std::string >
-             (&mThreadParams.adiosCompression)->default_value("none"),
-             "ADIOS compression method, e.g., zlib (see `adios_config -m` for help)")
             ("adios.file", po::value<std::string > (&filename)->default_value(filename),
-             "ADIOS output file")
-            ("adios.checkpoint-file", po::value<std::string > (&checkpointFilename),
-             "Optional ADIOS checkpoint filename (prefix)")
-            ("adios.restart-file", po::value<std::string > (&restartFilename),
-             "adios restart filename (prefix)")
-            /* 50,000 particles are around 200 frames at 256 particles per frame (each 8k memory)
-             * and match ~400MiB with typical picongpu particles.
-             **/
-            ("adios.restart-chunkSize", po::value<uint32_t > (&restartChunkSize)->default_value(50000),
-             "Number of particles processed in one kernel call during restart to prevent frame count blowup");
+             "ADIOS output file");
+        expandHelp("", desc);
+    }
+
+    virtual void expandHelp(
+        std::string const & prefix,
+        boost::program_options::options_description & desc
+    )
+    {
+        desc.add_options()
+            ((prefix + "adios.aggregators").c_str(), po::value<uint32_t >
+            (&mThreadParams.adiosAggregators)->default_value(0), "Number of aggregators [0 == number of MPI processes]")
+            ((prefix + "adios.ost").c_str(), po::value<uint32_t > (&mThreadParams.adiosOST)->default_value(1),
+             "Number of OST")
+            ((prefix + "adios.disable-meta").c_str(), po::bool_switch (&mThreadParams.adiosDisableMeta)->default_value(false),
+             "Disable online gather and write of a global meta file, can be time consuming (use `bpmeta` post-mortem)")
+            ((prefix + "adios.transport-params").c_str(), po::value<std::string > (&mThreadParams.adiosTransportParams),
+             "additional transport parameters, see ADIOS manual chapter 6.1.5, e.g., 'random_offset=1;stripe_count=4'")
+            ((prefix + "adios.compression").c_str(), po::value<std::string >
+             (&mThreadParams.adiosCompression)->default_value("none"),
+             "ADIOS compression method, e.g., zlib (see `adios_config -m` for help)");
     }
 
     std::string pluginGetName() const
@@ -583,18 +583,49 @@ public:
 
     void notify(uint32_t currentStep)
     {
-        notificationReceived(currentStep, false);
+        __getTransactionEvent().waitForFinished();
+
+        /* if file name is relative, prepend with common directory */
+        if( boost::filesystem::path(filename).has_root_path() )
+            mThreadParams.adiosFilename = filename;
+        else
+            mThreadParams.adiosFilename = outputDirectory + "/" + filename;
+
+        /* window selection */
+        mThreadParams.window = MovingWindow::getInstance().getWindow(currentStep);
+        mThreadParams.isCheckpoint = false;
+        dumpData(currentStep);
     }
 
-    void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
+    void dumpCheckpoint(
+        const uint32_t currentStep,
+        const std::string& checkpointDirectory,
+        const std::string& checkpointFilename
+    )
     {
-        this->checkpointDirectory = checkpointDirectory;
+        __getTransactionEvent().waitForFinished();
+        /* if file name is relative, prepend with common directory */
+        if( boost::filesystem::path(checkpointFilename).has_root_path() )
+            mThreadParams.adiosFilename = checkpointFilename;
+        else
+            mThreadParams.adiosFilename = checkpointDirectory + "/" + checkpointFilename;
 
-        notificationReceived(currentStep, true);
+        mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(currentStep);
+        mThreadParams.isCheckpoint = true;
+
+        dumpData(currentStep);
     }
 
-    void restart(uint32_t restartStep, const std::string restartDirectory)
+    void doRestart(
+        const uint32_t restartStep,
+        const std::string& restartDirectory,
+        const std::string& constRestartFilename,
+        const uint32_t restartChunkSize
+    )
     {
+        // allow to modify the restart file name
+        std::string restartFilename{ constRestartFilename };
+
         std::stringstream adiosPathBase;
         adiosPathBase << ADIOS_PATH_ROOT << restartStep << "/";
         mThreadParams.adiosBasePath = adiosPathBase.str();
@@ -769,36 +800,12 @@ private:
      * Notification for dump or checkpoint received
      *
      * @param currentStep current simulation step
-     * @param isCheckpoint checkpoint notification
      */
-    void notificationReceived(uint32_t currentStep, bool isCheckpoint)
+    void dumpData(uint32_t currentStep)
     {
         const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
-        mThreadParams.isCheckpoint = isCheckpoint;
-        mThreadParams.currentStep = currentStep;
         mThreadParams.cellDescription = this->cellDescription;
-
-        __getTransactionEvent().waitForFinished();
-
-        std::string bpFilename( filename );
-        std::string bpFiledir( outputDirectory );
-        if( isCheckpoint )
-        {
-            bpFilename = checkpointFilename;
-            bpFiledir = checkpointDirectory;
-        }
-
-        /* if file name is relative, prepend with common directory */
-        if( boost::filesystem::path(bpFilename).has_root_path() )
-            mThreadParams.adiosFilename = bpFilename;
-        else
-            mThreadParams.adiosFilename = bpFiledir + "/" + bpFilename;
-
-        /* window selection */
-        if( isCheckpoint )
-            mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(currentStep);
-        else
-            mThreadParams.window = MovingWindow::getInstance().getWindow(currentStep);
+        mThreadParams.currentStep = currentStep;
 
         for (uint32_t i = 0; i < simDim; ++i)
         {
@@ -810,7 +817,6 @@ private:
                     localDomain.offset[i];
             }
         }
-
 
         /* copy species only one time per timestep to the host */
         if( lastSpeciesSyncStep != currentStep )
@@ -881,11 +887,6 @@ private:
             strMPITransportParams << ";" << mThreadParams.adiosTransportParams;
 
         mpiTransportParams = strMPITransportParams.str();
-
-        if( restartFilename.empty() )
-        {
-            restartFilename = checkpointFilename;
-        }
 
         loaded = true;
     }
@@ -1132,15 +1133,11 @@ private:
 
     uint32_t notifyPeriod;
     std::string filename;
-    std::string checkpointFilename;
-    std::string restartFilename;
     std::string outputDirectory;
-    std::string checkpointDirectory;
 
     /* select MPI method, #OSTs and #aggregators */
     std::string mpiTransportParams;
 
-    uint32_t restartChunkSize;
     uint32_t lastSpeciesSyncStep;
 
     DataSpace<simDim> mpi_pos;

--- a/include/picongpu/plugins/hdf5/HDF5Writer.hpp
+++ b/include/picongpu/plugins/hdf5/HDF5Writer.hpp
@@ -89,6 +89,10 @@ class HDF5Writer : public IIOBackend
 {
 public:
 
+    /** constructor
+     *
+     * @param isIndependent if `true`: class register itself to PluginConnector
+     */
     HDF5Writer(bool isIndependent = true) :
     filename("simData"),
     outputDirectory("h5"),

--- a/include/picongpu/plugins/hdf5/HDF5Writer.hpp
+++ b/include/picongpu/plugins/hdf5/HDF5Writer.hpp
@@ -52,7 +52,7 @@
 #include "picongpu/simulationControl/MovingWindow.hpp"
 #include <pmacc/math/Vector.hpp>
 
-#include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/output/IIOBackend.hpp"
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/pair.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -81,25 +81,22 @@ using namespace pmacc;
 
 using namespace splash;
 
-
-namespace po = boost::program_options;
-
-/**
- * Writes simulation data to hdf5 files using libSplash.
- * Implements the ISimulationPlugin interface.
+/** Writes simulation data to hdf5 files using libSplash.
+ *
+ * Implements the IIOBackend interface.
  */
-class HDF5Writer : public ISimulationPlugin
+class HDF5Writer : public IIOBackend
 {
 public:
 
-    HDF5Writer() :
+    HDF5Writer(bool isIndependent = true) :
     filename("simData"),
     outputDirectory("h5"),
-    checkpointFilename("checkpoint"),
-    restartFilename(""), /* set to checkpointFilename by default */
     notifyPeriod(0)
     {
-        Environment<>::get().PluginConnector().registerPlugin(this);
+        // only register if plugin is not maintained by an wrapper
+        if(isIndependent)
+            Environment<>::get().PluginConnector().registerPlugin(this);
     }
 
     virtual ~HDF5Writer()
@@ -107,24 +104,21 @@ public:
 
     }
 
-    void pluginRegisterHelp(po::options_description& desc)
+    void pluginRegisterHelp(boost::program_options::options_description& desc)
     {
+        namespace po = boost::program_options;
         desc.add_options()
             ("hdf5.period", po::value<uint32_t > (&notifyPeriod)->default_value(0),
              "enable HDF5 IO [for each n-th step]")
             ("hdf5.file", po::value<std::string > (&filename)->default_value(filename),
-             "HDF5 output filename (prefix)")
-            ("hdf5.checkpoint-file", po::value<std::string > (&checkpointFilename),
-             "Optional HDF5 checkpoint filename (prefix)")
-            ("hdf5.restart-file", po::value<std::string > (&restartFilename),
-             "HDF5 restart filename (prefix)")
-            /* 1,000,000 particles are around 3900 frames at 256 particles per frame
-             * and match ~30MiB with typical picongpu particles.
-             * The only reason why we use 1M particles per chunk is that we can get a
-             * frame overflow in our memory manager if we process all particles in one kernel.
-             **/
-            ("hdf5.restart-chunkSize", po::value<uint32_t > (&restartChunkSize)->default_value(1000000),
-             "Number of particles processed in one kernel call during restart to prevent frame count blowup");
+             "HDF5 output filename (prefix)");
+    }
+
+    virtual void expandHelp(
+        std::string const & prefix,
+        boost::program_options::options_description & desc
+    )
+    {
     }
 
     std::string pluginGetName() const
@@ -134,32 +128,35 @@ public:
 
     void setMappingDescription(MappingDesc *cellDescription)
     {
-
         this->cellDescription = cellDescription;
         mThreadParams.cellDescription = this->cellDescription;
     }
 
     void notify(uint32_t currentStep)
     {
-        notificationReceived(currentStep, false);
+        __getTransactionEvent().waitForFinished();
+        /* if file name is relative, prepend with common directory */
+        if( boost::filesystem::path(filename).has_root_path() )
+            mThreadParams.h5Filename = filename;
+        else
+            mThreadParams.h5Filename = outputDirectory + "/" + filename;
+
+        /* window selection */
+        mThreadParams.window = MovingWindow::getInstance().getWindow(currentStep);
+        mThreadParams.isCheckpoint = false;
+        dumpData(currentStep);
     }
 
-    void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
+    void doRestart(
+        const uint32_t restartStep,
+        const std::string& restartDirectory,
+        const std::string& constRestartFilename,
+        const uint32_t restartChunkSize
+    )
     {
-#if(ENABLE_ADIOS == 1)
-        log<picLog::INPUT_OUTPUT > ("HDF5: Checkpoint skipped since ADIOS is enabled.");
-#else
-        this->checkpointDirectory = checkpointDirectory;
+        // allow to modify the restart file name
+        std::string restartFilename{ constRestartFilename };
 
-        notificationReceived(currentStep, true);
-#endif
-    }
-
-    void restart(uint32_t restartStep, const std::string restartDirectory)
-    {
-#if(ENABLE_ADIOS == 1)
-        log<picLog::INPUT_OUTPUT > ("HDF5: Restart skipped since ADIOS is enabled.");
-#else
         const uint32_t maxOpenFilesPerNode = 4;
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
         mThreadParams.dataCollector = new ParallelDomainCollector(
@@ -244,7 +241,25 @@ public:
             mThreadParams.dataCollector->finalize();
 
         __delete(mThreadParams.dataCollector);
-#endif
+    }
+
+    void dumpCheckpoint(
+        const uint32_t currentStep,
+        const std::string& checkpointDirectory,
+        const std::string& checkpointFilename
+    )
+    {
+        __getTransactionEvent().waitForFinished();
+        /* if file name is relative, prepend with common directory */
+        if( boost::filesystem::path(checkpointFilename).has_root_path() )
+            mThreadParams.h5Filename = checkpointFilename;
+        else
+            mThreadParams.h5Filename = checkpointDirectory + "/" + checkpointFilename;
+
+        mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(currentStep);
+        mThreadParams.isCheckpoint = true;
+
+        dumpData(currentStep);
     }
 
 private:
@@ -290,40 +305,16 @@ private:
         }
     }
 
-    /**
-     * Notification for dump or checkpoint received
+    /** dump data
      *
      * @param currentStep current simulation step
      * @param isCheckpoint checkpoint notification
      */
-    void notificationReceived(uint32_t currentStep, bool isCheckpoint)
+    void dumpData(uint32_t currentStep)
     {
         const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
-        mThreadParams.isCheckpoint = isCheckpoint;
-        mThreadParams.currentStep = currentStep;
         mThreadParams.cellDescription = this->cellDescription;
-
-        __getTransactionEvent().waitForFinished();
-
-        std::string h5Filename( filename );
-        std::string h5Filedir( outputDirectory );
-        if( isCheckpoint )
-        {
-            h5Filename = checkpointFilename;
-            h5Filedir = checkpointDirectory;
-        }
-
-        /* if file name is relative, prepend with common directory */
-        if( boost::filesystem::path(h5Filename).has_root_path() )
-            mThreadParams.h5Filename = h5Filename;
-        else
-            mThreadParams.h5Filename = h5Filedir + "/" + h5Filename;
-
-        /* window selection */
-        if( isCheckpoint )
-            mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(currentStep);
-        else
-            mThreadParams.window = MovingWindow::getInstance().getWindow(currentStep);
+        mThreadParams.currentStep = currentStep;
 
         for (uint32_t i = 0; i < simDim; ++i)
         {
@@ -371,11 +362,6 @@ private:
 
             /** create notify directory */
             Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(outputDirectory);
-        }
-
-        if (restartFilename == "")
-        {
-            restartFilename = checkpointFilename;
         }
 
         loaded = true;
@@ -448,14 +434,8 @@ private:
     MappingDesc *cellDescription;
 
     uint32_t notifyPeriod;
-    int64_t lastCheckpoint;
     std::string filename;
-    std::string checkpointFilename;
-    std::string restartFilename;
     std::string outputDirectory;
-    std::string checkpointDirectory;
-
-    uint32_t restartChunkSize;
 
     DataSpace<simDim> mpi_pos;
     DataSpace<simDim> mpi_size;

--- a/include/picongpu/plugins/output/IIOBackend.hpp
+++ b/include/picongpu/plugins/output/IIOBackend.hpp
@@ -1,0 +1,75 @@
+/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Alexander Grund
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/plugins/ILightweightPlugin.hpp"
+
+#include <string>
+#include <memory>
+
+namespace picongpu
+{
+
+//! Interface for IO-backends with restart capability
+class IIOBackend : public ILightweightPlugin
+{
+public:
+
+
+    IIOBackend()
+    {
+
+    }
+
+    template< typename T_IOBackend >
+    static std::shared_ptr<IIOBackend> create( bool const isIndependent = true )
+    {
+        return std::shared_ptr<IIOBackend>( new T_IOBackend( isIndependent ) );
+    }
+
+    virtual ~IIOBackend()
+    {
+
+    }
+
+    //! create a checkpoint
+    virtual void dumpCheckpoint(
+        uint32_t currentStep,
+        std::string const & checkpointDirectory,
+        std::string const & checkpointFilename
+    ) = 0;
+
+    //! restart from a checkpoint
+    virtual void doRestart(
+        uint32_t restartStep,
+        std::string const & restartDirectory,
+        std::string const & restartFilename,
+        uint32_t restartChunkSize
+    ) = 0;
+
+    virtual void expandHelp(
+        std::string const & prefix,
+        boost::program_options::options_description & desc
+    ) = 0;
+
+};
+
+} //namespace picongpu

--- a/include/picongpu/plugins/output/IIOBackend.hpp
+++ b/include/picongpu/plugins/output/IIOBackend.hpp
@@ -1,5 +1,4 @@
-/* Copyright 2013-2017 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Alexander Grund
+/* Copyright 2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -25,51 +24,58 @@
 #include <string>
 #include <memory>
 
+
 namespace picongpu
 {
 
-//! Interface for IO-backends with restart capability
-class IIOBackend : public ILightweightPlugin
-{
-public:
-
-
-    IIOBackend()
+    //! Interface for IO-backends with restart capability
+    class IIOBackend : public ILightweightPlugin
     {
+    public:
 
-    }
 
-    template< typename T_IOBackend >
-    static std::shared_ptr<IIOBackend> create( bool const isIndependent = true )
-    {
-        return std::shared_ptr<IIOBackend>( new T_IOBackend( isIndependent ) );
-    }
+        IIOBackend()
+        {
 
-    virtual ~IIOBackend()
-    {
+        }
 
-    }
+        /** create a instance of an interface
+         *
+         * @tparam T_IOBackend type of the interface implementation (must inherit from IIOBackend)
+         * @param isIndependent if `true`: class must be register itself to PluginConnector else
+         *                      class is not allowed to register itself
+         */
+        template< typename T_IOBackend >
+        static std::shared_ptr< IIOBackend > create( bool const isIndependent = true )
+        {
+            return std::shared_ptr< IIOBackend >( new T_IOBackend( isIndependent ) );
+        }
 
-    //! create a checkpoint
-    virtual void dumpCheckpoint(
-        uint32_t currentStep,
-        std::string const & checkpointDirectory,
-        std::string const & checkpointFilename
-    ) = 0;
+        virtual ~IIOBackend()
+        {
 
-    //! restart from a checkpoint
-    virtual void doRestart(
-        uint32_t restartStep,
-        std::string const & restartDirectory,
-        std::string const & restartFilename,
-        uint32_t restartChunkSize
-    ) = 0;
+        }
 
-    virtual void expandHelp(
-        std::string const & prefix,
-        boost::program_options::options_description & desc
-    ) = 0;
+        //! create a checkpoint
+        virtual void dumpCheckpoint(
+            uint32_t currentStep,
+            std::string const & checkpointDirectory,
+            std::string const & checkpointFilename
+        ) = 0;
 
-};
+        //! restart from a checkpoint
+        virtual void doRestart(
+            uint32_t restartStep,
+            std::string const & restartDirectory,
+            std::string const & restartFilename,
+            uint32_t restartChunkSize
+        ) = 0;
 
-} //namespace picongpu
+        virtual void expandHelp(
+            std::string const & prefix,
+            boost::program_options::options_description & desc
+        ) = 0;
+
+    };
+
+} // namespace picongpu

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -452,7 +452,7 @@ public:
             initialiserController->printInformation();
             if (this->restartRequested)
             {
-                /* we do not require --restart-step if a master checkpoint file is found */
+                /* we do not require --restart.step if a master checkpoint file is found */
                 if (this->restartStep < 0)
                 {
                     std::vector<uint32_t> checkpoints = readCheckpointMasterFile();
@@ -460,7 +460,8 @@ public:
                     if (checkpoints.empty())
                     {
                         throw std::runtime_error(
-                                                 "Restart failed. You must provide the '--restart-step' argument. See picongpu --help.");
+                            "Restart failed. You must provide the '--restart.step' argument. See picongpu --help."
+                        );
                     } else
                         this->restartStep = checkpoints.back();
                 }

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -290,17 +290,17 @@ public:
     {
         desc.add_options()
             ("steps,s", po::value<uint32_t > (&runSteps), "Simulation steps")
-            ("softRestarts", po::value<uint32_t > (&softRestarts)->default_value(0),
+            ("checkpoint.restart.soft", po::value<uint32_t > (&softRestarts)->default_value(0),
              "Number of times to restart the simulation after simulation has finished (for presentations). "
              "Note: does not yet work with all plugins, see issue #1305")
             ("percent,p", po::value<uint16_t > (&progress)->default_value(5),
              "Print time statistics after p percent to stdout")
-            ("restart", po::value<bool>(&restartRequested)->zero_tokens(), "Restart simulation")
-            ("restart-directory", po::value<std::string>(&restartDirectory)->default_value(restartDirectory),
+            ("checkpoint.restart", po::value<bool>(&restartRequested)->zero_tokens(), "Restart simulation")
+            ("checkpoint.restart.directory", po::value<std::string>(&restartDirectory)->default_value(restartDirectory),
              "Directory containing checkpoints for a restart")
-            ("restart-step", po::value<int32_t>(&restartStep), "Checkpoint step to restart from")
-            ("checkpoints", po::value<uint32_t>(&checkpointPeriod), "Period for checkpoint creation")
-            ("checkpoint-directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
+            ("checkpoint.restart.step", po::value<int32_t>(&restartStep), "Checkpoint step to restart from")
+            ("checkpoint.period", po::value<uint32_t>(&checkpointPeriod), "Period for checkpoint creation")
+            ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
              "Directory for checkpoints")
             ("author", po::value<std::string>(&author)->default_value(std::string("")),
              "The author that runs the simulation and is responsible for created output files");

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -290,7 +290,7 @@ public:
     {
         desc.add_options()
             ("steps,s", po::value<uint32_t > (&runSteps), "Simulation steps")
-            ("checkpoint.restart.soft", po::value<uint32_t > (&softRestarts)->default_value(0),
+            ("checkpoint.restart.loop", po::value<uint32_t > (&softRestarts)->default_value(0),
              "Number of times to restart the simulation after simulation has finished (for presentations). "
              "Note: does not yet work with all plugins, see issue #1305")
             ("percent,p", po::value<uint16_t > (&progress)->default_value(5),

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus_isaac.cfg
@@ -40,7 +40,7 @@ TBG_gridSize="-g 192 1024 12"
 TBG_steps="-s 2048"
 
 TBG_periodic="--periodic 0 0 1"
-TBG_softRestarts="--softRestarts 10000"
+TBG_softRestarts="--checkpoint.restart.soft 10000"
 
 #################################
 ## Section: Optional Variables ##

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0001gpus_isaac.cfg
@@ -40,7 +40,7 @@ TBG_gridSize="-g 192 1024 12"
 TBG_steps="-s 2048"
 
 TBG_periodic="--periodic 0 0 1"
-TBG_softRestarts="--checkpoint.restart.soft 10000"
+TBG_restartLoop="--checkpoint.restart.loop 10000"
 
 #################################
 ## Section: Optional Variables ##
@@ -60,7 +60,7 @@ TBG_programParams="!TBG_devices      \
                    !TBG_gridSize     \
                    !TBG_steps        \
                    !TBG_periodic     \
-                   !TBG_softRestarts \
+                   !TBG_restartLoop \
                    !TBG_plugins      \
                    --versionOnce"
 


### PR DESCRIPTION
This pull request adds a plugin which controls the checkpoint creation and restart which was before a part of the hdf5 and adios plugin.
This is the first step to refactor our IO plugins to allow the usage as multi plugin.
It is now possible to restart from adios and create new checkpoints with hdf5.
**This plugin renames all command line options to control the checkpoint creation and restart.**

- add checkpoint plugin 
  - add interface to unify usage of IO-backends (adios or hdf5)
  - add Checkpoint plugin
  - register `Checkpoint` as plugin
-  refactor adios and hdf writer interfaces 
  - Refactor interfaces that both plugins can be used as stand allown plugin and controlled checkpoint plugin.
- **rename command line parameter**
  - `--checkpoints` to `--checkpoint.period`
  - `--softRestarts` to `--checkpoint.restart.soft`
  - `--restart` to `--checkpoint.restart`
  - `--restart-directory` to `--checkpoint.restart.directory`
  - `--restart-step` to `--checkpoint.restart.step`
  - `--checkpoint-directory` to `checkpoint.directory`

# Test

- [x] compile without Adios/HDF5
- [x] restart from hdf5 -> than create checkpoints with adios
- [x] restart from adios -> than create checkpoints HDF5


# Help message if Adios and HDF5 is available

```
  --checkpoint.restart                  Restart simulation
  --checkpoint.restart.directory arg (=checkpoints)
                                        Directory containing checkpoints for a 
                                        restart
  --checkpoint.restart.step arg         Checkpoint step to restart from
  --checkpoint.period arg               Period for checkpoint creation
  --checkpoint.directory arg (=checkpoints)
                                        Directory for checkpoints
...

Checkpoint:
  --checkpoint.backend arg              Optional backend for checkpointing 
                                        [adios, hdf5] default: adios
  --checkpoint.file arg                 Optional checkpoint filename (prefix)
  --checkpoint.restart.backend arg      Optional backend for restarting [adios,
                                        hdf5] default: adios
  --checkpoint.restart.file arg         checkpoint restart filename (prefix)
  --checkpoint.restart.chunkSize arg (=1000000)
                                        Number of particles processed in one 
                                        kernel call during restart to prevent 
                                        frame count blowup
  --checkpoint.adios.aggregators arg (=0)
                                        Number of aggregators [0 == number of 
                                        MPI processes]
  --checkpoint.adios.ost arg (=1)       Number of OST
  --checkpoint.adios.disable-meta       Disable online gather and write of a 
                                        global meta file, can be time consuming
                                        (use `bpmeta` post-mortem)
  --checkpoint.adios.transport-params arg
                                        additional transport parameters, see 
                                        ADIOS manual chapter 6.1.5, e.g., 
                                        'random_offset=1;stripe_count=4'
  --checkpoint.adios.compression arg (=none)
                                        ADIOS compression method, e.g., zlib 
                                        (see `adios_config -m` for help)
```