### PR TITLE
Add lower electron temperature cut-off to ThomasFermi model

### DIFF
--- a/docs/source/models/collisional_ionization.rst
+++ b/docs/source/models/collisional_ionization.rst
@@ -39,7 +39,7 @@ Two of the artifacts can be seen in this plot:
     Via the variable ``CUTOFF_MAX_ENERGY_KEV`` in ``ionizer.param`` the user can exclude electrons with kinetic energy above this value from average energy calculation.
     That is motivated by a lower interaction cross section of particles with high relative velocities.
 
-2. Low ion-density cutoff
+2. Lower ion-density cutoff
 
     The Thomas-Fermi model displays unphysical behaviour for low ion densities in that it predicts an increasing charge state for decreasing ion densities.
     This occurs already for electron temperatures of 10 eV and the effect increases as the temperature increases.
@@ -52,15 +52,14 @@ Two of the artifacts can be seen in this plot:
     It is strongly suggested to do approximations for **every** setup or material first.
     To that end, a parameter scan with [FLYCHK]_ can help in choosing a reasonable value.
 
-3. Low electron-temperature cutoff
+3. Lower electron-temperature cutoff
 
-    Depending on the material the Thomas-Fermi prediction for the average charge
-    state can be unphysically high. For some materials it predicts non-zero
-    charge states at 0 temperature. That can be a reasonable approximation
-    for metals and their electrons in the conduction band.
+    Depending on the material the Thomas-Fermi prediction for the average charge state can be unphysically high.
+    For some materials it predicts non-zero charge states at 0 temperature.
+    That can be a reasonable approximation for metals and their electrons in the conduction band.
     Yet this cannot be generalized for all materials and therefore a cutoff should be explicitly defined.
 
-    - define via ``CUTOFF_LOW_TEMPERATURE_EV`` in ``ionizer.param``
+    - define via ``CUTOFF_LOW_TEMPERATURE_EV`` in :ref:`ionizer.param <usage-params-extensions>`
 
 NLTE Models
 -----------

--- a/docs/source/models/collisional_ionization.rst
+++ b/docs/source/models/collisional_ionization.rst
@@ -41,6 +41,16 @@ We therefore implemented additional conditions to mediate unphysical behavior bu
     It is strongly suggested to do approximations for **every** setup or material first.
     To that end, a parameter scan with [FLYCHK]_ can help in choosing a reasonable value.
 
+3. Low electron-temperature cutoff
+
+    Depending on the material the Thomas-Fermi prediction for the average charge
+    state can be unphysically high. For some materials it predicts non-zero
+    charge states at 0 temperature. That can be a reasonable approximation
+    for metals and their electrons in the conduction band.
+    Yet this cannot be generalized for all materials and therefore a cutoff should be explicitly defined.
+
+    - define via ``CUTOFF_LOW_TEMPERATURE_EV`` in ``ionizer.param``
+
 NLTE Models
 -----------
 

--- a/docs/source/models/collisional_ionization.rst
+++ b/docs/source/models/collisional_ionization.rst
@@ -21,6 +21,17 @@ The implementation of the Thomas-Fermi model takes the following input quantitie
 Due to the nature of our simulated setups it is also used in non-equilibrium situations.
 We therefore implemented additional conditions to mediate unphysical behavior but introduce arbitrariness.
 
+.. plot:: models/collisional_ionization_thomas-fermi_cutoffs.py
+
+Here is an example of hydrogen (in blue) and carbon (in orange) that we would use in a compound plastic target, for instance.
+The typical plastic density region is marked in green.
+Two of the artifacts can be seen in this plot:
+
+    1. Carbon is predicted to have an initial charge state :math:`\langle Z \rangle > 0` even at :math:`T = 0\,\mathrm{eV}`.
+    2. Carbon is predicted to have a charge state of :math:`\langle Z \rangle \approx 2` at solid plastic density and electron temperature of :math:`T = 10\,\mathrm{eV}` which increases even as the density decreases.
+       The average electron kinetic energy at such a temperature is 6.67 eV which is less than the 24.4 eV of binding energy for that state.
+       The increase in charge state with decreasing density would lead to very high charge states in the pre-plasmas that we model.
+
 1. Super-thermal electron cutoff
 
     We calculate the temperature according to :math:`T_\mathrm{e} = \frac{2}{3} E_\mathrm{kin, e}` in units of electron volts.

--- a/docs/source/models/collisional_ionization_thomas-fermi_cutoffs.py
+++ b/docs/source/models/collisional_ionization_thomas-fermi_cutoffs.py
@@ -49,7 +49,6 @@ class ThomasFermiIonization:
 
         self.alpha = 14.3139
         self.beta = 0.6624
-        # print("initialized")
 
     def CalcT_0(self,
                 temperature, protonNumber):

--- a/docs/source/models/collisional_ionization_thomas-fermi_cutoffs.py
+++ b/docs/source/models/collisional_ionization_thomas-fermi_cutoffs.py
@@ -1,0 +1,186 @@
+import matplotlib as mpl
+from matplotlib import pyplot as plt
+import numpy as np
+
+
+params = {
+    'font.size': 20,
+    'lines.linewidth': 3,
+    'legend.fontsize': 20,
+    'legend.frameon': False,
+    'xtick.labelsize': 20,
+    'ytick.labelsize': 20,
+    # RTD default textwidth: 800px
+    'figure.figsize': [12, 8]
+}
+mpl.rcParams.update(params)
+
+
+class ThomasFermiIonization:
+    """
+    Thomas-Fermi fitting model (@see More 1985) for statistical collisional
+    ionization.
+    """
+
+    def __init__(self,
+                 proton_number, mass_number):
+        """ Initialize model and read input parameters
+
+        Args:
+            proton_number : Proton number of the ion
+            mass_number   : Atomic mass number of the ion
+        """
+        # input parameters
+        self.Z = proton_number
+        self.massA = mass_number
+
+        # TF fitting parameters
+        self.a_1 = 0.003323
+        self.a_2 = 0.9718
+        self.a_3 = 9.26148e-5
+        self.a_4 = 3.10165
+
+        self.b_0 = -1.7630
+        self.b_1 = 1.43175
+        self.b_2 = 0.31546
+
+        self.c_1 = -0.366667
+        self.c_2 = 0.983333
+
+        self.alpha = 14.3139
+        self.beta = 0.6624
+        # print("initialized")
+
+    def CalcT_0(self,
+                temperature, protonNumber):
+        T = temperature
+        return T / np.power(protonNumber, (4. / 3.))
+
+    def CalcR(self,
+              density, massNumber, protonNumber):
+        rho = density
+        return rho / (protonNumber * massNumber)
+
+    def CalcT_F(self,
+                T_0):
+        return T_0 / (1 + T_0)
+
+    def CalcA(self,
+              T_0):
+        return self.a_1 * np.power(T_0, self.a_2) + \
+            self.a_3 * np.power(T_0, self.a_4)
+
+    def CalcB(self,
+              T_F):
+
+        return -np.exp(self.b_0 + self.b_1 * T_F +
+                       self.b_2 * np.power(T_F, 7.))
+
+    def CalcC(self,
+              T_F):
+
+        return self.c_1 * T_F + self.c_2
+
+    def CalcQ_1(self,
+                A_TF, R, B):
+        """
+        :param: A_TF the parameter A from ThomasFermi and NOT the mass number
+        """
+        return A_TF * np.power(R, B)
+
+    def CalcQ(self,
+              R, Q_1, C):
+        R_1 = (np.power(R, C) + np.power(Q_1, C))
+        return np.power(R_1, (1. / C))
+
+    def Calcx(self,
+              Q):
+
+        return self.alpha * np.power(Q, self.beta)
+
+    def CalcZStar(self,
+                  x, proton_number):
+        Z = proton_number
+        return Z * x / (1. + x + np.sqrt(1. + 2. * x))
+
+    def TFIonState(self,
+                   temperature, density):
+        """
+        Args:
+            temperature   : Electron "temperature" [unit: eV]
+            density       : Ion mass density [unit: g/cm^3]
+        """
+
+        self.T = temperature
+        self.rho = density
+
+        # calculation
+        T_0 = self.CalcT_0(self.T, self.Z)
+        T_F = self.CalcT_F(T_0)
+        A = self.CalcA(T_0)
+        R = self.CalcR(self.rho, self.massA, self.Z)
+        B = self.CalcB(T_F)
+        C = self.CalcC(T_F)
+        Q_1 = self.CalcQ_1(A, R, B)
+        Q = self.CalcQ(R, Q_1, C)
+        x = self.Calcx(Q)
+
+        ionState = self.CalcZStar(x, self.Z)
+        return ionState
+
+
+if __name__ == "__main__":
+    """
+    On execution this script produces the figure showing the Thomas-Fermi model
+    issues and cutoffs for the PIConGPU documentation.
+    """
+
+mass_density = 10**np.linspace(-2, 2, 1000)  # g/cm^3
+temp_array = np.array([0, 10, 100])       # eV
+
+Z_H = 1
+A_H = 1
+Z_C = 6
+A_C = 12
+
+TF_H = ThomasFermiIonization(Z_H, A_H)
+TF_C = ThomasFermiIonization(Z_C, A_C)
+
+# initial alpha value for the plots
+alpha = 1.0
+# linestyles to distinguish the plots further
+linestyles = ["solid", "dashed", "dotted"]
+# index for linestyles
+i = 0
+
+for temp in temp_array:
+
+    CS_H = TF_H.TFIonState(temp, mass_density)
+    CS_C = TF_C.TFIonState(temp, mass_density)
+
+    plt.plot(mass_density, CS_H, label="H @ {} eV".format(
+        temp), color="blue", alpha=alpha, ls=linestyles[i])
+    plt.plot(mass_density, CS_C, label="C @ {} eV".format(
+        temp), color="orange", alpha=alpha, ls=linestyles[i])
+
+    # reduce alpha value to differentiate between electron temperatures
+    alpha -= 0.1
+    # increment i
+    i += 1
+
+plt.xscale("log")
+plt.ylabel(r"Charge State Prediction $\langle Z \rangle$")
+plt.xlabel(r"Mass Density [g/cm$^3$]")
+
+filter_dens = np.less_equal(mass_density, 2.2) * \
+    np.greater_equal(mass_density, 0.8)
+plastic_density = mass_density[filter_dens]
+plt.fill_between(plastic_density, y1=6, y2=0, alpha=.5, color="green")
+plt.text(x=1.0, y=5, s="typ. plastic density", color="white", rotation=90)
+plt.ylim(0, 6)
+plt.legend(
+    loc="upper left"
+)
+
+plt.draw()
+plt.show()

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
@@ -75,15 +75,15 @@ namespace ionization
         {
 
             /* @TODO replace the float_64 with float_X and make sure the values are scaled to PIConGPU units */
-            constexpr float_64 protonNumber = GetAtomicNumbers<ParticleType>::type::numberOfProtons;
-            constexpr float_64 neutronNumber = GetAtomicNumbers<ParticleType>::type::numberOfNeutrons;
+            constexpr float_64 protonNumber = GetAtomicNumbers< ParticleType >::type::numberOfProtons;
+            constexpr float_64 neutronNumber = GetAtomicNumbers< ParticleType >::type::numberOfNeutrons;
 
             /* atomic mass number (usually A) A = N + Z */
             constexpr float_64 massNumber = neutronNumber + protonNumber;
 
-            float_64 const T_0 = temperature/math::pow(protonNumber,float_64(4./3.));
+            float_64 const T_0 = temperature/math::pow( protonNumber,float_64( 4./3. ) );
 
-            float_64 const T_F = T_0 / (float_64(1.) + T_0);
+            float_64 const T_F = T_0 / ( float_64( 1. ) + T_0 );
 
             /* for all the fitting parameters @see ionizer.param */
 
@@ -94,26 +94,26 @@ namespace ionization
             constexpr float_64 TFA4_temp = thomasFermi::TFA4;
             constexpr float_64 TFBeta_temp = thomasFermi::TFBeta;
 
-            float_64 const A = thomasFermi::TFA1 * math::pow(T_0,TFA2_temp) + thomasFermi::TFA3 * math::pow(T_0,TFA4_temp);
+            float_64 const A = thomasFermi::TFA1 * math::pow( T_0, TFA2_temp ) + thomasFermi::TFA3 * math::pow( T_0, TFA4_temp );
 
-            float_64 const B = -math::exp(thomasFermi::TFB0 + thomasFermi::TFB1*T_F + thomasFermi::TFB2*math::pow(T_F,float_64(7.)));
+            float_64 const B = -math::exp( thomasFermi::TFB0 + thomasFermi::TFB1 * T_F + thomasFermi::TFB2 * math::pow( T_F, float_64( 7. ) ) );
 
             float_64 const C = thomasFermi::TFC1 * T_F + thomasFermi::TFC2;
 
-            constexpr float_64 invAtomicTimesMassNumber = float_64(1.) / (protonNumber * massNumber);
+            constexpr float_64 invAtomicTimesMassNumber = float_64( 1. ) / ( protonNumber * massNumber );
             float_64 const R = massDensity * invAtomicTimesMassNumber;
 
-            float_64 const Q_1 = A * math::pow(R,B);
+            float_64 const Q_1 = A * math::pow( R, B );
 
-            float_64 const Q = math::pow(math::pow(R,C) + math::pow(Q_1, C), float_64(1.) / C);
+            float_64 const Q = math::pow( math::pow( R, C ) + math::pow( Q_1, C ), float_64( 1. ) / C );
 
-            float_64 const x = thomasFermi::TFAlpha * math::pow(Q, TFBeta_temp);
+            float_64 const x = thomasFermi::TFAlpha * math::pow( Q, TFBeta_temp );
 
             /* Thomas-Fermi average ionization state */
             float_X const ZStar = static_cast< float_X >(
                 protonNumber * x / (
-                    float_64(1.) + x +
-                    math::sqrt( float_64(1.) + float_64(2.) * x )
+                    float_64( 1. ) + x +
+                    math::sqrt( float_64( 1. ) + float_64( 2. ) * x )
                 )
             );
 
@@ -139,14 +139,14 @@ namespace ionization
          */
         template< typename ParticleType >
         HDINLINE uint32_t
-        operator()( float_X const kinEnergyDensity, float_X const density, ParticleType & parentIon, float_X randNr )
+        operator( )( float_X const kinEnergyDensity, float_X const density, ParticleType & parentIon, float_X randNr )
         {
 
             /* initialize functor return value: number of new macro electrons to create */
             uint32_t numNewFreeMacroElectrons = 0u;
 
             float_64 const densityUnit = static_cast< float_64 >( particleToGrid::derivedAttributes::Density( ).getUnit( )[ 0 ] );
-            float_64 const kinEnergyDensityUnit = static_cast<float_64>(particleToGrid::derivedAttributes::EnergyDensity().getUnit()[0]);
+            float_64 const kinEnergyDensityUnit = static_cast< float_64 >( particleToGrid::derivedAttributes::EnergyDensity( ).getUnit( )[ 0 ] );
             /* convert from kinetic energy density to average kinetic energy per particle */
             float_64 const kinEnergyUnit = kinEnergyDensityUnit / densityUnit;
             float_64 const avgKinEnergy = kinEnergyDensity / density * kinEnergyUnit;

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
@@ -81,7 +81,7 @@ namespace ionization
             /* atomic mass number (usually A) A = N + Z */
             constexpr float_64 massNumber = neutronNumber + protonNumber;
 
-            float_64 const T_0 = temperature/math::pow( protonNumber,float_64( 4./3. ) );
+            float_64 const T_0 = temperature / math::pow( protonNumber, float_64( 4. / 3. ) );
 
             float_64 const T_F = T_0 / ( float_64( 1. ) + T_0 );
 

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
@@ -50,7 +50,7 @@ namespace ionization
     {
         /** Detailed Balance implementation of the Thomas-Fermi model
          *
-         * This model uses local density and "temperature" values as input
+         * This model uses local ion density and "temperature" values as input
          * parameters to calculate an average charge state.
          * A physical temperature requires a defined equilibrium state.
          * Typical high power laser-plasma interaction is highly
@@ -63,14 +63,15 @@ namespace ionization
          * @tparam ParticleType type of particle for which to calculate
          *     an average charge state
          *
-         * @param density number density value
-         * @param kinEnergyDensity kinetic energy density value
+         * @param temperature electron "temperature" value calculated from average
+         *        kinetic electron energy per ion in units of eV
+         * @param massDensity ion mass density in units of g/cm^3
          *
          * @return average charge state prediction according to the Thomas-Fermi model
          */
         template< typename ParticleType >
         HDINLINE float_X
-        detailedBalanceThomasFermi( float_X const kinEnergyDensity, float_X const density, ParticleType & parentIon )
+        detailedBalanceThomasFermi( float_X const temperature, float_X const massDensity, ParticleType & parentIon )
         {
 
             /* @TODO replace the float_64 with float_X and make sure the values are scaled to PIConGPU units */
@@ -79,20 +80,6 @@ namespace ionization
 
             /* atomic mass number (usually A) A = N + Z */
             constexpr float_64 massNumber = neutronNumber + protonNumber;
-
-            /** @TODO replace the static_cast<float_64> by casts to float_X
-             * or leave out entirely and compute everything in PIConGPU scaled units
-             */
-            float_64 const densityUnit = static_cast<float_64>(particleToGrid::derivedAttributes::Density().getUnit()[0]);
-            float_64 const kinEnergyDensityUnit = static_cast<float_64>(particleToGrid::derivedAttributes::EnergyDensity().getUnit()[0]);
-            /* convert from kinetic energy density to average kinetic energy per particle */
-            float_64 const kinEnergyUnit = kinEnergyDensityUnit / densityUnit;
-            float_64 const kinEnergy = kinEnergyDensity / density * kinEnergyUnit;
-            /** convert kinetic energy in J to "temperature" in eV by assuming an ideal electron gas
-             * E_kin = 3/2 k*T
-             */
-            constexpr float_64 convKinEnergyToTemperature = UNITCONV_Joule_to_keV * float_64(1.e3) * float_64(2./3.);
-            float_64 const temperature = kinEnergy * convKinEnergyToTemperature;
 
             float_64 const T_0 = temperature/math::pow(protonNumber,float_64(4./3.));
 
@@ -112,13 +99,6 @@ namespace ionization
             float_64 const B = -math::exp(thomasFermi::TFB0 + thomasFermi::TFB1*T_F + thomasFermi::TFB2*math::pow(T_F,float_64(7.)));
 
             float_64 const C = thomasFermi::TFC1 * T_F + thomasFermi::TFC2;
-
-            /* requires mass density in g/cm^3 */
-            constexpr float_64 nAvogadro = SI::N_AVOGADRO;
-            constexpr float_64 convM3ToCM3 = 1.e6;
-
-            float_64 const convToMassDensity = densityUnit * massNumber / nAvogadro / convM3ToCM3;
-            float_64 const massDensity = density * convToMassDensity;
 
             constexpr float_64 invAtomicTimesMassNumber = float_64(1.) / (protonNumber * massNumber);
             float_64 const R = massDensity * invAtomicTimesMassNumber;
@@ -166,13 +146,49 @@ namespace ionization
             uint32_t numNewFreeMacroElectrons = 0u;
 
             float_64 const densityUnit = static_cast< float_64 >( particleToGrid::derivedAttributes::Density( ).getUnit( )[ 0 ] );
+            float_64 const kinEnergyDensityUnit = static_cast<float_64>(particleToGrid::derivedAttributes::EnergyDensity().getUnit()[0]);
+            /* convert from kinetic energy density to average kinetic energy per particle */
+            float_64 const kinEnergyUnit = kinEnergyDensityUnit / densityUnit;
+            float_64 const avgKinEnergy = kinEnergyDensity / density * kinEnergyUnit;
+            /** convert kinetic energy in J to "temperature" in eV by assuming an ideal electron gas
+             * E_kin = 3/2 k*T
+             */
+            constexpr float_64 convKinEnergyToTemperature = UNITCONV_Joule_to_keV * float_64( 1.e3 ) * float_64( 2./3. );
+            /** electron "temperature" in electron volts */
+            float_64 const temperature = avgKinEnergy * convKinEnergyToTemperature;
+
+            /* conversion factors from number density to mass density */
+            constexpr float_64 nAvogadro = SI::N_AVOGADRO;
+            constexpr float_64 convM3ToCM3 = 1.e6;
+
+            /* @TODO replace the float_64 with float_X and make sure the values are scaled to PIConGPU units */
+            constexpr float_64 protonNumber = GetAtomicNumbers<ParticleType>::type::numberOfProtons;
+            constexpr float_64 neutronNumber = GetAtomicNumbers<ParticleType>::type::numberOfNeutrons;
+
+            /* atomic mass number (usually A) A = N + Z */
+            constexpr float_64 massNumber = neutronNumber + protonNumber;
+
+            float_64 const convToMassDensity = densityUnit * massNumber / nAvogadro / convM3ToCM3;
+            /** mass density in units of g/cm^3 */
+            float_64 const massDensity = density * convToMassDensity;
+
             /** lower ion density cutoff
              *
              * The Thomas-Fermi model yields unphysical artifacts for low densities.
              * If `density` is lower than a user-definable ion number density value the model will not be applied.
              */
             constexpr float_X lowerDensityCutoff = particles::ionization::thomasFermi::CUTOFF_LOW_DENSITY;
-            if( density * densityUnit >= lowerDensityCutoff )
+            /** lower electron temperature cutoff
+             *
+             * The Thomas-Fermi model also yields partly unphysical artifacts for low electron temperatures.
+             * If `temperature` is lower than a user-definable ion number temperature value the model will not be applied.
+             */
+            constexpr float_X lowerTemperatureCutoff = particles::ionization::thomasFermi::CUTOFF_LOW_TEMPERATURE_EV;
+
+            if(
+                density * densityUnit >= lowerDensityCutoff &&
+                temperature >= lowerTemperatureCutoff
+            )
             {
 
                 float_64 const chargeState = attribute::getChargeState( parentIon );
@@ -187,8 +203,8 @@ namespace ionization
                      * LTE conditions.
                      */
                     float_X const ZStar = detailedBalanceThomasFermi(
-                        kinEnergyDensity,
-                        density,
+                        temperature,
+                        massDensity,
                         parentIon
                     );
 

--- a/include/picongpu/simulation_defines/param/ionizer.param
+++ b/include/picongpu/simulation_defines/param/ionizer.param
@@ -447,8 +447,18 @@ namespace thomasFermi
      * @note This cutoff value should be set in accordance to FLYCHK calculations,
      *       for instance! It is not a universal value and requires some preliminary
      *       approximations!
+     *
+     * unit: 1 / m^3
+     *
+     * default: ion number density = critical electron number density for lambda_laser = 800nm
+     *
+     * The choice of the default is motivated by by the following:
+     * In laser-driven plasmas all dynamics in density regions below the
+     * critical electron density will be laser-dominated. Once ions of that density
+     * are ionized once the laser will not penetrate fully anymore and the as electrons are heated
+     * the dynamics will be collision-dominated.
      */
-    constexpr float_X CUTOFF_LOW_DENSITY = 1.7422e27; // m^-3 - critical density 800nm laser
+    constexpr float_X CUTOFF_LOW_DENSITY = 1.7422e27;
 
     /** low temperature cutoff
      *

--- a/include/picongpu/simulation_defines/param/ionizer.param
+++ b/include/picongpu/simulation_defines/param/ionizer.param
@@ -437,7 +437,7 @@ namespace thomasFermi
     /** cutoff energy for electron "temperature" calculation in SI units*/
     constexpr float_X CUTOFF_MAX_ENERGY = CUTOFF_MAX_ENERGY_KEV * UNITCONV_keV_to_Joule;
 
-    /** lower density cutoff
+    /** lower ion density cutoff
      *
      * The Thomas-Fermi model yields unphysical artifacts for low ion densities.
      * Low ion densities imply lower collision frequency and thus less collisional ionization.
@@ -450,7 +450,7 @@ namespace thomasFermi
      *
      * unit: 1 / m^3
      *
-     * default: ion number density = critical electron number density for lambda_laser = 800nm
+     * example: 1.7422e27 as a hydrogen ion number density equal to the corresponding critical electron number density for an 800nm laser
      *
      * The choice of the default is motivated by by the following:
      * In laser-driven plasmas all dynamics in density regions below the
@@ -460,7 +460,7 @@ namespace thomasFermi
      */
     constexpr float_X CUTOFF_LOW_DENSITY = 1.7422e27;
 
-    /** low temperature cutoff
+    /** lower electron temperature cutoff
      *
      * The Thomas-Fermi model predicts initial ionization for many materials of
      * solid density even when the electron temperature is 0.

--- a/include/picongpu/simulation_defines/param/ionizer.param
+++ b/include/picongpu/simulation_defines/param/ionizer.param
@@ -450,6 +450,13 @@ namespace thomasFermi
      */
     constexpr float_X CUTOFF_LOW_DENSITY = 1.7422e27; // m^-3 - critical density 800nm laser
 
+    /** low temperature cutoff
+     *
+     * The Thomas-Fermi model predicts initial ionization for many materials of
+     * solid density even when the electron temperature is 0.
+     */
+    constexpr float_X CUTOFF_LOW_TEMPERATURE_EV = 1.0;
+
 } // namespace thomasFermi
 } // namespace ionization
 } // namespace particles


### PR DESCRIPTION
Depending on the material the Thomas-Fermi prediction for the average charge state can be unphysically high. For some materials it predicts non-zero charge states at 0 temperature. That can be a reasonable approximation for metals and their electrons in the conduction band. In the general case there should be no free electrons at 0 temperature, though.
    
Therefore this commit implements a lower temperature cutoff.
The `detailedBalanceThomasFermi` function now accepts the parameters

- `temperature` in eV
- `massDensity` in g/cm^3

just as the fitting model described by More (1985).

See the Thomas-Fermi prediction of the charge state of the constituents of polystyrene, carbon and hydrogen.
![tf_prediction_plastic_t 0](https://user-images.githubusercontent.com/5416860/32614663-01cb4c2e-c56e-11e7-9394-07034065f438.png)

- [x] run a simple test: *electron temperature cutoff at 1 eV - material: copper at solid density of 8.9 g/cm³*   
    - once run with 0 eV electron temperature - TF prediction: <Z> = 4.40
    - one run with 5 eV: TF prediction for - TF prediction: <Z> = 4.66
    - **result** success: due to cutoff at 1 eV, no ionization in the 0 eV case while in the 5 eV case the average charge state amounts to <Z> = 4.66

## To Do

- [x] please rebase against dev
- [x] add the "ion density" cutoff set to "potential free electron density" comment in more detail in example
- [x] add plots and parts of the great PR descriptions to the model page

**update 2017-11-23**

This plot will automatically be created by sphinx.
![tf_prediction_plastic_t 0_10_and_100ev](https://user-images.githubusercontent.com/5416860/33180363-c2395a24-d06c-11e7-9a42-b860bf988c4f.png)
