### PR TITLE
refactor PMacc functor interface

### DIFF
--- a/include/picongpu/particles/filter/All.hpp
+++ b/include/picongpu/particles/filter/All.hpp
@@ -49,7 +49,7 @@ namespace acc
             typename T_Particle,
             typename T_Acc
         >
-        DINLINE bool operator()(
+        HDINLINE bool operator()(
             T_Acc const &,
             T_Particle const & particle
         )
@@ -79,7 +79,7 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE acc::All
+        HDINLINE acc::All
         operator( )(
             T_Acc const & acc,
             DataSpace< simDim > const &,

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -38,7 +38,7 @@ namespace acc
     {
         using Params = T_Params;
 
-        DINLINE RelativeGlobalDomainPosition(
+        HDINLINE RelativeGlobalDomainPosition(
             DataSpace< simDim > const & localDomainOffset,
             DataSpace< simDim > const & globalDomainSize,
             DataSpace< simDim > const & localSuperCellOffset
@@ -53,7 +53,7 @@ namespace acc
             typename T_Acc,
             typename T_Particle
         >
-        DINLINE bool operator()(
+        HDINLINE bool operator()(
             T_Acc const &,
             T_Particle const & particle
         )
@@ -81,7 +81,7 @@ namespace acc
          *                              to the origin of the global domain
          */
         template< typename T_Particle >
-        DINLINE bool isParticleInsideRange( T_Particle const & particle, DataSpace< simDim > const & globalSuperCellOffset ) const
+        HDINLINE bool isParticleInsideRange( T_Particle const & particle, DataSpace< simDim > const & globalSuperCellOffset ) const
         {
             using SuperCellSize = typename T_Particle::SuperCellSize;
 
@@ -136,7 +136,7 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE acc::RelativeGlobalDomainPosition< Params >
+        HDINLINE acc::RelativeGlobalDomainPosition< Params >
         operator( )(
             T_Acc const & acc,
             DataSpace< simDim > const & localSuperCellOffset,

--- a/include/picongpu/particles/manipulators/binary/Assign.def
+++ b/include/picongpu/particles/manipulators/binary/Assign.def
@@ -52,7 +52,7 @@ namespace acc
             typename T_SrcParticle,
             typename ... T_Args
         >
-        DINLINE void
+        HDINLINE void
         operator( )(
             T_DestParticle & particleDest,
             T_SrcParticle & particleSrc,

--- a/include/picongpu/particles/manipulators/binary/DensityWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/DensityWeighting.def
@@ -67,7 +67,7 @@ namespace acc
             typename T_SrcParticle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_DesParticle & particleDes,
             T_SrcParticle const &,
             T_Args && ...

--- a/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
@@ -63,7 +63,7 @@ namespace acc
             typename T_SrcParticle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_DesParticle & particleDest,
             T_SrcParticle const &,
             T_Args && ...

--- a/include/picongpu/particles/manipulators/generic/Free.hpp
+++ b/include/picongpu/particles/manipulators/generic/Free.hpp
@@ -46,7 +46,7 @@ namespace acc
         using Functor = T_Functor;
 
         //! store user functor instance
-        DINLINE Free( Functor const & functor ) :
+        HDINLINE Free( Functor const & functor ) :
             Functor( functor )
         {
         }
@@ -60,7 +60,7 @@ namespace acc
         template<
             typename T_Acc,
             typename ... T_Args >
-        DINLINE
+        HDINLINE
         void operator( )(
             T_Acc const &,
             T_Args && ... args
@@ -139,7 +139,7 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE acc::Free< Functor >
+        HDINLINE acc::Free< Functor >
         operator()(
             T_Acc const &,
             DataSpace< simDim > const &,

--- a/include/picongpu/particles/manipulators/generic/FreeRng.def
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.def
@@ -49,7 +49,7 @@ namespace generic
      *   struct RandomXFunctor
      *   {
      *       template< typename T_Rng, typename T_Particle >
-     *       DINLINE void operator()( T_Rng& rng, T_Particle& particle )
+     *       HDINLINE void operator()( T_Rng& rng, T_Particle& particle )
      *       {
      *           particle[ position_ ].x() = rng();
      *       }

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -48,7 +48,7 @@ namespace acc
         using Functor = T_Functor;
         using RngType = T_RngType;
 
-        DINLINE FreeRng(
+        HDINLINE FreeRng(
             Functor const & functor,
             RngType const & rng
         ) :
@@ -73,7 +73,7 @@ namespace acc
             typename ... T_Args,
             typename T_Acc
         >
-        DINLINE
+        HDINLINE
         void operator()(
             T_Acc const &,
             T_Particle& particle,
@@ -182,7 +182,7 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE
+        HDINLINE
         acc::FreeRng<
             Functor,
             RngType< T_Acc >

--- a/include/picongpu/particles/manipulators/generic/None.def
+++ b/include/picongpu/particles/manipulators/generic/None.def
@@ -35,7 +35,7 @@ namespace acc
     struct None
     {
         template< typename ... T_Args >
-        DINLINE void
+        HDINLINE void
         operator( )( T_Args && ... )
         {
         }

--- a/include/picongpu/particles/manipulators/generic/detail/Rng.hpp
+++ b/include/picongpu/particles/manipulators/generic/detail/Rng.hpp
@@ -87,7 +87,7 @@ namespace detail
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE
+        HDINLINE
         RngType< T_Acc > operator()(
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,

--- a/include/picongpu/particles/manipulators/unary/CopyAttribute.def
+++ b/include/picongpu/particles/manipulators/unary/CopyAttribute.def
@@ -56,7 +56,7 @@ namespace acc
             typename T_Particle,
             typename ... T_Args
         >
-        DINLINE void operator( )(
+        HDINLINE void operator( )(
             T_Particle & particle,
             T_Args && ...
         )

--- a/include/picongpu/particles/manipulators/unary/Drift.hpp
+++ b/include/picongpu/particles/manipulators/unary/Drift.hpp
@@ -58,7 +58,7 @@ namespace acc
             typename T_Particle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_Particle & particle,
             T_Args && ...
         )

--- a/include/picongpu/particles/manipulators/unary/RandomPosition.def
+++ b/include/picongpu/particles/manipulators/unary/RandomPosition.def
@@ -60,7 +60,7 @@ namespace acc
             typename T_Particle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_Rng & rng,
             T_Particle & particle,
             T_Args && ...

--- a/include/picongpu/particles/manipulators/unary/Temperature.hpp
+++ b/include/picongpu/particles/manipulators/unary/Temperature.hpp
@@ -61,7 +61,7 @@ namespace acc
             typename T_Particle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_Rng & rng,
             T_Particle & particle,
             T_Args && ...

--- a/include/picongpu/particles/startPosition/OnePositionImpl.hpp
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.hpp
@@ -42,7 +42,7 @@ namespace detail
     struct SetWeighting
     {
         template< typename T_Particle >
-        DINLINE void
+        HDINLINE void
         operator()
         (
             T_Particle & particle,
@@ -57,7 +57,7 @@ namespace detail
     struct SetWeighting< false >
     {
         template< typename T_Particle >
-        DINLINE void
+        HDINLINE void
         operator()
         (
             T_Particle &,
@@ -84,7 +84,7 @@ namespace detail
             typename T_Particle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_Particle & particle,
             T_Args && ...
         )
@@ -104,7 +104,7 @@ namespace detail
         }
 
         template< typename T_Particle >
-        DINLINE uint32_t
+        HDINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
             bool const hasWeighting = pmacc::traits::HasIdentifier<

--- a/include/picongpu/particles/startPosition/QuietImpl.hpp
+++ b/include/picongpu/particles/startPosition/QuietImpl.hpp
@@ -52,7 +52,7 @@ namespace acc
             typename T_Particle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_Particle & particle,
             T_Args && ...
         )
@@ -92,7 +92,7 @@ namespace acc
         }
 
         template< typename T_Particle >
-        DINLINE uint32_t
+        HDINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
             auto numParInCell = T_ParamClass::numParticlesPerDimension::toRT();

--- a/include/picongpu/particles/startPosition/RandomImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomImpl.hpp
@@ -56,7 +56,7 @@ namespace acc
             typename T_Particle,
             typename ... T_Args
         >
-        DINLINE void operator()(
+        HDINLINE void operator()(
             T_Rng & rng,
             T_Particle & particle,
             T_Args && ...
@@ -72,7 +72,7 @@ namespace acc
         }
 
         template< typename T_Particle >
-        DINLINE uint32_t
+        HDINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
             return startPosition::detail::WeightMacroParticles{}(

--- a/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
+++ b/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
@@ -52,7 +52,7 @@ namespace detail
          * @return number of macro particles per cell with respect to
          *         MIN_WEIGHTING, range: [0;macroParticlesPerCell]
          */
-        DINLINE uint32_t
+        HDINLINE uint32_t
         operator()(
             float_X const realParticlesPerCell,
             uint32_t numMacroParticles,

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -47,7 +47,7 @@ namespace acc
         using Functor = T_Functor;
 
         //! store user functor instance
-        DINLINE Free( Functor const & functor ) :
+        HDINLINE Free( Functor const & functor ) :
             Functor( functor )
         { }
 
@@ -63,7 +63,7 @@ namespace acc
             typename ... T_Args,
             typename T_Acc
         >
-        DINLINE
+        HDINLINE
         void operator( )(
             T_Acc const &,
             T_Args && ... args
@@ -73,7 +73,7 @@ namespace acc
         }
 
         template< typename T_Particle >
-        DINLINE uint32_t
+        HDINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
             return Functor::template numberOfMacroParticles< T_Particle >( realParticlesPerCell );
@@ -149,7 +149,7 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE acc::Free< Functor >
+        HDINLINE acc::Free< Functor >
         operator()(
             T_Acc const & acc,
             DataSpace< simDim > const &,

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -48,7 +48,7 @@ namespace acc
         using Functor = T_Functor;
         using RngType = T_RngType;
 
-        DINLINE FreeRng(
+        HDINLINE FreeRng(
             Functor const & functor,
             RngType const & rng
         ) :
@@ -73,7 +73,7 @@ namespace acc
             typename ... T_Args,
             typename T_Acc
         >
-        DINLINE
+        HDINLINE
         void operator()(
             T_Acc const &,
             T_Particle& particle,
@@ -90,7 +90,7 @@ namespace acc
         }
 
         template< typename T_Particle >
-        DINLINE uint32_t
+        HDINLINE uint32_t
         numberOfMacroParticles( float_X const realParticlesPerCell )
         {
             return Functor::template numberOfMacroParticles< T_Particle >( realParticlesPerCell );
@@ -189,7 +189,7 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        DINLINE auto
+        HDINLINE auto
         operator()(
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,

--- a/include/picongpu/simulation_defines/param/radiation.param
+++ b/include/picongpu/simulation_defines/param/radiation.param
@@ -151,7 +151,7 @@ namespace picongpu
             static constexpr float_X radiationGamma = 5.0;
 
             template< typename T_Particle >
-            DINLINE void operator()( T_Particle& particle )
+            HDINLINE void operator()( T_Particle& particle )
             {
                 if(
                     picongpu::gamma<float_X>(

--- a/include/pmacc/filter/operators/And.hpp
+++ b/include/pmacc/filter/operators/And.hpp
@@ -38,7 +38,7 @@ namespace operators
          * @return the input argument
          */
         template< typename T_Arg >
-        DINLINE bool
+        HDINLINE bool
         operator()( T_Arg const a ) const
         {
             return a;
@@ -53,7 +53,7 @@ namespace operators
             typename T_Arg1,
             typename ... T_Args
         >
-        DINLINE bool
+        HDINLINE bool
         operator()( T_Arg1 const a, T_Args const ... args ) const
         {
             return a && And{}( args ... );

--- a/include/pmacc/filter/operators/Or.hpp
+++ b/include/pmacc/filter/operators/Or.hpp
@@ -38,7 +38,7 @@ namespace operators
          * @return the input argument
          */
         template< typename T_Arg >
-        DINLINE bool
+        HDINLINE bool
         operator()( T_Arg const a ) const
         {
             return a;
@@ -53,7 +53,7 @@ namespace operators
             typename T_Arg1,
             typename ... T_Args
         >
-        DINLINE bool
+        HDINLINE bool
         operator()( T_Arg1 const a, T_Args const ... args ) const
         {
             return a || Or{}( args ... );

--- a/include/pmacc/functor/Filtered.hpp
+++ b/include/pmacc/functor/Filtered.hpp
@@ -55,7 +55,7 @@ namespace acc
         using Filter = T_Filter;
         using Functor = T_Functor;
 
-        DINLINE Filtered(
+        HDINLINE Filtered(
             Filter const & filter,
             Functor const & functor
         ) :
@@ -77,7 +77,7 @@ namespace acc
             typename T_Acc,
             typename ... T_Args
         >
-        DINLINE auto operator( )(
+        HDINLINE auto operator( )(
             T_Acc const & acc,
             T_Args && ... args
         )
@@ -202,7 +202,7 @@ namespace acc
             uint32_t T_numWorkers,
             typename T_Acc
         >
-        DINLINE auto
+        HDINLINE auto
         operator( )(
             T_Acc const & acc,
             T_OffsetType const & domainOffset,

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -77,7 +77,7 @@ namespace detail
          *
          * @param functor user functor instance
          */
-        DINLINE Interface( UserFunctor const & functor ) :
+        HDINLINE Interface( UserFunctor const & functor ) :
             UserFunctor( functor )
         {
         }
@@ -96,7 +96,7 @@ namespace detail
             typename T_Acc,
             typename ... T_Args
         >
-        DINLINE auto operator( )(
+        HDINLINE auto operator( )(
             T_Acc const & acc,
             T_Args && ... args )
         -> decltype(
@@ -210,7 +210,7 @@ namespace detail
             uint32_t T_numWorkers,
             typename T_Acc
         >
-        DINLINE auto
+        HDINLINE auto
         operator( )(
             T_Acc const & acc,
             T_OffsetType const & domainOffset,

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/radiation.param
@@ -122,7 +122,7 @@ namespace radiation
         static constexpr float_X radiationGamma = 3.0;
 
         template< typename T_Particle >
-        DINLINE void operator()( T_Particle& particle )
+        HDINLINE void operator()( T_Particle& particle )
         {
             if(
                 picongpu::gamma<float_X>(

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/radiation.param
@@ -122,7 +122,7 @@ namespace radiation
         static constexpr float_X radiationGamma = 5.0;
 
         template< typename T_Particle >
-        DINLINE void operator()( T_Particle& particle )
+        HDINLINE void operator()( T_Particle& particle )
         {
             if(
                 picongpu::gamma<float_X>(


### PR DESCRIPTION
Refactor functor operator to `HDINLINE` to allow that functors and filter can be used on the host too.

This PR is required for the upcoming particle filters for PIConGPU, related to #1288.