### PR TITLE
Particle Init Methods: Unify API & Docs

### DIFF
--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -106,6 +106,14 @@ particle.param
    :path: include/picongpu/simulation_defines/param/particle.param
    :no-link:
 
+particleFilters.param
+^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: particleFilters.param
+   :project: PIConGPU
+   :path: include/picongpu/simulation_defines/param/particleFilters.param
+   :no-link:
+
 speciesInitialization.param
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/particles.rst
+++ b/docs/source/usage/particles.rst
@@ -137,9 +137,3 @@ FreeTotalCellOffset
 
 .. doxygenstruct:: picongpu::particles::filter::generic::FreeTotalCellOffset
    :project: PIConGPU
-
-Define a New Particle Filter
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note::
-   Not yet implemented.

--- a/docs/source/usage/particles.rst
+++ b/docs/source/usage/particles.rst
@@ -3,10 +3,14 @@
 Particles
 =========
 
+Particles are defined in modular steps.
+First, species need to be generally defined in :ref:`speciesDefinition.param <usage-params-core>`.
+Second, species are initialized with particles in :ref:`speciesInitialization.param <usage-params-core>`.
+
+The following operations can be applied in the ``picongpu::particles::InitPipeline`` of the latter:
+
 Initialization
 --------------
-
-The following operations can be applied in the picongpu::particles::InitPipeline inside speciesInitialization.param:
 
 CreateDensity
 ^^^^^^^^^^^^^
@@ -14,10 +18,10 @@ CreateDensity
 .. doxygenstruct:: picongpu::particles::CreateDensity
    :project: PIConGPU
 
-DeriveSpecies
-^^^^^^^^^^^^^
+Derive
+^^^^^^
 
-.. doxygenstruct:: picongpu::particles::DeriveSpecies
+.. doxygenstruct:: picongpu::particles::Derive
    :project: PIConGPU
 
 Manipulate
@@ -26,10 +30,10 @@ Manipulate
 .. doxygenstruct:: picongpu::particles::Manipulate
    :project: PIConGPU
 
-ManipulateDeriveSpecies
-^^^^^^^^^^^^^^^^^^^^^^^
+ManipulateDerive
+^^^^^^^^^^^^^^^^
 
-.. doxygenstruct:: picongpu::particles::ManipulateDeriveSpecies
+.. doxygenstruct:: picongpu::particles::ManipulateDerive
    :project: PIConGPU
 
 FillAllGaps
@@ -101,7 +105,7 @@ ProtonTimesWeighting
 Manipulation Filters
 --------------------
 
-Most of the particle functors shall operate on all valid particles, where filter::All is the default assumption.
+Most of the particle functors shall operate on all valid particles, where ``filter::All`` is the default assumption.
 One can limit the domain or subset of particles with filters such as the ones below (or define new ones).
 
 All

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -71,8 +71,8 @@ struct CallFunctor
  *
  * Create particles inside a species. The created particles are macroscopically
  * distributed according to a given normalized density profile
- * (T_DensityFunctor). Their microscopic position inside individual cells is
- * determined by the T_PositionFunctor.
+ * (`T_DensityFunctor`). Their microscopic position inside individual cells is
+ * determined by the `T_PositionFunctor`.
  *
  * @note FillAllGaps is automatically called after creation.
  *
@@ -80,7 +80,7 @@ struct CallFunctor
  *                          see density.param,
  *                          example: picongpu::particles::densityProfiles::Homogenous
  * @tparam T_PositionFunctor unary lambda functor with position description,
- *                           see particles.param,
+ *                           see particle.param,
  *                           examples: picongpu::particles::startPosition::Quiet,
  *                                     picongpu::particles::startPosition::Random
  * @tparam T_SpeciesType type of the used species,
@@ -121,10 +121,10 @@ struct CreateDensity
 
 /** Generate particles in a species by deriving and manipulating from another species' particles
  *
- * Create particles in T_DestSpeciesType by deriving (copying) all particles
- * and their matching attributes (except `particleId`) from T_SrcSpeciesType.
+ * Create particles in `T_DestSpeciesType` by deriving (copying) all particles
+ * and their matching attributes (except `particleId`) from `T_SrcSpeciesType`.
  * During the derivation, the particle attributes in can be manipulated with
- * T_ManipulateFunctor.
+ * `T_ManipulateFunctor`.
  *
  * @note FillAllGaps is called on on T_DestSpeciesType after the derivation is
  *       finished.
@@ -175,7 +175,7 @@ struct ManipulateDerive
         FilteredManipulator filteredManipulator( currentStep );
         SrcFilter srcFilter( currentStep );
 
-        speciesPtr->deviceDeriveFrom( *srcSpeciesPtr, manipulator, srcFilter );
+        speciesPtr->deviceDeriveFrom( *srcSpeciesPtr, filteredManipulator, srcFilter );
 
         dc.releaseData( DestFrameType::getName() );
         dc.releaseData( SrcFrameType::getName() );
@@ -185,10 +185,10 @@ struct ManipulateDerive
 
 /** Generate particles in a species by deriving from another species' particles
  *
- * Create particles in T_DestSpeciesType by deriving (copying) all particles
- * and their matching attributes (except `particleId`) from T_SrcSpeciesType.
+ * Create particles in `T_DestSpeciesType` by deriving (copying) all particles
+ * and their matching attributes (except `particleId`) from `T_SrcSpeciesType`.
  *
- * @note FillAllGaps is called on on T_DestSpeciesType after the derivation is
+ * @note FillAllGaps is called on on `T_DestSpeciesType` after the derivation is
  *       finished.
  *
  * @tparam T_SrcSpeciesType source species
@@ -222,7 +222,7 @@ struct Derive : ManipulateDerive<
  * After execution, the requirement that all particle frames must be filled
  * contiguously with valid particles and that all frames but the last are full
  * is fulfilled.
- * 
+ *
  * @tparam T_SpeciesType the particle species to fill gaps in memory
  */
 template< typename T_SpeciesType = bmpl::_1 >

--- a/include/picongpu/particles/Manipulate.hpp
+++ b/include/picongpu/particles/Manipulate.hpp
@@ -40,15 +40,16 @@ namespace particles
      *
      * @warning Does NOT call FillAllGaps after manipulation! If the
      *          manipulation deactivates particles or creates "gaps" in any
-     *          other way, FillAllGaps needs to be called for the T_SpeciesType
-     *          manually in the next step!
+     *          other way, FillAllGaps needs to be called for the
+     *          `T_SpeciesType` manually in the next step!
      *
      * @tparam T_Manipulator unary lambda functor accepting one particle
      *                       species,
      *                       @see picongpu::particles::manipulators
      * @tparam T_SpeciesType type of the used species
      * @tparam T_Filter picongpu::particles::filter, particle filter type to
- *                      select particles in T_SpeciesType to manipulate via T_DestSpeciesType
+     *                  select particles in `T_SpeciesType` to manipulate via
+     *                  `T_DestSpeciesType`
      */
     template<
         typename T_Manipulator,

--- a/include/picongpu/particles/Manipulate.hpp
+++ b/include/picongpu/particles/Manipulate.hpp
@@ -33,17 +33,25 @@ namespace picongpu
 namespace particles
 {
 
-    /** run a user defined functor for every particle
+    /** Run a user defined manipulation for each particle of a species
      *
-     * - constructor with current time step is called for the functor on the host side
-     * - \warning `fillAllGaps()` is not called
+     * Allows to manipulate attributes of existing particles in a species with
+     * arbitrary unary functors ("manipulators").
      *
-     * @tparam T_Functor unary lambda functor
+     * @warning Does NOT call FillAllGaps after manipulation! If the
+     *          manipulation deactivates particles or creates "gaps" in any
+     *          other way, FillAllGaps needs to be called for the T_SpeciesType
+     *          manually in the next step!
+     *
+     * @tparam T_Manipulator unary lambda functor accepting one particle
+     *                       species,
+     *                       @see picongpu::particles::manipulators
      * @tparam T_SpeciesType type of the used species
-     * @tparam T_Filter picongpu::particles::filter, particle filter type to select particles
+     * @tparam T_Filter picongpu::particles::filter, particle filter type to
+ *                      select particles in T_SpeciesType to manipulate via T_DestSpeciesType
      */
     template<
-        typename T_Functor,
+        typename T_Manipulator,
         typename T_SpeciesType = bmpl::_1,
         typename T_Filter = filter::All
     >
@@ -52,13 +60,13 @@ namespace particles
         using SpeciesType = T_SpeciesType;
         using FrameType = typename SpeciesType::FrameType;
 
-        using UserFunctor = typename bmpl::apply1<
-            T_Functor,
+        using SpeciesFunctor = typename bmpl::apply1<
+            T_Manipulator,
             SpeciesType
         >::type;
 
-        using Manipulator = manipulators::IUnary<
-            UserFunctor,
+        using FilteredManipulator = manipulators::IUnary<
+            SpeciesFunctor,
             T_Filter
         >;
 
@@ -71,10 +79,10 @@ namespace particles
                 true
             );
 
-            Manipulator manipulator( currentStep );
+            FilteredManipulator filteredManipulator( currentStep );
             speciesPtr->manipulateAllParticles(
                 currentStep,
-                manipulator
+                filteredManipulator
             );
 
             dc.releaseData( FrameType::getName() );

--- a/include/picongpu/particles/manipulators/IBinary.def
+++ b/include/picongpu/particles/manipulators/IBinary.def
@@ -37,7 +37,7 @@ namespace manipulators
      * The result of the filter is linked by a logic AND operation and the functor
      * is only called if the filter result is `true`.
      * The user functor and filter is passed by the manipulation algorithm
-     * (e.g. picongpu::particles::ManipulateDeriveSpecies, ...) to this interface, there is
+     * (e.g. picongpu::particles::ManipulateDerive, ...) to this interface, there is
      * no need to do this explicitly in the param files.
      *
      * @tparam T_BinaryFunctor binary particle functor, must contain

--- a/include/picongpu/particles/manipulators/binary/DensityWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/DensityWeighting.def
@@ -60,7 +60,7 @@ namespace acc
          * @param particleSrc source particle (the density ratio of this particle is used)
          * @param ... unused particles
          *
-         * @see picongpu::particles::ManipulateDeriveSpecies , picongpu::kernelCloneParticles
+         * @see picongpu::particles::ManipulateDerive, picongpu::kernelCloneParticles
          */
         template<
             typename T_DesParticle,

--- a/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
@@ -56,7 +56,7 @@ namespace acc
          * @param source particle (the number of protons of this particle is used)
          * @param unused particles
          *
-         * @see picongpu::particles::ManipulateDeriveSpecies , picongpu::particles::Manipulate
+         * @see picongpu::particles::ManipulateDerive, picongpu::particles::Manipulate
          */
         template<
             typename T_DesParticle,

--- a/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
@@ -56,7 +56,7 @@ namespace acc
          * @param source particle (the number of protons of this particle is used)
          * @param unused particles
          *
-         * @see picongpu::particles::ManipulateDeriveSpecies , picongpu::particles::Manipulate
+         * @see picongpu::particles::ManipulateDerive, picongpu::particles::Manipulate
          */
         template<
             typename T_DesParticle,

--- a/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
+++ b/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
@@ -37,7 +37,7 @@ namespace detail
      * Note: In the density regions where the weighting of macro particles would
      * violate the user-specified MIN_WEIGHTING, we reduce the number of
      * macro particles per cell to still initialize particles
-     * (see particles.param).
+     * (see particle.param).
      *
      * This calculates the number of macro particles and the weighting per macro
      * particle with respect to MIN_WEIGHTING.

--- a/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,55 +19,13 @@
 
 /** @file
  *
- * Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
  *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
+ * For a full list of options, see the user manual section "Usage" - "Particles".
  */
 
 #pragma once
@@ -79,7 +37,6 @@ namespace picongpu
 {
 namespace particles
 {
-
     /** InitPipeline defines in which order species are initialized
      *
      * the functors are called in order (from first to last functor)

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,82 +17,42 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"
+
 
 namespace picongpu
 {
 namespace particles
 {
-
-/* Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
- *
- * - CreateGas<T_GasFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a gas profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_GasFunctor      unary lambda functor with gas description,
- *                               \see gas.param
- *                               \example gasProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - CloneSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateCloneSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see CloneSpecies but allows a T_ManipulateFunctor to be called
- *     after cloning to manipulate the two particles that took part
- *     in the cloning (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
- */
-
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-using InitPipeline = mpl::vector<
-    CreateDensity<
-        densityProfiles::Foil,
-        startPosition::Quiet1ppc,
-        PIC_Ions
-    >,
-    CreateDensity<
-        densityProfiles::Foil,
-        startPosition::Random100ppc,
-        PIC_Electrons
-    >
->;
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        CreateDensity<
+            densityProfiles::Foil,
+            startPosition::Quiet1ppc,
+            PIC_Ions
+        >,
+        CreateDensity<
+            densityProfiles::Foil,
+            startPosition::Random100ppc,
+            PIC_Electrons
+        >
+    >;
 
 } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,89 +17,49 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"
+
 
 namespace picongpu
 {
 namespace particles
 {
-
-/* Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
- *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
- */
-
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-using InitPipeline = mpl::vector<
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
 #ifdef PARAM_SINGLE_PARTICLE
-    CreateDensity<
-        densityProfiles::FreeFormula,
-        startPosition::OnePosition,
-        PIC_Electrons
-    >,
+        CreateDensity<
+            densityProfiles::FreeFormula,
+            startPosition::OnePosition,
+            PIC_Electrons
+        >,
 #else
-    CreateDensity<
-        densityProfiles::GaussianCloud,
-        startPosition::Random,
-        PIC_Electrons
-    >,
+        CreateDensity<
+            densityProfiles::GaussianCloud,
+            startPosition::Random,
+            PIC_Electrons
+        >,
 #endif
-    Manipulate<
-        manipulators::AssignYDriftNegative,
-        PIC_Electrons
-    >
->;
+        Manipulate<
+            manipulators::AssignYDriftNegative,
+            PIC_Electrons
+        >
+    >;
 
-} /* namespace particles */
-} /* namespace picongpu  */
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,55 +19,13 @@
 
 /** @file
  *
- * Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
  *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
+ * For a full list of options, see the user manual section "Usage" - "Particles".
  */
 
 #pragma once
@@ -92,12 +50,12 @@ namespace particles
         >,
         /* derive the other two ion species and adjust their weighting to have always all
          * three of macro ions present in a cell, even in cut-off regions of the density profile */
-        ManipulateDeriveSpecies<
+        ManipulateDerive<
             manipulators::binary::DensityWeighting,
             Hydrogen,
             Carbon
         >,
-        ManipulateDeriveSpecies<
+        ManipulateDerive<
             manipulators::binary::DensityWeighting,
             Hydrogen,
             Nitrogen
@@ -122,16 +80,16 @@ namespace particles
             Nitrogen
         >,
         // partial pre-ionization: create free electrons
-        DeriveSpecies<
+        Derive<
             Hydrogen,
             Electrons
         >,
-        ManipulateDeriveSpecies<
+        ManipulateDerive<
             manipulators::binary::UnboundElectronsTimesWeighting,
             Carbon,
             Electrons
         >,
-        ManipulateDeriveSpecies<
+        ManipulateDerive<
             manipulators::binary::UnboundElectronsTimesWeighting,
             Nitrogen,
             Electrons

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,81 +17,75 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"
+
 
 namespace picongpu
 {
 namespace particles
 {
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        CreateDensity<
+            densityProfiles::Homogenous,
+            startPosition::Quiet25ppc,
+            PIC_Electrons
+        >,
+        Derive<
+            PIC_Electrons,
+            PIC_Ions
+        >,
+        Manipulate<
+            manipulators::AssignXDriftPositive,
+            PIC_Ions,
+            filter::LowerQuarterYPosition
+        >,
+        Manipulate<
+            manipulators::AssignXDriftNegative,
+            PIC_Ions,
+            filter::MiddleHalfYPosition
+        >,
+        Manipulate<
+            manipulators::AssignXDriftPositive,
+            PIC_Ions,
+            filter::UpperQuarterYPosition
+        >,
+        Manipulate<
+            manipulators::AssignXDriftPositive,
+            PIC_Electrons,
+            filter::LowerQuarterYPosition
+        >,
+        Manipulate<
+            manipulators::AssignXDriftNegative,
+            PIC_Electrons,
+            filter::MiddleHalfYPosition
+        >,
+        Manipulate<
+            manipulators::AssignXDriftPositive,
+            PIC_Electrons,
+            filter::UpperQuarterYPosition
+        >,
+        Manipulate<
+            manipulators::AddTemperature,
+            PIC_Electrons
+        >
+    >;
 
-/* Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
- *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
- */
-
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-using InitPipeline = mpl::vector<
-    CreateDensity<densityProfiles::Homogenous, startPosition::Quiet25ppc, PIC_Electrons>,
-    DeriveSpecies<PIC_Electrons, PIC_Ions>,
-    Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::LowerQuarterYPosition>,
-    Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleHalfYPosition>,
-    Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::UpperQuarterYPosition>,
-    Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::LowerQuarterYPosition>,
-    Manipulate<manipulators::AssignXDriftNegative, PIC_Electrons, filter::MiddleHalfYPosition>,
-    Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::UpperQuarterYPosition>,
-    Manipulate<manipulators::AddTemperature, PIC_Electrons>
->;
-
-} /* namespace particles */
-} /* namespace picongpu  */
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,99 +17,57 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"
+
 
 namespace picongpu
 {
 namespace particles
 {
-
-/* Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
- *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
- */
-
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-using InitPipeline = mpl::vector<
-
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
 #if( PARAM_IONIZATION == 0 )
-    CreateDensity<
-        densityProfiles::Gaussian,
-        startPosition::Random2ppc,
-        PIC_Electrons
-    >
+        CreateDensity<
+            densityProfiles::Gaussian,
+            startPosition::Random2ppc,
+            PIC_Electrons
+        >
 #   if( PARAM_IONS == 1 )
-    ,
-    DeriveSpecies<
-        PIC_Electrons,
-        PIC_Ions
-    >
+        ,
+        DeriveSpecies<
+            PIC_Electrons,
+            PIC_Ions
+        >
 #   endif
 #else
 
-    CreateDensity<
-        densityProfiles::Gaussian,
-        startPosition::Random2ppc,
-        PIC_Ions
-    >,
-    Manipulate<
-        manipulators::SetBoundElectrons,
-        PIC_Ions
-    >
+        CreateDensity<
+            densityProfiles::Gaussian,
+            startPosition::Random2ppc,
+            PIC_Ions
+        >,
+        Manipulate<
+            manipulators::SetBoundElectrons,
+            PIC_Ions
+        >
 #endif
-
->;
+    >;
 
 } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,81 +17,41 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"
+
 
 namespace picongpu
 {
 namespace particles
 {
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        CreateDensity<
+            densityProfiles::FreeFormula,
+            startPosition::OnePosition,
+            PIC_Electrons
+        >,
+        Manipulate<
+            manipulators::AssignYDrift,
+            PIC_Electrons
+        >
+    >;
 
-/* Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
- *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
- */
-
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-using InitPipeline = mpl::vector<
-    CreateDensity<
-        densityProfiles::FreeFormula,
-        startPosition::OnePosition,
-        PIC_Electrons
-    >,
-    Manipulate<
-        manipulators::AssignYDrift,
-        PIC_Electrons
-    >
->;
-
-} /* namespace particles */
-} /* namespace picongpu  */
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,90 +17,50 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"
+
 
 namespace picongpu
 {
 namespace particles
 {
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        CreateDensity<
+            densityProfiles::Homogenous,
+            startPosition::Random16ppc,
+            PIC_Ions
+        >,
+        ManipulateDerive<
+            manipulators::binary::ProtonTimesWeighting,
+            PIC_Ions,
+            PIC_Electrons
+        >,
+        Manipulate<
+            manipulators::AddTemperature,
+            PIC_Electrons
+        >,
+        Manipulate<
+            manipulators::AddTemperature,
+            PIC_Ions
+        >
+    >;
 
-/* Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
- *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
- */
-
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-using InitPipeline = mpl::vector<
-    CreateDensity<
-        densityProfiles::Homogenous,
-        startPosition::Random16ppc,
-        PIC_Ions
-    >,
-    ManipulateDeriveSpecies<
-        manipulators::binary::ProtonTimesWeighting,
-        PIC_Ions,
-        PIC_Electrons
-    >,
-    Manipulate<
-        manipulators::AddTemperature,
-        PIC_Electrons
-    >,
-    Manipulate<
-        manipulators::AddTemperature,
-        PIC_Ions
-    >
->;
-
-} /* namespace particles */
-} /* namespace picongpu  */
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */

--- a/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,57 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* @file
+/** @file
  *
- * Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
  *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
+ * For a full list of options, see the user manual section "Usage" - "Particles".
  */
 
 #pragma once
@@ -91,12 +49,12 @@ namespace particles
             startPosition::Quiet2ppc,
             CopperIons
         >,
-        ManipulateDeriveSpecies<
+        ManipulateDerive<
             manipulators::binary::DensityWeighting,
             CopperIons,
             BulkElectrons
         >,
-        ManipulateDeriveSpecies<
+        ManipulateDerive<
             manipulators::binary::DensityWeighting,
             CopperIons,
             PromptElectrons

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -17,99 +17,59 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Initialize particles inside particle species. This fill is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particles.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"
+
 
 namespace picongpu
 {
 namespace particles
 {
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        CreateDensity<
+            densityProfiles::Homogenous,
+            startPosition::Quiet4ppc,
+            PIC_Ions
+        >,
+        ManipulateDerive<
+            /* make sure in speciesDefinition.param that
+             *   densityRatio * chargeRatio
+             * of electrons and ions is quasi neutral!
+             * alternatively, use manipulators::ProtonTimesWeighting
+             */
+            manipulators::binary::DensityWeighting,
+            PIC_Ions,
+            PIC_Electrons
+        >,
+        Manipulate<
+            manipulators::AssignZDriftIons,
+            PIC_Ions
+        >,
+        Manipulate<
+            manipulators::AssignZDriftElectrons,
+            PIC_Electrons
+        >,
+        Manipulate<
+            manipulators::AddTemperature,
+            PIC_Electrons
+        >
+    >;
 
-/* Available species functors
- *   in include/picongpu/particles/InitFunctors.hpp
- *
- * - CreateDensity<T_DensityFunctor, T_PositionFunctor, T_SpeciesType>
- *     Create particle distribution based on a density profile and an in-cell
- *     positioning.
- *     Fills a particle species (`fillAllGaps()` is called).
- *     @tparam T_DensityFunctor  unary lambda functor with density description,
- *                               \see density.param
- *                               \example densityProfiles::Homogenous,
- *     @tparam T_PositionFunctor unary lambda functor with position description,
- *                               \see particles.param
- *                               \example startPosition::Quiet
- *                                        startPosition::Random
- *     @tparam T_SpeciesType type of the used species,
- *                               \see speciesDefinition.param
- *                               \example PIC_Electrons
- *
- * - DeriveSpecies<T_SrcSpeciesType, T_DestSpeciesType>
- *     Create a particle species by copying all matching attributes from an
- *     other species (`fillAllGaps()` is called on T_DestSpeciesType).
- *     @tparam T_SrcSpeciesType  source species
- *     @tparam T_DestSpeciesType destination species
- *
- * - Manipulate<T_Functor, T_SpeciesType>
- *     Run a user defined functor for every particle.
- *     \warning does not call `fillAllGaps()` if one removes or
- *              adds particles with it (\see FillAllGaps below)
- *     @tparam T_Functor     unary lambda functor,
- *                           \see particle.param
- *     @tparam T_SpeciesType type of the used species
- *
- * - ManipulateDeriveSpecies<T_ManipulateFunctor, T_SrcSpeciesType, T_DestSpeciesType>
- *     Same as \see DeriveSpecies but allows a T_ManipulateFunctor to be called
- *     after deriving to manipulate the two particles that took part
- *     in the deriving (e.g., assign and increase an attribute such as weighting).
- *     Note: `fillAllGaps()` is only called for the T_DestSpeciesType.
- *     @tparam T_ManipulateFunctor a pseudo-binary functor accepting two particle
- *                                 species: destination and source,
- *                                 \see particle.param
- *     @tparam T_SrcSpeciesType    source species
- *     @tparam T_DestSpeciesType   destination species
- *
- * - FillAllGaps<T_SpeciesType>
- *     The manipulate functor does not call `fillAllGaps` on
- *     the particle list of frames. For user-defined functors
- *     that are called via Manipulate and create/remove
- *     particles into/from frame lists, this must be called
- *     afterward to create a valid data structure.
- */
-
-/** InitPipeline define in which order species are initialized
- *
- * the functors are called in order (from first to last functor)
- */
-using InitPipeline = mpl::vector<
-    CreateDensity<
-        densityProfiles::Homogenous,
-        startPosition::Quiet4ppc,
-        PIC_Ions
-    >,
-    ManipulateDeriveSpecies<
-        /* make sure in speciesDefinition.param that
-         *   densityRatio * chargeRatio
-         * of electrons and ions is quasi neutral!
-         * alternatively, use manipulators::ProtonTimesWeighting
-         */
-        manipulators::binary::DensityWeighting,
-        PIC_Ions,
-        PIC_Electrons
-    >,
-    Manipulate<
-        manipulators::AssignZDriftIons,
-        PIC_Ions
-    >,
-    Manipulate<
-        manipulators::AssignZDriftElectrons,
-        PIC_Electrons
-    >,
-    Manipulate<
-        manipulators::AddTemperature,
-        PIC_Electrons
-    >
->;
-
-} /* namespace particles */
-} /* namespace picongpu  */
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/simulation_defines/param/speciesInitialization.param
@@ -19,11 +19,11 @@
 
 /** @file
  *
- * Initialize particles inside particle species. This fill is the final step in
+ * Initialize particles inside particle species. This is the final step in
  * setting up particles (defined in speciesDefinition.param) via density profiles
  * (defined in density.param). One can then further derive particles from one
  * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particles.param and particleFilters.param).
+ * (defined in particle.param and particleFilters.param).
  *
  * For a full list of options, see the user manual section "Usage" - "Particles".
  */


### PR DESCRIPTION
Updates particle initialization methods for consistency.

`speciesInitialization.param`: `DeriveSpecies` & `ManipulateDeriveSpecies` without the ~Species~ suffix now

Moves more docs to the manual section (by putting them in the user-facing API doxygen strings instead).