### PR TITLE
PMacc: fix CPU compile

### DIFF
--- a/include/pmacc/random/distributions/normal/Normal_double.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_double.hpp
@@ -40,6 +40,10 @@ namespace distributions
 {
 namespace detail
 {
+/* XorMin and MRG32k3aMin uses the alpaka RNG as fallback for CPU accelerators
+ * therefore we are not allowed to add a specialization for those RNG methods
+ */
+#if( PMACC_CUDA_ENABLED == 1 )
     //! specialization for XorMin
     template<
         typename T_Acc
@@ -73,6 +77,7 @@ namespace detail
     {
 
     };
+#endif
 }  // namespace detail
 }  // namespace distributions
 }  // namespace random

--- a/include/pmacc/random/distributions/normal/Normal_float.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_float.hpp
@@ -40,6 +40,10 @@ namespace distributions
 {
 namespace detail
 {
+/* XorMin and MRG32k3aMin uses the alpaka RNG as fallback for CPU accelerators
+ * therefore we are not allowed to add a specialization for those RNG methods
+ */
+#if( PMACC_CUDA_ENABLED == 1 )
     //! specialization for XorMin
     template<
         typename T_Acc
@@ -73,6 +77,7 @@ namespace detail
     {
 
     };
+#endif
 }  // namespace detail
 }  // namespace distributions
 }  // namespace random


### PR DESCRIPTION
Disable specializations for the normal distribution for the RNG methods
`XorMin`and `MRG32k3aMin`.