### PR TITLE
Manipulator: unary::FreeTotalCellOffset

### DIFF
--- a/docs/source/usage/particles.rst
+++ b/docs/source/usage/particles.rst
@@ -60,6 +60,12 @@ FreeRng
 .. doxygenstruct:: picongpu::particles::manipulators::generic::FreeRng
    :project: PIConGPU
 
+FreeTotalCellOffset
+^^^^^^^^^^^^^^^^^^^
+
+.. doxygenstruct:: picongpu::particles::manipulators::unary::FreeTotalCellOffset
+   :project: PIConGPU
+
 CopyAttribute
 ^^^^^^^^^^^^^
 

--- a/include/picongpu/particles/manipulators/manipulators.def
+++ b/include/picongpu/particles/manipulators/manipulators.def
@@ -29,6 +29,7 @@
 #include "picongpu/particles/manipulators/generic/FreeRng.def"
 #include "picongpu/particles/manipulators/generic/None.def"
 
+#include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.def"
 #include "picongpu/particles/manipulators/unary/Temperature.def"
 #include "picongpu/particles/manipulators/unary/Drift.def"
 #include "picongpu/particles/manipulators/unary/CopyAttribute.def"

--- a/include/picongpu/particles/manipulators/manipulators.hpp
+++ b/include/picongpu/particles/manipulators/manipulators.hpp
@@ -22,5 +22,6 @@
 #include "picongpu/particles/manipulators/generic/Free.hpp"
 #include "picongpu/particles/manipulators/generic/FreeRng.hpp"
 
+#include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp"
 #include "picongpu/particles/manipulators/unary/Temperature.hpp"
 #include "picongpu/particles/manipulators/unary/Drift.hpp"

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.def
@@ -1,0 +1,70 @@
+/* Copyright 2017-2018 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <boost/mpl/integral_c.hpp>
+#include <boost/mpl/placeholders.hpp>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+namespace unary
+{
+    /** call simple free user defined manipulators and provide the cell information
+     *
+     * The functor passes the cell offset of the particle relative to the total
+     * domain origin into the functor.
+     *
+     * @tparam T_Functor user defined unary functor
+     *
+     * example for `particle.param`: set a user-defined species attribute y0
+     * (type: uint32_t) to the current total y-cell index
+     *   @code{.cpp}
+     *   struct FunctorSaveYcell
+     *   {
+     *       template< typename T_Particle >
+     *       HDINLINE void operator()(
+     *          DataSpace< simDim > const & particleOffsetToTotalOrigin,
+     *          T_Particle & particle
+     *       )
+     *       {
+     *           particle[ y0_ ] = particleOffsetToTotalOrigin.y();
+     *       }
+     *       static constexpr char const * name = "saveYcell";
+     *   };
+     *
+     *   using SaveYcell = unary::FreeTotalCellOffset<
+     *      FunctorSaveYcell
+     *   >;
+     *   @endcode
+     */
+    template< typename T_Functor >
+    struct FreeTotalCellOffset;
+
+} // namespace unary
+} // namespace manipulators
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
@@ -1,0 +1,160 @@
+/* Copyright 2017-2018 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.def"
+#include "picongpu/particles/functor/misc/TotalCellOffset.hpp"
+
+#include <string>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace manipulators
+{
+namespace unary
+{
+namespace acc
+{
+    template< typename T_Functor >
+    struct FreeTotalCellOffset : private T_Functor
+    {
+
+        using Functor = T_Functor;
+
+        HDINLINE FreeTotalCellOffset(
+            Functor const & functor,
+            DataSpace< simDim > const & superCellToLocalOriginCellOffset
+        ) :
+            T_Functor( functor ),
+            m_superCellToLocalOriginCellOffset( superCellToLocalOriginCellOffset )
+        {
+        }
+
+        /** call user functor
+         *
+         * The random number generator is initialized with the first call.
+         *
+         * @tparam T_Particle type of the particle to manipulate
+         * @tparam T_Args type of the arguments passed to the user functor
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param particle particle which is given to the user functor
+         * @return void is used to enable the operator if the user functor expects two arguments
+         */
+        template<
+            typename T_Particle,
+            typename T_Acc
+        >
+        HDINLINE
+        void operator()(
+            T_Acc const &,
+            T_Particle & particle
+        )
+        {
+            DataSpace< simDim > const cellInSuperCell(
+                DataSpaceOperations< simDim >::template map< SuperCellSize >( particle[ localCellIdx_ ] )
+            );
+            Functor::operator( )(
+                m_superCellToLocalOriginCellOffset + cellInSuperCell,
+                particle
+            );
+        }
+
+    private:
+
+        DataSpace< simDim > const m_superCellToLocalOriginCellOffset;
+    };
+} // namespace acc
+
+    template< typename T_Functor >
+    struct FreeTotalCellOffset :
+        protected functor::User< T_Functor >,
+        private functor::misc::TotalCellOffset
+    {
+        using CellOffsetFunctor = functor::misc::TotalCellOffset;
+        using Functor = functor::User< T_Functor >;
+
+        template< typename T_SpeciesType >
+        struct apply
+        {
+            using type = FreeTotalCellOffset;
+        };
+
+        /** constructor
+         *
+         * @param currentStep current simulation time step
+         */
+        HINLINE FreeTotalCellOffset( uint32_t currentStep ) :
+            Functor( currentStep ),
+            CellOffsetFunctor( currentStep )
+        {
+        }
+
+        /** create functor for the accelerator
+         *
+         * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
+         * @tparam T_Acc alpaka accelerator type
+         *
+         * @param alpaka accelerator
+         * @param localSupercellOffset offset (in superCells, without any guards) relative
+         *                             to the origin of the local domain
+         * @param workerCfg configuration of the worker
+         */
+        template<
+            typename T_WorkerCfg,
+            typename T_Acc
+        >
+        HDINLINE auto
+        operator()(
+            T_Acc const & acc,
+            DataSpace< simDim > const & localSupercellOffset,
+            T_WorkerCfg const & workerCfg
+        )
+        -> acc::FreeTotalCellOffset< Functor >
+        {
+            auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor * >( this );
+            return acc::FreeTotalCellOffset< Functor >(
+                *static_cast< Functor * >( this ),
+                cellOffsetFunctor(
+                    acc,
+                    localSupercellOffset,
+                    workerCfg
+                )
+            );
+        }
+
+        static
+        HINLINE std::string
+        getName( )
+        {
+            // we provide the name from the param class
+            return Functor::name;
+        }
+    };
+
+} // namespace unary
+} // namespace manipulators
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
Add a new unary manipulator that also passes the current total cell index of a particle.

Potential usage in `particle.param`:
```C++
namespace manipulators
{
        struct FunctorSaveYcell
        {
            template< typename T_Particle >
            HDINLINE void operator()(
               DataSpace< simDim > const & particleOffsetToTotalOrigin,
               T_Particle & particle
            )
            {
                particle[ y0_ ] = particleOffsetToTotalOrigin.y();
            }
            static constexpr char const * name = "saveYcell";
        };
     
        using SaveYcell = unary::FreeTotalCellOffset<
            FunctorSaveYcell
        >;
}
```

(`y0` is a user-defined `speciesAttribute` of type `uint32_t` to store an initial particle position as of the cell index in y.)