### PR TITLE
Probe Particle Usage

### DIFF
--- a/docs/source/usage/workflows.rst
+++ b/docs/source/usage/workflows.rst
@@ -13,3 +13,5 @@ This section contains typical user workflows and best practices.
    workflows/laserPeakOnTarget
    workflows/compositeMaterials
    workflows/quasiNeutrality
+   workflows/probeParticles
+   workflows/tracerParticles

--- a/docs/source/usage/workflows/probeParticles.rst
+++ b/docs/source/usage/workflows/probeParticles.rst
@@ -1,0 +1,116 @@
+.. _usage-workflows-probeParticles:
+
+Probe Particles
+---------------
+
+.. sectionauthor:: Axel Huebl
+
+Probe particles ("probes") can be used to record field quantities at selected positions over time.
+
+As a geometric data-reduction technique, analyzing the discrete, regular field of a particle-in-cell simulation only at selected points over time can greatly reduce the need for I/O.
+Such particles are often arranged at isolated points, regularly as along lines, in planes or in any other user-defined manner.
+
+Probe particles are usually neutral, non-interacting test particles that are statically placed in the simulation or co-moving with along pre-defined path.
+Self-consistently interacting particles are usually called :ref:`tracer particles <usage-workflows-tracerParticles>`.
+
+Workflow
+""""""""
+
+* ``speciesDefinition.param``: create a species specifically for probes and add ``fieldE`` and ``fieldB`` attributes to it for storing interpolated fields
+
+.. code-block:: cpp
+
+    using ParticleFlagsProbes = bmpl::vector<
+        particlePusher< particles::pusher::Probe >,
+        shape< UsedParticleShape >,
+        interpolation< UsedField2Particle >
+    >;
+
+    using Probes = Particles<
+        bmpl::string< 'p', 'r', 'o', 'b', 'e' >,
+        ParticleFlagsProbes,
+        MakeSeq_t<
+            position< position_pic >,
+            probeB,
+            probeE
+        >
+    >;
+
+and add it to ``VectorAllSpecies``:
+
+.. code-block:: cpp
+
+   using VectorAllSpecies = MakeSeq_t<
+       Probes,
+       // ...
+   >;
+
+* ``density.param``: select in which cell a probe particle shall be placed, e.g. in each 4th cell per direction:
+
+.. code-block:: cpp
+
+   // put probe particles every 4th cell in X, Y(, Z)
+   using ProbeEveryFourthCell = EveryNthCellImpl<
+       mCT::UInt32<
+           4,
+           4,
+           4
+       >
+   >;
+
+* ``particle.param``: initialize the individual probe particles in-cell, e.g. always in the left-lower corner and only one per selected cell
+
+.. code-block:: cpp
+
+   CONST_VECTOR(
+       float_X,
+       3,
+       InCellOffset,
+       /* each x, y, z in-cell position component
+        * in range [0.0, 1.0) */
+       0.0,
+       0.0,
+       0.0
+   );
+   struct OnePositionParameter
+   {
+       static constexpr uint32_t numParticlesPerCell = 1u;
+       const InCellOffset_t inCellOffset;
+   };
+
+   using OnePosition = OnePositionImpl< OnePositionParameter >;
+
+* ``speciesInitialization.param``: initialize particles for the probe just as with regular particles
+
+.. code-block:: cpp
+
+   using InitPipeline = mpl::vector<
+       // ... ,
+       CreateDensity<
+           densityProfiles::ProbeEveryFourthCell,
+           startPosition::OnePosition,
+           Probes
+       >
+   >;
+
+* ``fileOutput.param``: make sure the the tracer particles are part of ``FileOutputParticles``
+
+.. code-block:: cpp
+
+   // either all via VectorAllSpecies or just select
+   using FileOutputParticles = MakeSeq_t< Probes >;
+
+Known Limitations
+"""""""""""""""""
+
+.. note::
+
+   currently, only the electric field :math:`\vec E` and the magnetic field :math:`\vec B` can be recorded
+
+.. note::
+
+   we currently do not support time averaging
+
+.. warning::
+
+   If the probe particles are dumped in the file output, the instantaneous fields they recorded will be one time step behind the last field update (since our runOneStep pushed the particles first and then calls the field solver).

--- a/docs/source/usage/workflows/tracerParticles.rst
+++ b/docs/source/usage/workflows/tracerParticles.rst
@@ -1,0 +1,31 @@
+.. _usage-workflows-tracerParticles:
+
+Tracer Particles
+----------------
+
+.. sectionauthor:: Axel Huebl
+
+Tracer particles are like :ref:`probe particles <usage-workflows-probeParticles>`, but interact self-consistenly with the simulation.
+They are usually used to visualize *representative* particle trajectories of a larger distribution.
+
+Workflow
+""""""""
+
+* ``speciesDefinition.param``: create a species specifically for tracer particles
+
+  * add the particle attribute ``particleId`` to your species' ``Particles< ... >`` class (third argument, ``T_Attributes``)
+  * optional: add ``fieldE`` and ``fieldB`` attributes to the species to store fields as in :ref:`probes <usage-workflows-probeParticles>` 
+
+* create tracer particles by either
+
+  * ``speciesInitialization.param``: initializing a low percentage of your initial density inside this species or
+  * ``speciesInitialization.param``: assigning the target (electron) species of an ion's ionization routine to the tracer species or
+  * ``speciesInitialization.param``: moving some particles of an already initialized species to the tracer species (upcoming)
+
+* ``fileOutput.param``: output the tracer particles
+
+Known Limitations
+"""""""""""""""""
+
+* currently, only the electric field :math:`\vec E` and the magnetic field :math:`\vec B` can be recorded
+* we currently do not support time averaging

--- a/include/picongpu/particles/densityProfiles/EveryNthCellImpl.def
+++ b/include/picongpu/particles/densityProfiles/EveryNthCellImpl.def
@@ -1,0 +1,55 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/static_assert.hpp>
+
+
+namespace picongpu
+{
+namespace densityProfiles
+{
+    /** A density profile which only initializes each nth cell
+     *
+     * Useful to initialize probe particles or material dopings. The result is
+     * either 0 (no particle) or the full density. The result of this particular
+     * functor can be larger 1.0 with T_SkipCells::toRT().productOfComponents()
+     * in order to properly fulfill the density of a species via increased
+     * weighting.
+     *
+     * @tparam T_SkipCells The period for the number of cells to skip for each
+     *                     direction before initializing a particle. Signature
+     *                     of a pmacc::math::CT::UInt32
+     */
+    template<
+        typename T_SkipCells
+    >
+    struct EveryNthCellImpl
+    {
+        // note: `sizeof(ANY_TYPE) != 0` defers the evaluation
+        PMACC_CASSERT_MSG_TYPE(
+            __Density_Profile_EveryNthCellImpl_expects_a_PMacc_math_CT_UInt32,
+            T_SkipCells,
+            false && sizeof( T_SkipCells ) != 0
+        );
+    };
+
+} // namespace densityProfiles
+} // namespace picongpu

--- a/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
@@ -1,0 +1,90 @@
+/* Copyright 2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/densityProfiles/EveryNthCellImpl.def"
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/math/Vector.hpp>
+
+
+namespace picongpu
+{
+namespace densityProfiles
+{
+    template<
+        uint32_t ... Args
+    >
+    struct EveryNthCellImpl<
+        pmacc::math::CT::UInt32<
+            Args ...
+        >
+    >
+    {
+        using OrgSkipCells = pmacc::math::CT::UInt32< Args ... >;
+        using SkipCells = typename pmacc::math::CT::shrinkTo<
+            OrgSkipCells,
+            simDim
+        >::type;
+
+        template<typename T_SpeciesType>
+        struct apply
+        {
+            using type = EveryNthCellImpl< OrgSkipCells >;
+        };
+
+        HINLINE
+        EveryNthCellImpl( uint32_t currentStep )
+        {
+        }
+
+        /** Calculate the normalized density
+         *
+         * @param totalCellOffset total offset including all slides [in cells]
+         */
+        HDINLINE float_X
+        operator()( DataSpace< simDim > const & totalCellOffset )
+        {
+            // modulo!
+            auto const isThisCellWithProbe( totalCellOffset % SkipCells::toRT() );
+
+            // is this cell populated with a probe particle?
+            bool const isPopulated(
+                isThisCellWithProbe.productOfComponents() == 0
+            );
+
+            /* every how many (volumentric) cells do we set a particle:
+             * scale up weighting accordingly */
+            float_X const weightingScaling(
+                precisionCast< float_X >(
+                    SkipCells::toRT().productOfComponents()
+                )
+            );
+
+            // fill only the selected cells
+            float_X result( 0.0 );
+            if( isPopulated )
+                result = weightingScaling;
+
+            return result;
+        }
+    };
+} // namespace densityProfiles
+} // namespace picongpu

--- a/include/picongpu/particles/densityProfiles/profiles.def
+++ b/include/picongpu/particles/densityProfiles/profiles.def
@@ -26,4 +26,5 @@
 #include "picongpu/particles/densityProfiles/LinearExponentialImpl.def"
 #include "picongpu/particles/densityProfiles/GaussianCloudImpl.def"
 #include "picongpu/particles/densityProfiles/SphereFlanksImpl.def"
+#include "picongpu/particles/densityProfiles/EveryNthCellImpl.def"
 #include "picongpu/particles/densityProfiles/FromHDF5Impl.def"

--- a/include/picongpu/particles/densityProfiles/profiles.hpp
+++ b/include/picongpu/particles/densityProfiles/profiles.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/particles/densityProfiles/LinearExponentialImpl.hpp"
 #include "picongpu/particles/densityProfiles/GaussianCloudImpl.hpp"
 #include "picongpu/particles/densityProfiles/SphereFlanksImpl.hpp"
+#include "picongpu/particles/densityProfiles/EveryNthCellImpl.hpp"
 
 #if( ENABLE_HDF5 == 1 )
 #    include "picongpu/particles/densityProfiles/FromHDF5Impl.hpp"

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/density.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/density.param
@@ -99,8 +99,16 @@ namespace densityProfiles
         }
     };
 
-    /* definition of free formula profile */
+    // definition of free formula profile
     using FlatFoilWithRamp = FreeFormulaImpl< FlatFoilWithRampFunctor >;
 
+    // put probe particles every 4th cell in X, Y(, Z)
+    using ProbeEveryFourthCell = EveryNthCellImpl<
+        mCT::UInt32<
+            4,
+            4,
+            4
+        >
+    >;
 } // namespace densityProfiles
 } // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/fileOutput.param
@@ -110,6 +110,6 @@ namespace picongpu
      * hint: to enable particle output set to
      *   using FileOutputParticles = VectorAllSpecies;
      */
-    using FileOutputParticles = bmpl::vector0<>;
+    using FileOutputParticles = MakeSeq_t< Probes >;
 
 }

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/particle.param
@@ -104,6 +104,29 @@ namespace startPosition
     /** definition of quiet particle start */
     using Quiet = QuietImpl< QuietParam >;
 
+    //! sit directly in lower corner of the cell
+    CONST_VECTOR(
+        float_X,
+        3,
+        InCellOffset,
+        /* each x, y, z in-cell position component in range [0.0, 1.0) */
+        0.0,
+        0.0,
+        0.0
+    );
+    struct OnePositionParameter
+    {
+        /** Count of particles per cell at initial state
+         *
+         *  unit: none */
+        static constexpr uint32_t numParticlesPerCell = 1u;
+
+        const InCellOffset_t inCellOffset;
+    };
+
+    //! definition of one specific position for particle start
+    using OnePosition = OnePositionImpl< OnePositionParameter >;
+
 } // namespace startPosition
 } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesDefinition.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesDefinition.param
@@ -194,6 +194,25 @@ using Nitrogen = Particles<
     IonParticleAttributes
 >;
 
+/*--------------------------- Probe Particles -------------------------------*/
+
+using ParticleFlagsProbes = bmpl::vector<
+    particlePusher< particles::pusher::Probe >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >
+>;
+
+/* define species Probe */
+using Probes = Particles<
+    bmpl::string< 'p', 'r', 'o', 'b', 'e' >,
+    ParticleFlagsProbes,
+    MakeSeq_t<
+        position< position_pic >,
+        probeB,
+        probeE
+    >
+>;
+
 /*########################### end species ####################################*/
 
 /** All known particle species of the simulation
@@ -205,7 +224,8 @@ using VectorAllSpecies = MakeSeq_t<
     Electrons,
     Hydrogen,
     Carbon,
-    Nitrogen
+    Nitrogen,
+    Probes
 >;
 
 } // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -132,6 +132,13 @@ namespace particles
         DeriveSpecies<
             Nitrogen,
             Electrons
+        >,
+        /* create non-physical "probe" particles that sit in every 4x4x4th cell
+         * and monitor the electro-magnetic fields */
+        CreateDensity<
+            densityProfiles::ProbeEveryFourthCell,
+            startPosition::OnePosition,
+            Probes
         >
     >;
 


### PR DESCRIPTION
Documentation on how to use probe particles ("probes") in PIConGPU. Adds probe particles to the `FoilLCT` ion acceleration example.

Probe particles (“probes”) can be used to record field quantities at selected positions over time.

As a geometric data-reduction technique, analyzing the discrete, regular field of a particle-in-cell simulation only at selected points over time can greatly reduce the need for I/O. Such particles are often arranged at isolated points, regularly as along lines, in planes or in any other user-defined manner.

Probe particles are usually neutral, non-interacting test particles that are statically placed in the simulation or co-moving with along pre-defined path. Self-consistently interacting particles are usually called tracer particles.

0563c0b16c6d2ba590c28c012529675f6a9d669c also adds a new density profile putting particles "every nth cell":  Useful to initialize probe particles or material dopings. The result is either 0 (no particle) or the full density. The result of this particular functor can be larger 1.0 with `T_SkipCells::toRT().productOfComponents()` in order to properly fulfill the density of a species via increased weighting.

### Example Plots

FoilLCT step 10'000: Ex raw fields vs. probe (every 4x4x4 with varying shapes) image
[plotFields.py](https://github.com/ComputationalRadiationPhysics/picongpu/files/1491639/plotFields.py.txt)

![probes_ex](https://user-images.githubusercontent.com/1353258/33076978-b981483c-cece-11e7-93cf-29deef39d44e.png)

### Depends on

- [x] RT tests
- [x] #2368
- [x] #2377
- [x] #2394
- [x] #2400 

