### PR TITLE
Boost: Format String Version

### DIFF
--- a/include/picongpu/versionFormat.cpp
+++ b/include/picongpu/versionFormat.cpp
@@ -85,7 +85,9 @@ namespace picongpu
 #endif
 
         std::stringstream boost;
-        boost << BOOST_PP_STRINGIZE(BOOST_VERSION);
+        boost << int(BOOST_VERSION / 100000) << "."
+              << int(BOOST_VERSION / 100 % 1000) << "."
+              << int(BOOST_VERSION % 100);
 
         std::stringstream mpiStandard;
         std::stringstream mpiFlavor;


### PR DESCRIPTION
Properly convert the running number into a dotted version, following the official formatting rules:
  https://www.boost.org/doc/libs/1_66_0/boost/version.hpp

Improves the version output and makes it consisten with other outputs. Related to #2146