### PR TITLE
Topic get species by name

### DIFF
--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -33,6 +33,7 @@
 #include <pmacc/traits/HasFlag.hpp>
 #include <pmacc/traits/GetFlagType.hpp>
 #include <pmacc/math/MapTuple.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
 
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/plus.hpp>
@@ -83,7 +84,7 @@ struct CallFunctor
  *                           see particle.param,
  *                           examples: picongpu::particles::startPosition::Quiet,
  *                                     picongpu::particles::startPosition::Random
- * @tparam T_SpeciesType type of the used species,
+ * @tparam T_SpeciesType type or name as boost::mpl::string of the used species,
  *                       see speciesDefinition.param
  */
 template<
@@ -93,7 +94,10 @@ template<
 >
 struct CreateDensity
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
 
@@ -135,8 +139,8 @@ struct CreateDensity
  * @tparam T_Manipulator a pseudo-binary functor accepting two particle species:
  *                       destination and source,
  *                       @see picongpu::particles::manipulators
- * @tparam T_SrcSpeciesType source species
- * @tparam T_DestSpeciesType destination species
+ * @tparam T_SrcSpeciesType type or name as boost::mpl::string of the source species
+ * @tparam T_DestSpeciesType type or name as boost::mpl::string of the destination species
  * @tparam T_SrcFilter picongpu::particles::filter, particle filter type to
  *                     select particles in T_SrcSpeciesType to derive into
  *                     T_DestSpeciesType
@@ -149,9 +153,15 @@ template<
 >
 struct ManipulateDerive
 {
-    using DestSpeciesType = T_DestSpeciesType;
+    using DestSpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_DestSpeciesType
+    >;
     using DestFrameType = typename DestSpeciesType::FrameType;
-    using SrcSpeciesType = T_SrcSpeciesType;
+    using SrcSpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SrcSpeciesType
+    >;
     using SrcFrameType = typename SrcSpeciesType::FrameType;
 
     using DestFunctor = typename bmpl::apply1<
@@ -191,8 +201,8 @@ struct ManipulateDerive
  * @note FillAllGaps is called on on `T_DestSpeciesType` after the derivation is
  *       finished.
  *
- * @tparam T_SrcSpeciesType source species
- * @tparam T_DestSpeciesType destination species
+ * @tparam T_SrcSpeciesType type or name as boost::mpl::string of the source species
+ * @tparam T_DestSpeciesType type or name as boost::mpl::string of the destination species
  * @tparam T_Filter picongpu::particles::filter,
  *                  particle filter type to select source particles to derive
  */
@@ -223,12 +233,16 @@ struct Derive : ManipulateDerive<
  * contiguously with valid particles and that all frames but the last are full
  * is fulfilled.
  *
- * @tparam T_SpeciesType the particle species to fill gaps in memory
+ * @tparam T_SpeciesType type or name as boost::mpl::string of the particle species
+ *                       to fill gaps in memory
  */
 template< typename T_SpeciesType = bmpl::_1 >
 struct FillAllGaps
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     HINLINE void operator()( const uint32_t currentStep )

--- a/include/picongpu/particles/Manipulate.hpp
+++ b/include/picongpu/particles/Manipulate.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/particles/manipulators/manipulators.def"
 
 #include <pmacc/Environment.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
 
 #include <boost/mpl/apply.hpp>
 
@@ -46,7 +47,7 @@ namespace particles
      * @tparam T_Manipulator unary lambda functor accepting one particle
      *                       species,
      *                       @see picongpu::particles::manipulators
-     * @tparam T_SpeciesType type of the used species
+     * @tparam T_SpeciesType type or name as boost::mpl::string of the used species
      * @tparam T_Filter picongpu::particles::filter, particle filter type to
      *                  select particles in `T_SpeciesType` to manipulate via
      *                  `T_DestSpeciesType`
@@ -58,7 +59,10 @@ namespace particles
     >
     struct Manipulate
     {
-        using SpeciesType = T_SpeciesType;
+        using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_SpeciesType
+        >;
         using FrameType = typename SpeciesType::FrameType;
 
         using SpeciesFunctor = typename bmpl::apply1<

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -36,6 +36,7 @@
 #include <pmacc/compileTime/GetKeyFromAlias.hpp>
 #include <pmacc/HandleGuardRegion.hpp>
 #include <pmacc/traits/Resolve.hpp>
+#include <pmacc/traits/GetCTName.hpp>
 
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/contains.hpp>
@@ -250,3 +251,26 @@ namespace traits
     };
 } //namespace traits
 } //namespace picongpu
+
+namespace pmacc
+{
+namespace traits
+{
+    template<
+        typename T_Name,
+        typename T_Flags,
+        typename T_Attributes
+    >
+    struct GetCTName<
+        ::picongpu::Particles<
+            T_Name,
+            T_Flags,
+            T_Attributes
+        >
+    >
+    {
+        using type = T_Name;
+    };
+
+} // namepsace traits
+} // namespace pmacc

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -27,6 +27,8 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/communication/AsyncCommunication.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
+
 #include "picongpu/particles/traits/GetIonizerList.hpp"
 #if( PMACC_CUDA_ENABLED == 1 )
 #   include "picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp"
@@ -50,10 +52,17 @@ namespace picongpu
 namespace particles
 {
 
+/** assign nullptr to all attributes of a species
+ *
+ * @tparam T_SpeciesType type or name as boost::mpl::string of the species
+ */
 template<typename T_SpeciesType>
 struct AssignNull
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     void operator()()
@@ -65,10 +74,17 @@ struct AssignNull
     }
 };
 
-template<typename T_SpeciesType>
+/** create memory for the given species type
+ *
+ * @tparam T_SpeciesType type or name as boost::mpl::string of the species
+ */
+template< typename T_SpeciesType >
 struct CreateSpecies
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     template<
@@ -93,10 +109,17 @@ struct CreateSpecies
     }
 };
 
-template<typename T_SpeciesType>
+/** write memory statistics to the terminal
+ *
+ * @tparam T_SpeciesType type or name as boost::mpl::string of the species
+ */
+template< typename T_SpeciesType >
 struct LogMemoryStatisticsForSpecies
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     template<typename T_DeviceHeap>
@@ -113,10 +136,17 @@ struct LogMemoryStatisticsForSpecies
     }
 };
 
-template<typename T_SpeciesType>
+/** call method reset for the given species
+ *
+ * @tparam T_SpeciesType type or name as boost::mpl::string of the species to reset
+ */
+template< typename T_SpeciesType >
 struct CallReset
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     HINLINE void operator()( const uint32_t currentStep )
@@ -132,13 +162,15 @@ struct CallReset
  *
  * energy histograms, rate matrix, etc.
  *
- * @tparam T_SpeciesName name of ion species
+ * @tparam T_SpeciesType type or name as boost::mpl::string of ion species
  */
-template< typename T_SpeciesName >
+template< typename T_SpeciesType >
 struct CallPopulationKineticsInit
 {
-    using SpeciesName = T_SpeciesName;
-    using SpeciesType = typename SpeciesName::type;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     using PopulationKineticsSolver = typename pmacc::traits::Resolve<
@@ -159,15 +191,16 @@ struct CallPopulationKineticsInit
 
 /** Calculate FLYlite population kinetics evolving one time step
  *
- * @tparam T_SpeciesName name of ion species as pmacc::TypeAsIdentifier
+ * @tparam T_SpeciesType type or name as boost::mpl::string of ion species
  */
-template< typename T_SpeciesName >
+template< typename T_SpeciesType >
 struct CallPopulationKinetics
 {
-    //! pmacc::TypeAsIdentifier for the particle species
-    using SpeciesName = T_SpeciesName;
-    //! expects a picongpu::Particles class
-    using SpeciesType = typename SpeciesName::type;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
+
     using FrameType = typename SpeciesType::FrameType;
 
     using PopulationKineticsSolver = typename pmacc::traits::Resolve<
@@ -191,12 +224,15 @@ struct CallPopulationKinetics
  *
  * push is only triggered for species with a pusher
  *
- * @tparam T_SpeciesType type of particle species that is checked
+ * @tparam T_SpeciesType type or name as boost::mpl::string of particle species that is checked
  */
 template<typename T_SpeciesType>
 struct PushSpecies
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     template<typename T_EventList>
@@ -221,12 +257,15 @@ struct PushSpecies
  *
  * communication is only triggered for species with a pusher
  *
- * @tparam T_SpeciesType type of particle species that is checked
+ * @tparam T_SpeciesType type or name as boost::mpl::string of particle species that is checked
  */
 template<typename T_SpeciesType>
 struct CommunicateSpecies
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     template<typename T_EventList>
@@ -300,13 +339,16 @@ struct PushAllSpecies
 
 /** Call an ionization method upon an ion species
  *
- * \tparam T_SpeciesType type of particle species that is going to be ionized with
+ * \tparam T_SpeciesType type or name as boost::mpl::string of particle species that is going to be ionized with
  *                       ionization scheme T_SelectIonizer
  */
 template< typename T_SpeciesType, typename T_SelectIonizer >
 struct CallIonizationScheme
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using SelectIonizer = T_SelectIonizer;
     using FrameType = typename SpeciesType::FrameType;
 
@@ -356,12 +398,15 @@ struct CallIonizationScheme
  *
  * Tests if species can be ionized and calls the kernels to do that
  *
- * \tparam T_SpeciesType type of particle species that is checked for ionization
+ * \tparam T_SpeciesType type or name as boost::mpl::string of particle species that is checked for ionization
  */
 template< typename T_SpeciesType >
 struct CallIonization
 {
-    using SpeciesType = T_SpeciesType;
+    using SpeciesType = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_SpeciesType
+    >;
     using FrameType = typename SpeciesType::FrameType;
 
     // SelectIonizer will be either the specified one or fallback: None
@@ -397,22 +442,31 @@ struct CallIonization
 
 /** Handles the bremsstrahlung effect for electrons on ions.
  *
- * \tparam T_ElectronSpecies type of electron particle species
+ * @tparam T_ElectronSpecies type or name as boost::mpl::string of electron particle species
  */
 template<typename T_ElectronSpecies>
 struct CallBremsstrahlung
 {
-    using ElectronSpecies = T_ElectronSpecies;
+    using ElectronSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_ElectronSpecies
+    >;
     using ElectronFrameType = typename ElectronSpecies::FrameType;
 
-    using IonSpecies = typename pmacc::particles::traits::ResolveAliasFromSpecies<
-        ElectronSpecies,
-        bremsstrahlungIons<>
-    >::type;
-    using PhotonSpecies = typename pmacc::particles::traits::ResolveAliasFromSpecies<
-        ElectronSpecies,
-        bremsstrahlungPhotons<>
-    >::type;
+    using IonSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        typename pmacc::particles::traits::ResolveAliasFromSpecies<
+            ElectronSpecies,
+            bremsstrahlungIons<>
+        >::type
+    >;
+    using PhotonSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        typename pmacc::particles::traits::ResolveAliasFromSpecies<
+            ElectronSpecies,
+            bremsstrahlungPhotons<>
+        >::type
+    >;
     using PhotonFrameType = typename PhotonSpecies::FrameType;
     using BremsstrahlungFunctor = bremsstrahlung::Bremsstrahlung<
         IonSpecies,
@@ -462,12 +516,15 @@ struct CallBremsstrahlung
 
 /** Handles the synchrotron radiation emission of photons from electrons
  *
- * \tparam T_ElectronSpecies type of electron particle species
+ * @tparam T_ElectronSpecies type or name as boost::mpl::string of electron particle species
  */
 template<typename T_ElectronSpecies>
 struct CallSynchrotronPhotons
 {
-    using ElectronSpecies = T_ElectronSpecies;
+    using ElectronSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_ElectronSpecies
+    >;
     using ElectronFrameType = typename ElectronSpecies::FrameType;
 
     /* SelectedPhotonCreator will be either PhotonCreator or fallback: CreatorBase */

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -27,6 +27,8 @@
 #include <pmacc/cuSTL/cursor/tools/LinearInterp.hpp>
 #include <pmacc/cuSTL/cursor/BufferCursor.hpp>
 #include <pmacc/algorithms/math.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
+
 #include <boost/array.hpp>
 #if( BOOST_VERSION == 106400 )
     /* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
@@ -159,17 +161,24 @@ public:
  * and stores it in a map<atomic number, ScaledSpectrum> object.
  *
  * This functor is called from MySimulation::init() to generate lookup tables.
+ *
+ * @tparam T_ElectronSpecies type or name as boost::mpl::string of the electron species
  */
 template<typename T_ElectronSpecies>
 struct FillScaledSpectrumMap
 {
-    using ElectronSpecies = T_ElectronSpecies;
+    using ElectronSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        T_ElectronSpecies
+    >;
 
-    typedef typename pmacc::particles::traits::ResolveAliasFromSpecies<
-        ElectronSpecies,
-        bremsstrahlungIons<>
-    >::type IonSpecies;
-
+    using IonSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+        VectorAllSpecies,
+        typename pmacc::particles::traits::ResolveAliasFromSpecies<
+            ElectronSpecies,
+            bremsstrahlungIons<>
+        >::type
+    >;
 
     template<typename T_Map>
     void operator()(T_Map& map) const

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -359,7 +359,7 @@ public:
         ForEach<
             AllFlyLiteIons,
             particles::CallPopulationKineticsInit< bmpl::_1 >,
-            MakeIdentifier< bmpl::_1>
+            bmpl::_1
         > initPopulationKinetics;
         initPopulationKinetics(
             gridSizeLocal
@@ -544,7 +544,7 @@ public:
         ForEach<
             AllFlyLiteIons,
             particles::CallPopulationKinetics< bmpl::_1 >,
-            MakeIdentifier< bmpl::_1 >
+            bmpl::_1
         > populationKinetics;
         populationKinetics( currentStep );
 

--- a/include/picongpu/simulation_defines/param/species.param
+++ b/include/picongpu/simulation_defines/param/species.param
@@ -30,12 +30,8 @@
 #include "picongpu/algorithms/FieldToParticleInterpolationNative.hpp"
 #include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
 #include "picongpu/algorithms/AssignedTrilinearInterpolation.hpp"
-
-#include "picongpu/fields/currentDeposition/Solver.def"
-
-#include "picongpu/particles/InitFunctors.hpp"
 #include "picongpu/particles/flylite/NonLTE.def"
-#include "picongpu/particles/manipulators/manipulators.def"
+#include "picongpu/fields/currentDeposition/Solver.def"
 
 
 namespace picongpu

--- a/include/pmacc/particles/compileTime/FindByNameOrType.hpp
+++ b/include/pmacc/particles/compileTime/FindByNameOrType.hpp
@@ -40,7 +40,10 @@ namespace particles
 namespace compileTime
 {
 
-    /* find a type within a sequence by name or the type it self
+    /* find a type within a sequence by name or the type itself
+     *
+     * pmacc::traits::GetCTName is used to translate each element of
+     * T_MPLSeq into a name.
      *
      * @tparam T_MPLSeq source sequence where we search T_Identifier
      * @tparam T_Identifier name or type to search
@@ -74,7 +77,7 @@ namespace compileTime
             HasTypeOrName< bmpl::_1 >
         >::type;
 
-        using type =typename bmpl::if_<
+        using type = typename bmpl::if_<
             bmpl::empty< FilteredSeq >,
             bmpl::apply<
                 KeyNotFoundPolicy,

--- a/include/pmacc/particles/compileTime/FindByNameOrType.hpp
+++ b/include/pmacc/particles/compileTime/FindByNameOrType.hpp
@@ -1,0 +1,101 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/traits/GetCTName.hpp"
+#include "pmacc/compileTime/errorHandlerPolicies/ThrowValueNotFound.hpp"
+
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/copy_if.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/empty.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/front.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+
+namespace pmacc
+{
+namespace particles
+{
+namespace compileTime
+{
+
+    /* find a type within a sequence by name or the type it self
+     *
+     * @tparam T_MPLSeq source sequence where we search T_Identifier
+     * @tparam T_Identifier name or type to search
+     */
+    template<
+        typename T_MPLSeq,
+        typename T_Identifier,
+        typename T_KeyNotFoundPolicy = pmacc::errorHandlerPolicies::ThrowValueNotFound
+    >
+    struct FindByNameOrType
+    {
+        using KeyNotFoundPolicy = T_KeyNotFoundPolicy;
+
+        template< typename T_Value >
+        struct HasTypeOrName
+        {
+            using type = bmpl::or_<
+                boost::is_same<
+                    T_Identifier,
+                    T_Value
+                >,
+                boost::is_same<
+                    pmacc::traits::GetCTName_t< T_Value >,
+                    T_Identifier
+                >
+            >;
+        };
+
+        using FilteredSeq = typename bmpl::copy_if<
+            T_MPLSeq,
+            HasTypeOrName< bmpl::_1 >
+        >::type;
+
+        using type =typename bmpl::if_<
+            bmpl::empty< FilteredSeq >,
+            bmpl::apply<
+                KeyNotFoundPolicy,
+                T_MPLSeq,
+                T_Identifier
+            >,
+            bmpl::front< FilteredSeq >
+        >::type::type;
+    };
+
+    template<
+        typename T_MPLSeq,
+        typename T_Identifier,
+        typename T_KeyNotFoundPolicy = pmacc::errorHandlerPolicies::ThrowValueNotFound
+    >
+    using FindByNameOrType_t = typename FindByNameOrType<
+        T_MPLSeq,
+        T_Identifier,
+        T_KeyNotFoundPolicy
+    >::type;
+
+} // namespace compileTime
+} // namespace particles
+} // namespace pmacc

--- a/include/pmacc/traits/GetCTName.hpp
+++ b/include/pmacc/traits/GetCTName.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/mpl/string.hpp>
+
+namespace pmacc
+{
+namespace traits
+{
+
+    /** Return the compile time name
+     *
+     * @tparam T_Type type of the object where the name is queried
+     * @return ::type name of the object as boost::mpl::string,
+     *         empty string is returned if the trait is not specified for
+     *         T_Type
+     */
+    template< typename T_Type >
+    struct GetCTName
+    {
+        using type = boost::mpl::string< >;
+    };
+
+    template< typename T_Type >
+    using GetCTName_t = typename GetCTName< T_Type >::type;
+
+}//namespace traits
+}//namespace pmacc

--- a/include/pmacc/traits/GetCTName.hpp
+++ b/include/pmacc/traits/GetCTName.hpp
@@ -23,6 +23,7 @@
 
 #include <boost/mpl/string.hpp>
 
+
 namespace pmacc
 {
 namespace traits
@@ -44,5 +45,5 @@ namespace traits
     template< typename T_Type >
     using GetCTName_t = typename GetCTName< T_Type >::type;
 
-}//namespace traits
-}//namespace pmacc
+} // namespace traits
+} // namespace pmacc


### PR DESCRIPTION
solve #2393

Instead of passing the particle species type to a functor like `CreateDensity` it is possible to use the name of the species. This solve an issue if two species cyclical reference to each other.

- PMacc: new traits ￼…
  - add generic `GetCTName` trait to get a compile time name of a class
  - add compile time method to find a species type by name or by the type
  it self within a sequence of species types
- PIConGPU:
  - remove the usage of `MakeIdentifier` to pass species to functors
  - use `particles::compileTime::FindByNameOrType_t` to search for a species within `VectorAllSpecies`
  - remove include from `species.param` which is useless and break the compile


# Example

```C++
using InitPipeline = mpl::vector<
        CreateDensity<
            densityProfiles::Foil,
            startPosition::Quiet1ppc,
            PIC_Ions
        >,
        CreateDensity<
            densityProfiles::Foil,
            startPosition::Random100ppc,
            PIC_Electrons
        >
    >;
```

can be written now as
```C++
using Electrons = bmpl::string< 'e' >;
using Ions = bmpl::string< 'i' >;

using InitPipeline = mpl::vector<
        CreateDensity<
            densityProfiles::Foil,
            startPosition::Quiet1ppc,
            Ions
        >,
        CreateDensity<
            densityProfiles::Foil,
            startPosition::Random100ppc,
            Electrons
        >
    >;
```

CC-ing: @n01r 