### PR TITLE
Foil Example: Fix CFL

### DIFF
--- a/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
@@ -37,7 +37,7 @@ TBG_gpu_y=2
 TBG_gpu_z=1
 
 TBG_gridSize="-g 256 1280"
-TBG_steps="-s 2000"
+TBG_steps="-s 5000"
 
 TBG_periodic="--periodic 1 0"
 

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/grid.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/grid.param
@@ -61,7 +61,7 @@ namespace picongpu
          *  unit: seconds                       CFL criteria for Yee MW Solver
          *                                             2D: sqrt(2)
          *                                             3D: sqrt(3)   */
-        constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / ( 1.4143 * SPEED_OF_LIGHT_SI );
+        constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / ( 1.415 * SPEED_OF_LIGHT_SI );
 
     } // namespace SI
 


### PR DESCRIPTION
Avoid getting too close to the CFL for the foil example in order to keep numerical stability.

Previous:
  Courant c*dt <= 1.00006 ? 1

Now:
  Courant c*dt <= 1.00056 ? 1

See issue #2391 

Also increases the runtime to 5k steps (~5min on K80) by default to provide more dynamics