### PR TITLE
pic-build: CMake multi-args

### DIFF
--- a/pic-build
+++ b/pic-build
@@ -45,7 +45,7 @@ help()
 }
 
 # save cmd line args
-cmd_line_args="$@"
+cmd_line_args=$@
 
 # show help
 while [[ $# -gt 0 ]] ; do
@@ -91,7 +91,7 @@ then
 fi
 
 # cmake call
-$this_dir/pic-configure $cmd_line_args ..
+$this_dir/pic-configure "$cmd_line_args" ..
 if [ $? -ne 0 ]
 then
     # let pic-configure errors speak for themselves


### PR DESCRIPTION
CMake multi-args to `pic-build -c "... ..."` were not forwarded properly to `pic-configure` and `cmake`.

The example `pic-build -c "-DPIC_VERBOSE=21 -DCMAKE_BUILD_TYPE=Debug"` did not work, the same way passing a non-standard generator with `-c "-G Ninja -D..."` failed.

@sbastrakov you were right, this is actually a problem in the script forwarding multi-args for cmake with spaces in general. This also affects linux systems and should fix your generator issue on Visual Studio as well. Thanks for the report!