### PR TITLE
tbg -f: mkdir -p submitAction

### DIFF
--- a/etc/picongpu/submitAction.sh
+++ b/etc/picongpu/submitAction.sh
@@ -33,7 +33,7 @@ fi
 
 ## copy memcheck programs
 cd $TBG_dstPath
-mkdir input
+mkdir -p input
 cp -ar $TBG_projectPath/bin input
 cp -ar $TBG_projectPath/include input
 cp -ar $TBG_projectPath/etc input


### PR DESCRIPTION
During the submit with `tbg`'s `--force` (overwrite) option, our `submitAction.sh` creates directories. If they exist, this throws and unnecessary warning. `mkdir -p` (for create "parent" directories) does not throw in such a situation and fixes this.