### PR TITLE
Fix build error concerning pmacc::math::Size_t<0>::create() in Visual Studio

### DIFF
--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -533,6 +533,15 @@ struct Vector<Type, 0 >
     {
         return false;
     }
+
+    HDINLINE
+    static Vector create(Type)
+    {
+        /* this method should never be actually called,
+         * it exists only for Visual Studio to handle pmacc::math::Size_t< 0 >
+         */
+        PMACC_CASSERT_MSG(Vector_dim_0_create_cannot_be_called, false);
+    }
 };
 
 template<typename Type, int dim, typename Accessor, typename Navigator>


### PR DESCRIPTION
This solves issue #2507

After some discussion offline @psychocoderHPC proposed a solution, which I implemented.

The error was caused by pmacc::container::DeviceBuffer with T_dim = DIM1. The DeviceBuffer class template has a constructor with a default value for pitch, involving pmacc::math::Size_t<0>::create(). This constructor is not actually used, but VS tries to compile the default value anyway. As a workaround add a fake method create() for Vector<T, 0> partial specialization. The new method will always fail to compile due to static assert.

So it should not matter for other compilers, since they did not try to compile that create() anyway, and is enough for Visual Studio to work. And nobody could actually call the new method by mistake as it won't compile.