### PR TITLE
PhaseSpace: add lockstep support

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -82,7 +82,12 @@ struct DirSplittingKernel
         float3_X fieldB_old;
         int threadPos_x = threadIdx.x;
 
-        algorithm::cudaBlock::Foreach<BlockDim> foreach;
+        //!@todo remove this explicit index calculation, this is a workaround during the lockstep refactoring
+        int linearThreadIdx = threadIdx.z * BlockDim::x::value * BlockDim::y::value +
+            threadIdx.y * BlockDim::x::value +
+            threadIdx.x;
+        algorithm::cudaBlock::Foreach<BlockDim> foreach(linearThreadIdx);
+
         for (int x_offset = 0; x_offset < this->m_totalLength; x_offset += BlockDim::x::value)
         {
             foreach(acc, typename CacheE::Zone(), cacheE.origin(), globalE(-1 + x_offset, 0, 0), pmacc::nvidia::functors::Assign{});

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -48,7 +48,6 @@
 #   include "picongpu/plugins/ChargeConservation.hpp"
 #   include "picongpu/plugins/particleMerging/ParticleMerger.hpp"
 #   if(ENABLE_HDF5 == 1)
-#       include "picongpu/plugins/PhaseSpace/PhaseSpace.hpp"
 #       include "picongpu/plugins/makroParticleCounter/PerSuperCell.hpp"
 #   endif
 
@@ -63,6 +62,7 @@
 #endif
 
 #if (ENABLE_HDF5 == 1)
+#   include "picongpu/plugins/PhaseSpace/PhaseSpace.hpp"
 #   include "picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp"
 #   include "picongpu/plugins/radiation/parameters.hpp"
 #   include "picongpu/plugins/radiation/Radiation.hpp"
@@ -216,13 +216,13 @@ private:
 #if(ENABLE_HDF5 == 1)
         , Radiation<bmpl::_1>
         , ParticleCalorimeter<bmpl::_1>
+        , plugins::multi::Master< PhaseSpace<particles::shapes::Counter::ChargeAssignment, bmpl::_1> >
 #endif
 #if( PMACC_CUDA_ENABLED == 1 )
         , PositionsParticles<bmpl::_1>
         , plugins::particleMerging::ParticleMerger<bmpl::_1>
 #   if(ENABLE_HDF5 == 1)
         , PerSuperCell<bmpl::_1>
-        , plugins::multi::Master< PhaseSpace<particles::shapes::Counter::ChargeAssignment, bmpl::_1> >
 #   endif
 #endif
     >;

--- a/include/pmacc/cuSTL/algorithm/cudaBlock/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/cudaBlock/Foreach.hpp
@@ -74,11 +74,7 @@ struct Foreach
 private:
     const int linearThreadIdx;
 public:
-    DINLINE Foreach()
-     : linearThreadIdx(
-        threadIdx.z * BlockDim::x::value * BlockDim::y::value +
-        threadIdx.y * BlockDim::x::value +
-        threadIdx.x) {}
+
     DINLINE Foreach(int linearThreadIdx) : linearThreadIdx(linearThreadIdx) {}
 
     /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)


### PR DESCRIPTION
- PMacc: Remove default constructor to avoid the usage of of `threadIdx,...` without an accelerator.
The second reasin is that the implicit index calculation break the usage of the lockstep model.
- PIConGPU:
  - DirSplitting: remove the usage of `cudaBlock::ForEach` default constructor
  - PhaseSpace: add full lockstep support to allow the usage together with an host accelerator

# Review:

The first two commits are dependent changes for the PhaseSpace. IMO it make no sense to provide the change in an separate PR because this mean that I need to provide the change also for the PhaseSpace plugin. This would require tests for a intermediate stage those is not necessary.

# Tests

- [x] compare PhaseSpace CPU vs GPU