### PR TITLE
add support for particle filters

### DIFF
--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -24,6 +24,7 @@
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/particles/filter/filter.hpp"
 
 #include <pmacc/mpi/reduceMethods/Reduce.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
@@ -175,11 +176,13 @@ private:
         DataConnector &dc = Environment<>::get().DataConnector();
         auto particles = dc.get< ParticlesType >( ParticlesType::FrameType::getName(), true );
 
+        particles::filter::All parFilter{};
         /*count local particles*/
         size = pmacc::CountParticles::countOnDevice<AREA>(*particles,
                                                           *cellDescription,
                                                           DataSpace<simDim>(),
-                                                          localSize);
+                                                          localSize,
+                                                          parFilter);
         dc.releaseData( ParticlesType::FrameType::getName() );
 
         uint64_cu reducedValueMax;

--- a/include/picongpu/plugins/ResourceLog.hpp
+++ b/include/picongpu/plugins/ResourceLog.hpp
@@ -29,6 +29,7 @@
 #include "picongpu/plugins/ILightweightPlugin.hpp"
 #include "ILightweightPlugin.hpp"
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/filter/filter.hpp"
 
 // Boost
 #include <boost/property_tree/ptree.hpp>
@@ -115,7 +116,8 @@ namespace picongpu
 
             if(contains(propertyMap,"particleCount"))
             {
-                std::vector<size_t> particleCounts = resourceMonitor.getParticleCounts<VectorAllSpecies>(*cellDescription);
+                particles::filter::All parFilter{};
+                std::vector<size_t> particleCounts = resourceMonitor.getParticleCounts<VectorAllSpecies>(*cellDescription, parFilter );
                 pt.put("resourceLog.particleCount", std::accumulate(particleCounts.begin(), particleCounts.end(), 0));
             }
 

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -54,6 +54,7 @@
 #include "picongpu/plugins/adios/restart/LoadSpecies.hpp"
 #include "picongpu/plugins/adios/restart/RestartFieldLoader.hpp"
 #include "picongpu/plugins/adios/NDScalars.hpp"
+#include "picongpu/plugins/misc/SpeciesFilter.hpp"
 
 #include <adios.h>
 #include <adios_read.h>
@@ -1042,12 +1043,26 @@ private:
         log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) counting particles.");
         if (threadParams->isCheckpoint)
         {
-            ForEach<FileCheckpointParticles, ADIOSCountParticles<bmpl::_1> > adiosCountParticles;
+            ForEach<
+                FileCheckpointParticles,
+                ADIOSCountParticles<
+                    plugins::misc::SpeciesFilter<
+                        bmpl::_1
+                    >
+                >
+            > adiosCountParticles;
             adiosCountParticles(threadParams);
         }
         else
         {
-            ForEach<FileOutputParticles, ADIOSCountParticles<bmpl::_1> > adiosCountParticles;
+            ForEach<
+                FileOutputParticles,
+                ADIOSCountParticles<
+                    plugins::misc::SpeciesFilter<
+                        bmpl::_1
+                    >
+                >
+            > adiosCountParticles;
             adiosCountParticles(threadParams);
         }
         log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) counting particles.");
@@ -1104,12 +1119,26 @@ private:
         log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) writing particle species.");
         if (threadParams->isCheckpoint)
         {
-            ForEach<FileCheckpointParticles, WriteSpecies<bmpl::_1> > writeSpecies;
+            ForEach<
+                FileCheckpointParticles,
+                WriteSpecies<
+                    plugins::misc::SpeciesFilter<
+                        bmpl::_1
+                    >
+                >
+            > writeSpecies;
             writeSpecies(threadParams, particleOffset);
         }
         else
         {
-            ForEach<FileOutputParticles, WriteSpecies<bmpl::_1> > writeSpecies;
+            ForEach<
+                FileOutputParticles,
+                WriteSpecies<
+                    plugins::misc::SpeciesFilter<
+                        bmpl::_1
+                    >
+                >
+            > writeSpecies;
             writeSpecies(threadParams, particleOffset);
         }
         log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) writing particle species.");

--- a/include/picongpu/plugins/adios/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/adios/restart/LoadSpecies.hpp
@@ -91,17 +91,17 @@ public:
      */
     HINLINE void operator()(ThreadParams* params, const uint32_t restartChunkSize)
     {
-
-        log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) load species: %1%") % AdiosFrameType::getName();
+        std::string const speciesName = FrameType::getName() + "_all";
+        log<picLog::INPUT_OUTPUT > ("ADIOS: (begin) load species: %1%") % speciesName;
         DataConnector &dc = Environment<>::get().DataConnector();
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
 
         std::string particlePath = params->adiosBasePath + std::string(ADIOS_PATH_PARTICLES) +
-                                   FrameType::getName() + std::string("/");
+                                   speciesName + std::string("/");
         const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
         /* load particle without copying particle data to host */
-        auto speciesTmp = dc.get< ThisSpecies >( ThisSpecies::FrameType::getName(), true );
+        auto speciesTmp = dc.get< ThisSpecies >( FrameType::getName(), true );
 
         /* count total number of particles on the device */
         uint64_t totalNumParticles = 0;
@@ -152,12 +152,12 @@ public:
             (long long unsigned) totalNumParticles % (long long unsigned) particleOffset;
 
         AdiosFrameType hostFrame;
-        log<picLog::INPUT_OUTPUT > ("ADIOS: malloc mapped memory: %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS: malloc mapped memory: %1%") % speciesName;
         /*malloc mapped memory*/
         ForEach<typename AdiosFrameType::ValueTypeSeq, MallocMemory<bmpl::_1> > mallocMem;
         mallocMem(forward(hostFrame), totalNumParticles);
 
-        log<picLog::INPUT_OUTPUT > ("ADIOS: get mapped memory device pointer: %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS: get mapped memory device pointer: %1%") % speciesName;
         /*load device pointer of mapped memory*/
         AdiosFrameType deviceFrame;
         ForEach<typename AdiosFrameType::ValueTypeSeq, GetDevicePtr<bmpl::_1> > getDevicePtr;
@@ -183,7 +183,7 @@ public:
             ForEach<typename AdiosFrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;
             freeMem(forward(hostFrame));
         }
-        log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) load species: %1%") % AdiosFrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("ADIOS: ( end ) load species: %1%") % speciesName;
     }
 };
 

--- a/include/picongpu/plugins/hdf5/HDF5Writer.hpp
+++ b/include/picongpu/plugins/hdf5/HDF5Writer.hpp
@@ -69,7 +69,10 @@
 #include "picongpu/plugins/hdf5/restart/LoadSpecies.hpp"
 #include "picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp"
 #include "picongpu/plugins/hdf5/NDScalars.hpp"
+#include "picongpu/plugins/misc/SpeciesFilter.hpp"
+
 #include <pmacc/memory/boxes/DataBoxDim1Access.hpp>
+
 
 namespace picongpu
 {
@@ -407,12 +410,26 @@ private:
         log<picLog::INPUT_OUTPUT > ("HDF5: (begin) writing particle species.");
         if (threadParams->isCheckpoint)
         {
-            ForEach<FileCheckpointParticles, WriteSpecies<bmpl::_1> > writeSpecies;
+            ForEach<
+                FileCheckpointParticles,
+                WriteSpecies<
+                    plugins::misc::SpeciesFilter<
+                        bmpl::_1
+                    >
+                >
+            > writeSpecies;
             writeSpecies(threadParams, domainOffset);
         }
         else
         {
-            ForEach<FileOutputParticles, WriteSpecies<bmpl::_1> > writeSpecies;
+            ForEach<
+                FileOutputParticles,
+                WriteSpecies<
+                    plugins::misc::SpeciesFilter<
+                        bmpl::_1
+                    >
+                >
+            > writeSpecies;
             writeSpecies(threadParams, domainOffset);
         }
         log<picLog::INPUT_OUTPUT > ("HDF5: ( end ) writing particle species.");

--- a/include/picongpu/plugins/hdf5/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/hdf5/restart/LoadSpecies.hpp
@@ -95,19 +95,19 @@ public:
      */
     HINLINE void operator()(ThreadParams* params, const uint32_t restartChunkSize)
     {
-
-        log<picLog::INPUT_OUTPUT > ("HDF5: (begin) load species: %1%") % Hdf5FrameType::getName();
+        std::string const speciesName = FrameType::getName() + "_all";
+        log<picLog::INPUT_OUTPUT > ("HDF5: (begin) load species: %1%") % speciesName;
         DataConnector &dc = Environment<>::get().DataConnector();
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
 
         const std::string speciesSubGroup(
-            std::string("particles/") + FrameType::getName() + std::string("/")
+            std::string("particles/") + speciesName + std::string("/")
         );
         const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
         const pmacc::Selection<simDim>& globalDomain = Environment<simDim>::get().SubGrid().getGlobalDomain();
 
         // load particle without copying particle data to host
-        auto speciesTmp = dc.get< ThisSpecies >( ThisSpecies::FrameType::getName(), true );
+        auto speciesTmp = dc.get< ThisSpecies >( FrameType::getName(), true );
 
         // count total number of particles on the device
         uint64_cu totalNumParticles = 0;
@@ -172,12 +172,12 @@ public:
             (long long unsigned) totalNumParticles % (long long unsigned) particleOffset;
 
         Hdf5FrameType hostFrame;
-        log<picLog::INPUT_OUTPUT > ("HDF5:  malloc mapped memory: %1%") % Hdf5FrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("HDF5:  malloc mapped memory: %1%") % speciesName;
         /*malloc mapped memory*/
         ForEach<typename Hdf5FrameType::ValueTypeSeq, MallocMemory<bmpl::_1> > mallocMem;
         mallocMem(forward(hostFrame), totalNumParticles);
 
-        log<picLog::INPUT_OUTPUT > ("HDF5:  get mapped memory device pointer: %1%") % Hdf5FrameType::getName();
+        log<picLog::INPUT_OUTPUT > ("HDF5:  get mapped memory device pointer: %1%") % speciesName;
         /*load device pointer of mapped memory*/
         Hdf5FrameType deviceFrame;
         ForEach<typename Hdf5FrameType::ValueTypeSeq, GetDevicePtr<bmpl::_1> > getDevicePtr;
@@ -202,7 +202,7 @@ public:
             /*free host memory*/
             ForEach<typename Hdf5FrameType::ValueTypeSeq, FreeMemory<bmpl::_1> > freeMem;
             freeMem(forward(hostFrame));
-            log<picLog::INPUT_OUTPUT > ("HDF5: ( end ) load species: %1%") % Hdf5FrameType::getName();
+            log<picLog::INPUT_OUTPUT > ("HDF5: ( end ) load species: %1%") % speciesName;
         }
     }
 };

--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -73,7 +73,8 @@ namespace picongpu
             typename T_Space,
             typename T_Identifier,
             typename T_Mapping,
-            typename T_Acc
+            typename T_Acc,
+            typename T_ParticleFilter
         >
         DINLINE void
         operator()(
@@ -84,7 +85,8 @@ namespace picongpu
             T_Filter filter,
             T_Space const domainOffset,
             T_Identifier const domainCellIdxIdentifier,
-            T_Mapping const mapper
+            T_Mapping const mapper,
+            T_ParticleFilter parFilter
         ) const
         {
             using namespace pmacc::particles::operations;
@@ -129,6 +131,11 @@ namespace picongpu
 
             // each virtual worker needs only one filter
             filter.setSuperCellPosition( localSuperCellCellOffset );
+            auto accParFilter = parFilter(
+                acc,
+                supcerCellIdx - mapper.getGuardingSuperCells( ),
+                WorkerCfg< numWorkers >{ workerIdx }
+            );
 
             ForEachIdx<
                 IdxConfig<
@@ -168,11 +175,17 @@ namespace picongpu
                                 localIdx
                             )
                         )
-                            storageOffsetCtx[ idx ] = nvidia::atomicAllInc(
-                                acc,
-                                &localCounter,
-                                ::alpaka::hierarchy::Threads{}
-                            );
+                            if(
+                                accParFilter(
+                                    acc,
+                                    parSrc
+                                )
+                            )
+                                storageOffsetCtx[ idx ] = nvidia::atomicAllInc(
+                                    acc,
+                                    &localCounter,
+                                    ::alpaka::hierarchy::Threads{}
+                                );
                     }
                 );
                 __syncthreads();

--- a/include/picongpu/plugins/misc/SpeciesFilter.hpp
+++ b/include/picongpu/plugins/misc/SpeciesFilter.hpp
@@ -1,0 +1,77 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/particles/filter/filter.def"
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace misc
+{
+
+    /** combines a particle species with a filter
+     *
+     * @tparam T_Species picongpu::Particle, type of the species
+     * @tparam T_Filter pmacc::filter::Interface, type of the filter
+     */
+    template<
+        typename T_Species,
+        typename T_Filter = particles::filter::All
+    >
+    struct SpeciesFilter
+    {
+        using Filter = T_Filter;
+        using Species = T_Species;
+
+        /** name of the filtered species
+         *
+         * @return <speciesName>_<filterName>`
+         */
+        static std::string getName()
+        {
+            return Species::FrameType::getName() + "_" + Filter::getName();
+        }
+    };
+
+namespace speciesFilter
+{
+    /** evaluate if the filter and species combination is valid
+     *
+     * @tparam T_SpeciesFilter SpeciesFilter, type of the filter and species
+     * @return ::type boost::mpl::bool_<>, if the species is eligible for the filter
+     */
+    template< typename T_SpeciesFilter >
+    struct IsEligible
+    {
+        using type = typename particles::traits::SpeciesEligibleForSolver<
+            typename T_SpeciesFilter::Species,
+            typename T_SpeciesFilter::Filter
+        >::type;
+    };
+} // namespace speciesFilter
+
+} //namespace misc
+} //namespace plugins
+} //namespace picongpu

--- a/include/pmacc/mappings/simulation/ResourceMonitor.hpp
+++ b/include/pmacc/mappings/simulation/ResourceMonitor.hpp
@@ -49,8 +49,8 @@ namespace pmacc
         /**
          * Returns the number of particles per species on the device
          */
-        template <typename T_Species, typename T_MappingDesc>
-        std::vector<std::size_t> getParticleCounts(T_MappingDesc &cellDescription);
+        template <typename T_Species, typename T_MappingDesc, typename T_ParticleFilter>
+        std::vector<std::size_t> getParticleCounts(T_MappingDesc &cellDescription, T_ParticleFilter & parFilter);
 
     };
 

--- a/include/pmacc/mappings/simulation/ResourceMonitor.tpp
+++ b/include/pmacc/mappings/simulation/ResourceMonitor.tpp
@@ -35,8 +35,8 @@ namespace pmacc
     template<typename T_DIM, typename T_Species>
     struct MyCountParticles
     {
-        template <typename T_Vector, typename T_MappingDesc>
-        void operator()(T_Vector & particleCounts, T_MappingDesc & cellDescription)
+        template <typename T_Vector, typename T_MappingDesc, typename T_ParticleFilter>
+        void operator()(T_Vector & particleCounts, T_MappingDesc & cellDescription,  T_ParticleFilter & parFilter)
         {
             DataConnector & dc = Environment<>::get().DataConnector();
 
@@ -48,7 +48,8 @@ namespace pmacc
                     *dc.get<T_Species >(T_Species::FrameType::getName(), true),
                     cellDescription,
                     DataSpace<T_DIM::value>(),
-                    localSize);
+                    localSize,
+                    parFilter);
             particleCounts.push_back(totalNumParticles);
         }
     };
@@ -66,13 +67,13 @@ namespace pmacc
     }
 
     template<unsigned T_DIM>
-    template <typename T_Species, typename T_MappingDesc>
-    std::vector<size_t> ResourceMonitor<T_DIM>::getParticleCounts(T_MappingDesc &cellDescription)
+    template <typename T_Species, typename T_MappingDesc, typename T_ParticleFilter>
+    std::vector<size_t> ResourceMonitor<T_DIM>::getParticleCounts(T_MappingDesc &cellDescription, T_ParticleFilter & parFilter)
     {
         typedef bmpl::integral_c<unsigned, T_DIM> dim;
         std::vector<size_t> particleCounts;
         algorithms::forEach::ForEach<T_Species, MyCountParticles<dim, bmpl::_1> > countParticles;
-        countParticles(forward(particleCounts), forward(cellDescription));
+        countParticles(forward(particleCounts), forward(cellDescription), forward(parFilter));
         return particleCounts;
     }
 

--- a/include/pmacc/particles/operations/ConcatListOfFrames.hpp
+++ b/include/pmacc/particles/operations/ConcatListOfFrames.hpp
@@ -25,6 +25,8 @@
 #include "pmacc/dimensions/DataSpaceOperations.hpp"
 #include "pmacc/math/vector/compile-time/Vector.hpp"
 
+#include "pmacc/mappings/threads/WorkerCfg.hpp"
+
 namespace pmacc
 {
 namespace particles
@@ -64,8 +66,10 @@ struct ConcatListOfFrames
      *                                that is calculated with respect to
      *                                domainOffset
      * @param mapper mapper which describes the area where particles are copied from
+     * @param parFilter particle filter method, must fulfill the interface of pmacc::filter::Interface
+     *                  The working domain for the filter is supercells.
      */
-    template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Identifier, class T_Mapping>
+    template<class T_DestFrame, class T_SrcBox, class T_Filter, class T_Space, class T_Identifier, class T_Mapping, typename T_ParticleFilter>
     void operator()(
         int& counter,
         T_DestFrame destFrame,
@@ -73,7 +77,8 @@ struct ConcatListOfFrames
         const T_Filter particleFilter,
         const T_Space domainOffset,
         const T_Identifier domainCellIdxIdentifier,
-        const T_Mapping mapper
+        const T_Mapping mapper,
+        T_ParticleFilter & parFilter
     )
     {
         #pragma omp parallel for
@@ -87,6 +92,7 @@ struct ConcatListOfFrames
             DataSpace<T_dim> blockIndex(DataSpaceOperations<T_dim>::map(m_gridSize, linearBlockIdx));
 
             using namespace pmacc::particles::operations;
+            using namespace mappings::threads;
 
             typedef T_DestFrame DestFrameType;
             typedef typename T_SrcBox::FrameType SrcFrameType;
@@ -102,6 +108,11 @@ struct ConcatListOfFrames
             const DataSpace<Mapping::Dim> superCellIdx = mapper.getSuperCellIndex(blockIndex);
             const DataSpace<Mapping::Dim> superCellPosition((superCellIdx - mapper.getGuardingSuperCells()) * mapper.getSuperCellSize());
             filter.setSuperCellPosition(superCellPosition);
+            auto accParFilter = parFilter(
+                1, /* @todo this is a hack, please add a alpaka accelerator here*/
+                superCellIdx - mapper.getGuardingSuperCells( ),
+                WorkerCfg< 1 >{ 0 } /* @todo this is a workaround because we use no alpaka*/
+            );
 
             SrcFramePtr srcFramePtr = srcBox.getFirstFrame(superCellIdx);
 
@@ -112,12 +123,17 @@ struct ConcatListOfFrames
                 int curNumParticles = 0;
                 for (int particleIdx = 0; particleIdx < particlesPerFrame; ++particleIdx)
                 {
+                    localIdxs[particleIdx] = -1;
                     auto parSrc = (srcFramePtr[particleIdx]);
                     /* Check if particle exists and is not filtered */
                     if (parSrc[multiMask_] == 1 && filter(*srcFramePtr, particleIdx))
-                        localIdxs[particleIdx] = curNumParticles++;
-                    else
-                        localIdxs[particleIdx] = -1;
+                        if(
+                            accParFilter(
+                                1, /* @todo this is a hack, please add a alpaka accelerator here*/
+                                parSrc
+                            )
+                        )
+                            localIdxs[particleIdx] = curNumParticles++;
                 }
 
                 int globalOffset;


### PR DESCRIPTION
- PMacc: use particle filters in `ResourceMonitor`, `ConcatListOfFrames` and `CountParticles`
- PIConGPU:
  - add helper class `SpeciesFilter`
  - Prepare all plugins which uses PMacc particle methods to be particle filter ready.

Note: `ConcatListOfFrames` is currently hacky. All usages of alpaka accelerators are filled with fake values. This means that is it currently not possible to use accelerator dependent functions (RNG, ...) with the filter. We need to rewrite `ConcatListOfFrames` as proper alpaka kernel. This is **not** possible currently until we fully switch to alpaka (currently we are running in a mixed mode with native CUDA).

**WARNING** the species names in the output files from HDF5 and ADIOS will be change after this PR. New name are `<speciesName>_<filternName>`. The current used default filter is `all` this means electrons are named `e_all`.

Related to #1288 

# Tests

- [x] write HDF5 and HDF5
- [x] restart ADIOS
- [x] restart HDF5
