### PR TITLE
pic-build: CMake multi-args with white spaces

### DIFF
--- a/pic-build
+++ b/pic-build
@@ -44,8 +44,7 @@ help()
     echo "$($this_dir/pic-configure --help | tail -n +12)"
 }
 
-# save cmd line args
-cmd_line_args=$@
+cmd_line_args=("$@")
 
 # show help
 while [[ $# -gt 0 ]] ; do
@@ -91,7 +90,7 @@ then
 fi
 
 # cmake call
-$this_dir/pic-configure "$cmd_line_args" ..
+$this_dir/pic-configure "${cmd_line_args[@]}" ..
 if [ $? -ne 0 ]
 then
     # let pic-configure errors speak for themselves


### PR DESCRIPTION
follow up of #2475 and fix the [reported issue](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2475#issuecomment-360741057)

Allow to use white spaces in arguments. e.g. `./pic-build -c "..." -b omp2b`

This issue with the fix from #2475 was that all arguments of `pic-build` are forwarded as one single argument to `pic-configure`

CC-ing: @sbastrakov 