### PR TITLE
Eliminate M_PI from PMacc

### DIFF
--- a/include/pmacc/algorithms/math.hpp
+++ b/include/pmacc/algorithms/math.hpp
@@ -36,6 +36,7 @@
 #include "pmacc/algorithms/math/defines/modf.hpp"
 #include "pmacc/algorithms/math/defines/fmod.hpp"
 #include "pmacc/algorithms/math/defines/bessel.hpp"
+#include "pmacc/algorithms/math/defines/pi.hpp"
 
 #include "pmacc/algorithms/math/floatMath/abs.tpp"
 #include "pmacc/algorithms/math/floatMath/sqrt.tpp"

--- a/include/pmacc/algorithms/math/defines/pi.hpp
+++ b/include/pmacc/algorithms/math/defines/pi.hpp
@@ -37,6 +37,7 @@ namespace math
         static constexpr T_Type value = static_cast< T_Type >(
             3.141592653589793238462643383279502884197169399
         );
+        static constexpr T_Type doubleValue = static_cast< T_Type >( 2.0 ) * value;
         static constexpr T_Type halfValue = value / static_cast< T_Type >( 2.0 );
         static constexpr T_Type quarterValue = value / static_cast< T_Type >( 4.0 );
         static constexpr T_Type doubleReciprocalValue = static_cast< T_Type >( 2.0 ) / value;

--- a/include/pmacc/algorithms/math/defines/pi.hpp
+++ b/include/pmacc/algorithms/math/defines/pi.hpp
@@ -30,13 +30,16 @@ namespace math
 namespace pi
 {
 
-    /** Value of pi as T_Type
+    /** Values of pi and related constants as T_Type
      */
     template< typename T_Type >
     struct Pi
-	{
-		static constexpr T_Type value = static_cast<T_Type>(3.141592653589793238462643383279502884197169399);
-	};
+    {
+        static constexpr T_Type value = static_cast<T_Type>(3.141592653589793238462643383279502884197169399);
+        static constexpr T_Type halfValue = value / static_cast<T_Type>(2.0);
+        static constexpr T_Type quarterValue = value / static_cast<T_Type>(4.0);
+        static constexpr T_Type doubleReciprocalValue = static_cast<T_Type>(2.0) / value;
+    };
 
 } //namespace pi
 } //namespace math

--- a/include/pmacc/algorithms/math/defines/pi.hpp
+++ b/include/pmacc/algorithms/math/defines/pi.hpp
@@ -1,0 +1,44 @@
+/* Copyright 2018 Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace pmacc
+{
+namespace algorithms
+{
+namespace math
+{
+namespace pi
+{
+
+    /** Value of pi as T_Type
+     */
+    template< typename T_Type >
+    struct Pi
+	{
+		static constexpr T_Type value = static_cast<T_Type>(3.141592653589793238462643383279502884197169399);
+	};
+
+} //namespace pi
+} //namespace math
+} //namespace algorithms
+} //namespace pmacc

--- a/include/pmacc/algorithms/math/defines/pi.hpp
+++ b/include/pmacc/algorithms/math/defines/pi.hpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #pragma once
 
 namespace pmacc
@@ -27,21 +28,20 @@ namespace algorithms
 {
 namespace math
 {
-namespace pi
-{
 
     /** Values of pi and related constants as T_Type
      */
     template< typename T_Type >
     struct Pi
     {
-        static constexpr T_Type value = static_cast<T_Type>(3.141592653589793238462643383279502884197169399);
-        static constexpr T_Type halfValue = value / static_cast<T_Type>(2.0);
-        static constexpr T_Type quarterValue = value / static_cast<T_Type>(4.0);
-        static constexpr T_Type doubleReciprocalValue = static_cast<T_Type>(2.0) / value;
+        static constexpr T_Type value = static_cast< T_Type >(
+            3.141592653589793238462643383279502884197169399
+        );
+        static constexpr T_Type halfValue = value / static_cast< T_Type >( 2.0 );
+        static constexpr T_Type quarterValue = value / static_cast< T_Type >( 4.0 );
+        static constexpr T_Type doubleReciprocalValue = static_cast< T_Type >( 2.0 ) / value;
     };
 
-} //namespace pi
-} //namespace math
-} //namespace algorithms
-} //namespace pmacc
+} // namespace math
+} // namespace algorithms
+} // namespace pmacc

--- a/include/pmacc/math/complex/Bessel.tpp
+++ b/include/pmacc/math/complex/Bessel.tpp
@@ -134,7 +134,7 @@ namespace bessel
                 if( a0 >= float_T( 50.0 ) ) kz = 8u;       // can be changed to 10
                 else if( a0 >= float_T( 35.0 ) ) kz = 10u; //   "      "     "  12
                 else kz = 12u;                             //   "      "     "  14
-                complex_T ct1 = z1 - pi::Pi<float_T>::quarterValue;
+                complex_T ct1 = z1 - Pi< float_T >::quarterValue;
                 complex_T cp0 = cone;
                 for ( uint32_t k = 0u; k < kz; k++ )
                 {
@@ -151,7 +151,7 @@ namespace bessel
                         float_T( -2.0 ) * k - float_T( 3.0 )
                     );
                 }
-                complex_T const cu = pmMath::sqrt( pi::Pi<float_T>::doubleReciprocalValue / z1 );
+                complex_T const cu = pmMath::sqrt( Pi< float_T >::doubleReciprocalValue / z1 );
                 cj0 = cu * ( cp0 * pmMath::cos( ct1 ) - cq0 * pmMath::sin( ct1 ) );
             }
             return cj0;
@@ -216,8 +216,8 @@ namespace bessel
                 if( a0 >= float_T( 50.0 ) ) kz = 8u;        // can be changed to 10
                 else if ( a0 >= float_T( 35.0 ) ) kz = 10u; //   "      "     "  12
                 else kz = 12u;                              //   "      "     "  14
-                complex_T const cu = pmMath::sqrt( pi::Pi<float_T>::doubleReciprocalValue / z1 );
-                complex_T const ct2 = z1 - float_T( 0.75 ) * pi::Pi<float_T>::value;
+                complex_T const cu = pmMath::sqrt( Pi< float_T >::doubleReciprocalValue / z1 );
+                complex_T const ct2 = z1 - float_T( 0.75 ) * Pi< float_T >::value;
                 complex_T cp1 = cone;
                 for ( uint32_t k = 0u; k < kz; k++ )
                 {

--- a/include/pmacc/math/complex/Bessel.tpp
+++ b/include/pmacc/math/complex/Bessel.tpp
@@ -134,7 +134,7 @@ namespace bessel
                 if( a0 >= float_T( 50.0 ) ) kz = 8u;       // can be changed to 10
                 else if( a0 >= float_T( 35.0 ) ) kz = 10u; //   "      "     "  12
                 else kz = 12u;                             //   "      "     "  14
-                complex_T ct1 = z1 - float_T( M_PI_4 );
+                complex_T ct1 = z1 - pi::Pi<float_T>::quarterValue;
                 complex_T cp0 = cone;
                 for ( uint32_t k = 0u; k < kz; k++ )
                 {
@@ -151,7 +151,7 @@ namespace bessel
                         float_T( -2.0 ) * k - float_T( 3.0 )
                     );
                 }
-                complex_T const cu = pmMath::sqrt( float_T( M_2_PI ) / z1 );
+                complex_T const cu = pmMath::sqrt( pi::Pi<float_T>::doubleReciprocalValue / z1 );
                 cj0 = cu * ( cp0 * pmMath::cos( ct1 ) - cq0 * pmMath::sin( ct1 ) );
             }
             return cj0;
@@ -216,8 +216,8 @@ namespace bessel
                 if( a0 >= float_T( 50.0 ) ) kz = 8u;        // can be changed to 10
                 else if ( a0 >= float_T( 35.0 ) ) kz = 10u; //   "      "     "  12
                 else kz = 12u;                              //   "      "     "  14
-                complex_T const cu = pmMath::sqrt( float_T( M_2_PI ) / z1 );
-                complex_T const ct2 = z1 - float_T( 0.75 ) * float_T( M_PI );
+                complex_T const cu = pmMath::sqrt( pi::Pi<float_T>::doubleReciprocalValue / z1 );
+                complex_T const ct2 = z1 - float_T( 0.75 ) * pi::Pi<float_T>::value;
                 complex_T cp1 = cone;
                 for ( uint32_t k = 0u; k < kz; k++ )
                 {

--- a/include/pmacc/math/complex/Complex.tpp
+++ b/include/pmacc/math/complex/Complex.tpp
@@ -130,11 +130,11 @@ struct Arg< ::pmacc::math::Complex<T_Type> >
         if ( other.get_real()==type(0.0) && other.get_imag()==type(0.0) )
             return type(0.0);
         else if ( other.get_real()==type(0.0) && other.get_imag()>type(0.0) )
-            return type(M_PI)/type(2.0);
+            return pi::Pi<type>::halfValue;
         else if ( other.get_real()==type(0.0) && other.get_imag()<type(0.0) )
-            return type(-M_PI)/type(2.0);
+            return -pi::Pi<type>::halfValue;
         else if ( other.get_real()<type(0.0) && other.get_imag()==type(0.0) )
-            return type(M_PI);
+            return pi::Pi<type>::value;
         else
             return pmMath::atan2(other.get_imag(),other.get_real());
     }

--- a/include/pmacc/math/complex/Complex.tpp
+++ b/include/pmacc/math/complex/Complex.tpp
@@ -130,11 +130,11 @@ struct Arg< ::pmacc::math::Complex<T_Type> >
         if ( other.get_real()==type(0.0) && other.get_imag()==type(0.0) )
             return type(0.0);
         else if ( other.get_real()==type(0.0) && other.get_imag()>type(0.0) )
-            return pi::Pi<type>::halfValue;
+            return Pi< type >::halfValue;
         else if ( other.get_real()==type(0.0) && other.get_imag()<type(0.0) )
-            return -pi::Pi<type>::halfValue;
+            return -Pi< type >::halfValue;
         else if ( other.get_real()<type(0.0) && other.get_imag()==type(0.0) )
-            return pi::Pi<type>::value;
+            return Pi< type >::value;
         else
             return pmMath::atan2(other.get_imag(),other.get_real());
     }


### PR DESCRIPTION
This is part of #2485. As discussed with @psychocoderHPC , fist I only made changes to PMacc: added a new file with Pi constants and some derivatives (only those currently used, not for all M_... cases), replace usage of M_PI with the new values.