### PR TITLE
RNG: use non generic place holder

### DIFF
--- a/include/pmacc/random/RNGHandle.hpp
+++ b/include/pmacc/random/RNGHandle.hpp
@@ -46,7 +46,7 @@ namespace random
         template<class T_Distribution>
         struct GetRandomType
         {
-            typedef typename bmpl::apply<T_Distribution, RNGMethod>::type Distribution;
+            typedef typename T_Distribution::applyMethod<RNGMethod>::type Distribution;
             typedef Random<Distribution, RNGMethod, RNGState*> type;
         };
 

--- a/include/pmacc/random/RNGProvider.hpp
+++ b/include/pmacc/random/RNGProvider.hpp
@@ -57,7 +57,7 @@ namespace random
         template<class T_Distribution>
         struct GetRandomType
         {
-            typedef typename bmpl::apply<T_Distribution, RNGMethod>::type Distribution;
+            typedef typename T_Distribution::applyMethod<RNGMethod>::type Distribution;
             typedef Random<Distribution, RNGMethod, Handle> type;
         };
 

--- a/include/pmacc/random/distributions/Uniform.hpp
+++ b/include/pmacc/random/distributions/Uniform.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/types.hpp"
+#include "pmacc/random/methods/RngPlaceholder.hpp"
 
 namespace pmacc
 {
@@ -48,9 +49,18 @@ namespace distributions
      * \endcode
      * @tparam T_RNGMethod method to create a random number
      */
-    template<typename T_Type, class T_RNGMethod = bmpl::_1>
-    class Uniform: public detail::Uniform<T_Type, T_RNGMethod>
-    {};
+    template<typename T_Type, class T_RNGMethod = methods::RngPlaceholder>
+    struct Uniform: public detail::Uniform<T_Type, T_RNGMethod>
+    {
+        template< typename T_Method >
+        struct applyMethod
+        {
+            using type = Uniform<
+                T_Type,
+                T_Method
+            >;
+        };
+    };
 
 }  // namespace distributions
 }  // namespace random

--- a/include/pmacc/random/methods/RngPlaceholder.hpp
+++ b/include/pmacc/random/methods/RngPlaceholder.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2017 Alexander Grund
+/* Copyright 2015-2017 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -22,39 +22,21 @@
 #pragma once
 
 #include "pmacc/types.hpp"
-#include "pmacc/random/methods/RngPlaceholder.hpp"
+
 
 namespace pmacc
 {
 namespace random
 {
-namespace distributions
+namespace methods
 {
-    namespace detail
-    {
-        /** Only this must be specialized for different types */
-        template<typename T_Type, class T_RNGMethod, class T_SFINAE = void>
-        class Normal;
-    }
 
-    /**
-     * Returns a random, normal distributed value of the given type
-     */
-    template<typename T_Type, class T_RNGMethod = methods::RngPlaceholder>
-    struct Normal: public detail::Normal<T_Type, T_RNGMethod>
+    //! placeholder for the rng method
+    struct RngPlaceholder
     {
-        template< typename T_Method >
-        struct applyMethod
-        {
-            using type = Normal<
-                T_Type,
-                T_Method
-            >;
-        };
+        using StateType = int;
     };
 
-}  // namespace distributions
+}  // namespace methods
 }  // namespace random
 }  // namespace pmacc
-
-#include "pmacc/random/distributions/normal/Normal_float.hpp"


### PR DESCRIPTION
By using non generic place holder to substitude the random number
generation method it is possible to avoid substitution failer
if a unspecified random number is embedded into other template signatures
with boost mpl placeholder.

This change is needed to allow the usage of random number generator where the state is stored between kernel calls.