### PR TITLE
InitController: Unphysical Particles

### DIFF
--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -128,7 +128,15 @@ public:
                                  (1./math::sqrt(INV_CELL2_SUM)) %
                                  (SPEED_OF_LIGHT * DELTA_T);
 
-            ForEach<VectorAllSpecies, LogOmegaP<> > logOmegaP;
+            using SpeciesWithMass = typename pmacc::particles::traits::FilterByFlag<
+                VectorAllSpecies,
+                massRatio<>
+            >::type;
+            using SpeciesWithMassCharge = typename pmacc::particles::traits::FilterByFlag<
+                SpeciesWithMass,
+                chargeRatio<>
+            >::type;
+            ForEach< SpeciesWithMassCharge, LogOmegaP<> > logOmegaP;
             logOmegaP();
 
             if (laserProfile::INIT_TIME > float_X(0.0))


### PR DESCRIPTION
Allow to initialize unphysical particles in the `InitialiserController`. Unphysical in the sense, that those particles have mass and/or charge *undefined*. In such a case, it makes no sense to try to output a plasma frequency from it.

Note: we allow to define particles without such fundamental types in PIConGPU (instead of falling back to zero) since this allows us to differentiate between physical particles (such as photons or neutrals) and unphysical particles (test particles, probes, etc.).