### PR TITLE
PIConGPU use tiny RNG

### DIFF
--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -38,8 +38,7 @@ namespace generic
      *
      *
      * @tparam T_Functor user defined unary functor
-     * @tparam T_Distribution random number distribution
-     * @tparam T_Seed seed to initialize the random number generator
+     * @tparam T_Distribution pmacc::random::distributions, random number distribution
      * @tparam T_SpeciesType type of the species that shall be manipulated
      *
      * example for `particleFilters.param`: get every second particle
@@ -61,18 +60,15 @@ namespace generic
      *       }
      *   };
      *
-     *   using EachSecondParticle = generic::Free<
-     *      FunctorEachSecondParticle
+     *   using EachSecondParticle = generic::FreeRng<
+     *      FunctorEachSecondParticle,
+     *      pmacc::random::distributions::Uniform< float_X >
      *   >;
      *   @endcode
      */
     template<
         typename T_Functor,
         typename T_Distribution,
-        typename T_Seed = boost::mpl::integral_c<
-            size_t,
-            FREERNG_SEED
-        >,
         typename T_SpeciesType = boost::mpl::_1
     >
     struct FreeRng;

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -97,25 +97,21 @@ namespace acc
     template<
         typename T_Functor,
         typename T_Distribution,
-        typename T_Seed,
         typename T_SpeciesType
     >
     struct FreeRng :
     protected functor::User< T_Functor >,
         private picongpu::particles::functor::misc::Rng<
             T_Distribution,
-            T_Seed,
             T_SpeciesType
         >
     {
         using RngGenerator = picongpu::particles::functor::misc::Rng<
             T_Distribution,
-            T_Seed,
             T_SpeciesType
         >;
 
-        template< typename T_Acc >
-        using RngType = typename RngGenerator::template RngType< T_Acc >;
+        using RngType = typename RngGenerator::RandomGen;
 
         using Functor = functor::User< T_Functor >;
         using Distribution = T_Distribution;
@@ -153,10 +149,10 @@ namespace acc
         )
         -> acc::FreeRng<
             Functor,
-            RngType< T_Acc >
+            RngType
         >
         {
-            RngType< T_Acc > const rng = ( *static_cast< RngGenerator * >( this ) )(
+            RngType const rng = ( *static_cast< RngGenerator * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -164,7 +160,7 @@ namespace acc
 
             return acc::FreeRng<
                 Functor,
-                RngType< T_Acc >
+                RngType
             >(
                 *static_cast< Functor * >( this ),
                 rng

--- a/include/picongpu/particles/functor/misc/Rng.def
+++ b/include/picongpu/particles/functor/misc/Rng.def
@@ -36,17 +36,11 @@ namespace misc
 
     /** provide a random number generator
      *
-     * @tparam T_Distribution random number distribution
-     * @tparam T_Seed seed to initialize the random number generator
+     * @tparam T_Distribution pmacc::random::distributions, random number distribution
      * @tparam T_SpeciesType type of the species that shall be manipulated
-     *
      */
     template<
         typename T_Distribution,
-        typename T_Seed = boost::mpl::integral_c<
-            size_t,
-            FREERNG_SEED
-        >,
         typename T_SpeciesType = boost::mpl::_1
     >
     struct Rng;

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -20,10 +20,14 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/functor/misc/RngWrapper.hpp"
+
 #include <pmacc/nvidia/rng/RNG.hpp>
 #include <pmacc/nvidia/rng/methods/Xor.hpp>
 #include <pmacc/mpi/SeedPerRank.hpp>
 #include <pmacc/traits/GetUniqueTypeId.hpp>
+#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/RNGProvider.hpp>
 
 #include <utility>
 #include <type_traits>
@@ -41,13 +45,11 @@ namespace misc
     /** call simple free user defined functor and provide a random number generator
      *
      * @tparam T_Distribution random number distribution
-     * @tparam T_Seed seed to initialize the random number generator
      * @tparam T_SpeciesType type of the species that shall used to generate a unique
      *                       seed to initialize the random number generator
      */
     template<
         typename T_Distribution,
-        typename T_Seed,
         typename T_SpeciesType
     >
     struct Rng
@@ -55,21 +57,24 @@ namespace misc
 
         using Distribution = T_Distribution;
         using SpeciesType = T_SpeciesType;
-
-        template< typename T_Acc >
-        using RngType = pmacc::nvidia::rng::RNG<
-            nvidia::rng::methods::Xor< T_Acc >,
-            decltype( Distribution::get( std::declval< T_Acc >( ) ) )
+        using RNGFactory = pmacc::random::RNGProvider<
+            simDim,
+            pmacc::random::methods::XorMin< cupla::Acc >
+        >;
+        using RngHandle = typename RNGFactory::Handle;
+        using RandomGen = RngWrapper<
+            cupla::Acc,
+            typename RngHandle::GetRandomType< Distribution >::type
         >;
 
         /** constructor
          *
          * @param currentStep current simulation time step
          */
-        HINLINE Rng( uint32_t currentStep )
+        HINLINE Rng( uint32_t currentStep ) : rngHandle( RNGFactory::createHandle() )
         {
-            hostInit( currentStep );
         }
+
 
         /** create functor a random number generator
          *
@@ -86,7 +91,8 @@ namespace misc
             typename T_Acc
         >
         HDINLINE
-        RngType< T_Acc > operator()(
+        RandomGen
+        operator()(
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
@@ -97,60 +103,18 @@ namespace misc
             using FrameType = typename SpeciesType::FrameType;
             using SuperCellSize = typename FrameType::SuperCellSize;
 
-            uint32_t const cellIdx = DataSpaceOperations< simDim >::map(
-                localCells,
-                localSupercellOffset * SuperCellSize::toRT( ) +
-                    DataSpaceOperations< simDim >::template map< SuperCellSize >( workerCfg.getWorkerIdx( ) )
+            rngHandle.init(
+                localSupercellOffset * SuperCellSize::toRT() +
+                DataSpaceOperations< simDim >::template map< SuperCellSize >( workerCfg.getWorkerIdx( ) )
             );
-            RngType< T_Acc > const rng = nvrng::create(
-                nvidia::rng::methods::Xor< T_Acc >(
-                    acc,
-                    seed,
-                    cellIdx
-                ),
-                Distribution::get( acc )
+            return RandomGen(
+                acc,
+                rngHandle.applyDistribution< Distribution >()
             );
-            return rng;
         }
 
     private:
-
-        /** initialize member variables
-         *
-         * set RNG seed and calculate simulation local size
-         *
-         * @param currentStep time step of the simulation
-         */
-        HINLINE
-        void
-        hostInit( uint32_t currentStep )
-        {
-            using FrameType = typename SpeciesType::FrameType;
-
-            GlobalSeed globalSeed;
-            mpi::SeedPerRank<simDim> seedPerRank;
-            /* generate a global unique id by xor the
-             *   - gpu id `globalSeed()`
-             *   - a species id
-             *   - a fix id for this functor `FREERNG_SEED` (defined in `seed.param`)
-             */
-            seed = globalSeed() ^
-                pmacc::traits::GetUniqueTypeId<
-                    FrameType,
-                    uint32_t
-                >::uid() ^
-                T_Seed::value;
-            /* mixing the final seed with the current time step to avoid
-             * correlations between time steps
-             */
-            seed = seedPerRank( seed ) ^ currentStep;
-
-            SubGrid< simDim > const & subGrid = Environment< simDim >::get().SubGrid();
-            localCells = subGrid.getLocalDomain().size;
-        }
-
-        DataSpace< simDim > localCells;
-        uint32_t seed;
+        RngHandle rngHandle;
     };
 
 } // namepsace misc

--- a/include/picongpu/particles/functor/misc/RngWrapper.hpp
+++ b/include/picongpu/particles/functor/misc/RngWrapper.hpp
@@ -1,0 +1,74 @@
+/* Copyright 2017 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/types.hpp>
+
+#include <functional>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace functor
+{
+namespace misc
+{
+
+    /** wraps an random number generator together with an alpaka accelerator
+     *
+     * This class allows to generate random numbers without passing the accelerator
+     * to each functor call.
+     *
+     * @tparam T_Acc type of the alpaka accelerator
+     * @tparam T_Rng type of the random number generator
+     */
+    template<
+        typename T_Acc,
+        typename T_Rng
+    >
+    struct RngWrapper
+    {
+        DINLINE RngWrapper(
+            T_Acc const & acc,
+            T_Rng const & rng
+
+        ) :
+            m_acc( &acc ),
+            m_rng( rng )
+        { }
+
+        //! generate a random number
+        DINLINE
+        typename T_Rng::result_type
+        operator()()
+        {
+            return m_rng( *m_acc );
+        }
+
+        T_Acc const * m_acc;
+        mutable T_Rng m_rng;
+    };
+
+} // namepsace misc
+} // namespace functor
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/manipulators/generic/FreeRng.def
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.def
@@ -38,8 +38,7 @@ namespace generic
      *
      *
      * @tparam T_Functor user defined unary functor
-     * @tparam T_Distribution random number distribution
-     * @tparam T_Seed seed to initialize the random number generator
+     * @tparam T_Distribution pmacc::random::distributions, random number distribution
      * @tparam T_SpeciesType type of the species that shall be manipulated
      *
      * example for `particle.param`: add
@@ -58,7 +57,7 @@ namespace generic
      *
      *   using RandomXPos = generic::FreeRng<
      *      FunctorRandomX,
-     *      nvidia::rng::distributions::Uniform_float
+     *      pmacc::random::distributions::Uniform< float_X >
      *   >;
      *   @endcode
      *
@@ -70,10 +69,6 @@ namespace generic
     template<
         typename T_Functor,
         typename T_Distribution,
-        typename T_Seed = boost::mpl::integral_c<
-            size_t,
-            FREERNG_SEED
-        >,
         typename T_SpeciesType = boost::mpl::_1
     >
     struct FreeRng;

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -99,25 +99,21 @@ namespace acc
     template<
         typename T_Functor,
         typename T_Distribution,
-        typename T_Seed,
         typename T_SpeciesType
     >
     struct FreeRng :
     protected functor::User< T_Functor >,
         private picongpu::particles::functor::misc::Rng<
             T_Distribution,
-            T_Seed,
             T_SpeciesType
         >
     {
         using RngGenerator = picongpu::particles::functor::misc::Rng<
             T_Distribution,
-            T_Seed,
             T_SpeciesType
         >;
 
-        template< typename T_Acc >
-        using RngType = typename RngGenerator::template RngType< T_Acc >;
+        using RngType = typename RngGenerator::RandomGen;
 
         using Functor = functor::User< T_Functor >;
         using Distribution = T_Distribution;
@@ -155,10 +151,10 @@ namespace acc
         )
         -> acc::FreeRng<
             Functor,
-            RngType< T_Acc >
+            RngType
         >
         {
-            RngType< T_Acc > const rng = ( *static_cast< RngGenerator * >( this ) )(
+            RngType const rng = ( *static_cast< RngGenerator * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -166,7 +162,7 @@ namespace acc
 
             return acc::FreeRng<
                 Functor,
-                RngType< T_Acc >
+                RngType
             >(
                 *static_cast< Functor * >( this ),
                 rng

--- a/include/picongpu/particles/manipulators/unary/RandomPosition.def
+++ b/include/picongpu/particles/manipulators/unary/RandomPosition.def
@@ -20,9 +20,8 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-#include "picongpu/particles/manipulators/generic/FreeRng.def"
 
-#include <pmacc/nvidia/rng/distributions/Uniform_float.hpp>
+#include <pmacc/random/distributions/Uniform.hpp>
 
 #include <boost/mpl/integral_c.hpp>
 
@@ -91,11 +90,7 @@ namespace acc
      */
     using RandomPosition = generic::FreeRng<
         acc::RandomPosition,
-        nvidia::rng::distributions::Uniform_float,
-        boost::mpl::integral_c<
-            size_t,
-            POSITION_SEED
-        >
+        pmacc::random::distributions::Uniform< float_X >
     >;
 } // namespace unary
 } // namespace manipulators

--- a/include/picongpu/particles/manipulators/unary/Temperature.def
+++ b/include/picongpu/particles/manipulators/unary/Temperature.def
@@ -20,8 +20,8 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-#include "picongpu/particles/manipulators/generic/FreeRng.def"
-#include <pmacc/nvidia/rng/distributions/Normal_float.hpp>
+
+#include <pmacc/random/distributions/Normal.hpp>
 #include <pmacc/nvidia/functors/Add.hpp>
 
 #include <boost/mpl/integral_c.hpp>
@@ -73,11 +73,7 @@ namespace param
             T_ParamClass,
             T_ValueFunctor
         >,
-        nvidia::rng::distributions::Normal_float,
-        boost::mpl::integral_c<
-            size_t,
-            TEMPERATURE_SEED
-        >
+        pmacc::random::distributions::Normal< float_X >
     >;
 
 } // namespace unary

--- a/include/picongpu/particles/startPosition/RandomImpl.def
+++ b/include/picongpu/particles/startPosition/RandomImpl.def
@@ -22,7 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/particles/startPosition/generic/FreeRng.def"
 
-#include <pmacc/nvidia/rng/distributions/Uniform_float.hpp>
+#include <pmacc/random/distributions/Uniform.hpp>
 
 #include <boost/mpl/integral_c.hpp>
 
@@ -55,11 +55,7 @@ namespace acc
     template< typename T_ParamClass >
     using RandomImpl = generic::FreeRng<
         acc::RandomImpl< T_ParamClass >,
-        nvidia::rng::distributions::Uniform_float,
-        boost::mpl::integral_c<
-            size_t,
-            POSITION_SEED
-        >
+        pmacc::random::distributions::Uniform< float_X >
     >;
 } // namespace startPosition
 } // namespace particles

--- a/include/picongpu/particles/startPosition/generic/FreeRng.def
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.def
@@ -38,17 +38,12 @@ namespace generic
      *
      *
      * @tparam T_Functor user defined unary functor
-     * @tparam T_Distribution random number distribution
-     * @tparam T_Seed seed to initialize the random number generator
+     * @tparam T_Distribution pmacc::random::distributions, random number distribution
      * @tparam T_SpeciesType type of the species that shall be manipulated
      */
     template<
         typename T_Functor,
         typename T_Distribution,
-        typename T_Seed = boost::mpl::integral_c<
-            size_t,
-            FREERNG_SEED
-        >,
         typename T_SpeciesType = boost::mpl::_1
     >
     struct FreeRng;

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -105,25 +105,21 @@ namespace acc
     template<
         typename T_Functor,
         typename T_Distribution,
-        typename T_Seed,
         typename T_SpeciesType
     >
     struct FreeRng :
         protected T_Functor,
         private picongpu::particles::functor::misc::Rng<
             T_Distribution,
-            T_Seed,
             T_SpeciesType
         >
     {
         using RngGenerator = picongpu::particles::functor::misc::Rng<
             T_Distribution,
-            T_Seed,
             T_SpeciesType
         >;
 
-        template< typename T_Acc >
-        using RngType = typename RngGenerator::template RngType< T_Acc >;
+        using RngType = typename RngGenerator::RandomGen;
 
         using Functor = T_Functor;
         using Distribution = T_Distribution;
@@ -197,10 +193,10 @@ namespace acc
         )
         -> acc::FreeRng<
             Functor,
-            RngType< T_Acc >
+            RngType
         >
         {
-            RngType< T_Acc > const rng = ( *static_cast< RngGenerator * >( this ) )(
+            RngType const rng = ( *static_cast< RngGenerator * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -208,7 +204,7 @@ namespace acc
 
             return acc::FreeRng<
                 Functor,
-                RngType< T_Acc >
+                RngType
             >(
                 *static_cast< Functor * >( this ),
                 rng

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -316,24 +316,14 @@ public:
         typedef typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies,
                                                                 bremsstrahlungPhotons<> >::type AllBremsstrahlungPhotonsSpecies;
 
-        // ... or if ionization methods need an RNG
-        using HasIonizerRNGs = typename particles::traits::HasIonizersWithRNG< VectorAllSpecies >::type;
-        constexpr bool hasIonizerRNGs = HasIonizerRNGs::value;
+        // create factory for the random number generator
+        using RNGFactory = pmacc::random::RNGProvider< simDim, pmacc::random::methods::XorMin< cupla::Acc> >;
+        auto rngFactory = new RNGFactory( Environment<simDim>::get().SubGrid().getLocalDomain().size );
 
-        if( !bmpl::empty<AllSynchrotronPhotonsSpecies>::value ||
-            !bmpl::empty<AllBremsstrahlungPhotonsSpecies>::value ||
-            hasIonizerRNGs
-        )
-        {
-            // create factory for the random number generator
-            using RNGFactory = pmacc::random::RNGProvider< simDim, pmacc::random::methods::XorMin< cupla::Acc> >;
-            auto rngFactory = new RNGFactory( Environment<simDim>::get().SubGrid().getLocalDomain().size );
-
-            // init and share random number generator
-            pmacc::GridController<simDim>& gridCon = pmacc::Environment<simDim>::get().GridController();
-            rngFactory->init( gridCon.getScalarPosition() );
-            dc.share( std::shared_ptr< ISimulationData >( rngFactory ) );
-        }
+        // init and share random number generator
+        pmacc::GridController<simDim>& gridCon = pmacc::Environment<simDim>::get().GridController();
+        rngFactory->init( gridCon.getScalarPosition() );
+        dc.share( std::shared_ptr< ISimulationData >( rngFactory ) );
 
         // Initialize synchrotron functions, if there are synchrotron photon species
         if(!bmpl::empty<AllSynchrotronPhotonsSpecies>::value)

--- a/include/picongpu/simulation_defines/param/particle.param
+++ b/include/picongpu/simulation_defines/param/particle.param
@@ -33,7 +33,7 @@
 #include "picongpu/particles/filter/filter.def"
 #include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
-#include <pmacc/nvidia/rng/distributions/Uniform_float.hpp>
+#include <pmacc/random/distributions/Uniform.hpp>
 
 
 namespace picongpu
@@ -111,7 +111,10 @@ namespace manipulators
     };
 
     /* definition of RandomEnableRadiation start */
-    using RandomEnabledRadiation = generic::FreeRng< RandomEnabledRadiationFunctor, nvidia::rng::distributions::Uniform_float >;
+    using RandomEnabledRadiation = generic::FreeRng<
+        RandomEnabledRadiationFunctor,
+        pmacc::random::distributions::Uniform< float_X >
+    >;
 
     /** changes the in-cell position of each particle of a species */
     using RandomPosition = unary::RandomPosition;


### PR DESCRIPTION
- add class `RngWrapper`
- refactor template signature for particle functors/manipulator/filter with RNG
- update documentation
- MySimulation: enable always the RNG which holds the states over the full simulation
- update default param files

# Tests

- [x] default LWFA
  - LWFA is running two times faster due to faster initialization during the slide
- [x] default KHI
- [x] rebase against #2451 to solve the compile issues