### PR TITLE
Examples: Init of Particles per Cell

### DIFF
--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/particle.param
@@ -21,6 +21,7 @@
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
+
 #include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
 
@@ -36,35 +37,39 @@ namespace particles
      *  unit: none */
     constexpr float_X MIN_WEIGHTING = 1.0;
 
-    constexpr float_X TYPICAL_PARTICLES_PER_CELL = 100;
-
 namespace startPosition
 {
 
-    struct RandomParameter
+    struct RandomParameter100ppc
     {
         /** Count of particles per cell at initial state
-         *  unit: none */
-        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+         *  unit: none
+         */
+        static constexpr uint32_t numParticlesPerCell = 100u;
     };
-
-    /* definition of random particle start */
-    using Random = RandomImpl< RandomParameter >;
+    using Random100ppc = RandomImpl< RandomParameter100ppc >;
 
 
-    struct QuietParameter
+    struct QuietParameter1ppc
     {
         /** Count of particles per cell per direction at initial state
-         *  unit: none */
+         *  unit: none
+         */
         using numParticlesPerDimension = typename mCT::shrinkTo<
             mCT::Int< 1, 1, 1 >,
             simDim
         >::type;
     };
-
-    /* definition of quiet particle start*/
-    using Quiet = QuietImpl<QuietParameter>;
+    using Quiet1ppc = QuietImpl< QuietParameter1ppc >;
 
 } // namespace startPosition
+
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL =
+        startPosition::RandomParameter100ppc::numParticlesPerCell;
+
 } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -84,15 +84,15 @@ namespace particles
 using InitPipeline = mpl::vector<
     CreateDensity<
         densityProfiles::Foil,
-        startPosition::Quiet,
+        startPosition::Quiet1ppc,
         PIC_Ions
     >,
     CreateDensity<
         densityProfiles::Foil,
-        startPosition::Random,
+        startPosition::Random100ppc,
         PIC_Electrons
     >
 >;
 
-} /* namespace particles */
-} /* namespace picongpu  */
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/particle.param
@@ -17,15 +17,16 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
+
 #include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
 
 #include <limits>
+
 
 namespace picongpu
 {
@@ -33,11 +34,12 @@ namespace picongpu
 namespace particles
 {
 
-    /** a particle with a weighting below MIN_WEIGHTING will not
+    /* a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
-     *  unit: none */
+     *  unit: none
+     */
 #ifdef PARAM_SINGLE_PARTICLE
-    /* note: this specific setting allows all kinds of weightings > 0.0 */
+    // note: this specific setting allows all kinds of weightings > 0.0
     constexpr float_X MIN_WEIGHTING = std::numeric_limits< float_X >::min();
 
     constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 1;
@@ -56,11 +58,12 @@ namespace manipulators
         /** Initial particle drift velocity for electrons and ions
          *  Examples:
          *    - No drift is equal to 1.0
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr float_64 gamma = 5.0;
         const DriftParamNegative_direction_t direction;
     };
-    /* definition of SetDrift start*/
+    // definition of SetDrift start
     using AssignYDriftNegative = unary::Drift<
         DriftParamNegative,
         nvidia::functors::Assign
@@ -75,15 +78,14 @@ namespace startPosition
     struct RandomParameter
     {
         /** Count of particles per cell at initial state
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
     };
-
-    /* definition of random particle start */
     using Random = RandomImpl< RandomParameter >;
 
 
-    /* sit directly in lower corner of the cell */
+    // sit directly in lower corner of the cell
     CONST_VECTOR(
         float_X,
         3,
@@ -97,17 +99,16 @@ namespace startPosition
     struct OnePositionParameter
     {
         /** Count of particles per cell at initial state
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
 
         const InCellOffset_t inCellOffset;
     };
 
-    /* definition of one specific position for particle start */
+    // definition of one specific position for particle start
     using OnePosition = OnePositionImpl< OnePositionParameter >;
 
-} //namespace startPosition
-
-} //namespace particles
-
-} //namespac picongpu
+} // namespace startPosition
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/particle.param
@@ -30,10 +30,11 @@
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
+#include "picongpu/particles/traits/GetAtomicNumbers.hpp"
+
 #include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
 #include <pmacc/nvidia/rng/distributions/Uniform_float.hpp>
-#include "picongpu/particles/traits/GetAtomicNumbers.hpp"
 
 
 namespace picongpu
@@ -50,16 +51,9 @@ namespace particles
      */
     constexpr float_X MIN_WEIGHTING = 0.0000001;
 
-    /** Number of maximum particles per cell during density profile evaluation.
-     *
-     * Determines the weighting of a macro particle and with it, the number of
-     * particles "sampling" dynamics in phase space.
-     */
-    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 6;
-
 namespace manipulators
 {
-    //! ionize ions once
+    // ionize ions once by removing one bound electron
     struct OnceIonizedImpl
     {
         template< typename T_Particle >
@@ -68,11 +62,9 @@ namespace manipulators
         )
         {
             constexpr float_X protonNumber = GetAtomicNumbers< T_Particle >::type::numberOfProtons;
-            particle[boundElectrons_] = protonNumber - 1;
+            particle[ boundElectrons_ ] = protonNumber - 1;
         }
     };
-
-    //! definition of OnceIonized manipulator
     using OnceIonized = generic::Free< OnceIonizedImpl >;
 
     //! changes the in-cell position of each particle of a species
@@ -83,33 +75,22 @@ namespace manipulators
 
 namespace startPosition
 {
-    struct RandomParameter
+    struct RandomParameter6ppc
     {
         /** Count of particles per cell at initial state
          *
-         *  unit: none */
-        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+         *  unit: none
+         */
+        static constexpr uint32_t numParticlesPerCell = 6u;
     };
-    /** definition of random particle start */
-    using Random = RandomImpl< RandomParameter >;
+    using Random6ppc = RandomImpl< RandomParameter6ppc >;
 
-    struct QuietParam
-    {
-        /** Count of particles per cell per direction at initial state
-         *
-         *  unit: none */
-        using numParticlesPerDimension = mCT::Int< 2, 3 >;
-    };
-
-    /** definition of quiet particle start */
-    using Quiet = QuietImpl< QuietParam >;
-
-    //! sit directly in lower corner of the cell
+    // probe particles sit directly in lower corner of the cell
     CONST_VECTOR(
         float_X,
         3,
         InCellOffset,
-        /* each x, y, z in-cell position component in range [0.0, 1.0) */
+        // each x, y, z in-cell position component in range [0.0, 1.0)
         0.0,
         0.0,
         0.0
@@ -118,15 +99,22 @@ namespace startPosition
     {
         /** Count of particles per cell at initial state
          *
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr uint32_t numParticlesPerCell = 1u;
 
         const InCellOffset_t inCellOffset;
     };
-
-    //! definition of one specific position for particle start
     using OnePosition = OnePositionImpl< OnePositionParameter >;
 
 } // namespace startPosition
+
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL =
+        startPosition::RandomParameter6ppc::numParticlesPerCell;
+
 } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -87,7 +87,7 @@ namespace particles
     using InitPipeline = mpl::vector<
         CreateDensity<
             densityProfiles::FlatFoilWithRamp,
-            startPosition::Random,
+            startPosition::Random6ppc,
             Hydrogen
         >,
         /* derive the other two ion species and adjust their weighting to have always all

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particle.param
@@ -18,43 +18,50 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
 #include "picongpu/particles/filter/filter.def"
+
 #include <pmacc/nvidia/functors/Assign.hpp>
 
 namespace picongpu
 {
-
 namespace particles
 {
-
     namespace startPosition
     {
-
-        struct QuietParam
+        struct QuietParam25ppc
         {
             /** Count of particles per cell per direction at initial state
-             *  unit: none */
-           using numParticlesPerDimension = typename mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type;
+             *  unit: none
+             */
+            using numParticlesPerDimension = typename mCT::shrinkTo<
+                mCT::Int<
+                    5,
+                    5,
+                    1
+                >,
+                simDim
+            >::type;
         };
+        using Quiet25ppc = QuietImpl< QuietParam25ppc >;
 
-        /* definition of quiet particle start */
-        using Quiet = QuietImpl<QuietParam>;
-
-    } //namespace startPosition
+    } // namespace startPosition
 
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
-     *  unit: none */
+     *  unit: none
+     */
     constexpr float_X MIN_WEIGHTING = 10.0;
 
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
     constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
-        startPosition::QuietParam::numParticlesPerDimension
+        startPosition::QuietParam25ppc::numParticlesPerDimension
     >::type::value;
 
 namespace manipulators
@@ -66,11 +73,11 @@ namespace manipulators
         /** Initial particle drift velocity for electrons and ions
          *  Examples:
          *    - No drift is equal to 1.0
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr float_64 gamma = 1.021;
         const DriftParamPositive_direction_t direction;
     };
-    /* definition of SetDrift start */
     using AssignXDriftPositive = unary::Drift<
         DriftParamPositive,
         nvidia::functors::Assign
@@ -82,11 +89,11 @@ namespace manipulators
         /** Initial particle drift velocity for electrons and ions
          *  Examples:
          *    - No drift is equal to 1.0
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr float_64 gamma = 1.021;
         const DriftParamNegative_direction_t direction;
     };
-    /* definition of SetDrift start */;
     using AssignXDriftNegative = unary::Drift<
         DriftParamNegative,
         nvidia::functors::Assign
@@ -99,7 +106,6 @@ namespace manipulators
          */
         static constexpr float_64 temperature = 0.0005;
     };
-    /* definition of AddTemperature start */
     using AddTemperature = unary::Temperature< TemperatureParam >;
 
 } // namespace manipulators

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -82,7 +82,7 @@ namespace particles
  * the functors are called in order (from first to last functor)
  */
 using InitPipeline = mpl::vector<
-    CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Electrons>,
+    CreateDensity<densityProfiles::Homogenous, startPosition::Quiet25ppc, PIC_Electrons>,
     DeriveSpecies<PIC_Electrons, PIC_Ions>,
     Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::LowerQuarterYPosition>,
     Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleHalfYPosition>,

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/particle.param
@@ -18,58 +18,45 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
+
 #include <pmacc/nvidia/functors/Assign.hpp>
+
 
 namespace picongpu
 {
-/* short namespace*/
-namespace mCT = pmacc::math::CT;
-
-// Macro Particle Configuration -------------------------------------------
-
 namespace particles
 {
 
-/** a particle with a weighting below MIN_WEIGHTING will not
- *      be created / will be deleted
- *  unit: none */
-constexpr float_X MIN_WEIGHTING = 10.0;
-
-constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 2u;
+    /** a particle with a weighting below MIN_WEIGHTING will not
+     *      be created / will be deleted
+     *  unit: none
+     */
+    constexpr float_X MIN_WEIGHTING = 10.0;
 
 namespace startPosition
 {
 
-struct RandomParameter
-{
-    /** Count of particles per cell at initial state
-     *  unit: none */
-    static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
-};
-/* definition of random particle start*/
-using Random = RandomImpl<RandomParameter>;
+    struct RandomParameter2ppc
+    {
+        /** Count of particles per cell at initial state
+         *  unit: none
+         */
+        static constexpr uint32_t numParticlesPerCell = 2u;
+    };
+    using Random2ppc = RandomImpl< RandomParameter2ppc >;
 
-struct QuietParameter
-{
-    /** Count of particles per cell per direction at initial state
-     *  unit: none */
-    using numParticlesPerDimension = typename mCT::shrinkTo<
-        mCT::Int< 1, TYPICAL_PARTICLES_PER_CELL, 1 >,
-        simDim
-    >::type;
-};
+} // namespace startPosition
 
-/* definition of quiet particle start*/
-using Quiet = QuietImpl<QuietParameter>;
-
-
-} //namespace startPosition
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL =
+        startPosition::RandomParameter2ppc::numParticlesPerCell;
 
 namespace manipulators
 {
@@ -81,15 +68,13 @@ namespace manipulators
         {
             using Particle = T_Particle;
 
-            /** Number of bound electrons at initialization state of the neutral atom */
+            // number of bound electrons at initialization state of the neutral atom
             float_X const protonNumber = traits::GetAtomicNumbers< T_Particle >::type::numberOfProtons;
 
             particle[ boundElectrons_ ] = protonNumber;
         }
     };
     using SetBoundElectrons = generic::Free< SetIonToNeutral >;
-} //namespace manipulators
-
-} //namespace particles
-
-} //namespac picongpu
+} // namespace manipulators
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -82,20 +82,34 @@ namespace particles
  * the functors are called in order (from first to last functor)
  */
 using InitPipeline = mpl::vector<
+
 #if( PARAM_IONIZATION == 0 )
-
-    CreateDensity<densityProfiles::Gaussian, startPosition::Random, PIC_Electrons>
+    CreateDensity<
+        densityProfiles::Gaussian,
+        startPosition::Random2ppc,
+        PIC_Electrons
+    >
 #   if( PARAM_IONS == 1 )
-    , DeriveSpecies<PIC_Electrons,PIC_Ions>
+    ,
+    DeriveSpecies<
+        PIC_Electrons,
+        PIC_Ions
+    >
 #   endif
-
 #else
 
-    CreateDensity<densityProfiles::Gaussian, startPosition::Random, PIC_Ions>,
-    Manipulate<manipulators::SetBoundElectrons, PIC_Ions>
-
+    CreateDensity<
+        densityProfiles::Gaussian,
+        startPosition::Random2ppc,
+        PIC_Ions
+    >,
+    Manipulate<
+        manipulators::SetBoundElectrons,
+        PIC_Ions
+    >
 #endif
+
 >;
 
-} /* namespace particles */
-} /* namespace picongpu  */
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/particle.param
@@ -18,16 +18,16 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
+
 #include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
 
 #include <limits>
+
 
 namespace picongpu
 {
@@ -42,16 +42,15 @@ namespace particles
      */
     constexpr float_X MIN_WEIGHTING = std::numeric_limits< float_X >::min();
 
-    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 1u;
-
 namespace manipulators
 {
 
+    // Parameters for a particle drift in X
     CONST_VECTOR(
         float_X,
         3,
         DriftParam_direction,
-        /* unit vector for direction of drift: x, y, z */
+        // unit vector for direction of drift: x, y, z
         1.0,
         0.0,
         0.0
@@ -61,8 +60,6 @@ namespace manipulators
         static constexpr float_64 gamma = 1.1547; // beta: 0.5
         const DriftParam_direction_t direction;
     };
-
-    /* definition of SetDrift start */
     using AssignYDrift = unary::Drift<
         DriftParam,
         nvidia::functors::Assign
@@ -78,7 +75,7 @@ namespace startPosition
         float_X,
         3,
         InCellOffset,
-        /* each x, y, z in-cell position component in range [0.0, 1.0) */
+        // each x, y, z in-cell position component in range [0.0, 1.0)
         0.0,
         0.0,
         0.0
@@ -86,16 +83,21 @@ namespace startPosition
     struct OnePositionParameter
     {
         /** Count of particles per cell at initial state
-         *  unit: none */
-        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+         *  unit: none
+         */
+        static constexpr uint32_t numParticlesPerCell = 1u;
 
         const InCellOffset_t inCellOffset;
     };
-
-    /* definition of one specific position for particle start */
     using OnePosition = OnePositionImpl< OnePositionParameter >;
 
 } // namespace startPosition
-} // namespace particles
 
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 1u;
+
+} // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/particle.param
@@ -17,56 +17,59 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
+
 #include <pmacc/nvidia/functors/Add.hpp>
+
 
 namespace picongpu
 {
-/* short namespace*/
-namespace mCT = pmacc::math::CT;
-
-// Macro Particle Configuration -------------------------------------------
 
 namespace particles
 {
 
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
-     *  unit: none */
+     *  unit: none
+     */
     constexpr float_X MIN_WEIGHTING = 10.0;
-
-    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 16u;
 
 namespace manipulators
 {
     struct TemperatureParam
     {
-        /*Initial temperature
+        /** Initial temperature
          *  unit: keV
          */
         static constexpr float_64 temperature = 51.16;
     };
-    /* definition of SetDrift start*/
-    using  AddTemperature = unary::Temperature< TemperatureParam> ;
-} //namespace manipulators
+    using AddTemperature = unary::Temperature< TemperatureParam > ;
+} // namespace manipulators
 
 namespace startPosition
 {
 
-    struct RandomParameter
+    struct RandomParameter16ppc
     {
         /** Count of particles per cell at initial state
-         *  unit: none */
-        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
+         *  unit: none
+         */
+        static constexpr uint32_t numParticlesPerCell = 16u;
     };
-    /* definition of random particle start*/
-    using Random = RandomImpl<RandomParameter>;
+    // definition of random particle start
+    using Random16ppc = RandomImpl< RandomParameter16ppc >;
 
-}//namespace startPosition
-}//namespace particles
-}//namespace picongpu
+} // namespace startPosition
+
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL =
+        startPosition::RandomParameter16ppc::numParticlesPerCell;
+
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -84,7 +84,7 @@ namespace particles
 using InitPipeline = mpl::vector<
     CreateDensity<
         densityProfiles::Homogenous,
-        startPosition::Random,
+        startPosition::Random16ppc,
         PIC_Ions
     >,
     ManipulateDeriveSpecies<

--- a/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/particle.param
@@ -35,31 +35,28 @@ namespace particles
 
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
-     *  unit: none */
+     *  unit: none
+     */
     constexpr float_X MIN_WEIGHTING = 10.0;
-
-    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 2;
 
 namespace manipulators
 {
-
+    // define a drift in X equal to 200 keV for electrons
     CONST_VECTOR(float_X, 3, DriftParam_direction, 1.0, 0.0, 0.0);
     struct Drift200keVParam
     {
         static constexpr float_64 gamma = 1.39139;
         const DriftParam_direction_t direction;
     };
-    /* define a drift equal to 200 keV for electrons */
     using Assign200keVDrift = unary::Drift< Drift200keVParam, nvidia::functors::Assign >;
 
     struct TemperatureParam
     {
-        /*Initial temperature
+        /** Initial temperature
          *  unit: keV
          */
         static constexpr float_64 temperature = 0.1;
     };
-    /* definition of SetDrift start*/
     using AddTemperature = unary::Temperature< TemperatureParam >;
 
     struct OnceIonizedImpl
@@ -67,47 +64,46 @@ namespace manipulators
         template< typename T_Particle >
         DINLINE void operator()( T_Particle& particle )
         {
-            /** number of bound electrons for a neutral atom */
             constexpr float_X ion1plus =
                 GetAtomicNumbers< T_Particle >::type::numberOfProtons -
                 float_X(1);
 
-            /* set (Z - 1) bound electrons */
+            // set (Z - 1) bound electrons
             particle[boundElectrons_] = ion1plus;
         }
     };
-    /* definition of SetDrift start*/
+    // definition of SetDrift start
     using OnceIonized = generic::Free< OnceIonizedImpl >;
 
-} //namespace manipulators
+} // namespace manipulators
 
 
 namespace startPosition
 {
 
-    struct RandomParameter
-    {
-        /** Count of particles per cell at initial state
-         *  unit: none */
-        static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
-    };
-    /* definition of random particle start */
-    using Random = RandomImpl< RandomParameter >;
-
-    struct QuietParam
+    struct QuietParam2ppc
     {
         /** Count of particles per cell per direction at initial state
-         *  unit: none */
+         *  unit: none
+         */
         using numParticlesPerDimension = typename mCT::shrinkTo<
-            mCT::Int< 1, TYPICAL_PARTICLES_PER_CELL, 1 >,
+            mCT::Int< 1, 2, 1 >,
             simDim
         >::type;
     };
 
-    /* definition of quiet particle start */
-    using Quiet = QuietImpl< QuietParam >;
+    // definition of quiet particle start
+    using Quiet2ppc = QuietImpl< QuietParam2ppc >;
 
-} //namespace startPosition
-} //namespace particles
+} // namespace startPosition
 
-} //namespac picongpu
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
+        startPosition::QuietParam2ppc::numParticlesPerDimension
+    >::type::value;
+
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -85,10 +85,10 @@ namespace particles
      * the functors are called in order (from first to last functor)
      */
     using InitPipeline = mpl::vector<
-        /* Generate Densities */
+        // Generate Densities
         CreateDensity<
             densityProfiles::Homogenous,
-            startPosition::Quiet,
+            startPosition::Quiet2ppc,
             CopperIons
         >,
         ManipulateDeriveSpecies<
@@ -101,18 +101,19 @@ namespace particles
             CopperIons,
             PromptElectrons
         >,
-        /* Set the Cu ions to Cu_1+ */
+        // Set the Cu ions to Cu_1+
         Manipulate<
             manipulators::OnceIonized,
             CopperIons
         >,
-        /* Set initial temperature of bulk electrons */
+        // Set initial temperature of bulk electrons
         Manipulate<
             manipulators::AddTemperature,
             BulkElectrons
         >,
         /* Set initial drift (directed in this case) of delta-distributed 200 keV
-         * prompt electrons */
+         * prompt electrons
+         */
         Manipulate<
             manipulators::Assign200keVDrift,
             PromptElectrons

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/particle.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/particle.param
@@ -18,14 +18,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/particles/startPosition/functors.def"
 #include "picongpu/particles/manipulators/manipulators.def"
+
 #include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
+
 
 namespace picongpu
 {
@@ -35,70 +35,77 @@ namespace particles
 
     /** a particle with a weighting below MIN_WEIGHTING will not
      *      be created / will be deleted
-     *  unit: none */
+     *  unit: none
+     */
     constexpr float_X MIN_WEIGHTING = 10.0;
-
-    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 4u;
 
 namespace manipulators
 {
 
-    CONST_VECTOR(float_X,3,DriftParamElectrons_direction,0.0,0.0,1.0);
+    CONST_VECTOR( float_X, 3, DriftParamElectrons_direction, 0.0, 0.0, 1.0 );
     struct DriftParamElectrons
     {
         /** Initial particle drift velocity for electrons and ions
          *  Examples:
          *    - No drift is equal to 1.0
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr float_64 gamma = 1.021;
         const DriftParamElectrons_direction_t direction;
     };
-    /* definition of SetDrift start*/
-    using AssignZDriftElectrons = unary::Drift< DriftParamElectrons,nvidia::functors::Assign >;
+    using AssignZDriftElectrons = unary::Drift< DriftParamElectrons, nvidia::functors::Assign >;
 
-    CONST_VECTOR(float_X,3,DriftParamIons_direction,0.0,0.0,-1.0);
+    CONST_VECTOR( float_X, 3, DriftParamIons_direction, 0.0, 0.0, -1.0 );
     struct DriftParamIons
     {
         /** Initial particle drift velocity for electrons and ions
          *  Examples:
          *    - No drift is equal to 1.0
-         *  unit: none */
+         *  unit: none
+         */
         static constexpr float_64 gamma = 1.021;
         const DriftParamIons_direction_t direction;
     };
-    /* definition of SetDrift start*/
-    using AssignZDriftIons = unary::Drift< DriftParamIons,nvidia::functors::Assign >;
+    // definition of SetDrift start
+    using AssignZDriftIons = unary::Drift< DriftParamIons, nvidia::functors::Assign >;
 
     struct TemperatureParam
     {
-        /*Initial temperature
+        /** Initial temperature
          *  unit: keV
          */
         static constexpr float_64 temperature = 0.005;
     };
-    /* definition of SetDrift start */
-    using AddTemperature = unary::Temperature<TemperatureParam>;
+    using AddTemperature = unary::Temperature< TemperatureParam >;
 
-} //namespace manipulators
-
+} // namespace manipulators
 
 namespace startPosition
 {
 
-    struct QuietParam
+    struct QuietParam4ppc
     {
         /** Count of particles per cell per direction at initial state
-         *  unit: none */
+         *  unit: none
+         */
         using numParticlesPerDimension = mCT::shrinkTo<
-            mCT::Int< TYPICAL_PARTICLES_PER_CELL / 2, TYPICAL_PARTICLES_PER_CELL / 2, 1 >,
+            mCT::Int< 2, 2, 1 >,
             simDim
         >::type;
     };
 
-    /* definition of quiet particle start */
-    using Quiet = QuietImpl< QuietParam >;
+    // definition of quiet particle start
+    using Quiet4ppc = QuietImpl< QuietParam4ppc >;
 
-} //namespace startPosition
-} //namespace particles
+} // namespace startPosition
 
-} //namespac picongpu
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
+        startPosition::QuietParam4ppc::numParticlesPerDimension
+    >::type::value;
+
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -84,7 +84,7 @@ namespace particles
 using InitPipeline = mpl::vector<
     CreateDensity<
         densityProfiles::Homogenous,
-        startPosition::Quiet,
+        startPosition::Quiet4ppc,
         PIC_Ions
     >,
     ManipulateDeriveSpecies<


### PR DESCRIPTION
This refactors the `particle.param` and `speciesInitialization.param` files for the examples to transport the particles-per-cell (ppc) parameters more transparently for the user into the density profile to discrete particle mapping step of the initialization.

See the related question in issue #2411.