### PR TITLE
(Manipulate)DeriveSpecies: Fix Filters

### DIFF
--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -115,7 +115,8 @@ struct CreateDensity
                                destination and source, \see include/picongpu/particles/manipulators
  * @tparam T_SrcSpeciesType source species
  * @tparam T_DestSpeciesType destination species
- * @tparam T_Filter picongpu::particles::filter, particle filter type to select particles
+ * @tparam T_Filter picongpu::particles::filter, particle filter type to select
+ *                  particles in T_SrcSpeciesType to derive into T_DestSpeciesType
  */
 template<
     typename T_Functor,
@@ -135,10 +136,8 @@ struct ManipulateDeriveSpecies
         DestSpeciesType
     >::type;
 
-    using Manipulator = manipulators::IBinary<
-        UserFunctor,
-        T_Filter
-    >;
+    using Manipulator = manipulators::IBinary< UserFunctor >;
+    using Filter = filter::IUnary< T_Filter >;
 
     HINLINE void operator()( const uint32_t currentStep )
     {
@@ -146,9 +145,10 @@ struct ManipulateDeriveSpecies
         auto speciesPtr = dc.get< DestSpeciesType >( DestFrameType::getName(), true );
         auto srcSpeciesPtr = dc.get< SrcSpeciesType >( SrcFrameType::getName(), true );
 
-        Manipulator manipulator(currentStep);
+        Manipulator manipulator( currentStep );
+        Filter filter( currentStep );
 
-        speciesPtr->deviceDeriveFrom(*srcSpeciesPtr, manipulator);
+        speciesPtr->deviceDeriveFrom(*srcSpeciesPtr, manipulator, filter);
 
         dc.releaseData( DestFrameType::getName() );
         dc.releaseData( SrcFrameType::getName() );
@@ -164,7 +164,7 @@ struct ManipulateDeriveSpecies
  *
  * @tparam T_SrcSpeciesType source species
  * @tparam T_DestSpeciesType destination species
- * @tparam T_Filter picongpu::particles::filter, particle filter type to select particles
+ * @tparam T_Filter picongpu::particles::filter, particle filter type to select source particles to derive
  */
 template<
     typename T_SrcSpeciesType,

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -105,7 +105,8 @@ public:
         typename T_SrcName,
         typename T_SrcAttributes,
         typename T_SrcFlags,
-        typename T_ManipulateFunctor
+        typename T_ManipulateFunctor,
+        typename T_SrcFilterFunctor
     >
     void deviceDeriveFrom(
         Particles<
@@ -113,7 +114,8 @@ public:
             T_SrcAttributes,
             T_SrcFlags
         >& src,
-        T_ManipulateFunctor& manipulateFunctor
+        T_ManipulateFunctor& manipulateFunctor,
+        T_SrcFilterFunctor& srcFilterFunctor
     );
 
     template<typename T_Functor>

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -74,12 +74,15 @@ struct KernelDeriveParticles
      * @param srcBox particles box of the source species
      * @param manipulateFunctor functor to derive a particle out of another one
      *                          must fulfill the interface particles::manipulators::IManipulator
+     * @param srcFilterFunctor unary filter to select in the source species
+     *                         species which particles to derive
      * @param mapper functor to map a block to a supercell
      */
    template<
         typename T_DestParBox,
         typename T_SrcParBox,
         typename T_ManipulateFunctor,
+        typename T_SrcFilterFunctor,
         typename T_Mapping,
         typename T_Acc
     >
@@ -88,6 +91,7 @@ struct KernelDeriveParticles
         T_DestParBox destBox,
         T_SrcParBox srcBox,
         T_ManipulateFunctor manipulateFunctor,
+        T_SrcFilterFunctor srcFilterFunctor,
         T_Mapping const mapper
     ) const
     {
@@ -146,6 +150,11 @@ struct KernelDeriveParticles
             localSuperCellOffset,
             WorkerCfg< numWorker >{ workerIdx }
         );
+        auto accSrcFilter = srcFilterFunctor(
+            acc,
+            localSuperCellOffset,
+            WorkerCfg< numWorker >{ workerIdx }
+        );
 
         __syncthreads( );
 
@@ -170,18 +179,19 @@ struct KernelDeriveParticles
                     if( parSrc[ multiMask_ ] != 1 )
                         parSrc.setHandleInvalid( );
 
-                    //! @todo us filtered functor
-                    if( parSrc.isHandleValid( ) )
+                    if( accSrcFilter( acc, parSrc ) )
+                    {
                         assign(
                             parDest,
                             deselect< particleId >( parSrc )
                         );
 
-                    accManipulator(
-                        acc,
-                        parDest,
-                        parSrc
-                    );
+                        accManipulator(
+                            acc,
+                            parDest,
+                            parSrc
+                        );
+                    }
                 }
             );
 

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -75,7 +75,7 @@ struct KernelDeriveParticles
      * @param manipulateFunctor functor to derive a particle out of another one
      *                          must fulfill the interface particles::manipulators::IManipulator
      * @param srcFilterFunctor unary filter to select in the source species
-     *                         species which particles to derive
+     *                         which particles to derive
      * @param mapper functor to map a block to a supercell
      */
    template<

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -348,7 +348,8 @@ template<
     typename T_SrcName,
     typename T_SrcAttributes,
     typename T_SrcFlags,
-    typename T_ManipulateFunctor
+    typename T_ManipulateFunctor,
+    typename T_SrcFilterFunctor
 >
 void
 Particles<
@@ -361,7 +362,8 @@ Particles<
         T_SrcAttributes,
         T_SrcFlags
     >& src,
-    T_ManipulateFunctor& functor
+    T_ManipulateFunctor& manipulatorFunctor,
+    T_SrcFilterFunctor& srcFilterFunctor
 )
 {
     log< picLog::SIMULATION_STATE > ( "clone species %1%" ) % FrameType::getName( );
@@ -378,7 +380,8 @@ Particles<
     )(
         this->getDeviceParticlesBox( ),
         src.getDeviceParticlesBox( ),
-        functor,
+        manipulatorFunctor,
+        srcFilterFunctor,
         mapper
     );
     this->fillAllGaps( );

--- a/include/picongpu/particles/filter/generic/Free.def
+++ b/include/picongpu/particles/filter/generic/Free.def
@@ -35,7 +35,7 @@ namespace generic
      *                   **optional**: can implement **one** host side constructor
      *                   `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
      *
-     * example for `particleFilters.param`: each particle with in cell position greater than 0.5
+     * example for `particleFilters.param`: each particle with in-cell position greater than 0.5
      *   @code{.cpp}
      *
      *   struct FunctorEachParticleAboveMiddleOfTheCell

--- a/include/picongpu/particles/filter/generic/Free.def
+++ b/include/picongpu/particles/filter/generic/Free.def
@@ -35,7 +35,7 @@ namespace generic
      *                   **optional**: can implement **one** host side constructor
      *                   `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
      *
-     * example: each particle with in cell position greater than 0.5
+     * example for `particleFilters.param`: each particle with in cell position greater than 0.5
      *   @code{.cpp}
      *
      *   struct FunctorEachParticleAboveMiddleOfTheCell
@@ -50,7 +50,7 @@ namespace generic
      *       }
      *   };
      *
-     *   using EachParticleAboveMiddleOfTheCell = Free<
+     *   using EachParticleAboveMiddleOfTheCell = generic::Free<
      *      FunctorEachParticleAboveMiddleOfTheCell
      *   >;
      *   @endcode

--- a/include/picongpu/particles/filter/generic/Free.hpp
+++ b/include/picongpu/particles/filter/generic/Free.hpp
@@ -68,7 +68,9 @@ namespace acc
             T_Particle const & particle
         )
         {
-            return Functor::operator( )( particle );
+            bool const isValid = particle.isHandleValid( );
+
+            return isValid && Functor::operator( )( particle );
         }
 
     };

--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -42,7 +42,8 @@ namespace generic
      * @tparam T_Seed seed to initialize the random number generator
      * @tparam T_SpeciesType type of the species that shall be manipulated
      *
-     * example for `particleFilters.param`: get each particle second particle
+     * example for `particleFilters.param`: get every second particle
+     *                                      (random sample of 50%)
      *   @code{.cpp}
      *
      *   struct FunctorEachSecondParticle

--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -42,7 +42,7 @@ namespace generic
      * @tparam T_Seed seed to initialize the random number generator
      * @tparam T_SpeciesType type of the species that shall be manipulated
      *
-     * example: get each particle second particle
+     * example for `particleFilters.param`: get each particle second particle
      *   @code{.cpp}
      *
      *   struct FunctorEachSecondParticle
@@ -60,7 +60,7 @@ namespace generic
      *       }
      *   };
      *
-     *   using EachSecondParticle = Free<
+     *   using EachSecondParticle = generic::Free<
      *      FunctorEachSecondParticle
      *   >;
      *   @endcode

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -80,7 +80,9 @@ namespace acc
         {
             namespace nvrng = nvidia::rng;
 
-            return Functor::operator()(
+            bool const isValid = particle.isHandleValid( );
+
+            return isValid && Functor::operator()(
                 m_rng,
                 particle
             );

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
@@ -41,7 +41,8 @@ namespace generic
      *
      * @tparam T_Functor user defined unary functor
      *
-     * example: each particle with a cell offset of 5 in X direction
+     * example for `particleFilters.param`: each particle with a cell offset of 5
+     * in X direction
      *   @code{.cpp}
      *
      *   struct FunctorEachParticleInXCell5

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -73,13 +73,18 @@ namespace acc
             T_Particle const & particle
         )
         {
-            DataSpace< simDim > const cellInSuperCell(
-                DataSpaceOperations< simDim >::template map< SuperCellSize > ( particle[ localCellIdx_ ] )
-            );
-            return Functor::operator( )(
-                m_superCellToLocalOriginCellOffset + cellInSuperCell,
-                particle
-            );
+            bool filterResult = false;
+            if( particle.isHandleValid( ) )
+            {
+                DataSpace< simDim > const cellInSuperCell(
+                    DataSpaceOperations< simDim >::template map< SuperCellSize > ( particle[ localCellIdx_ ] )
+                );
+                filterResult = Functor::operator( )(
+                    m_superCellToLocalOriginCellOffset + cellInSuperCell,
+                    particle
+                );
+            }
+            return filterResult;
         }
 
     private:

--- a/include/picongpu/particles/manipulators/generic/Free.def
+++ b/include/picongpu/particles/manipulators/generic/Free.def
@@ -35,7 +35,7 @@ namespace generic
      *                   **optional**: can implement **one** host side constructor
      *                   `T_Functor()` or `T_Functor(uint32_t currentTimeStep)`
      *
-     * example: set in cell position to zero
+     * example for `particle.param`: set in cell position to zero
      *   @code{.cpp}
      *
      *   struct FunctorInCellPositionZero
@@ -45,10 +45,10 @@ namespace generic
      *       {
      *           particle[ position_ ] = floatD_X::create( 0.0 );
      *       }
-     *       static constexpr char const * name = "InCellPositionZero";
+     *       static constexpr char const * name = "inCellPositionZero";
      *   };
      *
-     *   using InCellPositionZero = Free<
+     *   using InCellPositionZero = generic::Free<
      *      FunctorInCellPositionZero
      *   >;
      *   @endcode

--- a/include/picongpu/particles/manipulators/generic/FreeRng.def
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.def
@@ -42,27 +42,30 @@ namespace generic
      * @tparam T_Seed seed to initialize the random number generator
      * @tparam T_SpeciesType type of the species that shall be manipulated
      *
-     * example: add
+     * example for `particle.param`: add
      *   @code{.cpp}
      *   #include <pmacc/nvidia/rng/distributions/Uniform_float.hpp>
      *
-     *   struct RandomXFunctor
+     *   struct FunctorRandomX
      *   {
      *       template< typename T_Rng, typename T_Particle >
      *       HDINLINE void operator()( T_Rng& rng, T_Particle& particle )
      *       {
      *           particle[ position_ ].x() = rng();
      *       }
-     *       static constexpr char const * name = "RandomXPos";
+     *       static constexpr char const * name = "randomXPos";
      *   };
      *
-     *   using RandomXPos = FreeRng<
-     *      RandomXFunctor,
+     *   using RandomXPos = generic::FreeRng<
+     *      FunctorRandomX,
      *      nvidia::rng::distributions::Uniform_float
      *   >;
-     *   particles::Manipulate< RandomXPos, SPECIES_NAME >
      *   @endcode
-     *   to `InitPipeline` in `speciesInitialization.param`
+     *
+     * and to `InitPipeline` in `speciesInitialization.param`:
+     *   @code{.cpp}
+     *   Manipulate< manipulators::RandomXPos, SPECIES_NAME >
+     *   @endcode
      */
     template<
         typename T_Functor,

--- a/include/picongpu/simulation_defines/param/particleFilters.param
+++ b/include/picongpu/simulation_defines/param/particleFilters.param
@@ -28,35 +28,14 @@ namespace particles
 {
 namespace filter
 {
-
-    /** Parameters for an assignment in a relative position selection
-     */
-    struct IfRelativeGlobalPositionParam
-    {
-        /* lowerBound is included in the range */
-        static constexpr float_X lowerBound = 0.0;
-        /* upperBound is excluded in the range */
-        static constexpr float_X upperBound = 0.5;
-        /* dimension for the filter
-         * x = 0; y= 1; z = 2
-         */
-        static constexpr uint32_t dimension = 0u;
-
-        // filter name
-        static constexpr char const * name = "lowerHalfXPosition";
-    };
-    /** definition of a relative position selection that assigns a drift in X */
-    using LowerHalfXPosition = RelativeGlobalDomainPosition<
-        IfRelativeGlobalPositionParam
-    >;
-
-    /** collection of all available particle filters
+    /** Plugins: collection of all available particle filters
      *
-     * - filter All is defined in picongpu/particles/filter/filter.def
+     * Create a list of all filters here that you want to use in plugins.
+     *
+     * Note: filter All is defined in picongpu/particles/filter/filter.def
      */
     using AllParticleFilters = MakeSeq_t<
-        All,
-        LowerHalfXPosition
+        All
     >;
 
 } // namespace filter

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particleFilters.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/particleFilters.param
@@ -85,9 +85,11 @@ namespace filter
         IfRelativeGlobalPositionParamUpperQuarter
     >;
 
-    /** collection of all available particle filters
+    /** Plugins: collection of all available particle filters
      *
-     * - filter All is defined in picongpu/particles/filter/filter.def
+     * Create a list of all filters here that you want to use in plugins.
+     *
+     * Note: filter All is defined in picongpu/particles/filter/filter.def
      */
     using AllParticleFilters = MakeSeq_t<
         All,


### PR DESCRIPTION
The filters on `ManipulateDerive`- and `Derive`-Species should be filtering the particles to derive (in the source species). Before, this was accidentally filtering the destination species to manipulate and derived all particles from the source species. This is not necessary, lacks the filter in the source species and is confusing, also since a manipulator can simply filter with a simple if where needed.

### Additional Commits

In order to guarantee this works, the "Free" manipulators needed a fix to check for `isValid()` before applying a user-filter.

Also, the comments have been improved to be more accurate and the examples for input files have been fixed for little typos and are more clear now.

The default of the `particleFilters.param` should only be `All` as well (compile-time). The KHI example shows a more sophisticated example already (and we will add more for e.g. tracer particles soon).

Thx to @psychocoderHPC for pair programming with me for the fix. Fix related to the implementation of feature #1288.