### PR TITLE
refactor particle manipulators/filter/startPosition

### DIFF
--- a/include/picongpu/particles/filter/IUnary.def
+++ b/include/picongpu/particles/filter/IUnary.def
@@ -1,4 +1,4 @@
-/* Copyright 2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -19,6 +19,31 @@
 
 #pragma once
 
+#include <pmacc/functor/Filtered.hpp>
+#include <pmacc/functor/Interface.hpp>
+#include <pmacc/filter/Interface.hpp>
+#include "picongpu/particles/filter/filter.def"
+#include <pmacc/filter/operators/And.hpp>
 
-#include "picongpu/particles/filter/RelativeGlobalDomainPosition.hpp"
-#include "picongpu/particles/filter/All.hpp"
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+
+    /** interface for a unary particle filter
+     *
+     * @tparam T_UnaryFilter unary particle filter must contain `bool operator()(P && particle)`
+     */
+    template<
+        typename T_UnaryFilter
+    >
+    using IUnary = pmacc::filter::Interface<
+        T_UnaryFilter,
+        1u
+    >;
+
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/filter/filter.def
+++ b/include/picongpu/particles/filter/filter.def
@@ -19,5 +19,8 @@
 
 #pragma once
 
+
+#include "picongpu/particles/filter/IUnary.def"
+
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.def"
 #include "picongpu/particles/filter/All.def"

--- a/include/picongpu/particles/filter/filter.def
+++ b/include/picongpu/particles/filter/filter.def
@@ -19,7 +19,6 @@
 
 #pragma once
 
-
 #include "picongpu/particles/filter/IUnary.def"
 
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.def"

--- a/include/picongpu/particles/filter/filter.hpp
+++ b/include/picongpu/particles/filter/filter.hpp
@@ -19,6 +19,5 @@
 
 #pragma once
 
-
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.hpp"
 #include "picongpu/particles/filter/All.hpp"

--- a/include/picongpu/particles/functor/User.def
+++ b/include/picongpu/particles/functor/User.def
@@ -17,8 +17,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
 
 namespace picongpu
 {

--- a/include/picongpu/particles/functor/User.def
+++ b/include/picongpu/particles/functor/User.def
@@ -1,0 +1,41 @@
+/* Copyright 2015-2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace functor
+{
+
+    /** call simple free user defined functor
+     *
+     * @tparam T_Functor user defined functor
+     *                   **optional**: can implement **one** host side constructor
+     *                   `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
+     */
+    template< typename T_Functor >
+    struct User;
+
+} // namespace functor
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/functor/User.hpp
+++ b/include/picongpu/particles/functor/User.hpp
@@ -1,0 +1,83 @@
+/* Copyright 2013-2017 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <utility>
+#include <type_traits>
+
+namespace picongpu
+{
+namespace particles
+{
+namespace functor
+{
+template< typename T_Functor >
+    struct User : public T_Functor
+    {
+
+        using Functor = T_Functor;
+
+        /** constructor
+         *
+         * This constructor is only compiled if the user functor has
+         * a host side constructor with one (uint32_t) argument.
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                      the constructor
+         * @param currentStep current simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = Functor >
+        HINLINE User(
+            uint32_t currentStep,
+            typename std::enable_if<
+                std::is_constructible<
+                    DeferFunctor,
+                    uint32_t
+                >::value
+            >::type* = 0
+        ) : Functor( currentStep )
+        {
+        }
+
+        /** constructor
+         *
+         * This constructor is only compiled if the user functor has a default constructor.
+         *
+         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
+         *                      the constructor
+         * @param current simulation time step
+         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
+         */
+        template< typename DeferFunctor = Functor >
+        HINLINE User(
+            uint32_t,
+            typename std::enable_if<
+                std::is_constructible< DeferFunctor >::value
+            >::type* = 0
+        ) : Functor( )
+        {
+        }
+    };
+} // namespace functor
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/functor/User.hpp
+++ b/include/picongpu/particles/functor/User.hpp
@@ -24,13 +24,14 @@
 #include <utility>
 #include <type_traits>
 
+
 namespace picongpu
 {
 namespace particles
 {
 namespace functor
 {
-template< typename T_Functor >
+    template< typename T_Functor >
     struct User : public T_Functor
     {
 

--- a/include/picongpu/particles/functor/functor.def
+++ b/include/picongpu/particles/functor/functor.def
@@ -1,0 +1,24 @@
+/* Copyright 2014-2017 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include "picongpu/particles/functor/User.def"
+#include "picongpu/particles/misc/generic/Rng.def"

--- a/include/picongpu/particles/functor/functor.def
+++ b/include/picongpu/particles/functor/functor.def
@@ -19,6 +19,5 @@
 
 #pragma once
 
-
 #include "picongpu/particles/functor/User.def"
 #include "picongpu/particles/misc/generic/Rng.def"

--- a/include/picongpu/particles/functor/functor.hpp
+++ b/include/picongpu/particles/functor/functor.hpp
@@ -19,6 +19,5 @@
 
 #pragma once
 
-
 #include "picongpu/particles/functor/User.hpp"
 #include "picongpu/particles/misc/generic/Rng.hpp"

--- a/include/picongpu/particles/functor/functor.hpp
+++ b/include/picongpu/particles/functor/functor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2017 Rene Widera
+/* Copyright 2014-2017 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -19,35 +19,6 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
 
-#include <boost/mpl/integral_c.hpp>
-#include <boost/mpl/placeholders.hpp>
-
-
-namespace picongpu
-{
-namespace particles
-{
-namespace manipulators
-{
-namespace generic
-{
-namespace detail
-{
-
-    template<
-        typename T_Distribution,
-        typename T_Seed = boost::mpl::integral_c<
-            size_t,
-            FREERNG_SEED
-        >,
-        typename T_SpeciesType = boost::mpl::_1
-    >
-    struct Rng;
-
-} // namespace detail
-} // namespace generic
-} // namespace manipulators
-} // namespace particles
-} // namespace picongpu
+#include "picongpu/particles/functor/User.hpp"
+#include "picongpu/particles/misc/generic/Rng.hpp"

--- a/include/picongpu/particles/functor/misc/Rng.def
+++ b/include/picongpu/particles/functor/misc/Rng.def
@@ -1,0 +1,57 @@
+/* Copyright 2015-2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <boost/mpl/integral_c.hpp>
+#include <boost/mpl/placeholders.hpp>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace functor
+{
+namespace misc
+{
+
+    /** provide a random number generator
+     *
+     * @tparam T_Distribution random number distribution
+     * @tparam T_Seed seed to initialize the random number generator
+     * @tparam T_SpeciesType type of the species that shall be manipulated
+     *
+     */
+    template<
+        typename T_Distribution,
+        typename T_Seed = boost::mpl::integral_c<
+            size_t,
+            FREERNG_SEED
+        >,
+        typename T_SpeciesType = boost::mpl::_1
+    >
+    struct Rng;
+
+} // namespace misc
+} // namespace functor
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -34,11 +34,9 @@ namespace picongpu
 {
 namespace particles
 {
-namespace manipulators
+namespace functor
 {
-namespace generic
-{
-namespace detail
+namespace misc
 {
     /** call simple free user defined functor and provide a random number generator
      *
@@ -155,8 +153,7 @@ namespace detail
         uint32_t seed;
     };
 
-} // namespace detail
-} // namepsace generic
-} // namespace manipulators
+} // namepsace misc
+} // namespace functor
 } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/manipulators/generic/Free.def
+++ b/include/picongpu/particles/manipulators/generic/Free.def
@@ -29,11 +29,29 @@ namespace manipulators
 namespace generic
 {
 
-    /** call simple free user defined functor
+    /** call simple free user defined manipulators
      *
-     * @tparam T_Functor user defined functor
+     * @tparam T_Functor user defined manipulators
      *                   **optional**: can implement **one** host side constructor
      *                   `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
+     *
+     * example: set in cell position to zero
+     *   @code{.cpp}
+     *
+     *   struct FunctorInCellPositionZero
+     *   {
+     *       template< typename T_Particle >
+     *       HDINLINE void operator()( T_Particle & particle )
+     *       {
+     *           particle[ position_ ] = floatD_X::create( 0.0 );
+     *       }
+     *       static constexpr char const * name = "InCellPositionZero";
+     *   };
+     *
+     *   using InCellPositionZero = Free<
+     *      FunctorInCellPositionZero
+     *   >;
+     *   @endcode
      */
     template< typename T_Functor >
     struct Free;

--- a/include/picongpu/particles/manipulators/generic/FreeRng.def
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.def
@@ -19,6 +19,7 @@
 
 #pragma once
 
+
 #include "picongpu/simulation_defines.hpp"
 
 #include <boost/mpl/integral_c.hpp>
@@ -53,6 +54,7 @@ namespace generic
      *       {
      *           particle[ position_ ].x() = rng();
      *       }
+     *       static constexpr char const * name = "RandomXPos";
      *   };
      *
      *   using RandomXPos = FreeRng<
@@ -74,7 +76,7 @@ namespace generic
     >
     struct FreeRng;
 
-} // namespace generic
+} // namepsace generic
 } // namespace manipulators
 } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/manipulators/generic/FreeRng.def
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.def
@@ -19,7 +19,6 @@
 
 #pragma once
 
-
 #include "picongpu/simulation_defines.hpp"
 
 #include <boost/mpl/integral_c.hpp>
@@ -76,7 +75,7 @@ namespace generic
     >
     struct FreeRng;
 
-} // namepsace generic
+} // namespace generic
 } // namespace manipulators
 } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -21,7 +21,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/particles/manipulators/generic/FreeRng.def"
-#include "picongpu/particles/manipulators/generic/detail/Rng.hpp"
+#include "picongpu/particles/functor/misc/Rng.hpp"
+#include "picongpu/particles/functor/User.hpp"
 
 #include <utility>
 #include <type_traits>
@@ -102,14 +103,14 @@ namespace acc
         typename T_SpeciesType
     >
     struct FreeRng :
-        protected T_Functor,
-        private detail::Rng<
+    protected functor::User< T_Functor >,
+        private picongpu::particles::functor::misc::Rng<
             T_Distribution,
             T_Seed,
             T_SpeciesType
         >
     {
-        using RngGenerator = detail::Rng<
+        using RngGenerator = picongpu::particles::functor::misc::Rng<
             T_Distribution,
             T_Seed,
             T_SpeciesType
@@ -118,52 +119,16 @@ namespace acc
         template< typename T_Acc >
         using RngType = typename RngGenerator::template RngType< T_Acc >;
 
-        using Functor = T_Functor;
+        using Functor = functor::User< T_Functor >;
         using Distribution = T_Distribution;
         using SpeciesType = T_SpeciesType;
 
         /** constructor
          *
-         * This constructor is only compiled if the user functor has
-         * a host side constructor with one (uint32_t) argument.
-         *
-         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
-         *                      the constructor
          * @param currentStep current simulation time step
-         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
          */
-        template< typename DeferFunctor = Functor >
-        HINLINE FreeRng(
-            uint32_t currentStep,
-            typename std::enable_if<
-                std::is_constructible<
-                    DeferFunctor,
-                    uint32_t
-                >::value
-            >::type* = 0
-        ) :
+        HINLINE FreeRng( uint32_t currentStep ) :
             Functor( currentStep ),
-            RngGenerator( currentStep )
-        {
-        }
-
-        /** constructor
-         *
-         * This constructor is only compiled if the user functor has a default constructor.
-         *
-         * @tparam DeferFunctor is used to defer the functor type evaluation to enable/disable
-         *                      the constructor
-         * @param currentStep simulation time step
-         * @param is used to enable/disable the constructor (do not pass any value to this parameter)
-         */
-        template< typename DeferFunctor = Functor >
-        HINLINE FreeRng(
-            uint32_t currentStep,
-            typename std::enable_if<
-                std::is_constructible< DeferFunctor >::value
-            >::type* = 0
-        ) :
-            Functor( ),
             RngGenerator( currentStep )
         {
         }
@@ -182,15 +147,16 @@ namespace acc
             typename T_WorkerCfg,
             typename T_Acc
         >
-        HDINLINE
-        acc::FreeRng<
-            Functor,
-            RngType< T_Acc >
-        > operator()(
+        HDINLINE auto
+        operator()(
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
         )
+        -> acc::FreeRng<
+            Functor,
+            RngType< T_Acc >
+        >
         {
             RngType< T_Acc > const rng = ( *static_cast< RngGenerator * >( this ) )(
                 acc,
@@ -207,10 +173,12 @@ namespace acc
             );
         }
 
+        static
         HINLINE std::string
-        getName( ) const
+        getName( )
         {
-            return std::string("FreeRNG");
+            // we provide the name from the param class
+            return Functor::name;
         }
     };
 

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -182,7 +182,7 @@ namespace acc
         }
     };
 
-} // namepsace generic
+} // namespace generic
 } // namespace manipulators
 } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/manipulators/generic/None.def
+++ b/include/picongpu/particles/manipulators/generic/None.def
@@ -19,8 +19,6 @@
 
 #pragma once
 
-#include "picongpu/particles/manipulators/generic/Free.def"
-
 
 namespace picongpu
 {
@@ -39,6 +37,8 @@ namespace acc
         operator( )( T_Args && ... )
         {
         }
+
+        static constexpr char const * name = "None";
     };
 } // namespace acc
 

--- a/include/picongpu/particles/manipulators/manipulators.hpp
+++ b/include/picongpu/particles/manipulators/manipulators.hpp
@@ -19,8 +19,6 @@
 
 #pragma once
 
-//#include "picongpu/particles/manipulators/IManipulator.hpp"
-
 #include "picongpu/particles/manipulators/generic/Free.hpp"
 #include "picongpu/particles/manipulators/generic/FreeRng.hpp"
 

--- a/include/picongpu/particles/startPosition/generic/FreeRng.def
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.def
@@ -53,7 +53,7 @@ namespace generic
     >
     struct FreeRng;
 
-} // namepsace generic
+} // namespace generic
 } // namespace startPosition
 } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -21,7 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/particles/startPosition/generic/FreeRng.def"
-#include "picongpu/particles/manipulators/generic/detail/Rng.hpp"
+#include "picongpu/particles/functor/misc/Rng.hpp"
 
 #include <utility>
 #include <type_traits>
@@ -110,13 +110,13 @@ namespace acc
     >
     struct FreeRng :
         protected T_Functor,
-        private picongpu::particles::manipulators::generic::detail::Rng<
+        private picongpu::particles::functor::misc::Rng<
             T_Distribution,
             T_Seed,
             T_SpeciesType
         >
     {
-        using RngGenerator = picongpu::particles::manipulators::generic::detail::Rng<
+        using RngGenerator = picongpu::particles::functor::misc::Rng<
             T_Distribution,
             T_Seed,
             T_SpeciesType
@@ -215,8 +215,9 @@ namespace acc
             );
         }
 
+        static
         HINLINE std::string
-        getName( ) const
+        getName( )
         {
             return std::string("FreeRNG");
         }

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -223,7 +223,7 @@ namespace acc
         }
     };
 
-} // namepsace generic
+} // namespace generic
 } // namespace startPosition
 } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -176,7 +176,9 @@ private:
         DataConnector &dc = Environment<>::get().DataConnector();
         auto particles = dc.get< ParticlesType >( ParticlesType::FrameType::getName(), true );
 
-        particles::filter::All parFilter{};
+        // enforce that the filter interface is fulfilled
+        particles::filter::IUnary< particles::filter::All > parFilter{ currentStep };
+        
         /*count local particles*/
         size = pmacc::CountParticles::countOnDevice<AREA>(*particles,
                                                           *cellDescription,

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -178,7 +178,7 @@ private:
 
         // enforce that the filter interface is fulfilled
         particles::filter::IUnary< particles::filter::All > parFilter{ currentStep };
-        
+
         /*count local particles*/
         size = pmacc::CountParticles::countOnDevice<AREA>(*particles,
                                                           *cellDescription,

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -551,6 +551,7 @@ namespace picongpu
                 plugins::misc::ExecuteIfNameIsEqual< bmpl::_1 >
             >{ }(
                 m_help->filter[ m_id ],
+                currentStep,
                 binaryKernel
             );
 

--- a/include/picongpu/plugins/ResourceLog.hpp
+++ b/include/picongpu/plugins/ResourceLog.hpp
@@ -116,7 +116,8 @@ namespace picongpu
 
             if(contains(propertyMap,"particleCount"))
             {
-                particles::filter::All parFilter{};
+                // enforce that the filter interface is fulfilled
+                particles::filter::IUnary< particles::filter::All > parFilter{ currentStep };
                 std::vector<size_t> particleCounts = resourceMonitor.getParticleCounts<VectorAllSpecies>(*cellDescription, parFilter );
                 pt.put("resourceLog.particleCount", std::accumulate(particleCounts.begin(), particleCounts.end(), 0));
             }

--- a/include/picongpu/plugins/adios/ADIOSCountParticles.hpp
+++ b/include/picongpu/plugins/adios/ADIOSCountParticles.hpp
@@ -102,7 +102,8 @@ public:
 
         /* load particle without copy particle data to host */
         auto speciesTmp = dc.get< ThisSpecies >( ThisSpecies::FrameType::getName(), true );
-        typename T_SpeciesFilter::Filter particleFilter{};
+        // enforce that the filter interface is fulfilled
+        particles::filter::IUnary< typename T_SpeciesFilter::Filter > particleFilter{ params->currentStep };
         /* count total number of particles on the device */
         uint64_cu totalNumParticles = 0;
         totalNumParticles = pmacc::CountParticles::countOnDevice < CORE + BORDER > (

--- a/include/picongpu/plugins/adios/WriteSpecies.hpp
+++ b/include/picongpu/plugins/adios/WriteSpecies.hpp
@@ -100,7 +100,8 @@ public:
 
         /* count total number of particles on the device */
         log<picLog::INPUT_OUTPUT > ("ADIOS:   (begin) count particles: %1%") % T_SpeciesFilter::getName();
-        typename T_SpeciesFilter::Filter particleFilter{};
+        // enforce that the filter interface is fulfilled
+        particles::filter::IUnary< typename T_SpeciesFilter::Filter > particleFilter{ params->currentStep };
         uint64_cu totalNumParticles = 0;
         totalNumParticles = pmacc::CountParticles::countOnDevice < CORE + BORDER > (
                                                                                     *speciesTmp,

--- a/include/picongpu/plugins/hdf5/WriteSpecies.hpp
+++ b/include/picongpu/plugins/hdf5/WriteSpecies.hpp
@@ -173,7 +173,8 @@ public:
 
         log<picLog::INPUT_OUTPUT > ("HDF5:  (begin) count particles: %1%") % T_SpeciesFilter::getName();
 
-        typename T_SpeciesFilter::Filter particleFilter{};
+        // enforce that the filter interface is fulfilled
+        particles::filter::IUnary< typename T_SpeciesFilter::Filter > particleFilter{ params->currentStep };
         /* at this point we cast to uint64_t, before we assume that per GPU
          * less then 1e9 (int range) particles will be counted
          */

--- a/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
+++ b/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
@@ -46,11 +46,12 @@ namespace misc
         >
         void operator( )(
             std::string filterName,
+            uint32_t const currentStep,
             T_Kernel const unaryFunctor
         ) const
         {
             if( filterName == T_Filter::getName( ) )
-                unaryFunctor( T_Filter{ } );
+                unaryFunctor( particles::filter::IUnary< T_Filter >{ currentStep } );
         }
     };
 } // namespace misc

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -99,9 +99,7 @@ namespace detail
         HDINLINE auto operator( )(
             T_Acc const & acc,
             T_Args && ... args )
-        -> decltype(
-            std::declval< UserFunctor >( )( acc, args ... )
-        )
+        -> T_ReturnType
         {
             /* check if the current used number of arguments to execute the
              * functor is equal to the interface requirements
@@ -239,10 +237,11 @@ namespace detail
          *
          * @return name to identify the functor
          */
+        static
         HINLINE std::string
-        getName( ) const
+        getName( )
         {
-            return ( *static_cast< UserFunctor * >( this ) ).getName( );
+            return UserFunctor::getName( );
         }
     };
 


### PR DESCRIPTION
# PIConGPU
- create functor folder
  - move `manipulators/generic/detail/Rng.*` to `functor/misc`
  - add functor `User` to reduce code duplication for the optional current step within the constructor
- filter: add `IUnary` interface for filter to secure the interfaces
- plugin: enforce in all plugins which uses filter that the interface is fulfilled
- manipulator:
  - update used dependency `Rng`
  - add documentation
  - set `getName()` static
  - use `misc::User` to initialize the user functor

# PMacc
- make `getName()` static to allow working with the name withou creating a instance
- remove return type detection (simplefy the code)
**Note:** There is no change in the algorithmic part of the methods.
