### PR TITLE
Spack: Compiler Already There

### DIFF
--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -26,9 +26,7 @@ First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html
    spack bootstrap
 
    # install a supported compiler
-   spack install gcc@5.4.0
-   spack load gcc@5.4.0
-   spack compiler add
+   spack compiler list | grep gcc@5.4.0 || spack install gcc@5.4.0 && spack load gcc@5.4.0 && spack compiler add
 
    # add the PIConGPU repository
    git clone https://github.com/ComputationalRadiationPhysics/spack-repo.git $HOME/src/spack-repo


### PR DESCRIPTION
Fix the spack instructions on how to install a compiler. In case the compiler is already present as a system compiler, @berceanu reported problems.

Closes #2456 with a work-around for now.

Related upstream issue: https://github.com/spack/spack/issues/6902