### PR TITLE
Fix buffer cursor dim

### DIFF
--- a/include/pmacc/cuSTL/cursor/BufferCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/BufferCursor.hpp
@@ -38,15 +38,15 @@ namespace cursor
  *
  * BufferCursor does access and jumping on a cartesian memory buffer.
  *
- * \tparam Type type of a single datum
+ * \tparam T_Type type of a single datum
  * \tparam T_dim dimension of the memory buffer
  */
 template<
-    typename Type,
+    typename T_Type,
     int T_dim
 >
 struct BufferCursor
- : public Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * >
+ : public Cursor< PointerAccessor< T_Type >, BufferNavigator< T_dim >, T_Type * >
 {
     /* \param pointer data pointer
      * \param pitch pitch of the memory buffer
@@ -55,13 +55,13 @@ struct BufferCursor
      * pitch[1] is the distance in bytes to the incremented z-coordiante
      */
     HDINLINE
-    BufferCursor( Type * pointer, math::Size_t< T_dim - 1 > pitch )
-     : Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * >
-            ( PointerAccessor< Type >(), BufferNavigator< T_dim >( pitch ), pointer ) {}
+    BufferCursor( T_Type * pointer, math::Size_t< T_dim - 1 > pitch )
+     : Cursor< PointerAccessor< T_Type >, BufferNavigator< T_dim >, T_Type * >
+            ( PointerAccessor< T_Type >(), BufferNavigator< T_dim >( pitch ), pointer ) {}
 
     HDINLINE
-    BufferCursor( const Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * > & other )
-     : Cursor<PointerAccessor< Type >, BufferNavigator< T_dim >, Type * >( other ) {}
+    BufferCursor( const Cursor< PointerAccessor< T_Type >, BufferNavigator< T_dim >, T_Type * > & other )
+     : Cursor<PointerAccessor< T_Type >, BufferNavigator< T_dim >, T_Type * >( other ) {}
 };
 
 namespace traits
@@ -69,13 +69,13 @@ namespace traits
 
 /* type trait to get the BufferCursor's dimension if it has one */
 template<
-    typename Type,
+    typename T_Type,
     int T_dim
 >
-struct dim< BufferCursor< Type, T_dim > >
+struct dim< BufferCursor< T_Type, T_dim > >
 {
     static constexpr int value = pmacc::cursor::traits::dim<
-        Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * > >::value;
+        Cursor< PointerAccessor< T_Type >, BufferNavigator< T_dim >, T_Type * > >::value;
 };
 
 } // namespace traits

--- a/include/pmacc/cuSTL/cursor/BufferCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/BufferCursor.hpp
@@ -39,9 +39,9 @@ namespace cursor
  * \tparam Type type of a single datum
  * \tparam dim dimension of the memory buffer
  */
-template<typename Type, int dim>
+template<typename Type, int T_dim>
 struct BufferCursor
- : public Cursor<PointerAccessor<Type>, BufferNavigator<dim>, Type*>
+ : public Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>
 {
     /* \param pointer data pointer
      * \param pitch pitch of the memory buffer
@@ -50,13 +50,13 @@ struct BufferCursor
      * pitch[1] is the distance in bytes to the incremented z-coordiante
      */
     HDINLINE
-    BufferCursor(Type* pointer, math::Size_t<dim-1> pitch)
-     : Cursor<PointerAccessor<Type>, BufferNavigator<dim>, Type*>
-            (PointerAccessor<Type>(), BufferNavigator<dim>(pitch), pointer) {}
+    BufferCursor(Type* pointer, math::Size_t<T_dim-1> pitch)
+     : Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>
+            (PointerAccessor<Type>(), BufferNavigator<T_dim>(pitch), pointer) {}
 
     HDINLINE
-    BufferCursor(const Cursor<PointerAccessor<Type>, BufferNavigator<dim>, Type*>& other)
-     : Cursor<PointerAccessor<Type>, BufferNavigator<dim>, Type*>(other) {}
+    BufferCursor(const Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>& other)
+     : Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>(other) {}
 };
 
 namespace traits

--- a/include/pmacc/cuSTL/cursor/BufferCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/BufferCursor.hpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #pragma once
 
 #include "Cursor.hpp"
@@ -26,6 +27,7 @@
 #include "navigator/BufferNavigator.hpp"
 #include "pmacc/math/vector/Size_t.hpp"
 #include "pmacc/cuSTL/cursor/traits.hpp"
+
 
 namespace pmacc
 {
@@ -37,11 +39,14 @@ namespace cursor
  * BufferCursor does access and jumping on a cartesian memory buffer.
  *
  * \tparam Type type of a single datum
- * \tparam dim dimension of the memory buffer
+ * \tparam T_dim dimension of the memory buffer
  */
-template<typename Type, int T_dim>
+template<
+    typename Type,
+    int T_dim
+>
 struct BufferCursor
- : public Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>
+ : public Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * >
 {
     /* \param pointer data pointer
      * \param pitch pitch of the memory buffer
@@ -50,28 +55,31 @@ struct BufferCursor
      * pitch[1] is the distance in bytes to the incremented z-coordiante
      */
     HDINLINE
-    BufferCursor(Type* pointer, math::Size_t<T_dim-1> pitch)
-     : Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>
-            (PointerAccessor<Type>(), BufferNavigator<T_dim>(pitch), pointer) {}
+    BufferCursor( Type * pointer, math::Size_t< T_dim - 1 > pitch )
+     : Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * >
+            ( PointerAccessor< Type >(), BufferNavigator< T_dim >( pitch ), pointer ) {}
 
     HDINLINE
-    BufferCursor(const Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>& other)
-     : Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*>(other) {}
+    BufferCursor( const Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * > & other )
+     : Cursor<PointerAccessor< Type >, BufferNavigator< T_dim >, Type * >( other ) {}
 };
 
 namespace traits
 {
 
 /* type trait to get the BufferCursor's dimension if it has one */
-template<typename Type, int T_dim>
-struct dim<BufferCursor<Type, T_dim> >
+template<
+    typename Type,
+    int T_dim
+>
+struct dim< BufferCursor< Type, T_dim > >
 {
     static constexpr int value = pmacc::cursor::traits::dim<
-        Cursor<PointerAccessor<Type>, BufferNavigator<T_dim>, Type*> >::value;
+        Cursor< PointerAccessor< Type >, BufferNavigator< T_dim >, Type * > >::value;
 };
 
-} // traits
+} // namespace traits
 
-} // cursor
-} // pmacc
+} // namespace cursor
+} // namespace pmacc
 


### PR DESCRIPTION
There has been a problem with `dim `used both as a template parameter of `BufferCursor `and a member of a privately inherited base class. So the code does not compile in Visual Studio, as the member overshadowed the template parameter (ofc it might be a bug in VS, but my understanding of how name lookup works in this case agrees with VS here). Renamed parameter `dim `to the guidelines-conforming `T_dim` and also fix formatting in this file.