### PR TITLE
fix wrong quoting of `'`

### DIFF
--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -43,7 +43,8 @@ function tooltpl_replace
         # echo " $data_set" > /dev/stderr
         tooltpl_src=`echo "$data_set" | cut -d"=" -f2- `
         #s/\$'//g delete $' ' before a multi line argument
-        tooltpl_src_esc=`echo "$tooltpl_src" | sed -e 's/[\/&]/\\\\&/g' | sed '/^[[:blank:]]*$/d'| sed "s/^\$'//g; s/^'//g; s/'$//; s/&/\\\\\&/g "`
+        #sed "s/\\\\\''//g" removes `\''` which is created out of `'` from environment variables
+        tooltpl_src_esc=`echo "$tooltpl_src" | sed "s/\\\\\''//g" | sed -e 's/[\/&]/\\\\&/g' | sed '/^[[:blank:]]*$/d'| sed "s/^\$'//g; s/^'//g; s/'$//; s/&/\\\\\&/g "`
         #echo $tooltpl_src_esc
         if [ -n  "$tooltpl_dst" ] ; then
            #echo "$tooltpl_dst $tooltpl_src_esc $tooltpl_src " > /dev/stderr


### PR DESCRIPTION
fix #2414

A single `'` is quoted with `'\''` which creates an error in combination with slurm.
The issue is solved by removing `\''` from the environment variables.