### PR TITLE
Docs: Namespace ComputeGridValuePerFrame

### DIFF
--- a/docs/source/dev/picongpu.rst
+++ b/docs/source/dev/picongpu.rst
@@ -46,7 +46,7 @@ Particles
 ComputeGridValuePerFrame
 ------------------------
 
-.. doxygenclass:: picongpu::particleToGrid::ComputeGridValuePerFrame
+.. doxygenclass:: picongpu::particles::particleToGrid::ComputeGridValuePerFrame
    :project: PIConGPU
    :members:
    :undoc-members:


### PR DESCRIPTION
Fix the namespace of `ComputeGridValuePerFrame` in the docs.

Follow-up to #2377