### PR TITLE
fix module name openmpi hypnos

### DIFF
--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -25,7 +25,7 @@ then
         module load cmake/3.10.1
         module load boost/1.62.0
         module load cuda/8.0
-        module load openmpi/2.1.2.kepler.cuda80
+        module load openmpi/2.1.2.cuda80
 
         # Plugins (optional)
         module load pngwriter/0.7.0


### PR DESCRIPTION
Followup to #2521 - fixes wrong name of openmpi module on hypnos