### PR TITLE
Docs: unit.param

### DIFF
--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -106,6 +106,14 @@ particle.param
    :path: include/picongpu/simulation_defines/param/particle.param
    :no-link:
 
+unit.param
+^^^^^^^^^^^^^^
+
+.. doxygenfile:: unit.param
+   :project: PIConGPU
+   :path: include/picongpu/simulation_defines/param/unit.param
+   :no-link:
+
 particleFilters.param
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/include/picongpu/simulation_defines/param/unit.param
+++ b/include/picongpu/simulation_defines/param/unit.param
@@ -17,6 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * In this file we define typical scales for normalization of physical
+ * quantities aka "units". Usually, a user would not change this file
+ * but might use the defined constants in other input files.
+ */
+
 #pragma once
 
 


### PR DESCRIPTION
Add doxygen file description and linkage in manual for the new `unit.param` input file.

Follow-up to: #2457