### PR TITLE
generic multi plugin

### DIFF
--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -26,6 +26,7 @@
 
 #include "picongpu/plugins/CountParticles.hpp"
 #include "picongpu/plugins/EnergyParticles.hpp"
+#include "picongpu/plugins/multi/Master.hpp"
 #include "picongpu/plugins/EnergyFields.hpp"
 #include "picongpu/plugins/SumCurrents.hpp"
 #include "picongpu/plugins/BinEnergyParticles.hpp"
@@ -164,7 +165,7 @@ private:
 
     /* define species plugins */
     using UnspecializedSpeciesPlugins = bmpl::vector <
-        EnergyParticles<bmpl::_1>,
+        plugins::multi::Master< EnergyParticles<bmpl::_1> >,
         BinEnergyParticles<bmpl::_1>,
         CountParticles<bmpl::_1>,
         PngPlugin< Visualisation<bmpl::_1, PngCreator> >

--- a/include/picongpu/plugins/multi/IHelp.hpp
+++ b/include/picongpu/plugins/multi/IHelp.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace multi
+{
+
+    //! Interface to expose a help of a plugin
+    struct IHelp
+    {
+        ///! method used by plugin controller to get --help description
+        virtual void registerHelp(
+            boost::program_options::options_description & desc,
+            std::string const & masterPrefix = std::string{ }
+        ) = 0;
+
+        //! validate if the command line interface options are well formated
+        virtual void validateOptions() = 0;
+
+        //! number of plugin which must be created
+        virtual size_t getNumPlugins() const = 0;
+
+        //! short description of the plugin functionality
+        virtual std::string getDescription() const = 0;
+
+        //! name of the plugin
+        virtual std::string getName() const = 0;
+    };
+
+} // namespace multi
+} // namespace plugins
+} // namespace picongpu

--- a/include/picongpu/plugins/multi/ISlave.hpp
+++ b/include/picongpu/plugins/multi/ISlave.hpp
@@ -1,0 +1,88 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/plugins/multi/IHelp.hpp"
+
+#include <pmacc/pluginSystem/INotify.hpp>
+
+#include <memory>
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace multi
+{
+
+    /** Interface for a slave plugin
+     *
+     * A plugin which fulfil l this interface can be used as slave plugin for
+     * multi::Master.
+     *
+     * A slave must register itself to the PluginConnector to receive the notify calls.
+     */
+    struct ISlave : public pmacc::INotify
+    {
+        /** creates a instance of ISlave
+         *
+         * @tparam T_Slave type of the interface implementation (must inherit from ISlave)
+         * @param help plugin defined help
+         * @param id index of the plugin, range: [0;help->getNumPlugins())
+         */
+        template<
+            typename T_Slave
+        >
+        static std::shared_ptr< ISlave > create(
+            std::shared_ptr< IHelp > & help,
+            size_t const id,
+            MappingDesc* cellDescription
+        )
+        {
+            return std::shared_ptr< ISlave >(
+                new T_Slave(
+                    help,
+                    id,
+                    cellDescription
+                )
+            );
+        }
+
+        //! must be implemented by the user
+        static std::shared_ptr< IHelp > getHelp();
+
+        //! restart the plugin from a checkpoint
+        virtual void restart(
+            uint32_t restartStep,
+            std::string const & restartDirectory
+        ) = 0;
+
+        //! create a check point forthe plugin
+        virtual void checkpoint(
+            uint32_t currentStep,
+            std::string const & checkpointDirectory
+        ) = 0;
+    };
+
+} // namespace multi
+} // namespace plugins
+} // namespace picongpu

--- a/include/picongpu/plugins/multi/Master.hpp
+++ b/include/picongpu/plugins/multi/Master.hpp
@@ -1,0 +1,149 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/multi/ISlave.hpp"
+#include "picongpu/plugins/multi/IHelp.hpp"
+
+#include <vector>
+#include <list>
+#include <stdexcept>
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace multi
+{
+    /** Master class to create multi plugins
+     *
+     * Create and handle a plugin as multi plugin. Parameter of a multi plugin
+     * can be used multiple times on the command line.
+     *
+     * @tparam T_Slave type of the plugin (must inherit from ISlave)
+     */
+    template< typename T_Slave >
+    class Master : public ISimulationPlugin
+    {
+    public:
+
+        using Slave = T_Slave;
+        using SlaveList =  std::list< std::shared_ptr< ISlave > >;
+        SlaveList slaveList;
+
+        std::shared_ptr< IHelp > slaveHelp;
+
+        MappingDesc* m_cellDescription = nullptr;
+
+        Master( ) : slaveHelp( Slave::getHelp() )
+        {
+            Environment<>::get( ).PluginConnector( ).registerPlugin(this);
+        }
+
+        virtual ~Master( )
+        {
+
+        }
+
+        std::string pluginGetName( ) const
+        {
+            // the PMacc plugin system needs a short description instead of the plugin name
+            return slaveHelp->getDescription( ) + ": " + slaveHelp->getDescription( );
+        }
+
+        void pluginRegisterHelp( boost::program_options::options_description& desc )
+        {
+            slaveHelp->registerHelp( desc );
+        }
+
+        void setMappingDescription( MappingDesc* cellDescription )
+        {
+            m_cellDescription = cellDescription;
+        }
+
+        /** restart a checkpoint
+         *
+         * Trigger the method restart() for all slave instances.
+         */
+        void restart(
+            uint32_t restartStep,
+            std::string const restartDirectory
+        )
+        {
+            for( auto & slave : slaveList )
+                slave->restart(
+                    restartStep,
+                    restartDirectory
+                );
+        }
+
+        /** create a checkpoint
+         *
+         * Trigger the method checkpoint() for all slave instances.
+         */
+        void checkpoint(
+            uint32_t currentStep,
+            std::string const checkpointDirectory
+        )
+        {
+            for( auto & slave : slaveList )
+                slave->checkpoint(
+                    currentStep,
+                    checkpointDirectory
+                );
+        }
+
+    private:
+
+        void pluginLoad( )
+        {
+            size_t const numSlaves = slaveHelp->getNumPlugins( );
+            if( numSlaves > 0u )
+                slaveHelp->validateOptions( );
+            for( size_t i = 0; i < numSlaves; ++i )
+            {
+                slaveList.emplace_back(
+                    ISlave::create< Slave >(
+                        slaveHelp,
+                        i,
+                        m_cellDescription
+                    )
+                );
+            }
+        }
+
+        void pluginUnload( )
+        {
+            slaveList.clear( );
+        }
+
+        void notify(uint32_t currentStep)
+        {
+            // nothing to do here
+        }
+
+    };
+
+} // namespace multi
+} // namespace plugins
+} // namespace picongpu


### PR DESCRIPTION
- add class to create a generic multi plugin `multi:::Master`
- add interfaces
  - `IHelp` allow to expose the command line requirements of a plugin
  - `ISlave` interface that a plugin can be used from the multi plugin `multi::Master`
- make `EnergyParticles` multi plugin ready
  it is currently not allowed to call this plugin multiple time (we need particle filter support)
- `PluginController`: register `EnergyParticles` as multi plugin

related to #1288