### PR TITLE
Fixed excess 5p shell entry in gold effective Z

### DIFF
--- a/include/picongpu/param/ionizer.param
+++ b/include/picongpu/param/ionizer.param
@@ -173,90 +173,95 @@ namespace effectiveNuclearCharge
 {
     /* For hydrogen Z_eff is obviously equal to Z */
     PMACC_CONST_VECTOR(float_X, 1, Hydrogen,
-        /* 1s */
+        /* 1s^1 */
         1.
     );
 
     /* Example: deuterium */
     PMACC_CONST_VECTOR(float_X, 1, Deuterium,
-        /* 1s */
+        /* 1s^1 */
         1.
     );
 
     /* Example: helium */
     PMACC_CONST_VECTOR(float_X, 2, Helium,
-        /* 1s */
+        /* 1s^2 */
         1.688,
         1.688
     );
 
     /* Example: carbon */
     PMACC_CONST_VECTOR(float_X, 6, Carbon,
-        /* 2p */
+        /* 2p^2 */
         3.136,
         3.136,
-        /* 2s */
+        /* 2s^2 */
         3.217,
         3.217,
-        /* 1s */
+        /* 1s^2 */
         5.673,
         5.673
     );
 
     /* Example: nitrogen */
     PMACC_CONST_VECTOR(float_X, 7, Nitrogen,
-        /* 2p */
+        /* 2p^3 */
         3.834,
         3.834,
         3.834,
-        /* 2s */
+        /* 2s^2 */
         3.874,
         3.874,
-        /* 1s */
+        /* 1s^2 */
         6.665,
         6.665
     );
 
     /* Example: oxygen */
     PMACC_CONST_VECTOR(float_X, 8, Oxygen,
-        /* 2p */
+        /* 2p^4 */
         4.453,
         4.453,
         4.453,
         4.453,
-        /* 2s */
+        /* 2s^2 */
         4.492,
         4.492,
-        /* 1s */
+        /* 1s^2 */
         7.658,
         7.658
     );
 
     /* Example: aluminium */
     PMACC_CONST_VECTOR(float_X, 13, Aluminum,
-        /* 3p */
+        /* 3p^1 */
         4.066,
-        /* 3s */
+        /* 3s^2 */
         4.117,
         4.117,
-        /* 2p */
+        /* 2p^6 */
         8.963,
         8.963,
         8.963,
         8.963,
         8.963,
         8.963,
-        /* 2s */
+        /* 2s^2 */
         8.214,
         8.214,
-        /* 1s */
+        /* 1s^2 */
         12.591,
         12.591
     );
 
-    /* Example: copper */
+    /* Example: copper
+     * Note: Copper is one of the few exceptions to the Madelung energy ordering
+     *       rule! Other exceptions: Au, Ag, Pd, Cr, Mo
+     *       predicted configuration: [Ar] 4s^2 3d^9
+     *       actual configuration:    [Ar] 4s^1 3d^10
+     */
     PMACC_CONST_VECTOR(float_X, 29, Copper,
-        /* 3d */
+        /* 3d^10 */
         13.201,
         13.201,
         13.201,
@@ -266,37 +271,42 @@ namespace effectiveNuclearCharge
         13.201,
         13.201,
         13.201,
-        /* 4s */
+        13.201,
+        /* 4s^1 */
         5.842,
-        5.842,
-        /* 3p */
+        /* 3p^6 */
         14.731,
         14.731,
         14.731,
         14.731,
         14.731,
         14.731,
-        /* 3s */
+        /* 3s^2 */
         15.594,
         15.594,
-        /* 2p */
+        /* 2p^6 */
         25.097,
         25.097,
         25.097,
         25.097,
         25.097,
         25.097,
-        /* 2s */
+        /* 2s^2 */
         21.020,
         21.020,
-        /* 1s */
+        /* 1s^2 */
         28.339,
         28.339
     );
 
-    /* Example: gold */
+    /* Example: gold
+     * Note: Gold is one of the few exceptions to the Madelung energy ordering
+     *       rule! Other exceptions: Cu, Ag, Pd, Cr, Mo
+     *       predicted configuration: [Xe] 6s^2 4f^14 5d^9
+     *       actual configuration:    [Xe] 6s^1 4f^14 5d^10
+     */
     PMACC_CONST_VECTOR(float_X, 79, Gold,
-        /* 5d */
+        /* 5d^10 */
         20.126,
         20.126,
         20.126,
@@ -306,7 +316,8 @@ namespace effectiveNuclearCharge
         20.126,
         20.126,
         20.126,
-        /* 4f */
+        20.126,
+        /* 4f^14 */
         40.650,
         40.650,
         40.650,
@@ -321,18 +332,16 @@ namespace effectiveNuclearCharge
         40.650,
         40.650,
         40.650,
-        /* 6s */
+        /* 6s^1 */
         10.938,
-        10.938,
-        /* 5p */
+        /* 5p^6 */
         25.170,
         25.170,
         25.170,
         25.170,
         25.170,
         25.170,
-        25.170,
-        /* 4d */
+        /* 4d^10 */
         41.528,
         41.528,
         41.528,
@@ -343,17 +352,17 @@ namespace effectiveNuclearCharge
         41.528,
         41.528,
         41.528,
-        /* 5s */
+        /* 5s^2 */
         27.327,
         27.327,
-        /* 4p */
+        /* 4p^6 */
         43.547,
         43.547,
         43.547,
         43.547,
         43.547,
         43.547,
-        /* 3d */
+        /* 3d^10 */
         65.508,
         65.508,
         65.508,
@@ -364,30 +373,30 @@ namespace effectiveNuclearCharge
         65.508,
         65.508,
         65.508,
-        /* 4s */
+        /* 4s^2 */
         44.413,
         44.413,
-        /* 3p */
+        /* 3p^6 */
         56.703,
         56.703,
         56.703,
         56.703,
         56.703,
         56.703,
-        /* 3s */
+        /* 3s^2 */
         55.763,
         55.763,
-        /* 2p */
+        /* 2p^6 */
         74.513,
         74.513,
         74.513,
         74.513,
         74.513,
         74.513,
-        /* 2s */
+        /* 2s^2 */
         58.370,
         58.370,
-        /* 1s */
+        /* 1s^2 */
         77.476,
         77.476
     );


### PR DESCRIPTION
`ionizer.param`:
* the effective Z array contained too many 5p orbital entries   
      --> fix: delete 1 value and go to 6
* changed the configuration of Cu and Au to their real-life   
      ground state configuration which slightly differs from the   
      Madelung rule prediction
* updated documentation on shell occupation