### PR TITLE
[Hotfix] CMake is too accurate

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CMAKE_CXX_STANDARD 11)
 
 get_filename_component(SOURCE_DIR_ROOT ${PIConGPU_SOURCE_DIR}/../.. ABSOLUTE)
 string(FIND "${PIConGPU_BINARY_DIR}"
-            "${SOURCE_DIR_ROOT}" IN_SRC_POS)
+            "${SOURCE_DIR_ROOT}/" IN_SRC_POS)
 if(IN_SRC_POS GREATER -1)
   message(FATAL_ERROR
     "PICoNGPU requires an out of source build. "


### PR DESCRIPTION
The check should prevent in-source-builds. If your source directory is picongpu and the build directory is picongpu_build, this check throws an error. But this isn't an error. To prevent this, I add a /. This should be correct because SOURCE_DIR_ROOT is a file (It is the result of get_filename_component(...) ). I checked it and get no error with the directory names picongpu and picongpu_build. The directory picongpu/build throws an error message.