### PR TITLE
New Trait: SpeciesEligibleForSolver

### DIFF
--- a/include/picongpu/particles/traits/SpeciesEligibleForSolver.hpp
+++ b/include/picongpu/particles/traits/SpeciesEligibleForSolver.hpp
@@ -1,0 +1,50 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/mpl/bool.hpp>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace traits
+{
+    /** Check if species fulfills requirements of a solver
+     *
+     * Defines a boost::mpl::bool_ true type is the particle species as all
+     * requirements fulfilled for a solver.
+     *
+     * @tparam T_Species Species to check
+     * @tparam T_Solver Solver with requirements
+     */
+    template<
+        typename T_Species,
+        typename T_Solver
+    >
+    struct SpeciesEligibleForSolver
+    {
+        using type = boost::mpl::bool_< true >;
+    };
+
+} // namespace traits
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
Allows to check if a defined `picongpu::Particles` class is eligible for computations with a specific solver.

Algorithms, Plugins and core methods can implement this trait to signal which identifiers (particle attributes), flags (particle frame attributes) or other requirements they have regarding particle species.

Use as follows:

```C++
using isEligible = traits::SpeciesEligibleForSolver<
    PIC_Electrons,      // any picongpu::Particles species
    ChargeConservation  // any solver class here
>::type; // this is a boost::mpl::bool_

// or if you need a bool
bool const okToUse = isEligible::value;
```

Of course you can also filter for the species from `VectorAllSpecies` for which a solver can be compiled:

```C++
using SeqEligibleSpecies = typename bmpl::copy_if<
    VectorAllSpecies,
    traits::SpeciesEligibleForSolver<
        bmpl::_1,
        ChargeConservation
    >
>::type; // this is a standard boost::mpl forward sequence
```