### PR TITLE
Particle Pusher: Probe

### DIFF
--- a/include/picongpu/particles/pusher/particlePusherProbe.hpp
+++ b/include/picongpu/particles/pusher/particlePusherProbe.hpp
@@ -1,0 +1,157 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include <pmacc/nvidia/functors/Assign.hpp>
+
+
+namespace picongpu
+{
+namespace particlePusherProbe
+{
+    /** Probe electro-magnetic fields and store the result with a particle
+     *
+     * @tparam T_ValueFunctor pmacc::nvidia::functors::*, binary functor
+     *         handling how to store the obtained field on the particle,
+     *         default is assigning a new value
+     * @tparam T_ActualPush allows to perform a real particle push after
+     *         probing the electro-magnetic field (e.g. to let a probe
+     *         particle stream with a moving window or to define a tracer
+     *         particle species that records its fields),
+     *         default is void and means no push (just a static probe)
+     */
+    template<
+        typename T_ValueFunctor = pmacc::nvidia::functors::Assign,
+        typename T_ActualPush = void
+    >
+    struct Push
+    {
+        using ActualPush = T_ActualPush;
+
+        /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+         * for particle positions outside the super cell in one push
+         */
+        using LowerMargin = typename ActualPush::LowerMargin;
+        using UpperMargin = typename ActualPush::UpperMargin;
+
+        template<
+            typename T_FunctorFieldE,
+            typename T_FunctorFieldB,
+            typename T_Particle,
+            typename T_Pos
+        >
+        HDINLINE void
+        operator()(
+            T_FunctorFieldB const functorBField,
+            T_FunctorFieldE const functorEField,
+            T_Particle & particle,
+            T_Pos & pos,
+            uint32_t const currentStep
+        )
+        {
+            T_ValueFunctor valueFunctor;
+            valueFunctor(
+                particle[ probeB_ ],
+                functorBField( pos )
+            );
+            valueFunctor(
+                particle[ probeE_ ],
+                functorEField( pos )
+            );
+
+            ActualPush actualPush();
+            actualPush(
+                functorBField,
+                functorEField,
+                particle,
+                pos,
+                currentStep
+            );
+        }
+
+        static
+        pmacc::traits::StringProperty
+        getStringProperties()
+        {
+            pmacc::traits::GetStringProperties< ActualPush > propList;
+            propList[ "param" ] = "moving probe";
+            return propList;
+        }
+    };
+
+    template< typename T_ValueFunctor >
+    struct Push<
+        T_ValueFunctor,
+        void
+    >
+    {
+        /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+         * for particle positions outside the super cell in one push
+         */
+        using LowerMargin = typename pmacc::math::CT::make_Int<
+            simDim,
+            0
+        >::type;
+        using UpperMargin = typename pmacc::math::CT::make_Int<
+            simDim,
+            0
+        >::type;
+
+        template<
+            typename T_FunctorFieldE,
+            typename T_FunctorFieldB,
+            typename T_Particle,
+            typename T_Pos
+        >
+        HDINLINE void
+        operator()(
+            T_FunctorFieldB const functorBField,
+            T_FunctorFieldE const functorEField,
+            T_Particle & particle,
+            T_Pos & pos,
+            uint32_t const
+        )
+        {
+            T_ValueFunctor valueFunctor;
+            valueFunctor(
+                particle[ probeB_ ],
+                functorBField( pos )
+            );
+            valueFunctor(
+                particle[ probeE_ ],
+                functorEField( pos )
+            );
+        }
+
+        static
+        pmacc::traits::StringProperty
+        getStringProperties()
+        {
+            pmacc::traits::StringProperty propList(
+                "name",
+                "other"
+            );
+            propList[ "param" ] = "static probe";
+            return propList;
+        }
+    };
+} // namespace particlePusherProbe
+} // namespace picongpu

--- a/include/picongpu/simulation_defines/param/pusher.param
+++ b/include/picongpu/simulation_defines/param/pusher.param
@@ -37,7 +37,6 @@ namespace picongpu
         namespace sqrt_Vay = precision64Bit;
     }
 
-
     namespace particlePusherAxel
     {
 
@@ -58,11 +57,28 @@ namespace picongpu
         struct Boris;
         struct Photon;
         struct Free;
+        struct Probe;
         struct ReducedLandauLifshitz;
 #if(SIMDIM==DIM3)
         struct Axel;
 #endif
     } // namespace pusher
     } // namespace particles
+
+    namespace particlePusherProbe
+    {
+        /** Also push the probe particles?
+         *
+         * In many cases, probe particles are static throughout the simulation.
+         * This option allows to set an "actual" pusher that shall be used to
+         * also change the probe particle positions.
+         *
+         * Examples:
+         * - particles::pusher::Boris
+         * - particles::pusher::[all others from above]
+         * - void (no push)
+         */
+        using ActualPusher = void;
+    }
 
 } // namespace picongpu

--- a/include/picongpu/simulation_defines/param/speciesAttributes.param
+++ b/include/picongpu/simulation_defines/param/speciesAttributes.param
@@ -90,12 +90,25 @@ namespace picongpu
         float_X( 0. )
     );
 
-
     //! Voronoi cell of the macro particle
     value_identifier(
         int16_t,
         voronoiCellId,
         -1
+    );
+
+    //! interpolated electric field with respect to particle shape
+    value_identifier(
+        float3_X,
+        probeE,
+        float3_X::create( 0. )
+    );
+
+    //! interpolated electric field with respect to particle shape
+    value_identifier(
+        float3_X,
+        probeB,
+        float3_X::create( 0. )
     );
 
     /** masking a particle for radiation

--- a/include/picongpu/simulation_defines/unitless/pusher.unitless
+++ b/include/picongpu/simulation_defines/unitless/pusher.unitless
@@ -17,22 +17,24 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/algorithms/Gamma.hpp"
 #include "picongpu/algorithms/Velocity.hpp"
 
-
 #include "picongpu/particles/pusher/particlePusherBoris.hpp"
 #include "picongpu/particles/pusher/particlePusherVay.hpp"
 #include "picongpu/particles/pusher/particlePusherFree.hpp"
 #include "picongpu/particles/pusher/particlePusherPhoton.hpp"
+#include "picongpu/particles/pusher/particlePusherProbe.hpp"
 #include "picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp"
 #if(SIMDIM==DIM3)
 #include "picongpu/particles/pusher/particlePusherAxel.hpp"
 #endif
+
+#include <pmacc/nvidia/functors/Assign.hpp>
+#include <pmacc/nvidia/functors/Add.hpp>
+
 
 namespace picongpu
 {
@@ -72,6 +74,14 @@ public particlePusherPhoton::Push<Velocity, Gamma<> >
 
 struct ReducedLandauLifshitz :
 public particlePusherReducedLandauLifshitz::Push<Velocity, Gamma<> >
+{
+};
+
+struct Probe :
+public particlePusherProbe::Push<
+    pmacc::nvidia::functors::Assign,
+    particlePusherProbe::ActualPusher
+>
 {
 };
 

--- a/include/picongpu/simulation_defines/unitless/speciesAttributes.unitless
+++ b/include/picongpu/simulation_defines/unitless/speciesAttributes.unitless
@@ -335,6 +335,102 @@ struct WeightingPower<voronoiCellId>
     }
 };
 
+template<>
+struct Unit<probeE>
+{
+    static std::vector<double> get()
+    {
+        uint32_t const components = 3u;
+
+        std::vector< double > const unit( components, UNIT_EFIELD);
+
+        return unit;
+    }
+};
+template<>
+struct UnitDimension<probeE>
+{
+    static std::vector<float_64> get()
+    {
+       /* L, M, T, I, theta, N, J
+        *
+        * E is in volts per meters: V / m = kg * m / (A * s^3)
+        *   -> L * M * T^-3 * I^-1
+        */
+       std::vector<float_64> unitDimension( 7, 0.0 );
+       unitDimension.at(SIBaseUnits::length) =  1.0;
+       unitDimension.at(SIBaseUnits::mass)   =  1.0;
+       unitDimension.at(SIBaseUnits::time)   = -3.0;
+       unitDimension.at(SIBaseUnits::electricCurrent) = -1.0;
+
+       return unitDimension;
+    }
+};
+template<>
+struct MacroWeighted<probeE>
+{
+    static bool get()
+    {
+        return false;
+    }
+};
+template<>
+struct WeightingPower<probeE>
+{
+    // local electric fields do not scale with weighting
+    static float_64 get()
+    {
+        return 0.0;
+    }
+};
+
+template<>
+struct Unit<probeB>
+{
+    static std::vector<double> get()
+    {
+        uint32_t const components = 3u;
+
+        std::vector< double > const unit( components, UNIT_BFIELD);
+
+        return unit;
+    }
+};
+template<>
+struct UnitDimension<probeB>
+{
+    static std::vector<float_64> get()
+    {
+       /* L, M, T, I, theta, N, J
+        *
+        * B is in Tesla : kg / (A * s^2)
+        *   -> M * T^-2 * I^-1
+        */
+       std::vector<float_64> unitDimension( 7, 0.0 );
+       unitDimension.at(SIBaseUnits::mass) =  1.0;
+       unitDimension.at(SIBaseUnits::time) = -2.0;
+       unitDimension.at(SIBaseUnits::electricCurrent) = -1.0;
+
+       return unitDimension;
+    }
+};
+template<>
+struct MacroWeighted<probeB>
+{
+    static bool get()
+    {
+        return false;
+    }
+};
+template<>
+struct WeightingPower<probeB>
+{
+    // local magnetic fields do not scale with weighting
+    static float_64 get()
+    {
+        return 0.0;
+    }
+};
 
 template<>
 struct Unit<particleId>


### PR DESCRIPTION
Add a new particle pusher (probe).

Interpolates the electro-magnetic fields as a usual pusher but instead of pushing the particle (changing the momentum) it saves the result on particle attributes.

As an additional feature, this allows to add an additional pusher attribute. This allows to *probe* the fields and at the same time move the particle (free streaming with a moving window) or even to create a tracer particle (which fully interacts with the simulation).

Also adds two species attributes that can be used to store a particle's E and B field as seen after fieldToParticle interpolation with respect to shape.

More details on the usage will follow in the main PR.