### PR TITLE
Hypnos (HZDR): fix openmpi module name

### DIFF
--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -25,7 +25,7 @@ then
         module load cmake/3.10.1
         module load boost/1.62.0
         module load cuda/8.0
-        module load openmpi/2.1.2.kepler.cuda80
+        module load openmpi/2.1.2.cuda80
 
         # Plugins (optional)
         module load pngwriter/0.7.0

--- a/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
@@ -25,7 +25,7 @@ then
         module load cmake/3.10.1
         module load boost/1.62.0
         module load cuda/8.0
-        module load openmpi/2.1.2.kepler.cuda80
+        module load openmpi/2.1.2.cuda80
 
         # Plugins (optional)
         module load pngwriter/0.7.0


### PR DESCRIPTION
follow up of #2521

Change module name `openmpi/2.1.2.kepler.cuda80` to `openmpi/2.1.2.cuda80`