### PR TITLE
ISAAC: unify the usage of period

### DIFF
--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -236,7 +236,7 @@ public:
         visualization(nullptr),
         cellDescription(nullptr),
         movingWindow(false),
-        render_interval(0),
+        render_interval(1),
         step(0),
         drawing_time(0),
         cell_count(0),
@@ -310,7 +310,7 @@ public:
     {
         /* register command line parameters for your plugin */
         desc.add_options()
-            ("isaac.period", po::value< uint32_t > (&render_interval),
+            ("isaac.period", po::value< std::string > (&notifyPeriod),
              "Enable IsaacPlugin [for each n-th step].")
             ("isaac.name", po::value< std::string > (&name)->default_value("default"),
              "The name of the simulation. Default is \"default\".")
@@ -350,6 +350,10 @@ private:
     int numProc;
     bool movingWindow;
     SourceList sources;
+    /** render interval within the notify period
+     *
+     * render each n-th time step within an interval defined by notifyPeriod
+     */
     uint32_t render_interval;
     uint32_t step;
     int drawing_time;
@@ -361,11 +365,8 @@ private:
 
     void pluginLoad()
     {
-        if (render_interval > 0)
+        if(!notifyPeriod.empty())
         {
-            //using an internal variable "render_interval" as notifyPeroid
-            //of PIConGPU cannot be changed at runtime
-            notifyPeriod = "1";
             MPI_Comm_rank(MPI_COMM_WORLD, &rank);
             MPI_Comm_size(MPI_COMM_WORLD, &numProc);
             if ( MovingWindow::getInstance().isSlidingWindowActive() )
@@ -412,7 +413,7 @@ private:
             if (visualization->init( communicatorBehaviour ) != 0)
             {
                 if (rank == 0)
-                    log<picLog::INPUT_OUTPUT > ("ISAAC Init failed");
+                    log<picLog::INPUT_OUTPUT > ("ISAAC Init failed, disable plugin");
                 notifyPeriod = "";
             }
             else


### PR DESCRIPTION
follow up of #2452

Unify the meaning of `isaac.period` with other plugins.

- define `notifyPeriod` as `std::string`
- map the command line option `.period` to `notifyPeriod` instead of `render_interval`