### PR TITLE
Docs: Fix Headline Plugins

### DIFF
--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -28,6 +28,13 @@ Plugin name                                                                     
 :ref:`sum currents <usage-plugins-sumCurrents>`                                    compute the total current summed over all cells
 ================================================================================== =======================================================================
 
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :hidden:
+
+   plugins/*
+
 Period Syntax
 =============
 
@@ -66,10 +73,3 @@ Examples
 .. [#f5] Deprecated
 .. [#f6] Only runs on the *CUDA* backend (GPU).
 .. [#f7] Multi-Plugin: Can be configured to run multiple times with varying parameters.
-
-.. toctree::
-   :glob:
-   :maxdepth: 1
-   :hidden:
-
-   plugins/*


### PR DESCRIPTION
Moves the inclusion of the toctree for plugins up in the document. Otherwise the heading "Period Syntax" takes precedence in the menu / sections.

Follow-up to #2452