### PR TITLE
add particle filter to `EnergyParticles`

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -155,7 +155,7 @@ TBG_JField_slice="--J_slice.period 100 --J_slice.fileName sliceJ --J_slice.plane
 # Sum up total energy every .period steps for
 # - species   (--<species>_energy)
 # - fields    (--fields_energy)
-TBG_sumEnergy="--fields_energy.period 10 --<species>_energy.period 10"
+TBG_sumEnergy="--fields_energy.period 10 --<species>_energy.period 10 --<species>_energy.filter <filter name>"
 
 
 # Count the number of macro particles per species for every .period steps

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -155,7 +155,7 @@ TBG_JField_slice="--J_slice.period 100 --J_slice.fileName sliceJ --J_slice.plane
 # Sum up total energy every .period steps for
 # - species   (--<species>_energy)
 # - fields    (--fields_energy)
-TBG_sumEnergy="--fields_energy.period 10 --<species>_energy.period 10 --<species>_energy.filter <filter name>"
+TBG_sumEnergy="--fields_energy.period 10 --<species>_energy.period 10 --<species>_energy.filter all"
 
 
 # Count the number of macro particles per species for every .period steps

--- a/docs/source/usage/plugins/energyFields.rst
+++ b/docs/source/usage/plugins/energyFields.rst
@@ -41,10 +41,10 @@ Python example snippet:
    simDir = "path/to/simOutput/"
 
    # Ekin in Joules (see EnergyParticles)
-   e_sum_ene = np.loadtxt(simDir + "e_energy_All.dat")[:, 0:2]
-   p_sum_ene = np.loadtxt(simDir + "p_energy_All.dat")[:, 0:2]
-   C_sum_ene = np.loadtxt(simDir + "C_energy_All.dat")[:, 0:2]
-   N_sum_ene = np.loadtxt(simDir + "N_energy_All.dat")[:, 0:2]
+   e_sum_ene = np.loadtxt(simDir + "e_energy_all.dat")[:, 0:2]
+   p_sum_ene = np.loadtxt(simDir + "p_energy_all.dat")[:, 0:2]
+   C_sum_ene = np.loadtxt(simDir + "C_energy_all.dat")[:, 0:2]
+   N_sum_ene = np.loadtxt(simDir + "N_energy_all.dat")[:, 0:2]
    # Etotal in Joules
    fields_sum_ene = np.loadtxt(simDir + "fields_energy.dat")[:, 0:2]
 

--- a/docs/source/usage/plugins/energyFields.rst
+++ b/docs/source/usage/plugins/energyFields.rst
@@ -41,10 +41,10 @@ Python example snippet:
    simDir = "path/to/simOutput/"
 
    # Ekin in Joules (see EnergyParticles)
-   e_sum_ene = np.loadtxt(simDir + "e_energy.dat")[:, 0:2]
-   p_sum_ene = np.loadtxt(simDir + "p_energy.dat")[:, 0:2]
-   C_sum_ene = np.loadtxt(simDir + "C_energy.dat")[:, 0:2]
-   N_sum_ene = np.loadtxt(simDir + "N_energy.dat")[:, 0:2]
+   e_sum_ene = np.loadtxt(simDir + "e_energy_All.dat")[:, 0:2]
+   p_sum_ene = np.loadtxt(simDir + "p_energy_All.dat")[:, 0:2]
+   C_sum_ene = np.loadtxt(simDir + "C_energy_All.dat")[:, 0:2]
+   N_sum_ene = np.loadtxt(simDir + "N_energy_All.dat")[:, 0:2]
    # Etotal in Joules
    fields_sum_ene = np.loadtxt(simDir + "fields_energy.dat")[:, 0:2]
 

--- a/docs/source/usage/plugins/energyParticles.rst
+++ b/docs/source/usage/plugins/energyParticles.rst
@@ -10,19 +10,20 @@ This plugin computes the **kinetic and total energy summed over all particles** 
 
 Only the time steps at which the total kinetic energy of all particles should be specified needs to be set via command line argument.
 
-================================ ========================================================================================================
-PIConGPU command line option     Description
-================================ ========================================================================================================
-``--e_energy.period 100``        Sets the time step period at which the energy of all **electrons** in the simulation should be simulated.
-                                 If set to e.g. ``100``, the energy is computed for time steps *0, 100, 200, ...*.
-                                 The default value is ``0``, meaning that the plugin does not compute the particle energy.
-``--<species>_energy.period 42`` Same as above, for any other species available.
-================================ ========================================================================================================
+================================== ========================================================================================================
+PIConGPU command line option       Description
+================================== ========================================================================================================
+``--e_energy.period 100``          Sets the time step period at which the energy of all **electrons** in the simulation should be simulated.
+                                   If set to e.g. ``100``, the energy is computed for time steps *0, 100, 200, ...*.
+                                   The default value is ``0``, meaning that the plugin does not compute the particle energy.
+``--<species>_energy.period 42``   Same as above, for any other species available.
+``--<species>_energy.filter name`` Use filtered particles. All available filters will be shown with ``picongpu --help``
+================================== ========================================================================================================
 
 Output
 ^^^^^^
 
-The plugin creates files prefixed with the species' name, e.g. `e_energy.dat` for the electron energies and `p_energy.dat` for proton energies.
+The plugin creates files prefixed with the species' name and the filter name as postfix, e.g. `e_energy_<filter name>.dat` for the electron energies and `p_energy_<filter name>.dat` for proton energies.
 The file contains a header describing the columns.
 
 .. code::
@@ -46,10 +47,10 @@ Python snippet:
    simDir = "path/to/simOutput/"
 
    # Ekin in Joules (see EnergyParticles)
-   e_sum_ene = np.loadtxt(simDir + "e_energy.dat")[:, 0:2]
-   p_sum_ene = np.loadtxt(simDir + "p_energy.dat")[:, 0:2]
-   C_sum_ene = np.loadtxt(simDir + "C_energy.dat")[:, 0:2]
-   N_sum_ene = np.loadtxt(simDir + "N_energy.dat")[:, 0:2]
+   e_sum_ene = np.loadtxt(simDir + "e_energy_All.dat")[:, 0:2]
+   p_sum_ene = np.loadtxt(simDir + "p_energy_All.dat")[:, 0:2]
+   C_sum_ene = np.loadtxt(simDir + "C_energy_All.dat")[:, 0:2]
+   N_sum_ene = np.loadtxt(simDir + "N_energy_All.dat")[:, 0:2]
    # Etotal in Joules
    fields_sum_ene = np.loadtxt(simDir + "fields_energy.dat")[:, 0:2]
 

--- a/docs/source/usage/plugins/energyParticles.rst
+++ b/docs/source/usage/plugins/energyParticles.rst
@@ -10,20 +10,20 @@ This plugin computes the **kinetic and total energy summed over all particles** 
 
 Only the time steps at which the total kinetic energy of all particles should be specified needs to be set via command line argument.
 
-================================== ========================================================================================================
-PIConGPU command line option       Description
-================================== ========================================================================================================
-``--e_energy.period 100``          Sets the time step period at which the energy of all **electrons** in the simulation should be simulated.
-                                   If set to e.g. ``100``, the energy is computed for time steps *0, 100, 200, ...*.
-                                   The default value is ``0``, meaning that the plugin does not compute the particle energy.
-``--<species>_energy.period 42``   Same as above, for any other species available.
-``--<species>_energy.filter name`` Use filtered particles. All available filters will be shown with ``picongpu --help``
-================================== ========================================================================================================
+================================ ========================================================================================================
+PIConGPU command line option     Description
+================================ ========================================================================================================
+``--e_energy.period 100``        Sets the time step period at which the energy of all **electrons** in the simulation should be simulated.
+                                 If set to e.g. ``100``, the energy is computed for time steps *0, 100, 200, ...*.
+                                 The default value is ``0``, meaning that the plugin does not compute the particle energy.
+``--<species>_energy.period 42`` Same as above, for any other species available.
+``--<species>_energy.filter``    Use filtered particles. All available filters will be shown with ``picongpu --help``
+================================ ========================================================================================================
 
 Output
 ^^^^^^
 
-The plugin creates files prefixed with the species' name and the filter name as postfix, e.g. `e_energy_<filter name>.dat` for the electron energies and `p_energy_<filter name>.dat` for proton energies.
+The plugin creates files prefixed with the species' name and the filter name as postfix, e.g. `e_energy_<filterName>.dat` for the electron energies and `p_energy_<filterName>.dat` for proton energies.
 The file contains a header describing the columns.
 
 .. code::
@@ -47,10 +47,10 @@ Python snippet:
    simDir = "path/to/simOutput/"
 
    # Ekin in Joules (see EnergyParticles)
-   e_sum_ene = np.loadtxt(simDir + "e_energy_All.dat")[:, 0:2]
-   p_sum_ene = np.loadtxt(simDir + "p_energy_All.dat")[:, 0:2]
-   C_sum_ene = np.loadtxt(simDir + "C_energy_All.dat")[:, 0:2]
-   N_sum_ene = np.loadtxt(simDir + "N_energy_All.dat")[:, 0:2]
+   e_sum_ene = np.loadtxt(simDir + "e_energy_all.dat")[:, 0:2]
+   p_sum_ene = np.loadtxt(simDir + "p_energy_all.dat")[:, 0:2]
+   C_sum_ene = np.loadtxt(simDir + "C_energy_all.dat")[:, 0:2]
+   N_sum_ene = np.loadtxt(simDir + "N_energy_all.dat")[:, 0:2]
    # Etotal in Joules
    fields_sum_ene = np.loadtxt(simDir + "fields_energy.dat")[:, 0:2]
 

--- a/include/picongpu/plugins/misc/AppendName.hpp
+++ b/include/picongpu/plugins/misc/AppendName.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace misc
+{
+    /** append the name of an filter to a vector
+     *
+     * @tparam T_Filter filter class (required interface: `getName( )`)
+     */
+    template< typename T_Filter >
+    struct AppendName
+    {
+        void operator( )( std::vector< std::string > & vector ) const
+        {
+            vector.emplace_back( T_Filter::getName() );
+        }
+    };
+} // namespace misc
+} // namespace plugins
+} // namespace picongpu

--- a/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
+++ b/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
@@ -1,0 +1,58 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace misc
+{
+    /** execute an unary functor if the name is equal
+     *
+     * @tparam T_Filter filter class (required interface: `getName( )` and default constructor)
+     */
+    template< typename T_Filter >
+    struct ExecuteIfNameIsEqual
+    {
+        /** evaluate if functor must executed
+         *
+         * @param filterName name of the filter which should started
+         * @param unaryFunctor any unary functor
+         */
+        template<
+            typename T_Kernel,
+            typename ... T_Args
+        >
+        void operator( )(
+            std::string filterName,
+            T_Kernel const unaryFunctor
+        ) const
+        {
+            if( filterName == T_Filter::getName( ) )
+                unaryFunctor( T_Filter{ } );
+        }
+    };
+} // namespace misc
+} // namespace plugins
+} // namespace picongpu

--- a/include/picongpu/plugins/misc/concatenateToString.hpp
+++ b/include/picongpu/plugins/misc/concatenateToString.hpp
@@ -1,0 +1,60 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <numeric>
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace misc
+{
+    /** concatenate all values of an string container
+     *
+     * @tparam T_Container type of the container
+     *
+     * @param vector source container (required interface: `begin(), end()`)
+     * @param separator separator between two elements
+     */
+    template< typename T_Container >
+    std::string concatenateToString(
+        T_Container & container,
+        std::string const & separator = ","
+    )
+    {
+        return std::accumulate(
+            container.begin(),
+            container.end(),
+            std::string(),
+            [ & ](
+                std::string & result,
+                std::string & inString
+            )
+            {
+                return result.empty() ? inString : result + separator + inString;
+            }
+        );
+    }
+} // namespace misc
+} // namespace plugins
+} // namespace picongpu

--- a/include/picongpu/plugins/misc/misc.hpp
+++ b/include/picongpu/plugins/misc/misc.hpp
@@ -1,0 +1,24 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp"
+#include "picongpu/plugins/misc/AppendName.hpp"
+#include "picongpu/plugins/misc/concatenateToString.hpp"

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
@@ -63,10 +63,10 @@ TBG_N_PSypy="--N_phaseSpace.period 250 --N_phaseSpace.space y --N_phaseSpace.mom
 
 # useful for heating tests
 TBG_sumEnergy="--fields_energy.period 100 \
-               --e_energy.period 100 --e_energy.filter All \
-               --H_energy.period 100 --H_energy.filter All \
-               --C_energy.period 100 --C_energy.filter All \
-               --N_energy.period 100 --N_energy.filter All"
+               --e_energy.period 100 --e_energy.filter all \
+               --H_energy.period 100 --H_energy.filter all \
+               --C_energy.period 100 --C_energy.filter all \
+               --N_energy.period 100 --N_energy.filter all"
 TBG_chargeConservation="--chargeConservation.period 100"
 
 # regular output

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
@@ -62,7 +62,11 @@ TBG_C_PSypy="--C_phaseSpace.period 250 --C_phaseSpace.space y --C_phaseSpace.mom
 TBG_N_PSypy="--N_phaseSpace.period 250 --N_phaseSpace.space y --N_phaseSpace.momentum py --N_phaseSpace.min -0.02 --N_phaseSpace.max 0.02"
 
 # useful for heating tests
-TBG_sumEnergy="--fields_energy.period 100 --e_energy.period 100 --H_energy.period 100 --C_energy.period 100 --N_energy.period 100"
+TBG_sumEnergy="--fields_energy.period 100 \
+               --e_energy.period 100 --e_energy.filter All \
+               --H_energy.period 100 --H_energy.filter All \
+               --C_energy.period 100 --C_energy.filter All \
+               --N_energy.period 100 --N_energy.filter All"
 TBG_chargeConservation="--chargeConservation.period 100"
 
 # regular output

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0004gpus.cfg
@@ -61,8 +61,8 @@ TBG_plugins="!TBG_ipngYX                   \
               --i_macroParticlesCount.period 100         \
               --e_macroParticlesCount.period 100         \
               --fields_energy.period 10     \
-              --e_energy.period 10          \
-              --i_energy.period 10"
+              --e_energy.period 10 --e_energy.filter All \
+              --i_energy.period 10 --i_energy.filter All"
 
 
 #################################

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0004gpus.cfg
@@ -61,8 +61,8 @@ TBG_plugins="!TBG_ipngYX                   \
               --i_macroParticlesCount.period 100         \
               --e_macroParticlesCount.period 100         \
               --fields_energy.period 10     \
-              --e_energy.period 10 --e_energy.filter All \
-              --i_energy.period 10 --i_energy.filter All"
+              --e_energy.period 10 --e_energy.filter all \
+              --i_energy.period 10 --i_energy.filter all"
 
 
 #################################

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
@@ -67,8 +67,8 @@ TBG_plugins="!TBG_ipngYZ                   \
               --i_macroParticlesCount.period 100         \
               --e_macroParticlesCount.period 100         \
               --fields_energy.period 10     \
-              --e_energy.period 10          \
-              --i_energy.period 10"
+              --e_energy.period 10 --e_energy.filter All \
+              --i_energy.period 10 --i_energy.filter All"
 
 
 #################################

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
@@ -67,8 +67,8 @@ TBG_plugins="!TBG_ipngYZ                   \
               --i_macroParticlesCount.period 100         \
               --e_macroParticlesCount.period 100         \
               --fields_energy.period 10     \
-              --e_energy.period 10 --e_energy.filter All \
-              --i_energy.period 10 --i_energy.filter All"
+              --e_energy.period 10 --e_energy.filter all \
+              --i_energy.period 10 --i_energy.filter all"
 
 
 #################################

--- a/share/picongpu/examples/WeibelTransverse/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/WeibelTransverse/etc/picongpu/0004gpus.cfg
@@ -64,8 +64,8 @@ TBG_plugins="!TBG_ipngYX                   \
               --i_macroParticlesCount.period 100         \
               --e_macroParticlesCount.period 100         \
               --fields_energy.period 10     \
-              --e_energy.period 10 --e_energy.filter All \
-              --i_energy.period 10 --i_energy.filter All"
+              --e_energy.period 10 --e_energy.filter all \
+              --i_energy.period 10 --i_energy.filter all"
 
 
 #################################

--- a/share/picongpu/examples/WeibelTransverse/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/WeibelTransverse/etc/picongpu/0004gpus.cfg
@@ -64,8 +64,8 @@ TBG_plugins="!TBG_ipngYX                   \
               --i_macroParticlesCount.period 100         \
               --e_macroParticlesCount.period 100         \
               --fields_energy.period 10     \
-              --e_energy.period 10          \
-              --i_energy.period 10"
+              --e_energy.period 10 --e_energy.filter All \
+              --i_energy.period 10 --i_energy.filter All"
 
 
 #################################

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -119,7 +119,7 @@ for sim in directories:
     mydir = sim+simDir
     # get relevant files with energy
     files = [f for f in os.listdir(mydir)
-             if os.path.isfile(os.path.join(mydir, f)) and re.search('^.*_energy.dat', f)]
+             if os.path.isfile(os.path.join(mydir, f)) and re.search('^.*_energy_All.dat', f)]
     # check if file list is empty
     if len(files) == 0:
         sys.exit("There were no energy files in \"{}\".".format(mydir))

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -119,7 +119,7 @@ for sim in directories:
     mydir = sim+simDir
     # get relevant files with energy
     files = [f for f in os.listdir(mydir)
-             if os.path.isfile(os.path.join(mydir, f)) and re.search('^.*_energy_All.dat', f)]
+             if os.path.isfile(os.path.join(mydir, f)) and re.search('^.*_energy_all.dat', f)]
     # check if file list is empty
     if len(files) == 0:
         sys.exit("There were no energy files in \"{}\".".format(mydir))


### PR DESCRIPTION
refactor `EnergyParticles` to allow
  - usage as multiplugin
  - filter particles
- add command line parameter `.filter`
- tool `plotNumericalHeating`: update uased filename of particle energies
- plugins: add miscellaneous helpers 
  - `misc::AppendName<>` adds the name of a filter to a vector of strings
  - `ExecuteIfNameIsEqual` execute a unary functor
  - `concatenateToString()` concatenate all values of an string container

# Review

Please only review the three latest commits.

# Rebase after
- [x] #2381
- [x] #2382 
- [x] #2385 
- [x] rebase against #2389