### PR TITLE
Topic io fields as source

### DIFF
--- a/include/picongpu/fields/Fields.def
+++ b/include/picongpu/fields/Fields.def
@@ -38,6 +38,15 @@ namespace picongpu
 
         using LowerMargin = typename Solver::LowerMargin;
         using UpperMargin = typename Solver::UpperMargin;
+
+        static std::string getName()
+        {
+            std::stringstream str;
+            str << T_Species::FrameType::getName();
+            str << "_";
+            str << T_Solver::getName();
+            return str.str();
+        }
     };
 
     /** Tmp (at the moment: scalar) field for plugins and tmp data like

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -85,7 +85,8 @@ namespace particleToGrid
         /** return name of the this solver
          * @return name of solver
          */
-        HINLINE std::string getName() const;
+        HINLINE static
+        std::string getName();
 
         template<
             typename FrameType,

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -54,9 +54,9 @@ ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::getUnitDimension(
 
 template<class T_ParticleShape, class T_DerivedAttribute>
 HINLINE std::string
-ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::getName() const
+ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::getName()
 {
-    return T_DerivedAttribute().getName();
+    return T_DerivedAttribute::getName();
 }
 
 template<class T_ParticleShape, class T_DerivedAttribute>

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
@@ -63,8 +63,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        static HINLINE
+        std::string
+        getName()
         {
             return "boundElectronDensity";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -70,8 +70,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "chargeDensity";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.def
@@ -66,8 +66,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "particleCounter";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Density.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Density.def
@@ -61,8 +61,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "density";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.def
@@ -70,8 +70,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "particleEnergy";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -72,8 +72,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "energyDensity";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
@@ -56,8 +56,9 @@ namespace derivedAttributes
     struct EnergyDensityCutoff : public EnergyDensity
     {
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "energyDensityCutoff";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -67,8 +67,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "larmorPower";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def
@@ -63,8 +63,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "macroParticleCounter";
         }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -79,8 +79,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             const std::string name_lookup[] = {"x", "y", "z"};
 

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def
@@ -69,8 +69,9 @@ namespace derivedAttributes
            return unitDimension;
         }
 
-        HINLINE std::string
-        getName() const
+        HINLINE static
+        std::string
+        getName()
         {
             return "particleMomentumComponent";
         }

--- a/include/picongpu/plugins/hdf5/WriteFields.hpp
+++ b/include/picongpu/plugins/hdf5/WriteFields.hpp
@@ -149,11 +149,7 @@ private:
      */
     static std::string getName()
     {
-        std::stringstream str;
-        str << Species::FrameType::getName();
-        str << "_";
-        str << Solver().getName();
-        return str.str();
+        return FieldTmpOperation<Solver, Species>::getName();
     }
 
     /** Get the unit for the result from the solver*/


### PR DESCRIPTION
- derived attributes
  - set method `getName()` static
  - add method `getName()` to class `FieldTmpOperation`
- IO plugins ADIOS/HDF5
  - use method `getName()` to get the name of `FieldTmpOperation`
  - ADIOS/HDF5 plugin: add support for command line parameter `.source` to select fields

**this PR fixes a bug that the name of the derived fields in combination with ADIOS used the wrong naming schema.**
  - wrong: `<solver name>_<species name>`
  - correct: `<species name> _<solver name>`

# Tests

- [x] IO test HDF5
- [x] IO test ADIOS

CC-ing: @n01r, @HighIander, @PrometheusPi