### PR TITLE
[WIP] Landau Damping

### DIFF
--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -598,6 +598,7 @@ public:
 
         __setTransactionEvent(updateEvent);
         /** remove background field for particle pusher */
+        /*
         auto fieldE = dc.get< FieldE >( FieldE::getName(), true );
         auto fieldB = dc.get< FieldB >( FieldB::getName(), true );
         (*pushBGField)(fieldE, nvfct::Sub(), FieldBackgroundE(fieldE->getUnit()),
@@ -606,6 +607,7 @@ public:
                        currentStep, FieldBackgroundB::InfluenceParticlePusher);
         dc.releaseData( FieldE::getName() );
         dc.releaseData( FieldB::getName() );
+         */
 
         this->myFieldSolver->update_beforeCurrent(currentStep);
 

--- a/share/picongpu/examples/LandauDamping/README.rst
+++ b/share/picongpu/examples/LandauDamping/README.rst
@@ -1,0 +1,16 @@
+LandauDamping: Landau Damping 
+=============================
+
+.. sectionauthor:: Axel Huebl <a.huebl (at) hzdr.de>, Jakob Ameres <Jakob.Ameres (at) ipp.mpg.de>
+.. moduleauthor:: Axel Huebl <a.huebl (at) hzdr.de>, Jakob Ameres <Jakob.Ameres (at) ipp.mpg.de>
+
+This example simulates ... [ABC]_.
+
+References
+----------
+
+.. [ABC]
+       A. BC, D. EF.
+       *Some title*,
+       Some Journal Letters (2019),
+       https://dx.doi.org/XXX/YYY

--- a/share/picongpu/examples/LandauDamping/bin/plotEnergyEvolution.png
+++ b/share/picongpu/examples/LandauDamping/bin/plotEnergyEvolution.png
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+simDir="./simOutput/"
+
+# Ekin in Joules (see EnergyParticles)
+e_sum_ene = np.loadtxt(simDir + "e_energy_all.dat")[:, 0:2]
+# Etotal in Joules
+fields_all_sum_ene = np.loadtxt(simDir + "fields_energy.dat")[:, 0:8]
+Bx_sum_ene = fields_all_sum_ene[:, 2]
+By_sum_ene = fields_all_sum_ene[:, 3]
+Bz_sum_ene = fields_all_sum_ene[:, 4]
+Ex_sum_ene = fields_all_sum_ene[:, 5]
+Ey_sum_ene = fields_all_sum_ene[:, 6]
+Ez_sum_ene = fields_all_sum_ene[:, 7]
+fields_sum_ene = fields_all_sum_ene[:, 0:2]
+
+
+plt.figure()
+plt.plot(e_sum_ene[:,0], e_sum_ene[:,1], label="e")
+plt.plot(fields_sum_ene[:,0], fields_sum_ene[:,1], label="fields")
+plt.plot(fields_sum_ene[:,0], Ex_sum_ene[:], label="Ex")
+plt.plot(
+    e_sum_ene[:,0],
+    e_sum_ene[:,1] + fields_sum_ene[:,1],
+    label="sum"
+)
+ax = plt.gca()
+ax.set_yscale("log")
+plt.legend()
+plt.show()

--- a/share/picongpu/examples/LandauDamping/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LandauDamping/etc/picongpu/1.cfg
@@ -1,0 +1,87 @@
+# Copyright 2013-2018 Rene Widera, Axel Huebl, Jakob Ameres
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="0:30:00"
+
+TBG_devices_x=1
+TBG_devices_y=4
+TBG_devices_z=1
+
+TBG_gridSize="192 512 12"
+TBG_steps="2500"
+
+TBG_periodic="--periodic 1 1 1"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
+TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+
+TBG_ipngYZ="--i_png.period 10 --i_png.axis yz --i_png.slicePoint 0.5 --i_png.folder pngIonsYZ"
+TBG_ipngYX="--i_png.period 10 --i_png.axis yx --i_png.slicePoint 0.5 --i_png.folder pngIonsYX"
+
+# [in keV]
+TBG_eBin="--e_energyHistogram.period 100 --e_energyHistogram.filter all --e_energyHistogram.binCount 1024 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 5000"
+TBG_iBin="--i_energyHistogram.period 100 --i_energyHistogram.filter all --i_energyHistogram.binCount 1024 --i_energyHistogram.minEnergy 0 --i_energyHistogram.maxEnergy 2000000"
+
+TBG_plugins="!TBG_ipngYX                   \
+              !TBG_ipngYZ                   \
+              !TBG_eBin                     \
+              !TBG_iBin                     \
+              !TBG_pngYX                    \
+              !TBG_pngYZ                    \
+              --i_macroParticlesCount.period 100         \
+              --e_macroParticlesCount.period 100         \
+              --fields_energy.period 10     \
+              --e_energy.period 10 --e_energy.filter all \
+              --i_energy.period 10 --i_energy.filter all"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+"$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/LandauDamping/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LandauDamping/etc/picongpu/1.cfg
@@ -33,11 +33,11 @@
 TBG_wallTime="0:30:00"
 
 TBG_devices_x=1
-TBG_devices_y=4
+TBG_devices_y=1
 TBG_devices_z=1
 
-TBG_gridSize="192 512 12"
-TBG_steps="2500"
+TBG_gridSize="32 32 32"
+TBG_steps="1000"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -45,27 +45,9 @@ TBG_periodic="--periodic 1 1 1"
 ## Section: Optional Variables ##
 #################################
 
-TBG_pngYZ="--e_png.period 10 --e_png.axis yz --e_png.slicePoint 0.5 --e_png.folder pngElectronsYZ"
-TBG_pngYX="--e_png.period 10 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX"
+TBG_sumEnergy="--fields_energy.period 10 --e_energy.period 10 --e_energy.filter all"
 
-TBG_ipngYZ="--i_png.period 10 --i_png.axis yz --i_png.slicePoint 0.5 --i_png.folder pngIonsYZ"
-TBG_ipngYX="--i_png.period 10 --i_png.axis yx --i_png.slicePoint 0.5 --i_png.folder pngIonsYX"
-
-# [in keV]
-TBG_eBin="--e_energyHistogram.period 100 --e_energyHistogram.filter all --e_energyHistogram.binCount 1024 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 5000"
-TBG_iBin="--i_energyHistogram.period 100 --i_energyHistogram.filter all --i_energyHistogram.binCount 1024 --i_energyHistogram.minEnergy 0 --i_energyHistogram.maxEnergy 2000000"
-
-TBG_plugins="!TBG_ipngYX                   \
-              !TBG_ipngYZ                   \
-              !TBG_eBin                     \
-              !TBG_iBin                     \
-              !TBG_pngYX                    \
-              !TBG_pngYZ                    \
-              --i_macroParticlesCount.period 100         \
-              --e_macroParticlesCount.period 100         \
-              --fields_energy.period 10     \
-              --e_energy.period 10 --e_energy.filter all \
-              --i_energy.period 10 --i_energy.filter all"
+TBG_plugins="!TBG_sumEnergy"
 
 
 #################################

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/density.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/density.param
@@ -1,0 +1,77 @@
+/* Copyright 2013-2018 Axel Huebl, Jakob Ameres
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/densityProfiles/profiles.def"
+
+
+namespace picongpu
+{
+namespace SI
+{
+    /** Base density in particles per m^3 in the density profiles.
+     *
+     * This is often taken as reference maximum density in normalized profiles.
+     * Individual particle species can define a `densityRatio` flag relative
+     * to this value.
+     *
+     * unit: ELEMENTS/m^3
+     */
+    constexpr float_64 BASE_DENSITY_SI = 1.;
+}
+
+namespace densityProfiles
+{
+    struct CosinePertubationFunctor
+    {
+        /** This formula uses SI quantities only.
+         *  The profile will be multiplied by BASE_DENSITY_SI.
+         *
+         * @param position_SI total offset including all slides [meter]
+         * @param cellSize_SI cell sizes [meter]
+         *
+         * @return float_X density [normalized to 1.0]
+         */
+        HDINLINE float_X
+        operator()(
+            const floatD_64& position_SI,
+            const float3_64& cellSize_SI
+        )
+        {
+            /* calculate cells -> SI [m] */
+            float_64 const x_SI = position_SI.x();
+
+            /* specify your E-Field in V/m and convert to PIConGPU units */
+            float_X const arg = precisionCast< float_X >( x_SI * k_0 );
+            float_X const eps = 0.05;
+
+            // range: [0.0:2.0]
+            float_X s = float_X( 1. ) + eps * math::cos( arg );
+
+            /* all parts of the function MUST be > 0 */
+            s *= float_X( s >= 0.0 );
+            return s;
+        }
+    };
+
+    /* definition of free formula profile */
+    using CosinePertubation = FreeFormulaImpl< CosinePertubationFunctor >;
+}
+}

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/fieldBackground.param
@@ -1,0 +1,135 @@
+/* Copyright 2013-2018 Axel Huebl, Jakob Ameres
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file fieldBackground.param
+ *
+ * Load external background fields
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    class FieldBackgroundE
+    {
+    public:
+        /* Add this additional field for pushing particles */
+        static constexpr bool InfluenceParticlePusher = true;
+
+        /* We use this to calculate your SI input back to our unit system */
+        PMACC_ALIGN(m_unitField, const float3_64);
+
+        HDINLINE FieldBackgroundE( const float3_64 unitField ) : m_unitField(unitField)
+        {}
+
+        /** Specify your background field E(r,t) here
+         *
+         * \param cellIdx The total cell id counted from the start at t = 0
+         * \param currentStep The current time step */
+        HDINLINE float3_X
+        operator()( const DataSpace<simDim>& cellIdx,
+                    const uint32_t currentStep ) const
+        {
+            /* calculate cells -> SI [m] */
+            float_64 const x_SI = cellIdx.x() * SI::CELL_WIDTH_SI;
+
+            /* note: you can also transform the time step to seconds by
+             *       multiplying with DELTA_T_SI */
+
+            /* specify your E-Field in V/m and convert to PIConGPU units */
+            float_X const arg = precisionCast< float_X >( x_SI * k_0 );
+            float_X const eps = 0.05;
+            float_X const C = SI::EPS0_SI * SI::BASE_CHARGE_SI;
+
+            return float3_X(
+                -C * eps * math::sin( arg ) / k_0 / m_unitField[0],
+                0.0,
+                0.0
+            );
+        }
+    };
+
+    class FieldBackgroundB
+    {
+    public:
+        /* Add this additional field for pushing particles */
+        static constexpr bool InfluenceParticlePusher = false;
+
+        /* We use this to calculate your SI input back to our unit system */
+        PMACC_ALIGN(m_unitField, const float3_64);
+
+        HDINLINE FieldBackgroundB( const float3_64 unitField ) : m_unitField(unitField)
+        {}
+
+        /** Specify your background field B(r,t) here
+         *
+         * \param cellIdx The total cell id counted from the start at t=0
+         * \param currentStep The current time step */
+        HDINLINE float3_X
+        operator()( const DataSpace<simDim>& cellIdx,
+                    const uint32_t currentStep ) const
+        {
+            /* example: periodicity of 20 microns ( = 2.0e-5 m) */
+            constexpr float_64 period_SI(20.0e-6);
+            /* calculate cells -> SI -> [m] */
+            const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI;
+            /* note: you can also transform the time step to seconds by
+             *       multiplying with DELTA_T_SI */
+
+            /* specify your B-Field in T and convert to PIConGPU units */
+            const float_X sinArg = precisionCast<float_X>( y_SI / period_SI * 2.0 * PI );
+            return float3_X(0.0, math::cos( sinArg ) / m_unitField[1], 0.0);
+        }
+    };
+
+    class FieldBackgroundJ
+    {
+    public:
+        /* Add this additional field? */
+        static constexpr bool activated = false;
+
+        /* We use this to calculate your SI input back to our unit system */
+        PMACC_ALIGN(m_unitField, const float3_64);
+
+        HDINLINE FieldBackgroundJ( const float3_64 unitField ) : m_unitField(unitField)
+        {}
+
+        /** Specify your background field J(r,t) here
+         *
+         * \param cellIdx The total cell id counted from the start at t=0
+         * \param currentStep The current time step */
+        HDINLINE float3_X
+        operator()( const DataSpace<simDim>& cellIdx,
+                    const uint32_t currentStep ) const
+        {
+            /* example: periodicity of 20 microns ( = 2.0e-5 m) */
+            constexpr float_64 period_SI(20.0e-6);
+            /* calculate cells -> SI -> m to microns*/
+            const float_64 y_SI = cellIdx.y() * SI::CELL_HEIGHT_SI * 1.0e6;
+            /* note: you can also transform the time step to seconds by
+             *       multiplying with DELTA_T_SI */
+
+            /* specify your J-Field in A/m^2 and convert to PIConGPU units */
+            const float_X sinArg = precisionCast<float_X>( y_SI / period_SI * 2.0 * PI );
+            return float3_X(0.0, math::cos( sinArg ) / m_unitField[1], 0.0);
+        }
+    };
+
+} // namespace picongpu

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/fieldBackground.param
@@ -47,22 +47,27 @@ namespace picongpu
         operator()( const DataSpace<simDim>& cellIdx,
                     const uint32_t currentStep ) const
         {
-            /* calculate cells -> SI [m] */
-            float_64 const x_SI = cellIdx.x() * SI::CELL_WIDTH_SI;
+            if( currentStep == 0 )
+            {
+                /* calculate cells -> SI [m] */
+                float_64 const x_SI = cellIdx.x() * SI::CELL_WIDTH_SI;
 
-            /* note: you can also transform the time step to seconds by
-             *       multiplying with DELTA_T_SI */
+                /* note: you can also transform the time step to seconds by
+                 *       multiplying with DELTA_T_SI */
 
-            /* specify your E-Field in V/m and convert to PIConGPU units */
-            float_X const arg = precisionCast< float_X >( x_SI * k_0 );
-            float_X const eps = 0.05;
-            float_X const C = SI::EPS0_SI * SI::BASE_CHARGE_SI;
+                /* specify your E-Field in V/m and convert to PIConGPU units */
+                float_X const arg = precisionCast< float_X >( x_SI * k_0 );
+                float_X const eps = 0.05;
+                float_X const C = SI::EPS0_SI * SI::BASE_CHARGE_SI;
 
-            return float3_X(
-                -C * eps * math::sin( arg ) / k_0 / m_unitField[0],
-                0.0,
-                0.0
-            );
+                return float3_X(
+                    -C * eps * math::sin( arg ) / k_0 / m_unitField[0],
+                    0.0,
+                    0.0
+                );
+            }
+            else
+                return float3_X::create( 0. );
         }
     };
 

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/grid.param
@@ -24,7 +24,7 @@
 namespace picongpu
 {
     //! wavenumber of first mode
-    constexpr float_64 k_0 = 0.05;
+    constexpr float_64 k_0 = 0.5; // 0.05
 
     //! box length: set in .cfg file!
     constexpr float_64 L_x = 2. * PI / k_0;
@@ -45,8 +45,10 @@ namespace picongpu
         constexpr float_64 CELL_DEPTH_SI = L_x / N_x;
 
         /** Duration of one timestep
-         *  unit: seconds */
-        constexpr float_64 DELTA_T_SI = 0.577;
+         *  unit: seconds                       CFL criteria for Yee MW Solver
+         *                                             2D: sqrt(2) = 1.415
+         *                                             3D: sqrt(3) = 1.733  */
+        constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / ( 1.733 * SPEED_OF_LIGHT_SI );
 
         /** Note on units in reduced dimensions
          *

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/grid.param
@@ -1,0 +1,96 @@
+/* Copyright 2013-2018 Axel Huebl, Jakob Ameres
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#pragma once
+
+namespace picongpu
+{
+    //! wavenumber of first mode
+    constexpr float_64 k_0 = 0.05;
+
+    //! box length: set in .cfg file!
+    constexpr float_64 L_x = 2. * PI / k_0;
+    //! number of cells: set in .cfg file!
+    constexpr float_64 N_x = 32.;
+
+    namespace SI
+    {
+
+        /** equals X
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = L_x / N_x;
+        /** equals Y
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = L_x / N_x;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = L_x / N_x;
+
+        /** Duration of one timestep
+         *  unit: seconds */
+        constexpr float_64 DELTA_T_SI = 0.577;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
+    } //namespace SI
+
+        //! Defines the size of the absorbing zone (in cells)
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
+        {0, 0},  /*x direction [negative,positive]*/
+        {0, 0},  /*y direction [negative,positive]*/
+        {0, 0}   /*z direction [negative,positive]*/
+    }; //unit: number of cells
+
+    //! Define the strength of the absorber for any direction
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
+        {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
+    }; //unit: none
+
+    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
+
+    /** When to move the co-moving window.
+     *  An initial pseudo particle, flying with the speed of light,
+     *  is fired at the begin of the simulation.
+     *  When it reaches movePoint % of the absolute(*) simulation area,
+     *  the co-moving window starts to move with the speed of light.
+     *
+     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
+     *            when you use the co-moving window
+     *  0.75 means only 75% of simulation area is used for real simulation
+     */
+    constexpr float_64 movePoint = 0.90;
+
+}
+
+
+

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/memory.param
@@ -58,11 +58,11 @@ namespace picongpu
     struct DefaultExchangeMemCfg
     {
         // memory used for a direction
-        static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
-        static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
-        static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB
-        static constexpr uint32_t BYTES_EDGES = 32 * 1024; // 32 kiB
-        static constexpr uint32_t BYTES_CORNER = 8 * 1024; // 8 kiB
+        static constexpr uint32_t BYTES_EXCHANGE_X = 32 * 1024 * 1024; // 32 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Y = 32 * 1024 * 1024; // 32 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Z = 32 * 1024 * 1024; // 32 MiB
+        static constexpr uint32_t BYTES_EDGES = 128 * 1024; // 128 kiB
+        static constexpr uint32_t BYTES_CORNER = 32 * 1024; // 32 kiB
     };
 
     /** number of scalar fields that are reserved as temporary fields */

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/memory.param
@@ -1,0 +1,81 @@
+/* Copyright 2013-2018 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/mappings/kernel/MappingDescription.hpp>
+
+
+namespace picongpu
+{
+
+    /* We have to hold back 350MiB for gpu-internal operations:
+     *   - random number generator
+     *   - reduces
+     *   - ...
+     */
+    constexpr size_t reservedGpuMemorySize = 350 *1024*1024;
+
+    /* short namespace */
+    namespace mCT = pmacc::math::CT;
+    /** size of a superCell
+     *
+     * volume of a superCell must be <= 1024
+     */
+    using SuperCellSize = typename mCT::shrinkTo<
+        mCT::Int< 4, 4, 4 >,
+        simDim
+    >::type;
+
+    /** define mapper which is used for kernel call mappings */
+    using MappingDesc = MappingDescription<simDim, SuperCellSize >;
+
+    constexpr uint32_t GUARD_SIZE = 1;
+
+    /** bytes reserved for species exchange buffer
+     *
+     * This is the default configuration for species exchanges buffer sizes.
+     * The default exchange buffer sizes can be changed per species by adding
+     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
+     * to its flag list.
+     */
+    struct DefaultExchangeMemCfg
+    {
+        // memory used for a direction
+        static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EDGES = 32 * 1024; // 32 kiB
+        static constexpr uint32_t BYTES_CORNER = 8 * 1024; // 8 kiB
+    };
+
+    /** number of scalar fields that are reserved as temporary fields */
+    constexpr uint32_t fieldTmpNumSlots = 1;
+
+    /** can `FieldTmp` gather neighbor information
+     *
+     * If `true` it is possible to call the method `asyncCommunicationGather()`
+     * to copy data from the border of neighboring GPU into the local guard.
+     * This is also known as building up a "ghost" or "halo" region in domain
+     * decomposition and only necessary for specific algorithms that extend
+     * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+     */
+    constexpr bool fieldTmpSupportGatherCommunication = true;
+
+} // namespace picongpu

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/particle.param
@@ -36,7 +36,7 @@ namespace particles
      *      be created / will be deleted
      *  unit: none
      */
-    constexpr float_X MIN_WEIGHTING = 0.0001;
+    constexpr float_X MIN_WEIGHTING = 1.e-10;
 
 namespace manipulators
 {

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/particle.param
@@ -1,0 +1,88 @@
+/* Copyright 2013-2018 Axel Huebl, Jakob Ameres
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/startPosition/functors.def"
+#include "picongpu/particles/manipulators/manipulators.def"
+
+#include <pmacc/nvidia/functors/Add.hpp>
+#include <pmacc/nvidia/functors/Assign.hpp>
+
+
+namespace picongpu
+{
+
+namespace particles
+{
+
+    /** a particle with a weighting below MIN_WEIGHTING will not
+     *      be created / will be deleted
+     *  unit: none
+     */
+    constexpr float_X MIN_WEIGHTING = 0.0001;
+
+namespace manipulators
+{
+    struct TemperatureParam
+    {
+        /** Initial temperature
+         *  unit: keV
+         */
+        static constexpr float_64 temperature = 1.0;
+    };
+    using AddTemperature = unary::Temperature< TemperatureParam >;
+
+} // namespace manipulators
+
+namespace startPosition
+{
+    struct QuietParam125ppc
+    {
+        /** Count of particles per cell per direction at initial state
+         *  unit: none
+         */
+        using numParticlesPerDimension = mCT::shrinkTo<
+            mCT::Int< 5, 5, 5 >,
+            simDim
+        >::type;
+    };
+    using Quiet125ppc = QuietImpl< QuietParam125ppc >;
+
+    struct RandomParameter125ppc
+    {
+        /** Count of particles per cell at initial state
+         *  unit: none
+         */
+        static constexpr uint32_t numParticlesPerCell = 125u;
+    };
+    using Random125ppc = RandomImpl< RandomParameter125ppc >;
+
+} // namespace startPosition
+
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
+        startPosition::QuietParam125ppc::numParticlesPerDimension
+    >::type::value;
+
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/physicalConstants.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/physicalConstants.param
@@ -1,0 +1,108 @@
+/* Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#pragma once
+
+namespace picongpu
+{
+    constexpr float_64 PI = 3.141592653589793238462643383279502884197169399;
+
+    namespace SI
+    {
+        /** unit: m / s */
+        constexpr float_64 SPEED_OF_LIGHT_SI = 1.0;
+
+        /** unit: N / A^2 */
+        constexpr float_64 MUE0_SI = PI * 4.e-7;
+        /** unit: C / (V m) */
+        constexpr float_64 EPS0_SI = 1.0 / MUE0_SI / SPEED_OF_LIGHT_SI
+            / SPEED_OF_LIGHT_SI;
+
+        /** reduced Planck constant
+         * unit: J * s
+         */
+        constexpr float_64 HBAR_SI = 1.054571800e-34;
+
+        // Electron properties
+        /** unit: kg */
+        constexpr float_64 ELECTRON_MASS_SI = 9.109382e-31;
+        /** unit: C */
+        constexpr float_64 ELECTRON_CHARGE_SI = -1.602176e-19;
+
+        /* atomic unit for energy:
+         * 1 Rydberg = 27.21 eV --> converted to Joule
+         */
+        constexpr float_64 ATOMIC_UNIT_ENERGY = 4.36e-18;
+
+        /* atomic unit for electric field in V/m:
+         * field strength between electron and core in ground state hydrogen
+         */
+        constexpr float_64 ATOMIC_UNIT_EFIELD = 5.14e11;
+
+        /* atomic unit for time in s:
+         * 150 attoseconds (classical electron orbit time in hydrogen)  / 2 PI
+         */
+        constexpr float_64 ATOMIC_UNIT_TIME = 2.4189e-17;
+
+        /** Avogadro number
+         * unit: mol^-1
+         *
+         * Y. Azuma et al. Improved measurement results for the Avogadro
+         * constant using a 28-Si-enriched crystal, Metrologie 52, 2015, 360-375
+         * doi:10.1088/0026-1394/52/2/360
+         */
+        constexpr float_64 N_AVOGADRO = 6.02214076e23;
+    }
+
+    // converts
+    //
+    // UNIT_A to UNIT_B
+    //
+    // CONVENTION: WE DO NOT CONVERT FROM ANY STRANGE UNIT TO UNITLESS UNITS DIRECTLY!
+    //             convert steps: INPUT -> float_64_convert to SI -> float_64_convert to unitless
+    //                                  -> cast to float
+    // WE DO NOT define "UNIT_ENERGY_keV" or something similar! Never!
+    // Stay SI, stay free ;-)
+    //
+    // example:
+    //   // some particle physicist beloved input:
+    //   constexpr float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
+    //
+    //   // first convert to SI (because SI stays our standard Unit System!)
+    //   constexpr float_64 An_Arbitrary_Energy_Input_SI = An_Arbitrary_Energy_Input_keV * UNITCONV_keV_to_Joule // unit: Joule
+    //
+    //   // now the "real" convert to our internal unitless system
+    //   constexpr float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI / UNIT_ENERGY) // unit: none
+    //
+    // As a convention, we DO NOT use the short track:
+    //   constexpr float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
+    //   constexpr float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI * UNITCONV_keV_to_Joule / UNIT_ENERGY) // unit: none
+    //
+    constexpr float_64 UNITCONV_keV_to_Joule = 1.60217646e-16;
+    constexpr float_64 UNITCONV_Joule_to_keV = (1.0 / UNITCONV_keV_to_Joule);
+
+    /* 1 atomic unit of energy is equal to 1 Hartree or 2 Rydberg
+     * which is twice the ground state binding energy of atomic hydrogen */
+    constexpr float_64 UNITCONV_AU_to_eV = 27.21139;
+    constexpr float_64 UNITCONV_eV_to_AU = (1.0 / UNITCONV_AU_to_eV);
+
+}

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/physicalConstants.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/physicalConstants.param
@@ -31,7 +31,7 @@ namespace picongpu
         constexpr float_64 SPEED_OF_LIGHT_SI = 1.0;
 
         /** unit: N / A^2 */
-        constexpr float_64 MUE0_SI = PI * 4.e-7;
+        constexpr float_64 MUE0_SI = 1.0;
         /** unit: C / (V m) */
         constexpr float_64 EPS0_SI = 1.0 / MUE0_SI / SPEED_OF_LIGHT_SI
             / SPEED_OF_LIGHT_SI;
@@ -45,7 +45,7 @@ namespace picongpu
         /** unit: kg */
         constexpr float_64 ELECTRON_MASS_SI = 1.0;
         /** unit: C */
-        constexpr float_64 ELECTRON_CHARGE_SI = -1.0;
+        constexpr float_64 ELECTRON_CHARGE_SI = 1.0;
 
         /* atomic unit for energy:
          * 1 Rydberg = 27.21 eV --> converted to Joule
@@ -96,7 +96,7 @@ namespace picongpu
     //   constexpr float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
     //   constexpr float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI * UNITCONV_keV_to_Joule / UNIT_ENERGY) // unit: none
     //
-    constexpr float_64 UNITCONV_keV_to_Joule = 1.60217646e-16;
+    constexpr float_64 UNITCONV_keV_to_Joule = 1.0;
     constexpr float_64 UNITCONV_Joule_to_keV = (1.0 / UNITCONV_keV_to_Joule);
 
     /* 1 atomic unit of energy is equal to 1 Hartree or 2 Rydberg

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/physicalConstants.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/physicalConstants.param
@@ -1,5 +1,4 @@
-/* Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
- *                     Marco Garten
+/* Copyright 2013-2018 Axel Huebl, Jakob Ameres
  *
  * This file is part of PIConGPU.
  *
@@ -44,9 +43,9 @@ namespace picongpu
 
         // Electron properties
         /** unit: kg */
-        constexpr float_64 ELECTRON_MASS_SI = 9.109382e-31;
+        constexpr float_64 ELECTRON_MASS_SI = 1.0;
         /** unit: C */
-        constexpr float_64 ELECTRON_CHARGE_SI = -1.602176e-19;
+        constexpr float_64 ELECTRON_CHARGE_SI = -1.0;
 
         /* atomic unit for energy:
          * 1 Rydberg = 27.21 eV --> converted to Joule

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/png.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/png.param
@@ -1,0 +1,81 @@
+/* Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cmath>
+
+
+namespace picongpu
+{
+    /*scale image before write to file, only scale if value is not 1.0
+     */
+    constexpr float_64 scale_image = 1.0;
+
+    /*if true image is scaled if cellsize is not quadratic, else no scale*/
+    constexpr bool scale_to_cellsize = false;
+
+    constexpr bool white_box_per_GPU = false;
+
+    namespace visPreview
+    {
+        // normalize EM fields to typical laser or plasma quantities
+        //-1: Auto:    enable adaptive scaling for each output
+        // 1: Laser:   typical fields calculated out of the laser amplitude
+        // 2: Drift:   [outdated]
+        // 3: PlWave:  typical fields calculated out of the plasma freq.,
+        //             assuming the wave moves approx. with c
+        // 4: Thermal: typical fields calculated out of the electron temperature
+        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
+        //             regime causes a bubble with radius of approx. the laser's
+        //             beam waist (use for bubble fields)
+#define EM_FIELD_SCALE_CHANNEL1 -1
+#define EM_FIELD_SCALE_CHANNEL2 -1
+#define EM_FIELD_SCALE_CHANNEL3 -1
+
+        // multiply highest undisturbed particle density with factor
+        constexpr float_X preParticleDens_opacity = 0.25;
+        constexpr float_X preChannel1_opacity = 1.0;
+        constexpr float_X preChannel2_opacity = 1.0;
+        constexpr float_X preChannel3_opacity = 1.0;
+
+        // specify color scales for each channel
+        namespace preParticleDensCol = colorScales::grayInv;
+        namespace preChannel1Col     = colorScales::blue;
+        namespace preChannel2Col     = colorScales::green;
+        namespace preChannel3Col     = colorScales::red;
+
+        /* png preview settings for each channel */
+        DINLINE float_X preChannel1 ( const float3_X& field_B, const float3_X& field_E, const float3_X& field_J )
+        {
+            return field_E.x() * field_E.x();
+        }
+
+        DINLINE float_X preChannel2 ( const float3_X& field_B, const float3_X& field_E, const float3_X& field_J )
+        {
+            return field_E.y() * field_E.y();
+        }
+
+        DINLINE float_X preChannel3 ( const float3_X& field_B, const float3_X& field_E, const float3_X& field_J )
+        {
+            return field_E.z() * field_E.z();
+        }
+    }
+}
+

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/speciesConstants.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/speciesConstants.param
@@ -1,0 +1,69 @@
+/* Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Constants and thresholds for particle species.
+ *
+ * Defines the reference mass and reference charge to express species
+ * with (default: electrons with negative charge).
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    /** Threshold between relativistic and non-relativistic regime
+     *
+     * Threshold used for calculations that want to separate between
+     * high-precision formulas for relativistic and non-relativistic
+     * use-cases, e.g. energy-binning algorithms.
+     */
+    constexpr float_X GAMMA_THRESH = float_X(1.005);
+
+    /** Threshold in radiation plugin between relativistic and non-relativistic regime
+     *
+     * This limit is used to decide between a pure 1-sqrt(1-x) calculation
+     * and a 5th order Taylor approximation of 1-sqrt(1-x) to avoid halving
+     * of significant digits due to the sqrt() evaluation at x = 1/gamma^2 near 0.0.
+     * With 0.18 the relative error between Taylor approximation and real value
+     * will be below 0.001% = 1e-5 * for x=1/gamma^2 < 0.18
+     */
+    constexpr float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
+
+    namespace SI
+    {
+        /** base particle mass
+         *
+         * reference for massRatio in speciesDefinition.param
+         *
+         * unit: kg
+         */
+        constexpr float_64 BASE_MASS_SI = 1.0;
+
+        /** base particle charge
+         *
+         * reference for chargeRatio in speciesDefinition.param
+         *
+         * unit: C
+         */
+        constexpr float_64 BASE_CHARGE_SI = 1.0;
+    }
+}

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/speciesDefinition.param
@@ -1,0 +1,77 @@
+/* Copyright 2013-2018 Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/compileTime/conversion/MakeSeq.hpp>
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/compileTime/String.hpp>
+
+
+namespace picongpu
+{
+
+/*########################### define particle attributes #####################*/
+
+/** describe attributes of a particle */
+using DefaultParticleAttributes = MakeSeq_t<
+    position<position_pic>,
+    momentum,
+    weighting
+>;
+
+/*########################### end particle attributes ########################*/
+
+/*########################### define species #################################*/
+
+
+/*--------------------------- electrons --------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+
+using ParticleFlagsElectrons = bmpl::vector<
+    particlePusher<UsedParticlePusher>,
+    shape<UsedParticleShape>,
+    interpolation<UsedField2Particle>,
+    current<UsedParticleCurrentSolver>,
+    massRatio<MassRatioElectrons>,
+    chargeRatio<ChargeRatioElectrons>
+>;
+
+/* define species electrons */
+using PIC_Electrons = Particles<
+    PMACC_CSTRING( "e" ),
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
+>;
+
+/*########################### end species ####################################*/
+
+using VectorAllSpecies = MakeSeq_t<
+    PIC_Electrons
+>;
+
+} //namespace picongpu

--- a/share/picongpu/examples/LandauDamping/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/LandauDamping/include/picongpu/param/speciesInitialization.param
@@ -1,0 +1,57 @@
+/* Copyright 2015-2018 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Initialize particles inside particle species. This is the final step in
+ * setting up particles (defined in speciesDefinition.param) via density profiles
+ * (defined in density.param). One can then further derive particles from one
+ * species to an other and manipulate attributes with "manipulators" and "filters"
+ * (defined in particle.param and particleFilters.param).
+ *
+ * For a full list of options, see the user manual section "Usage" - "Particles".
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = mpl::vector<
+        CreateDensity<
+            densityProfiles::CosinePertubation,
+            startPosition::Random125ppc,
+            PIC_Electrons
+        >,
+        Manipulate<
+            manipulators::AddTemperature,
+            PIC_Electrons
+        >
+    >;
+
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
Add a Landau damping example case.

## To Do

- [x] compile
- [ ] verify normalization still works (units)
- [x] modify `memory.param` for this extremely small setup for speed
- [x] init E-field only once (hack!)
  - [ ] generalize hack
- [ ] add proper `README.rst` to example
- [ ] add plot scripts in `bin/`
  - [x] Ene of E_x(t)
  - [ ] optional: ps(t) x-px
  - [ ] optional: E_x(t), n_e(t)
- [x] check again CPU run: segfault on Jakob's machine in std::mersenne_twister on Random start
- [ ] warning:
```
include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp(96):
warning: floating-point operation result is out of range
```