### PR TITLE
fix zero size transform writes

### DIFF
--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -109,16 +109,6 @@ int64_t defineAdiosVar(int64_t group_id,
                        bool compression,
                        std::string compressionMethod)
 {
-    /* disable compression if this rank writes no data */
-    bool canCompress = true;
-    for (size_t i = 0; i < DIM; ++i)
-    {
-        if (dimensions[i] == 0 || globalDimensions[i] == 0)
-        {
-            canCompress = false;
-        }
-    }
-
     int64_t var_id = 0;
 
     var_id = adios_define_var(
@@ -128,9 +118,9 @@ int64_t defineAdiosVar(int64_t group_id,
         offset.revert().toString(",", "").c_str()
     );
 
-    if (compression && canCompress)
+    if(compression)
     {
-        /* enable zlib compression for variable, default compression level */
+        /* enable adios transform layer for variable */
         adios_set_transform(var_id, compressionMethod.c_str());
     }
 


### PR DESCRIPTION
Fix that particles dumped with adios (tranform layer enabled, MPI aggregate enabled) causing reading errors.
Solved by enable compression for all MPI ranks even if the size of data which must be written is zero.

issue: https://github.com/ornladios/ADIOS/issues/170

requires a post-1.13.0 ADIOS for the following fixes:
- reads:
  - https://github.com/ornladios/ADIOS/pull/162
  - https://github.com/ornladios/ADIOS/pull/163
- writes:
  - zlib https://github.com/ornladios/ADIOS/pull/165
  - bzip2, isobar and zfp https://github.com/ornladios/ADIOS/issues/174

Cc-ing: @n01r 