### PR TITLE
RNG: Normal distribution

### DIFF
--- a/include/pmacc/random/distributions/misc/MullerBox.hpp
+++ b/include/pmacc/random/distributions/misc/MullerBox.hpp
@@ -1,0 +1,142 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+#include "pmacc/algorithms/math.hpp"
+#include "pmacc/random/distributions/Uniform.hpp"
+
+
+namespace pmacc
+{
+namespace random
+{
+namespace distributions
+{
+
+    /** create a normal distributed random number
+     *
+     * Create a random number with mean 0 and standard deviation 1.
+     * The implementation based on the Wikipedia article:
+     *    - source: https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
+     *    - date: 01/12/2017
+     */
+    template<
+        typename T_Type,
+        typename T_RNGMethod
+    >
+    class MullerBox :
+        Uniform<
+            uniform::ExcludeZero< float >,
+            T_RNGMethod
+        >
+    {
+        /** The muller box is creating two random number, each second time
+         * this number is valid and can be used.
+         */
+        T_Type secondRngNumber;
+        //! true if secondRngNumber is valid else false
+        bool hasSecondRngNumber;
+
+        using RNGMethod = T_RNGMethod;
+        using UniformRng = Uniform<
+            uniform::ExcludeZero< T_Type >,
+            RNGMethod
+        >;
+        using StateType = typename RNGMethod::StateType;
+
+        /** generate a normal distributed random number
+         *
+         * @param acc alpaka accelerator
+         * @param state the state of an pmacc random number generator
+         */
+        template< typename T_Acc >
+        DINLINE T_Type getNormal(
+            T_Acc const & acc,
+            StateType& state
+        )
+        {
+            constexpr T_Type valueTwoPI = 6.2831853071795860;
+
+            T_Type u1 = UniformRng::operator()(
+                acc,
+                state
+            );
+            T_Type u2 = UniformRng::operator()(
+                acc,
+                state
+            ) * valueTwoPI;
+
+            T_Type s = algorithms::math::sqrt( T_Type( -2.0 ) * algorithms::math::log( u1 ) );
+
+            T_Type firstRngNumber;
+            algorithms::math::sincos(
+                u2,
+                firstRngNumber,
+                secondRngNumber
+            );
+
+            firstRngNumber *= s;
+            secondRngNumber *= s;
+            hasSecondRngNumber = true;
+            return firstRngNumber;
+        }
+
+    public:
+        //! result type of the random number
+        using result_type = T_Type;
+
+        /** generate a normal distributed random number
+         *
+         * Generates two random numbers with the first call, each second call
+         * the precomputed random number is returned.
+         *
+         * @param acc alpaka accelerator
+         * @param state the state of an pmacc random number generator
+         */
+        template< typename T_Acc >
+        DINLINE result_type
+        operator()(
+            T_Acc const & acc,
+            StateType& state
+        )
+        {
+            float result;
+            if( hasSecondRngNumber )
+            {
+                result = secondRngNumber;
+                hasSecondRngNumber = false;
+            }
+            else
+            {
+                result = getNormal(
+                    acc,
+                    state
+                );
+            }
+            return result;
+        }
+    };
+
+}  // namespace distributions
+}  // namespace random
+}  // namespace pmacc

--- a/include/pmacc/random/distributions/normal/Normal_float.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_float.hpp
@@ -23,6 +23,12 @@
 
 #include "pmacc/types.hpp"
 #include "pmacc/random/distributions/Normal.hpp"
+#include "pmacc/random/distributions/misc/MullerBox.hpp"
+#include "pmacc/random/methods/XorMin.hpp"
+#include "pmacc/random/methods/MRG32k3aMin.hpp"
+#include "pmacc/random/distributions/Uniform.hpp"
+#include "pmacc/algorithms/math.hpp"
+
 
 namespace pmacc
 {
@@ -33,14 +39,12 @@ namespace distributions
 namespace detail
 {
 
-    /**
-     * Returns a random float value in [0,1) with normal distribution
-     */
+    //!Returns a random float value in [0,1) with normal distribution
     template< typename T_RNGMethod>
     class Normal<float, T_RNGMethod, void>
     {
-        typedef T_RNGMethod RNGMethod;
-        typedef typename RNGMethod::StateType StateType;
+        using RNGMethod = T_RNGMethod;
+        using StateType = typename RNGMethod::StateType;
     public:
         using result_type = float;
 
@@ -51,13 +55,45 @@ namespace detail
             StateType& state
         )
         {
-            return RNGMethod().getNormal(
-                acc,
-                state
-            );
+            return ::alpaka::rand::distribution::createNormalReal< float >(
+                acc
+            )( state );
         }
     };
 
+    //! specialization for XorMin
+    template<
+        typename T_Acc
+    >
+    struct Normal<
+        float,
+        methods::XorMin< T_Acc >,
+        void
+    > :
+        public MullerBox<
+            float,
+            methods::XorMin< T_Acc >
+        >
+    {
+
+    };
+
+    //! specialization for MRG32k3aMin
+    template<
+        typename T_Acc
+    >
+    struct Normal<
+        float,
+        methods::MRG32k3aMin< T_Acc >,
+        void
+    > :
+        public MullerBox<
+            float,
+            methods::MRG32k3aMin< T_Acc >
+        >
+    {
+
+    };
 }  // namespace detail
 }  // namespace distributions
 }  // namespace random

--- a/include/pmacc/random/methods/AlpakaRand.hpp
+++ b/include/pmacc/random/methods/AlpakaRand.hpp
@@ -58,23 +58,6 @@ namespace methods
             );
         }
 
-        /** get a normal distributed random number
-         *
-         * @param acc alpaka accelerator
-         * @param state random number state
-         */
-        template< typename T_Type >
-        DINLINE T_Type
-        getNormal(
-            T_Acc const & acc,
-            StateType & state
-        ) const
-        {
-            return ::alpaka::rand::distribution::createNormalReal< T_Type >(
-                acc
-            )( state );
-        }
-
         DINLINE uint32_t
         get32Bits(
             T_Acc const & acc,

--- a/include/pmacc/random/methods/MRG32k3aMin.hpp
+++ b/include/pmacc/random/methods/MRG32k3aMin.hpp
@@ -84,25 +84,6 @@ namespace methods
             return curand( reinterpret_cast< curandStateMRG32k3a* >( &state ) );
         }
 
-        /** get a normal distributed random number
-         *
-         * @param acc alpaka accelerator
-         * @param state random number state
-         */
-        template< typename T_Type >
-        DINLINE T_Type
-        getNormal(
-            T_Acc const & acc,
-            StateType& state
-        ) const
-        {
-            PMACC_CASSERT_MSG(
-                __MRG32k3aMin_random_number_with_normal_distribution_is_not_supported,
-                false
-            );
-            return T_Type{};
-        }
-
         static std::string
         getName()
         {

--- a/include/pmacc/random/methods/XorMin.hpp
+++ b/include/pmacc/random/methods/XorMin.hpp
@@ -113,25 +113,6 @@ namespace methods
             return state.v[ 4 ] + state.d;
         }
 
-        /** get a normal distributed random number
-         *
-         * @param acc alpaka accelerator
-         * @param state random number state
-         */
-        template< typename T_Type >
-        DINLINE T_Type
-        getNormal(
-            T_Acc const & acc,
-            StateType& state
-        ) const
-        {
-            PMACC_CASSERT_MSG(
-                __XorMin_random_number_with_normal_distribution_is_not_supported,
-                false
-            );
-            return T_Type{ };
-        }
-
         static std::string
         getName( )
         {


### PR DESCRIPTION
- revert interface change from #2410 (remove fmethod `getNormal` from the method)
- add helper class `MullerBox` to generate normal distributed random numbers from uniform distributed
- add specialization to create uniform random number with `MRG32k3aMin` and `XorMin`