### PR TITLE
ADIOS: Fix 1 Particle Dumps

### DIFF
--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -120,17 +120,13 @@ int64_t defineAdiosVar(int64_t group_id,
     }
 
     int64_t var_id = 0;
-    if ((DIM == 1) && (globalDimensions.productOfComponents() == 1)) {
-        /* scalars need empty size strings */
-        var_id = adios_define_var(
-            group_id, name, path, type, 0, 0, 0);
-    } else {
-        var_id = adios_define_var(
-            group_id, name, path, type,
-            dimensions.revert().toString(",", "").c_str(),
-            globalDimensions.revert().toString(",", "").c_str(),
-            offset.revert().toString(",", "").c_str());
-    }
+
+    var_id = adios_define_var(
+        group_id, name, path, type,
+        dimensions.revert().toString(",", "").c_str(),
+        globalDimensions.revert().toString(",", "").c_str(),
+        offset.revert().toString(",", "").c_str()
+    );
 
     if (compression && canCompress)
     {


### PR DESCRIPTION
This removes an old work-around for ADIOS in which we handled scalar writes differently than normal variables.

This should not be necessary anymore and caused problems on Piz Daint when writing a species with exactly one particle in it together with blosc compression.

thx to @n01r for spotting it and testing the patch on Piz Daint, thx to @psychocoderHPC for investigating the issue with me.

Note: an alternative work-around would have been to set `canCompress = false;` in the first part of the `if` branch, but this code section looks overall fishy and should not be necessary.