### PR TITLE
Fix signed and unsigned comparison

### DIFF
--- a/include/pmacc/memory/buffers/HostBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/HostBufferIntern.hpp
@@ -124,12 +124,12 @@ public:
     void setValue(const TYPE& value)
     {
         __startOperation(ITask::TASK_HOST);
-        size_t current_size = this->getCurrentSize();
+        int64_t current_size = static_cast< int64_t >(this->getCurrentSize());
         auto memBox = getDataBox();
         typedef DataBoxDim1Access<DataBoxType > D1Box;
         D1Box d1Box(memBox, this->getDataSpace());
         #pragma omp parallel for
-        for (int i = 0; i < current_size; i++)
+        for (int64_t i = 0; i < current_size; i++)
         {
             d1Box[i] = value;
         }


### PR DESCRIPTION
The issue was introduced in my earlier pull request #2505 (sorry, did not check it back then) and results in a very long compile warning on Linux.