### PR TITLE
remove template dimension from current interpolator's

### DIFF
--- a/include/picongpu/fields/currentInterpolation/Binomial/Binomial.def
+++ b/include/picongpu/fields/currentInterpolation/Binomial/Binomial.def
@@ -19,35 +19,18 @@
 
 #pragma once
 
+
 namespace picongpu
 {
 namespace currentInterpolation
 {
 
-/* 2nd order Binomial filter */
-template<uint32_t T_dim>
-struct Binomial;
+    /** 2nd order Binomial filter
+     *
+     * Smooths the current before assignment in staggered grid.
+     * Updates E & breaks local charge conservation slightly.
+     */
+    struct Binomial;
 
-} /* namespace currentInterpolation */
-
-namespace traits
-{
-
-/* Get margin of the current interpolation
- *
- * This class defines a LowerMargin and an UpperMargin.
- */
-template<uint32_t T_dim>
-struct GetMargin<picongpu::currentInterpolation::Binomial<T_dim > >
-{
-private:
-    typedef picongpu::currentInterpolation::Binomial<T_dim> MyInterpolation;
-
-public:
-    typedef typename MyInterpolation::LowerMargin LowerMargin;
-    typedef typename MyInterpolation::UpperMargin UpperMargin;
-};
-
-} /* namespace traits */
-
-} /* namespace picongpu */
+} // namespace currentInterpolation
+} // namespace picongpu

--- a/include/picongpu/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/include/picongpu/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -20,65 +20,83 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-#include <pmacc/types.hpp>
-
 #include "picongpu/fields/currentInterpolation/None/None.def"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
 
 namespace picongpu
 {
 namespace currentInterpolation
 {
-using namespace pmacc;
 
-template<uint32_t T_dim>
-struct Binomial
-{
-    static constexpr uint32_t dim = T_dim;
-
-    typedef typename pmacc::math::CT::make_Int<dim, 1>::type LowerMargin;
-    typedef typename pmacc::math::CT::make_Int<dim, 1>::type UpperMargin;
-
-    template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
-    HDINLINE void operator()(DataBoxE fieldE,
-                             DataBoxB,
-                             DataBoxJ fieldJ )
+    struct Binomial
     {
-        const DataSpace<dim> self;
-        using TypeJ = typename DataBoxJ::ValueType;
+        static constexpr uint32_t dim = simDim;
 
-        /* 1 2 1 weighting for "left"(1x) "center"(2x) "right"(1x),
-         * see Pascal's triangle level N=2 */
-        TypeJ dirSum( TypeJ::create(0.0) );
-        for( uint32_t d = 0; d < dim; ++d )
+        typedef typename pmacc::math::CT::make_Int<dim, 1>::type LowerMargin;
+        typedef typename pmacc::math::CT::make_Int<dim, 1>::type UpperMargin;
+
+        template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
+        HDINLINE void operator()(DataBoxE fieldE,
+                                 DataBoxB,
+                                 DataBoxJ fieldJ )
         {
-            DataSpace<dim> dw;
-            dw[d] = -1;
-            DataSpace<dim> up;
-            up[d] =  1;
-            const TypeJ dirDw = fieldJ(dw) + fieldJ(self);
-            const TypeJ dirUp = fieldJ(up) + fieldJ(self);
+            const DataSpace<dim> self;
+            using TypeJ = typename DataBoxJ::ValueType;
 
-            /* each fieldJ component is added individually */
-            dirSum += dirDw + dirUp;
+            /* 1 2 1 weighting for "left"(1x) "center"(2x) "right"(1x),
+             * see Pascal's triangle level N=2 */
+            TypeJ dirSum( TypeJ::create(0.0) );
+            for( uint32_t d = 0; d < dim; ++d )
+            {
+                DataSpace<dim> dw;
+                dw[d] = -1;
+                DataSpace<dim> up;
+                up[d] =  1;
+                const TypeJ dirDw = fieldJ(dw) + fieldJ(self);
+                const TypeJ dirUp = fieldJ(up) + fieldJ(self);
+
+                /* each fieldJ component is added individually */
+                dirSum += dirDw + dirUp;
+            }
+
+            /* component-wise division by sum of all weightings,
+             * in the second order binomial filter these are 4 values per direction
+             * (1D: 4 values; 2D: 8 values; 3D: 12 values) */
+            const TypeJ filteredJ = dirSum / TypeJ::create(4.0 * dim);
+
+            const float_X deltaT = DELTA_T;
+            fieldE(self) -= filteredJ * (float_X(1.0) / EPS0) * deltaT;
         }
 
-        /* component-wise division by sum of all weightings,
-         * in the second order binomial filter these are 4 values per direction
-         * (1D: 4 values; 2D: 8 values; 3D: 12 values) */
-        const TypeJ filteredJ = dirSum / TypeJ::create(4.0 * dim);
+        static pmacc::traits::StringProperty getStringProperties()
+        {
+            pmacc::traits::StringProperty propList( "name", "Binomial" );
+            propList["param"] = "period=1;numPasses=1;compensator=false";
+            return propList;
+        }
+    };
 
-        const float_X deltaT = DELTA_T;
-        fieldE(self) -= filteredJ * (float_X(1.0) / EPS0) * deltaT;
-    }
+} // namespace currentInterpolation
 
-    static pmacc::traits::StringProperty getStringProperties()
+namespace traits
+{
+
+    /* Get margin of the current interpolation
+     *
+     * This class defines a LowerMargin and an UpperMargin.
+     */
+    template< >
+    struct GetMargin< picongpu::currentInterpolation::Binomial >
     {
-        pmacc::traits::StringProperty propList( "name", "Binomial" );
-        propList["param"] = "period=1;numPasses=1;compensator=false";
-        return propList;
-    }
-};
+    private:
+        typedef picongpu::currentInterpolation::Binomial MyInterpolation;
 
-} /* namespace currentInterpolation */
+    public:
+        typedef typename MyInterpolation::LowerMargin LowerMargin;
+        typedef typename MyInterpolation::UpperMargin UpperMargin;
+    };
 
-} /* namespace picongpu */
+} // namespace traits
+} // namespace picongpu

--- a/include/picongpu/fields/currentInterpolation/None/None.def
+++ b/include/picongpu/fields/currentInterpolation/None/None.def
@@ -19,34 +19,18 @@
 
 #pragma once
 
+
 namespace picongpu
 {
 namespace currentInterpolation
 {
 
-template<uint32_t T_dim>
-struct None;
+    /* None interpolated current assignment
+     *
+     * Default for staggered grids/Yee-scheme.
+     * Updates field E only.
+     */
+    struct None;
 
-} /* namespace currentInterpolation */
-
-namespace traits
-{
-
-/* Get margin of the current interpolation
- *
- * This class defines a LowerMargin and an UpperMargin.
- */
-template<uint32_t T_dim>
-struct GetMargin<picongpu::currentInterpolation::None<T_dim > >
-{
-private:
-    typedef picongpu::currentInterpolation::None<T_dim> MyInterpolation;
-
-public:
-    typedef typename MyInterpolation::LowerMargin LowerMargin;
-    typedef typename MyInterpolation::UpperMargin UpperMargin;
-};
-
-} /* namespace traits */
-
-} /* namespace picongpu */
+} // namespace currentInterpolation
+} // namespace picongpu

--- a/include/picongpu/fields/currentInterpolation/None/None.hpp
+++ b/include/picongpu/fields/currentInterpolation/None/None.hpp
@@ -33,23 +33,35 @@ namespace currentInterpolation
     {
         static constexpr uint32_t dim = simDim;
 
-        typedef typename pmacc::math::CT::make_Int<dim, 0>::type LowerMargin;
-        typedef typename pmacc::math::CT::make_Int<dim, 0>::type UpperMargin;
+        using LowerMargin = typename pmacc::math::CT::make_Int<
+            dim,
+            0
+        >::type;
+        using UpperMargin = LowerMargin;
 
-        template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
-        HDINLINE void operator()(DataBoxE fieldE,
-                                 DataBoxB,
-                                 DataBoxJ fieldJ )
+        template<
+            typename T_DataBoxE,
+            typename T_DataBoxB,
+            typename T_DataBoxJ
+        >
+        HDINLINE void operator()(
+            T_DataBoxE fieldE,
+            T_DataBoxB const,
+            T_DataBoxJ const fieldJ
+        )
         {
-            const DataSpace<dim> self;
+            DataSpace< dim > const self;
 
-            const float_X deltaT = DELTA_T;
-            fieldE(self) -= fieldJ(self) * (float_X(1.0) / EPS0) * deltaT;
+            constexpr float_X deltaT = DELTA_T;
+            fieldE( self ) -= fieldJ( self ) * ( float_X( 1.0 ) / EPS0 ) * deltaT;
         }
 
-        static pmacc::traits::StringProperty getStringProperties()
+        static pmacc::traits::StringProperty getStringProperties( )
         {
-            pmacc::traits::StringProperty propList( "name", "none" );
+            pmacc::traits::StringProperty propList(
+                "name",
+                "none"
+            );
             return propList;
         }
     };
@@ -67,11 +79,11 @@ namespace traits
     struct GetMargin< picongpu::currentInterpolation::None >
     {
     private:
-        typedef picongpu::currentInterpolation::None MyInterpolation;
+        using MyInterpolation = picongpu::currentInterpolation::None;
 
     public:
-        typedef typename MyInterpolation::LowerMargin LowerMargin;
-        typedef typename MyInterpolation::UpperMargin UpperMargin;
+        using LowerMargin = typename MyInterpolation::LowerMargin;
+        using UpperMargin = typename MyInterpolation::UpperMargin;
     };
 
 } // namespace traits

--- a/include/picongpu/fields/currentInterpolation/None/None.hpp
+++ b/include/picongpu/fields/currentInterpolation/None/None.hpp
@@ -20,42 +20,59 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-#include <pmacc/types.hpp>
-
 #include "picongpu/fields/currentInterpolation/None/None.def"
+
+#include <pmacc/dimensions/DataSpace.hpp>
 
 namespace picongpu
 {
 namespace currentInterpolation
 {
-using namespace pmacc;
 
-template<uint32_t T_dim>
-struct None
+    struct None
+    {
+        static constexpr uint32_t dim = simDim;
+
+        typedef typename pmacc::math::CT::make_Int<dim, 0>::type LowerMargin;
+        typedef typename pmacc::math::CT::make_Int<dim, 0>::type UpperMargin;
+
+        template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
+        HDINLINE void operator()(DataBoxE fieldE,
+                                 DataBoxB,
+                                 DataBoxJ fieldJ )
+        {
+            const DataSpace<dim> self;
+
+            const float_X deltaT = DELTA_T;
+            fieldE(self) -= fieldJ(self) * (float_X(1.0) / EPS0) * deltaT;
+        }
+
+        static pmacc::traits::StringProperty getStringProperties()
+        {
+            pmacc::traits::StringProperty propList( "name", "none" );
+            return propList;
+        }
+    };
+
+} // namespace currentInterpolation
+
+namespace traits
 {
-    static constexpr uint32_t dim = T_dim;
 
-    typedef typename pmacc::math::CT::make_Int<dim, 0>::type LowerMargin;
-    typedef typename pmacc::math::CT::make_Int<dim, 0>::type UpperMargin;
-
-    template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
-    HDINLINE void operator()(DataBoxE fieldE,
-                             DataBoxB,
-                             DataBoxJ fieldJ )
+    /* Get margin of the current interpolation
+     *
+     * This class defines a LowerMargin and an UpperMargin.
+     */
+    template< >
+    struct GetMargin< picongpu::currentInterpolation::None >
     {
-        const DataSpace<dim> self;
+    private:
+        typedef picongpu::currentInterpolation::None MyInterpolation;
 
-        const float_X deltaT = DELTA_T;
-        fieldE(self) -= fieldJ(self) * (float_X(1.0) / EPS0) * deltaT;
-    }
+    public:
+        typedef typename MyInterpolation::LowerMargin LowerMargin;
+        typedef typename MyInterpolation::UpperMargin UpperMargin;
+    };
 
-    static pmacc::traits::StringProperty getStringProperties()
-    {
-        pmacc::traits::StringProperty propList( "name", "none" );
-        return propList;
-    }
-};
-
-} /* namespace currentInterpolation */
-
-} /* namespace picongpu */
+} // namespace traits
+} // namespace picongpu

--- a/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.def
+++ b/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.def
@@ -24,34 +24,12 @@ namespace picongpu
 namespace currentInterpolation
 {
 
-/* The standard interpolation for Directional Splitting
- *
- * In the Directional Splitting scheme (see MaxwellSolver and
- * numericalCellTypes
- */
-template<uint32_t T_simDim>
-struct NoneDS;
+    /* The standard interpolation for Directional Splitting
+     *
+     * Experimental assignment for all-centered cells used in directional splitting.
+     * Updates E & B at the same time.
+     */
+    struct NoneDS;
 
-} /* namespace currentInterpolation */
-
-namespace traits
-{
-
-/* Get margin of the current interpolation
- *
- * This class defines a LowerMargin and an UpperMargin.
- */
-template<uint32_t T_dim>
-struct GetMargin<picongpu::currentInterpolation::NoneDS<T_dim > >
-{
-private:
-    typedef picongpu::currentInterpolation::NoneDS<T_dim> MyInterpolation;
-
-public:
-    typedef typename MyInterpolation::LowerMargin LowerMargin;
-    typedef typename MyInterpolation::UpperMargin UpperMargin;
-};
-
-} /* namespace traits */
-
-} /* namespace picongpu */
+} // namespace currentInterpolation
+} // namespace picongpu

--- a/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.hpp
+++ b/include/picongpu/fields/currentInterpolation/NoneDS/NoneDS.hpp
@@ -41,21 +41,27 @@ namespace detail
         static constexpr uint32_t dim = T_simDim;
 
         /* UpperMargin is actually 0 in direction of T_plane */
-        typedef typename pmacc::math::CT::make_Int<dim, 0>::type LowerMargin;
-        typedef typename pmacc::math::CT::make_Int<dim, 1>::type UpperMargin;
+        using LowerMargin = typename pmacc::math::CT::make_Int<
+            dim,
+            0
+        >::type;
+        using UpperMargin = typename pmacc::math::CT::make_Int<
+            dim,
+            1
+        >::type;
 
         template<typename DataBox>
-        HDINLINE float_X operator()(DataBox field) const
+        HDINLINE float_X operator()( DataBox const & field ) const
         {
-            const DataSpace<dim> self;
-            DataSpace<dim> up;
+            DataSpace< dim > const self;
+            DataSpace< dim > up;
             up[(T_plane + 1) % dim] = 1;
 
             using Avg = LinearInterpolateWithUpper< dim >;
 
-            const typename Avg::template GetInterpolatedValue< (T_plane + 2) % dim > avg;
+            typename Avg::template GetInterpolatedValue< ( T_plane + 2 ) % dim > const avg;
 
-            return float_X(0.5) * ( avg(field)[T_plane] + avg(field.shift(up))[T_plane] );
+            return float_X( 0.5 ) * ( avg( field )[ T_plane ] + avg( field.shift( up ) )[ T_plane ] );
         }
     };
 
@@ -74,7 +80,11 @@ namespace detail
      * \tparam isShiftAble auto-filled value that decides if this direction
      *                     is actually non-existent == periodic
      */
-    template<uint32_t T_simDim, uint32_t T_direction, bool isShiftAble=(T_direction<T_simDim) >
+    template<
+        uint32_t T_simDim,
+        uint32_t T_direction,
+        bool isShiftAble = ( T_direction < T_simDim )
+    >
     struct ShiftMeIfYouCan
     {
         static constexpr uint32_t dim = T_simDim;
@@ -84,50 +94,68 @@ namespace detail
         {
         }
 
-        template<class T_DataBox >
-        HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
+        template< typename T_DataBox >
+        HDINLINE T_DataBox operator()( T_DataBox const & dataBox ) const
         {
-            DataSpace<dim> shift;
-            shift[dir] = 1;
-            return dataBox.shift(shift);
+            DataSpace< dim > shift;
+            shift[ dir ] = 1;
+            return dataBox.shift( shift );
         }
     };
 
-    template<uint32_t T_simDim, uint32_t T_direction>
-    struct ShiftMeIfYouCan<T_simDim, T_direction, false>
+    template<
+        uint32_t T_simDim,
+        uint32_t T_direction
+    >
+    struct ShiftMeIfYouCan<
+        T_simDim,
+        T_direction,
+        false
+    >
     {
         HDINLINE ShiftMeIfYouCan()
         {
         }
 
-        template<class T_DataBox >
-        HDINLINE T_DataBox operator()(const T_DataBox& dataBox) const
+        template< typename T_DataBox >
+        HDINLINE T_DataBox operator()( T_DataBox const & dataBox ) const
         {
             return dataBox;
         }
     };
 
     /* that is not a "real" yee curl, but it looks a bit like it */
-    template<class Difference>
+    template< typename Difference >
     struct ShiftCurl
     {
         using LowerMargin = typename Difference::OffsetOrigin;
         using UpperMargin = typename Difference::OffsetEnd;
 
         template<class DataBox >
-        HDINLINE typename DataBox::ValueType operator()(const DataBox& mem) const
+        HDINLINE typename DataBox::ValueType operator()( DataBox const & mem ) const
         {
-            const typename Difference::template GetDifference<0> Dx;
-            const typename Difference::template GetDifference<1> Dy;
-            const typename Difference::template GetDifference<2> Dz;
+            typename Difference::template GetDifference< 0 > const Dx;
+            typename Difference::template GetDifference< 1 > const Dy;
+            typename Difference::template GetDifference< 2 > const Dz;
 
-            const ShiftMeIfYouCan<simDim, 0> sx;
-            const ShiftMeIfYouCan<simDim, 1> sy;
-            const ShiftMeIfYouCan<simDim, 2> sz;
+            ShiftMeIfYouCan<
+                simDim,
+                0
+            > const sx;
+            ShiftMeIfYouCan<
+                simDim,
+                1
+            > const sy;
+            ShiftMeIfYouCan<
+                simDim,
+                2
+            > const sz;
 
-            return float3_X(Dy(sx(mem)).z() - Dz(sx(mem)).y(),
-                            Dz(sy(mem)).x() - Dx(sy(mem)).z(),
-                            Dx(sz(mem)).y() - Dy(sz(mem)).x());
+            return float3_X(
+                Dy( sx( mem ) ).z( ) - Dz( sx( mem ) ).y( ),
+                Dz( sy( mem ) ).x( ) - Dx( sy( mem ) ).z( ),
+                Dx( sz( mem ) ).y( ) - Dy( sz( mem ) ).x( )
+            );
         }
     };
 } // namespace detail
@@ -139,42 +167,64 @@ namespace detail
         typedef typename pmacc::math::CT::make_Int<dim, 0>::type LowerMargin;
         typedef typename pmacc::math::CT::make_Int<dim, 1>::type UpperMargin;
 
-        template<typename DataBoxE, typename DataBoxB, typename DataBoxJ>
-        HDINLINE void operator()(DataBoxE fieldE,
-                                 DataBoxB fieldB,
-                                 DataBoxJ fieldJ )
+        template<
+            typename T_DataBoxE,
+            typename T_DataBoxB,
+            typename T_DataBoxJ
+        >
+        HDINLINE void operator()(
+            T_DataBoxE fieldE,
+            T_DataBoxB fieldB,
+            T_DataBoxJ const fieldJ
+        )
         {
-            typedef typename DataBoxJ::ValueType TypeJ;
-            typedef typename GetComponentsType<TypeJ>::type ComponentJ;
+            using TypeJ = typename T_DataBoxJ::ValueType;
+            using ComponentJ = typename GetComponentsType< TypeJ >::type;
 
-            const DataSpace<dim> self;
+            DataSpace< dim > const self;
 
-            const ComponentJ deltaT = DELTA_T;
-            const ComponentJ constE = (float_X(1.0)  / EPS0) * deltaT;
-            const ComponentJ constB = (float_X(0.25) / EPS0) * deltaT * deltaT;
+            constexpr ComponentJ deltaT = DELTA_T;
+            ComponentJ const constE = ( float_X( 1.0 )  / EPS0 ) * deltaT;
+            ComponentJ const constB = ( float_X( 0.25 ) / EPS0 ) * deltaT * deltaT;
 
-            const detail::LinearInterpolateComponentPlaneUpper<dim, 0> avgX;
-            const ComponentJ jXavg = avgX(fieldJ);
-            const detail::LinearInterpolateComponentPlaneUpper<dim, 1> avgY;
-            const ComponentJ jYavg = avgY(fieldJ);
-            const detail::LinearInterpolateComponentPlaneUpper<dim, 2> avgZ;
-            const ComponentJ jZavg = avgZ(fieldJ);
+            detail::LinearInterpolateComponentPlaneUpper<
+                dim,
+                0
+            > const avgX;
+            ComponentJ const jXavg = avgX( fieldJ );
+            detail::LinearInterpolateComponentPlaneUpper<
+                dim,
+                1
+            > const avgY;
+            ComponentJ const jYavg = avgY( fieldJ );
+            detail::LinearInterpolateComponentPlaneUpper<
+                dim,
+                2
+            > const avgZ;
+            ComponentJ const jZavg = avgZ( fieldJ );
 
-            const TypeJ jAvgE = TypeJ(jXavg, jYavg, jZavg);
-            fieldE(self) -= jAvgE * constE;
+            TypeJ const jAvgE = TypeJ(
+                jXavg,
+                jYavg,
+                jZavg
+            );
+            fieldE( self ) -= jAvgE * constE;
 
             using CurlRight = yeeSolver::Curl< DifferenceToUpper< dim > >;
             using ShiftCurlRight = detail::ShiftCurl< DifferenceToUpper< dim > >;
             CurlRight curl;
             ShiftCurlRight shiftCurl;
 
-            const TypeJ jAvgB = curl(fieldJ) + shiftCurl(fieldJ);
+            TypeJ const jAvgB = curl( fieldJ ) + shiftCurl( fieldJ );
             fieldB(self) += jAvgB * constB;
         }
 
         static pmacc::traits::StringProperty getStringProperties()
         {
-            pmacc::traits::StringProperty propList( "name", "none" );
+            pmacc::traits::StringProperty propList(
+                "name",
+                "none"
+            );
             return propList;
         }
     };
@@ -192,11 +242,11 @@ namespace traits
     struct GetMargin< picongpu::currentInterpolation::NoneDS >
     {
     private:
-        typedef picongpu::currentInterpolation::NoneDS MyInterpolation;
+        using MyInterpolation = picongpu::currentInterpolation::NoneDS;
 
     public:
-        typedef typename MyInterpolation::LowerMargin LowerMargin;
-        typedef typename MyInterpolation::UpperMargin UpperMargin;
+        using LowerMargin = typename MyInterpolation::LowerMargin;
+        using UpperMargin = typename MyInterpolation::UpperMargin;
     };
 
 } // namespace traits

--- a/include/picongpu/simulation_defines/param/fieldSolver.param
+++ b/include/picongpu/simulation_defines/param/fieldSolver.param
@@ -29,13 +29,13 @@
  * species to the electro-magnetic fields.
  *
  * Allowed values are:
- *   - None< simDim >:
+ *   - None:
  *     - default for staggered grids/Yee-scheme
  *     - updates E
- *   - Binomial< simDim >: 2nd order Binomial filter
+ *   - Binomial: 2nd order Binomial filter
  *     - smooths the current before assignment in staggered grid
  *     - updates E & breaks local charge conservation slightly
- *   - NoneDS< simDim >:
+ *   - NoneDS:
  *     - experimental assignment for all-centered/directional splitting
  *     - updates E & B at the same time
  */
@@ -49,22 +49,22 @@ namespace picongpu
 {
     namespace fieldSolverNone
     {
-        using CurrentInterpolation = currentInterpolation::None< simDim >;
+        using CurrentInterpolation = currentInterpolation::None;
     }
 
     namespace fieldSolverYee
     {
-        using CurrentInterpolation = currentInterpolation::None< simDim >;
+        using CurrentInterpolation = currentInterpolation::None;
     }
 
     namespace fieldSolverYeeNative
     {
-        using CurrentInterpolation = currentInterpolation::None< simDim >;
+        using CurrentInterpolation = currentInterpolation::None;
     }
 #if( PMACC_CUDA_ENABLED == 1 )
     namespace fieldSolverDirSplitting
     {
-        using CurrentInterpolation = currentInterpolation::NoneDS< simDim >;
+        using CurrentInterpolation = currentInterpolation::NoneDS;
     }
 #endif
     /** Lehe Solver
@@ -82,7 +82,7 @@ namespace picongpu
          */
         using CherenkovFreeDir = CherenkovFreeDirection_Y;
 
-        using CurrentInterpolation = currentInterpolation::None< simDim >;
+        using CurrentInterpolation = currentInterpolation::None;
     }
 
 } // namespace picongpu


### PR DESCRIPTION
- remove the template parameter for the simulation dimension from all current interpolation classes
- move trait specialization to hpp file to avoid usage of a incomplete type
- update documentation
- update code style following [this](https://github.com/ComputationalRadiationPhysics/contributing/blob/dc58d36e537248329fdd780dc0e8b852dca40d2f/codingGuideLines/cpp.md) style guides

# Review

Please check the last commit independent of each other, this commit contains only the style updates.