### PR TITLE
fix RNG cpu compile

### DIFF
--- a/include/pmacc/random/RNGHandle.hpp
+++ b/include/pmacc/random/RNGHandle.hpp
@@ -46,7 +46,7 @@ namespace random
         template<class T_Distribution>
         struct GetRandomType
         {
-            typedef typename T_Distribution::applyMethod<RNGMethod>::type Distribution;
+            typedef typename T_Distribution::template applyMethod<RNGMethod>::type Distribution;
             typedef Random<Distribution, RNGMethod, RNGState*> type;
         };
 

--- a/include/pmacc/random/RNGProvider.hpp
+++ b/include/pmacc/random/RNGProvider.hpp
@@ -57,7 +57,7 @@ namespace random
         template<class T_Distribution>
         struct GetRandomType
         {
-            typedef typename T_Distribution::applyMethod<RNGMethod>::type Distribution;
+            typedef typename T_Distribution::template applyMethod<RNGMethod>::type Distribution;
             typedef Random<Distribution, RNGMethod, Handle> type;
         };
 


### PR DESCRIPTION
The current dev is not compiling with the accelerator `omp2b`.

- fix `GetRandomType` trait (add missing `template` keyword)