### PR TITLE
remove modulo in 1D to ND index transformation

### DIFF
--- a/include/pmacc/dimensions/DataSpaceOperations.hpp
+++ b/include/pmacc/dimensions/DataSpaceOperations.hpp
@@ -149,10 +149,10 @@ namespace pmacc
         template<class TVEC>
         static HDINLINE DataSpace<DIM2> map(uint32_t pos)
         {
-            return DataSpace< DIM2 >(
-                pos % TVEC::x::value,
-                pos / TVEC::x::value
-            );
+            auto const y = pos / TVEC::x::value;
+            auto const x = pos - y * TVEC::x::value;
+
+            return DataSpace< DIM2 >( x , y );
         }
 
         template<class TVEC>
@@ -165,10 +165,10 @@ namespace pmacc
 
         static HDINLINE DataSpace<DIM2> map(const DataSpace<DIM2>& size, uint32_t pos)
         {
-            return DataSpace< DIM2 >(
-                pos % size.x(),
-                pos / size.x()
-            );
+            auto const y = pos / size.x();
+            auto const x = pos - y * size.x();
+
+            return DataSpace< DIM2 >( x , y );
         }
 
         static HDINLINE uint32_t map(const DataSpace<DIM2>& size, const DataSpace<DIM2>& pos)
@@ -266,27 +266,31 @@ namespace pmacc
         template<class TVEC>
         static HDINLINE DataSpace<DIM3> map(uint32_t pos)
         {
-            return DataSpace< DIM3 >(
-                pos                                      % TVEC::x::value,
-                pos /   TVEC::x::value                   % TVEC::y::value,
-                pos / ( TVEC::x::value * TVEC::y::value )
-            );
+            constexpr auto xyPlane = TVEC::x::value * TVEC::y::value;
+            auto const z = pos / xyPlane;
+            pos -= z * xyPlane;
+            auto const y = pos / TVEC::x::value;
+            auto const x = pos - y * TVEC::x::value;
+
+            return DataSpace< DIM3 >( x , y, z );
         }
 
         static HDINLINE DataSpace<DIM3> map(const DataSpace<DIM3>& size, uint32_t pos)
         {
-            return DataSpace< DIM3 >(
-                pos                           % size.x(),
-                pos /   size.x()              % size.y(),
-                pos / ( size.x() * size.y() )
-            );
+            auto const xyPlane = size.x() * size.y();
+            auto const z = pos / xyPlane;
+            pos -= z * xyPlane;
+            auto const y = pos / size.x();
+            auto const x = pos - y * size.x();
+
+            return DataSpace< DIM3 >( x , y, z );
         }
 
         template<class TVEC>
         static HDINLINE uint32_t map(const DataSpace<DIM3>& pos)
         {
             return
-                pos.z() * TVEC::x::value * TVEC::y::value +
+                pos.z() * ( TVEC::x::value * TVEC::y::value ) +
                 pos.y() * TVEC::x::value +
                 pos.x();
         }


### PR DESCRIPTION
remove expensive modulo operation

With this PR the expression `X % Y` cannot be changed by  the compiler into a bit shift if Y is not a power of two. Nevertheless, on my Laptop with back-end `omp2b` we get a very small (<1.02) speedup.
For CUDA, I can see that the register usage decreases for most kernels of PIConGPU.

- [x] GPU speed test
- [x] CPU speed test
- [x] 4xK20 KHI heating test