### PR TITLE
PMacc RNG 64bit support

### DIFF
--- a/include/pmacc/random/distributions/Normal.hpp
+++ b/include/pmacc/random/distributions/Normal.hpp
@@ -57,4 +57,6 @@ namespace distributions
 }  // namespace random
 }  // namespace pmacc
 
+#include "pmacc/random/distributions/normal/Normal_generic.hpp"
 #include "pmacc/random/distributions/normal/Normal_float.hpp"
+#include "pmacc/random/distributions/normal/Normal_double.hpp"

--- a/include/pmacc/random/distributions/Uniform.hpp
+++ b/include/pmacc/random/distributions/Uniform.hpp
@@ -23,6 +23,10 @@
 
 #include "pmacc/types.hpp"
 #include "pmacc/random/methods/RngPlaceholder.hpp"
+#include "pmacc/random/distributions/uniform/Range.hpp"
+
+#include <type_traits>
+
 
 namespace pmacc
 {
@@ -30,20 +34,20 @@ namespace random
 {
 namespace distributions
 {
-    namespace detail {
+namespace detail {
 
-        /** Only this must be specialized for different types */
-        template<typename T_Type, class T_RNGMethod, class T_SFINAE = void>
-        class Uniform;
+    /** Only this must be specialized for different types */
+    template<typename T_Type, class T_RNGMethod, class T_SFINAE = void>
+    class Uniform;
 
-    }  // namespace detail
+}  // namespace detail
 
     /**
      * Returns a random, uniformly distributed value of the given type
      *
      * @tparam T_Type the result type or a range description @see uniform/Range.hpp
      * \code
-     * Uniform<uniform::ExcludeOne<float>::Use24Bit> Uniform24BitDistribution; //default for float
+     * Uniform<uniform::ExcludeOne<float>::Reduced> UniformReducedDistribution; //default
      * Uniform<float> UniformDefaultDistribution; //equal to line one
      * Uniform<uniform::ExcludeZero<float> > UniformNoZeroDistribution;
      * \endcode
@@ -67,4 +71,7 @@ namespace distributions
 }  // namespace pmacc
 
 #include "pmacc/random/distributions/uniform/Uniform_float.hpp"
+#include "pmacc/random/distributions/uniform/Uniform_double.hpp"
+#include "pmacc/random/distributions/uniform/Uniform_generic.hpp"
 #include "pmacc/random/distributions/uniform/Uniform_Integral32Bit.hpp"
+#include "pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp"

--- a/include/pmacc/random/distributions/misc/MullerBox.hpp
+++ b/include/pmacc/random/distributions/misc/MullerBox.hpp
@@ -46,7 +46,7 @@ namespace distributions
     >
     class MullerBox :
         Uniform<
-            uniform::ExcludeZero< float >,
+            uniform::ExcludeZero< T_Type >,
             T_RNGMethod
         >
     {
@@ -120,7 +120,7 @@ namespace distributions
             StateType& state
         )
         {
-            float result;
+            T_Type result;
             if( hasSecondRngNumber )
             {
                 result = secondRngNumber;

--- a/include/pmacc/random/distributions/normal/Normal_double.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_double.hpp
@@ -45,12 +45,12 @@ namespace detail
         typename T_Acc
     >
     struct Normal<
-        float,
+        double,
         methods::XorMin< T_Acc >,
         void
     > :
         public MullerBox<
-            float,
+            double,
             methods::XorMin< T_Acc >
         >
     {
@@ -62,12 +62,12 @@ namespace detail
         typename T_Acc
     >
     struct Normal<
-        float,
+        double,
         methods::MRG32k3aMin< T_Acc >,
         void
     > :
         public MullerBox<
-            float,
+            double,
             methods::MRG32k3aMin< T_Acc >
         >
     {

--- a/include/pmacc/random/distributions/normal/Normal_generic.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_generic.hpp
@@ -23,11 +23,6 @@
 
 #include "pmacc/types.hpp"
 #include "pmacc/random/distributions/Normal.hpp"
-#include "pmacc/random/distributions/misc/MullerBox.hpp"
-#include "pmacc/random/methods/XorMin.hpp"
-#include "pmacc/random/methods/MRG32k3aMin.hpp"
-#include "pmacc/random/distributions/Uniform.hpp"
-#include "pmacc/algorithms/math.hpp"
 
 #include <type_traits>
 
@@ -40,39 +35,36 @@ namespace distributions
 {
 namespace detail
 {
-    //! specialization for XorMin
-    template<
-        typename T_Acc
-    >
-    struct Normal<
-        float,
-        methods::XorMin< T_Acc >,
-        void
-    > :
-        public MullerBox<
-            float,
-            methods::XorMin< T_Acc >
-        >
-    {
 
+    //!Returns a normally distributed floating point with value with mean 0.0 and standard deviation 1.0
+    template<
+        typename T_Type,
+        typename T_RNGMethod
+    >
+    class Normal<
+        T_Type,
+        T_RNGMethod,
+        void
+    >
+    {
+        using RNGMethod = T_RNGMethod;
+        using StateType = typename RNGMethod::StateType;
+    public:
+        using result_type = T_Type;
+
+        template< typename T_Acc >
+        DINLINE result_type
+        operator()(
+            T_Acc const & acc,
+            StateType& state
+        )
+        {
+            return ::alpaka::rand::distribution::createNormalReal< T_Type >(
+                acc
+            )( state );
+        }
     };
 
-    //! specialization for MRG32k3aMin
-    template<
-        typename T_Acc
-    >
-    struct Normal<
-        float,
-        methods::MRG32k3aMin< T_Acc >,
-        void
-    > :
-        public MullerBox<
-            float,
-            methods::MRG32k3aMin< T_Acc >
-        >
-    {
-
-    };
 }  // namespace detail
 }  // namespace distributions
 }  // namespace random

--- a/include/pmacc/random/distributions/uniform/Range.hpp
+++ b/include/pmacc/random/distributions/uniform/Range.hpp
@@ -41,7 +41,7 @@ namespace uniform
     struct ExcludeZero
     {};
 
-    /**  floating point number in the range (0,1]
+    /**  floating point number in the range [0,1)
      *
      * @tparam T_Type type of the result
      */
@@ -49,11 +49,14 @@ namespace uniform
     struct ExcludeOne
     {
 
-        /** Reduce the random range to 2^24.
+        /** Reduce the random range.
+         *
+         * range for `float` is `2^24`
+         * range for double is `2^53`
          *
          * Creates intervals with the width of epsilon/2.
          */
-        struct Use24Bit
+        struct Reduced
         {};
 
         /** Loops until a random value inside the defined range is created.

--- a/include/pmacc/random/distributions/uniform/Range.hpp
+++ b/include/pmacc/random/distributions/uniform/Range.hpp
@@ -49,19 +49,21 @@ namespace uniform
     struct ExcludeOne
     {
 
-        /** Reduce the random range.
+        /** Reduce the random range
          *
-         * range for `float` is `2^24`
-         * range for double is `2^53`
+         * number of unique random numbers for
+         *   - `float` is `2^24`
+         *   - `double` is `2^53`
          *
          * Creates intervals with the width of epsilon/2.
          */
         struct Reduced
         {};
 
-        /** Loops until a random value inside the defined range is created.
+        /** Loops until a random value inside the defined range is created
          *
          * The runtime of this method is not deterministic.
+         * @warning zero is excluded which results in a range (0,1)
          */
         struct Repeat
         {};
@@ -74,7 +76,6 @@ namespace uniform
         {};
 
     };
-
 
 }  // namespace uniform
 }  // namespace distributions

--- a/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
@@ -22,14 +22,9 @@
 #pragma once
 
 #include "pmacc/types.hpp"
-#include "pmacc/random/distributions/Normal.hpp"
-#include "pmacc/random/distributions/misc/MullerBox.hpp"
-#include "pmacc/random/methods/XorMin.hpp"
-#include "pmacc/random/methods/MRG32k3aMin.hpp"
 #include "pmacc/random/distributions/Uniform.hpp"
-#include "pmacc/algorithms/math.hpp"
 
-#include <type_traits>
+#include <boost/type_traits.hpp>
 
 
 namespace pmacc
@@ -40,39 +35,43 @@ namespace distributions
 {
 namespace detail
 {
-    //! specialization for XorMin
-    template<
-        typename T_Acc
-    >
-    struct Normal<
-        float,
-        methods::XorMin< T_Acc >,
-        void
-    > :
-        public MullerBox<
-            float,
-            methods::XorMin< T_Acc >
-        >
-    {
 
+    /**
+     * Returns a random, uniformly distributed (up to) 64 bit integral value
+     */
+    template<
+        typename T_Type,
+        class T_RNGMethod
+    >
+    class Uniform<
+        T_Type,
+        T_RNGMethod,
+        typename bmpl::if_c<
+            boost::is_integral< T_Type >::value && sizeof( T_Type ) == 8,
+            void,
+            T_Type
+        >::type
+    >
+    {
+        typedef T_RNGMethod RNGMethod;
+        typedef typename RNGMethod::StateType StateType;
+    public:
+        typedef T_Type result_type;
+
+        template< typename T_Acc >
+        DINLINE result_type
+        operator()(
+            T_Acc const & acc,
+            StateType& state
+        )
+        {
+            return static_cast< result_type >( RNGMethod().get64Bits(
+                acc,
+                state
+            ) );
+        }
     };
 
-    //! specialization for MRG32k3aMin
-    template<
-        typename T_Acc
-    >
-    struct Normal<
-        float,
-        methods::MRG32k3aMin< T_Acc >,
-        void
-    > :
-        public MullerBox<
-            float,
-            methods::MRG32k3aMin< T_Acc >
-        >
-    {
-
-    };
 }  // namespace detail
 }  // namespace distributions
 }  // namespace random

--- a/include/pmacc/random/distributions/uniform/Uniform_double.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_double.hpp
@@ -34,13 +34,13 @@ namespace distributions
 namespace detail
 {
 
-    /** Returns a random float value uniformly distributed in (0,1]
+    /** Returns a random double value uniformly distributed in (0,1]
      *
-     * The smallest created value is `2^-33` (~ `1.164*10^-10`)
+     * The smallest created value is `2^-65` (~ `2.710505431213761*10^-20`)
      */
     template<class T_RNGMethod>
     class Uniform<
-        uniform::ExcludeZero<float>,
+        uniform::ExcludeZero<double>,
         T_RNGMethod,
         void
     >
@@ -48,29 +48,32 @@ namespace detail
     public:
         typedef T_RNGMethod RNGMethod;
         typedef typename RNGMethod::StateType StateType;
-        typedef float result_type;
+        typedef double result_type;
 
         template< typename T_Acc >
-        DINLINE float
+        DINLINE double
         operator()(
             T_Acc const & acc,
             StateType& state
         ) const
         {
-            const float value2pow32Inv = 2.3283064e-10f;
-            const uint32_t random = RNGMethod().get32Bits(acc, state);
-            return static_cast<float>( random ) * value2pow32Inv +
-                ( value2pow32Inv / 2.0f );
+            double const value2pow64Inv = 5.421010862427522e-20;
+            uint64_t const random = RNGMethod().get64Bits(
+                acc,
+                state
+            );
+            return static_cast< double >( random ) * value2pow64Inv +
+                ( value2pow64Inv / 2.0 );
         }
     };
 
-    /** Returns a random float value uniformly distributed in [0,1)
+    /** Returns a random double value uniformly distributed in [0,1)
      *
      * Swap the value one to zero (creates a small error in uniform distribution)
      */
     template<class T_RNGMethod>
     class Uniform<
-        uniform::ExcludeOne<float>::SwapOneToZero,
+        uniform::ExcludeOne< double >::SwapOneToZero,
         T_RNGMethod,
         void
     >
@@ -78,33 +81,33 @@ namespace detail
     public:
         typedef T_RNGMethod RNGMethod;
         typedef typename RNGMethod::StateType StateType;
-        typedef float result_type;
+        typedef double result_type;
 
         template< typename T_Acc >
-        DINLINE float
+        DINLINE double
         operator()(
             T_Acc const & acc,
             StateType& state
         ) const
         {
-            const float randomValue =
+            double const randomValue =
                 pmacc::random::distributions::Uniform<
-                    uniform::ExcludeZero<float>,
+                    uniform::ExcludeZero< double >,
                     RNGMethod
             >()(acc, state);
-            return randomValue == 1.0f ? 0.0f : randomValue;
+            return randomValue == 1.0 ? 0.0 : randomValue;
         }
     };
 
-    /** Returns a random float value uniformly distributed in [0,1)
+    /** Returns a random double value uniformly distributed in [0,1)
      *
-     * Reduce the random range to `2^24`.
-     * Uses a uniform distance of `2^-24` (`epsilon/2`) between each possible
+     * Reduce the random range to `2^53`.
+     * Uses a uniform distance of `2^-53` (`epsilon/2`) between each possible
      * random number.
      */
     template<class T_RNGMethod>
     class Uniform<
-        uniform::ExcludeOne<float>::Reduced,
+        uniform::ExcludeOne< double >::Reduced,
         T_RNGMethod,
         void
     >
@@ -112,29 +115,31 @@ namespace detail
     public:
         typedef T_RNGMethod RNGMethod;
         typedef typename RNGMethod::StateType StateType;
-        typedef float result_type;
+        typedef double result_type;
 
         template< typename T_Acc >
-        DINLINE float
+        DINLINE double
         operator()(
             T_Acc const & acc,
             StateType& state
         ) const
         {
-            const float value2pow24Inv = 5.9604645e-08f;
-            const float randomValue24Bit = RNGMethod().get32Bits(acc, state) >> 8;
-            return static_cast<float>( randomValue24Bit ) * value2pow24Inv;
+            double const value2pow53Inv = 1.1102230246251565e-16;
+            double const randomValue53Bit = RNGMethod().get64Bits( acc, state ) >> 11;
+            return randomValue53Bit * value2pow53Inv;
         }
     };
 
-    /** Returns a random float value uniformly distributed in [0,1)
+    /** Returns a random double value uniformly distributed in [0,1)
      *
      * Loops until a random value inside the defined range is created.
      * The runtime of this method is not deterministic.
      */
-    template<class T_RNGMethod>
+    template<
+        class T_RNGMethod
+    >
     class Uniform<
-        typename uniform::ExcludeOne<float>::Repeat,
+        typename uniform::ExcludeOne< double >::Repeat,
         T_RNGMethod,
         void
     >
@@ -142,10 +147,10 @@ namespace detail
     public:
         typedef T_RNGMethod RNGMethod;
         typedef typename RNGMethod::StateType StateType;
-        typedef float result_type;
+        typedef double  result_type;
 
         template< typename T_Acc >
-        DINLINE float
+        DINLINE result_type
         operator()(
             T_Acc const & acc,
             StateType& state
@@ -153,13 +158,13 @@ namespace detail
         {
             do
             {
-                const float randomValue =
+                const double randomValue =
                     pmacc::random::distributions::Uniform<
-                        uniform::ExcludeZero<float>,
+                        uniform::ExcludeZero< double >,
                         RNGMethod
                     >()(acc, state);
 
-                if( randomValue != 1.0f )
+                if( randomValue != 1.0 )
                     return randomValue;
             }
             while(true);

--- a/include/pmacc/random/distributions/uniform/Uniform_double.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_double.hpp
@@ -101,7 +101,7 @@ namespace detail
 
     /** Returns a random double value uniformly distributed in [0,1)
      *
-     * Reduce the random range to `2^53`.
+     * Number of unique random numbers is reduced to `2^53`.
      * Uses a uniform distance of `2^-53` (`epsilon/2`) between each possible
      * random number.
      */
@@ -130,7 +130,7 @@ namespace detail
         }
     };
 
-    /** Returns a random double value uniformly distributed in [0,1)
+    /** Returns a random double value uniformly distributed in (0,1)
      *
      * Loops until a random value inside the defined range is created.
      * The runtime of this method is not deterministic.

--- a/include/pmacc/random/distributions/uniform/Uniform_float.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_float.hpp
@@ -98,7 +98,7 @@ namespace detail
 
     /** Returns a random float value uniformly distributed in [0,1)
      *
-     * Reduce the random range to `2^24`.
+     * Number of unique random numbers is reduced to `2^24`.
      * Uses a uniform distance of `2^-24` (`epsilon/2`) between each possible
      * random number.
      */
@@ -127,7 +127,7 @@ namespace detail
         }
     };
 
-    /** Returns a random float value uniformly distributed in [0,1)
+    /** Returns a random float value uniformly distributed in (0,1)
      *
      * Loops until a random value inside the defined range is created.
      * The runtime of this method is not deterministic.

--- a/include/pmacc/random/distributions/uniform/Uniform_generic.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_generic.hpp
@@ -22,15 +22,10 @@
 #pragma once
 
 #include "pmacc/types.hpp"
-#include "pmacc/random/distributions/Normal.hpp"
-#include "pmacc/random/distributions/misc/MullerBox.hpp"
-#include "pmacc/random/methods/XorMin.hpp"
-#include "pmacc/random/methods/MRG32k3aMin.hpp"
 #include "pmacc/random/distributions/Uniform.hpp"
-#include "pmacc/algorithms/math.hpp"
-
-#include <type_traits>
-
+#include "pmacc/random/distributions/uniform/Uniform_float.hpp"
+#include "pmacc/random/distributions/uniform/Uniform_double.hpp"
+#include "pmacc/random/distributions/uniform/Range.hpp"
 
 namespace pmacc
 {
@@ -40,38 +35,49 @@ namespace distributions
 {
 namespace detail
 {
-    //! specialization for XorMin
+
+    /** Returns a random floating point value uniformly distributed in [0,1)
+     *
+     * Equivalent to uniform::ExcludeOne< T_Type >::Reduced
+     */
     template<
-        typename T_Acc
+        typename T_Type,
+        class T_RNGMethod
     >
-    struct Normal<
-        float,
-        methods::XorMin< T_Acc >,
-        void
+    class Uniform<
+        T_Type,
+        T_RNGMethod,
+        typename std::enable_if<
+            std::is_floating_point< T_Type >::value
+        >::type
     > :
-        public MullerBox<
-            float,
-            methods::XorMin< T_Acc >
+        public pmacc::random::distributions::Uniform<
+            typename uniform::ExcludeOne< T_Type >::Reduced,
+            T_RNGMethod
         >
     {
-
     };
 
-    //! specialization for MRG32k3aMin
+    /** Returns a random floating point value uniformly distributed in [0,1)
+     *
+     * Equivalent to uniform::ExcludeOne< T_Type >::Reduced
+     */
     template<
-        typename T_Acc
+        typename T_Type,
+        class T_RNGMethod
     >
-    struct Normal<
-        float,
-        methods::MRG32k3aMin< T_Acc >,
-        void
+    class Uniform<
+        uniform::ExcludeOne< T_Type>,
+        T_RNGMethod,
+        typename std::enable_if<
+            std::is_floating_point< T_Type >::value
+        >::type
     > :
-        public MullerBox<
-            float,
-            methods::MRG32k3aMin< T_Acc >
+        public pmacc::random::distributions::Uniform<
+            typename uniform::ExcludeOne< T_Type >::Reduced,
+            T_RNGMethod
         >
     {
-
     };
 }  // namespace detail
 }  // namespace distributions

--- a/include/pmacc/random/methods/AlpakaRand.hpp
+++ b/include/pmacc/random/methods/AlpakaRand.hpp
@@ -69,6 +69,21 @@ namespace methods
             )( state );
         }
 
+        DINLINE uint64_t
+        get64Bits(
+            T_Acc const & acc,
+            StateType& state
+        ) const
+        {
+            /* Two 32bit values are packed into a 64bit value because alpaka is not
+             * supporting 64bit integer random numbers
+             */
+            uint64_t result = get32Bits( acc, state);
+            result <<= 32;
+            result ^= get32Bits( acc, state);
+            return result;
+        }
+
         static std::string
         getName()
         {

--- a/include/pmacc/random/methods/MRG32k3aMin.hpp
+++ b/include/pmacc/random/methods/MRG32k3aMin.hpp
@@ -84,6 +84,19 @@ namespace methods
             return curand( reinterpret_cast< curandStateMRG32k3a* >( &state ) );
         }
 
+        DINLINE uint64_t
+        get64Bits(
+            T_Acc const & acc,
+            StateType& state
+        ) const
+        {
+            // two 32bit values are packed into a 64bit value
+            uint64_t result = get32Bits( acc, state);
+            result <<= 32;
+            result ^= get32Bits( acc, state);
+            return result;
+        }
+
         static std::string
         getName()
         {

--- a/include/pmacc/random/methods/XorMin.hpp
+++ b/include/pmacc/random/methods/XorMin.hpp
@@ -113,6 +113,19 @@ namespace methods
             return state.v[ 4 ] + state.d;
         }
 
+        DINLINE uint64_t
+        get64Bits(
+            T_Acc const & acc,
+            StateType& state
+        ) const
+        {
+            // two 32bit values are packed into a 64bit value
+            uint64_t result = get32Bits( acc, state);
+            result <<= 32;
+            result ^= get32Bits( acc, state);
+            return result;
+        }
+
         static std::string
         getName( )
         {


### PR DESCRIPTION
- fix minor documentation bugs
- add support for 64Bit floating point
  - normal distributed numbers
  - uniform distributed numbers
- add 64bit integer support to generate uniform distributed random numbers
- fix usage of `float` in the generic `MullerBox`
- RNG methods: extent interface with to generate a 64bit integer random number
- rename the range `ExcludeOne<...>::Use24Bit` to `ExcludeOne<...>::Reduced`

I fixed a documentation to the normal distributes number ranges and some hard coded usages of `float`. I have not added the label **BUG** because both are very tiny and has no real effect to the users.

# Tests

- [x] run PMacc RNG unit test 
  
  