### PR TITLE
Plugins: SpeciesEligibleForSolver Traits

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceMulti.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceMulti.hpp
@@ -79,6 +79,31 @@ namespace picongpu
         std::string pluginGetName() const { return this->name; }
     };
 
-}
+namespace particles
+{
+namespace traits
+{
+    template<
+        typename T_Species,
+        typename T_AssignmentFunction
+    >
+    struct SpeciesEligibleForSolver<
+        T_Species,
+        PhaseSpaceMulti<
+            T_AssignmentFunction,
+            T_Species
+        >
+    > : public SpeciesEligibleForSolver<
+        T_Species,
+        PhaseSpace<
+            T_AssignmentFunction,
+            T_Species
+        >
+    >
+    {
+    };
+} // namespace traits
+} // namespace particles
+} // namespace picongpu
 
 #include "PhaseSpaceMulti.tpp"

--- a/include/picongpu/plugins/PngPlugin.hpp
+++ b/include/picongpu/plugins/PngPlugin.hpp
@@ -18,15 +18,19 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-#include <pmacc/dimensions/DataSpace.hpp>
 
 #include "picongpu/plugins/ILightweightPlugin.hpp"
 #include "picongpu/simulationControl/MovingWindow.hpp"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/traits/HasIdentifiers.hpp>
+#include <pmacc/traits/HasFlag.hpp>
+
+#include <boost/mpl/and.hpp>
 
 #include <vector>
 #include <list>
@@ -214,5 +218,31 @@ namespace picongpu
 
     };
 
-}//namespace
+namespace particles
+{
+namespace traits
+{
+    template<
+        typename T_Species,
+        typename T_VisClass
+    >
+    struct SpeciesEligibleForSolver<
+        T_Species,
+        PngPlugin< T_VisClass >
+    >
+    {
+        using FrameType = typename T_Species::FrameType;
+
+        using RequiredIdentifiers = MakeSeq_t<
+            weighting
+        >;
+
+        using type = typename pmacc::traits::HasIdentifiers<
+            FrameType,
+            RequiredIdentifiers
+        >::type;
+    };
+} // namespace traits
+} // namespace particles
+} // namespace picongpu
 


### PR DESCRIPTION
Implement the `SpeciesEligibleForSolver` trait for all plugins working on particles.

This allows to query each plugin and check if it is possible to compile it for a specific particle species before specializing the class for it.

Note: as soon as the interface in #2364 does not change during review, this PR can be merged independently / in parallel and does not need to be rebased.

- [x] depends on #2363

Note: radiation is not yet set up with the same trait (defaults to: assume it will work with each species) since it already checks manually for `momentumPrev1`; we should refactor this check to the new trait in a follow-up PR.