### PR TITLE
pic-configure: fix old structure check

### DIFF
--- a/pic-configure
+++ b/pic-configure
@@ -141,12 +141,6 @@ if [ -f "$extension_param/cmakeFlags" ] ; then
     fi
 fi
 
-# set default install path if no path is set by paramater
-if [ -z "$install_path" ] ; then
-    install_path="-DCMAKE_INSTALL_PREFIX=$extension_param"
-fi
-extension_param="-DPIC_EXTENSION_PATH=$extension_param"
-
 # legacy check: we removed simulation_defines/ after PIConGPU 0.3.X
 if [ -d "$extension_param/include/picongpu/simulation_defines" ]; then
     echo "ERROR: simulation_defines/ directory found!" >&2
@@ -154,12 +148,18 @@ if [ -d "$extension_param/include/picongpu/simulation_defines" ]; then
     exit 3
 fi
 
+# set default install path if no path is set by parameter
+if [ -z "$install_path" ] ; then
+    install_path="-DCMAKE_INSTALL_PREFIX=$extension_param"
+fi
+cmake_extension_param="-DPIC_EXTENSION_PATH=$extension_param"
+
 # warn on missing backend selection
 if [ -z "$alpaka_backend" ] ; then
     echo "Warning: no compute backend set! " >&2
     echo "(Use -b|--backend or export PIC_BACKEND)" >&2
 fi
 
-own_command="cmake $cmake_flags $install_path $extension_param $cmake_options $alpaka_backend $this_dir/include/picongpu"
+own_command="cmake $cmake_flags $install_path $cmake_extension_param $cmake_options $alpaka_backend $this_dir/include/picongpu"
 echo -e "\033[32mcmake command:\033[0m $own_command"
 eval $own_command


### PR DESCRIPTION
Fix the check for old param file structure in `pic-configure`

follow-up to #2331