### PR TITLE
Docker: Update ISAAC Client URL

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/start_lwfa.sh
+++ b/share/picongpu/dockerfiles/ubuntu-1604/start_lwfa.sh
@@ -6,7 +6,7 @@ server_id=$!
 
 echo ""
 echo "Let's watch a laser-plasma movie!"
-echo "  http://plasma.ninja/isaac_1_3_0/interface.htm"
+echo "  http://laser.plasma.ninja/isaac_1_3_0/interface.htm"
 echo ""
 
 # wait until server is up


### PR DESCRIPTION
Add a new sub-domain for serving the ISAAC HTML client. The main domain is now redirected to HTTPS by default which can interfere with the unencrypted ws:// sockets in ISAAC (mixed content warnings).