### PR TITLE
Docs: Hide Double ToC

### DIFF
--- a/docs/source/_static/hide_chapter_titles.css
+++ b/docs/source/_static/hide_chapter_titles.css
@@ -1,0 +1,3 @@
+#how-to-read-this-document.section div.section {
+    display:none;
+}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,4 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+    <link href="{{ pathto("_static/hide_chapter_titles.css", True) }}" rel="stylesheet" type="text/css">
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,7 +133,7 @@ todo_include_todos = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ Installation
 .. toctree::
    :caption: INSTALLATION
    :maxdepth: 1
+   :hidden:
 
    install/path
    install/instructions
@@ -50,6 +51,7 @@ Usage
 .. toctree::
    :caption: USAGE
    :maxdepth: 1
+   :hidden:
 
    usage/reference
    usage/basics
@@ -66,6 +68,7 @@ Models
 .. toctree::
    :caption: MODELS
    :maxdepth: 1
+   :hidden:
 
    models/pic
    models/LL_RR
@@ -79,6 +82,7 @@ Post-Processing
 .. toctree::
    :caption: Post-Processing
    :maxdepth: 2
+   :hidden:
 
    postprocessing/python
    postprocessing/openPMD
@@ -90,6 +94,7 @@ Development
 .. toctree::
    :caption: DEVELOPMENT
    :maxdepth: 1
+   :hidden:
 
    dev/CONTRIBUTING.md
    dev/repostructure
@@ -107,5 +112,6 @@ Programming Patterns
 .. toctree::
    :caption: PROGRAMMING PATTERNS
    :maxdepth: 1
+   :hidden:
 
    prgpatterns/lockstep


### PR DESCRIPTION
In the HTML version of our docs, the table of contents and the general titles was unnecessarily shown.

It is accessible in the left side bar, so the ToC can be hidden.
Still, the manual chapters are needed for proper pdf chapters, which does grouping by ToC only while ToC captions are irrelevant.

This keeps the old structure which works on both formats (and epub) but hides the superfluous titles via [css](https://stackoverflow.com/questions/23211695/modifying-content-width-of-the-sphinx-theme-read-the-docs).