### PR TITLE
Fix warning concerning forward declarations of pmacc::detail::Environment

### DIFF
--- a/include/pmacc/dataManagement/DataConnector.hpp
+++ b/include/pmacc/dataManagement/DataConnector.hpp
@@ -216,7 +216,7 @@ namespace pmacc
 
     private:
 
-        friend class detail::Environment;
+        friend struct detail::Environment;
 
         static DataConnector&
         getInstance()

--- a/include/pmacc/eventSystem/Manager.hpp
+++ b/include/pmacc/eventSystem/Manager.hpp
@@ -76,7 +76,7 @@ namespace pmacc
 
     private:
 
-        friend class detail::Environment;
+        friend struct detail::Environment;
 
         inline ITask* getPassiveITaskIfNotFinished(id_t taskId) const;
 

--- a/include/pmacc/eventSystem/events/EventPool.hpp
+++ b/include/pmacc/eventSystem/events/EventPool.hpp
@@ -96,7 +96,7 @@ namespace pmacc
 
     private:
 
-        friend class detail::Environment;
+        friend struct detail::Environment;
 
         static EventPool& getInstance( )
         {

--- a/include/pmacc/eventSystem/streams/StreamController.hpp
+++ b/include/pmacc/eventSystem/streams/StreamController.hpp
@@ -111,7 +111,7 @@ namespace pmacc
 
     private:
 
-        friend class detail::Environment;
+        friend struct detail::Environment;
 
         /**
          * Constructor.

--- a/include/pmacc/eventSystem/tasks/Factory.hpp
+++ b/include/pmacc/eventSystem/tasks/Factory.hpp
@@ -164,7 +164,7 @@ namespace pmacc
 
     private:
 
-        friend class detail::Environment;
+        friend struct detail::Environment;
 
         Factory() {};
 

--- a/include/pmacc/eventSystem/transactions/TransactionManager.hpp
+++ b/include/pmacc/eventSystem/transactions/TransactionManager.hpp
@@ -87,7 +87,7 @@ public:
 
 private:
 
-    friend class detail::Environment;
+    friend struct detail::Environment;
 
     TransactionManager();
 

--- a/include/pmacc/mappings/simulation/EnvironmentController.hpp
+++ b/include/pmacc/mappings/simulation/EnvironmentController.hpp
@@ -64,7 +64,7 @@ public:
 
 private:
 
-    friend class detail::Environment;
+    friend struct detail::Environment;
 
     /*! Default constructor.
      */

--- a/include/pmacc/nvidia/memory/MemoryInfo.hpp
+++ b/include/pmacc/nvidia/memory/MemoryInfo.hpp
@@ -112,7 +112,7 @@ protected:
 
 private:
 
-    friend class detail::Environment;
+    friend struct detail::Environment;
 
     static MemoryInfo& getInstance()
     {

--- a/include/pmacc/particles/tasks/ParticleFactory.hpp
+++ b/include/pmacc/particles/tasks/ParticleFactory.hpp
@@ -68,7 +68,7 @@ namespace pmacc
 
     private:
 
-        friend class detail::Environment;
+        friend struct detail::Environment;
 
         /**
          * returns the instance of this factory

--- a/include/pmacc/pluginSystem/PluginConnector.hpp
+++ b/include/pmacc/pluginSystem/PluginConnector.hpp
@@ -233,7 +233,7 @@ namespace pmacc
 
     private:
 
-        friend class detail::Environment;
+        friend struct detail::Environment;
 
         static PluginConnector& getInstance()
         {

--- a/include/pmacc/simulationControl/SimulationDescription.hpp
+++ b/include/pmacc/simulationControl/SimulationDescription.hpp
@@ -112,7 +112,7 @@ protected:
 
 private:
 
-    friend class detail::Environment;
+    friend struct detail::Environment;
 
     static SimulationDescription& getInstance()
     {


### PR DESCRIPTION
This is a structure, but in several places forward declared as a class, which caused a warning. Replace `class `with `struct `in forward declarations.

Of course, it would be easier to just make `pmacc::detail::Environment` a class. However, it does not store any internal state, so to me structure feels better fitting. Btw, there is a similar type `pmacc::Environment`, which is a class. Maybe it would make sense to make it a structure too (or make both a class for uniformity).