### PR TITLE
Fix type cast in pmacc::exec::KernelStarter::operator()

### DIFF
--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -238,7 +238,7 @@ namespace exec
             T_Args const &... args
         )
         {
-            return static_cast< const KernelStarter >(*this)( args ... );
+            return static_cast< const KernelStarter & >(*this)( args ... );
         }
 
         /** @} */


### PR DESCRIPTION
The previous implementation casted *this to const KernelStarter instead of const reference to it, thus creating a copy for no apparent reason. A cast to reference seems more fitting here, not only because of a copy but for readability (the code in question just calls const version of `operator()`).

Additionally the original version does not compile correctly in Visual Studio, however it seems to be a bug in VS.