### PR TITLE
Fix issues with name hiding in Particles

### DIFF
--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -110,7 +110,7 @@ class Particles : public ParticlesBase<
 {
 public:
 
-    typedef ParticleDescription<
+    typedef pmacc::ParticleDescription<
         T_Name,
         SuperCellSize,
         T_Attributes,
@@ -138,13 +138,13 @@ public:
             >
         >::type
     > SpeciesParticleDescription;
-    typedef ParticlesBase<SpeciesParticleDescription, MappingDesc, DeviceHeap> ParticlesBaseType;
+    typedef ParticlesBase<SpeciesParticleDescription, picongpu::MappingDesc, DeviceHeap> ParticlesBaseType;
     typedef typename ParticlesBaseType::FrameType FrameType;
     typedef typename ParticlesBaseType::FrameTypeBorder FrameTypeBorder;
     typedef typename ParticlesBaseType::ParticlesBoxType ParticlesBoxType;
 
 
-    Particles(const std::shared_ptr<DeviceHeap>& heap, MappingDesc cellDescription, SimulationDataId datasetID);
+    Particles(const std::shared_ptr<DeviceHeap>& heap, picongpu::MappingDesc cellDescription, SimulationDataId datasetID);
 
     void createParticleBuffer();
 

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -67,12 +67,12 @@ Particles<
     T_Attributes
 >::Particles(
     const std::shared_ptr<DeviceHeap>& heap,
-    MappingDesc cellDescription,
+    picongpu::MappingDesc cellDescription,
     SimulationDataId datasetID
 ) :
     ParticlesBase<
         SpeciesParticleDescription,
-        MappingDesc,
+        picongpu::MappingDesc,
         DeviceHeap
     >(
         heap,
@@ -257,7 +257,7 @@ Particles<
 
     AreaMapping<
         CORE + BORDER,
-        MappingDesc
+        picongpu::MappingDesc
     > mapper( this->cellDescription );
 
     constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
@@ -316,7 +316,7 @@ Particles<
 
     AreaMapping<
         CORE + BORDER,
-        MappingDesc
+        picongpu::MappingDesc
     > mapper( this->cellDescription );
     PMACC_KERNEL(
         KernelFillGridWithParticles<


### PR DESCRIPTION
Some (relatively) global names were hidden by inaccessible base class members. Explicitly put namespace for such names.