### PR TITLE
Group parameters in LWFA example

### DIFF
--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -166,6 +166,24 @@ class UiParameter(Parameter):
         self.value = self.dtype(x)
         return self.formatter(self.value)
 
+    def on_value_change(self, change):
+        """
+        Callback function used with observe() function of ipython widgets.
+        Just a wrapper of the set_value function.
+
+        Parameters
+        ----------
+        change: dict
+                  As passed by the Ipython widgets framework.
+
+        Returns
+        -------
+        Whatever the set_value function returns.
+        """
+
+        if change["type"] == "change":
+            return self.set_value(x=change["new"])
+
     def get_value(self):
         """
         Returns

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -21,30 +21,35 @@ from picongpu.input.parameters import LogScaledParameter, LinearScaledParameter
 pico = 1.e-12
 dt_r = 1. / 1.39e-16 * pico
 
-PARAMETER_LIST = [
-    LogScaledParameter(
-        name="Base_Density_SI", ptype="compile", unit="1/m^3",
-        default=25.0, slider_min=20.0, slider_max=26.0,
-        slider_step=1, base=10),
+PARAMETERS = {
+    'laser': [
+        LinearScaledParameter(
+            name="_A0", ptype="compile", unit="",
+            default=1.5, slider_min=0.1, slider_max=50.01,
+            slider_step=0.1),
 
-    LinearScaledParameter(
-        name="_A0", ptype="compile", unit="",
-        default=1.5, slider_min=0.1, slider_max=50.01,
-        slider_step=0.1),
+        LinearScaledParameter(
+            name="Wave_Length_SI", ptype="compile", unit="nm",
+            default=800.0, slider_min=400.0, slider_max=1400.0,
+            slider_step=1, scale_factor=1.e-9),
 
-    LinearScaledParameter(
-        name="Wave_Length_SI", ptype="compile", unit="nm",
-        default=800.0, slider_min=400.0, slider_max=1400.0,
-        slider_step=1, scale_factor=1.e-9),
+        LinearScaledParameter(
+            name="Pulse_Length_SI", ptype="compile", unit="fs",
+            default=5.0, slider_min=1.0, slider_max=150.0,
+            slider_step=1, scale_factor=1.e-15),
+    ],
+    'target': [
+        LogScaledParameter(
+            name="Base_Density_SI", ptype="compile", unit="1/m^3",
+            default=25.0, slider_min=20.0, slider_max=26.0,
+            slider_step=1, base=10),
+    ],
+    'resolution': [
+        LinearScaledParameter(
+            name="TBG_steps", ptype="run", unit="ps",
+            default=1.0, slider_min=0.1, slider_max=10.0,
+            slider_step=0.1, scale_factor=dt_r, dtype=int,
+            label="simulation time")
 
-    LinearScaledParameter(
-        name="Pulse_Length_SI", ptype="compile", unit="fs",
-        default=5.0, slider_min=1.0, slider_max=150.0,
-        slider_step=1, scale_factor=1.e-15),
-
-    LinearScaledParameter(
-        name="TBG_steps", ptype="run", unit="ps",
-        default=1.0, slider_min=0.1, slider_max=10.0,
-        slider_step=0.1, scale_factor=dt_r, dtype=int,
-        label="simulation time")
-]
+    ]
+}


### PR DESCRIPTION
Changes the structure of the params.py parameter definition to a dictionary containing group names as keys and a list of parameters as the value for each group.
This will be used to better represent the adjustable parameters in the jupyter notebook UI.

Besides, a wrapper function for the set_value function of the UiParameter is introduced. This becomes necessary since we refactored the callback functions for the sliders in the notebook UI.