### PR TITLE
Plugin Docs: Memory Complexity

### DIFF
--- a/docs/source/usage/plugins/adios.rst
+++ b/docs/source/usage/plugins/adios.rst
@@ -60,6 +60,20 @@ PIConGPU command line option description
    #. dump all species data each 128th time step, **do not create** the adios journal meta file.
    #. dump all field data each 1000th time step but **create** the adios journal meta file.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+no extra allocations.
+
+Host
+""""
+
+as soon as ADIOS is compiled in, one extra ``mallocMC`` heap for the particle buffer is permanently reserved.
+During I/O, particle attributes are allocated one after another.
+
 Additional Tools
 ^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/chargeConservation.rst
+++ b/docs/source/usage/plugins/chargeConservation.rst
@@ -21,6 +21,19 @@ PIConGPU command line argument (for ``.cfg`` files):
 
    --chargeConservation.period <periodOfSteps>
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+no extra allocations (needs at least one FieldTmp slot).
+
+Host
+""""
+
+negligible.
+
 Output and Analysis Tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/checkpoint.rst
+++ b/docs/source/usage/plugins/checkpoint.rst
@@ -55,8 +55,8 @@ PIConGPU command line option                  Description
 
 Depending on the available external dependencies (see above), the options for the ``<IO-backend>`` are:
 
-* ``hdf5``
-* ``adios``
+* :ref:`hdf5 <usage-plugins-HDF5>`
+* :ref:`adios <usage-plugins-ADIOS>`
 
 Interacting Manually with Checkpoint Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/usage/plugins/countParticles.rst
+++ b/docs/source/usage/plugins/countParticles.rst
@@ -14,6 +14,18 @@ The *CountParticles* plugin is always complied for all species.
 By specifying the perodicity of the output using the comand line argument ``--e_macroParticlesCount.period`` (here for an electron species called ``e``) with picongpu, the plugin is enabled.
 Setting ``--e_macroParticlesCount.period 100`` adds the number of all electron like macro particles to the file `ElectronsCount.dat` for every 100th time step of the simulation.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+no extra allocations.
+
+Host
+""""
+
+negligible.
 
 Output
 ^^^^^^

--- a/docs/source/usage/plugins/countPerSupercell.rst
+++ b/docs/source/usage/plugins/countPerSupercell.rst
@@ -14,11 +14,20 @@ The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <insta
 .cfg files
 ^^^^^^^^^^
 
-By specifying the perodicity of the output using the comand line argument ``--e_macroParticlesPerSuperCell.period`` (here for an electron species `e`) with picongpu, the plugin is enabled.
+By specifying the perodicity of the output using the comand line argument ``--e_macroParticlesPerSuperCell.period`` (here for an electron species ``e``) with picongpu, the plugin is enabled.
 Setting ``--e_macroParticlesPerSuperCell.period 100`` adds the number of all electron like macro particles to the file ``e_macroParticlesCount.dat`` for every 100th time step of the simulation.
+
+Accelerator
+"""""""""""
+
+an extra permanent allocation of ``size_t`` for each local supercell.
+
+Host
+""""
+
+negligible.
 
 Output
 ^^^^^^
 
-The output is stores as hdf5 file in a separate directory. 
-
+The output is stored as hdf5 file in a separate directory.

--- a/docs/source/usage/plugins/energyFields.rst
+++ b/docs/source/usage/plugins/energyFields.rst
@@ -13,6 +13,18 @@ By setting the PIConGPU command line flag ``--fields_energy.period`` to a non-ze
 The default value is ``0``, meaning that the total field energy is not stored.
 By setting e.g. ``--fields_energy.period 100`` the total field energy is computed for time steps *0, 100, 200, ...*.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+negligible.
+
+Host
+""""
+
+negligible.
 
 Output
 ^^^^^^

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -59,6 +59,19 @@ PIConGPU command line option                description
    #. create an electron histogram **with 512 bins** each 128th time step.
    #. create an electron histogram **with 1024 bins** (this is the default) each 100th time step.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+an extra array with the number of bins.
+
+Host
+""""
+
+negligible.
+
 Output
 ^^^^^^
 

--- a/docs/source/usage/plugins/energyParticles.rst
+++ b/docs/source/usage/plugins/energyParticles.rst
@@ -20,6 +20,19 @@ PIConGPU command line option     Description
 ``--<species>_energy.filter``    Use filtered particles. All available filters will be shown with ``picongpu --help``
 ================================ ========================================================================================================
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+negligible.
+
+Host
+""""
+
+negligible.
+
 Output
 ^^^^^^
 

--- a/docs/source/usage/plugins/hdf5.rst
+++ b/docs/source/usage/plugins/hdf5.rst
@@ -74,6 +74,19 @@ PIConGPU command line option Description
    #. dump **all species data** each 128th time step.
    #. dump **all fields and species data** (this is the default) data each 1000th time step.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+no extra allocations.
+
+Host
+""""
+
+During I/O, each complete particle species is allocated one after an other.
+
 Additional Tools
 ^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/intensity.rst
+++ b/docs/source/usage/plugins/intensity.rst
@@ -21,6 +21,19 @@ By setting the PIConGPU command line flag ``--intensity.period`` to a non-zero v
 The default value is ``0``, meaning that nothing is computed.
 By setting e.g. ``--intensity.period 100`` the electric field analysis is computed for time steps *0, 100, 200, ...*.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+negligible.
+
+Host
+""""
+
+negligible.
+
 Output
 ^^^^^^
 

--- a/docs/source/usage/plugins/isaac.rst
+++ b/docs/source/usage/plugins/isaac.rst
@@ -74,6 +74,20 @@ Beside the functor chains the client allows to setup the weights per source (val
 Furthermore interpolation can be activated.
 However this is quite slow and most of the time not needed for non-iso-surface rendering.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+locally, a framebuffer with full resolution and 4 byte per pixel is allocated.
+For each ``FieldTmp`` derived field and ``FieldJ`` a copy is allocated, depending on the input in the :ref:`isaac.param <usage-params-plugins>` file.
+
+Host
+""""
+
+negligible.
+
 Example renderings
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/particleCalorimeter.rst
+++ b/docs/source/usage/plugins/particleCalorimeter.rst
@@ -61,15 +61,16 @@ Coordinate System
 
 Yaw and pitch are `Euler angles <https://en.wikipedia.org/wiki/Euler_angles>`_ defining a point on a sphere's surface, where ``(0,0)`` points to the ``+y`` direction here. In the vicinity of ``(0,0)``, yaw points to ``+x`` and pitch to ``+z``.
 
-**Orientation detail:** Since the calorimeters's three-dimensional orientation is given by just two parameters (`posYaw` and `posPitch`) there is one degree of freedom left which has to be fixed.
+**Orientation detail:** Since the calorimeters's three-dimensional orientation is given by just two parameters (``posYaw`` and ``posPitch``) there is one degree of freedom left which has to be fixed.
 Here, this is achieved by eliminating the Euler angle roll.
-However, when `posPitch` is exactly ``+90`` or ``-90`` degrees, the choice of roll is ambiguous, depending on the yaw angle one approaches the singularity.
+However, when ``posPitch`` is exactly ``+90`` or ``-90`` degrees, the choice of roll is ambiguous, depending on the yaw angle one approaches the singularity.
 Here we assume an approach from ``yaw = 0``.
 
 Tuning the spatial resolution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, the spatial bin size is chosen by dividing the opening angle by the number of bins for yaw and pitch respectively. The bin size can be tuned by customizing the mapping function in ``particleCalorimeter.param``.
+By default, the spatial bin size is chosen by dividing the opening angle by the number of bins for yaw and pitch respectively.
+The bin size can be tuned by customizing the mapping function in ``particleCalorimeter.param``.
 
 Detection of outgoing particles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,6 +93,19 @@ This is established by adding the ``GuardHandlerCallPlugins`` template argument 
 
 
 Please make sure to have ``picongpu/GuardHandlerCallPlugins.hpp`` included.
+
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+each energy bin times each coordinate bin allocates two counter (``float_X``) permanently and on each accelerator for active and outgoing particles.
+
+Host
+""""
+
+as on accelerator.
 
 Output
 ^^^^^^

--- a/docs/source/usage/plugins/particleMerger.rst
+++ b/docs/source/usage/plugins/particleMerger.rst
@@ -40,6 +40,19 @@ Notes
  - ``absMomSpreadThreshold`` and ``relMomSpreadThreshold`` are mutually exclusive
  - ``absMomSpreadThreshold`` is always given in [electron mass * speed of light]!
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+no extra allocations, but requires an extra particle attribute per species, ``voronoiCellId``.
+
+Host
+""""
+
+no extra allocations.
+
 Reference
 ^^^^^^^^^
 

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -36,6 +36,19 @@ Option                                 Usage                                    
 ``--e_phaseSpace.max <ValR>``          maximum of the momentum range                            :math:`m_\mathrm{species} c`
 ====================================== ======================================================== ============================
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+locally, a counter matrix of the size local-cells of ``space`` direction times ``1024`` (for momentum bins) is permanently allocated.
+
+Host
+""""
+
+negligible.
+
 Output
 ^^^^^^
 

--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -65,7 +65,7 @@ The two param files :ref:`visualization.param <usage-params-plugins>` and :ref:`
 
 Depending on the used prefix in the command line flags, electron and/or ion density is drawn. 
 Additionally to that, three field values can be visualized together with the particle density.
-In order to set up the visualized field values, the `visualization.param` needs to be changed.
+In order to set up the visualized field values, the ``visualization.param`` needs to be changed.
 In this file, a variety of other parameters used for the PngModule can be specified. 
 
 The ratio of the image can be set.
@@ -86,13 +86,13 @@ In order to scale the image, ``scale_to_cellsize`` needs to be set to ``true`` a
    Make sure to reduce the preview size!
 
 It  is possible to draw the borders between the GPUs used as white lines. 
-This can be done by setting the parameter `white_box_per_GPU` in `visualization.param` to `true`
+This can be done by setting the parameter ``white_box_per_GPU`` in ``visualization.param`` to ``true``
 
 .. code:: cpp
 
    const bool white_box_per_GPU = true;
 
-There are three field values that can be drawn: `CHANNEL1`, `CHANNEL2` and `CHANNEL3`.
+There are three field values that can be drawn: ``CHANNEL1``, ``CHANNEL2`` and ``CHANNEL3``.
 
 Since an adequate color scaling is essential, there several option the user can choose from. 
 
@@ -114,7 +114,7 @@ Since an adequate color scaling is essential, there several option the user can 
 
 In the above example, all channels are set to **auto scale**.
 **Be careful**, when using other normalizations than auto scale, because depending on your set up, the normalization might fail due to parameters not set by PIConGPU.
-*Use the other normalization options only in case of the specified scenarios or if you know, how the scaling is computed. *
+*Use the other normalization options only in case of the specified scenarios or if you know, how the scaling is computed.*
 
 
 You can also add opacity to the particle density and the three field values:
@@ -141,7 +141,7 @@ The colors available are defined in ``visColorScales.param`` and their usage is 
 If ``colorScales::none`` is used, the channel is not drawn.
 
 
-In order to specify what the three channels represent, three functions can be defined in `visualization.param`. 
+In order to specify what the three channels represent, three functions can be defined in ``visualization.param``. 
 The define the values computed for the png visualization.
 The data structures used are those available in PIConGPU. 
 
@@ -171,10 +171,10 @@ The data structures used are those available in PIConGPU.
    }
 
 Only positive values are drawn. Negative values are clipped to zero. 
-In the above example, this feature is used for `preChannel3`. 
+In the above example, this feature is used for ``preChannel3``. 
 
 
-**Defining coloring schemes in** `visColorScales.param` 
+**Defining coloring schemes in** ``visColorScales.param``
 
 There are several predefined color schemes available:
 
@@ -185,7 +185,7 @@ There are several predefined color schemes available:
 - green
 - blue
 
-But the user can also specify his or her own color scheme by defining a namespace with the color name that provides an `addRGB`function:
+But the user can also specify his or her own color scheme by defining a namespace with the color name that provides an ``addRGB`` function:
 
 .. code:: cpp
 
@@ -214,6 +214,21 @@ But the user can also specify his or her own color scheme by defining a namespac
    }
 
 For most cases, using the predefined colors should be enough.
+
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+locally, memory for the local 2D slice is allocated with 3 channels in ``float_X``.
+
+Host
+""""
+
+as on accelerator.
+Additionally, the master rank has to allocate three channels for the full-resolution image.
+This is the original size **before** reduction via ``scale_image``.
 
 Output
 ^^^^^^

--- a/docs/source/usage/plugins/positionsParticles.rst
+++ b/docs/source/usage/plugins/positionsParticles.rst
@@ -13,6 +13,18 @@ By setting the command line flag ``--<species>_position.period`` to a non-zero n
 In order to get the particle trajectory for each time step the period needs to be set to ``1``, meaning e.g. ``--e_position.period 1`` for electrons.
 If less output is needed, e.g. only every 10th time step, the period can be set to different values, e.g. ``--e_position.period 10``.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+negligible.
+
+Host
+""""
+
+negligible.
 
 Output
 ^^^^^^

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -272,6 +272,18 @@ Command line option                       Description
 ``--radiation_<species>.compression``     If set, the hdf5 output is compressed.
 ========================================= ==============================================================================================================================
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+each energy bin times each coordinate bin allocates one counter (``float_X``) permanently and on each accelerator.
+
+Host
+""""
+
+as on accelerator.
 
 Output
 ^^^^^^

--- a/docs/source/usage/plugins/resourceLog.rst
+++ b/docs/source/usage/plugins/resourceLog.rst
@@ -22,6 +22,19 @@ Command line option          Description
 ``--resourceLog.prefix``     Selects the prefix for the file stream name
 ============================ ===================================================================================
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+no extra allocation.
+
+Host
+""""
+
+negligible.
+
 Output / Example
 ^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/sliceFieldPrinter.rst
+++ b/docs/source/usage/plugins/sliceFieldPrinter.rst
@@ -49,6 +49,19 @@ The second slice is a cut along the y-z axis. It is printed every 50th step. It 
 
 In the case of 2D fields, the plugin outputs a 1D slice. Be aware that ``--E_slice.plane`` still refers to the orthogonal axis, i.e. ``--E_slice.plane 1`` outputs a line along the **x-axis** and ``--E_slice.plane 0`` along the **y-axis**.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+the local slice is permanently allocated in the type of the field (``float3_X``).
+
+Host
+""""
+
+as on accelerator.
+
 Output
 ^^^^^^
 

--- a/docs/source/usage/plugins/sumCurrents.rst
+++ b/docs/source/usage/plugins/sumCurrents.rst
@@ -12,6 +12,19 @@ The plugin can be activated by setting a non-zero value with the command line fl
 The value set with ``--sumcurr.period`` is the periodicity, at which the total current is computed.
 E.g. ``--sumcurr.period 100`` computes and prints the total current for time step *0, 100, 200, ...*.
 
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+negligible.
+
+Host
+""""
+
+negligible.
+
 Output
 ^^^^^^
 


### PR DESCRIPTION
Start a sub-paragraph in each plugin explaining the memory complexity it adds (e.g. memory costs at RT) as soon as a plugin is compiled in or activated.

Wording:
- no extra allocations: no (global) memory is allocated at all
- negligible: the extra allocations are too small to be relevant (e.g. a few scalar values)

For people added as reviewers: please take a look at the sections of your plugins and add comments as necessary :)