### PR TITLE
Hypnos: Zlib

### DIFF
--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -28,6 +28,7 @@ then
         module load openmpi/2.1.2.cuda80
 
         # Plugins (optional)
+        module load zlib/1.2.8
         module load pngwriter/0.7.0
         module load hdf5-parallel/1.8.20 libsplash/1.7.0
 

--- a/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
@@ -28,6 +28,7 @@ then
         module load openmpi/2.1.2.cuda80
 
         # Plugins (optional)
+        module load zlib/1.2.8
         module load pngwriter/0.7.0
         module load hdf5-parallel/1.8.20 libsplash/1.7.0
 

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -28,6 +28,7 @@ then
         module load numactl
 
         # Plugins (optional)
+        module load zlib/1.2.8
         module load pngwriter/0.7.0
         module load hdf5-parallel/1.8.15 libsplash/1.7.0
 


### PR DESCRIPTION
Hypnos did not yet properly build zlib in the dependency chain.

This led to several severe instabilities and several bug reports in the past months, mainly with unpredictible crashes & segfaults during I/O (e.g. #2504) but also with compile errors in CPUs #2549.

While modules are getting rebuild, a lack of auto-loading the dependency means we have to load zlib manually for now. Loading zlib explicitly is also useful if you build some dependencies by hand as a developer.