### PR TITLE
Phase Space Plugin: Fix Weighted Particles

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -239,13 +239,16 @@ namespace picongpu
         const float_64 unit = UNIT_CHARGE / UNIT_VOLUME;
 
         /* (momentum) p range: unit is m_species * c
-         *   During the kernels we calculate with a typical MAKRO momentum range
-         *   to avoid over- / underflows. Now for the dump the meta information
+         *   During the kernels we calculate with a typical single/real
+         *   momentum range. Now for the dump the meta information of units
          *   on the p-axis should be scaled to represent single/real particles.
-         *   \see PhaseSpaceMulti::pluginLoad( ) */
-        float_64 pRange_unit = float_64( frame::getMass<typename Species::FrameType>() ) *
-                               float_64( SPEED_OF_LIGHT ) *
-                               UNIT_MASS * UNIT_SPEED;
+         *   \see PhaseSpaceMulti::pluginLoad( )
+         */
+        float_64 const pRange_unit =
+            float_64( frame::getMass< typename Species::FrameType >() ) *
+            float_64( SPEED_OF_LIGHT ) *
+            ( UNIT_MASS * float_64( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE ) ) *
+            UNIT_SPEED;
 
         DumpHBuffer dumpHBuffer;
 

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -103,7 +103,7 @@ namespace picongpu
             const float_PS particleChargeDensity =
               precisionCast<float_PS>( charge / CELL_VOLUME );
 
-            const float_X rel_bin = (mom_i - axis_p_range.first)
+            const float_X rel_bin = (mom_i / weighting - axis_p_range.first)
                                   / (axis_p_range.second - axis_p_range.first);
             int p_bin = int( rel_bin * float_X(num_pbins) );
 

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceMulti.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceMulti.tpp
@@ -66,20 +66,14 @@ namespace picongpu
         this->children.reserve( this->numChildren );
         for(uint32_t i = 0; i < this->numChildren; i++)
         {
-            /* unit is m_species c - we use the typical weighting already since
-             * it scales linear in momentum and we avoid over- & under-flows
-             * during momentum-binning while staying at a
-             * "typical macro particle momentum scale"
-             *
-             * we correct that during the output of the pAxis range
-             * (linearly shrinking the single particle scale again)
-             */
-            float_X pRangeMakro_unit = float_X( frame::getMass<typename Species::FrameType>()*
-                                                particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE *
-                                                SPEED_OF_LIGHT );
+            // unit is m_species c (for a single "real" particle)
+            float_X pRangeSingle_unit(
+                frame::getMass< typename Species::FrameType >() *
+                SPEED_OF_LIGHT
+            );
             std::pair<float_X, float_X> new_p_range(
-                    this->momentum_range_min.at(i) * pRangeMakro_unit,
-                    this->momentum_range_max.at(i) * pRangeMakro_unit );
+                    this->momentum_range_min.at(i) * pRangeSingle_unit,
+                    this->momentum_range_max.at(i) * pRangeSingle_unit );
             /* String to Enum conversion */
             uint32_t el_space;
             if( this->element_space.at(i) == "x" )


### PR DESCRIPTION
### Phase Space Plugin

Fix for weighted particles with a weighting off the "typical" (nominal) weighting. The plugin calculated, since its introduction in #347 (releases: `beta-rc5`-`0.3.1`), the momentum bin of particles with non-typical weighting wrong: particles with lower weighting were put in proportionally lower momentum bins and with higher weighting than "typical weighting" were put in proportionally higher bins.

## Affected Setups

Entries to phase space bins originating from
- up/downramp particles
- material dopings with non-"typical" weighting
- below-1.0 areas of the normalized density profile

are ill-placed in the phase space image. Momenta of lower-weighting (macro) particles were underestimated, momenta of higher-weighting (macro) particles were overestimated.

## Unaffected setups

This *only* affects a plugin, deriving a 2D phase space on the fly. The general PIC cycle, the physics it solves and any other output of particle data, e.g. ADIOS or HDF5, energy histograms, etc. are NOT affected. If you did e.g. filter the particle data by hand and created a phase space image from yourself the result was correct.

If you did, e.g. a self-injection LWFA setup, an ion acceleration setup where the main phase space signature is coming from particles in the "bulk", a plasma instability setup (KHI, Weibel, etc.) where the density is always nominal "1.0", etc. the error does not affect you.

Also, integrals of the phase-space matrix over the momentum direction will still lead to the correct particle count (just wrong bins were selected, but the particle numbers are correct).

## Demonstrating Setup

The following setup shows a typical TNSA foil setup: an exponential density slope (due to finite laser contrast) before a plateau phase starting at 0.5 microns. The plateau density was set with a free density profile to `0.5` (instead of 1.0) times the `BASE_DENSITY_SI` (all in `density.param`). An initial particle drift of `1 MeV` for electrons (gamma = 2.957; momentum in beta gamma = 2.783) in y direction. In phase space y-py one would expect a straight line at beta gamma.

**Before:**

(instead of a straight line, the momentum-bins are weighted with the density resulting from the lower macro-particle weighting)

![ps_broken](https://user-images.githubusercontent.com/1353258/33822282-47b270f8-de57-11e7-81cc-e2a95572d227.png)

**After:**

![ps_fix](https://user-images.githubusercontent.com/1353258/33825704-cff5991c-de62-11e7-9297-65ab557253ca.png)

### To Do

- [ ] after initial review, announce on user-list
- [x] add image demonstrating the issue
- [x] add to 0.3.2 backport candidates
- [ ] please merge this PR *before* merging #2425