### PR TITLE
Refactor .cfg files: devices

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -39,19 +39,19 @@
 # Batch system walltime
 TBG_wallTime="1:00:00"
 
-# Number of GPUs in each dimension (x,y,z) to use for the simulation
-TBG_gpu_x=1
-TBG_gpu_y=2
-TBG_gpu_z=1
+# Number of devices in each dimension (x,y,z) to use for the simulation
+TBG_devices_x=1
+TBG_devices_y=2
+TBG_devices_z=1
 
-# Size of the simulation grid in cells as "-g X Y Z"
+# Size of the simulation grid in cells as "X Y Z"
 # note: the number of cells needs to be an exact multiple of a supercell
-#       and has to be at least 3 supercells per GPU,
+#       and has to be at least 3 supercells per device,
 #       the size of a supercell (in cells) is defined in `memory.param`
-TBG_gridSize="-g 128 256 128"
+TBG_gridSize="128 256 128"
 
-# Number of simulation steps/iterations as "-s N"
-TBG_steps="-s 100"
+# Number of simulation steps/iterations as "N"
+TBG_steps="100"
 
 
 ################################################################################
@@ -76,8 +76,8 @@ TBG_dstPath
 TBG_version="--versionOnce"
 
 
-# Regex to describe the static distribution of the cells for each GPU
-# default: equal distribution over all GPUs
+# Regex to describe the static distribution of the cells for each device
+# default: equal distribution over all devices
 # example for -d 2 4 1 -g 128 192 12
 TBG_gridDist="--gridDist '64{2}' '64,32{2},64'"
 
@@ -260,16 +260,16 @@ TBG_resourceLog="--resourceLog.period 1 --resourceLog.stream stdout
 ## variables. These should not be modified except when you know what you are doing!
 ################################################################################
 
-# Number of compute devices in each dimension as "-d X Y Z"
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+# Number of compute devices in each dimension as "X Y Z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
 
 # Combines all declared variables. These are passed to PIConGPU as command line flags.
 # The program output (stdout) is stored in a file called output.stdout.
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
                    !TBG_plugins"
 
-# Total number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# Total number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"

--- a/share/picongpu/dockerfiles/ubuntu-1604/start_lwfa.sh
+++ b/share/picongpu/dockerfiles/ubuntu-1604/start_lwfa.sh
@@ -16,7 +16,7 @@ sleep 5
 cd /opt/picInputs/lwfa
 tbg \
   -s "bash -l" \
-  -c etc/picongpu/0001gpus_isaac.cfg \
+  -c etc/picongpu/1_isaac.cfg \
   -t etc/picongpu/bash/mpirun.tpl \
   /tmp/lwfa_001
 

--- a/share/picongpu/examples/Bremsstrahlung/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/Bremsstrahlung/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Axel Huebl, Felix Schmitt
+# Copyright 2013-2018 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -17,12 +17,13 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+
 ##
 ## This configuration file is used by PIConGPU's TBG tool to create a
 ## batch script for PIConGPU runs. For a detailed description of PIConGPU
 ## configuration files including all available variables, see
 ##
-##                      docs/TBG_macros.cfg
+##                      doc/TBG_macros.cfg
 ##
 
 
@@ -30,44 +31,47 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="2:00:00"
+TBG_wallTime="8:00:00"
 
-TBG_gpu_x=4
-TBG_gpu_y=4
-TBG_gpu_z=2
+TBG_devices_x=8
+TBG_devices_y=1
+TBG_devices_z=1
 
-TBG_gridSize="-g 256 1024 256"
-TBG_steps="-s 4000"
+TBG_gridSize="2048 2048 1"
+TBG_steps="5000"
 
-# leave TBG_movingWindow empty to disable moving window
-TBG_movingWindow="-m"
+TBG_periodic="--periodic 0 0 0"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# create preview images (png)
-TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
-TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+TBG_ph_calorimeter="--ph_calorimeter.period 1000 --ph_calorimeter.openingYaw 360 --ph_calorimeter.openingPitch 180 \
+                    --ph_calorimeter.numBinsEnergy 1024 --ph_calorimeter.minEnergy 10 --ph_calorimeter.maxEnergy 10000"
 
-TBG_plugins="!TBG_pngYX                    \
-              !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 100"
+TBG_ph_energyHistogram="--ph_energyHistogram.period 1000 --ph_energyHistogram.filter all --ph_energyHistogram.minEnergy 10 --ph_energyHistogram.maxEnergy 10000"
+
+TBG_plugins="--hdf5.period 1000 --hdf5.file simData \
+             --e_macroParticlesCount.period 1000 \
+             --i_macroParticlesCount.period 1000 \
+             --ph_macroParticlesCount.period 1000 \
+             !TBG_ph_calorimeter \
+             !TBG_ph_energyHistogram"
+
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_movingWindow \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/Bunch/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/Bunch/etc/picongpu/32.cfg
@@ -33,12 +33,12 @@
 
 TBG_wallTime="72:00:00"
 
-TBG_gpu_x=2
-TBG_gpu_y=8
-TBG_gpu_z=2
+TBG_devices_x=2
+TBG_devices_y=8
+TBG_devices_z=2
 
-TBG_gridSize="-g 128 3072 128"
-TBG_steps="-s 7500"
+TBG_gridSize="128 3072 128"
+TBG_steps="7500"
 
 TBG_periodic="--periodic 1 0 1"
 
@@ -64,16 +64,16 @@ TBG_plugins="!TBG_eBin                     \
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/Empty/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/Empty/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
+# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #
@@ -17,13 +17,12 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 ##
 ## This configuration file is used by PIConGPU's TBG tool to create a
 ## batch script for PIConGPU runs. For a detailed description of PIConGPU
 ## configuration files including all available variables, see
 ##
-##                      doc/TBG_macros.cfg
+##                      docs/TBG_macros.cfg
 ##
 
 
@@ -31,47 +30,39 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="8:00:00"
+TBG_wallTime="2:00:00"
 
-TBG_gpu_x=8
-TBG_gpu_y=1
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
 
-TBG_gridSize="-g 2048 2048 1"
-TBG_steps="-s 5000"
-
-TBG_periodic="--periodic 0 0 0"
+TBG_gridSize="128 256 128"
+TBG_steps="1000"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-TBG_ph_calorimeter="--ph_calorimeter.period 1000 --ph_calorimeter.openingYaw 360 --ph_calorimeter.openingPitch 180 \
-                    --ph_calorimeter.numBinsEnergy 1024 --ph_calorimeter.minEnergy 10 --ph_calorimeter.maxEnergy 10000"
+# Create a particle-energy histogram [in keV] for species "e" for every 100 steps
+TBG_e_histogram="--e_energyHistogram.period 100 --e_energyHistogram.filter all  --e_energyHistogram.binCount 1024    \
+                 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 500000"
 
-TBG_ph_energyHistogram="--ph_energyHistogram.period 1000 --ph_energyHistogram.filter all --ph_energyHistogram.minEnergy 10 --ph_energyHistogram.maxEnergy 10000"
-
-TBG_plugins="--hdf5.period 1000 --hdf5.file simData \
-             --e_macroParticlesCount.period 1000 \
-             --i_macroParticlesCount.period 1000 \
-             --ph_macroParticlesCount.period 1000 \
-             !TBG_ph_calorimeter \
-             !TBG_ph_energyHistogram"
+TBG_plugins="!TBG_e_histogram"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
@@ -32,12 +32,12 @@
 
 TBG_wallTime="2:00:00"
 
-TBG_gpu_x=2
-TBG_gpu_y=2
-TBG_gpu_z=1
+TBG_devices_x=2
+TBG_devices_y=2
+TBG_devices_z=1
 
-TBG_gridSize="-g 256 1280"
-TBG_steps="-s 5000"
+TBG_gridSize="256 1280"
+TBG_steps="5000"
 
 TBG_periodic="--periodic 1 0"
 
@@ -82,16 +82,16 @@ TBG_plugins="!TBG_e_histogram !TBG_H_histogram !TBG_C_histogram !TBG_N_histogram
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_periodic     \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/16.cfg
@@ -32,12 +32,12 @@
 
 TBG_wallTime="23:53:00"
 
-TBG_gpu_x=2
-TBG_gpu_y=8
-TBG_gpu_z=1
+TBG_devices_x=2
+TBG_devices_y=8
+TBG_devices_z=1
 
-TBG_gridSize="-g 192 512 12"
-TBG_steps="-s 2000"
+TBG_gridSize="192 512 12"
+TBG_steps="2000"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -75,16 +75,16 @@ TBG_plugins="!TBG_ipngYZ                   \
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Rene Widera, Axel Huebl
+# Copyright 2013-2018 Rene Widera, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -22,7 +22,7 @@
 ## batch script for PIConGPU runs. For a detailed description of PIConGPU
 ## configuration files including all available variables, see
 ##
-##                      docs/TBG_macros.cfg
+##                 docs/TBG_macros.cfg.
 ##
 
 
@@ -32,12 +32,12 @@
 
 TBG_wallTime="23:53:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=4
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=4
+TBG_devices_z=1
 
-TBG_gridSize="-g 192 512 12"
-TBG_steps="-s 2500"
+TBG_gridSize="192 512 12"
+TBG_steps="2000"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -48,15 +48,12 @@ TBG_periodic="--periodic 1 1 1"
 TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
 TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
-TBG_ipngYZ="--i_png.period 10 --i_png.axis yz --i_png.slicePoint 0.5 --i_png.folder pngIonsYZ"
 TBG_ipngYX="--i_png.period 10 --i_png.axis yx --i_png.slicePoint 0.5 --i_png.folder pngIonsYX"
 
-# [in keV]
 TBG_eBin="--e_energyHistogram.period 100 --e_energyHistogram.filter all --e_energyHistogram.binCount 1024 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 5000"
 TBG_iBin="--i_energyHistogram.period 100 --i_energyHistogram.filter all --i_energyHistogram.binCount 1024 --i_energyHistogram.minEnergy 0 --i_energyHistogram.maxEnergy 2000000"
 
 TBG_plugins="!TBG_ipngYX                   \
-              !TBG_ipngYZ                   \
               !TBG_eBin                     \
               !TBG_iBin                     \
               !TBG_pngYX                    \
@@ -72,16 +69,16 @@ TBG_plugins="!TBG_ipngYX                   \
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
@@ -30,46 +30,39 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="2:00:00"
+TBG_wallTime="1:00:00"
 
-TBG_gpu_x=2
-TBG_gpu_y=4
-TBG_gpu_z=2
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
 
-TBG_gridSize="-g 192 1024 192"
-TBG_steps="-s 4000"
-
-# leave TBG_movingWindow empty to disable moving window
-TBG_movingWindow="-m"
-
+TBG_gridSize="128 256 128"
+TBG_steps="1024"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# create preview images (png)
-TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
-TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+# png image output (electron density)
+TBG_pngYX="--e_png.period 64 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
 TBG_plugins="!TBG_pngYX                    \
-              !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 100"
+             --e_macroParticlesCount.period 100"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_movingWindow \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/16.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #
@@ -30,25 +30,29 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="1:00:00"
+TBG_wallTime="2:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=1
+TBG_devices_x=2
+TBG_devices_y=4
+TBG_devices_z=2
 
-TBG_gridSize="-g 64 64 32"
-TBG_steps="-s 100"
+TBG_gridSize="192 1024 192"
+TBG_steps="4000"
 
-TBG_periodic="--periodic 1 1 1"
+# leave TBG_movingWindow empty to disable moving window
+TBG_movingWindow="-m"
+
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# write position to stdout (messy):
-# --e_position.period 1
+# create preview images (png)
+TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
+TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
-TBG_plugins="--hdf5.period 1 --hdf5.file simData \
+TBG_plugins="!TBG_pngYX                    \
+             !TBG_pngYZ                    \
              --e_macroParticlesCount.period 100"
 
 
@@ -56,16 +60,16 @@ TBG_plugins="--hdf5.period 1 --hdf5.file simData \
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_movingWindow  \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1_isaac.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #
@@ -30,44 +30,41 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="24:00:00"
+TBG_wallTime="1:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
 
-TBG_gridSize="-g 128 128 128"
-TBG_steps="-s 1600"
+TBG_gridSize="192 1024 12"
+TBG_steps="2048"
 
-TBG_periodic="--periodic 1 1 1"
+TBG_periodic="--periodic 0 0 1"
+TBG_restartLoop="--checkpoint.restart.loop 10000"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# create preview images (png)
-TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
-TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+TBG_isaac="--isaac.period 1"
 
-TBG_plugins="!TBG_pngYX                    \
-              !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 250"
-
+TBG_plugins="!TBG_isaac"
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic     \
+                   !TBG_restartLoop  \
+                   !TBG_plugins      \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/32.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Axel Huebl
+# Copyright 2013-2018 Axel Huebl, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #
@@ -22,7 +22,7 @@
 ## batch script for PIConGPU runs. For a detailed description of PIConGPU
 ## configuration files including all available variables, see
 ##
-##                      doc/TBG_macros.cfg
+##                      docs/TBG_macros.cfg
 ##
 
 
@@ -32,45 +32,42 @@
 
 TBG_wallTime="2:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=1
+TBG_devices_x=4
+TBG_devices_y=4
+TBG_devices_z=2
 
-TBG_gridSize="-g 32 32 32"
-TBG_steps="-s 1000"
-TBG_period="--periodic 1 1 1"
+TBG_gridSize="256 1024 256"
+TBG_steps="4000"
+
+# leave TBG_movingWindow empty to disable moving window
+TBG_movingWindow="-m"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# Create a particle-energy histogram [in keV] for e- species every 100 steps
-TBG_eth_histogram="--eth_energyHistogram.period 100 --eth_energyHistogram.filter all --eth_energyHistogram.binCount 1024       \
-                   --eth_energyHistogram.minEnergy 0 --eth_energyHistogram.maxEnergy 5"
-TBG_ehot_histogram="--ehot_energyHistogram.period 100 --ehot_energyHistogram.filter all --ehot_energyHistogram.binCount 1024    \
-                    --ehot_energyHistogram.minEnergy 0 --ehot_energyHistogram.maxEnergy 250"
+# create preview images (png)
+TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
+TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
-# file I/O
-TBG_hdf5="--hdf5.period 100 --hdf5.file simData"
-
-TBG_plugins="!TBG_eth_histogram !TBG_ehot_histogram \
-             !TBG_hdf5"
-
+TBG_plugins="!TBG_pngYX                    \
+              !TBG_pngYZ                    \
+              --e_macroParticlesCount.period 100"
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_period       \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_movingWindow  \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4_gui.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4_gui.cfg
@@ -32,9 +32,9 @@
 
 TBG_wallTime="1:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=4
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=4
+TBG_devices_z=1
 
 TBG_gridSize="128 2048 128"
 TBG_steps="10000"
@@ -71,16 +71,16 @@ TBG_plugins="!TBG_pngYX                    \
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="!TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="-d !TBG_devices   \
-                   -g !TBG_gridSize  \
-                   -s !TBG_steps     \
-                   !TBG_movingWindow \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_movingWindow  \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt,
+#                     Richard Pausch
 #
 # This file is part of PIConGPU.
 #
@@ -30,41 +31,44 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="1:00:00"
+TBG_wallTime="2:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=1
+TBG_devices_x=2
+TBG_devices_y=4
+TBG_devices_z=1
 
-TBG_gridSize="-g 192 1024 12"
-TBG_steps="-s 2048"
+TBG_gridSize="192 1024 192"
+TBG_steps="4000"
 
-TBG_periodic="--periodic 0 0 1"
-TBG_restartLoop="--checkpoint.restart.loop 10000"
+# leave TBG_movingWindow empty to disable moving window
+TBG_movingWindow="-m"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-TBG_isaac="--isaac.period 1"
+TBG_pngYZ="--e_png.period 32 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
+TBG_pngYX="--e_png.period 32 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
-TBG_plugins="!TBG_isaac"
+TBG_plugins="!TBG_pngYX                    \
+              !TBG_pngYZ                    \
+              --e_macroParticlesCount.period 100"
+
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_periodic     \
-                   !TBG_restartLoop \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_movingWindow  \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2018 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -32,21 +32,23 @@
 
 TBG_wallTime="1:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
 
-TBG_gridSize="-g 128 256 128"
-TBG_steps="-s 1024"
+TBG_gridSize="64 64 32"
+TBG_steps="100"
+
+TBG_periodic="--periodic 1 1 1"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# png image output (electron density)
-TBG_pngYX="--e_png.period 64 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+# write position to stdout (messy):
+# --e_position.period 1
 
-TBG_plugins="!TBG_pngYX                    \
+TBG_plugins="--hdf5.period 1 --hdf5.file simData \
              --e_macroParticlesCount.period 100"
 
 
@@ -54,15 +56,16 @@ TBG_plugins="!TBG_pngYX                    \
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #
@@ -30,39 +30,44 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="2:00:00"
+TBG_wallTime="24:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
 
-TBG_gridSize="-g 128 256 128"
-TBG_steps="-s 1000"
+TBG_gridSize="128 128 128"
+TBG_steps="1600"
+
+TBG_periodic="--periodic 1 1 1"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# Create a particle-energy histogram [in keV] for species "e" for every 100 steps
-TBG_e_histogram="--e_energyHistogram.period 100 --e_energyHistogram.filter all  --e_energyHistogram.binCount 1024    \
-                 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 500000"
+# create preview images (png)
+TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
+TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
-TBG_plugins="!TBG_e_histogram"
+TBG_plugins="!TBG_pngYX                    \
+              !TBG_pngYZ                    \
+              --e_macroParticlesCount.period 250"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/32.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2018 Heiko Burau, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -32,12 +32,12 @@
 
 TBG_wallTime="24:00:00"
 
-TBG_gpu_x=4
-TBG_gpu_y=4
-TBG_gpu_z=4
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=32
 
-TBG_gridSize="-g 512 512 512"
-TBG_steps="-s 1600"
+TBG_gridSize="512 512 512"
+TBG_steps="1600"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -50,24 +50,24 @@ TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.fold
 TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
 TBG_plugins="!TBG_pngYX                    \
-              !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 250"
+             !TBG_pngYZ                    \
+             --e_macroParticlesCount.period 250"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/4.cfg
@@ -30,14 +30,14 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="24:00:00"
+TBG_wallTime="4:00:00"
 
-TBG_gpu_x=2
-TBG_gpu_y=2
-TBG_gpu_z=2
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=4
 
-TBG_gridSize="-g 512 512 512"
-TBG_steps="-s 1600"
+TBG_gridSize="128 128 128"
+TBG_steps="1600"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -50,24 +50,24 @@ TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.fold
 TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
 TBG_plugins="!TBG_pngYX                    \
-              !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 100"
+             !TBG_pngYZ                    \
+             --e_macroParticlesCount.period 100"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/64.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/64.cfg
@@ -30,14 +30,14 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="4:00:00"
+TBG_wallTime="24:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=4
+TBG_devices_x=4
+TBG_devices_y=4
+TBG_devices_z=4
 
-TBG_gridSize="-g 128 128 128"
-TBG_steps="-s 1600"
+TBG_gridSize="512 512 512"
+TBG_steps="1600"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -51,23 +51,23 @@ TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.fold
 
 TBG_plugins="!TBG_pngYX                    \
               !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 100"
+              --e_macroParticlesCount.period 250"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Heiko Burau, Felix Schmitt, Axel Huebl
+# Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #
@@ -32,12 +32,12 @@
 
 TBG_wallTime="24:00:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=1
-TBG_gpu_z=32
+TBG_devices_x=2
+TBG_devices_y=2
+TBG_devices_z=2
 
-TBG_gridSize="-g 512 512 512"
-TBG_steps="-s 1600"
+TBG_gridSize="512 512 512"
+TBG_steps="1600"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -51,23 +51,23 @@ TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.fold
 
 TBG_plugins="!TBG_pngYX                    \
               !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 250"
+              --e_macroParticlesCount.period 100"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/WarmCopper/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/WarmCopper/etc/picongpu/1.cfg
@@ -1,5 +1,4 @@
-# Copyright 2013-2018 Axel Huebl, Rene Widera, Felix Schmitt,
-#                     Richard Pausch
+# Copyright 2013-2018 Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -23,7 +22,7 @@
 ## batch script for PIConGPU runs. For a detailed description of PIConGPU
 ## configuration files including all available variables, see
 ##
-##                      docs/TBG_macros.cfg
+##                      doc/TBG_macros.cfg
 ##
 
 
@@ -33,42 +32,45 @@
 
 TBG_wallTime="2:00:00"
 
-TBG_gpu_x=2
-TBG_gpu_y=4
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
 
-TBG_gridSize="-g 192 1024 192"
-TBG_steps="-s 4000"
-
-# leave TBG_movingWindow empty to disable moving window
-TBG_movingWindow="-m"
+TBG_gridSize="32 32 32"
+TBG_steps="1000"
+TBG_period="--periodic 1 1 1"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-TBG_pngYZ="--e_png.period 32 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
-TBG_pngYX="--e_png.period 32 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+# Create a particle-energy histogram [in keV] for e- species every 100 steps
+TBG_eth_histogram="--eth_energyHistogram.period 100 --eth_energyHistogram.filter all --eth_energyHistogram.binCount 1024       \
+                   --eth_energyHistogram.minEnergy 0 --eth_energyHistogram.maxEnergy 5"
+TBG_ehot_histogram="--ehot_energyHistogram.period 100 --ehot_energyHistogram.filter all --ehot_energyHistogram.binCount 1024    \
+                    --ehot_energyHistogram.minEnergy 0 --ehot_energyHistogram.maxEnergy 250"
 
-TBG_plugins="!TBG_pngYX                    \
-              !TBG_pngYZ                    \
-              --e_macroParticlesCount.period 100"
+# file I/O
+TBG_hdf5="--hdf5.period 100 --hdf5.file simData"
+
+TBG_plugins="!TBG_eth_histogram !TBG_ehot_histogram \
+             !TBG_hdf5"
 
 
 #################################
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices      \
-                   !TBG_gridSize     \
-                   !TBG_steps        \
-                   !TBG_movingWindow \
-                   !TBG_plugins      \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_period        \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/WeibelTransverse/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/WeibelTransverse/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2018 Rene Widera, Axel Huebl
 #
 # This file is part of PIConGPU.
 #
@@ -22,7 +22,7 @@
 ## batch script for PIConGPU runs. For a detailed description of PIConGPU
 ## configuration files including all available variables, see
 ##
-##                 docs/TBG_macros.cfg.
+##                      docs/TBG_macros.cfg
 ##
 
 
@@ -32,12 +32,12 @@
 
 TBG_wallTime="23:53:00"
 
-TBG_gpu_x=1
-TBG_gpu_y=4
-TBG_gpu_z=1
+TBG_devices_x=1
+TBG_devices_y=4
+TBG_devices_z=1
 
-TBG_gridSize="-g 192 512 12"
-TBG_steps="-s 2000"
+TBG_gridSize="192 512 12"
+TBG_steps="2500"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -48,12 +48,15 @@ TBG_periodic="--periodic 1 1 1"
 TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
 TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
 
+TBG_ipngYZ="--i_png.period 10 --i_png.axis yz --i_png.slicePoint 0.5 --i_png.folder pngIonsYZ"
 TBG_ipngYX="--i_png.period 10 --i_png.axis yx --i_png.slicePoint 0.5 --i_png.folder pngIonsYX"
 
+# [in keV]
 TBG_eBin="--e_energyHistogram.period 100 --e_energyHistogram.filter all --e_energyHistogram.binCount 1024 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 5000"
 TBG_iBin="--i_energyHistogram.period 100 --i_energyHistogram.filter all --i_energyHistogram.binCount 1024 --i_energyHistogram.minEnergy 0 --i_energyHistogram.maxEnergy 2000000"
 
 TBG_plugins="!TBG_ipngYX                   \
+              !TBG_ipngYZ                   \
               !TBG_eBin                     \
               !TBG_iBin                     \
               !TBG_pngYX                    \
@@ -69,16 +72,16 @@ TBG_plugins="!TBG_ipngYX                   \
 ## Section: Program Parameters ##
 #################################
 
-TBG_devices="-d !TBG_gpu_x !TBG_gpu_y !TBG_gpu_z"
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_devices     \
-                   !TBG_gridSize    \
-                   !TBG_steps       \
-                   !TBG_periodic    \
-                   !TBG_plugins     \
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
                    --versionOnce"
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y * TBG_gpu_z ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 
 "$TBG_cfgPath"/submitAction.sh

--- a/share/pmacc/examples/gameOfLife2D/submit/1.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/1.cfg
@@ -28,13 +28,13 @@
 # TBG_dstPath
 
 
-TBG_gpu_x=2
-TBG_gpu_y=1
+TBG_devices_x=1
+TBG_devices_y=1
 
 
-TBG_programParams="-g 256 256 -s 200 --periodic 1 1  -r 23/3"
+TBG_programParams="-d !TBG_devices_x !TBG_devices_y -g 256 256 -s 200 --periodic 1 1  -r 23/3"
 
-TBG_PROGRAM="./gameOfLife -d !TBG_gpu_x !TBG_gpu_y !TBG_programParams"
+TBG_PROGRAM="./gameOfLife !TBG_programParams"
 
 ## copy binary and submit folder to destination folder
 cd $TBG_dstPath
@@ -42,5 +42,5 @@ cp -r $TBG_projectPath/bin .
 cp -r $TBG_projectPath/submit .
 
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y ))"

--- a/share/pmacc/examples/gameOfLife2D/submit/2.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/2.cfg
@@ -28,13 +28,13 @@
 # TBG_dstPath
 
 
-TBG_gpu_x=2
-TBG_gpu_y=2
+TBG_devices_x=2
+TBG_devices_y=1
 
 
-TBG_programParams="-d !TBG_gpu_x !TBG_gpu_y -g 256 256 -s 200 --periodic 1 1  -r 23/3"
+TBG_programParams="-g 256 256 -s 200 --periodic 1 1  -r 23/3"
 
-TBG_PROGRAM="./gameOfLife !TBG_programParams"
+TBG_PROGRAM="./gameOfLife -d !TBG_devices_x !TBG_devices_y !TBG_programParams"
 
 ## copy binary and submit folder to destination folder
 cd $TBG_dstPath
@@ -42,5 +42,5 @@ cp -r $TBG_projectPath/bin .
 cp -r $TBG_projectPath/submit .
 
 
-# TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y ))"
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y ))"

--- a/share/pmacc/examples/gameOfLife2D/submit/4.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/4.cfg
@@ -28,11 +28,11 @@
 # TBG_dstPath
 
 
-TBG_gpu_x=1
-TBG_gpu_y=1
+TBG_devices_x=2
+TBG_devices_y=2
 
 
-TBG_programParams="-d !TBG_gpu_x !TBG_gpu_y -g 256 256 -s 200 --periodic 1 1  -r 23/3"
+TBG_programParams="-d !TBG_devices_x !TBG_devices_y -g 256 256 -s 200 --periodic 1 1  -r 23/3"
 
 TBG_PROGRAM="./gameOfLife !TBG_programParams"
 
@@ -43,4 +43,4 @@ cp -r $TBG_projectPath/submit .
 
 
 # TOTAL number of GPUs
-TBG_tasks="$(( TBG_gpu_x * TBG_gpu_y ))"
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y ))"


### PR DESCRIPTION
Removes the naming of "GPUs" from `.cfg` file names and variables and uses (as `-d|--devices`) the more general *device* naming.

Changes the composition of required parameters `-d`, `-g` and `-s` in order to allow easier editing with the python bindings.