### PR TITLE
bracket test for external libraries includes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,23 @@ jobs:
         # Disallow spaces before pre-compiler macros                                #
         #############################################################################
         - test/hasSpaceBeforePrecompiler
+
+        #############################################################################
+        # Enforce angle brackets <...> for includes of external library files       #
+        #############################################################################
+        - test/hasExtLibIncludeBrackets include boost
+        - test/hasExtLibIncludeBrackets include alpaka
+        - test/hasExtLibIncludeBrackets include cupla
+        - test/hasExtLibIncludeBrackets include splash
+        - test/hasExtLibIncludeBrackets include mallocMC
+        - test/hasExtLibIncludeBrackets include/picongpu pmacc
+        - test/hasExtLibIncludeBrackets share/picongpu/examples pmacc
+        - test/hasExtLibIncludeBrackets share/picongpu/examples boost
+        - test/hasExtLibIncludeBrackets share/picongpu/examples alpaka
+        - test/hasExtLibIncludeBrackets share/picongpu/examples cupla
+        - test/hasExtLibIncludeBrackets share/picongpu/examples splash
+        - test/hasExtLibIncludeBrackets share/picongpu/examples mallocMC
+        - test/hasExtLibIncludeBrackets share/pmacc/examples pmacc
     - &test-cpp-unit
       stage: 'C++ Unit Tests'
       language: cpp

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
@@ -29,7 +29,7 @@
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
 #include <pmacc/memory/Array.hpp>
-#include "pmacc/mappings/threads/WorkerCfg.hpp"
+#include <pmacc/mappings/threads/WorkerCfg.hpp>
 
 
 namespace picongpu

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
@@ -24,7 +24,7 @@
 
 #include "pmacc/dataManagement/ISimulationData.hpp"
 
-#include "mallocMC/mallocMC.hpp"
+#include <mallocMC/mallocMC.hpp>
 
 #include <string>
 #include <memory>

--- a/test/hasExtLibIncludeBrackets
+++ b/test/hasExtLibIncludeBrackets
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2017 Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# search recursive inside the `$1` folder if a file is using the
+# wrong include brackets "..." instead of <...> to include external library files
+#
+# @param $1 path to the folder
+# @param $2 prefix of the extern library e.g pmacc, boost
+# @result 0 if no files are found, else 1
+
+folderName=$1
+libPrefix=$2
+
+ok=0
+files=()
+
+pattern="\.def$|\.h$|\.cpp$|\.cu$|\.hpp$|\.tpp$|\.kernel$|\.loader$|"\
+"\.param$|\.unitless$"
+
+for i in $(find $folderName \
+    -not -path "./.git/*" \
+    -type f | \
+    grep -P "${pattern}")
+do
+    grep -q "include.*\"$libPrefix\/.*\"" $i
+    if [ $? -eq 0 ]
+    then
+        files+=($i)
+        echo "$i uses \"...\" instead of <...> for '$libPrefix' includes!"
+        ok=1
+    fi
+done
+
+if [ $ok -ne 0 ]
+then
+    echo ""
+    echo "SUMMARY"
+    echo "-------"
+    echo "Run the following command(s) on the above files to fix"
+    echo "the include brackets which are including '$libPrefix' files:"
+    echo ""
+    for i in ${files[@]}
+    do
+        echo "sed -i 's/\(include.*\)\"\($libPrefix\/.*\)\"/\1<\2>/' $i"
+    done
+fi
+
+exit $ok


### PR DESCRIPTION
- add test check if external libraries are included with `<>` brackets
- add `hasExtLibIncludeBrackets` to travis code style checks
- fix wrong include brackets in `LocalDensity.kernel` and `MallocMCBuffer.hpp`