### PR TITLE
tbg: Add content of -o arg to env

### DIFF
--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -461,6 +461,10 @@ fi
 mkdir -p "$job_outDir/tbg"
 cd "$job_outDir"
 
+# Add -o args to env to allow for all variables used in the *.tpl file to be set through the -o option
+for i in $tooltpl_overwrite; do
+    export $i
+done
 
 # get the full replaced and evaluated variable definitions
 tooltpl_solved_variables=`run_cfg_and_get_solved_variables "$TBG_cfgFile" tooltpl_file_data tooltpl_overwrite`


### PR DESCRIPTION
This is to allow for all variables used in the *.tpl file to be set through the -o option, instead of only being able to override variables which have otherwise been defined in either the *.tpl or *.cfg.