### PR TITLE
DGX Docker

### DIFF
--- a/etc/picongpu/bash/mpiexec.tpl
+++ b/etc/picongpu/bash/mpiexec.tpl
@@ -24,8 +24,8 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
+# 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi)
 
 ## end calculations ##
 

--- a/etc/picongpu/bash/mpirun.tpl
+++ b/etc/picongpu/bash/mpirun.tpl
@@ -24,8 +24,8 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi)
+# 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi)
 
 ## end calculations ##
 

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -73,7 +73,7 @@ RUN        /bin/echo -e "source $SPACK_ROOT/share/spack/setup-env.sh\n" \
 RUN        /bin/bash -l -c ' \
                pic-create $PICSRC/share/picongpu/examples/LaserWakefield /opt/picInputs/lwfa && \
                cd /opt/picInputs/lwfa && \
-               pic-build -b "cuda:30;35;37;50;60" && \
+               pic-build -b "cuda:30;35;37;50;60" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
                rm -rf .build'
 
 COPY       start_lwfa.sh /usr/bin/lwfa

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -61,7 +61,12 @@ RUN        /bin/echo -e "source $SPACK_ROOT/share/spack/setup-env.sh\n" \
                         "spack load $PIC_PACKAGE\n" \
                         'if [ $(id -u) -eq 0 ]; then\n' \
                         '   function mpirun { $(which mpirun) --allow-run-as-root $@; }\n' \
-                        'fi' \
+                        'fi\n' \
+                        'export -f mpirun\n' \
+                        'if [ $(id -u) -eq 0 ]; then\n' \
+                        '   function mpiexec { $(which mpiexec) --allow-run-as-root $@; }\n' \
+                        'fi\n' \
+                        'export -f mpiexec\n' \
                > /etc/profile.d/picongpu.sh
 
 # build example for out-of-the-box usage: LWFA


### PR DESCRIPTION
Contains two bug fixes for running a container smoothly on DGX-1.

- TBG bash template: support up to 8 GPUs per node

Usually, one would do one-node runs with those anyway or would need to adjust it by hand of multi-node is desired. With this setting, using a full 8-GPU DGX-1 node is possible without hacks.

- OpenMPI root execution fix and mpiexec as well

Make the root work-around more robust via an export (`export -f mpi...`) and include mpiexec as well.


Also does not not build cuda_memtest on containers anymore since it wastes time on startup for demos.