### PR TITLE
Docs: Limit Filters to Eligible Species

### DIFF
--- a/docs/source/usage/particles.rst
+++ b/docs/source/usage/particles.rst
@@ -9,6 +9,8 @@ Second, species are initialized with particles in :ref:`speciesInitialization.pa
 
 The following operations can be applied in the ``picongpu::particles::InitPipeline`` of the latter:
 
+.. _usage-particles-init:
+
 Initialization
 --------------
 
@@ -41,6 +43,8 @@ FillAllGaps
 
 .. doxygenstruct:: picongpu::particles::FillAllGaps
    :project: PIConGPU
+
+.. _usage-particles-manipulation:
 
 Manipulation Functors
 ---------------------
@@ -107,6 +111,8 @@ ProtonTimesWeighting
 
 .. doxygentypedef:: picongpu::particles::manipulators::binary::ProtonTimesWeighting
    :project: PIConGPU
+
+.. _usage-particles-filters:
 
 Manipulation Filters
 --------------------

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -10,61 +10,7 @@ The acceptance of particles for counting in the energy histogram can be adjusted
 ^^^^^^^^^^^
 
 The :ref:`particleFilters.param <usage-params-core>` file allows to define accepted particles for the energy histogram.
-A typical :ref:`filter <usage-particles>` could select particles within a specified opening angle in forward direction.
-
-For example, to limit to particles within a cone with an opening angle of five degrees (pinhole):
-
-.. code:: cpp
-
-   namespace picongpu
-   {
-   namespace particles
-   {
-   namespace filter
-   {
-       struct FunctorParticlesForwardPinhole
-       {
-           static constexpr char const * name = "forwardPinhole";
-
-           template< typename T_Particle >
-           HDINLINE bool operator()(
-               T_Particle const & particle
-           )
-           {
-               bool result = false;
-               float3_X const mom = particle[ momentum_ ];
-               float_X const absMom = math::abs( mom );
-
-               if( absMom > float_X( 0. ) )
-               {
-                   /* place detector in y direction, "infinite distance" to target,
-                    * and five degree opening angle
-                    */
-                   constexpr float_X openingAngle = 5.0 * PI / 180.;
-                   float_X const dotP = mom.y() / absMom;
-                   float_X const degForw = math::acos( dotP );
-
-                   if( math::abs( degForw ) <= openingAngle * float_X( 0.5 ) )
-                       result = true;
-               }
-               return result;
-           }
-       };
-       using ParticlesForwardPinhole = generic::Free<
-          FunctorParticlesForwardPinhole
-       >;
-   }
-   }
-   }
-
-and add ``ParticlesForwardPinhole`` to the ``AllParticleFilters`` list:
-
-.. code:: cpp
-
-   using AllParticleFilters = MakeSeq_t<
-       All,
-       ParticlesForwardPinhole
-   >;
+A typical :ref:`filter <usage-particles-filters>` could select particles within a specified :ref:`opening angle in forward direction <usage-workflows-particleFilters>`.
 
 .cfg files
 ^^^^^^^^^^

--- a/docs/source/usage/workflows.rst
+++ b/docs/source/usage/workflows.rst
@@ -15,3 +15,4 @@ This section contains typical user workflows and best practices.
    workflows/quasiNeutrality
    workflows/probeParticles
    workflows/tracerParticles
+   workflows/particleFilters

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -81,7 +81,7 @@ That means: if one accesses specific *attributes* or *flags* of a species in a f
 As an example, :ref:`probe particles <usage-workflows-probeParticles>` usually do not need even have a ``momentum`` attribute which would be used for an energy filter.
 So they should be ignored from compilation when combining filters with particle species.
 
-In order to exclude all species that have no ``momentum`` attribute from the ``ParticlesForwardPinhole`` filter, define the C++ trait ``SpeciesEligibleForSolver``.
+In order to exclude all species that have no ``momentum`` attribute from the ``ParticlesForwardPinhole`` filter, specialize the C++ trait ``SpeciesEligibleForSolver``.
 This trait is implemented to be checked during compile time when combining filters with species:
 
 .. code:: cpp

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -72,13 +72,13 @@ and add ``ParticlesForwardPinhole`` to the ``AllParticleFilters`` list:
 Limiting Filters to Eligible Species
 """"""""""""""""""""""""""""""""""""
 
-Besides :ref:`the list of pre-defined filters <usage-particles-filters>` with parametrization users can also define generic, "free" implementations as shown above.
+Besides :ref:`the list of pre-defined filters <usage-particles-filters>` with parametrization, users can also define generic, "free" implementations as shown above.
 All filters are added to ``AllParticleFilters`` and then *combined with all available species* from ``VectorAllSpecies`` (see :ref:`speciesDefinition.param <usage-params-core>`).
 
 In the case of user-defined free filters we can now check if each species in ``VectorAllSpecies`` fulfills the requirements of the filter.
 That means: if one accesses specific *attributes* or *flags* of a species in a filter, they must exist or will lead to a compile error.
 
-As an example, :ref:`probe particles <usage-workflows-probeParticles>` usually do not need even have a ``momentum`` attribute which would be used for an energy filter.
+As an example, :ref:`probe particles <usage-workflows-probeParticles>` usually do not need a ``momentum`` attribute which would be used for an energy filter.
 So they should be ignored from compilation when combining filters with particle species.
 
 In order to exclude all species that have no ``momentum`` attribute from the ``ParticlesForwardPinhole`` filter, specialize the C++ trait ``SpeciesEligibleForSolver``.

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -5,7 +5,7 @@ Particle Filters
 
 .. sectionauthor:: Axel Huebl
 
-A common task in both modeling and in situ processing (output) is the selection of particles of a particle species by attributes.
+A common task in both modeling, initializing and in situ processing (output) is the selection of particles of a particle species by attributes.
 PIConGPU implements such selections as *particle filters*.
 
 Particle filters are simple mappings assigning each particle of a species either ``true`` or ``false`` (ignore / filter out).
@@ -65,17 +65,17 @@ and add ``ParticlesForwardPinhole`` to the ``AllParticleFilters`` list:
        ParticlesForwardPinhole
    >;
 
-   } // filter
-   } // particles
-   } // picongpu
+   } // namespace filter
+   } // namespace particles
+   } // namespace picongpu
 
 Limiting Filters to Eligible Species
 """"""""""""""""""""""""""""""""""""
 
-Besides the list of pre-defined filters with parametrization users can also define generic, "free" implementations as shown above.
-All filters are added to ``AllParticleFilters`` and then *combined with all available species* from ``VectorAllSpecies`` (see :ref:`speciesDefinition.param <usage-params-core>`.
+Besides :ref:`the list of pre-defined filters <usage-particles-filters>` with parametrization users can also define generic, "free" implementations as shown above.
+All filters are added to ``AllParticleFilters`` and then *combined with all available species* from ``VectorAllSpecies`` (see :ref:`speciesDefinition.param <usage-params-core>`).
 
-In the case of user-defined free filters we can not check if each species in ``VectorAllSpecies`` fulfills the requirements of the filter.
+In the case of user-defined free filters we can now check if each species in ``VectorAllSpecies`` fulfills the requirements of the filter.
 That means: if one accesses specific *attributes* or *flags* of a species in a filter, they must exist or will lead to a compile error.
 
 As an example, :ref:`probe particles <usage-workflows-probeParticles>` usually do not need even have a ``momentum`` attribute which would be used for an energy filter.

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -1,0 +1,110 @@
+.. _usage-workflows-particleFilters:
+
+Particle Filters
+----------------
+
+.. sectionauthor:: Axel Huebl
+
+A common task in both modeling and in situ processing (output) is the selection of particles of a particle species by attributes.
+PIConGPU implements such selections as *particle filters*.
+
+Particle filters are simple mappings assigning each particle of a species either ``true`` or ``false`` (ignore / filter out).
+These filters can be defined in :ref:`particleFilters.param <usage-params-core>`.
+
+Example
+"""""""
+
+Let us select particles with momentum vector within a cone with an opening angle of five degrees (pinhole):
+
+.. code:: cpp
+
+   namespace picongpu
+   {
+   namespace particles
+   {
+   namespace filter
+   {
+       struct FunctorParticlesForwardPinhole
+       {
+           static constexpr char const * name = "forwardPinhole";
+
+           template< typename T_Particle >
+           HDINLINE bool operator()(
+               T_Particle const & particle
+           )
+           {
+               bool result = false;
+               float3_X const mom = particle[ momentum_ ];
+               float_X const absMom = math::abs( mom );
+
+               if( absMom > float_X( 0. ) )
+               {
+                   /* place detector in y direction, "infinite distance" to target,
+                    * and five degree opening angle
+                    */
+                   constexpr float_X openingAngle = 5.0 * PI / 180.;
+                   float_X const dotP = mom.y() / absMom;
+                   float_X const degForw = math::acos( dotP );
+
+                   if( math::abs( degForw ) <= openingAngle * float_X( 0.5 ) )
+                       result = true;
+               }
+               return result;
+           }
+       };
+       using ParticlesForwardPinhole = generic::Free<
+          FunctorParticlesForwardPinhole
+       >;
+
+and add ``ParticlesForwardPinhole`` to the ``AllParticleFilters`` list:
+
+.. code:: cpp
+
+   using AllParticleFilters = MakeSeq_t<
+       All,
+       ParticlesForwardPinhole
+   >;
+
+   } // filter
+   } // particles
+   } // picongpu
+
+Limiting Filters to Eligible Species
+""""""""""""""""""""""""""""""""""""
+
+Besides the list of pre-defined filters with parametrization users can also define generic, "free" implementations as shown above.
+All filters are added to ``AllParticleFilters`` and then *combined with all available species* from ``VectorAllSpecies`` (see :ref:`speciesDefinition.param <usage-params-core>`.
+
+In the case of user-defined free filters we can not check if each species in ``VectorAllSpecies`` fulfills the requirements of the filter.
+That means: if one accesses specific *attributes* or *flags* of a species in a filter, they must exist or will lead to a compile error.
+
+As an example, :ref:`probe particles <usage-workflows-probeParticles>` usually do not need even have a ``momentum`` attribute which would be used for an energy filter.
+So they should be ignored from compilation when combining filters with particle species.
+
+In order to exclude all species that have no ``momentum`` attribute from the ``ParticlesForwardPinhole`` filter, define the C++ trait ``SpeciesEligibleForSolver``.
+This trait is implemented to be checked during compile time when combining filters with species:
+
+.. code:: cpp
+
+   // ...
+
+   } // namespace filter
+
+   namespace traits
+   {
+       template<
+           typename T_Species
+       >
+       struct SpeciesEligibleForSolver<
+           T_Species,
+           filter::ParticlesForwardPinhole
+       >
+       {
+           using type = typename pmacc::traits::HasIdentifiers<
+               typename T_Species::FrameType,
+               MakeSeq_t< momentum >
+           >::type;
+       };
+   } // namespace traits
+   } // namespace particles
+   } // namespace picongpu

--- a/include/picongpu/param/particleFilters.param
+++ b/include/picongpu/param/particleFilters.param
@@ -17,9 +17,26 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * A common task in both modeling and in situ processing (output) is the
+ * selection of particles of a particle species by attributes. Users can
+ * define such selections as particle filters in this file.
+ *
+ * Particle filters are simple mappings assigning each particle of a species
+ * either `true` or `false` (ignore / filter out).
+ *
+ * All active filters need to be listed in `AllParticleFilters`. They are then
+ * combined with `VectorAllSpecies` at compile-time, e.g. for plugins.
+ */
+
 #pragma once
 
 #include "picongpu/particles/filter/filter.def"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+
+#include <pmacc/traits/HasIdentifiers.hpp>
+#include <pmacc/traits/HasFlag.hpp>
 
 
 namespace picongpu
@@ -39,5 +56,12 @@ namespace filter
     >;
 
 } // namespace filter
+
+namespace traits
+{
+    /* if needed for generic "free" filters,
+     * place `SpeciesEligibleForSolver` traits for filters here
+     */
+} // namespace traits
 } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particleFilters.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particleFilters.param
@@ -17,9 +17,26 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * A common task in both modeling and in situ processing (output) is the
+ * selection of particles of a particle species by attributes. Users can
+ * define such selections as particle filters in this file.
+ *
+ * Particle filters are simple mappings assigning each particle of a species
+ * either `true` or `false` (ignore / filter out).
+ *
+ * All active filters need to be listed in `AllParticleFilters`. They are then
+ * combined with `VectorAllSpecies` at compile-time, e.g. for plugins.
+ */
+
 #pragma once
 
 #include "picongpu/particles/filter/filter.def"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+
+#include <pmacc/traits/HasIdentifiers.hpp>
+#include <pmacc/traits/HasFlag.hpp>
 
 
 namespace picongpu
@@ -99,5 +116,12 @@ namespace filter
     >;
 
 } // namespace filter
+
+namespace traits
+{
+    /* if needed for generic "free" filters,
+     * place `SpeciesEligibleForSolver` traits for filters here
+     */
+} // namespace traits
 } // namespace particles
 } // namespace picongpu


### PR DESCRIPTION
Document how to limit generic "free" filters to eligible particle species as asked in #2573.

Add to `particleFilters.param` files:

* docstring
* includes commonly needed for eligible traits
* section with prepared namespace for traits