### PR TITLE
Patch get-by-name functionality for ionization

### DIFF
--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include <pmacc/traits/Resolve.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
 #include "picongpu/traits/UsesRNG.hpp"
 
 #include "picongpu/fields/FieldTmp.hpp"
@@ -64,15 +65,21 @@ namespace ionization
      *
      * @tparam T_IonizationAlgorithm functor that returns a number of
      *         new free macro electrons to create, range: [0, boundElectrons]
-     * @tparam T_DestSpecies electron species to be created
-     * @tparam T_SrcSpecies particle species that is ionized
+     * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * @tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
      */
     template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies>
     struct ThomasFermi_Impl
     {
 
-        using DestSpecies = T_DestSpecies;
-        using SrcSpecies = T_SrcSpecies;
+        using DestSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_DestSpecies
+        >;
+        using SrcSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_SrcSpecies
+        >;
 
         using FrameType =  typename SrcSpecies::FrameType;
 
@@ -135,7 +142,7 @@ namespace ionization
              *        density of ionic potential wells
              */
             using DensitySolver = typename particleToGrid::CreateFieldTmpOperation_t<
-                T_SrcSpecies,
+                SrcSpecies,
                 particleToGrid::derivedAttributes::Density
             >::Solver;
 
@@ -145,7 +152,7 @@ namespace ionization
              * instead of just the destination species
              */
             using EnergyDensitySolver = typename particleToGrid::CreateFieldTmpOperation_t<
-                T_DestSpecies,
+                DestSpecies,
                 particleToGrid::derivedAttributes::EnergyDensityCutoff< CutoffMaxEnergy >
             >::Solver;
 

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include <pmacc/traits/Resolve.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
 #include "picongpu/traits/UsesRNG.hpp"
 
 #include "picongpu/fields/FieldB.hpp"
@@ -65,15 +66,21 @@ namespace ionization
      * \brief Ammosov-Delone-Krainov
      *        Tunneling ionization for hydrogenlike atoms
      *
-     * \tparam T_DestSpecies electron species to be created
-     * \tparam T_SrcSpecies particle species that is ionized
+     * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * \tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
      */
     template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies>
     struct ADK_Impl
     {
 
-        using DestSpecies = T_DestSpecies;
-        using SrcSpecies = T_SrcSpecies;
+        using DestSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_DestSpecies
+        >;
+        using SrcSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_SrcSpecies
+        >;
 
         using FrameType = typename SrcSpecies::FrameType;
 

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -36,6 +36,7 @@
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/traits/Resolve.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
 #include <pmacc/mappings/threads/WorkerCfg.hpp>
 
 
@@ -50,15 +51,21 @@ namespace ionization
      *
      * \brief Barrier Suppression Ionization - Implementation
      *
-     * \tparam T_DestSpecies electron species to be created
-     * \tparam T_SrcSpecies particle species that is ionized
+     * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * \tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
      */
     template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies>
     struct BSI_Impl
     {
 
-        using DestSpecies = T_DestSpecies;
-        using SrcSpecies = T_SrcSpecies;
+        using DestSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_DestSpecies
+        >;
+        using SrcSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_SrcSpecies
+        >;
 
         using FrameType = typename SrcSpecies::FrameType;
 

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -37,6 +37,7 @@
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/traits/Resolve.hpp>
+#include <pmacc/particles/compileTime/FindByNameOrType.hpp>
 #include <pmacc/mappings/threads/WorkerCfg.hpp>
 
 #include <boost/type_traits/integral_constant.hpp>
@@ -66,15 +67,21 @@ namespace ionization
      * \brief Ammosov-Delone-Krainov
      *        Tunneling ionization for hydrogenlike atoms
      *
-     * \tparam T_DestSpecies electron species to be created
-     * \tparam T_SrcSpecies particle species that is ionized
+     * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * \tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
      */
     template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies>
     struct Keldysh_Impl
     {
 
-        using DestSpecies = T_DestSpecies;
-        using SrcSpecies = T_SrcSpecies;
+        using DestSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_DestSpecies
+        >;
+        using SrcSpecies = pmacc::particles::compileTime::FindByNameOrType_t<
+            VectorAllSpecies,
+            T_SrcSpecies
+        >;
 
         using FrameType = typename SrcSpecies::FrameType;
 


### PR DESCRIPTION
This is a fix for #2464 which now fully solves #2393.

The `FindByNameOrType` functionality was missing from the
<IonizationModel>_Impl.hpp files.
Now it's possible to just give a predefined particle species name in the
`speciesDefinition.param` for the electrons as destination species for ionization.

- [x] compile-test
- [x] run-test

I used the standard Bremsstrahlung example, kicked the electrons out of the initialization pipeline and let the gold atoms be ionized be the laser. I then looked for the electrons and photons to appear in the `<species>_macroParticlesCount.dat`.

Just to illustrate usage now:
```c++
// name for the electron species that will be created through ionization
using Electrons = bmpl::string< 'e' >;

using ParticleFlagsIons = bmpl::vector<
...
    ionizers<
        MakeSeq_t<
            particles::ionization::BSIEffectiveZ< Electrons >,
            particles::ionization::ADKLinPol< Electrons >,
            particles::ionization::ThomasFermi< Electrons >
        >
    >
>;

// and only below somewhere follows the definition of PIC_Electrons with the same "name"
using PIC_Electrons = Particles<
    bmpl::string< 'e' >,
    ParticleFlagsElectrons,
    DefaultParticleAttributes
>;
// PIC-Electrons is then added to `VectorAllSpecies`
```

**cc'ing** @HighIander 