### PR TITLE
Simpler Python Parameter class

### DIFF
--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -28,7 +28,6 @@ class Parameter(object):
     user adjusts time in nanoseconds but internally the precise number is
     needed (--> linear conversion)
     )
-
     Also the kind of widget representation should depend on the attributes of
     this class. Either as MultiRangeSlider or as MultiSelection or as Checkbox
     depending on the 'values' (discrete) or 'range' (continuous)
@@ -57,9 +56,11 @@ class Parameter(object):
             The default value for this parameter (on the UI scale) used when\
             no 'values' or 'range' parameter is passed.
         values: list
-            list of discrete options for the parameter as shown on UI side
+            list of discrete options for the parameter as shown on UI side.
+            Only one of the attributes range/value can be given.
         range: tuple
-            start and stop value for the selectable range on UI side
+            start and stop value for the selectable range on UI side.
+            Only one of the attributes range/value can be given.
         label: string [optional]
             Overwrite the name for UI
         pic_to_SI: callable, e.g. lambda function
@@ -102,7 +103,17 @@ class Parameter(object):
 
     def _check_input(self, vals):
         """
-        Assumes vals are in UI units, i.e. with unit = self.unit
+        For values that are assumed to be on the UI scale (i.e. with unit =
+        self.unit), checks whether they are in the allowed range or the
+        allowed discrete values.
+        Raises a ValueError if a value value outside the range is detected.
+
+        Parameters
+        ----------
+        vals: float or list of floats
+            values on the parameters UI scale which will be checked.
+
+
         """
         if self.values is not None:
             # check for valid values
@@ -122,6 +133,18 @@ class Parameter(object):
         """
         Takes values in UI units, converts them to SI and after that
         to quantities used within PIConGPU.
+
+        Parameters
+        ----------
+        vals: float or list of floats
+            values that will be converted to the PIC scale
+        check_vals: bool
+            Flag to decide whether given values are within the allowed
+            range for this parameters UI scale.
+
+        Returns
+        -------
+        A list of converted values.
         """
         # todo check if vals are in specified range
         if check_vals:
@@ -134,6 +157,19 @@ class Parameter(object):
         """
         Takes PIC values and returns values on UI scale after converting to SI
         values as intermediate step.
+
+        Parameters
+        ----------
+        vals: float or list of floats
+            values that will be converted to the UI scale.
+
+        check_vals: bool
+            Flag to decide whether converted values are within the allowed
+            range for this parameters UI scale.
+
+        Returns
+        -------
+        A list of converted values.
         """
         # v is given in PIC quantity, so we convert to UI unit
         ui_results = [

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -14,7 +14,7 @@ class Parameter(object):
     """
     Parameter that can have a corresponding representation as a jupyter widget
     within interactive jupyter notebooks.
-    The widget allows the user to adjust values as he likes but this class
+    The widget allows the user to adjust values as he/she likes but this class
     controls the true value that will be passed to PIConGPU. This is necessary
     since possibly internal values (the pic-scale) and the scale presented in
     the UI might differ
@@ -32,8 +32,7 @@ class Parameter(object):
     this class. Either as MultiRangeSlider or as MultiSelection or as Checkbox
     depending on the 'values' (discrete) or 'range' (continuous)
 
-    Stepsizes will be handled by the widget representation, not here.q
-
+    Stepsizes will be handled by the widget representation, not here.
     """
 
     def __init__(self, name, ptype, unit, default,
@@ -53,7 +52,7 @@ class Parameter(object):
             Implicitely we assume the pic unit is SI. If this is not possible,
             the converter needs to translate those scales.
         default: float, int or string
-            The default value for this parameter (on the UI scale) used when\
+            The default value for this parameter (on the UI scale) used when
             no 'values' or 'range' parameter is passed.
         values: list
             list of discrete options for the parameter as shown on UI side.
@@ -64,7 +63,7 @@ class Parameter(object):
         label: string [optional]
             Overwrite the name for UI
         pic_to_SI: callable, e.g. lambda function
-            Specifies how to transform a value on the pic scale to an\
+            Specifies how to transform a value on the pic scale to an
             appropriate SI value. Usually given via a Converter object.
         pic_from_SI: callable, e.g. lambda function
             Specifies how to transform an SI value to the internal pic scale.
@@ -94,8 +93,8 @@ class Parameter(object):
                 self.values = [values]
             if not self.values:
                 self.values = [self.default]
-                print("WARNING: Values attribute can not be an empty\
-                    iterable! Settting values to", self.values)
+                print("WARNING: Values attribute can not be an empty "
+                      "iterable! Setting values to", self.values)
 
         if range is not None:
             if len(range) != 2:
@@ -117,22 +116,20 @@ class Parameter(object):
         ----------
         vals: float or list of floats
             values on the parameters UI scale which will be checked.
-
-
         """
         if self.values is not None:
             # check for valid values
             res = all([v in self.values for v in vals])
             if not res:
                 raise ValueError(
-                    "Invalid values found! Values should be elements of\
-                     self.values!")
+                    "Invalid values found! Values should be elements of "
+                    "self.values!")
         else:
             # check for valid range
             res = all([self.range[0] <= v <= self.range[1] for v in vals])
             if not res:
-                raise ValueError("Invalid values found! Values should be\
-                contained in self.range!")
+                raise ValueError("Invalid values found! Values should be "
+                                 "contained in self.range!")
 
     def convert_to_PIC(self, vals, check_vals=True):
         """
@@ -151,7 +148,6 @@ class Parameter(object):
         -------
         A list of converted values.
         """
-        # todo check if vals are in specified range
         if check_vals:
             self._check_input(vals)
 

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -92,6 +92,10 @@ class Parameter(object):
         if values is not None:
             if not isinstance(values, collections.Iterable):
                 self.values = [values]
+            if not self.values:
+                raise ValueError("Values attribute can not be an empty\
+                    iterable!")
+
         if range is not None:
             if len(range) != 2:
                 raise ValueError("Range needs to be a tuple of length 2!")

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -38,7 +38,7 @@ class Parameter(object):
     """
 
     def __init__(self, name, ptype, unit, default,
-                 values=None, range=None, ,
+                 values=None, range=None,
                  label=None, pic_to_SI=lambda x: x,
                  pic_from_SI=lambda x: x):
         """
@@ -144,15 +144,6 @@ class Parameter(object):
             self._check_input(ui_results)
         return ui_results
 
-    def macro_name(self):
-        """
-        Returns
-        -------
-        A string containing the objects name as it will be used within cmake
-        defines and cpp headers.
-        """
-        return "PARAM_" + self.name.upper()
-
     def dict_name(self):
         """
         Returns
@@ -168,4 +159,4 @@ class Parameter(object):
         A new Parameter object with the same name, type and unit but whose
         value is set to the default value.
         """
-        return UiParameter(self.name, self.type, self.unit, self.default)
+        return Parameter(self.name, self.type, self.unit, self.default)

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -32,7 +32,7 @@ class Parameter(object):
     this class. Either as MultiRangeSlider or as MultiSelection or as Checkbox
     depending on the 'values' (discrete) or 'range' (continuous)
 
-    Stepsizes will be handled by the widget representation, not here.
+    Stepping will be handled by the widget representation, not here.
     """
 
     def __init__(self, name, ptype, unit, default,

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -5,17 +5,42 @@ Copyright 2017-2018 PIConGPU contributors
 Authors: Sebastian Starke, Jeffrey Kelling
 License: GPLv3+
 """
-
-import numpy as np
-import inspect
+import collections
+import pint
+ureg = pint.UnitRegistry()
 
 
 class Parameter(object):
     """
-    Base class for exposable parameters.
+    Parameter that can have a corresponding representation as a jupyter widget
+    within interactive jupyter notebooks.
+    The widget allows the user to adjust values as he likes but this class
+    controls the true value that will be passed to PIConGPU. This is necessary
+    since possibly internal values (the pic-scale) and the scale presented in
+    the UI might differ
+    (e.g.
+    user adjusts simulation time which is internally handled as discrete steps
+        (--> continuous to discrete conversion)
+    or
+    user adjusts the exponent of magnitude of particles but internally the
+    precise number is needed (--> log scale conversion)
+    or
+    user adjusts time in nanoseconds but internally the precise number is
+    needed (--> linear conversion)
+    )
+
+    Also the kind of widget representation should depend on the attributes of
+    this class. Either as MultiRangeSlider or as MultiSelection or as Checkbox
+    depending on the 'values' (discrete) or 'range' (continuous)
+
+    Stepsizes will be handled by the widget representation, not here.q
+
     """
 
-    def __init__(self, name, ptype, unit, default, value=None, dtype=None):
+    def __init__(self, name, ptype, unit, default,
+                 values=None, range=None, ,
+                 label=None, pic_to_SI=lambda x: x,
+                 pic_from_SI=lambda x: x):
         """
         Parameters
         ----------
@@ -25,55 +50,99 @@ class Parameter(object):
             The type of parameter object, should be one of 'compile' or 'run'
             to mark parameter as PIConGPU run/compile-time parameter
         unit: string
-            The measurement unit of this parameter
-        default: float
-            The default value for this parameter used when no 'value' parameter
-            is passed.
-        value: float (optional)
-            The value of the parameter object. If it is not provided, the value
-            of the 'default' argument is used.
-        dtype: type (optional)
-            The data type of the parameter value. If it is not provided, the
-            type of the 'default' argument is used.
+            The measurement unit of this parameter as shown on the UI side.
+            Implicitely we assume the pic unit is SI. If this is not possible,
+            the converter needs to translate those scales.
+        default: float, int or string
+            The default value for this parameter (on the UI scale) used when\
+            no 'values' or 'range' parameter is passed.
+        values: list
+            list of discrete options for the parameter as shown on UI side
+        range: tuple
+            start and stop value for the selectable range on UI side
+        label: string [optional]
+            Overwrite the name for UI
+        pic_to_SI: callable, e.g. lambda function
+            Specifies how to transform a value on the pic scale to an\
+            appropriate SI value. Usually given via a Converter object.
+        pic_from_SI: callable, e.g. lambda function
+            Specifies how to transform an SI value to the internal pic scale.
         """
+
         self.name = name
         self.type = ptype
-        self.unit = unit
+        self.unit = ureg.parse_units(unit)
+        self.base_unit = ureg.get_base_units(self.unit)[1]
         self.default = default
 
-        self.dtype = dtype if dtype is not None else type(default)
-        # use the dtype to cast the value to the correct type
-        self.value = self.dtype(
-            value) if value is not None else self.dtype(default)
+        # for slider widget creation
+        self.label = label or name
 
-    def as_dict(self):
+        self.values = values
+        self.range = range
+        # either set range or values
+        if values is not None and range is not None:
+            raise ValueError("Can only set either 'values' or 'range'!")
+        if values is None and range is None:
+            # raise ValueError("Need either 'values' or 'range' parameter!")
+            self.values = [self.default]
+            print("WARNING: Neither 'values' nor 'range' was given, setting"
+                  " 'values' to ", self.values)
+        if values is not None:
+            if not isinstance(values, collections.Iterable):
+                self.values = [values]
+        if range is not None:
+            if len(range) != 2:
+                raise ValueError("Range needs to be a tuple of length 2!")
+            else:
+                self.range = tuple(range)
+
+        self.pic_to_SI = pic_to_SI
+        self.pic_from_SI = pic_from_SI
+
+    def _check_input(self, vals):
         """
-        Convert Parameter object into a plain dictionary
-
-        Returns
-        --------
-        A dictionary with the member variables as (key, value) pairs.
+        Assumes vals are in UI units, i.e. with unit = self.unit
         """
-        d = dict(
-            cls=type(self).__name__,
-            name=self.name,
-            type=self.type,
-            unit=self.unit,
-            default=self.default,
-            value=self.value,
-            dtype=self.dtype.__name__)
+        if self.values is not None:
+            # check for valid values
+            res = all([v in self.values for v in vals])
+            if not res:
+                raise ValueError(
+                    "Invalid values found! Values should be elements of\
+                     self.values!")
+        else:
+            # check for valid range
+            res = all([self.range[0] <= v <= self.range[1] for v in vals])
+            if not res:
+                raise ValueError("Invalid values found! Values should be\
+                contained in self.range!")
 
-        return d
-
-    def __str__(self):
+    def convert_to_PIC(self, vals, check_vals=True):
         """
-        Enable use of print() function with Parameter objects.
-
-        Returns
-        -------
-        A string representation of the Parameter objects member values.
+        Takes values in UI units, converts them to SI and after that
+        to quantities used within PIConGPU.
         """
-        return self.as_dict().__str__()
+        # todo check if vals are in specified range
+        if check_vals:
+            self._check_input(vals)
+
+        return [self.pic_from_SI(
+            (v * self.unit).to_base_units().magnitude) for v in vals]
+
+    def convert_from_PIC(self, vals, check_vals=True):
+        """
+        Takes PIC values and returns values on UI scale after converting to SI
+        values as intermediate step.
+        """
+        # v is given in PIC quantity, so we convert to UI unit
+        ui_results = [
+            ureg.convert(self.pic_to_SI(v), self.base_unit, self.unit)
+            for v in vals]
+
+        if check_vals:
+            self._check_input(ui_results)
+        return ui_results
 
     def macro_name(self):
         """
@@ -99,343 +168,4 @@ class Parameter(object):
         A new Parameter object with the same name, type and unit but whose
         value is set to the default value.
         """
-        return Parameter(self.name, self.type, self.unit, self.default)
-
-
-class UiParameter(Parameter):
-    """
-    Parameter that can be displayed and modified through slider widgets
-    in jupyter notebooks.
-    """
-
-    def __init__(self, name, ptype, unit, default, slider_min, slider_max,
-                 slider_step, label=None, formatter=None,
-                 value=None, dtype=None):
-        """
-        Parameters
-        ----------
-        In addition to base class parameters:
-
-        slider_min: float
-            The minimal value of the slider widget
-        slider_max: float
-            The maximal value of the slider widget
-        slider_step: float
-            The stepsize when adjusting the slider
-        label: string [optional]
-            Overwrite the name for UI
-        formatter: function or lambda of form f(x) -> string [optional]
-            representation of the current value for UI
-
-        """
-        Parameter.__init__(self, name, ptype, unit, default, value, dtype)
-
-        # for slider widget creation
-        self.min = slider_min
-        self.max = slider_max
-        self.step = slider_step
-
-        if label is None:
-            self.label = name
-        else:
-            self.label = label
-        if formatter is None:
-            self.formatter = lambda x: str(x)
-        else:
-            self.formatter = formatter
-
-        # explicitely call the set_value function to handle
-        # scaling and transformation in derived classes
-        # already on initialization. if this was missing, then
-        # parameter values would possibly be on the wrong scale
-        self.set_value(self.value)
-
-    def convert_value_to_internal_scale(self, x):
-        """
-        Computes for a given value x its corresponding
-        representation on the 'internal scale' of the parameter
-        after taking into account the possible transformation operation.
-        For UiParameters it just returns the identity, but derived
-        classes might perform e.g. scaling or exponential transformation
-        to convert values to the internal scale of the parameters
-        for usage within picongpu.
-
-        Parameters
-        ----------
-        x: float
-            The value whose corresponding representation
-            needs to be computed.
-
-        Returns
-        -------
-        The value cast to the parameters dtype
-        """
-
-        return self.dtype(x)
-
-    def set_value(self, x):
-        """
-        Updates the objects 'value' attribute to (a possibly transformed)
-        internal representation
-
-        Parameters
-        ----------
-        x: float
-            The current value of the slider widget
-
-        Returns
-        -------
-        A float containing the updated 'value' attribute. Is printed
-        below the slider-widget for user-feedback.
-        """
-
-        self.value = self.convert_value_to_internal_scale(x)
-        return self.formatter(self.value)
-
-    def on_value_change(self, change):
-        """
-        Callback function used with observe() function of ipython widgets.
-        Just a wrapper of the set_value function.
-
-        Parameters
-        ----------
-        change: dict
-                  As passed by the Ipython widgets framework.
-
-        Returns
-        -------
-        Whatever the set_value function returns.
-        """
-
-        if change["type"] == "change":
-            return self.set_value(x=change["new"])
-
-    def convert_value_from_internal_scale(self, x):
-        """
-        Used for value conversion from the parameters internal scale
-        to the ui scale
-        It computes the inverse of the transformation
-        that is used in convert_value_to_internal_scale().
-
-        Since those scales are the same for UiParameter
-        objects, this computes the identity function.
-
-        In derived classes however, there might exist a
-        transformation function to convert between ui scale
-        values and internal parameter scale values
-        (e.g. slider shows values between
-        3 and 6, but the internal parameter scale is
-        between 3.e-9 and 6.e-9).
-
-        Parameters
-        ----------
-        x: float
-            a value on the same scale as the parameters self.value
-
-        Returns
-        -------
-        the outcome of the identity function since the ui
-        scale and the internal scale are identical.
-        """
-
-        return x
-
-    def get_value_on_ui_scale(self):
-        """
-        Function that reverts a possible transformation of ui
-        value to internal value.
-        Since for UiParameter there is no conversion, it returns
-        the self.value.
-        In derived classes however, there will be a reverse
-        transformation of the self.value to the scale of the ui range
-        (which e.g. the slider will use for displaying purposes)
-
-        Returns
-        -------
-        The self.value after conversion to the ui scale
-        """
-        return self.convert_value_from_internal_scale(self.value)
-
-    def as_dict(self):
-        """
-        Convert Parameter object into a plain dictionary
-
-        Returns
-        --------
-        A dictionary with the member variables as (key, value) pairs.
-        """
-
-        members = super(UiParameter, self).as_dict()
-        members["label"] = self.label
-        members["formatter"] = str(inspect.getsourcelines(self.formatter)[
-                                   0]).strip("['\\n']").split(" = ")[1]
-
-        return members
-
-
-class LinearScaledParameter(UiParameter):
-    """
-    Parameter that can be displayed in jupyter notebooks but whose internal
-    'value' is a linear transformation of the slider values.
-    """
-
-    def __init__(self, name, ptype, unit, default, slider_min, slider_max,
-                 slider_step, scale_factor=1.0, label=None, formatter=None,
-                 value=None, dtype=None):
-        """
-        Parameters
-        ----------
-        In addition to base class parameters:
-
-        scale_factor: float
-            The factor for the linear transformation of slider ui value to
-            internal value.
-        """
-        self.scale_factor = scale_factor
-        # since base class UiParameter now calls the set_value() to carry out
-        # linear scaling of the value, we need to define the scale_factor
-        # before entering the constructor since it is used in set_value()
-
-        UiParameter.__init__(self, name, ptype, unit, default,
-                             slider_min, slider_max, slider_step,
-                             label, formatter, value, dtype)
-
-    def convert_value_to_internal_scale(self, x):
-        """
-        Computes for a given value its corresponding
-        representation on the 'internal scale' of the parameter
-        after taking into account the possible linear
-        scaling operation.
-
-        Parameters
-        ----------
-        x: float
-            The value whose corresponding representation
-            needs to be computed.
-
-        Returns
-        -------
-        The value multiplied by the parameters scale_factor
-        and cast to the parameters dtype
-        """
-
-        return self.dtype(x * self.scale_factor)
-
-    def convert_value_from_internal_scale(self, x):
-        """
-        Computes the inverse of the scaling transformation
-        that is used in convert_value_to_internal_scale().
-        This is intended to switch from the internal scale
-        of the parameters to the scale of the ui.
-
-        Parameters
-        ----------
-        x: float
-
-        Returns
-        -------
-        A float containing the value (on the ui scale) that the slider needs
-        to display for proper representation of the internal 'value' attribute.
-        This inverts the linear scaling procedure.
-        Overrides the base class method.
-        """
-
-        return float(x) / self.scale_factor
-
-    def as_dict(self):
-        """
-        Convert Parameter object into a plain dictionary
-
-        Returns
-        --------
-        A dictionary with the member variables as (key, value) pairs.
-        """
-
-        members = super(LinearScaledParameter, self).as_dict()
-        members["scale_factor"] = self.scale_factor
-
-        return members
-
-
-class LogScaledParameter(UiParameter):
-    """
-    Parameter that can be displayed in jupyter notebooks but whose internal
-    'value' is computed from a power transformation of the slider values.
-    """
-
-    def __init__(self, name, ptype, unit, default, slider_min, slider_max,
-                 slider_step, base, label=None, formatter=None,
-                 value=None, dtype=None):
-        """
-        Parameters
-        ----------
-        In addition to base class parameters:
-
-        base: float
-            The base for the power transformation from slider ui value to
-            the internal 'value'.
-        """
-        self.base = float(base)
-
-        UiParameter.__init__(self, name, ptype, unit, default,
-                             slider_min, slider_max, slider_step,
-                             label, formatter, value, dtype)
-
-    def convert_value_to_internal_scale(self, x):
-        """
-        Computes for a given value its corresponding
-        representation on the 'internal scale' of the parameter
-        after taking into account the exponential transform operation.
-
-        Parameters
-        ----------
-        x: float
-            The value whose corresponding representation
-            needs to be computed.
-
-        Returns
-        -------
-        The value taken as power of the parameters base
-        and cast to the parameters dtype
-        """
-
-        return self.dtype(self.base ** x)
-
-    def convert_value_from_internal_scale(self, x):
-        """
-        Computes the inverse of the power transformation
-        that is used in convert_value_to_internal_scale().
-        This is intended to switch from the internal scale
-        of the parameters to the scale of the ui.
-
-        Parameters
-        ----------
-        x: float
-
-        Returns
-        -------
-        A float containing the value (on the ui scale) that the slider
-        needs to display for proper representation of the
-        internal 'value' attribute.
-        This inverts the power transformation by using log.
-        Overrides the base class method.
-        """
-
-        # want to return log_b(x)
-        # which is identical to log_10(x) / log_10(b)
-        # by logarithmic law.
-        return np.log10(float(x)) / np.log10(self.base)
-
-    def as_dict(self):
-        """
-        Convert Parameter object into a plain dictionary
-
-        Returns
-        --------
-        A dictionary with the member variables as (key, value) pairs.
-        """
-
-        members = super(LogScaledParameter, self).as_dict()
-        members["base"] = self.base
-
-        return members
+        return UiParameter(self.name, self.type, self.unit, self.default)

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -93,8 +93,9 @@ class Parameter(object):
             if not isinstance(values, collections.Iterable):
                 self.values = [values]
             if not self.values:
-                raise ValueError("Values attribute can not be an empty\
-                    iterable!")
+                self.values = [self.default]
+                print("WARNING: Values attribute can not be an empty\
+                    iterable! Settting values to", self.values)
 
         if range is not None:
             if len(range) != 2:

--- a/lib/python/picongpu/input/requirements.txt
+++ b/lib/python/picongpu/input/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+pint

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -13,42 +13,39 @@ C language macro statements. The names of the macros should be the uppercase
 versions of the names provided here with an additional PARAM_ prefix.
 
 In order to visualize parameters via jupyter notebooks and ipython widgets,
-they need to be at least of class UiParameter (or inherited).
+they need to be at least of class Parameter (or inherited).
 """
 
-from picongpu.input.parameters import LogScaledParameter, LinearScaledParameter
+from picongpu.input.parameters import Parameter
 
-pico = 1.e-12
-dt_r = 1. / 1.39e-16 * pico
+
+dt = 1.39e-16
 
 PARAMETERS = {
     'laser': [
-        LinearScaledParameter(
-            name="_A0", ptype="compile", unit="",
-            default=1.5, slider_min=0.1, slider_max=50.01,
-            slider_step=0.1),
+        Parameter(
+            name="_A0", ptype="compile", unit="1",
+            default=1.5, range=(0.1, 50.01)),
 
-        LinearScaledParameter(
+        Parameter(
             name="Wave_Length_SI", ptype="compile", unit="nm",
-            default=800.0, slider_min=400.0, slider_max=1400.0,
-            slider_step=1, scale_factor=1.e-9),
+            default=800.0, range=(400.0, 1400.0)),
 
-        LinearScaledParameter(
+        Parameter(
             name="Pulse_Length_SI", ptype="compile", unit="fs",
-            default=5.0, slider_min=1.0, slider_max=150.0,
-            slider_step=1, scale_factor=1.e-15),
+            default=5.0, range=(1.0, 150.0)),
     ],
     'target': [
-        LogScaledParameter(
+        Parameter(
             name="Base_Density_SI", ptype="compile", unit="1/m^3",
-            default=25.0, slider_min=20.0, slider_max=26.0,
-            slider_step=1, base=10),
+            default=1.e25, range=(1.e20, 1.e26)),
     ],
     'resolution': [
-        LinearScaledParameter(
+        Parameter(
             name="TBG_steps", ptype="run", unit="ps",
-            default=1.0, slider_min=0.1, slider_max=10.0,
-            slider_step=0.1, scale_factor=dt_r, dtype=int,
+            default=1.0, range=(0.1, 10.0),
+            pic_to_SI=lambda steps: steps * dt,
+            pic_from_SI=lambda time: int(time / dt),
             label="simulation time")
 
     ]


### PR DESCRIPTION
This PR gets rid of `UiParameter`, `LinearScaledParameter` and `LogScaledParameter` and instead introduces a single `Parameter` class which has the option to pass in arbitrary conversion functions to handle different scales on the UI and on the internal PIC scale of each parameter.
It also makes use of the `pint` package for easier unit conversion.