### PR TITLE
Start Pos: OnePosition w/o Weighting

### DIFF
--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -124,6 +124,8 @@ namespace picongpu
             uint32_t const workerIdx = threadIdx.x;
 
             using FramePtr = typename T_ParBox::FramePtr;
+            using FrameType = typename T_ParBox::FrameType;
+            using ParticleType = typename FrameType::ParticleType;
             DataSpace< simDim > const superCells( mapper.getGridSuperCells( ) );
 
             PMACC_SMEM(
@@ -237,7 +239,7 @@ namespace picongpu
                     );
 
                     numParsPerCellCtx[ idx ] =
-                        positionFunctorCtx[ idx ].numberOfMacroParticles( realParticlesPerCell );
+                        positionFunctorCtx[ idx ].template numberOfMacroParticles< ParticleType >( realParticlesPerCell );
 
                     if( numParsPerCellCtx[ idx ] > 0 )
                         nvidia::atomicAllExch(
@@ -305,7 +307,6 @@ namespace picongpu
                              *   in the following lines since they are already known at this point.
                              */
                             {
-                                using FrameType = typename T_ParBox::FrameType;
                                 using ParticleAttrList = typename FrameType::ValueTypeSeq;
                                 using AttrToIgnore = bmpl::vector4<
                                     position<>,

--- a/include/picongpu/particles/startPosition/OnePositionImpl.def
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.def
@@ -48,6 +48,9 @@ namespace acc
      *
      * All macro particles are set to the same in cell position defined in
      * T_ParamClass.
+     *
+     * @tparam T_ParamClass Parameter class with off `InCellOffset` defined as
+     *                      CONST_VECTOR of 3 float_X [0.0, 1.0).
      */
     template< typename T_ParamClass >
     using OnePositionImpl = generic::Free< acc::OnePositionImpl< T_ParamClass > >;

--- a/include/picongpu/particles/startPosition/OnePositionImpl.hpp
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.hpp
@@ -23,6 +23,8 @@
 #include "picongpu/particles/startPosition/OnePositionImpl.def"
 #include "picongpu/particles/startPosition/detail/WeightMacroParticles.hpp"
 
+#include <pmacc/traits/HasIdentifier.hpp>
+
 #include <boost/mpl/integral_c.hpp>
 
 
@@ -34,6 +36,38 @@ namespace startPosition
 {
 namespace acc
 {
+namespace detail
+{
+    template< bool T_hasWeighting >
+    struct SetWeighting
+    {
+        template< typename T_Particle >
+        DINLINE void
+        operator()
+        (
+            T_Particle & particle,
+            float_X const weighting
+        )
+        {
+            particle[ weighting_ ] = weighting;
+        }
+    };
+
+    template<>
+    struct SetWeighting< false >
+    {
+        template< typename T_Particle >
+        DINLINE void
+        operator()
+        (
+            T_Particle &,
+            float_X const
+        )
+        {
+        }
+    };
+
+} // namespace detail
 
     template< typename T_ParamClass >
     struct OnePositionImpl
@@ -56,19 +90,42 @@ namespace acc
         )
         {
             particle[ position_ ] = T_ParamClass{}.inCellOffset.template shrink< simDim >( );
-            particle[ weighting_ ] = m_weighting;
-        }
 
-        DINLINE uint32_t
-        numberOfMacroParticles( float_X const realParticlesPerCell )
-        {
-            return detail::WeightMacroParticles{}(
-                realParticlesPerCell,
-                T_ParamClass::numParticlesPerCell,
+            // set the weighting attribute if the particle species has it
+            bool const hasWeighting = pmacc::traits::HasIdentifier<
+                typename T_Particle::FrameType,
+                weighting
+            >::type::value;
+            detail::SetWeighting< hasWeighting > setWeighting;
+            setWeighting(
+                particle,
                 m_weighting
             );
         }
 
+        template< typename T_Particle >
+        DINLINE uint32_t
+        numberOfMacroParticles( float_X const realParticlesPerCell )
+        {
+            bool const hasWeighting = pmacc::traits::HasIdentifier<
+                typename T_Particle::FrameType,
+                weighting
+            >::type::value;
+
+            // note: m_weighting member might stay uninitialized!
+            uint32_t result( T_ParamClass::numParticlesPerCell );
+
+            if( hasWeighting )
+                result = startPosition::detail::WeightMacroParticles{}(
+                    realParticlesPerCell,
+                    T_ParamClass::numParticlesPerCell,
+                    m_weighting
+                );
+
+            return result;
+        }
+
+    private:
         float_X m_weighting;
     };
 

--- a/include/picongpu/particles/startPosition/QuietImpl.hpp
+++ b/include/picongpu/particles/startPosition/QuietImpl.hpp
@@ -91,6 +91,7 @@ namespace acc
 
         }
 
+        template< typename T_Particle >
         DINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {

--- a/include/picongpu/particles/startPosition/RandomImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomImpl.hpp
@@ -71,10 +71,11 @@ namespace acc
             particle[ weighting_ ] = m_weighting;
         }
 
+        template< typename T_Particle >
         DINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
-            return detail::WeightMacroParticles{}(
+            return startPosition::detail::WeightMacroParticles{}(
                 realParticlesPerCell,
                 T_ParamClass::numParticlesPerCell,
                 m_weighting

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -72,10 +72,11 @@ namespace acc
             Functor::operator( )( args ... );
         }
 
+        template< typename T_Particle >
         DINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
-            return Functor::numberOfMacroParticles( realParticlesPerCell );
+            return Functor::template numberOfMacroParticles< T_Particle >( realParticlesPerCell );
         }
     };
 } // namespace acc

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -89,10 +89,11 @@ namespace acc
             );
         }
 
+        template< typename T_Particle >
         DINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
-            return Functor::numberOfMacroParticles( realParticlesPerCell );
+            return Functor::template numberOfMacroParticles< T_Particle >( realParticlesPerCell );
         }
 
     private:


### PR DESCRIPTION
Allows to transparently use the `OnePosition` particle initialization `startPosition` with particles without weighting (such as probe particles).

This will straight initialize the number of particles per cell (ppc). It is recommended to only use one ppc with this start position.