### PR TITLE
move conversion units to `unit.param`

### DIFF
--- a/include/picongpu/simulation_defines/_defaultParam.loader
+++ b/include/picongpu/simulation_defines/_defaultParam.loader
@@ -42,6 +42,7 @@
 #include "picongpu/simulation_defines/param/ionizationEnergies.param"
 #include "picongpu/simulation_defines/param/density.param"
 #include "picongpu/simulation_defines/param/particle.param"
+#include "picongpu/simulation_defines/param/unit.param"
 #include "picongpu/simulation_defines/param/particleFilters.param"
 #if( PMACC_CUDA_ENABLED == 1 )
 #   include "picongpu/simulation_defines/param/bremsstrahlung.param"

--- a/include/picongpu/simulation_defines/param/unit.param
+++ b/include/picongpu/simulation_defines/param/unit.param
@@ -1,0 +1,53 @@
+/* Copyright 2013-2018 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    /** Unit of Speed */
+    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
+    /** Unit of time */
+    constexpr float_64 UNIT_TIME = SI::DELTA_T_SI;
+    /** Unit of length */
+    constexpr float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
+
+    namespace particles
+    {
+        /** Number of particles per makro particle (= macro particle weighting)
+         *  unit: none */
+        constexpr float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE =
+            float_64( SI::BASE_DENSITY_SI * SI::CELL_WIDTH_SI * SI::CELL_HEIGHT_SI * SI::CELL_DEPTH_SI ) /
+            float_64( particles::TYPICAL_PARTICLES_PER_CELL );
+    }
+
+
+    /** Unit of mass */
+    constexpr float_64 UNIT_MASS = SI::BASE_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    /** Unit of charge */
+    constexpr float_64 UNIT_CHARGE = -1.0 * SI::BASE_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    /** Unit of energy */
+    constexpr float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
+    /** Unit of EField: V/m */
+    constexpr float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
+    //** Unit of BField: Tesla [T] = Vs/m^2 */
+    constexpr float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
+
+}

--- a/include/picongpu/simulation_defines/unitless/physicalConstants.unitless
+++ b/include/picongpu/simulation_defines/unitless/physicalConstants.unitless
@@ -22,36 +22,6 @@
 
 namespace picongpu
 {
-    /** Unit of Speed */
-    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
-    /** Unit of time */
-    constexpr float_64 UNIT_TIME = SI::DELTA_T_SI;
-    /** Unit of length */
-    constexpr float_64 UNIT_LENGTH = UNIT_TIME*UNIT_SPEED;
-
-    namespace particles
-    {
-        /** Number of particles per makro particle (= macro particle weighting)
-         *  unit: none */
-        constexpr float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE =
-            float_64( SI::BASE_DENSITY_SI * SI::CELL_WIDTH_SI * SI::CELL_HEIGHT_SI * SI::CELL_DEPTH_SI ) /
-            float_64( particles::TYPICAL_PARTICLES_PER_CELL );
-    }
-
-
-    /** Unit of mass */
-    constexpr float_64 UNIT_MASS = SI::BASE_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
-    /** Unit of charge */
-    constexpr float_64 UNIT_CHARGE = -1.0 * SI::BASE_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
-    /** Unit of energy */
-    constexpr float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
-    /** Unit of EField: V/m */
-    constexpr float_64 UNIT_EFIELD = 1.0 / (UNIT_TIME * UNIT_TIME / UNIT_MASS / UNIT_LENGTH * UNIT_CHARGE);
-    //** Unit of BField: Tesla [T] = Vs/m^2 */
-    constexpr float_64 UNIT_BFIELD = (UNIT_MASS / (UNIT_TIME * UNIT_CHARGE));
-
-
-
 
     constexpr float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
 


### PR DESCRIPTION
Move conversion units from `physicalConstants.unitless` to `unit.param` to allow the usage within particle filters.