### PR TITLE
compile time string

### DIFF
--- a/docs/source/usage/workflows/probeParticles.rst
+++ b/docs/source/usage/workflows/probeParticles.rst
@@ -27,7 +27,7 @@ Workflow
     >;
 
     using Probes = Particles<
-        bmpl::string< 'p', 'r', 'o', 'b', 'e' >,
+        PMACC_CSTRING( "probe" ),
         ParticleFlagsProbes,
         MakeSeq_t<
             position< position_pic >,

--- a/include/picongpu/param/speciesDefinition.param
+++ b/include/picongpu/param/speciesDefinition.param
@@ -33,13 +33,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
 #include <pmacc/particles/traits/FilterByFlag.hpp>
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 namespace picongpu
 {
@@ -72,7 +72,7 @@ using ParticleFlagsPhotons = bmpl::vector<
 
 /* define species photons */
 using PIC_Photons = Particles<
-    bmpl::string< 'p', 'h' >,
+    PMACC_CSTRING( "ph" ),
     ParticleFlagsPhotons,
     DefaultParticleAttributes
 >;
@@ -97,7 +97,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species electrons */
 using PIC_Electrons = Particles<
-    bmpl::string< 'e' >,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;
@@ -124,7 +124,7 @@ using ParticleFlagsIons = bmpl::vector<
 
 /* define species ions */
 using PIC_Ions = Particles<
-    bmpl::string< 'i' >,
+    PMACC_CSTRING( "i" ),
     ParticleFlagsIons,
     DefaultParticleAttributes
 >;

--- a/include/pmacc/compileTime/String.hpp
+++ b/include/pmacc/compileTime/String.hpp
@@ -1,0 +1,117 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+
+namespace pmacc
+{
+namespace compileTime
+{
+    /** get character of an C-string
+     *
+     * @tparam T_len length of the string
+     *
+     * @param cstr input string
+     * @param idx index of the character
+     * @return if x < T_len character at index idx, else '0'
+     */
+    template<
+        int T_len
+    >
+    constexpr auto
+    elem_at(
+        char const ( & cstr )[ T_len ],
+        size_t const idx
+    )
+    -> char
+    {
+        return idx < T_len ? cstr[ idx ] : 0;
+    }
+
+    /** compile time string
+     *
+     * The size of the instance is 1 byte.
+     */
+    template< char ... T_c >
+    struct String
+    {
+        /** get stored string */
+        static auto
+        str()
+        -> std::string
+        {
+            return std::string(
+                std::array<
+                    char,
+                    sizeof...( T_c ) + 1
+                >( {
+                    T_c ...,
+                    // at terminal zero to support empty strings
+                    0
+                } ).data( )
+            );
+        }
+    };
+
+
+#define PMACC_CHAR_AT_N(z, n, name ) pmacc::compileTime::elem_at< sizeof(name) >( name, n ),
+
+/** create a compile time string type
+ *
+ * Support strings with up to 64 characters.
+ * Longer strings are cropped to 64 characters.
+ *
+ * usage example:
+ * @code{.cpp}
+ * // create an instance of the compile time string
+ * auto particleName = PMACC_CSTRING( "electrons" ){};
+ * // create a C++ type (can be used as template parameter)
+ * using Electrons = PMACC_CSTRING( "electrons" );
+ * @endcode
+ */
+
+#define PMACC_CSTRING( str )                                                   \
+    /* // PMACC_CSTRING("example") is transformed in                           \
+     * pmacc::compileTime::String<                                             \
+     *     pmacc::compileTime::elem_at< sizeof("example") >( sizeof("example", 0 ), \
+     *     pmacc::compileTime::elem_at< sizeof("example") >( sizeof("example", 1 ), \
+     *     ...                                                                 \
+     *     pmacc::compileTime::elem_at< sizeof("example") >( sizeof("example", 63 ), \
+     *     0                                                                   \
+     * >                                                                       \
+     */                                                                        \
+    pmacc::compileTime::String<                                                \
+        BOOST_PP_REPEAT_FROM_TO(                                               \
+            0,                                                                 \
+            /* support up to 64 charactres */                                  \
+            64,                                                                \
+            PMACC_CHAR_AT_N,                                                   \
+            str                                                                \
+        )                                                                      \
+        /* add a end zero because PMACC_CHAR_AT_N end with a comma */          \
+        0                                                                      \
+    >
+
+} // namespace compileTime
+} // namespace pmacc

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -47,7 +47,6 @@
 #include <boost/mpl/contains.hpp>
 
 #include "pmacc/particles/ParticleDescription.hpp"
-#include <boost/mpl/string.hpp>
 
 namespace pmacc
 {
@@ -156,7 +155,7 @@ public InheritLinearly<
 
     HINLINE static std::string getName()
     {
-        return std::string(boost::mpl::c_str<Name>::value);
+        return Name::str();
     }
 
 };

--- a/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
+++ b/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
@@ -50,7 +50,7 @@ namespace traits
  * > ParticleFlagsElectrons;
  *
  * typedef picongpu::Particles<
- *     bmpl::string<'e'>,
+ *     PMACC_CSTRING( "e" ),
  *     ParticleFlagsElectrons,
  *     DefaultAttributesSeq
  * > PIC_Electrons;

--- a/include/pmacc/traits/GetCTName.hpp
+++ b/include/pmacc/traits/GetCTName.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <boost/mpl/string.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace pmacc
@@ -32,14 +32,14 @@ namespace traits
     /** Return the compile time name
      *
      * @tparam T_Type type of the object where the name is queried
-     * @return ::type name of the object as boost::mpl::string,
+     * @return ::type name of the object as pmacc::compileTime::String,
      *         empty string is returned if the trait is not specified for
      *         T_Type
      */
     template< typename T_Type >
     struct GetCTName
     {
-        using type = boost::mpl::string< >;
+        using type = pmacc::compileTime::String< >;
     };
 
     template< typename T_Type >

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
@@ -20,13 +20,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
 #include <pmacc/particles/traits/FilterByFlag.hpp>
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace picongpu
@@ -65,7 +65,7 @@ using ParticleFlagsPhotons = bmpl::vector<
 
 /* define species photons */
 using PIC_Photons = Particles<
-    bmpl::string< 'p', 'h' >,
+    PMACC_CSTRING( "ph" ),
     ParticleFlagsPhotons,
     DefaultParticleAttributes
 >;
@@ -91,7 +91,7 @@ using ParticleFlagsIons = bmpl::vector<
 
 /* define species ions */
 using PIC_Ions = Particles<
-    bmpl::string< 'i' >,
+    PMACC_CSTRING( "i" ),
     ParticleFlagsIons,
     DefaultParticleAttributes
 >;
@@ -118,7 +118,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species electrons */
 using PIC_Electrons = Particles<
-    bmpl::string< 'e' >,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;

--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
@@ -20,13 +20,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
 #include <pmacc/particles/traits/FilterByFlag.hpp>
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace picongpu
@@ -71,7 +71,7 @@ using ParticleFlagsPhotons = bmpl::vector<
 
 /* define species photons */
 using PIC_Photons = Particles<
-    bmpl::string< 'p', 'h' >,
+    PMACC_CSTRING( "ph" ),
     ParticleFlagsPhotons,
     DefaultParticleAttributes
 >;
@@ -96,7 +96,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species electrons */
 using PIC_Electrons = Particles<
-    bmpl::string< 'e' >,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
@@ -33,13 +33,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
 #include <pmacc/particles/traits/FilterByFlag.hpp>
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace picongpu
@@ -81,7 +81,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species electrons */
 using Electrons = Particles<
-    bmpl::string< 'e' >,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;
@@ -117,7 +117,7 @@ using ParticleFlagsHydrogen = bmpl::vector<
 
 /* define species Hydrogen */
 using Hydrogen = Particles<
-    bmpl::string< 'H' >,
+    PMACC_CSTRING( "H" ),
     ParticleFlagsHydrogen,
     IonParticleAttributes
 >;
@@ -153,7 +153,7 @@ using ParticleFlagsCarbon = bmpl::vector<
 
 /* define species Carbon */
 using Carbon = Particles<
-    bmpl::string< 'C' >,
+    PMACC_CSTRING( "C" ),
     ParticleFlagsCarbon,
     IonParticleAttributes
 >;
@@ -189,7 +189,7 @@ using ParticleFlagsNitrogen = bmpl::vector<
 
 /* define species Nitrogen */
 using Nitrogen = Particles<
-    bmpl::string< 'N' >,
+    PMACC_CSTRING( "N" ),
     ParticleFlagsNitrogen,
     IonParticleAttributes
 >;
@@ -204,7 +204,7 @@ using ParticleFlagsProbes = bmpl::vector<
 
 /* define species Probe */
 using Probes = Particles<
-    bmpl::string< 'p', 'r', 'o', 'b', 'e' >,
+    PMACC_CSTRING( "probe" ),
     ParticleFlagsProbes,
     MakeSeq_t<
         position< position_pic >,

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
@@ -20,13 +20,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
 #include <pmacc/particles/traits/FilterByFlag.hpp>
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 #ifndef PARAM_RADIATION
@@ -71,7 +71,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species electrons */
 using PIC_Electrons = Particles<
-    bmpl::string< 'e' >,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;
@@ -98,7 +98,7 @@ using ParticleFlagsIons = bmpl::vector<
 
 /* define species ions */
 using PIC_Ions = Particles<
-    bmpl::string< 'i' >,
+    PMACC_CSTRING( "i" ),
     ParticleFlagsIons,
     DefaultParticleAttributes
 >;

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
@@ -21,12 +21,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace picongpu
@@ -71,7 +72,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species: electrons */
 using PIC_Electrons = Particles<
-    bmpl::string< 'e' >,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;
@@ -104,7 +105,7 @@ using ParticleFlagsIons = bmpl::vector<
 
 /* define species: ions */
 using PIC_Ions = Particles<
-    bmpl::string< 'i' >,
+    PMACC_CSTRING( "i" ),
     ParticleFlagsIons,
     AttributeSeqIons
 >;

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
@@ -22,12 +22,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace picongpu
@@ -71,7 +72,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species electrons */
 using PIC_Electrons = Particles<
-    bmpl::string<'e'>,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
@@ -20,12 +20,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace picongpu
@@ -71,7 +72,7 @@ using ParticleFlagsPhotons = bmpl::vector<
 
 /* define species photons */
 using Photons = Particles<
-    bmpl::string< 'p', 'h' >,
+    PMACC_CSTRING( "ph" ),
     ParticleFlagsPhotons,
     DefaultParticleAttributes
 >;
@@ -108,7 +109,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* thermal bulk electrons */
 using BulkElectrons = Particles<
-    bmpl::string< 'e', 't', 'h' >,
+    PMACC_CSTRING( "eth" ),
     MakeSeq_t<
         ParticleFlagsElectrons,
         densityRatio< DensityRatioBulkElectrons >
@@ -118,7 +119,7 @@ using BulkElectrons = Particles<
 
 /* non-thermal "hot"/prompt electrons */
 using PromptElectrons = Particles<
-    bmpl::string< 'e', 'h', 'o', 't' >,
+    PMACC_CSTRING( "ehot" ),
     MakeSeq_t<
         ParticleFlagsElectrons,
         densityRatio< DensityRatioPromptElectrons >
@@ -162,7 +163,7 @@ using ParticleFlagsCopper = bmpl::vector<
 
 /* define species ions */
 using CopperIons = Particles<
-    bmpl::string< 'C', 'u' >,
+    PMACC_CSTRING( "Cu" ),
     ParticleFlagsCopper,
     MakeSeq_t<
         DefaultParticleAttributes,

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
@@ -20,12 +20,13 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
 #include <pmacc/particles/Identifier.hpp>
 #include <pmacc/compileTime/conversion/MakeSeq.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
-
-#include "picongpu/particles/Particles.hpp"
-#include <boost/mpl/string.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/compileTime/String.hpp>
 
 
 namespace picongpu
@@ -62,7 +63,7 @@ using ParticleFlagsElectrons = bmpl::vector<
 
 /* define species electrons */
 using PIC_Electrons = Particles<
-    bmpl::string< 'e' >,
+    PMACC_CSTRING( "e" ),
     ParticleFlagsElectrons,
     DefaultParticleAttributes
 >;
@@ -89,7 +90,7 @@ using ParticleFlagsIons = bmpl::vector<
 
 /*define specie ions*/
 using PIC_Ions = Particles<
-    bmpl::string<'i'>,
+    PMACC_CSTRING( "i" ),
     ParticleFlagsIons,
     DefaultParticleAttributes
 >;


### PR DESCRIPTION
- add function to get the n-th character of an compile time C-string
- add compile time string without runtime size (encoded in template signature)
- remove usage of `boost::mpl::string<>` with `PMACC_CSTRING()`
- update documentation 