### PR TITLE
cuSTL kernel::ForEach: add lockstep support

### DIFF
--- a/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -107,7 +107,7 @@ namespace RT
     /** Run a cuSTL KernelForeach
      *
      * Allow to run the cuSTL foreach with runtime block sizes.
-     * @warning collective functors which containing synchronization are not supported
+     * @warning collective functors which contain synchronization are not supported
      */
     struct KernelForeachLockstep
     {
@@ -130,8 +130,8 @@ namespace RT
             T_Args ... args
         ) const
         {
-            /* KernelForeachLockstep is always call as kernel with three dimansions
-             * therefore we need to reduce the dimension if the mapper is only 2D or 1D.
+            /* KernelForeachLockstep is always called as kernel with three dimensions
+             * therefore we have to reduce the dimension if the mapper is only 2D or 1D.
              */
             auto const blockSizeShrinked = blockSize.template shrink< T_Mapper::dim >( );
             uint32_t const domainElementCount = blockSizeShrinked.productOfComponents();

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -197,23 +197,26 @@ struct SphericMapper<1, mpl::void_>
     DINLINE
     math::Int<1> operator()(
         T_Acc const & acc,
+        const math::Int<1>& _blockDim,
         const math::Int<1>& _blockIdx,
         const math::Int<1>& _threadIdx
     ) const
     {
-        return _blockIdx.x() * blockDim.x + _threadIdx.x();
+        return _blockIdx.x() * _blockDim.x() + _threadIdx.x();
     }
 
     template< typename T_Acc >
     DINLINE
     math::Int<1> operator()(
         T_Acc const & acc,
+        const dim3& _blockDim,
         const dim3& _blockIdx,
-        const dim3& _threadIdx = dim3(0,0,0)
+        const dim3& _threadIdx
     ) const
     {
         return operator()(
             acc,
+            math::Int<1>((int)_blockDim.x),
             math::Int<1>((int)_blockIdx.x),
             math::Int<1>((int)_threadIdx.x)
         );
@@ -239,24 +242,27 @@ struct SphericMapper<2, mpl::void_>
     DINLINE
     math::Int<2> operator()(
         T_Acc const & acc,
+        const math::Int<2>& _blockDim,
         const math::Int<2>& _blockIdx,
         const math::Int<2>& _threadIdx
     ) const
     {
-        return math::Int<2>( _blockIdx.x() * blockDim.x + _threadIdx.x(),
-                             _blockIdx.y() * blockDim.y + _threadIdx.y() );
+        return math::Int<2>( _blockIdx.x() * _blockDim.x() + _threadIdx.x(),
+                             _blockIdx.y() * _blockDim.y() + _threadIdx.y() );
     }
 
     template< typename T_Acc >
     DINLINE
     math::Int<2> operator()(
         T_Acc const & acc,
+        const dim3& _blockDim,
         const dim3& _blockIdx,
-        const dim3& _threadIdx = dim3(0,0,0)
+        const dim3& _threadIdx
     ) const
     {
         return operator()(
             acc,
+            math::Int<2>(_blockDim.x, _blockDim.y),
             math::Int<2>(_blockIdx.x, _blockIdx.y),
             math::Int<2>(_threadIdx.x, _threadIdx.y)
         );
@@ -282,25 +288,28 @@ struct SphericMapper<3, mpl::void_>
     DINLINE
     math::Int<3> operator()(
         T_Acc const & acc,
+        const math::Int<3>& _blockDim,
         const math::Int<3>& _blockIdx,
         const math::Int<3>& _threadIdx
     ) const
     {
-        return math::Int<3>( _blockIdx.x() * blockDim.x + _threadIdx.x(),
-                             _blockIdx.y() * blockDim.y + _threadIdx.y(),
-                             _blockIdx.z() * blockDim.z + _threadIdx.z() );
+        return math::Int<3>( _blockIdx.x() * _blockDim.x() + _threadIdx.x(),
+                             _blockIdx.y() * _blockDim.y() + _threadIdx.y(),
+                             _blockIdx.z() * _blockDim.z() + _threadIdx.z() );
     }
 
     template< typename T_Acc >
     DINLINE
     math::Int<3> operator()(
         T_Acc const & acc,
+        const dim3& _blockDim,
         const dim3& _blockIdx,
-        const dim3& _threadIdx = dim3(0,0,0)
+        const dim3& _threadIdx
     ) const
     {
         return operator()(
             acc,
+            math::Int<3>(_blockDim.x, _blockDim.y, _blockDim.z),
             math::Int<3>(_blockIdx.x, _blockIdx.y, _blockIdx.z),
             math::Int<3>(_threadIdx.x, _threadIdx.y, _threadIdx.z)
         );

--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -158,7 +158,7 @@ math::Size_t<DIM3> getBestCudaBlockDim(const math::Size_t<dim> gridDimension)
  * This is the run-time version of kernel::Foreach where the
  * cuda blockDim is specified in the constructor
  *
- * @warning collective functors (containing synchronization) are not supported *
+ * @warning collective functors (containing synchronization) are not supported
  */
 struct Foreach
 {


### PR DESCRIPTION
- add `algorithm::detail::KernelForeachLockstep`
- change the interface of `algorithm::kernel::detail`
- update `algorithm::kernel::RT::ForEach` to run with a lockstep kernel

This PR is currently a workaround and must be refactored as soon as cuSTl is fully supported on the host side.

This PR is marked also as **BUG** because it solves that the assign function of a host cuSTL buffer was broken on CPU side due to the missing lockstep support. As I know only the `ParticleCalorimeter` was affected.
  