### PR TITLE
add `hdf5.file` to cfg's with IO

### DIFF
--- a/share/picongpu/examples/Bremsstrahlung/etc/picongpu/0008gpus.cfg
+++ b/share/picongpu/examples/Bremsstrahlung/etc/picongpu/0008gpus.cfg
@@ -51,7 +51,7 @@ TBG_ph_calorimeter="--ph_calorimeter.period 1000 --ph_calorimeter.openingYaw 360
 
 TBG_ph_energyHistogram="--ph_energyHistogram.period 1000  --ph_energyHistogram.minEnergy 10 --ph_energyHistogram.maxEnergy 10000"
 
-TBG_plugins="--hdf5.period 1000  \
+TBG_plugins="--hdf5.period 1000 --hdf5.file simData \
              --e_macroParticlesCount.period 1000 \
              --i_macroParticlesCount.period 1000 \
              --ph_macroParticlesCount.period 1000 \

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/0004gpus.cfg
@@ -70,7 +70,7 @@ TBG_sumEnergy="--fields_energy.period 100 \
 TBG_chargeConservation="--chargeConservation.period 100"
 
 # regular output
-TBG_hdf5="--hdf5.period 250"
+TBG_hdf5="--hdf5.period 250 --hdf5.file simData"
 
 TBG_plugins="!TBG_e_histogram !TBG_H_histogram !TBG_C_histogram !TBG_N_histogram \
              !TBG_e_PSypy !TBG_H_PSypy !TBG_C_PSypy !TBG_N_PSypy                 \

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/0016gpus.cfg
@@ -45,7 +45,7 @@ TBG_periodic="--periodic 1 1 1"
 ## Section: Optional Variables ##
 #################################
 
-TBG_hdf5="--hdf5.period 250"
+TBG_hdf5="--hdf5.period 250 --hdf5.file simData"
 
 TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
 TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"

--- a/share/picongpu/examples/SingleParticleTest/etc/picongpu/0001gpu.cfg
+++ b/share/picongpu/examples/SingleParticleTest/etc/picongpu/0001gpu.cfg
@@ -48,7 +48,7 @@ TBG_periodic="--periodic 1 1 1"
 # write position to stdout (messy):
 # --e_position.period 1
 
-TBG_plugins="--hdf5.period 1                   \
+TBG_plugins="--hdf5.period 1 --hdf5.file simData \
              --e_macroParticlesCount.period 100"
 
 

--- a/share/picongpu/examples/WarmCopper/etc/picongpu/1gpu.cfg
+++ b/share/picongpu/examples/WarmCopper/etc/picongpu/1gpu.cfg
@@ -51,7 +51,7 @@ TBG_ehot_histogram="--ehot_energyHistogram.period 100 --ehot_energyHistogram.bin
                     --ehot_energyHistogram.minEnergy 0 --ehot_energyHistogram.maxEnergy 250"
 
 # file I/O
-TBG_hdf5="--hdf5.period 100"
+TBG_hdf5="--hdf5.period 100 --hdf5.file simData"
 
 TBG_plugins="!TBG_eth_histogram !TBG_ehot_histogram \
              !TBG_hdf5"


### PR DESCRIPTION
follow up of #2403 (thx @ax3l for the hint that I missed it in the original PR)

add missing required option `hdf5.file` to example cfg's