### PR TITLE
fix #2477: adjust LWFA setup for 8GPUs

### DIFF
--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/0008gpus.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/0008gpus.cfg
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt,
+#                     Richard Pausch
 #
 # This file is part of PIConGPU.
 #
@@ -33,10 +34,10 @@
 TBG_wallTime="2:00:00"
 
 TBG_gpu_x=2
-TBG_gpu_y=2
-TBG_gpu_z=2
+TBG_gpu_y=4
+TBG_gpu_z=1
 
-TBG_gridSize="-g 192 512 192"
+TBG_gridSize="-g 192 1024 192"
 TBG_steps="-s 4000"
 
 # leave TBG_movingWindow empty to disable moving window


### PR DESCRIPTION
This pull request resolves issue #2477 by extending the number of cells in y direction by 50% (+256 cells), pushing the slide point a bit farther, adjusting the GPU distribution and shortening the laser init without changing the laser duration. 

Now, moving window simulations with 8 GPUs produce meaningful result. 