### PR TITLE
Visual Studio: ERROR macro defined in wingdi.h

### DIFF
--- a/include/picongpu/main.cpp
+++ b/include/picongpu/main.cpp
@@ -33,6 +33,14 @@
 #include <picongpu/simulation_defines.hpp>
 
 
+/* Workaround for Visual Studio to avoid a collision between ERROR macro
+ * defined in wingdi.h file (included from some standard library headers) and
+ * enumerator ArgsParser::ArgsErrorCode::ERROR.
+ */
+#ifdef _MSC_VER
+#   undef ERROR
+#endif
+
 /*! start of PIConGPU
  *
  * @param argc count of arguments in argv


### PR DESCRIPTION
There is ERROR macro defined in wingdi.h file. I assume it is somehow included from VS's implementation of the standard library. So there is a collision with ArgsParser::ArgsErrorCode::ERROR. Since the problem is only in main.cpp, I decided just to undef it manually there.