### PR TITLE
fix clang device compile

### DIFF
--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -172,11 +172,11 @@ namespace picongpu
                 decltype(
                     positionFunctor(
                         acc,
-                        std::declval< DataSpace< simDim > const >( ),
+                        alpaka::core::declval< DataSpace< simDim > const >( ),
                         /* cellsPerSupercell is used because each virtual worker
                          * is creating **exactly one** functor
                          */
-                        std::declval< WorkerCfg< cellsPerSupercell > const >( )
+                        alpaka::core::declval< WorkerCfg< cellsPerSupercell > const >( )
                     )
                 ),
                 SuperCellDomCfg

--- a/include/picongpu/particles/flylite/IFlyLite.hpp
+++ b/include/picongpu/particles/flylite/IFlyLite.hpp
@@ -67,9 +67,16 @@ namespace flylite
         )
         {
             boost::ignore_unused( ionSpeciesName, currentStep );
-
+            /* The compiler is allowed to evaluate an expression those not depends on a template parameter
+             * even if the class is never instantiated. In that case static assert is always
+             * evaluated (e.g. with clang), this results in an error if the condition is false.
+             * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
+             *
+             * A workaround is to add a template dependency to the expression.
+             * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
+             */
             PMACC_STATIC_ASSERT_MSG(
-                false,
+                false && sizeof(T_IonSpecies) != 0,
                 FLYlite_the_update_method_for_ion_population_kinetics_is_not_implemented
             );
         }

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -146,13 +146,14 @@ namespace acc
          * @param configuration of the worker
          */
         template<
+            typename T,
             typename T_WorkerCfg,
             typename T_Acc
         >
         HDINLINE acc::Free< Functor >
         operator()(
             T_Acc const & acc,
-            DataSpace< simDim > const &,
+            T const &,
             T_WorkerCfg const &
         )
         {

--- a/include/pmacc/functor/Filtered.hpp
+++ b/include/pmacc/functor/Filtered.hpp
@@ -211,14 +211,14 @@ namespace acc
         -> acc::Filtered<
             T_FilterOperator,
             decltype(
-                std::declval< Filter >( )(
+                alpaka::core::declval< Filter >( )(
                     acc,
                     domainOffset,
                     workerCfg
                 )
             ),
             decltype(
-                std::declval< Functor >( )(
+                alpaka::core::declval< Functor >( )(
                     acc,
                     domainOffset,
                     workerCfg
@@ -229,14 +229,14 @@ namespace acc
             return acc::Filtered<
                 T_FilterOperator,
                 decltype(
-                    std::declval< Filter >( )(
+                    alpaka::core::declval< Filter >( )(
                         acc,
                         domainOffset,
                         workerCfg
                     )
                 ),
                 decltype(
-                    std::declval< Functor >( )(
+                    alpaka::core::declval< Functor >( )(
                         acc,
                         domainOffset,
                         workerCfg

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -112,7 +112,7 @@ namespace detail
 
             // get the return type of the user functor
             using UserFunctorReturnType = decltype(
-                std::declval< UserFunctor >( )( acc, args ... )
+                alpaka::core::declval< UserFunctor >( )( acc, args ... )
             );
 
             // compare user functor return type with the interface requirements
@@ -216,7 +216,7 @@ namespace detail
         )
         -> acc::Interface<
             decltype(
-                std::declval< UserFunctor >( )(
+                alpaka::core::declval< UserFunctor >( )(
                     acc,
                     domainOffset,
                     workerCfg

--- a/include/pmacc/nvidia/rng/distributions/Normal_float.hpp
+++ b/include/pmacc/nvidia/rng/distributions/Normal_float.hpp
@@ -45,7 +45,7 @@ namespace detail
         using Dist =
             decltype(
                 ::alpaka::rand::distribution::createNormalReal<Type>(
-                    std::declval<T_Acc const &>()));
+                    alpaka::core::declval<T_Acc const &>()));
         PMACC_ALIGN(dist, Dist);
     public:
         HDINLINE Normal_float()

--- a/include/pmacc/nvidia/rng/distributions/Uniform_float.hpp
+++ b/include/pmacc/nvidia/rng/distributions/Uniform_float.hpp
@@ -45,7 +45,7 @@ namespace detail
         using Dist =
             decltype(
                 ::alpaka::rand::distribution::createUniformReal<Type>(
-                    std::declval<T_Acc const &>()));
+                    alpaka::core::declval<T_Acc const &>()));
         PMACC_ALIGN(dist, Dist);
     public:
 

--- a/include/pmacc/nvidia/rng/distributions/Uniform_int32.hpp
+++ b/include/pmacc/nvidia/rng/distributions/Uniform_int32.hpp
@@ -48,7 +48,7 @@ namespace detail
         using Dist =
             decltype(
                 ::alpaka::rand::distribution::createUniformUint<RngType>(
-                    std::declval<T_Acc const &>()));
+                    alpaka::core::declval<T_Acc const &>()));
         PMACC_ALIGN(dist, Dist);
     public:
         HDINLINE Uniform_int()

--- a/include/pmacc/nvidia/rng/methods/Xor.hpp
+++ b/include/pmacc/nvidia/rng/methods/Xor.hpp
@@ -40,9 +40,9 @@ namespace methods
          using Gen =
             decltype(
                 ::alpaka::rand::generator::createDefault(
-                    std::declval<T_Acc const &>(),
-                    std::declval<uint32_t &>(),
-                    std::declval<uint32_t &>()));
+                    alpaka::core::declval<T_Acc const &>(),
+                    alpaka::core::declval<uint32_t &>(),
+                    alpaka::core::declval<uint32_t &>()));
         PMACC_ALIGN(gen, Gen);
     public:
         typedef Gen StateType;

--- a/include/pmacc/random/RNGHandle.hpp
+++ b/include/pmacc/random/RNGHandle.hpp
@@ -91,7 +91,7 @@ namespace random
         HDINLINE typename GetRandomType<T_Distribution>::type
         applyDistribution()
         {
-            return GetRandomType<T_Distribution>::type(&getState());
+            return typename GetRandomType<T_Distribution>::type(&getState());
         }
 
     protected:

--- a/include/pmacc/random/methods/AlpakaRand.hpp
+++ b/include/pmacc/random/methods/AlpakaRand.hpp
@@ -37,9 +37,9 @@ namespace methods
         using StateType =
             decltype(
                 ::alpaka::rand::generator::createDefault(
-                    std::declval<T_Acc const &>(),
-                    std::declval<uint32_t &>(),
-                    std::declval<uint32_t &>()
+                    alpaka::core::declval<T_Acc const &>(),
+                    alpaka::core::declval<uint32_t &>(),
+                    alpaka::core::declval<uint32_t &>()
                 )
             );
 

--- a/include/pmacc/static_assert.hpp
+++ b/include/pmacc/static_assert.hpp
@@ -45,7 +45,7 @@ namespace pmacc
  * @param pmacc_unique_id pre compiler unique id
  * @param pmacc_typeInfo a type that is shown in error message
  */
-#if ( PMACC_CUDA_COMPILER_CLANG == 1 )
+#if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA
 /* device compile with clang: boost static assert can not be used
  * error is: calling a `__host__` function from `__device__`
  * Therefore C++11 `static_assert` is used


### PR DESCRIPTION
- remove `std::declval` with `alpaka::core::declval`
- use C++ static assert for clang
- defer assert if the compiler is allowed to evaluate the expression even if it is never used

# Tests

- [x] compile with clang 7.0.0