### PR TITLE
cupla: no .gitmodules

### DIFF
--- a/thirdParty/cupla/.gitmodules
+++ b/thirdParty/cupla/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "alpaka"]
-	path = alpaka
-	url = git://github.com/ComputationalRadiationPhysics/alpaka.git
-	branch = develop


### PR DESCRIPTION
Remove the .gitmodules file from cupla.  We ship alpaka ourselves and it can confuse git clone steps to have it in there.

First seen as an issue with ReadTheDocs builds (activated by default [since November last year](https://github.com/rtfd/readthedocs-build/issues/30)).