### PR TITLE
Piz Daint: Module Update

### DIFF
--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -14,7 +14,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 # module load nano
 #export EDITOR="nano"
 
-# General Modules #############################################################
+# Programming Environment #####################################################
 #
 # if the wrong environment is loaded we switch to the gnu environment
 # note: this loads gcc/5.3.0 (6.0.4 is the version of the programming env!)
@@ -25,19 +25,29 @@ else
     module load PrgEnv-gnu/6.0.4
 fi
 
-module load cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12
+module load daint-gpu
+# currently loads CUDA 8.0
+module load craype-accel-nvidia60
+
+# Compile for cluster nodes
+#   (CMake likes to unwrap the Cray wrappers)
+export CC=$(which cc)
+export CXX=$(which CC)
+
+# define cray compiler target architecture
+# if not defined the linker crashed because wrong from */lib instead
+# of */lib64 are used
+export CRAY_CPU_TARGET=x86-64
 
 # Libraries ###################################################################
+module load CMake/3.10.1
+
 module load cray-mpich/7.6.0
 module load cray-hdf5-parallel/1.10.0.3
 
-# Other Software ##############################################################
-#
-
-# Environment #################################################################
+# Self-Build Software #########################################################
 #
 # needs to be compiled by the user
-export CMAKE_ROOT=$SCRATCH/lib/cmake-3.10.1
 export BOOST_ROOT=$SCRATCH/lib/boost-1.62.0
 export ZLIB_ROOT=$SCRATCH/lib/zlib-1.2.11
 export PNG_ROOT=$SCRATCH/lib/libpng-1.6.34
@@ -46,7 +56,6 @@ export PNGWRITER_ROOT=$SCRATCH/lib/pngwriter-0.7.0
 export ADIOS_ROOT=$SCRATCH/lib/adios-1.13.0
 export SPLASH_ROOT=$SCRATCH/lib/splash-1.7.0
 
-export LD_LIBRARY_PATH=$CMAKE_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$ZLIB_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$PNG_ROOT/lib:$LD_LIBRARY_PATH
@@ -55,7 +64,6 @@ export LD_LIBRARY_PATH=$PNGWRITER_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$SPLASH_ROOT/lib:$LD_LIBRARY_PATH
 
-export PATH=$CMAKE_ROOT/bin:$PATH
 export PATH=$PNG_ROOT/bin:$PATH
 export PATH=$ADIOS_ROOT/bin:$PATH
 
@@ -65,16 +73,8 @@ export CMAKE_PREFIX_PATH=$PNG_ROOT:$CMAKE_PREFIX_PATH
 export MPI_ROOT=$MPICH_DIR
 export HDF5_ROOT=$HDF5_DIR
 
-# define cray compiler target architecture
-# if not defined the linker crashed because wrong from */lib instead
-# of */lib64 are used
-export CRAY_CPU_TARGET=x86-64
-
-# Compile for cluster nodes
-#   (CMake likes to unwrap the Cray wrappers)
-export CC=$(which cc)
-export CXX=$(which CC)
-
+# Environment #################################################################
+#
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:60"


### PR DESCRIPTION
Use the proper general environments to load GPU nodes and CUDA toolkit.
With that, we can also use the new CMake 3.10+ module now :)

Boost module request is currently pending.

Note: if you are using an older `dev` version of PIConGPU or a 0.3.X release, replace the [quick start](https://gist.github.com/ax3l/68cb4caa597df3def9b01640959ea56b) gist's installs of:
- libSplash 1.7.0 with 1.6.0
- PNGwriter 0.7.0 with 0.6.0

We also learned about this Cray-CMake manual today:
http://docs.cray.com/books/S-2801-1608/S-2801-1608.pdf