### PR TITLE
RNG with reduced state

### DIFF
--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -24,7 +24,7 @@
 #include "PhotonEmissionAngle.hpp"
 #include "picongpu/fields/FieldTmp.hpp"
 
-#include <pmacc/random/methods/AlpakaRand.hpp>
+#include <pmacc/random/methods/XorMin.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
@@ -100,7 +100,7 @@ private:
     PMACC_ALIGN(photonMom, float3_X);
 
     /* random number generator */
-    typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::AlpakaRand< cupla::Acc>> RNGFactory;
+    typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
     typedef pmacc::random::distributions::Uniform<float> Distribution;
     typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
     RandomGen randomGen;

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -28,7 +28,7 @@
 #include "picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def"
 #include "picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp"
 
-#include <pmacc/random/methods/AlpakaRand.hpp>
+#include <pmacc/random/methods/XorMin.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
@@ -111,7 +111,7 @@ namespace ionization
             using IonizationAlgorithm =  T_IonizationAlgorithm;
 
             /* random number generator */
-            using RNGFactory = pmacc::random::RNGProvider<simDim, pmacc::random::methods::AlpakaRand< cupla::Acc>>;
+            using RNGFactory = pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>>;
             using Distribution = pmacc::random::distributions::Uniform<float>;
             using RandomGen = typename RNGFactory::GetRandomType<Distribution>::type;
             RandomGen randomGen;

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -29,7 +29,7 @@
 #include "picongpu/particles/ionization/byField/ADK/ADK.def"
 #include "picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp"
 
-#include <pmacc/random/methods/AlpakaRand.hpp>
+#include <pmacc/random/methods/XorMin.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
@@ -101,7 +101,7 @@ namespace ionization
             using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
-            typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::AlpakaRand< cupla::Acc>> RNGFactory;
+            typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
             typedef pmacc::random::distributions::Uniform<float> Distribution;
             typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
             RandomGen randomGen;

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -28,7 +28,7 @@
 #include "picongpu/particles/ionization/byField/Keldysh/Keldysh.def"
 #include "picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp"
 
-#include <pmacc/random/methods/AlpakaRand.hpp>
+#include <pmacc/random/methods/XorMin.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
@@ -102,7 +102,7 @@ namespace ionization
             using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
-            typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::AlpakaRand< cupla::Acc>> RNGFactory;
+            typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
             typedef pmacc::random::distributions::Uniform<float> Distribution;
             typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
             RandomGen randomGen;

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -34,7 +34,7 @@
 #include "picongpu/fields/FieldB.hpp"
 #include "picongpu/fields/FieldE.hpp"
 
-#include <pmacc/random/methods/AlpakaRand.hpp>
+#include <pmacc/random/methods/XorMin.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
@@ -113,7 +113,7 @@ private:
     PMACC_ALIGN(photon_mom, float3_X);
 
     /* random number generator */
-    typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::AlpakaRand< cupla::Acc>> RNGFactory;
+    typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
     typedef pmacc::random::distributions::Uniform<float> Distribution;
     typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
     RandomGen randomGen;

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -55,7 +55,7 @@
 #include "picongpu/particles/manipulators/manipulators.hpp"
 #include "picongpu/particles/filter/filter.hpp"
 #include "picongpu/particles/flylite/NonLTE.tpp"
-#include <pmacc/random/methods/AlpakaRand.hpp>
+#include <pmacc/random/methods/XorMin.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
 #if( PMACC_CUDA_ENABLED == 1 )
@@ -326,7 +326,7 @@ public:
         )
         {
             // create factory for the random number generator
-            using RNGFactory = pmacc::random::RNGProvider< simDim, pmacc::random::methods::AlpakaRand< cupla::Acc> >;
+            using RNGFactory = pmacc::random::RNGProvider< simDim, pmacc::random::methods::XorMin< cupla::Acc> >;
             auto rngFactory = new RNGFactory( Environment<simDim>::get().SubGrid().getLocalDomain().size );
 
             // init and share random number generator

--- a/include/pmacc/random/distributions/normal/Normal_float.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_float.hpp
@@ -51,9 +51,10 @@ namespace detail
             StateType& state
         )
         {
-            return ::alpaka::rand::distribution::createNormalReal< result_type >(
-                acc
-            )( state );
+            return RNGMethod().getNormal(
+                acc,
+                state
+            );
         }
     };
 

--- a/include/pmacc/random/methods/AlpakaRand.hpp
+++ b/include/pmacc/random/methods/AlpakaRand.hpp
@@ -58,6 +58,23 @@ namespace methods
             );
         }
 
+        /** get a normal distributed random number
+         *
+         * @param acc alpaka accelerator
+         * @param state random number state
+         */
+        template< typename T_Type >
+        DINLINE T_Type
+        getNormal(
+            T_Acc const & acc,
+            StateType & state
+        ) const
+        {
+            return ::alpaka::rand::distribution::createNormalReal< T_Type >(
+                acc
+            )( state );
+        }
+
         DINLINE uint32_t
         get32Bits(
             T_Acc const & acc,

--- a/include/pmacc/random/methods/MRG32k3aMin.hpp
+++ b/include/pmacc/random/methods/MRG32k3aMin.hpp
@@ -1,0 +1,141 @@
+/* Copyright 2016-2017 Alexander Grund, Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+#include "pmacc/static_assert.hpp"
+
+#if( PMACC_CUDA_ENABLED != 1 )
+#   include "pmacc/random/methods/AlpakaRand.hpp"
+#else
+#   include <curand_kernel.h>
+#endif
+
+
+namespace pmacc
+{
+namespace random
+{
+namespace methods
+{
+
+#if( PMACC_CUDA_ENABLED != 1 )
+    //! fallback to alpaka RNG if a cpu accelerator is used
+    template< typename T_Acc >
+    using MRG32k3aMin = AlpakaRand< T_Acc >;
+#else
+    //! Mersenne-Twister random number generator with a reduced state
+    template< typename T_Acc >
+    class MRG32k3aMin
+    {
+    public:
+        struct StateType
+        {
+            double s1[3];
+            double s2[3];
+        };
+
+        DINLINE void
+        init(
+            T_Acc const & acc,
+            StateType & state,
+            uint32_t seed,
+            uint32_t subsequence = 0
+        ) const
+        {
+            curandStateMRG32k3a tmpState;
+            curand_init(
+                seed,
+                subsequence,
+                0,
+                &tmpState
+            );
+            AssignState(state, tmpState);
+        }
+
+        DINLINE uint32_t
+        get32Bits(
+            T_Acc const & acc,
+            StateType& state
+        ) const
+        {
+            /* We can do this cast if: 1) Only state data is used and
+             *                         2) Data is aligned and positioned the same way
+             */
+            return curand( reinterpret_cast< curandStateMRG32k3a* >( &state ) );
+        }
+
+        /** get a normal distributed random number
+         *
+         * @param acc alpaka accelerator
+         * @param state random number state
+         */
+        template< typename T_Type >
+        DINLINE T_Type
+        getNormal(
+            T_Acc const & acc,
+            StateType& state
+        ) const
+        {
+            PMACC_CASSERT_MSG(
+                __MRG32k3aMin_random_number_with_normal_distribution_is_not_supported,
+                false
+            );
+            return T_Type{};
+        }
+
+        static std::string
+        getName()
+        {
+            return "MRG32k3aMin";
+        }
+
+    private:
+        // Sizes must match
+        PMACC_STATIC_ASSERT_MSG(
+            sizeof( StateType::s1 ) == sizeof( curandStateMRG32k3a::s1 ),
+            Unexpected_sizes
+        );
+        PMACC_STATIC_ASSERT_MSG(
+            sizeof( StateType::s2 ) == sizeof( curandStateMRG32k3a::s2 ),
+            Unexpected_sizes
+        );
+        // Offsets must match
+        PMACC_STATIC_ASSERT_MSG(
+            offsetof( StateType, s1 ) == offsetof( curandStateMRG32k3a, s1 ) &&
+            offsetof( StateType, s2 ) == offsetof( curandStateMRG32k3a, s2 ),
+            Incompatible_structs
+        );
+
+        static DINLINE void AssignState(
+            StateType& dest,
+            curandStateMRG32k3a const & src
+        )
+        {
+            // Check if we can do this cast
+            dest = reinterpret_cast< StateType const & >( src );
+        }
+    };
+#endif
+}  // namespace methods
+}  // namespace random
+}  // namespace pmacc

--- a/include/pmacc/random/methods/XorMin.hpp
+++ b/include/pmacc/random/methods/XorMin.hpp
@@ -1,0 +1,144 @@
+/* Copyright 2015-2017 Alexander Grund, Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+#include "pmacc/static_assert.hpp"
+
+#if( PMACC_CUDA_ENABLED != 1 )
+#   include "pmacc/random/methods/AlpakaRand.hpp"
+#else
+#   include <curand_kernel.h>
+#endif
+
+
+namespace pmacc
+{
+namespace random
+{
+namespace methods
+{
+
+#if( PMACC_CUDA_ENABLED != 1 )
+    //! fallback to alpaka RNG if a cpu accelerator is used
+    template< typename T_Acc >
+    using XorMin = AlpakaRand< T_Acc >;
+#else
+    //! Uses the CUDA XORWOW RNG but does not store state members required for normal distribution
+    template< typename T_Acc >
+    class XorMin
+    {
+    public:
+        class StateType
+        {
+        public:
+            PMACC_ALIGN(
+                d,
+                unsigned int
+            );
+            PMACC_ALIGN(
+                v[ 5 ],
+                unsigned int
+            );
+
+            HDINLINE StateType( )
+            { }
+
+            DINLINE StateType( curandStateXORWOW_t const & other ): d( other.d )
+            {
+                PMACC_STATIC_ASSERT_MSG(
+                    sizeof( v ) == sizeof( other.v ),
+                    Unexpected_sizes
+                );
+                for( unsigned i = 0; i < sizeof( v ) / sizeof( v[ 0 ] ); i++ )
+                    v[ i ] = other.v[ i ];
+            }
+        };
+
+        DINLINE void
+        init(
+            T_Acc const & acc,
+            StateType & state,
+            uint32_t seed,
+            uint32_t subsequence = 0
+        ) const
+        {
+            curandStateXORWOW_t tmpState;
+            curand_init(
+                seed,
+                subsequence,
+                0,
+                &tmpState
+            );
+            state = tmpState;
+        }
+
+        DINLINE uint32_t
+        get32Bits(
+            T_Acc const & acc,
+            StateType & state
+        ) const
+        {
+            /* This generator uses the xorwow formula of
+             * www.jstatsoft.org/v08/i14/paper page 5
+             * Has period 2^192 - 2^32.
+             */
+            uint32_t t;
+            t = ( state.v[ 0 ] ^ ( state.v[ 0 ] >> 2 ) );
+            state.v[ 0 ] = state.v[ 1 ];
+            state.v[ 1 ] = state.v[ 2 ];
+            state.v[ 2 ] = state.v[ 3 ];
+            state.v[ 3 ] = state.v[ 4 ];
+            state.v[ 4 ] = ( state.v[ 4 ] ^ ( state.v[ 4 ] << 4 ) ) ^ ( t ^ ( t << 1 ) );
+            state.d += 362437;
+            return state.v[ 4 ] + state.d;
+        }
+
+        /** get a normal distributed random number
+         *
+         * @param acc alpaka accelerator
+         * @param state random number state
+         */
+        template< typename T_Type >
+        DINLINE T_Type
+        getNormal(
+            T_Acc const & acc,
+            StateType& state
+        ) const
+        {
+            PMACC_CASSERT_MSG(
+                __XorMin_random_number_with_normal_distribution_is_not_supported,
+                false
+            );
+            return T_Type{ };
+        }
+
+        static std::string
+        getName( )
+        {
+            return "XorMin";
+        }
+    };
+#endif
+}  // namespace methods
+}  // namespace random
+}  // namespace pmacc


### PR DESCRIPTION
- re-add `RNG` XorMin and `MRG32k3aMin` (was emoved with #2226)
- on CPU: the RNG has a fallback to the default alpaka RNG
- PIConGPU: use XorMin by default

- [x] add XorMin (6xint32!)
- [x] Runtime test

CC-ing: @n01r 