### PR TITLE
Plugins: Fix SpeciesEligibleForSolver

### DIFF
--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -569,11 +569,12 @@ namespace particles
 namespace traits
 {
     template<
-        typename T_Species
+        typename T_Species,
+        typename T_UnspecifiedSpecies
     >
     struct SpeciesEligibleForSolver<
         T_Species,
-        BinEnergyParticles< T_Species >
+        BinEnergyParticles< T_UnspecifiedSpecies >
     >
     {
         using FrameType = typename T_Species::FrameType;

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -616,11 +616,12 @@ namespace particles
 namespace traits
 {
     template<
-        typename T_Species
+        typename T_Species,
+        typename T_UnspecifiedSpecies
     >
     struct SpeciesEligibleForSolver<
         T_Species,
-        EnergyParticles< T_Species >
+        EnergyParticles< T_UnspecifiedSpecies >
     >
     {
         using FrameType = typename T_Species::FrameType;

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -112,13 +112,14 @@ namespace traits
 {
     template<
         typename T_Species,
-        typename T_AssignmentFunction
+        typename T_AssignmentFunction,
+        typename T_UnspecifiedSpecies
     >
     struct SpeciesEligibleForSolver<
         T_Species,
         PhaseSpace<
             T_AssignmentFunction,
-            T_Species
+            T_UnspecifiedSpecies
         >
     >
     {

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceMulti.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceMulti.hpp
@@ -85,19 +85,20 @@ namespace traits
 {
     template<
         typename T_Species,
-        typename T_AssignmentFunction
+        typename T_AssignmentFunction,
+        typename T_UnspecifiedSpecies
     >
     struct SpeciesEligibleForSolver<
         T_Species,
         PhaseSpaceMulti<
             T_AssignmentFunction,
-            T_Species
+            T_UnspecifiedSpecies
         >
     > : public SpeciesEligibleForSolver<
         T_Species,
         PhaseSpace<
             T_AssignmentFunction,
-            T_Species
+            T_UnspecifiedSpecies
         >
     >
     {

--- a/include/picongpu/plugins/PositionsParticles.hpp
+++ b/include/picongpu/plugins/PositionsParticles.hpp
@@ -293,11 +293,12 @@ namespace particles
 namespace traits
 {
     template<
-        typename T_Species
+        typename T_Species,
+        typename T_UnspecifiedSpecies
     >
     struct SpeciesEligibleForSolver<
         T_Species,
-        PositionsParticles< T_Species >
+        PositionsParticles< T_UnspecifiedSpecies >
     >
     {
         using FrameType = typename T_Species::FrameType;

--- a/include/picongpu/plugins/multi/Master.hpp
+++ b/include/picongpu/plugins/multi/Master.hpp
@@ -23,6 +23,7 @@
 #include "picongpu/plugins/ISimulationPlugin.hpp"
 #include "picongpu/plugins/multi/ISlave.hpp"
 #include "picongpu/plugins/multi/IHelp.hpp"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 
 #include <vector>
 #include <list>
@@ -146,4 +147,25 @@ namespace multi
 
 } // namespace multi
 } // namespace plugins
+
+namespace particles
+{
+namespace traits
+{
+    template<
+        typename T_Species,
+        typename T_Slave
+    >
+    struct SpeciesEligibleForSolver<
+        T_Species,
+        plugins::multi::Master< T_Slave >
+    >
+    {
+        using type = typename SpeciesEligibleForSolver<
+            T_Species,
+            T_Slave
+        >::type;
+    };
+} // namespace traits
+} // namespace particles
 } // namespace picongpu

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -565,11 +565,12 @@ namespace particles
 namespace traits
 {
     template<
-        typename T_Species
+        typename T_Species,
+        typename T_UnspecifiedSpecies
     >
     struct SpeciesEligibleForSolver<
         T_Species,
-        ParticleCalorimeter< T_Species >
+        ParticleCalorimeter< T_UnspecifiedSpecies >
     >
     {
         using FrameType = typename T_Species::FrameType;


### PR DESCRIPTION
Fix traits for `SpeciesEligibleForSolver` for species plugins (introduced in #2367). This worked previously when applied in the right way but now it is properly implemented without accidentally specializing non-eligible combinations of species & plugins.

Also adds the new trait to the new Master class for Multi-Plugins.