### PR TITLE
particle boundary conditions

### DIFF
--- a/docs/source/usage/plugins/particleCalorimeter.rst
+++ b/docs/source/usage/plugins/particleCalorimeter.rst
@@ -72,27 +72,6 @@ Tuning the spatial resolution
 By default, the spatial bin size is chosen by dividing the opening angle by the number of bins for yaw and pitch respectively.
 The bin size can be tuned by customizing the mapping function in ``particleCalorimeter.param``.
 
-Detection of outgoing particles
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In order to detect particles which are leaving the global simulation volume, the calorimeter plugin has to be triggered whenever this happens.
-This is established by adding the ``GuardHandlerCallPlugins`` template argument to ``ParticleDescription`` (see :ref:`speciesDefinition.param <usage-params-core>`):
-
-.. code:: cpp
-
-   // example for photons
-   using PIC_Photons = Particles<
-       ParticleDescription<
-           bmpl::string<'p', 'h'>,
-           SuperCellSize,
-           DefaultAttributesSeq,
-           ParticleFlagsPhotons,
-           GuardHandlerCallPlugins
-       >
-   > ;
-
-
-Please make sure to have ``picongpu/GuardHandlerCallPlugins.hpp`` included.
 
 Memory Complexity
 ^^^^^^^^^^^^^^^^^
@@ -106,7 +85,6 @@ Host
 """"
 
 as on accelerator.
-
 Output
 ^^^^^^
 

--- a/include/picongpu/simulationControl/GuardHandlerCallPlugins.hpp
+++ b/include/picongpu/simulationControl/GuardHandlerCallPlugins.hpp
@@ -36,9 +36,6 @@ namespace picongpu
  */
 struct GuardHandlerCallPlugins
 {
-    typedef pmacc::particles::policies::ExchangeParticles HandleExchanged;
-    typedef GuardHandlerCallPlugins HandleNotExchanged;
-
     template< class T_Particles >
     void
     handleOutgoing(T_Particles& particles, const int32_t direction) const

--- a/include/picongpu/simulation_defines/param/speciesAttributes.param
+++ b/include/picongpu/simulation_defines/param/speciesAttributes.param
@@ -254,4 +254,15 @@ namespace picongpu
      */
     alias( exchangeMemCfg );
 
+    /** alias to specify the boundary condition for particles
+     *
+     * The default behavior if this alias is not given to a species is that the
+     * particles which leave the global simulation box where deleted.
+     * This also notifies all plugins that can handle leaving particles.
+     *
+     * Note: alias `boundaryCondition` will be ignored if the runtime parameter
+     * `--periodic` is set.
+     */
+    alias( boundaryCondition );
+
 } // namespace picongpu


### PR DESCRIPTION
- add species attribute `boundaryCondition<>`
- extent particle description with the in flag defined boundary condition
- call method `onParticleLeave` for all plugins by default if `boundaryCondition` is not defined
- remove section that the user needs to activate monitoring of leaving particles via extenting of the species flags

**attention** This PR change the default behavior, now all plugins will be notified if particles leave the global simulation box.

Fixes #2433

# Tests

I run the LWFA example 3000 steps once with calorimeter which monitors the leaving particles and one without. I compared a few samples in the hdf5 (plain) and saw that the energies in the file where the leaving particles are monitored are higher than within the other run. I also checked that the function to monitors the leaving particles is only called if the alias `boundaryCondition` was set.
Any further independent tests are welcome.

CC-ing: @n01r 