### PR TITLE
add missing includes

### DIFF
--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -18,11 +18,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.def"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+
+#include <pmacc/traits/HasIdentifiers.hpp>
+
 
 namespace picongpu
 {


### PR DESCRIPTION
The used types `SpeciesEligibleForSolver` and `HasIdentifiers` are not included.