### PR TITLE
Piz Daint: ADIOS 1.13.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -73,6 +73,15 @@ zlib
 - *Debian/Ubuntu:* ``sudo apt-get install zlib1g-dev``
 - *Arch Linux:* ``sudo pacman --sync zlib``
 - *Spack:* ``spack install zlib``
+- *from source:*
+
+  - ``./configure --prefix=$HOME/lib/zlib``
+  - ``make && make install``
+- *environent:* (assumes install from source in ``$HOME/lib/zlib``)
+
+  - ``export ZLIB_ROOT=$HOME/lib/zlib``
+  - ``export LD_LIBRARY_PATH=$ZLIB_ROOT/lib:$LD_LIBRARY_PATH``
+  - ``export CMAKE_PREFIX_PATH=$ZLIB_ROOT:$CMAKE_PREFIX_PATH``
 
 boost
 """""
@@ -147,8 +156,8 @@ pngwriter
 - *Spack:* ``spack install pngwriter``
 - *from source:*
 
-  - download our modified version from `github.com/pngwriter/pngwriter <https://github.com/pngwriter/pngwriter>`_
-  - Requires [libpng](http://www.libpng.org/)
+  - download from `github.com/pngwriter/pngwriter <https://github.com/pngwriter/pngwriter>`_
+  - Requires `libpng <http://www.libpng.org>`_
 
     - *Debian/Ubuntu:* ``sudo apt-get install libpng-dev``
     - *Arch Linux:* ``sudo pacman --sync libpng``

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -60,7 +60,7 @@ For this profile to work, you need to download the :ref:`PIConGPU source code <i
 Piz Daint (CSCS)
 ----------------
 
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`boost, PNGwriter, libSplash and ADIOS <install-dependencies>` manually.
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`boost, zlib, libpng, c-blosc, PNGwriter, libSplash and ADIOS <install-dependencies>` manually.
 
 .. note::
 

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -18,8 +18,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 # if the wrong environment is loaded we switch to the gnu environment
 # note: this loads gcc/5.3.0 (6.0.4 is the version of the programming env!)
-module li 2>&1 | grep "PrgEnv-cray" > /dev/null
-if [ $? -eq 0 ] ; then
+CRAYENV_FOUND=$(module li 2>&1 | grep "PrgEnv-cray" > /dev/null && { echo 0; } || { echo 1; })
+if [ $CRAYENV_FOUND -eq 0 ]; then
     module swap PrgEnv-cray PrgEnv-gnu/6.0.4
 else
     module load PrgEnv-gnu/6.0.4
@@ -39,14 +39,26 @@ module load cray-hdf5-parallel/1.10.0.3
 #
 # needs to be compiled by the user
 export BOOST_ROOT=$SCRATCH/lib/boost-1.62.0
+export ZLIB_ROOT=$SCRATCH/lib/zlib-1.2.11
+export PNG_ROOT=$SCRATCH/lib/libpng-1.6.34
+export BLOSC_ROOT=$SCRATCH/lib/blosc-1.12.1
 export PNGWRITER_ROOT=$SCRATCH/lib/pngwriter-0.6.0
-export ADIOS_ROOT=$SCRATCH/lib/adios-1.11.1
+export ADIOS_ROOT=$SCRATCH/lib/adios-1.13.0
 export SPLASH_ROOT=$SCRATCH/lib/splash-1.6.0
 
-export LD_LIBRARY_PATH=$PNGWRITER_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$ZLIB_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PNG_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PNGWRITER_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$SPLASH_ROOT/lib:$LD_LIBRARY_PATH
+
+export PATH=$PNG_ROOT/bin:$PATH
+export PATH=$ADIOS_ROOT/bin:$PATH
+
+export CMAKE_PREFIX_PATH=$ZLIB_ROOT:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$PNG_ROOT:$CMAKE_PREFIX_PATH
 
 export MPI_ROOT=$MPICH_DIR
 export HDF5_ROOT=$HDF5_DIR


### PR DESCRIPTION
This updates the profiles for Piz Daint (CSCS):

- ADIOS 1.11.1 -> 1.13.0
  - enables transforms:
    - zlib (serial) (`--adios.compression zlib`)
    - [blosc](https://github.com/ornladios/ADIOS/pull/135) (with zlib and more; parallel) (e.g. `--adios.compression blosc:threshold=2048,shuffle=bit,lvl=1,threads=10,compressor=zstd`)
- own zlib
- own libpng

The install scripts under https://gist.github.com/ax3l/68cb4caa597df3def9b01640959ea56b are updated accordingly.

### Tests on Piz Daint

- [x] compile foil example
- [x] run foil example (HDF5, ADIOS+ZLIB, ADIOS+BLOSC(zlib))

Note: blosc with 10 theads and zstd was the [fastest & best-compressing option](https://arxiv.org/abs/1706.00522) of the three tested above

ccing @n01r @PrometheusPi @BeyondEspresso @HighIander 