### PR TITLE
new particle filters

### DIFF
--- a/docs/source/usage/particles.rst
+++ b/docs/source/usage/particles.rst
@@ -116,6 +116,24 @@ RelativeGlobalDomainPosition
 .. doxygenstruct:: picongpu::particles::filter::RelativeGlobalDomainPosition
    :project: PIConGPU
 
+Free
+^^^^
+
+.. doxygenstruct:: picongpu::particles::filter::generic::Free
+   :project: PIConGPU
+
+FreeRng
+^^^^^^^
+
+.. doxygenstruct:: picongpu::particles::filter::generic::FreeRng
+   :project: PIConGPU
+
+FreeTotalCellOffset
+^^^^^^^^^^^^^^^^^^^
+
+.. doxygenstruct:: picongpu::particles::filter::generic::FreeTotalCellOffset
+   :project: PIConGPU
+
 Define a New Particle Filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/include/picongpu/particles/filter/filter.def
+++ b/include/picongpu/particles/filter/filter.def
@@ -21,5 +21,8 @@
 
 #include "picongpu/particles/filter/IUnary.def"
 
+#include "picongpu/particles/filter/generic/Free.def"
+#include "picongpu/particles/filter/generic/FreeRng.def"
+#include "picongpu/particles/filter/generic/FreeTotalCellOffset.def"
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.def"
 #include "picongpu/particles/filter/All.def"

--- a/include/picongpu/particles/filter/filter.hpp
+++ b/include/picongpu/particles/filter/filter.hpp
@@ -19,5 +19,8 @@
 
 #pragma once
 
+#include "picongpu/particles/filter/generic/Free.hpp"
+#include "picongpu/particles/filter/generic/FreeRng.hpp"
+#include "picongpu/particles/filter/generic/FreeTotalCellOffset.hpp"
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.hpp"
 #include "picongpu/particles/filter/All.hpp"

--- a/include/picongpu/particles/filter/generic/Free.def
+++ b/include/picongpu/particles/filter/generic/Free.def
@@ -1,0 +1,64 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+namespace generic
+{
+
+    /** call simple free user defined filter
+     *
+     * @tparam T_Functor user defined filter
+     *                   **optional**: can implement **one** host side constructor
+     *                   `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
+     *
+     * example: each particle with in cell position greater than 0.5
+     *   @code{.cpp}
+     *
+     *   struct FunctorEachParticleAboveMiddleOfTheCell
+     *   {
+     *       template< typename T_Particle >
+     *       HDINLINE bool operator()( T_Particle const & particle )
+     *       {
+     *           bool result = false;
+     *           if( particle[ position_ ] >= float_X( 0.5 ) )
+     *               result = true;
+     *           return result;
+     *       }
+     *   };
+     *
+     *   using EachParticleAboveMiddleOfTheCell = Free<
+     *      FunctorEachParticleAboveMiddleOfTheCell
+     *   >;
+     *   @endcode
+     */
+    template< typename T_Functor >
+    struct Free;
+
+} // namespace generic
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/filter/generic/Free.hpp
+++ b/include/picongpu/particles/filter/generic/Free.hpp
@@ -1,0 +1,134 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/filter/generic/Free.def"
+#include "picongpu/particles/functor/User.hpp"
+
+#include <string>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+namespace generic
+{
+namespace acc
+{
+    /** wrapper for the user filter on the accelerator
+     *
+     * @tparam T_Functor user defined filter
+     */
+    template< typename T_Functor >
+    struct Free : private T_Functor
+    {
+        //! type of the user filter
+        using Functor = T_Functor;
+
+        //! store user filter instance
+        HDINLINE Free( Functor const & filter ) :
+            Functor( filter )
+        {
+        }
+
+        /** execute the user filter
+         *
+         * @tparam T_Args type of the arguments passed to the user filter
+         *
+         * @param particle particle to use for the filtering
+         */
+        template<
+            typename T_Acc,
+            typename T_Particle
+        >
+        HDINLINE
+        bool operator( )(
+            T_Acc const &,
+            T_Particle const & particle
+        )
+        {
+            return Functor::operator( )( particle );
+        }
+
+    };
+} // namespace acc
+
+    template< typename T_Functor >
+    struct Free : protected functor::User< T_Functor >
+    {
+
+        using Functor = functor::User< T_Functor >;
+
+        template< typename T_SpeciesType >
+        struct apply
+        {
+            using type = Free;
+        };
+
+        /** constructor
+         *
+         * @param currentStep current simulation time step
+         */
+        HINLINE Free( uint32_t currentStep ) : Functor( currentStep )
+        {
+        }
+
+        /** create device filter
+         *
+         * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param offset (in supercells, without any guards) to the
+         *         origin of the local domain
+         * @param configuration of the worker
+         */
+        template<
+            typename T_WorkerCfg,
+            typename T_Acc
+        >
+        HDINLINE acc::Free< Functor >
+        operator()(
+            T_Acc const &,
+            DataSpace< simDim > const &,
+            T_WorkerCfg const &
+        )
+        {
+            return acc::Free< Functor >( *static_cast< Functor * >( this ) );
+        }
+
+        static
+        HINLINE std::string
+        getName( )
+        {
+            // provide the name from the user functor
+            return Functor::name;
+        }
+
+    };
+
+} // namespace generic
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -1,0 +1,82 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <boost/mpl/integral_c.hpp>
+#include <boost/mpl/placeholders.hpp>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+namespace generic
+{
+
+    /** call simple free user defined functor and provide a random number generator
+     *
+     *
+     * @tparam T_Functor user defined unary functor
+     * @tparam T_Distribution random number distribution
+     * @tparam T_Seed seed to initialize the random number generator
+     * @tparam T_SpeciesType type of the species that shall be manipulated
+     *
+     * example: get each particle second particle
+     *   @code{.cpp}
+     *
+     *   struct FunctorEachSecondParticle
+     *   {
+     *       template< typename T_Rng, typename T_Particle >
+     *       HDINLINE bool operator()(
+     *           T_Rng & rng,
+     *           T_Particle const & particle
+     *       )
+     *       {
+     *           bool result = false;
+     *           if( rng >= float_X( 0.5 ) )
+     *               result = true;
+     *           return result;
+     *       }
+     *   };
+     *
+     *   using EachSecondParticle = Free<
+     *      FunctorEachSecondParticle
+     *   >;
+     *   @endcode
+     */
+    template<
+        typename T_Functor,
+        typename T_Distribution,
+        typename T_Seed = boost::mpl::integral_c<
+            size_t,
+            FREERNG_SEED
+        >,
+        typename T_SpeciesType = boost::mpl::_1
+    >
+    struct FreeRng;
+
+} // namespace generic
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -1,0 +1,184 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/filter/generic/FreeRng.def"
+#include "picongpu/particles/functor/misc/Rng.hpp"
+#include "picongpu/particles/functor/User.hpp"
+
+#include <string>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+namespace generic
+{
+namespace acc
+{
+    template<
+        typename T_Functor,
+        typename T_RngType
+    >
+    struct FreeRng : private T_Functor
+    {
+
+        using Functor = T_Functor;
+        using RngType = T_RngType;
+
+        HDINLINE FreeRng(
+            Functor const & functor,
+            RngType const & rng
+        ) :
+            T_Functor( functor ), m_rng( rng )
+        {
+        }
+
+        /** call user functor
+         *
+         * The random number generator is initialized with the first call.
+         *
+         * @tparam T_Particle type of the particle to manipulate
+         * @tparam T_Args type of the arguments passed to the user functor
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param particle particle which is given to the user functor
+         * @return void is used to enable the operator if the user functor except two arguments
+         */
+        template<
+            typename T_Particle,
+            typename ... T_Args,
+            typename T_Acc
+        >
+        HDINLINE
+        bool operator()(
+            T_Acc const &,
+            T_Particle const & particle
+        )
+        {
+            namespace nvrng = nvidia::rng;
+
+            return Functor::operator()(
+                m_rng,
+                particle
+            );
+        }
+
+    private:
+
+        RngType m_rng;
+    };
+} // namespace acc
+
+    template<
+        typename T_Functor,
+        typename T_Distribution,
+        typename T_Seed,
+        typename T_SpeciesType
+    >
+    struct FreeRng :
+    protected functor::User< T_Functor >,
+        private picongpu::particles::functor::misc::Rng<
+            T_Distribution,
+            T_Seed,
+            T_SpeciesType
+        >
+    {
+        using RngGenerator = picongpu::particles::functor::misc::Rng<
+            T_Distribution,
+            T_Seed,
+            T_SpeciesType
+        >;
+
+        template< typename T_Acc >
+        using RngType = typename RngGenerator::template RngType< T_Acc >;
+
+        using Functor = functor::User< T_Functor >;
+        using Distribution = T_Distribution;
+        using SpeciesType = T_SpeciesType;
+
+        /** constructor
+         *
+         * @param currentStep current simulation time step
+         */
+        HINLINE FreeRng( uint32_t currentStep ) :
+            Functor( currentStep ),
+            RngGenerator( currentStep )
+        {
+        }
+
+        /** create functor for the accelerator
+         *
+         * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param localSupercellOffset offset (in superCells, without any guards) relative
+         *                        to the origin of the local domain
+         * @param workerCfg configuration of the worker
+         */
+        template<
+            typename T_WorkerCfg,
+            typename T_Acc
+        >
+        HDINLINE auto
+        operator()(
+            T_Acc const & acc,
+            DataSpace< simDim > const & localSupercellOffset,
+            T_WorkerCfg const & workerCfg
+        )
+        -> acc::FreeRng<
+            Functor,
+            RngType< T_Acc >
+        >
+        {
+            RngType< T_Acc > const rng = ( *static_cast< RngGenerator * >( this ) )(
+                acc,
+                localSupercellOffset,
+                workerCfg
+            );
+
+            return acc::FreeRng<
+                Functor,
+                RngType< T_Acc >
+            >(
+                *static_cast< Functor * >( this ),
+                rng
+            );
+        }
+
+        static
+        HINLINE std::string
+        getName( )
+        {
+            // we provide the name from the param class
+            return Functor::name;
+        }
+    };
+
+} // namespace generic
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
@@ -1,0 +1,73 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <boost/mpl/integral_c.hpp>
+#include <boost/mpl/placeholders.hpp>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+namespace generic
+{
+
+    /** call simple free user defined functor and provide the cell information
+     *
+     * The functor pass the cell offset of the particle relative to the total
+     * domain origin into the functor.     *
+     *
+     * @tparam T_Functor user defined unary functor
+     *
+     * example: each particle with a cell offset of 5 in X direction
+     *   @code{.cpp}
+     *
+     *   struct FunctorEachParticleInXCell5
+     *   {
+     *       template< typename T_Particle >
+     *       HDINLINE bool operator()(
+     *           DataSpace< simDim > const & particleOffsetToTotalOrigin,
+     *           T_Particle const & particle
+     *       )
+     *       {
+     *           bool result = false;
+     *           if( particleOffsetToTotalOrigin.x() == 5 )
+     *               result = true;
+     *           return result;
+     *       }
+     *   };
+     *
+     *   using EachParticleInXCell5 = FreeTotalCellOffset<
+     *      FunctorEachParticleInXCell5
+     *   >;
+     *   @endcode
+     */
+    template< typename T_Functor >
+    struct FreeTotalCellOffset;
+
+} // namespace generic
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -1,0 +1,160 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/filter/generic/FreeTotalCellOffset.def"
+#include "picongpu/particles/functor/misc/TotalCellOffset.hpp"
+
+#include <string>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace filter
+{
+namespace generic
+{
+namespace acc
+{
+    template< typename T_Functor >
+    struct FreeTotalCellOffset : private T_Functor
+    {
+
+        using Functor = T_Functor;
+
+        HDINLINE FreeTotalCellOffset(
+            Functor const & functor,
+            DataSpace< simDim > const & superCellToLocalOriginCellOffset
+        ) :
+            T_Functor( functor ),
+            m_superCellToLocalOriginCellOffset( superCellToLocalOriginCellOffset )
+        {
+        }
+
+        /** call user functor
+         *
+         * The random number generator is initialized with the first call.
+         *
+         * @tparam T_Particle type of the particle to manipulate
+         * @tparam T_Args type of the arguments passed to the user functor
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param particle particle which is given to the user functor
+         * @return void is used to enable the operator if the user functor except two arguments
+         */
+        template<
+            typename T_Particle,
+            typename T_Acc
+        >
+        HDINLINE
+        bool operator()(
+            T_Acc const &,
+            T_Particle const & particle
+        )
+        {
+            DataSpace< simDim > const cellInSuperCell(
+                DataSpaceOperations< simDim >::template map< SuperCellSize > ( particle[ localCellIdx_ ] )
+            );
+            return Functor::operator( )(
+                m_superCellToLocalOriginCellOffset + cellInSuperCell,
+                particle
+            );
+        }
+
+    private:
+
+        DataSpace< simDim > const m_superCellToLocalOriginCellOffset;
+    };
+} // namespace acc
+
+    template< typename T_Functor >
+    struct FreeTotalCellOffset :
+        protected functor::User< T_Functor >,
+        private functor::misc::TotalCellOffset
+    {
+        using CellOffsetFunctor = functor::misc::TotalCellOffset;
+        using Functor = functor::User< T_Functor >;
+
+        template< typename T_SpeciesType >
+        struct apply
+        {
+            using type = FreeTotalCellOffset;
+        };
+
+        /** constructor
+         *
+         * @param currentStep current simulation time step
+         */
+        HINLINE FreeTotalCellOffset( uint32_t currentStep ) :
+            Functor( currentStep ),
+            CellOffsetFunctor( currentStep )
+        {
+        }
+
+        /** create functor for the accelerator
+         *
+         * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param localSupercellOffset offset (in superCells, without any guards) relative
+         *                        to the origin of the local domain
+         * @param workerCfg configuration of the worker
+         */
+        template<
+            typename T_WorkerCfg,
+            typename T_Acc
+        >
+        HDINLINE auto
+        operator()(
+            T_Acc const & acc,
+            DataSpace< simDim > const & localSupercellOffset,
+            T_WorkerCfg const & workerCfg
+        )
+        -> acc::FreeTotalCellOffset< Functor >
+        {
+            auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor * >( this );
+            return acc::FreeTotalCellOffset< Functor >(
+                *static_cast< Functor * >( this ),
+                cellOffsetFunctor(
+                    acc,
+                    localSupercellOffset,
+                    workerCfg
+                )
+            );
+        }
+
+        static
+        HINLINE std::string
+        getName( )
+        {
+            // we provide the name from the param class
+            return Functor::name;
+        }
+    };
+
+} // namespace generic
+} // namespace filter
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/functor/functor.def
+++ b/include/picongpu/particles/functor/functor.def
@@ -20,4 +20,5 @@
 #pragma once
 
 #include "picongpu/particles/functor/User.def"
+#include "picongpu/particles/misc/generic/TotalCellOffset.def"
 #include "picongpu/particles/misc/generic/Rng.def"

--- a/include/picongpu/particles/functor/misc/TotalCellOffset.def
+++ b/include/picongpu/particles/functor/misc/TotalCellOffset.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2017 Rene Widera, Axel Huebl
+/* Copyright 2017 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -19,6 +19,18 @@
 
 #pragma once
 
-#include "picongpu/particles/functor/User.hpp"
-#include "picongpu/particles/misc/generic/TotalCellOffset.hpp"
-#include "picongpu/particles/misc/generic/Rng.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace functor
+{
+namespace misc
+{
+    //! Provide the cell offset of a supercell to the total domain origin
+    struct TotalCellOffset;
+} // namespace misc
+} // namespace functor
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
+++ b/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
@@ -1,0 +1,87 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/functor/misc/TotalCellOffset.def"
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace functor
+{
+namespace misc
+{
+    struct TotalCellOffset
+    {
+
+        /** constructor
+         *
+         * @param currentStep current simulation time step
+         */
+        HINLINE TotalCellOffset( uint32_t currentStep )
+        {
+            uint32_t const numSlides = MovingWindow::getInstance( ).getSlideCounter( currentStep );
+            SubGrid< simDim > const & subGrid = Environment< simDim >::get( ).SubGrid( );
+            DataSpace< simDim > const localCells = subGrid.getLocalDomain( ).size;
+            gpuCellOffsetToTotalOrigin = subGrid.getLocalDomain( ).offset;
+            gpuCellOffsetToTotalOrigin.y( ) += numSlides * localCells.y( );
+        }
+
+        /** get cell offset of the supercell
+         *
+         * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param offset (in supercells, without any guards) to the
+         *         origin of the local domain
+         * @param configuration of the worker
+         */
+        template<
+            typename T_WorkerCfg,
+            typename T_Acc
+        >
+        HDINLINE DataSpace< simDim >
+        operator()(
+            T_Acc const & acc,
+            DataSpace< simDim > const & localSupercellOffset,
+            T_WorkerCfg const &
+        )
+        {
+            DataSpace< simDim > const superCellToLocalOriginCellOffset(
+                localSupercellOffset * SuperCellSize::toRT( )
+            );
+
+            return gpuCellOffsetToTotalOrigin + superCellToLocalOriginCellOffset;
+        }
+
+    private:
+
+        //! offset in cells to the total domain origin
+        DataSpace< simDim > gpuCellOffsetToTotalOrigin;
+    };
+
+} // namespace misc
+} // namespace functor
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
- add helper to provide the cell offset to the total domain origin of a supercell
- add generic filter:
  - `Free` - calls a user defined filter
  - `FreeRng` - calls a user defined filter and provide a random number generator
  - `FreeTotalCellOffset` - calls a user defined filter and provide the offset of the particle (in cells)
- update `particles.rst`