### PR TITLE
rename filter: `IsHandleValid` -> `All`

### DIFF
--- a/docs/source/usage/particles.rst
+++ b/docs/source/usage/particles.rst
@@ -101,13 +101,13 @@ ProtonTimesWeighting
 Manipulation Filters
 --------------------
 
-Most of the particle functors shall operate on all valid particles, where IsHandleValid is the default assumption.
+Most of the particle functors shall operate on all valid particles, where filter::All is the default assumption.
 One can limit the domain or subset of particles with filters such as the ones below (or define new ones).
 
-IsHandleValid
-^^^^^^^^^^^^^
+All
+^^^
 
-.. doxygenstruct:: picongpu::particles::filter::IsHandleValid
+.. doxygenstruct:: picongpu::particles::filter::All
    :project: PIConGPU
 
 RelativeGlobalDomainPosition

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -121,7 +121,7 @@ template<
     typename T_Functor,
     typename T_SrcSpeciesType,
     typename T_DestSpeciesType = bmpl::_1,
-    typename T_Filter = filter::IsHandleValid
+    typename T_Filter = filter::All
 >
 struct ManipulateDeriveSpecies
 {
@@ -169,7 +169,7 @@ struct ManipulateDeriveSpecies
 template<
     typename T_SrcSpeciesType,
     typename T_DestSpeciesType = bmpl::_1,
-    typename T_Filter = filter::IsHandleValid
+    typename T_Filter = filter::All
 >
 struct DeriveSpecies : ManipulateDeriveSpecies<
     manipulators::generic::None,

--- a/include/picongpu/particles/Manipulate.hpp
+++ b/include/picongpu/particles/Manipulate.hpp
@@ -45,7 +45,7 @@ namespace particles
     template<
         typename T_Functor,
         typename T_SpeciesType = bmpl::_1,
-        typename T_Filter = filter::IsHandleValid
+        typename T_Filter = filter::All
     >
     struct Manipulate
     {

--- a/include/picongpu/particles/filter/All.def
+++ b/include/picongpu/particles/filter/All.def
@@ -31,7 +31,7 @@ namespace filter
      *
      * the particle method `::isValidHandle()` is called.
      */
-    struct IsHandleValid;
+    struct All;
 
 } //namespace filter
 } //namespace particles

--- a/include/picongpu/particles/filter/All.hpp
+++ b/include/picongpu/particles/filter/All.hpp
@@ -33,7 +33,7 @@ namespace acc
 {
 
     //! check the particle handle
-    struct IsHandleValid
+    struct All
     {
 
         /** check particle handle
@@ -60,12 +60,12 @@ namespace acc
 
 } // namespace acc
 
-    struct IsHandleValid
+    struct All
     {
         template< typename T_SpeciesType >
         struct apply
         {
-            using type = IsHandleValid;
+            using type = All;
         };
 
         /** create filter for the accelerator
@@ -79,15 +79,22 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE acc::IsHandleValid
+        DINLINE acc::All
         operator( )(
             T_Acc const & acc,
             DataSpace< simDim > const &,
             T_WorkerCfg const &
         )
         {
-            return acc::IsHandleValid{ };
+            return acc::All{ };
 
+        }
+
+        static
+        HINLINE std::string
+        getName( )
+        {
+            return std::string("All");
         }
     };
 

--- a/include/picongpu/particles/filter/filter.def
+++ b/include/picongpu/particles/filter/filter.def
@@ -20,4 +20,4 @@
 #pragma once
 
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.def"
-#include "picongpu/particles/filter/IsHandleValid.def"
+#include "picongpu/particles/filter/All.def"

--- a/include/picongpu/particles/filter/filter.hpp
+++ b/include/picongpu/particles/filter/filter.hpp
@@ -20,4 +20,4 @@
 #pragma once
 
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.hpp"
-#include "picongpu/particles/filter/IsHandleValid.hpp"
+#include "picongpu/particles/filter/All.hpp"

--- a/include/picongpu/particles/manipulators/IBinary.def
+++ b/include/picongpu/particles/manipulators/IBinary.def
@@ -48,7 +48,7 @@ namespace manipulators
      */
     template<
         typename T_BinaryFunctor,
-        typename T_UnaryFilter = filter::IsHandleValid
+        typename T_UnaryFilter = filter::All
     >
     using IBinary = pmacc::functor::Filtered<
         pmacc::filter::operators::And,

--- a/include/picongpu/particles/manipulators/IUnary.def
+++ b/include/picongpu/particles/manipulators/IUnary.def
@@ -47,7 +47,7 @@ namespace manipulators
      */
     template<
         typename T_UnaryFunctor,
-        typename T_UnaryFilter = filter::IsHandleValid
+        typename T_UnaryFilter = filter::All
     >
     using IUnary = pmacc::functor::Filtered<
         pmacc::filter::operators::And,


### PR DESCRIPTION
This pull request changed the name for the particle filter which is necessary to allow the usage later in our plugin e.g. `--e_energy.filter All`

- rename particle filter
- add static `getName()` method to the filter
- update usage
- update documentation

related to #1288