### PR TITLE
Update cuda_memtest: no cuBLAS

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -22,7 +22,6 @@ RUN        apt-get update && \
               build-essential \
               ca-certificates \
               coreutils \
-              cuda-cublas-dev-$CUDA_PKG_VERSION \
               cuda-command-line-tools-$CUDA_PKG_VERSION \
               cuda-core-$CUDA_PKG_VERSION \
               cuda-cudart-dev-$CUDA_PKG_VERSION \

--- a/thirdParty/cuda_memtest/cuda_memtest.h
+++ b/thirdParty/cuda_memtest/cuda_memtest.h
@@ -48,7 +48,6 @@
 #include <stdexcept>
 
 #include <cuda.h>
-#include <cublas.h>
 #if (ENABLE_NVML==1)
 #include <nvml.h>
 #endif


### PR DESCRIPTION
Updates cuda_memtest:
- remove cuBLAS include [#14](https://github.com/ComputationalRadiationPhysics/cuda_memtest/pull/14)

From
- `cuda_memtest@dev` (https://github.com/ComputationalRadiationPhysics/cuda_memtest/commit/8a0e21bea7be98a1d0f0f9fc48ae90f87c3ecb81) to
- `cuda_memtest@dev` (https://github.com/ComputationalRadiationPhysics/cuda_memtest/commit/7a585d504831431d0e95ff00d0217181201dbb12)

```bash
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git subtree pull --prefix thirdParty/cuda_memtest \
  git@github.com:ComputationalRadiationPhysics/cuda_memtest.git dev --squash
```