### PR TITLE
Manipulators: UnboundElectronsTimesWeighting

### DIFF
--- a/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
@@ -1,0 +1,102 @@
+/* Copyright 2015-2017 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/manipulators/generic/Free.def"
+#include "picongpu/particles/traits/GetAtomicNumbers.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+namespace binary
+{
+namespace acc
+{
+
+    //! Re-scale the weighting of a cloned species by numberOfProtons - boundElectrons
+    struct UnboundElectronsTimesWeighting
+    {
+
+        /** Increase weighting of particleDest by ... number of SrcParticle
+         *
+         * The frame's `numberOfProtons`of `T_SrcParticle`
+         * is used to increase the weighting of particleDest.
+         * Useful to increase the weighting of macro electrons when cloned from an
+         * ion with Z>1. Otherwise one would need Z macro electrons (each with the
+         * same weighting as the initial ion) to keep the charge of a pre-ionized
+         * atom neutral.
+         *
+         * @tparam T_DestParticle type of the particle species with weighting to manipulate
+         * @tparam T_SrcParticle type of the particle species with proton number Z
+         * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+         *
+         * @param particleDest destination particle
+         * @param source particle (the number of protons of this particle is used)
+         * @param unused particles
+         *
+         * @see picongpu::particles::ManipulateDeriveSpecies , picongpu::particles::Manipulate
+         */
+        template<
+            typename T_DesParticle,
+            typename T_SrcParticle,
+            typename ... T_Args
+        >
+        DINLINE void operator()(
+            T_DesParticle & particleDest,
+            T_SrcParticle const & particleSrc,
+            T_Args && ...
+        )
+        {
+            float_X const protonNumber = traits::GetAtomicNumbers< T_SrcParticle >::type::numberOfProtons;
+            float_X const boundElectrons = particleSrc[ boundElectrons_ ];
+            float_X const freeElectrons = protonNumber - boundElectrons;
+            particleDest[ weighting_ ] *= freeElectrons;
+        }
+    };
+} // namespace acc
+
+    /** Re-scale the weighting of a cloned species by numberOfProtons - ...
+     *
+     * When deriving species from each other, the new
+     * species "inherits" the macro-particle weighting
+     * of the first one.
+     * This functor can be used to manipulate the weighting
+     * of the new species' macro particles to be a multiplied by
+     * the number of protons of the initial species.
+     *
+     * As an example, this is useful when initializing a quasi-neutral,
+     * pre-ionized plasma of ions and electrons. Electrons can be created
+     * from ions via deriving and increasing their weight to avoid simulating
+     * multiple macro electrons per macro ion (with Z>1).
+     *
+     * note: needs the atomicNumbers flag on the initial species,
+     *       used by the GetAtomicNumbers trait.
+     */
+    using UnboundElectronsTimesWeighting = generic::Free< acc::UnboundElectronsTimesWeighting >;
+
+} // namespace binary
+} // namespace manipulators
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/manipulators/manipulators.def
+++ b/include/picongpu/particles/manipulators/manipulators.def
@@ -37,3 +37,4 @@
 #include "picongpu/particles/manipulators/binary/DensityWeighting.def"
 #include "picongpu/particles/manipulators/binary/Assign.def"
 #include "picongpu/particles/manipulators/binary/ProtonTimesWeighting.def"
+#include "picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def"

--- a/share/picongpu/examples/FoilLCT/README.rst
+++ b/share/picongpu/examples/FoilLCT/README.rst
@@ -9,11 +9,11 @@ FoilLCT: Ion Acceleration from a Liquid-Crystal Target
 The following example models a laser-ion accelerator in the [TNSA]_ regime.
 An optically over-dense target (:math:`n_\text{max} = 192 n_\text{c}`) consisting of a liquid-crystal material *8CB* (4-octyl-4'-cyanobiphenyl) :math:`C_{21}H_{25}N` is used.
 
-Irradiated with a high-power laser pulse with :math:`a_0 = 5` the target is assumed to be once pre-ionized due to realistic laser contrast and pre-pulses to :math:`C^+`, :math:`H^+` and :math:`N^+` while being slightly expanded on its surfaces (modeled as exponential density slope).
+Irradiated with a high-power laser pulse with :math:`a_0 = 5` the target is assumed to be partly pre-ionized due to realistic laser contrast and pre-pulses to :math:`C^{2+}`, :math:`H^+` and :math:`N^{2+}` while being slightly expanded on its surfaces (modeled as exponential density slope).
 The overall target is assumed to be initially quasi-neutral and the *8CB* ion components are are not demixed in the surface regions.
 Surface contamination with, e.g. water vapor is neglected.
 
-The laser is assumed to be in-focus and approximated as a plane wave with temporally Gaussian intensity envelope of :math:`\tau^\text{FWHM}_I = 25` fs.
+The laser is assumed to be in focus and approximated as a plane wave with temporally Gaussian intensity envelope of :math:`\tau^\text{FWHM}_I = 25` fs.
 
 This example is used to demonstrate:
 

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/particle.param
@@ -67,6 +67,22 @@ namespace manipulators
     };
     using OnceIonized = generic::Free< OnceIonizedImpl >;
 
+    //! ionize ions twice
+    struct TwiceIonizedImpl
+    {
+        template< typename T_Particle >
+        DINLINE void operator()(
+            T_Particle& particle
+        )
+        {
+            constexpr float_X protonNumber = GetAtomicNumbers< T_Particle >::type::numberOfProtons;
+            particle[ boundElectrons_ ] = protonNumber - float_X( 2. );
+        }
+    };
+
+    //! definition of TwiceIonizedImpl manipulator
+    using TwiceIonized = generic::Free< TwiceIonizedImpl >;
+
     //! changes the in-cell position of each particle of a species
     using RandomPosition = unary::RandomPosition;
 

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -111,13 +111,14 @@ namespace particles
             manipulators::unary::RandomPosition,
             Nitrogen
         >,
-        // partial pre-ionization: set bound electrons for C & N
+        // partial pre-ionization: set bound electrons for C2+ & N2+
         Manipulate<
-            manipulators::OnceIonized,
+            manipulators::TwiceIonized,
             Carbon
         >,
+        // note: boundElectrons default is 0, so Hydrogen's default is H+
         Manipulate<
-            manipulators::OnceIonized,
+            manipulators::TwiceIonized,
             Nitrogen
         >,
         // partial pre-ionization: create free electrons
@@ -125,11 +126,13 @@ namespace particles
             Hydrogen,
             Electrons
         >,
-        DeriveSpecies<
+        ManipulateDeriveSpecies<
+            manipulators::binary::UnboundElectronsTimesWeighting,
             Carbon,
             Electrons
         >,
-        DeriveSpecies<
+        ManipulateDeriveSpecies<
+            manipulators::binary::UnboundElectronsTimesWeighting,
             Nitrogen,
             Electrons
         >,


### PR DESCRIPTION
Add a new binary manipulator suitable for partially pre-ionized targets (more than once pre-ionized).

`speciesInitialization.param`:

```C++
   using InitPipeline = mpl::vector<
        // ... ,

        // partial pre-ionization: set bound electrons for C & N
        Manipulate<
            manipulators::TwiceIonized,
            Carbon
        >,
        ManipulateDeriveSpecies<
            manipulators::binary::UnboundElectronsTimesWeighting,
            Carbon,
            Electrons
        >,
    >;
```

`particle.param`:

```C++
// ...

namespace manipulators
{
    //! ionize ions 2x
    struct TwiceIonizedImpl
    {
        template< typename T_Particle >
        DINLINE void operator()(
            T_Particle& particle
        )
        {
            constexpr float_X protonNumber = GetAtomicNumbers< T_Particle >::type::numberOfProtons;
            particle[ boundElectrons_ ] = protonNumber - 2.;
        }
    };

    //! definition of TwiceIonizedImpl manipulator
    using TwiceIonized = generic::Free< TwiceIonizedImpl >;

} // namespace manipulators

// ...
```

## To Do

- [x] update rst Workflows for pre-ionized targets
- [x] add to foil LCT example?