### PR TITLE
Derived Attribute: Bound Electron Density

### DIFF
--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
@@ -41,7 +41,7 @@ namespace derivedAttributes
      * Derives a scalar density field from a particle species at runtime.
      * Each value is mapped per cell according to the species' spatial shape.
      *
-     * @note only makes sense for party ionized ions
+     * @note only makes sense for partially ionized ions
      */
     struct BoundElectronDensity
     {
@@ -69,7 +69,7 @@ namespace derivedAttributes
             return "boundElectronDensity";
         }
 
-        /** Calculate a new attribute  per particle
+        /** Calculate a new attribute per particle
          *
          * Returns a new (on-the-fly calculated) attribute of a particle
          * that can then be mapped to the cells the particle contributes to.

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
@@ -1,0 +1,114 @@
+/* Copyright 2015-2018 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+
+#include <pmacc/traits/HasIdentifiers.hpp>
+
+#include <vector>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+    /** Density of Bound Electrons Operation for Particle to Grid Projections
+     *
+     * Derives a scalar density field from a particle species at runtime.
+     * Each value is mapped per cell according to the species' spatial shape.
+     *
+     * @note only makes sense for party ionized ions
+     */
+    struct BoundElectronDensity
+    {
+
+        HDINLINE float1_64
+        getUnit() const;
+
+        HINLINE std::vector< float_64 >
+        getUnitDimension() const
+        {
+           /* L, M, T, I, theta, N, J
+            *
+            * Density is in inverse cubic meter: m^-3
+            *   -> L^-3
+            */
+           std::vector< float_64 > unitDimension( 7, 0.0 );
+           unitDimension.at( SIBaseUnits::length ) = -3.0;
+
+           return unitDimension;
+        }
+
+        HINLINE std::string
+        getName() const
+        {
+            return "boundElectronDensity";
+        }
+
+        /** Calculate a new attribute  per particle
+         *
+         * Returns a new (on-the-fly calculated) attribute of a particle
+         * that can then be mapped to the cells the particle contributes to.
+         * This method is called on a per-thread basis (each thread of a block
+         * handles a particle of a frame).
+         *
+         * @tparam T_Particle particle in the frame
+         * @param particle particle in the frame
+         *
+         * @return new attribute for the particle (type @see T_AttributeType)
+         */
+        template< class T_Particle >
+        DINLINE float_X
+        operator()( T_Particle& particle ) const;
+    };
+} // namespace derivedAttributes
+} // namespace particleToGrid
+
+namespace traits
+{
+    template< typename T_Species >
+    struct SpeciesEligibleForSolver<
+        T_Species,
+        particleToGrid::derivedAttributes::BoundElectronDensity
+    >
+    {
+        using FrameType = typename T_Species::FrameType;
+
+        using RequiredIdentifiers = MakeSeq_t<
+            weighting,
+            position<>,
+            boundElectrons
+        >;
+
+        using type = typename pmacc::traits::HasIdentifiers<
+            FrameType,
+            RequiredIdentifiers
+        >::type;
+    };
+} // namespace traits
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
@@ -1,0 +1,59 @@
+/* Copyright 2015-2018 Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace particleToGrid
+{
+namespace derivedAttributes
+{
+
+    HDINLINE float1_64
+    BoundElectronDensity::getUnit() const
+    {
+        constexpr float_64 UNIT_VOLUME = UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH;
+        return particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE / UNIT_VOLUME;
+    }
+
+    template< class T_Particle >
+    DINLINE float_X
+    BoundElectronDensity::operator()( T_Particle& particle ) const
+    {
+        // read existing attributes
+        float_X const weighting = particle[ weighting_ ];
+        float_X const boundElectrons = particle[ boundElectrons_ ];
+
+        // calculate new attribute
+        float_X const boundElectronDensity = weighting * boundElectrons /
+            ( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME );
+
+        return boundElectronDensity;
+    }
+} // namespace derivedAttributes
+} // namespace particleToGrid
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -23,6 +23,7 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/Counter.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def"

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -23,6 +23,7 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/Counter.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp"

--- a/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/include/picongpu/simulation_defines/param/fileOutput.param
@@ -40,7 +40,7 @@ namespace picongpu
      * you can choose any of these particle to grid projections:
      *   - Density: particle position + shape on the grid
      *   - BoundElectronDensity: density of bound electrons
-     *       note: only makes sense for partly ionized ions
+     *       note: only makes sense for partially ionized ions
      *   - ChargeDensity: density * charge
      *       note: for species that do not change their charge state, this is
      *             the same as the density times a constant for the charge

--- a/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/include/picongpu/simulation_defines/param/fileOutput.param
@@ -39,6 +39,8 @@ namespace picongpu
      *
      * you can choose any of these particle to grid projections:
      *   - Density: particle position + shape on the grid
+     *   - BoundElectronDensity: density of bound electrons
+     *       note: only makes sense for partly ionized ions
      *   - ChargeDensity: density * charge
      *       note: for species that do not change their charge state, this is
      *             the same as the density times a constant for the charge

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/fileOutput.param
@@ -40,7 +40,7 @@ namespace picongpu
      * you can choose any of these particle to grid projections:
      *   - Density: particle position + shape on the grid
      *   - BoundElectronDensity: density of bound electrons
-     *       note: only makes sense for partly ionized ions
+     *       note: only makes sense for partially ionized ions
      *   - ChargeDensity: density * charge
      *       note: for species that do not change their charge state, this is
      *             the same as the density times a constant for the charge

--- a/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/simulation_defines/param/fileOutput.param
@@ -39,6 +39,8 @@ namespace picongpu
      *
      * you can choose any of these particle to grid projections:
      *   - Density: particle position + shape on the grid
+     *   - BoundElectronDensity: density of bound electrons
+     *       note: only makes sense for partly ionized ions
      *   - ChargeDensity: density * charge
      *       note: for species that do not change their charge state, this is
      *             the same as the density times a constant for the charge
@@ -66,6 +68,12 @@ namespace picongpu
         deriveField::derivedAttributes::Density
     >;
 
+    /* BoundElectronDensity section */
+    using BoundElectronDensity_Seq = deriveField::CreateEligible_t<
+        VectorAllSpecies,
+        deriveField::derivedAttributes::BoundElectronDensity
+    >;
+
     /* ChargeDensity section */
     using ChargeDensity_Seq = deriveField::CreateEligible_t<
         VectorAllSpecies,
@@ -84,6 +92,7 @@ namespace picongpu
      */
     using FieldTmpSolvers = MakeSeq_t<
         Density_Seq,
+        BoundElectronDensity_Seq,
         ChargeDensity_Seq,
         EnergyDensity_Seq
     >;

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/fileOutput.param
@@ -40,7 +40,7 @@ namespace picongpu
      * you can choose any of these particle to grid projections:
      *   - Density: particle position + shape on the grid
      *   - BoundElectronDensity: density of bound electrons
-     *       note: only makes sense for partly ionized ions
+     *       note: only makes sense for partially ionized ions
      *   - ChargeDensity: density * charge
      *       note: for species that do not change their charge state, this is
      *             the same as the density times a constant for the charge

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/fileOutput.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/simulation_defines/param/fileOutput.param
@@ -39,6 +39,8 @@ namespace picongpu
      *
      * you can choose any of these particle to grid projections:
      *   - Density: particle position + shape on the grid
+     *   - BoundElectronDensity: density of bound electrons
+     *       note: only makes sense for partly ionized ions
      *   - ChargeDensity: density * charge
      *       note: for species that do not change their charge state, this is
      *             the same as the density times a constant for the charge


### PR DESCRIPTION
Adds a new attribute to derive the density of bound electrons of an ion species.
 

## RT Test: FoilLCT at step 2000

![ne](https://user-images.githubusercontent.com/1353258/34679321-e6cc3f3a-f495-11e7-9a4d-a05fa2d164a3.png)
![ne_bnd_c](https://user-images.githubusercontent.com/1353258/34679322-e6e924ec-f495-11e7-9ae2-cf8d4c45c074.png)
![ne_bnd_h](https://user-images.githubusercontent.com/1353258/34679324-e70584c0-f495-11e7-9de6-38f53001a6ae.png)
![ne_bnd_n](https://user-images.githubusercontent.com/1353258/34679325-e71eacca-f495-11e7-9c16-dfea2bea053e.png)
