### PR TITLE
CI/Deps: CUDA 8.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -134,7 +134,7 @@ Optional Libraries
 
 CUDA
 """"
-- `7.5+ <https://developer.nvidia.com/cuda-downloads>`_
+- `8.0+ <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -94,7 +94,7 @@ touch "$thisDir"runGuard
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DALPAKA_CUDA_ARCH=35"
             export PIC_BACKEND="cuda"
             . /etc/profile
-            module load gcc/4.9.4 boost/1.62.0 cmake/3.7.0 cuda/7.5.18 openmpi/1.10.4
+            module load gcc/4.9.4 boost/1.62.0 cmake/3.7.0 cuda/8.0.44 openmpi/1.10.4
             module load libSplash/1.6.0 adios/1.10.0
             module load pngwriter/0.5.6 rivlib/1.0.2
             module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.1.0


### PR DESCRIPTION
This documents the changes to CUDA 8.0+ on the CI and our dependencies.

We do not remove the CUDA 7.5 work-arounds (e.g. for boost) yet since it can in principle still be needed and work, e.g. if we replace Boost::mpl with something more modern #1997