### PR TITLE
PIConGPU: C++11 Using

### DIFF
--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -43,7 +43,7 @@ namespace picongpu
 template<class T_Shape, class InterpolationMethod>
 struct FieldToParticleInterpolation
 {
-    typedef typename T_Shape::ChargeAssignmentOnSupport AssignmentFunction;
+    using AssignmentFunction = typename T_Shape::ChargeAssignmentOnSupport;
     static constexpr int supp = AssignmentFunction::support;
 
     static constexpr int lowerMargin = supp / 2 ;

--- a/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
@@ -44,7 +44,7 @@ namespace picongpu
 template<class T_Shape, class InterpolationMethod>
 struct FieldToParticleInterpolationNative
 {
-    typedef typename T_Shape::ChargeAssignment AssignmentFunction;
+    using AssignmentFunction = typename T_Shape::ChargeAssignment;
     static constexpr int supp = AssignmentFunction::support;
 
     static constexpr int lowerMargin = supp / 2;

--- a/include/picongpu/algorithms/KinEnergy.hpp
+++ b/include/picongpu/algorithms/KinEnergy.hpp
@@ -39,7 +39,7 @@ using namespace pmacc;
 template< typename T_PrecisionType = float_X >
 struct KinEnergy
 {
-    typedef T_PrecisionType ValueType;
+    using ValueType = T_PrecisionType;
 
     template< typename MomType, typename MassType >
     HDINLINE ValueType operator()( MomType const & mom, MassType const & mass )

--- a/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
+++ b/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
@@ -49,10 +49,10 @@ struct AssignToDim
     operator()(T_Type& cursor, T_Vector& pos, const T_FieldType& fieldPos)
     {
         const uint32_t dim = T_Vector::dim;
-        typedef typename T_Vector::type ValueType;
+        using ValueType = typename T_Vector::type;
 
-        typedef T_Supports Supports;
-        typedef T_Component Component;
+        using Supports = T_Supports;
+        using Component = T_Component;
 
         const uint32_t component = Component::x::value;
         const uint32_t support = Supports::template at<component>::type::value;

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -46,7 +46,7 @@ namespace picongpu
 
 using namespace pmacc;
 
-typedef FieldJ::DataBoxType J_DataBox;
+using J_DataBox = FieldJ::DataBoxType;
 
 /** compute current
  *

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -265,7 +265,7 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
      */
     const int workerMultiplier = 2;
 
-    typedef typename ParticlesClass::FrameType FrameType;
+    using FrameType = typename ParticlesClass::FrameType;
     typedef typename pmacc::traits::Resolve<
         typename GetFlagType<FrameType, current<> >::type
     >::type ParticleCurrentSolver;

--- a/include/picongpu/fields/Fields.def
+++ b/include/picongpu/fields/Fields.def
@@ -33,11 +33,11 @@ namespace picongpu
     template<typename T_Solver, typename T_Species>
     struct FieldTmpOperation
     {
-        typedef T_Solver Solver;
-        typedef T_Species Species;
+        using Solver = T_Solver;
+        using Species = T_Species;
 
-        typedef typename Solver::LowerMargin LowerMargin;
-        typedef typename Solver::UpperMargin UpperMargin;
+        using LowerMargin = typename Solver::LowerMargin;
+        using UpperMargin = typename Solver::UpperMargin;
     };
 
     /** Tmp (at the moment: scalar) field for plugins and tmp data like

--- a/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -34,7 +34,7 @@ namespace picongpu
 template<typename BlockDim>
 struct DirSplittingKernel
 {
-    typedef void result_type;
+    using result_type = void;
 
     PMACC_ALIGN(m_totalLength,int);
     DirSplittingKernel(int totalLength) : m_totalLength(totalLength) {}

--- a/include/picongpu/fields/MaxwellSolver/Lehe/LeheSolver.def
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/LeheSolver.def
@@ -33,7 +33,7 @@ namespace leheSolver
 {
     using namespace pmacc;
 
-    typedef CurlELehe< picongpu::fieldSolverLehe::CherenkovFreeDir > CurlELeheDir;
+    using CurlELeheDir = CurlELehe< picongpu::fieldSolverLehe::CherenkovFreeDir >;
 
     typedef ::picongpu::yeeSolver::YeeSolver< CurlELeheDir > LeheSolver;
 

--- a/include/picongpu/fields/MaxwellSolver/Yee/Curl.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Curl.hpp
@@ -31,8 +31,8 @@ using namespace pmacc;
 template<class Difference>
 struct Curl
 {
-    typedef typename Difference::OffsetOrigin LowerMargin;
-    typedef typename Difference::OffsetEnd UpperMargin;
+    using LowerMargin = typename Difference::OffsetOrigin;
+    using UpperMargin = typename Difference::OffsetEnd;
 
     template<class Memory >
     HDINLINE typename Memory::ValueType operator()(const Memory & mem) const

--- a/include/picongpu/fields/MaxwellSolver/Yee/YeeSolver.def
+++ b/include/picongpu/fields/MaxwellSolver/Yee/YeeSolver.def
@@ -29,8 +29,8 @@ namespace picongpu
 {
 namespace yeeSolver
 {
-typedef Curl<DifferenceToLower<simDim> > CurlLeft;
-typedef Curl<DifferenceToUpper<simDim> > CurlRight;
+using CurlLeft = Curl< DifferenceToLower< simDim > >;
+using CurlRight = Curl< DifferenceToUpper< simDim > >;
 
 template<class CurlE = CurlRight, class CurlB = CurlLeft>
 class YeeSolver;
@@ -43,15 +43,15 @@ namespace traits
 template<class CurlE, class CurlB>
 struct GetMargin<picongpu::yeeSolver::YeeSolver<CurlE, CurlB>, FIELD_B>
 {
-    typedef typename CurlB::LowerMargin LowerMargin;
-    typedef typename CurlB::UpperMargin UpperMargin;
+    using LowerMargin = typename CurlB::LowerMargin;
+    using UpperMargin = typename CurlB::UpperMargin;
 };
 
 template<class CurlE, class CurlB>
 struct GetMargin<picongpu::yeeSolver::YeeSolver<CurlE, CurlB>, FIELD_E>
 {
-    typedef typename CurlE::LowerMargin LowerMargin;
-    typedef typename CurlE::UpperMargin UpperMargin;
+    using LowerMargin = typename CurlE::LowerMargin;
+    using UpperMargin = typename CurlE::UpperMargin;
 };
 
 } //namespace traits

--- a/include/picongpu/fields/background/templates/TWTS/BField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.hpp
@@ -38,7 +38,7 @@ namespace twts
 class BField
 {
 public:
-    typedef float_X float_T;
+    using float_T = float_X;
 
     enum PolarizationType
     {

--- a/include/picongpu/fields/background/templates/TWTS/BField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.tpp
@@ -295,8 +295,8 @@ namespace twts
     HDINLINE BField::float_T
     BField::calcTWTSBy( const float3_64& pos, const float_64 time ) const
     {
-        typedef pmacc::math::Complex<float_T> complex_T;
-        typedef pmacc::math::Complex<float_64> complex_64;
+        using complex_T = pmacc::math::Complex< float_T >;
+        using complex_64 = pmacc::math::Complex< float_64 >;
         /* Unit of speed */
         const float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /* Unit of time */
@@ -452,7 +452,7 @@ namespace twts
     HDINLINE BField::float_T
     BField::calcTWTSBz_Ex( const float3_64& pos, const float_64 time ) const
     {
-        typedef pmacc::math::Complex<float_T> complex_T;
+        using complex_T = pmacc::math::Complex< float_T >;
         /** Unit of Speed */
         const float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /** Unit of time */
@@ -580,8 +580,8 @@ namespace twts
     HDINLINE BField::float_T
     BField::calcTWTSBz_Ey( const float3_64& pos, const float_64 time ) const
     {
-        typedef pmacc::math::Complex<float_T> complex_T;
-        typedef pmacc::math::Complex<float_64> complex_64;
+        using complex_T = pmacc::math::Complex< float_T >;
+        using complex_64 = pmacc::math::Complex< float_64 >;
         /** Unit of speed */
         const float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /** Unit of time */

--- a/include/picongpu/fields/background/templates/TWTS/EField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.hpp
@@ -38,7 +38,7 @@ namespace twts
 class EField
 {
 public:
-    typedef float_X float_T;
+    using float_T = float_X;
 
     enum PolarizationType
     {

--- a/include/picongpu/fields/background/templates/TWTS/EField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.tpp
@@ -201,8 +201,8 @@ namespace twts
     HDINLINE EField::float_T
     EField::calcTWTSEx( const float3_64& pos, const float_64 time) const
     {
-        typedef pmacc::math::Complex<float_T> complex_T;
-        typedef pmacc::math::Complex<float_64> complex_64;
+        using complex_T = pmacc::math::Complex< float_T >;
+        using complex_64 = pmacc::math::Complex< float_64 >;
         /* Unit of speed */
         const float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
         /* Unit of time */

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -36,7 +36,7 @@ template<
 >
 struct EmZ
 {
-    typedef typename T_ParticleShape::ChargeAssignmentOnSupport ParticleAssign;
+    using ParticleAssign = typename T_ParticleShape::ChargeAssignmentOnSupport;
     static constexpr int supp = ParticleAssign::support;
 
     static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -40,7 +40,7 @@ using namespace pmacc;
 template<typename T_ParticleShape>
 struct Esirkepov<T_ParticleShape, DIM3>
 {
-    typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
+    using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
     static constexpr int supp = ParticleAssign::support;
 
     static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -47,7 +47,7 @@ using namespace pmacc;
 template<typename T_ParticleShape>
 struct Esirkepov<T_ParticleShape, DIM2>
 {
-    typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
+    using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
     static constexpr int supp = ParticleAssign::support;
 
     static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -47,7 +47,7 @@ using namespace pmacc;
 template<typename T_ParticleShape>
 struct EsirkepovNative
 {
-    typedef typename T_ParticleShape::ChargeAssignment ParticleAssign;
+    using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
     static constexpr int supp = ParticleAssign::support;
 
     static constexpr int currentLowerMargin = supp / 2 + 1;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Line.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Line.hpp
@@ -33,7 +33,7 @@ using namespace pmacc;
 template<typename T_Type>
 struct Line
 {
-    typedef T_Type type;
+    using type = T_Type;
 
     type m_pos0;
     type m_pos1;

--- a/include/picongpu/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
+++ b/include/picongpu/fields/currentDeposition/ZigZag/EvalAssignmentFunction.hpp
@@ -50,7 +50,7 @@ using namespace pmacc;
 template<typename T_Shape, typename T_pos>
 struct EvalAssignmentFunction
 {
-    typedef typename T_Shape::ChargeAssignmentOnSupport ParticleAssign;
+    using ParticleAssign = typename T_Shape::ChargeAssignmentOnSupport;
 
     HDINLINE float_X
     operator()(const float_X parPos)

--- a/include/picongpu/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/include/picongpu/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -44,7 +44,7 @@ struct Binomial
                              DataBoxJ fieldJ )
     {
         const DataSpace<dim> self;
-        typedef typename DataBoxJ::ValueType TypeJ;
+        using TypeJ = typename DataBoxJ::ValueType;
 
         /* 1 2 1 weighting for "left"(1x) "center"(2x) "right"(1x),
          * see Pascal's triangle level N=2 */

--- a/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -53,9 +53,9 @@ namespace detail
             DataSpace<dim> up;
             up[(T_plane + 1) % dim] = 1;
 
-            typedef LinearInterpolateWithUpper<dim> Avg;
+            using Avg = LinearInterpolateWithUpper< dim >;
 
-            const typename Avg::template GetInterpolatedValue<(T_plane + 2) % dim> avg;
+            const typename Avg::template GetInterpolatedValue< (T_plane + 2) % dim > avg;
 
             return float_X(0.5) * ( avg(field)[T_plane] + avg(field.shift(up))[T_plane] );
         }
@@ -113,8 +113,8 @@ namespace detail
     template<class Difference>
     struct ShiftCurl
     {
-        typedef typename Difference::OffsetOrigin LowerMargin;
-        typedef typename Difference::OffsetEnd UpperMargin;
+        using LowerMargin = typename Difference::OffsetOrigin;
+        using UpperMargin = typename Difference::OffsetEnd;
 
         template<class DataBox >
         HDINLINE typename DataBox::ValueType operator()(const DataBox& mem) const
@@ -166,8 +166,8 @@ struct NoneDS
         const TypeJ jAvgE = TypeJ(jXavg, jYavg, jZavg);
         fieldE(self) -= jAvgE * constE;
 
-        typedef yeeSolver::Curl<DifferenceToUpper<dim> > CurlRight;
-        typedef detail::ShiftCurl<DifferenceToUpper<dim> > ShiftCurlRight;
+        using CurlRight = yeeSolver::Curl< DifferenceToUpper< dim > >;
+        using ShiftCurlRight = detail::ShiftCurl< DifferenceToUpper< dim > >;
         CurlRight curl;
         ShiftCurlRight shiftCurl;
 

--- a/include/picongpu/fields/numericalCellTypes/EMFCenteredCell.hpp
+++ b/include/picongpu/fields/numericalCellTypes/EMFCenteredCell.hpp
@@ -53,7 +53,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef ReturnType type;
+            using type = ReturnType;
         };
 
         HDINLINE FieldPosition()
@@ -89,7 +89,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef VectorVector2D3V type;
+            using type = VectorVector2D3V;
         };
 
         HDINLINE FieldPosition()
@@ -116,7 +116,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef VectorVector3D3V type;
+            using type = VectorVector3D3V;
         };
 
         HDINLINE FieldPosition()
@@ -148,7 +148,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef ReturnType type;
+            using type = ReturnType;
         };
 
         HDINLINE FieldPosition()

--- a/include/picongpu/fields/numericalCellTypes/YeeCell.hpp
+++ b/include/picongpu/fields/numericalCellTypes/YeeCell.hpp
@@ -49,7 +49,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef VectorVector2D3V type;
+            using type = VectorVector2D3V;
         };
 
         HDINLINE FieldPosition()
@@ -76,7 +76,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef VectorVector3D3V type;
+            using type = VectorVector3D3V;
         };
 
         HDINLINE FieldPosition()
@@ -103,7 +103,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef VectorVector2D3V type;
+            using type = VectorVector2D3V;
         };
 
         HDINLINE FieldPosition()
@@ -130,7 +130,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef VectorVector3D3V type;
+            using type = VectorVector3D3V;
         };
 
         HDINLINE FieldPosition()
@@ -174,7 +174,7 @@ namespace traits
 
         template<class F>
         struct result<F()> {
-            typedef ReturnType type;
+            using type = ReturnType;
         };
 
         HDINLINE FieldPosition()

--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -108,7 +108,7 @@ public:
     {
         void operator()()
         {
-            typedef typename T_Species::FrameType FrameType;
+            using FrameType = typename T_Species::FrameType;
             const float_32 charge = frame::getCharge<FrameType>();
             const float_32 mass = frame::getMass<FrameType>();
             log<picLog::PHYSICS >("species %2%: omega_p * dt <= 0.1 ? %1%") %

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -85,7 +85,7 @@ struct CreateDensity
 
     typedef typename bmpl::apply1<T_DensityFunctor, SpeciesType>::type UserDensityFunctor;
     /* add interface for compile time interface validation*/
-    typedef densityProfiles::IProfile<UserDensityFunctor> DensityFunctor;
+    using DensityFunctor = densityProfiles::IProfile<UserDensityFunctor>;
 
     typedef typename bmpl::apply1<T_PositionFunctor, SpeciesType>::type UserPositionFunctor;
     /* add interface for compile time interface validation*/

--- a/include/picongpu/particles/InterpolationForPusher.hpp
+++ b/include/picongpu/particles/InterpolationForPusher.hpp
@@ -34,7 +34,7 @@ namespace picongpu
 template< typename T_Field2PartInt, typename T_MemoryType, typename T_FieldPosition >
 struct InterpolationForPusher
 {
-    typedef T_Field2PartInt Field2PartInt;
+    using Field2PartInt = T_Field2PartInt;
 
     HDINLINE
     InterpolationForPusher( const T_MemoryType& mem, const T_FieldPosition& fieldPos )

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -420,7 +420,7 @@ struct KernelMoveAndMarkParticles
 
         uint32_t const workerIdx = threadIdx.x;
 
-        typedef typename T_ParBox::FramePtr FramePtr;
+        using FramePtr = typename T_ParBox::FramePtr;
 
         DataSpace< simDim > const block(
             mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
@@ -577,11 +577,11 @@ struct PushParticlePerFrame
     )
     {
 
-        typedef TVec Block;
-        typedef T_Field2ParticleInterpolation Field2ParticleInterpolation;
+        using Block = TVec;
+        using Field2ParticleInterpolation = T_Field2ParticleInterpolation;
 
-        typedef typename BoxB::ValueType BType;
-        typedef typename BoxE::ValueType EType;
+        using BType = typename BoxB::ValueType;
+        using EType = typename BoxE::ValueType;
 
         auto particle = frame[localIdx];
 

--- a/include/picongpu/particles/access/Cell2Particle.hpp
+++ b/include/picongpu/particles/access/Cell2Particle.hpp
@@ -40,7 +40,7 @@ namespace particleAccess
 template<typename SuperCellSize>
 struct Cell2Particle
 {
-    typedef void result_type;
+    using result_type = void;
 
     BOOST_PP_REPEAT(5, CELL2PARTICLE_OPERATOR, _)
 };

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -59,11 +59,11 @@ namespace bremsstrahlung
 template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
 struct Bremsstrahlung
 {
-    typedef T_IonSpecies IonSpecies;
-    typedef T_ElectronSpecies ElectronSpecies;
-    typedef T_PhotonSpecies PhotonSpecies;
+    using IonSpecies = T_IonSpecies;
+    using ElectronSpecies = T_ElectronSpecies;
+    using PhotonSpecies = T_PhotonSpecies;
 
-    typedef typename ElectronSpecies::FrameType FrameType;
+    using FrameType = typename ElectronSpecies::FrameType;
 
     /* specify field to particle interpolation scheme */
     typedef typename pmacc::traits::Resolve<
@@ -85,7 +85,7 @@ struct Bremsstrahlung
 
     typedef MappingDesc::SuperCellSize TVec;
 
-    typedef FieldTmp::ValueType ValueTypeIonDensity;
+    using ValueTypeIonDensity = FieldTmp::ValueType;
 
 private:
     /* global memory ion density field device databoxes */

--- a/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -60,7 +60,7 @@ struct GetPhotonAngleFunctor
         ::pmacc::cursor::tools::LinearInterp<float_X>,
         ::pmacc::cursor::BufferCursor<float_X, DIM2> >::type LinInterpCursor;
 
-    typedef float_X type;
+    using type = float_X;
 
     LinInterpCursor linInterpCursor;
     float_X lnMinGamma;
@@ -111,7 +111,7 @@ struct GetPhotonAngleFunctor
  */
 struct GetPhotonAngle
 {
-    typedef detail::GetPhotonAngleFunctor GetPhotonAngleFunctor;
+    using GetPhotonAngleFunctor = detail::GetPhotonAngleFunctor;
 
 private:
 

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -60,7 +60,7 @@ struct LookupTableFunctor
         ::pmacc::cursor::tools::LinearInterp<float_X>,
         ::pmacc::cursor::BufferCursor<float_X, DIM2> >::type LinInterpCursor;
 
-    typedef float_X type;
+    using type = float_X;
 
     LinInterpCursor linInterpCursor;
     float_X lnEMin;
@@ -96,7 +96,7 @@ struct LookupTableFunctor
 struct ScaledSpectrum
 {
 public:
-    typedef detail::LookupTableFunctor LookupTableFunctor;
+    using LookupTableFunctor = detail::LookupTableFunctor;
 private:
 
     typedef boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM2> > MyBuf;
@@ -163,7 +163,7 @@ public:
 template<typename T_ElectronSpecies>
 struct FillScaledSpectrumMap
 {
-    typedef T_ElectronSpecies ElectronSpecies;
+    using ElectronSpecies = T_ElectronSpecies;
 
     typedef typename pmacc::particles::traits::ResolveAliasFromSpecies<
         ElectronSpecies,

--- a/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
@@ -31,12 +31,12 @@ namespace densityProfiles
 template<typename T_ParamClass>
 struct FreeFormulaImpl : public T_ParamClass
 {
-    typedef T_ParamClass ParamClass;
+    using ParamClass = T_ParamClass;
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef FreeFormulaImpl<ParamClass> type;
+        using type = FreeFormulaImpl<ParamClass>;
     };
 
     HINLINE FreeFormulaImpl(uint32_t currentStep)

--- a/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
@@ -31,12 +31,12 @@ namespace densityProfiles
 template<typename T_ParamClass>
 struct GaussianCloudImpl : public T_ParamClass
 {
-    typedef T_ParamClass ParamClass;
+    using ParamClass = T_ParamClass;
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef GaussianCloudImpl<ParamClass> type;
+        using type = GaussianCloudImpl<ParamClass>;
     };
 
     HINLINE GaussianCloudImpl(uint32_t currentStep)

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -31,12 +31,12 @@ namespace densityProfiles
 template<typename T_ParamClass>
 struct GaussianImpl : public T_ParamClass
 {
-    typedef T_ParamClass ParamClass;
+    using ParamClass = T_ParamClass;
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef GaussianImpl<ParamClass> type;
+        using type = GaussianImpl<ParamClass>;
     };
 
     HINLINE GaussianImpl(uint32_t currentStep)

--- a/include/picongpu/particles/densityProfiles/IProfile.hpp
+++ b/include/picongpu/particles/densityProfiles/IProfile.hpp
@@ -32,7 +32,7 @@ template<typename T_Base>
 struct IProfile : private T_Base
 {
 
-    typedef T_Base Base;
+    using Base = T_Base;
 
     HINLINE IProfile(uint32_t currentStep) : Base(currentStep)
     {

--- a/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
@@ -30,12 +30,12 @@ namespace densityProfiles
 template<typename T_ParamClass>
 struct LinearExponentialImpl : public T_ParamClass
 {
-    typedef T_ParamClass ParamClass;
+    using ParamClass = T_ParamClass;
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef LinearExponentialImpl<ParamClass> type;
+        using type = LinearExponentialImpl<ParamClass>;
     };
 
     HINLINE LinearExponentialImpl(uint32_t currentStep)

--- a/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
@@ -31,12 +31,12 @@ namespace densityProfiles
 template<typename T_ParamClass>
 struct SphereFlanksImpl : public T_ParamClass
 {
-    typedef T_ParamClass ParamClass;
+    using ParamClass = T_ParamClass;
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef SphereFlanksImpl<ParamClass> type;
+        using type = SphereFlanksImpl<ParamClass>;
     };
 
     HINLINE SphereFlanksImpl(uint32_t currentStep)

--- a/include/picongpu/particles/ionization/byField/ADK/ADK.def
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK.def
@@ -61,8 +61,8 @@ namespace ionization
         /* Boolean value that results in an additional polarization factor in
          * the ionization rate for linear polarization */
         static constexpr bool linPol = true;
-        typedef particles::ionization::AlgorithmADK<linPol> IonizationAlgorithm;
-        typedef ADK_Impl<IonizationAlgorithm, T_DestSpecies> type;
+        using IonizationAlgorithm = particles::ionization::AlgorithmADK< linPol >;
+        using type = ADK_Impl< IonizationAlgorithm, T_DestSpecies >;
     };
 
     /** Ammosov-Delone-Krainov tunneling model - circular laser polarization
@@ -87,8 +87,8 @@ namespace ionization
         /* Boolean value that results in an additional polarization factor in
          * the ionization rate for linear polarization */
         static constexpr bool linPol = false;
-        typedef particles::ionization::AlgorithmADK<linPol> IonizationAlgorithm;
-        typedef ADK_Impl<IonizationAlgorithm, T_DestSpecies> type;
+        using IonizationAlgorithm = particles::ionization::AlgorithmADK< linPol >;
+        using type = ADK_Impl< IonizationAlgorithm, T_DestSpecies >;
     };
 
 } // namespace ionization

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -72,10 +72,10 @@ namespace ionization
     struct ADK_Impl
     {
 
-        typedef T_DestSpecies DestSpecies;
-        typedef T_SrcSpecies  SrcSpecies;
+        using DestSpecies = T_DestSpecies;
+        using SrcSpecies = T_SrcSpecies;
 
-        typedef typename SrcSpecies::FrameType FrameType;
+        using FrameType = typename SrcSpecies::FrameType;
 
         /* specify field to particle interpolation scheme */
         typedef typename pmacc::traits::Resolve<
@@ -98,7 +98,7 @@ namespace ionization
         private:
 
             /* define ionization ALGORITHM (calculation) for ionization MODEL */
-            typedef T_IonizationAlgorithm IonizationAlgorithm;
+            using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
             typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::AlpakaRand< cupla::Acc>> RNGFactory;
@@ -108,8 +108,8 @@ namespace ionization
 
             typedef MappingDesc::SuperCellSize TVec;
 
-            typedef FieldE::ValueType ValueType_E;
-            typedef FieldB::ValueType ValueType_B;
+            using ValueType_E = FieldE::ValueType;
+            using ValueType_B = FieldB::ValueType;
             /* global memory EM-field device databoxes */
             PMACC_ALIGN(eBox, FieldE::DataBoxType);
             PMACC_ALIGN(bBox, FieldB::DataBoxType);

--- a/include/picongpu/particles/ionization/byField/BSI/BSI.def
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI.def
@@ -35,7 +35,7 @@ namespace ionization
      *         cannot be known in list of particle species' flags
      *         \see speciesDefinition.param
      */
-    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
+    template< typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1 >
     struct BSI_Impl;
 
     /** Barrier Suppression Ionization - Hydrogen-Like
@@ -60,11 +60,11 @@ namespace ionization
      * first specialization of the ionization model in the particle definition
      * \see speciesDefinition.param
      */
-    template<typename T_DestSpecies>
+    template< typename T_DestSpecies >
     struct BSI
     {
-        typedef particles::ionization::AlgorithmBSI IonizationAlgorithm;
-        typedef BSI_Impl<IonizationAlgorithm, T_DestSpecies> type;
+        using IonizationAlgorithm = particles::ionization::AlgorithmBSI;
+        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies >;
     };
 
     /** Barrier Suppression Ionization - Effective Atomic Numbers
@@ -77,11 +77,11 @@ namespace ionization
      *
      * \tparam T_DestSpecies electron species to be created
      */
-    template<typename T_DestSpecies>
+    template< typename T_DestSpecies >
     struct BSIEffectiveZ
     {
-        typedef particles::ionization::AlgorithmBSIEffectiveZ IonizationAlgorithm;
-        typedef BSI_Impl<IonizationAlgorithm, T_DestSpecies> type;
+        using IonizationAlgorithm = particles::ionization::AlgorithmBSIEffectiveZ;
+        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies >;
     };
 
     /** Barrier Suppression Ionization - Ion. energies Stark-upshifted
@@ -95,11 +95,11 @@ namespace ionization
      *
      * \tparam T_DestSpecies electron species to be created
      */
-    template<typename T_DestSpecies>
+    template< typename T_DestSpecies >
     struct BSIStarkShifted
     {
-        typedef particles::ionization::AlgorithmBSIStarkShifted IonizationAlgorithm;
-        typedef BSI_Impl<IonizationAlgorithm, T_DestSpecies> type;
+        using IonizationAlgorithm = particles::ionization::AlgorithmBSIStarkShifted;
+        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies >;
     };
 
 } // namespace ionization

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -57,10 +57,10 @@ namespace ionization
     struct BSI_Impl
     {
 
-        typedef T_DestSpecies DestSpecies;
-        typedef T_SrcSpecies  SrcSpecies;
+        using DestSpecies = T_DestSpecies;
+        using SrcSpecies = T_SrcSpecies;
 
-        typedef typename SrcSpecies::FrameType FrameType;
+        using FrameType = typename SrcSpecies::FrameType;
 
         /* specify field to particle interpolation scheme */
         typedef typename pmacc::traits::Resolve<
@@ -83,11 +83,11 @@ namespace ionization
         private:
 
             /* define ionization ALGORITHM (calculation) for ionization MODEL */
-            typedef T_IonizationAlgorithm IonizationAlgorithm;
+            using IonizationAlgorithm = T_IonizationAlgorithm;
 
             typedef MappingDesc::SuperCellSize TVec;
 
-            typedef FieldE::ValueType ValueType_E;
+            using ValueType_E = FieldE::ValueType;
             /* global memory EM-field device databoxes */
             FieldE::DataBoxType eBox;
             /* shared memory EM-field device databoxes */

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
@@ -61,8 +61,8 @@ namespace ionization
     template<typename T_DestSpecies>
     struct Keldysh
     {
-        typedef particles::ionization::AlgorithmKeldysh IonizationAlgorithm;
-        typedef Keldysh_Impl<IonizationAlgorithm, T_DestSpecies> type;
+        using IonizationAlgorithm = particles::ionization::AlgorithmKeldysh;
+        using type = Keldysh_Impl< IonizationAlgorithm, T_DestSpecies >;
     };
 
 } // namespace ionization

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -73,10 +73,10 @@ namespace ionization
     struct Keldysh_Impl
     {
 
-        typedef T_DestSpecies DestSpecies;
-        typedef T_SrcSpecies  SrcSpecies;
+        using DestSpecies = T_DestSpecies;
+        using SrcSpecies = T_SrcSpecies;
 
-        typedef typename SrcSpecies::FrameType FrameType;
+        using FrameType = typename SrcSpecies::FrameType;
 
         /* specify field to particle interpolation scheme */
         typedef typename pmacc::traits::Resolve<
@@ -99,7 +99,7 @@ namespace ionization
         private:
 
             /* define ionization ALGORITHM (calculation) for ionization MODEL */
-            typedef T_IonizationAlgorithm IonizationAlgorithm;
+            using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
             typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::AlpakaRand< cupla::Acc>> RNGFactory;
@@ -109,8 +109,8 @@ namespace ionization
 
             typedef MappingDesc::SuperCellSize TVec;
 
-            typedef FieldE::ValueType ValueType_E;
-            typedef FieldB::ValueType ValueType_B;
+            using ValueType_E = FieldE::ValueType;
+            using ValueType_B = FieldB::ValueType;
             /* global memory EM-field device databoxes */
             PMACC_ALIGN(eBox, FieldE::DataBoxType);
             PMACC_ALIGN(bBox, FieldB::DataBoxType);

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -56,7 +56,7 @@ namespace particleToGrid
     {
     public:
 
-        typedef typename T_ParticleShape::ChargeAssignment AssignmentFunction;
+        using AssignmentFunction = typename T_ParticleShape::ChargeAssignment;
         static constexpr int supp = AssignmentFunction::support;
 
         static constexpr int lowerMargin = supp / 2;

--- a/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -117,17 +117,17 @@ struct Push
   {
 
     // alias for types to  follow coding guide line
-    typedef T_Var VariableType;
-    typedef T_Time TimeType;
-    typedef T_FieldEFunc EFieldFuncType;
-    typedef T_FieldBFunc BFieldFuncType;
-    typedef T_Pos PositionType;
-    typedef T_Mom MomentumType;
-    typedef T_Mass MassType;
-    typedef T_Charge ChargeType;
-    typedef T_Weighting WeightingType;
-    typedef T_Velocity VelocityType;
-    typedef T_Gamma GammaType;
+    using VariableType = T_Var;
+    using TimeType = T_Time;
+    using EFieldFuncType = T_FieldEFunc;
+    using BFieldFuncType = T_FieldBFunc;
+    using PositionType = T_Pos;
+    using MomentumType = T_Mom;
+    using MassType = T_Mass;
+    using ChargeType = T_Charge;
+    using WeightingType = T_Weighting;
+    using VelocityType = T_Velocity;
+    using GammaType = T_Gamma;
 
 
     HDINLINE DiffEquation(EFieldFuncType funcE, BFieldFuncType funcB, MassType m, ChargeType q, WeightingType w)

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -43,7 +43,7 @@ struct CIC
 
 struct CIC : public shared_CIC::CIC
 {
-    typedef picongpu::particles::shapes::NGP CloudShape;
+    using CloudShape = picongpu::particles::shapes::NGP;
 
     struct ChargeAssignment : public shared_CIC::CIC
     {

--- a/include/picongpu/particles/shapes/P4S.hpp
+++ b/include/picongpu/particles/shapes/P4S.hpp
@@ -86,7 +86,7 @@ struct P4S
  */
 struct P4S : public shared_P4S::P4S
 {
-    typedef picongpu::particles::shapes::PCS CloudShape;
+    using CloudShape = picongpu::particles::shapes::PCS;
 
     struct ChargeAssignmentOnSupport : public shared_P4S::P4S
     {

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -60,7 +60,7 @@ struct PCS
 } //namespace shared_PCS
 struct PCS : public shared_PCS::PCS
 {
-    typedef  picongpu::particles::shapes::TSC CloudShape;
+    using CloudShape = picongpu::particles::shapes::TSC;
 
     struct ChargeAssignment : public shared_PCS::PCS
     {

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -65,7 +65,7 @@ struct TSC
 
 struct TSC : public shared_TSC::TSC
 {
-    typedef  picongpu::particles::shapes::CIC CloudShape;
+    using CloudShape = picongpu::particles::shapes::CIC;
 
     struct ChargeAssignment : public shared_TSC::TSC
     {

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -70,10 +70,10 @@ namespace synchrotronPhotons
 template<typename T_ElectronSpecies, typename T_PhotonSpecies>
 struct PhotonCreator
 {
-    typedef T_ElectronSpecies ElectronSpecies;
-    typedef T_PhotonSpecies PhotonSpecies;
+    using ElectronSpecies = T_ElectronSpecies;
+    using PhotonSpecies = T_PhotonSpecies;
 
-    typedef typename ElectronSpecies::FrameType FrameType;
+    using FrameType = typename ElectronSpecies::FrameType;
 
     /* specify field to particle interpolation scheme */
     typedef typename pmacc::particles::traits::ResolveAliasFromSpecies<
@@ -96,8 +96,8 @@ struct PhotonCreator
 
     typedef MappingDesc::SuperCellSize TVec;
 
-    typedef FieldE::ValueType ValueType_E;
-    typedef FieldB::ValueType ValueType_B;
+    using ValueType_E = FieldE::ValueType;
+    using ValueType_B = FieldB::ValueType;
 
 private:
     /* global memory EM-field device databoxes */

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -49,7 +49,7 @@ struct MapToLookupTable
         ::pmacc::cursor::tools::LinearInterp<float_X>,
         ::pmacc::cursor::BufferCursor<float_X, DIM1> >::type LinInterpCursor;
 
-    typedef float_X type;
+    using type = float_X;
 
     LinInterpCursor linInterpCursor;
 
@@ -83,7 +83,7 @@ typedef ::pmacc::cursor::Cursor<
 class SynchrotronFunctions
 {
 public:
-    typedef detail::SyncFuncCursor SyncFuncCursor;
+    using SyncFuncCursor = detail::SyncFuncCursor;
 private:
 
     typedef boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM1> > MyBuf;

--- a/include/picongpu/particles/traits/GetAtomicNumbers.hpp
+++ b/include/picongpu/particles/traits/GetAtomicNumbers.hpp
@@ -32,7 +32,7 @@ namespace traits
 template<typename T_Species>
 struct GetAtomicNumbers
 {
-    typedef typename T_Species::FrameType FrameType;
+    using FrameType = typename T_Species::FrameType;
 
     typedef typename HasFlag<FrameType, atomicNumbers<> >::type hasAtomicNumbers;
     /* throw static assert if species has no protons or neutrons */

--- a/include/picongpu/particles/traits/GetDensityRatio.hpp
+++ b/include/picongpu/particles/traits/GetDensityRatio.hpp
@@ -47,7 +47,7 @@ namespace detail
 template<typename T_Species>
 struct GetDensityRatio
 {
-    typedef typename T_Species::FrameType FrameType;
+    using FrameType = typename T_Species::FrameType;
     typedef typename HasFlag<FrameType, densityRatio<> >::type hasDensityRatio;
     typedef typename pmacc::traits::Resolve<
         typename GetFlagType<

--- a/include/picongpu/particles/traits/GetIonizationEnergies.hpp
+++ b/include/picongpu/particles/traits/GetIonizationEnergies.hpp
@@ -32,8 +32,8 @@ namespace traits
 template<typename T_Species>
 struct GetIonizationEnergies
 {
-    typedef T_Species SpeciesType;
-    typedef typename SpeciesType::FrameType FrameType;
+    using SpeciesType = T_Species;
+    using FrameType = typename SpeciesType::FrameType;
 
     typedef typename HasFlag<FrameType, ionizationEnergies<> >::type hasIonizationEnergies;
     /* throw static assert if species has no protons or neutrons */

--- a/include/picongpu/particles/traits/GetMarginPusher.hpp
+++ b/include/picongpu/particles/traits/GetMarginPusher.hpp
@@ -49,13 +49,13 @@ struct GetMarginPusher
 template<typename T_Species>
 struct GetLowerMarginPusher
 {
-    typedef typename traits::GetMarginPusher<T_Species>::LowerMargin type;
+    using type = typename traits::GetMarginPusher<T_Species>::LowerMargin;
 };
 
 template<typename T_Species>
 struct GetUpperMarginPusher
 {
-    typedef typename traits::GetMarginPusher<T_Species>::UpperMargin type;
+    using type = typename traits::GetMarginPusher<T_Species>::UpperMargin;
 };
 
 }// namespace traits

--- a/include/picongpu/particles/traits/GetPhotonCreator.hpp
+++ b/include/picongpu/particles/traits/GetPhotonCreator.hpp
@@ -37,8 +37,8 @@ namespace traits
 template<typename T_SpeciesType>
 struct GetPhotonCreator
 {
-    typedef T_SpeciesType SpeciesType;
-    typedef typename SpeciesType::FrameType FrameType;
+    using SpeciesType = T_SpeciesType;
+    using FrameType = typename SpeciesType::FrameType;
 
     /* The following line only fetches the alias */
     typedef typename GetFlagType<FrameType, picongpu::synchrotronPhotons<> >::type FoundSynchrotronPhotonsAlias;

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -541,7 +541,7 @@ private:
 
         if (writeToFile)
         {
-            typedef std::numeric_limits< float_64 > dbl;
+            using dbl = std::numeric_limits<float_64>;
 
             outFile.precision(dbl::digits10);
 

--- a/include/picongpu/plugins/ChargeConservation.hpp
+++ b/include/picongpu/plugins/ChargeConservation.hpp
@@ -54,7 +54,7 @@ private:
     MappingDesc* cellDescription;
     std::ofstream output_file;
 
-    typedef boost::shared_ptr<pmacc::algorithm::mpi::Reduce<simDim> > AllGPU_reduce;
+    using AllGPU_reduce = boost::shared_ptr<pmacc::algorithm::mpi::Reduce<simDim> >;
     AllGPU_reduce allGPU_reduce;
 
     void restart(uint32_t restartStep, const std::string restartDirectory);

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -134,7 +134,7 @@ struct Div;
 template<typename ValueType>
 struct Div<DIM3, ValueType>
 {
-    typedef ValueType result_type;
+    using result_type = ValueType;
 
     template<typename Field>
     HDINLINE ValueType operator()(Field field) const
@@ -151,7 +151,7 @@ struct Div<DIM3, ValueType>
 template<typename ValueType>
 struct Div<DIM2, ValueType>
 {
-    typedef ValueType result_type;
+    using result_type = ValueType;
 
     template<typename Field>
     HDINLINE ValueType operator()(Field field) const
@@ -167,7 +167,7 @@ struct Div<DIM2, ValueType>
 template<typename T_SpeciesName, typename T_Area>
 struct ComputeChargeDensity
 {
-    typedef typename T_SpeciesName::type SpeciesName;
+    using SpeciesName = typename T_SpeciesName::type;
     static const uint32_t area = T_Area::value;
 
     HINLINE void operator()( FieldTmp* fieldTmp,

--- a/include/picongpu/plugins/EnergyFields.hpp
+++ b/include/picongpu/plugins/EnergyFields.hpp
@@ -66,7 +66,7 @@ struct cast64Bit
 template<typename T_Type>
 struct squareComponentWise
 {
-    typedef T_Type result;
+    using result = T_Type;
 
     HDINLINE result operator()(const T_Type& value) const
     {
@@ -242,7 +242,7 @@ private:
 
         if (writeToFile)
         {
-            typedef std::numeric_limits< float_64 > dbl;
+            using dbl = std::numeric_limits<float_64>;
 
             outFile.precision(dbl::digits10);
             outFile << currentStep << " " << std::scientific << globalEnergy * UNIT_ENERGY << " "
@@ -259,7 +259,7 @@ private:
         /*define stacked DataBox's for reduce algorithm*/
         typedef DataBoxUnaryTransform<typename T_Field::DataBoxType, energyFields::squareComponentWise > TransformedBox;
         typedef DataBoxUnaryTransform<TransformedBox, energyFields::cast64Bit > Box64bit;
-        typedef DataBoxDim1Access<Box64bit > D1Box;
+        using D1Box = DataBoxDim1Access<Box64bit>;
 
         /* reduce field E*/
         DataSpace<simDim> fieldSize = field->getGridLayout().getDataSpaceWithoutGuarding();

--- a/include/picongpu/plugins/PositionsParticles.hpp
+++ b/include/picongpu/plugins/PositionsParticles.hpp
@@ -85,7 +85,7 @@ struct SglParticle
         const float_64 mass = precisionCast<float_64>(v.mass) * UNIT_MASS;
         const float_64 charge = precisionCast<float_64>(v.charge) * UNIT_CHARGE;
 
-        typedef std::numeric_limits< float_64 > dbl;
+        using dbl = std::numeric_limits<float_64>;
         out.precision(dbl::digits10);
 
         out << std::scientific << pos << " " << mom << " " << mass << " "
@@ -115,11 +115,11 @@ struct KernelPositionsParticles
     ) const
     {
 
-        typedef typename ParBox::FramePtr FramePtr;
+        using FramePtr = typename ParBox::FramePtr;
         PMACC_SMEM( acc, frame, FramePtr );
 
 
-        typedef typename Mapping::SuperCellSize SuperCellSize;
+        using SuperCellSize = typename Mapping::SuperCellSize;
 
         const DataSpace<simDim > threadIndex(threadIdx);
         const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -39,7 +39,7 @@ using namespace pmacc;
 
 namespace po = boost::program_options;
 
-typedef FieldJ::DataBoxType J_DataBox;
+using J_DataBox = FieldJ::DataBoxType;
 
 struct KernelSumCurrents
 {
@@ -54,7 +54,7 @@ struct KernelSumCurrents
         Mapping mapper
     ) const
     {
-        typedef typename Mapping::SuperCellSize SuperCellSize;
+        using SuperCellSize = typename Mapping::SuperCellSize;
 
         PMACC_SMEM( acc, sh_sumJ, float3_X );
 
@@ -136,7 +136,7 @@ public:
                                  float_64(realCurrent.z()) * (UNIT_CHARGE / UNIT_TIME));
 
         /*FORMAT OUTPUT*/
-        typedef std::numeric_limits< float_64 > dbl;
+        using dbl = std::numeric_limits<float_64>;
 
         std::cout.precision(dbl::digits10);
         if (math::abs(gCurrent.x()) + math::abs(gCurrent.y()) + math::abs(gCurrent.z()) != float_X(0.0))

--- a/include/picongpu/plugins/output/GatherSlice.hpp
+++ b/include/picongpu/plugins/output/GatherSlice.hpp
@@ -114,7 +114,7 @@ struct GatherSlice
     template<class Box >
     Box operator()(Box & data, const MessageHeader & header)
     {
-        typedef typename Box::ValueType ValueType;
+        using ValueType = typename Box::ValueType;
 
         Box dstBox = Box(PitchedBox<ValueType, DIM2 > (
                                                        (ValueType*) filteredData,

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -831,8 +831,8 @@ private:
 
 
 public:
-    typedef typename ParticlesType::FrameType FrameType;
-    typedef Output CreatorType;
+    using FrameType = typename ParticlesType::FrameType;
+    using CreatorType = Output;
 
     Visualisation(std::string name, Output output, uint32_t notifyPeriod, DataSpace<DIM2> transpose, float_X slicePoint) :
     m_output(output),

--- a/include/picongpu/simulation_types.hpp
+++ b/include/picongpu/simulation_types.hpp
@@ -56,12 +56,12 @@ enum FieldType
 
 namespace precision32Bit
 {
-typedef float precisionType;
+using precisionType = float;
 }
 
 namespace precision64Bit
 {
-typedef double precisionType;
+using precisionType = double;
 }
 
 namespace math = pmacc::algorithms::math;

--- a/include/picongpu/traits/GetMargin.hpp
+++ b/include/picongpu/traits/GetMargin.hpp
@@ -38,8 +38,8 @@ namespace traits
 template<class Solver,unsigned int SubSetName=0>
 struct GetMargin
 {
-    typedef typename Solver::LowerMargin LowerMargin;
-    typedef typename Solver::UpperMargin UpperMargin;
+    using LowerMargin = typename Solver::LowerMargin;
+    using UpperMargin = typename Solver::UpperMargin;
 };
 
 template<typename T_Type>

--- a/include/picongpu/traits/attribute/GetCharge.hpp
+++ b/include/picongpu/traits/attribute/GetCharge.hpp
@@ -96,7 +96,7 @@ struct LoadBoundElectrons<false>
 template<typename T_Particle>
 HDINLINE float_X getCharge(const float_X weighting, const T_Particle& particle)
 {
-    typedef T_Particle ParticleType;
+    using ParticleType = T_Particle;
     typedef typename pmacc::traits::HasIdentifier<ParticleType, boundElectrons>::type hasBoundElectrons;
     return detail::LoadBoundElectrons<hasBoundElectrons::value >()(
         weighting,

--- a/include/picongpu/traits/attribute/GetChargeState.hpp
+++ b/include/picongpu/traits/attribute/GetChargeState.hpp
@@ -89,7 +89,7 @@ struct LoadChargeState<false>
 template<typename T_Particle>
 HDINLINE float_X getChargeState(const T_Particle& particle)
 {
-    typedef T_Particle ParticleType;
+    using ParticleType = T_Particle;
     typedef typename pmacc::traits::HasIdentifier<ParticleType, boundElectrons>::type hasBoundElectrons;
     return detail::LoadChargeState<hasBoundElectrons::value >()(particle);
 }

--- a/include/picongpu/traits/attribute/GetMass.hpp
+++ b/include/picongpu/traits/attribute/GetMass.hpp
@@ -39,7 +39,7 @@ namespace attribute
 template<typename T_Particle>
 HDINLINE float_X getMass(const float_X weighting, const T_Particle& particle)
 {
-    typedef T_Particle ParticleType;
+    using ParticleType = T_Particle;
     return frame::getMass<typename ParticleType::FrameType > () * weighting;
 }
 


### PR DESCRIPTION
Experimented with
```bash
  clang-tidy -checks='-*,modernize-use-using' -fix -fix-errors
```
(see #2303).

and controlled the output. Where applicable and correct, added the transformed file for conversion to C++11 `using`. This is a partial replacement, catching about 1/3rd of the `typedef`s in `include/picongpu/`.

Commited as generic tools "author":
```bash
  git add -p
  # checked manually

  GIT_AUTHOR_NAME="Tools" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" git commit
```