### PR TITLE
add new param file `particleFilters.param`

### DIFF
--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.def
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.def
@@ -38,6 +38,9 @@ namespace param
          * x = 0; y= 1; z = 2
          */
         static constexpr uint32_t dimension = 0;
+
+        // name of the filter
+        static constexpr char const * name = "RelativeGlobalDomainPosition";
     };
 } // namespace param
 

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -151,10 +151,36 @@ namespace acc
 
         }
 
+        static
+        HINLINE std::string
+        getName( )
+        {
+            // we provide the name from the param class
+            return T_Params::name;
+        }
+
         DataSpace< simDim > localDomainOffset;
         DataSpace< simDim > globalDomainSize;
     };
 
 } //namespace filter
-} //namespace particles
-} //namespace picongpu
+
+namespace traits
+{
+    template<
+        typename T_Species,
+        typename T_Params
+    >
+    struct SpeciesEligibleForSolver<
+        T_Species,
+        filter::RelativeGlobalDomainPosition< T_Params >
+    >
+    {
+        using type = typename pmacc::traits::HasIdentifiers<
+            typename T_Species::FrameType,
+            MakeSeq_t< localCellIdx >
+        >::type;
+    };
+} // namespace traits
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/simulation_defines/_defaultParam.loader
+++ b/include/picongpu/simulation_defines/_defaultParam.loader
@@ -42,6 +42,7 @@
 #include "picongpu/simulation_defines/param/ionizationEnergies.param"
 #include "picongpu/simulation_defines/param/density.param"
 #include "picongpu/simulation_defines/param/particle.param"
+#include "picongpu/simulation_defines/param/particleFilters.param"
 #if( PMACC_CUDA_ENABLED == 1 )
 #   include "picongpu/simulation_defines/param/bremsstrahlung.param"
 #endif

--- a/include/picongpu/simulation_defines/param/particle.param
+++ b/include/picongpu/simulation_defines/param/particle.param
@@ -118,27 +118,6 @@ namespace manipulators
 
 } // namespace manipulators
 
-namespace filter
-{
-    /** Parameters for an assignment in a relative position selection
-     */
-    struct IfRelativeGlobalPositionParam
-    {
-        /* lowerBound is included in the range */
-        static constexpr float_X lowerBound = 0.0;
-        /* upperBound is excluded in the range */
-        static constexpr float_X upperBound = 0.5;
-        /* dimension for the filter
-         * x = 0; y= 1; z = 2
-         */
-        static constexpr uint32_t dimension = 0u;
-    };
-    /** definition of a relative position selection that assigns a drift in X */
-    using AssignXDriftToLowerHalfXPosition = RelativeGlobalDomainPosition<
-        IfRelativeGlobalPositionParam
-    >;
-} // namespace filter
-
 namespace startPosition
 {
 

--- a/include/picongpu/simulation_defines/param/particleFilters.param
+++ b/include/picongpu/simulation_defines/param/particleFilters.param
@@ -1,0 +1,64 @@
+/* Copyright 2013-2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/filter/filter.def"
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+
+    /** Parameters for an assignment in a relative position selection
+     */
+    struct IfRelativeGlobalPositionParam
+    {
+        /* lowerBound is included in the range */
+        static constexpr float_X lowerBound = 0.0;
+        /* upperBound is excluded in the range */
+        static constexpr float_X upperBound = 0.5;
+        /* dimension for the filter
+         * x = 0; y= 1; z = 2
+         */
+        static constexpr uint32_t dimension = 0u;
+
+        // filter name
+        static constexpr char const * name = "LowerHalfXPosition";
+    };
+    /** definition of a relative position selection that assigns a drift in X */
+    using LowerHalfXPosition = RelativeGlobalDomainPosition<
+        IfRelativeGlobalPositionParam
+    >;
+
+    /** collection of all available particle filters
+     *
+     * - filter All is defined in picongpu/particles/filter/filter.def
+     */
+    using AllParticleFilters = MakeSeq_t<
+        All,
+        LowerHalfXPosition
+    >;
+
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
@@ -102,58 +102,6 @@ namespace manipulators
     /* definition of AddTemperature start */
     using AddTemperature = unary::Temperature< TemperatureParam >;
 
-} //namespace manipulators
-
-namespace filter
-{
-    struct IfRelativeGlobalPositionParamLowQuarter
-    {
-        /* lowerBound is included in the range */
-        static constexpr float_X lowerBound = 0.0;
-        /* upperBound is excluded in the range */
-        static constexpr float_X upperBound = 0.25;
-        /* dimension for the filter
-         * x = 0; y= 1; z = 2
-         */
-        static constexpr uint32_t dimension = 1u;
-    };
-    /* definition of SetDrift start */
-    using LowerQuarterYPosition = filter::RelativeGlobalDomainPosition<
-        IfRelativeGlobalPositionParamLowQuarter
-    >;
-
-    struct IfRelativeGlobalPositionParamMiddleHalf
-    {
-        /* lowerBound is included in the range */
-        static constexpr float_X lowerBound = 0.25;
-        /* upperBound is excluded in the range */
-        static constexpr float_X upperBound = 0.75;
-        /* dimension for the filter
-         * x = 0; y= 1; z = 2
-         */
-        static constexpr uint32_t dimension = 1u;
-    };
-    /* definition of SetDrift start */
-    using MiddleHalfYPosition = filter::RelativeGlobalDomainPosition<
-        IfRelativeGlobalPositionParamMiddleHalf
-    >;
-
-    struct IfRelativeGlobalPositionParamUpperQuarter
-    {
-        /* lowerBound is included in the range */
-        static constexpr float_X lowerBound = 0.75;
-        /* upperBound is excluded in the range */
-        static constexpr float_X upperBound = 1.0;
-        /* dimension for the filter
-         * x = 0; y= 1; z = 2
-         */
-        static constexpr uint32_t dimension = 1u;
-    };
-    /* definition of SetDrift start */
-    using UpperQuarterYPosition = filter::RelativeGlobalDomainPosition<
-        IfRelativeGlobalPositionParamUpperQuarter
-    >;
-
-} //namespace filter
-} //namespace particles
-} //namespac picongpu
+} // namespace manipulators
+} // namespace particles
+} // namespac picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particleFilters.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particleFilters.param
@@ -1,0 +1,101 @@
+/* Copyright 2013-2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/filter/filter.def"
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+    struct IfRelativeGlobalPositionParamLowQuarterPosition
+    {
+        /* lowerBound is included in the range */
+        static constexpr float_X lowerBound = 0.0;
+        /* upperBound is excluded in the range */
+        static constexpr float_X upperBound = 0.25;
+        /* dimension for the filter
+         * x = 0; y= 1; z = 2
+         */
+        static constexpr uint32_t dimension = 1u;
+
+        // filter name
+        static constexpr char const * name = "LowerQuarterYPosition";
+    };
+
+    using LowerQuarterYPosition = filter::RelativeGlobalDomainPosition<
+        IfRelativeGlobalPositionParamLowQuarterPosition
+    >;
+
+    struct IfRelativeGlobalPositionParamMiddleHalf
+    {
+        /* lowerBound is included in the range */
+        static constexpr float_X lowerBound = 0.25;
+        /* upperBound is excluded in the range */
+        static constexpr float_X upperBound = 0.75;
+        /* dimension for the filter
+         * x = 0; y= 1; z = 2
+         */
+        static constexpr uint32_t dimension = 1u;
+
+        // filter name
+        static constexpr char const * name = "MiddleHalfYPosition";
+    };
+
+    using MiddleHalfYPosition = filter::RelativeGlobalDomainPosition<
+        IfRelativeGlobalPositionParamMiddleHalf
+    >;
+
+    struct IfRelativeGlobalPositionParamUpperQuarter
+    {
+        /* lowerBound is included in the range */
+        static constexpr float_X lowerBound = 0.75;
+        /* upperBound is excluded in the range */
+        static constexpr float_X upperBound = 1.0;
+        /* dimension for the filter
+         * x = 0; y= 1; z = 2
+         */
+        static constexpr uint32_t dimension = 1u;
+
+        // filter name
+        static constexpr char const * name = "UpperQuarterYPosition";
+    };
+
+    using UpperQuarterYPosition = filter::RelativeGlobalDomainPosition<
+        IfRelativeGlobalPositionParamUpperQuarter
+    >;
+
+    /** collection of all available particle filters
+     *
+     * - filter All is defined in picongpu/particles/filter/filter.def
+     */
+    using AllParticleFilters = MakeSeq_t<
+        All,
+        LowerQuarterYPosition,
+        MiddleHalfYPosition,
+        UpperQuarterYPosition
+    >;
+
+} // namespace filter
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
`RelativeGlobalDomainPosition`: add static method `getName()`
- move particle filter from `particles.paramm` to `particleFilters.param`
- add a name to each filter configuration

related to #1288 

- [x] must be rebased against #2381