### PR TITLE
Doxygen: Publish As Well 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ PIConGPU - A Many GPGPU PIC Code
 [![Code Status master](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/master.svg?label=master)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
 [![Code Status dev](https://img.shields.io/travis/ComputationalRadiationPhysics/picongpu/dev.svg?label=dev)](https://travis-ci.org/ComputationalRadiationPhysics/picongpu/branches)
 [![Documentation Status](https://readthedocs.org/projects/picongpu/badge/?version=latest)](http://picongpu.readthedocs.io)
+[![Doxygen](https://img.shields.io/badge/API-Doxygen-blue.svg)](http://computationalradiationphysics.github.io/picongpu)
 [![Language](https://img.shields.io/badge/language-C%2B%2B11-orange.svg)](https://isocpp.org/)
 [![License PIConGPU](https://img.shields.io/badge/license-GPLv3-blue.svg?label=PIConGPU)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![License PMacc](https://img.shields.io/badge/license-LGPLv3-blue.svg?label=PMacc)](https://www.gnu.org/licenses/lgpl-3.0.html)

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,6 +1,7 @@
 PROJECT_NAME      = "PIConGPU"
 XML_OUTPUT        = xml
 INPUT             = ../include
+INPUT             += ../README.md
 GENERATE_LATEX    = NO
 GENERATE_MAN      = NO
 GENERATE_RTF      = NO
@@ -27,7 +28,8 @@ FILE_PATTERNS          = *.cu       \
                          *.def      \
                          *.param    \
                          *.unitless \
-                         *.loader
+                         *.loader   \
+                         *.md
 
 EXTENSION_MAPPING      = .cu=C++       \
                          .cpp=C++      \

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -27,8 +27,7 @@ FILE_PATTERNS          = *.cu       \
                          *.def      \
                          *.param    \
                          *.unitless \
-                         *.loader   \
-                         *.md
+                         *.loader
 
 EXTENSION_MAPPING      = .cu=C++       \
                          .cpp=C++      \

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -10,6 +10,7 @@ GENERATE_XML      = YES
 RECURSIVE         = YES
 #QUIET             = YES
 JAVADOC_AUTOBRIEF = YES
+USE_MDFILE_AS_MAINPAGE = README.md
 
 # ideally, you want to warn on missing doc coverage!
 WARN_IF_UNDOCUMENTED = NO

--- a/docs/source/dev/doxygen.rst
+++ b/docs/source/dev/doxygen.rst
@@ -5,8 +5,23 @@ Doxygen
 
 .. sectionauthor:: Axel Huebl
 
-Although our main documentation is integrated via :ref:`Sphinx <development-sphinx>`, some developers might still want to read the plain HTML build of Doxygen.
-If you need these docs, this section explains how to build it locally.
+An online version of our Doxygen build can be found at
+
+http://computationalradiationphysics.github.io/picongpu
+
+We regularly update it via
+
+.. code-block:: bash
+
+   git checkout gh-pages
+
+   # optional argument: branch or tag name
+   ./update.sh
+
+   git commit -a
+   git push
+
+This section explains what is done when this script is run to build it manually.
 
 Requirements
 ------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,8 +26,16 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    If you are looking for the latest *development* version, `click here <https://picongpu.readthedocs.io/en/latest/>`_.
 
 
-We are migrating our `wiki`_ to this manual, but some pages might still be missing.
-We also have an `official homepage`_ .
+.. note::
+
+   We are migrating our `wiki`_ to this manual, but some pages might still be missing.
+   We also have an `official homepage`_ .
+
+.. note::
+
+   Are you looking for our latest Doxygen docs for the API?
+
+   See http://computationalradiationphysics.github.io/picongpu
 
 .. _wiki: https://github.com/ComputationalRadiationPhysics/picongpu/wiki
 .. _official homepage: http://picongpu.hzdr.de

--- a/include/picongpu/main.cpp
+++ b/include/picongpu/main.cpp
@@ -17,16 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * @mainpage PIConGPU-Frame
- *
- * Project with HZDR for porting their PiC-code to a GPU cluster.
- *
- * \image html ../../docs/logo/pic_logo_320x140.png
- *
- * @author Heiko Burau, Rene Widera, Wolfgang Hoenig, Felix Schmitt, Axel Huebl, Michael Bussmann, Guido Juckeland
- */
-
 #include "picongpu/ArgsParser.hpp"
 #include <pmacc/Environment.hpp>
 


### PR DESCRIPTION
Let's publish our doxygen builds on [`gh-pages`](http://computationalradiationphysics.github.io/picongpu).

This adds the instructions on how to update it. Doxygen docs are not versioned as sphinx docs are, so we should decide when we update the docs to keep possible confusion small.