### PR TITLE
extended period syntax

### DIFF
--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -28,6 +28,33 @@ Plugin name                                                                     
 :ref:`sum currents <usage-plugins-sumCurrents>`                                    compute the total current summed over all cells
 ================================================================================== =======================================================================
 
+Period Syntax
+=============
+
+Most plugins allow to define a period on how often a plugin shall be executed (notified).
+Its simple syntax is: ``<period>`` with a simple number.
+
+Additionally, the following syntax allows to define intervals for periods:
+
+``<start>:<end>[:<period>]``
+
+* `<start>`: begin of the interval; default: 0
+* `<end>`: end of the interval, including the upper bound; default: end of the simulation
+* `<period>`: notify period within the interval; default: 1
+
+Multiple intervals can be combined via a comma separated list.
+
+Examples
+--------
+
+* ``42`` every 42th time step
+* ``::`` equal to just writing ``1``, every time step from start (0) to the end of the simulation
+* ``11:11`` only once at time step 11
+* ``10:100:2`` every second time step between steps 10 and 100 (included)
+* ``42,30:50:10``: at steps 30 40 42 50 84 126 168 ...
+* ``5,10``: at steps 0 5 10 15 20 25 ... (only executed once per step in overlapping intervals)
+
+
 .. rubric:: Footnotes
 
 .. [#f1] On restart, plugins with that footnote overwrite their output of previous runs.

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -358,7 +358,7 @@ private:
         >::type;
 
         //! periodicity of computing the particle energy
-        plugins::multi::Option< uint32_t > notifyPeriod = {
+        plugins::multi::Option< std::string > notifyPeriod = {
             "period",
             "enable plugin [for each n-th step]"
         };

--- a/include/picongpu/plugins/ChargeConservation.hpp
+++ b/include/picongpu/plugins/ChargeConservation.hpp
@@ -49,7 +49,7 @@ class ChargeConservation : public ISimulationPlugin
 private:
     std::string name;
     std::string prefix;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
     const std::string filename;
     MappingDesc* cellDescription;
     std::ofstream output_file;

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -61,14 +61,14 @@ void ChargeConservation::pluginRegisterHelp(po::options_description& desc)
 {
     desc.add_options()
         ((this->prefix + ".period").c_str(),
-        po::value<uint32_t > (&this->notifyPeriod)->default_value(0), "enable plugin [for each n-th step]");
+        po::value<std::string> (&this->notifyPeriod), "enable plugin [for each n-th step]");
 }
 
 std::string ChargeConservation::pluginGetName() const {return this->name;}
 
 void ChargeConservation::pluginLoad()
 {
-    if(this->notifyPeriod == 0u)
+    if(this->notifyPeriod.empty())
         return;
 
     Environment<>::get().PluginConnector().setNotificationPeriod(this, this->notifyPeriod);
@@ -88,7 +88,7 @@ void ChargeConservation::pluginLoad()
 
 void ChargeConservation::restart(uint32_t restartStep, const std::string restartDirectory)
 {
-    if(this->notifyPeriod == 0u)
+    if(this->notifyPeriod.empty())
         return;
 
     if(!this->allGPU_reduce->root())
@@ -102,7 +102,7 @@ void ChargeConservation::restart(uint32_t restartStep, const std::string restart
 
 void ChargeConservation::checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
 {
-    if(this->notifyPeriod == 0u)
+    if(this->notifyPeriod.empty())
         return;
 
     if(!this->allGPU_reduce->root())

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -53,7 +53,7 @@ private:
     typedef MappingDesc::SuperCellSize SuperCellSize;
 
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
 
     std::string pluginName;
     std::string pluginPrefix;
@@ -71,7 +71,6 @@ public:
     pluginPrefix(ParticlesType::FrameType::getName() + std::string("_macroParticlesCount")),
     filename(pluginPrefix + ".dat"),
     cellDescription(nullptr),
-    notifyPeriod(0),
     writeToFile(false)
     {
         Environment<>::get().PluginConnector().registerPlugin(this);
@@ -91,7 +90,7 @@ public:
     {
         desc.add_options()
             ((pluginPrefix + ".period").c_str(),
-             po::value<uint32_t > (&notifyPeriod), "enable plugin [for each n-th step]");
+             po::value<std::string> (&notifyPeriod), "enable plugin [for each n-th step]");
     }
 
     std::string pluginGetName() const
@@ -108,7 +107,7 @@ private:
 
     void pluginLoad()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             writeToFile = reduce.hasResult(mpi::reduceMethods::Reduce());
 
@@ -130,7 +129,7 @@ private:
 
     void pluginUnload()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             if (writeToFile)
             {

--- a/include/picongpu/plugins/EnergyFields.hpp
+++ b/include/picongpu/plugins/EnergyFields.hpp
@@ -80,7 +80,7 @@ class EnergyFields : public ISimulationPlugin
 {
 private:
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
 
     std::string pluginName;
     std::string pluginPrefix;
@@ -102,7 +102,6 @@ public:
     pluginName("EnergyFields: calculate the energy of the fields"),
     pluginPrefix(std::string("fields_energy")),
     filename(pluginPrefix + ".dat"),
-    notifyPeriod(0),
     writeToFile(false),
     localReduce(nullptr)
     {
@@ -123,7 +122,7 @@ public:
     {
         desc.add_options()
             ((pluginPrefix + ".period").c_str(),
-             po::value<uint32_t > (&notifyPeriod)->default_value(0), "enable plugin [for each n-th step]");
+             po::value<std::string> (&notifyPeriod), "enable plugin [for each n-th step]");
     }
 
     std::string pluginGetName() const
@@ -140,7 +139,7 @@ private:
 
     void pluginLoad()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             localReduce = new nvidia::reduce::Reduce(1024);
             writeToFile = mpiReduce.hasResult(mpi::reduceMethods::Reduce());
@@ -162,7 +161,7 @@ private:
 
     void pluginUnload()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             if (writeToFile)
             {

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -330,7 +330,7 @@ namespace picongpu
             >::type;
 
             //! periodicity of computing the particle energy
-            plugins::multi::Option< uint32_t > notifyPeriod = {
+            plugins::multi::Option< std::string > notifyPeriod = {
                 "period",
                 "compute kinetic and total energy [for each n-th step] enable plugin by setting a non-zero value"
             };

--- a/include/picongpu/plugins/IntensityPlugin.hpp
+++ b/include/picongpu/plugins/IntensityPlugin.hpp
@@ -139,7 +139,7 @@ private:
     GridBuffer<float_32, DIM1> *localMaxIntensity;
     GridBuffer<float_32, DIM1> *localIntegratedIntensity;
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
 
     std::string pluginName;
     std::string pluginPrefix;
@@ -160,7 +160,6 @@ public:
     localMaxIntensity(nullptr),
     localIntegratedIntensity(nullptr),
     cellDescription(nullptr),
-    notifyPeriod(0),
     writeToFile(false)
     {
         Environment<>::get().PluginConnector().registerPlugin(this);
@@ -181,7 +180,7 @@ public:
     {
         desc.add_options()
             ((pluginPrefix + ".period").c_str(),
-             po::value<uint32_t > (&notifyPeriod), "enable plugin [for each n-th step]");
+             po::value<std::string> (&notifyPeriod), "enable plugin [for each n-th step]");
     }
 
     std::string pluginGetName() const
@@ -198,7 +197,7 @@ private:
 
     void pluginLoad()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             writeToFile = Environment<simDim>::get().GridController().getGlobalRank() == 0;
             int yCells = cellDescription->getGridLayout().getDataSpaceWithoutGuarding().y();
@@ -218,7 +217,7 @@ private:
 
     void pluginUnload()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             if (writeToFile)
             {

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -241,8 +241,7 @@ public:
         drawing_time(0),
         cell_count(0),
         particle_count(0),
-        last_notify(0),
-        notifyPeriod(0)
+        last_notify(0)
     {
         Environment<>::get().PluginConnector().registerPlugin(this);
     }
@@ -311,7 +310,7 @@ public:
     {
         /* register command line parameters for your plugin */
         desc.add_options()
-            ("isaac.period", po::value< uint32_t > (&render_interval)->default_value(0),
+            ("isaac.period", po::value< uint32_t > (&render_interval),
              "Enable IsaacPlugin [for each n-th step].")
             ("isaac.name", po::value< std::string > (&name)->default_value("default"),
              "The name of the simulation. Default is \"default\".")
@@ -339,7 +338,7 @@ public:
 
 private:
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
     std::string url;
     std::string name;
     uint16_t port;
@@ -366,7 +365,7 @@ private:
         {
             //using an internal variable "render_interval" as notifyPeroid
             //of PIConGPU cannot be changed at runtime
-            notifyPeriod = 1;
+            notifyPeriod = "1";
             MPI_Comm_rank(MPI_COMM_WORLD, &rank);
             MPI_Comm_size(MPI_COMM_WORLD, &numProc);
             if ( MovingWindow::getInstance().isSlidingWindowActive() )
@@ -414,7 +413,7 @@ private:
             {
                 if (rank == 0)
                     log<picLog::INPUT_OUTPUT > ("ISAAC Init failed");
-                notifyPeriod = 0;
+                notifyPeriod = "";
             }
             else
             {
@@ -431,7 +430,7 @@ private:
 
     void pluginUnload()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             delete visualization;
             visualization = nullptr;

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -97,7 +97,7 @@ namespace picongpu
             >::type;
 
             //! periodicity of computing the particle energy
-            plugins::multi::Option< uint32_t > notifyPeriod = {
+            plugins::multi::Option< std::string > notifyPeriod = {
                 "period",
                 "notify period"
             };

--- a/include/picongpu/plugins/PngPlugin.hpp
+++ b/include/picongpu/plugins/PngPlugin.hpp
@@ -74,7 +74,7 @@ namespace picongpu
         {
 #if( PIC_ENABLE_PNG == 1 )
             desc.add_options()
-                    ((pluginPrefix + ".period").c_str(), po::value<std::vector<uint32_t> > (&notifyPeriod)->multitoken(), "enable data output [for each n-th step]")
+                    ((pluginPrefix + ".period").c_str(), po::value<std::vector<std::string> > (&notifyPeriod)->multitoken(), "enable data output [for each n-th step]")
                     ((pluginPrefix + ".axis").c_str(), po::value<std::vector<std::string > > (&axis)->multitoken(), "axis which are shown [valid values x,y,z] example: yz")
                     ((pluginPrefix + ".slicePoint").c_str(), po::value<std::vector<float_32> > (&slicePoints)->multitoken(), "value range: 0 <= x <= 1 , point of the slice")
                     ((pluginPrefix + ".folder").c_str(), po::value<std::vector<std::string> > (&folders)->multitoken(), "folder for output files");
@@ -102,8 +102,8 @@ namespace picongpu
                 {
                     for (int i = 0; i < (int) slicePoints.size(); ++i) /*!\todo: use vactor with max elements*/
                     {
-                        uint32_t frequ = getValue(notifyPeriod, i);
-                        if (frequ != 0)
+                        std::string frequ = getValue(notifyPeriod, i);
+                        if(!frequ.empty())
                         {
 
                             if (getValue(axis, i).length() == 2u)
@@ -208,7 +208,7 @@ namespace picongpu
         std::string pluginName;
         std::string pluginPrefix;
 
-        std::vector<uint32_t> notifyPeriod;
+        std::vector<std::string> notifyPeriod;
         std::vector<float_32> slicePoints;
         std::vector<std::string> folders;
         std::vector<std::string> axis;

--- a/include/picongpu/plugins/PngPlugin.hpp
+++ b/include/picongpu/plugins/PngPlugin.hpp
@@ -102,8 +102,8 @@ namespace picongpu
                 {
                     for (int i = 0; i < (int) slicePoints.size(); ++i) /*!\todo: use vactor with max elements*/
                     {
-                        std::string frequ = getValue(notifyPeriod, i);
-                        if(!frequ.empty())
+                        std::string period = getValue(notifyPeriod, i);
+                        if(!period.empty())
                         {
 
                             if (getValue(axis, i).length() == 2u)
@@ -137,7 +137,7 @@ namespace picongpu
                                                                       (transpose.x()==1 || transpose.y()==1);
                                 if( isAllowed2DSlice && isAllowedMovingWindowSlice )
                                 {
-                                    VisType* tmp = new VisType(pluginName, pngCreator, frequ, transpose, getValue(slicePoints, i));
+                                    VisType* tmp = new VisType(pluginName, pngCreator, period, transpose, getValue(slicePoints, i));
                                     visIO.push_back(tmp);
                                     tmp->setMappingDescription(cellDescription);
                                     tmp->init();

--- a/include/picongpu/plugins/PositionsParticles.hpp
+++ b/include/picongpu/plugins/PositionsParticles.hpp
@@ -183,7 +183,7 @@ private:
     GridBuffer<SglParticle<FloatPos>, DIM1> *gParticle;
 
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
 
     std::string pluginName;
     std::string pluginPrefix;
@@ -194,8 +194,7 @@ public:
     pluginName("PositionsParticles: write position of one particle of a species to std::cout"),
     pluginPrefix(ParticlesType::FrameType::getName() + std::string("_position")),
     gParticle(nullptr),
-    cellDescription(nullptr),
-    notifyPeriod(0)
+    cellDescription(nullptr)
     {
 
         Environment<>::get().PluginConnector().registerPlugin(this);
@@ -221,7 +220,7 @@ public:
     {
         desc.add_options()
             ((pluginPrefix + ".period").c_str(),
-             po::value<uint32_t > (&notifyPeriod), "enable plugin [for each n-th step]");
+             po::value<std::string> (&notifyPeriod), "enable plugin [for each n-th step]");
     }
 
     std::string pluginGetName() const
@@ -238,7 +237,7 @@ private:
 
     void pluginLoad()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             //create one float3_X on gpu und host
             gParticle = new GridBuffer<SglParticle<FloatPos>, DIM1 > (DataSpace<DIM1 > (1));

--- a/include/picongpu/plugins/ResourceLog.hpp
+++ b/include/picongpu/plugins/ResourceLog.hpp
@@ -171,7 +171,7 @@ namespace picongpu
         {
             /* register command line parameters for your plugin */
             desc.add_options()
-                    ("resourceLog.period", po::value<uint32_t>(&notifyPeriod)->default_value(0),
+                    ("resourceLog.period", po::value<std::string>(&notifyPeriod),
                      "Enable ResourceLog plugin [for each n-th step]")
                     ("resourceLog.prefix", po::value<std::string>(&outputFilePrefix)->default_value("resourceLog_"),
                      "Set the filename prefix for output file if a filestream was selected")
@@ -189,10 +189,10 @@ namespace picongpu
         }
 
     private:
-        uint32_t notifyPeriod;
+        std::string notifyPeriod;
 
         void pluginLoad() {
-            if(notifyPeriod != 0) {
+            if(!notifyPeriod.empty()) {
                 Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
 
                 // Set default resources to log

--- a/include/picongpu/plugins/SliceFieldPrinter.hpp
+++ b/include/picongpu/plugins/SliceFieldPrinter.hpp
@@ -40,7 +40,7 @@ template<typename Field>
 class SliceFieldPrinter : public ILightweightPlugin
 {
 private:
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
     bool sliceIsOK;
     std::string fileName;
     int plane;

--- a/include/picongpu/plugins/SliceFieldPrinterMulti.hpp
+++ b/include/picongpu/plugins/SliceFieldPrinterMulti.hpp
@@ -39,7 +39,7 @@ class SliceFieldPrinterMulti : public ILightweightPlugin
 private:
     std::string name;
     std::string prefix;
-    std::vector<uint32_t> notifyPeriod;
+    std::vector<std::string> notifyPeriod;
     std::vector<std::string> fileName;
     std::vector<int> plane;
     std::vector<float_X> slicePoint;

--- a/include/picongpu/plugins/SliceFieldPrinterMulti.tpp
+++ b/include/picongpu/plugins/SliceFieldPrinterMulti.tpp
@@ -52,7 +52,7 @@ void SliceFieldPrinterMulti<Field>::pluginRegisterHelp(po::options_description& 
 {
     desc.add_options()
         ((this->prefix + ".period").c_str(),
-        po::value<std::vector<uint32_t> > (&this->notifyPeriod)->multitoken(), "notify period");
+        po::value<std::vector<std::string> > (&this->notifyPeriod)->multitoken(), "notify period");
     desc.add_options()
         ((this->prefix + ".fileName").c_str(),
         po::value<std::vector<std::string> > (&this->fileName)->multitoken(), "file name to store slices in");

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -93,15 +93,14 @@ class SumCurrents : public ILightweightPlugin
 {
 private:
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
 
     GridBuffer<float3_X, DIM1> *sumcurrents;
 
 public:
 
     SumCurrents() :
-    cellDescription(nullptr),
-    notifyPeriod(0)
+    cellDescription(nullptr)
     {
 
         Environment<>::get().PluginConnector().registerPlugin(this);
@@ -148,7 +147,7 @@ public:
     void pluginRegisterHelp(po::options_description& desc)
     {
         desc.add_options()
-            ("sumcurr.period", po::value<uint32_t > (&notifyPeriod), "enable plugin [for each n-th step]");
+            ("sumcurr.period", po::value<std::string> (&notifyPeriod), "enable plugin [for each n-th step]");
     }
 
     std::string pluginGetName() const
@@ -165,7 +164,7 @@ private:
 
     void pluginLoad()
     {
-        if (notifyPeriod > 0)
+        if (!notifyPeriod.empty())
         {
             sumcurrents = new GridBuffer<float3_X, DIM1 > (DataSpace<DIM1 > (1)); //create one int on gpu und host
 
@@ -175,7 +174,7 @@ private:
 
     void pluginUnload()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             __delete(sumcurrents);
         }

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -169,7 +169,7 @@ public:
             );
         }
 
-        plugins::multi::Option< uint32_t > notifyPeriod = {
+        plugins::multi::Option< std::string > notifyPeriod = {
             "period",
             "enable ADIOS IO [for each n-th step]"
         };
@@ -811,9 +811,9 @@ public:
 
         if( m_help->selfRegister )
         {
-            uint32_t notifyPeriod = m_help->notifyPeriod.get( id );
+            std::string notifyPeriod = m_help->notifyPeriod.get( id );
             /* only register for notify callback when .period is set on command line */
-            if (notifyPeriod > 0)
+            if(!notifyPeriod.empty())
             {
                 Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
 

--- a/include/picongpu/plugins/hdf5/HDF5Writer.hpp
+++ b/include/picongpu/plugins/hdf5/HDF5Writer.hpp
@@ -122,7 +122,7 @@ public:
             );
         }
 
-        plugins::multi::Option< uint32_t > notifyPeriod = {
+        plugins::multi::Option< std::string > notifyPeriod = {
             "period",
             "enable HDF5 IO [for each n-th step]"
         };
@@ -331,9 +331,9 @@ public:
 
         if( m_help->selfRegister )
         {
-            uint32_t notifyPeriod = m_help->notifyPeriod.get( id );
+            std::string notifyPeriod = m_help->notifyPeriod.get( id );
             /* only register for notify callback when .period is set on command line */
-            if (notifyPeriod > 0)
+            if(!notifyPeriod.empty())
             {
                 Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
 

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -126,7 +126,7 @@ private:
     typedef GridBuffer<size_t, simDim> GridBufferType;
 
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
 
     std::string pluginName;
     std::string pluginPrefix;
@@ -146,7 +146,6 @@ public:
     pluginPrefix(ParticlesType::FrameType::getName() + std::string("_macroParticlesPerSuperCell")),
     foldername(pluginPrefix),
     cellDescription(nullptr),
-    notifyPeriod(0),
     localResult(nullptr),
     dataCollector(nullptr)
     {
@@ -167,7 +166,7 @@ public:
     {
         desc.add_options()
             ((pluginPrefix + ".period").c_str(),
-             po::value<uint32_t > (&notifyPeriod), "enable plugin [for each n-th step]");
+             po::value<std::string > (&notifyPeriod), "enable plugin [for each n-th step]");
     }
 
     std::string pluginGetName() const
@@ -184,7 +183,7 @@ private:
 
     void pluginLoad()
     {
-        if (notifyPeriod > 0)
+        if(!notifyPeriod.empty())
         {
             Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
             const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -834,7 +834,7 @@ public:
     using FrameType = typename ParticlesType::FrameType;
     using CreatorType = Output;
 
-    Visualisation(std::string name, Output output, uint32_t notifyPeriod, DataSpace<DIM2> transpose, float_X slicePoint) :
+    Visualisation(std::string name, Output output, std::string notifyPeriod, DataSpace<DIM2> transpose, float_X slicePoint) :
     m_output(output),
     pluginName(name),
     cellDescription(nullptr),
@@ -861,7 +861,7 @@ public:
     {
         /* wait that shared buffers can destroyed */
         m_output.join();
-        if (m_notifyPeriod > 0)
+        if(!m_notifyPeriod.empty())
         {
             __delete(img);
             MessageHeader::destroy(header);
@@ -1048,7 +1048,7 @@ public:
 
     void init()
     {
-        if (m_notifyPeriod > 0)
+        if(!m_notifyPeriod.empty())
         {
             PMACC_ASSERT(cellDescription != nullptr);
             const DataSpace<simDim> localSize(cellDescription->getGridLayout().getDataSpaceWithoutGuarding());
@@ -1103,7 +1103,7 @@ private:
     GridBuffer<float3_X, DIM2 > *img;
 
     int sliceOffset;
-    uint32_t m_notifyPeriod;
+    std::string m_notifyPeriod;
     float_X m_slicePoint;
 
     std::string pluginName;

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -72,7 +72,7 @@ private:
     std::string name;
     std::string prefix;
     std::string foldername;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
     MappingDesc* cellDescription;
     std::ofstream outFile;
     const std::string leftParticlesDatasetName;
@@ -134,7 +134,7 @@ private:
 
     void restart(uint32_t restartStep, const std::string restartDirectory)
     {
-        if(this->notifyPeriod == 0)
+        if(this->notifyPeriod.empty())
             return;
 
         HBufCalorimeter hBufLeftParsCalorimeter(this->dBufLeftParsCalorimeter->size());
@@ -187,7 +187,7 @@ private:
 
     void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
     {
-        if(this->notifyPeriod == 0)
+        if(this->notifyPeriod.empty())
             return;
 
         HBufCalorimeter hBufLeftParsCalorimeter(this->dBufLeftParsCalorimeter->size());
@@ -233,7 +233,7 @@ private:
     {
         namespace pm = pmacc::math;
 
-        if(this->notifyPeriod == 0)
+        if(this->notifyPeriod.empty())
             return;
 
         if(!(this->openingYaw_deg > float_X(0.0) && this->openingYaw_deg <= float_X(360.0)))
@@ -328,7 +328,7 @@ private:
 
     void pluginUnload()
     {
-        if(this->notifyPeriod == 0)
+        if(this->notifyPeriod.empty())
             return;
 
         __delete(this->dBufCalorimeter);
@@ -431,7 +431,6 @@ public:
         name("ParticleCalorimeter: (virtually) propagates and collects particles to infinite distance"),
         prefix(ParticlesType::FrameType::getName() + std::string("_calorimeter")),
         foldername(prefix),
-        notifyPeriod(0),
         cellDescription(nullptr),
         leftParticlesDatasetName("calorimeterLeftParticles"),
         dBufCalorimeter(nullptr),
@@ -497,7 +496,7 @@ public:
     void pluginRegisterHelp(po::options_description& desc)
     {
         desc.add_options()
-        ((this->prefix + ".period").c_str(), po::value<uint32_t > (&this->notifyPeriod)->default_value(0),
+        ((this->prefix + ".period").c_str(), po::value<std::string> (&this->notifyPeriod),
             "enable plugin [for each n-th step]")
         ((this->prefix + ".numBinsYaw").c_str(), po::value<uint32_t > (&this->numBinsYaw)->default_value(64),
             "number of bins for angle yaw.")
@@ -530,7 +529,7 @@ public:
 
     void onParticleLeave(const std::string& speciesName, int32_t direction)
     {
-        if(this->notifyPeriod == 0)
+        if(this->notifyPeriod.empty())
             return;
         if(speciesName != ParticlesType::FrameType::getName())
             return;

--- a/include/picongpu/plugins/particleMerging/ParticleMerger.hpp
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.hpp
@@ -67,7 +67,7 @@ namespace particleMerging
     private:
         std::string name;
         std::string prefix;
-        uint32_t notifyPeriod;
+        std::string notifyPeriod;
         MappingDesc* cellDescription;
 
         uint32_t minParticlesToMerge;
@@ -87,7 +87,6 @@ namespace particleMerging
                 " similar position and momentum into a single one"
             ),
             prefix( ParticlesType::FrameType::getName() + std::string("_merger") ),
-            notifyPeriod( 0 ),
             cellDescription( nullptr )
         {
             Environment<>::get().PluginConnector().registerPlugin( this );
@@ -154,9 +153,9 @@ namespace particleMerging
             desc.add_options()
             (
                 ( this->prefix + ".period" ).c_str(),
-                po::value< uint32_t > (
+                po::value< std::string > (
                     &this->notifyPeriod
-                )->default_value( 0 ),
+                ),
                 "enable plugin [for each n-th step]"
             )
             (
@@ -212,7 +211,7 @@ namespace particleMerging
 
         void pluginLoad()
         {
-            if( notifyPeriod == 0 )
+            if( notifyPeriod.empty() )
                 return;
 
             Environment<>::get().PluginConnector().setNotificationPeriod(
@@ -270,7 +269,7 @@ namespace particleMerging
     private:
         std::string name;
         std::string prefix;
-    uint32_t notifyPeriod;
+        std::string notifyPeriod;
         MappingDesc* cellDescription;
 
     public:
@@ -284,7 +283,6 @@ namespace particleMerging
                 " attribute to the particle attribute list."
             ),
             prefix( ParticlesType::FrameType::getName() + std::string("_merger") ),
-            notifyPeriod( 0 ),
             cellDescription( nullptr )
         {
             Environment<>::get().PluginConnector().registerPlugin( this );

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -98,7 +98,7 @@ private:
     radiation_frequencies::FreqFunctor freqFkt;
 
     MappingDesc *cellDescription;
-    uint32_t notifyPeriod;
+    std::string notifyPeriod;
     uint32_t dumpPeriod;
     uint32_t radStart;
     uint32_t radEnd;
@@ -158,7 +158,6 @@ public:
     filename_prefix(pluginPrefix),
     radiation(nullptr),
     cellDescription(nullptr),
-    notifyPeriod(0),
     dumpPeriod(0),
     totalRad(false),
     lastRad(false),
@@ -214,7 +213,7 @@ public:
         if(dependenciesFulfilled)
         {
             desc.add_options()
-                ((pluginPrefix + ".period").c_str(), po::value<uint32_t > (&notifyPeriod), "enable plugin [for each n-th step]")
+                ((pluginPrefix + ".period").c_str(), po::value<std::string> (&notifyPeriod), "enable plugin [for each n-th step]")
                 ((pluginPrefix + ".dump").c_str(), po::value<uint32_t > (&dumpPeriod)->default_value(0), "dump integrated radiation from last dumped step [for each n-th step] (0 = only print data at end of simulation)")
                 ((pluginPrefix + ".lastRadiation").c_str(), po::bool_switch(&lastRad), "enable calculation of integrated radiation from last dumped step")
                 ((pluginPrefix + ".folderLastRad").c_str(), po::value<std::string > (&folderLastRad)->default_value("lastRad"), "folder in which the integrated radiation from last dumped step is written")
@@ -250,7 +249,7 @@ public:
     void restart(uint32_t timeStep, const std::string restartDirectory)
     {
         // only load backup if radiation is calculated:
-        if(notifyPeriod == 0)
+        if(notifyPeriod.empty())
             return;
 
         if(dependenciesFulfilled && isMaster)
@@ -267,7 +266,7 @@ public:
     void checkpoint(uint32_t timeStep, const std::string restartDirectory)
     {
         // only write backup if radiation is calculated:
-        if(notifyPeriod == 0)
+        if(notifyPeriod.empty())
             return;
 
         if(dependenciesFulfilled)
@@ -305,7 +304,7 @@ private:
             // allocate memory for all amplitudes for temporal data collection
             tmp_result = new Amplitude[elements_amplitude()];
 
-            if (notifyPeriod > 0)
+            if(!notifyPeriod.empty())
             {
                 /*only rank 0 create a file*/
                 isMaster = reduce.hasResult(mpi::reduceMethods::Reduce());
@@ -374,7 +373,7 @@ private:
 
     void pluginUnload()
     {
-        if(dependenciesFulfilled && notifyPeriod > 0)
+        if(dependenciesFulfilled && !notifyPeriod.empty())
         {
 
             // Some funny things that make it possible for the kernel to calculate

--- a/include/pmacc/misc/splitString.hpp
+++ b/include/pmacc/misc/splitString.hpp
@@ -42,10 +42,10 @@ namespace misc
      */
     std::vector< std::string > splitString(
         std::string const & input,
-        std::string const & regex = ","
+        std::string const & delimiter = ","
     )
     {
-        std::regex re( regex );
+        std::regex re( delimiter );
         // passing -1 as the submatch index parameter performs splitting
         std::sregex_token_iterator first{
             input.begin(),

--- a/include/pmacc/misc/splitString.hpp
+++ b/include/pmacc/misc/splitString.hpp
@@ -1,0 +1,64 @@
+/* Copyright 2017-2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <regex>
+#include <vector>
+
+
+namespace pmacc
+{
+namespace misc
+{
+    /** split a string in a vector of strings
+     *
+     * Based on Stack Overflow post:
+     *   source: https://stackoverflow.com/a/28142357
+     *   author: Marcin
+     *   date: Jan 25 '15
+     *
+     * @param input string to split
+     * @param regex separator between two elements
+     */
+    std::vector< std::string > splitString(
+        std::string const & input,
+        std::string const & regex = ","
+    )
+    {
+        std::regex re( regex );
+        // passing -1 as the submatch index parameter performs splitting
+        std::sregex_token_iterator first{
+            input.begin(),
+            input.end(),
+            re,
+            -1
+        };
+        std::sregex_token_iterator last;
+
+        return {
+            first,
+            last
+        };
+    }
+} // namespace misc
+} // namespace pmacc

--- a/include/pmacc/pluginSystem/PluginConnector.hpp
+++ b/include/pmacc/pluginSystem/PluginConnector.hpp
@@ -26,7 +26,7 @@
 #include "pmacc/pluginSystem/IPlugin.hpp"
 #include "pmacc/pluginSystem/TimeSlice.hpp"
 #include "pmacc/pluginSystem/toTimeSlice.hpp"
-#include "pmacc/pluginSystem/cointainsStep.hpp"
+#include "pmacc/pluginSystem/containsStep.hpp"
 
 #include <vector>
 #include <list>
@@ -157,7 +157,7 @@ namespace pmacc
                     iter != notificationList.end(); ++iter)
             {
                 if(
-                    cointainsStep(
+                    containsStep(
                         (*iter).second,
                         currentStep
                     )

--- a/include/pmacc/pluginSystem/TimeSlice.hpp
+++ b/include/pmacc/pluginSystem/TimeSlice.hpp
@@ -65,7 +65,7 @@ namespace pluginSystem
                 uint32_t value = std::stoul( str );
                 PMACC_VERIFY_MSG(
                     !( idx == 2 && value == 0 ),
-                    "Zero is not valid period"
+                    "Zero is not a valid period"
                 );
                 values.at( idx )  = value;
             }

--- a/include/pmacc/pluginSystem/TimeSlice.hpp
+++ b/include/pmacc/pluginSystem/TimeSlice.hpp
@@ -1,0 +1,83 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+#include "pmacc/verify.hpp"
+
+#include <string>
+#include <array>
+
+
+namespace pmacc
+{
+namespace pluginSystem
+{
+    struct TimeSlice
+    {
+        /** time slice configuration
+         *
+         * 0 = begin of the interval
+         * 1 = end of the interval
+         * 2 = period
+         */
+        std::array< uint32_t, 3 > values;
+
+        std::string toString() const
+        {
+            std::string result;
+            result = std::to_string(values[0]) + ":" +
+                std::to_string(values[1]) + ":" +
+                std::to_string(values[2]);
+            return result;
+        }
+
+        /** set the value
+         *
+         * if str is empty the default value for the given index is selected
+         *
+         * @param idx index to set, range [0,3)
+         * @param str value to set, can be empty
+         */
+        void setValue(uint32_t const idx, std::string const & str)
+        {
+            if(!str.empty())
+            {
+                uint32_t value = std::stoul( str );
+                PMACC_VERIFY_MSG(
+                    !( idx == 2 && value == 0 ),
+                    "Zero is not valid period"
+                );
+                values.at( idx )  = value;
+            }
+        }
+
+        //! create a time slice instance
+        TimeSlice() :
+            /* default: start:end:period
+             * -1 stored as unsigned is the highest available unsigned integer
+             */
+            values( { 0, uint32_t( -1 ), 1 } )
+        { }
+    };
+} // namespace pluginSystem
+} // namespace pmacc

--- a/include/pmacc/pluginSystem/cointainsStep.hpp
+++ b/include/pmacc/pluginSystem/cointainsStep.hpp
@@ -1,0 +1,59 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/pluginSystem/TimeSlice.hpp"
+
+#include <vector>
+
+
+namespace pmacc
+{
+namespace pluginSystem
+{
+    /** check if a given step is defined within a interval list
+     *
+     * @param seqTimeSlices vector with time intervals
+     * @param timeStep simulation time step to check
+     * @return true if step is included in the interval list else false
+     */
+    bool cointainsStep(
+        std::vector< pluginSystem::TimeSlice > const & seqTimeSlices,
+        uint32_t const timeStep
+    )
+    {
+        for(auto const & timeSlice : seqTimeSlices)
+        {
+            if(
+                timeStep >= timeSlice.values[ 0 ] &&
+                timeStep <= timeSlice.values[ 1 ]
+            )
+            {
+                uint32_t const timeRelativeToStart = timeStep - timeSlice.values[ 0 ];
+                if( timeRelativeToStart % timeSlice.values[ 2 ] == 0 )
+                    return true;
+            }
+        }
+        return false;
+    }
+} // namespace pluginSystem
+} // namespace pmacc

--- a/include/pmacc/pluginSystem/containsStep.hpp
+++ b/include/pmacc/pluginSystem/containsStep.hpp
@@ -30,13 +30,13 @@ namespace pmacc
 {
 namespace pluginSystem
 {
-    /** check if a given step is defined within a interval list
+    /** check if a given step is within an interval list
      *
      * @param seqTimeSlices vector with time intervals
      * @param timeStep simulation time step to check
      * @return true if step is included in the interval list else false
      */
-    bool cointainsStep(
+    bool containsStep(
         std::vector< pluginSystem::TimeSlice > const & seqTimeSlices,
         uint32_t const timeStep
     )

--- a/include/pmacc/pluginSystem/toTimeSlice.hpp
+++ b/include/pmacc/pluginSystem/toTimeSlice.hpp
@@ -1,0 +1,108 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+#include "pmacc/pluginSystem/TimeSlice.hpp"
+#include "pmacc/misc/splitString.hpp"
+#include "pmacc/verify.hpp"
+
+#include <string>
+#include <regex>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+#include <array>
+
+
+namespace pmacc
+{
+namespace pluginSystem
+{
+namespace detail
+{
+    /** check if string contains only digits
+     *
+     * @param str string to check
+     * @return true if str contains only digits else false
+     */
+    bool is_number( std::string const & str )
+    {
+        return std::all_of(
+            str.begin(),
+            str.end(),
+            ::isdigit
+        );
+    }
+} // namespace detail
+
+    /** create a TimeSlice out of an string
+     *
+     * Parse a comma separated list of time slices and creates a vector of TimeSlices.
+     * TimeSlice Syntax:
+     *   - `start:stop:period`
+     *   - a number ``N is equal to `::N`
+     */
+    std::vector< TimeSlice > toTimeSlice( std::string const & str )
+    {
+        std::vector< TimeSlice > result;
+        auto seqOfSlices = misc::splitString(
+            str,
+            ","
+        );
+        for( auto const & slice : seqOfSlices )
+        {
+            auto sliceComponents = misc::splitString(
+                slice,
+                ":"
+            );
+            PMACC_VERIFY_MSG(
+                !sliceComponents.empty( ),
+                std::string( "time slice without a defined element is not allowed" ) + str
+            );
+
+            // id of the component
+            size_t n = 0;
+            bool hasOnlyPeriod = sliceComponents.size() == 1u;
+            TimeSlice timeSlice;
+            for( auto& component : sliceComponents )
+            {
+                // be sure that component it is a number or empty
+                PMACC_VERIFY_MSG(
+                    component.empty() || detail::is_number( component ),
+                    std::string("value") + component +
+                        " in " + str + "is not a number"
+                );
+
+                timeSlice.setValue(
+                    hasOnlyPeriod ? 2 : n,
+                    component
+                );
+                n++;
+            }
+            result.push_back( timeSlice );
+
+        }
+        return result;
+    }
+} // namespace pluginSystem
+} // namespace pmacc

--- a/include/pmacc/pluginSystem/toTimeSlice.hpp
+++ b/include/pmacc/pluginSystem/toTimeSlice.hpp
@@ -65,13 +65,13 @@ namespace detail
     std::vector< TimeSlice > toTimeSlice( std::string const & str )
     {
         std::vector< TimeSlice > result;
-        auto seqOfSlices = misc::splitString(
+        auto const seqOfSlices = misc::splitString(
             str,
             ","
         );
         for( auto const & slice : seqOfSlices )
         {
-            auto sliceComponents = misc::splitString(
+            auto const sliceComponents = misc::splitString(
                 slice,
                 ":"
             );
@@ -82,7 +82,7 @@ namespace detail
 
             // id of the component
             size_t n = 0;
-            bool hasOnlyPeriod = sliceComponents.size() == 1u;
+            bool const hasOnlyPeriod = sliceComponents.size() == 1u;
             TimeSlice timeSlice;
             for( auto& component : sliceComponents )
             {

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -31,10 +31,16 @@
 #include "pmacc/dataManagement/DataConnector.hpp"
 #include "pmacc/Environment.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
+#include "pmacc/pluginSystem/cointainsStep.hpp"
+#include "pmacc/pluginSystem/toTimeSlice.hpp"
+
 #include <boost/filesystem.hpp>
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <string>
+#include <vector>
+
 
 namespace pmacc
 {
@@ -52,13 +58,14 @@ class SimulationHelper : public IPlugin
 {
 public:
 
+    using SeqOfTimeSlices = std::vector< pluginSystem::TimeSlice >;
+
     /**
      * Constructor
      *
      */
     SimulationHelper() :
     runSteps(0),
-    checkpointPeriod(0),
     checkpointDirectory("checkpoints"),
     numCheckpoints(0),
     restartStep(-1),
@@ -134,7 +141,13 @@ public:
         Environment<DIM>::get().PluginConnector().notifyPlugins(currentStep);
 
         /* trigger checkpoint notification */
-        if (checkpointPeriod && (currentStep % checkpointPeriod == 0))
+        if(
+            !checkpointPeriod.empty() &&
+            pluginSystem::cointainsStep(
+                seqCheckpointPeriod,
+                currentStep
+            )
+        )
         {
             /* first synchronize: if something failed, we can spare the time
              * for the checkpoint writing */
@@ -213,6 +226,9 @@ public:
     void startSimulation()
     {
         init();
+
+        // translate checkpointPeriod string into checkpoint intervals
+        seqCheckpointPeriod = pluginSystem::toTimeSlice( checkpointPeriod );
 
         for (uint32_t nthSoftRestart = 0; nthSoftRestart <= softRestarts; ++nthSoftRestart)
         {
@@ -299,7 +315,7 @@ public:
             ("checkpoint.restart.directory", po::value<std::string>(&restartDirectory)->default_value(restartDirectory),
              "Directory containing checkpoints for a restart")
             ("checkpoint.restart.step", po::value<int32_t>(&restartStep), "Checkpoint step to restart from")
-            ("checkpoint.period", po::value<uint32_t>(&checkpointPeriod), "Period for checkpoint creation")
+            ("checkpoint.period", po::value<std::string>(&checkpointPeriod), "Period for checkpoint creation")
             ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
              "Directory for checkpoints")
             ("author", po::value<std::string>(&author)->default_value(std::string("")),
@@ -342,7 +358,10 @@ protected:
     uint32_t softRestarts;
 
     /* period for checkpoint creation */
-    uint32_t checkpointPeriod;
+    std::string checkpointPeriod;
+
+    /* checkpoint intervals */
+    SeqOfTimeSlices seqCheckpointPeriod;
 
     /* common directory for checkpoints */
     std::string checkpointDirectory;

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -31,7 +31,7 @@
 #include "pmacc/dataManagement/DataConnector.hpp"
 #include "pmacc/Environment.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
-#include "pmacc/pluginSystem/cointainsStep.hpp"
+#include "pmacc/pluginSystem/containsStep.hpp"
 #include "pmacc/pluginSystem/toTimeSlice.hpp"
 
 #include <boost/filesystem.hpp>
@@ -143,7 +143,7 @@ public:
         /* trigger checkpoint notification */
         if(
             !checkpointPeriod.empty() &&
-            pluginSystem::cointainsStep(
+            pluginSystem::containsStep(
                 seqCheckpointPeriod,
                 currentStep
             )


### PR DESCRIPTION
- redistribute the function `splitString()` from PIConGPU within PMacc
-  add helper function `cointainsStep()`
- add parser function `toTimeSlice()`
- add class TimeSlice
- refactore `PluginConnector`
  - change internal stored type
  - change interface of `setNotificationPeriod()`, change type of period
- use new syntax for checkpoint period definition
- add time slice feature to all PIConGPU plugins
- add documentation

# Tests

- [x] create checkpoints `--checkpoint.period 50,10:12:1`
- [x] phase space plugin with `--e_phaseSpace.period 0:50:10,::`
