### PR TITLE
fix muller box

### DIFF
--- a/include/pmacc/random/distributions/misc/MullerBox.hpp
+++ b/include/pmacc/random/distributions/misc/MullerBox.hpp
@@ -55,7 +55,7 @@ namespace distributions
          */
         T_Type secondRngNumber;
         //! true if secondRngNumber is valid else false
-        bool hasSecondRngNumber;
+        bool hasSecondRngNumber = false;
 
         using RNGMethod = T_RNGMethod;
         using UniformRng = Uniform<


### PR DESCRIPTION
The flag to mark a valid second generated random number was not initialized.
The result of this bug are wrong normal distributed normal numbers (not used in PIConGPU yet).

bug was introduced with #2415