### PR TITLE
Free Density: Fix float_X

### DIFF
--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -266,13 +266,13 @@ namespace densityProfiles
 
             /* triangle function example
              * for a density profile from 0 to 400 microns */
-            float_64 s = 1.0 - 5.0 * math::abs(y - 0.2);
+            float_X s = float_X( 1.0 - 5.0 * math::abs( y - 0.2 ) );
 
             /* give it an empty/filled striping for every second cell */
-            //s *= float_64( (y_cell_id % 2) == 0 );
+            //s *= float_X( (y_cell_id % 2) == 0 );
 
             /* all parts of the function MUST be > 0 */
-            s *= float_64(s >= 0.0);
+            s *= float_X( s >= 0.0 );
             return s;
         }
     };


### PR DESCRIPTION
Properly stay with float_X for the normalized density profile (usually between 0. and 1.)