### PR TITLE
Calorimeter: Validate minEnergy

### DIFF
--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -252,6 +252,22 @@ private:
                 << std::endl;
             throw std::runtime_error(msg.str());
         }
+        if(this->minEnergy < float_X(0.0))
+        {
+            std::stringstream msg;
+            msg << "[Plugin] [" << this->prefix
+                << "] minEnergy can not be negative."
+                << std::endl;
+            throw std::runtime_error(msg.str());
+        }
+        if(this->logScale && this->minEnergy == float_X(0.0))
+        {
+            std::stringstream msg;
+            msg << "[Plugin] [" << this->prefix
+                << "] minEnergy can not be zero in logarithmic scaling."
+                << std::endl;
+            throw std::runtime_error(msg.str());
+        }
         if(this->numBinsEnergy > 1 && this->maxEnergy <= this->minEnergy)
         {
             std::stringstream msg;


### PR DESCRIPTION
Validate the input of `minEnergy` in the particle calorimeter plugin.

Avoids both negative energies as minimum and zero-energies for log scale energy ranges.

Fix #2511