### PR TITLE
Param Docs: Title Only

### DIFF
--- a/docs/source/_static/hide_chapter_titles.css
+++ b/docs/source/_static/hide_chapter_titles.css
@@ -1,3 +1,25 @@
+/* front page: hide chapter titles
+ * needed for consistent HTML-PDF-EPUB chapters
+ */
 #how-to-read-this-document.section div.section {
     display:none;
 }
+
+/* parameter files: only show short intro of title
+ * and description in HTML.
+ * Work-Around for https://github.com/michaeljones/breathe/issues/318
+ */
+div#pic-core.section > div > dl.type,
+div#pic-core.section > div > div.breathe-sectiondef,
+div#memory.section > div > dl.type,
+div#memory.section > div > div.breathe-sectiondef,
+div#pic-extensions.section > div > dl.type,
+div#pic-extensions.section > div > div.breathe-sectiondef,
+div#plugins.section > div > dl.type,
+div#plugins.section > div > div.breathe-sectiondef,
+div#misc.section > div > dl.type,
+div#misc.section > div > div.breathe-sectiondef
+{
+    display: none;
+}
+


### PR DESCRIPTION
In the section that introduces the usage of .param files, only the titles of the files shall be shown. This is currently not possible, see https://github.com/michaeljones/breathe/issues/318

This PR applies a work-around for HTML to hide additional doxygen information (does not fix the underlying issue and is issue still exists in pdf & epub).