### PR TITLE
Radiation Plugin: Namespace

### DIFF
--- a/include/picongpu/plugins/radiation/ExecuteParticleFilter.hpp
+++ b/include/picongpu/plugins/radiation/ExecuteParticleFilter.hpp
@@ -45,7 +45,7 @@ namespace radiation
         template< typename T_Species >
         void operator()( std::shared_ptr<T_Species> const &, const uint32_t currentStep )
         {
-            picongpu::particles::Manipulate<
+            particles::Manipulate<
                 picongpu::radiation::RadiationParticleFilter,
                 T_Species
             >{}( currentStep );
@@ -83,7 +83,7 @@ namespace radiation
     template< typename T_Species >
     void executeParticleFilter( std::shared_ptr<T_Species>& species, const uint32_t currentStep )
     {
-        constexpr bool hasRadiationFilter = ::pmacc::traits::HasIdentifier<
+        constexpr bool hasRadiationFilter = pmacc::traits::HasIdentifier<
             typename T_Species::FrameType,
             radiationMask
         >::type::value;

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -352,7 +352,7 @@ namespace picongpu
 
                                         // set up particle using the radiation's own particle class
                                         /*!\todo please add a namespace for Particle class*/
-                                        ::Particle const particle(
+                                        Particle const particle(
                                             particle_locationNow,
                                             particle_momentumOld,
                                             particle_momentumNow,

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -24,13 +24,16 @@
 #include "parameters.hpp"
 #include <pmacc/mpi/GetMPI_StructAsArray.hpp>
 
-typedef pmacc::math::Complex<picongpu::float_64> complex_64;
 
+namespace picongpu
+{
 /** class to store 3 complex numbers for the radiated amplitude
  */
 class Amplitude
 {
 public:
+  using complex_64 = pmacc::math::Complex< picongpu::float_64 >;
+
   /* number of scalar components in Amplitude = 3 (3D) * 2 (complex) = 6 */
   static constexpr uint32_t numComponents = uint32_t(3) * uint32_t(sizeof(complex_64) / sizeof(typename complex_64::type));
 
@@ -132,7 +135,7 @@ private:
   complex_64 amp_z; // complex amplitude z-component
 
 };
-
+} // namespace picongpu
 
 namespace pmacc
 {
@@ -141,15 +144,12 @@ namespace mpi
 
   /** implementation of MPI transaction on Amplitude class */
   template<>
-  MPI_StructAsArray getMPI_StructAsArray< ::Amplitude >()
+  MPI_StructAsArray getMPI_StructAsArray< picongpu::Amplitude >()
   {
-      MPI_StructAsArray result = getMPI_StructAsArray< complex_64::type > ();
-      result.sizeMultiplier *= Amplitude::numComponents;
+      MPI_StructAsArray result = getMPI_StructAsArray< picongpu::Amplitude::complex_64::type > ();
+      result.sizeMultiplier *= picongpu::Amplitude::numComponents;
       return result;
   };
 
-}//namespace mpi
-}//namespace pmacc
-
-
-
+} // namespace mpi
+} // namespace pmacc

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -17,14 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <iostream>
-
 #pragma once
-
 
 #include "particle.hpp"
 
+#include <iostream>
 
+
+namespace picongpu
+{
 //protected:
 // error class for wrong time access
 
@@ -169,5 +170,4 @@ private:
 
 };
 
-
-
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
+++ b/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
@@ -17,12 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "calc_amplitude.hpp"
 #include "parameters.hpp"
 #include "particle.hpp"
+
+
+namespace picongpu
+{
 
 class NyquistLowPass : public One_minus_beta_times_n
 {
@@ -34,8 +37,8 @@ public:
      * so that all Amplitudes for higher frequencies can be ignored
     **/
     HDINLINE NyquistLowPass(const vector_64& n, const Particle& particle)
-      : omegaNyquist((picongpu::PI - 0.01)/
-           (picongpu::DELTA_T *
+      : omegaNyquist((PI - 0.01)/
+           (DELTA_T *
             One_minus_beta_times_n()(n, particle)))
     { }
 
@@ -49,12 +52,13 @@ public:
     /**
      * checks if frequency omega is below Nyquist frequency
     **/
-    HDINLINE bool check(const picongpu::float_32 omega)
+    HDINLINE bool check(const float_32 omega)
     {
-        return omega < omegaNyquist * picongpu::radiationNyquist::NyquistFactor;
+        return omega < omegaNyquist * radiationNyquist::NyquistFactor;
     }
 
 private:
-    picongpu::float_32 omegaNyquist; // Nyquist frequency for a particle (at a certain time step) for one direction
+    float_32 omegaNyquist; // Nyquist frequency for a particle (at a certain time step) for one direction
 };
 
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/parameters.hpp
+++ b/include/picongpu/plugins/radiation/parameters.hpp
@@ -20,12 +20,13 @@
 #pragma once
 
 
-#include "vector.hpp"
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/plugins/radiation/vector.hpp"
 
 
-typedef cuda_vec<picongpu::float3_X, picongpu::float_X> vector_X;
-typedef /*__align__(16)*/ cuda_vec<picongpu::float3_32, picongpu::float_32> vector_32;
-typedef /*__align__(32)*/ cuda_vec<picongpu::float3_64, picongpu::float_64> vector_64;
-
-
+namespace picongpu
+{
+    using vector_X = cuda_vec< picongpu::float3_X, picongpu::float_X >;
+    using vector_32 = /*__align__(16)*/ cuda_vec< picongpu::float3_32, picongpu::float_32 >;
+    using vector_64 = /*__align__(32)*/ cuda_vec< picongpu::float3_64, picongpu::float_64 >;
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -26,6 +26,9 @@
 #include "taylor.hpp"
 
 
+namespace picongpu
+{
+
 class When
 {
     // a enum to describe all needed times
@@ -148,7 +151,6 @@ private:
 }; // end of Particle definition
 
 
-
 template<>
 HDINLINE vector_64 Particle::get_location<When::now>(void) const
 {
@@ -167,3 +169,4 @@ HDINLINE vector_64 Particle::get_momentum<When::old>(void) const
     return momentum_old;
 } // get momentum at time when
 
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -17,8 +17,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
 
 namespace picongpu
 {

--- a/include/picongpu/plugins/radiation/taylor.hpp
+++ b/include/picongpu/plugins/radiation/taylor.hpp
@@ -17,11 +17,12 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "parameters.hpp"
 
+namespace picongpu
+{
 struct Taylor
 {
     // a Taylor development for 1-sqrt(1-x)
@@ -36,5 +37,4 @@ struct Taylor
 
 };
 
-
-
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/utilities.hpp
+++ b/include/picongpu/plugins/radiation/utilities.hpp
@@ -17,8 +17,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
+namespace picongpu
+{
 
 namespace util
 {
@@ -106,3 +108,5 @@ namespace details
   }
 
 } // namespace util
+
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -17,11 +17,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include <iostream>
 #include <pmacc/types.hpp>
+
+
+namespace picongpu
+{
 
 template<typename V, typename T>
 struct cuda_vec : public V
@@ -164,14 +167,13 @@ struct cuda_vec : public V
 
 };
 
-
+} // namespace picongpu
 
 // print
 
 template<typename V, typename T>
-HINLINE std::ostream & operator <<(std::ostream & os, const cuda_vec<V, T> & v)
+HINLINE std::ostream & operator <<(std::ostream & os, const picongpu::cuda_vec<V, T> & v)
 {
     os << " ( " << v.x() << " , " << v.y() << " , " << v.z() << " ) ";
     return os;
 }
-


### PR DESCRIPTION
Add at least the basic picongpu namespace.

Later on, needs proper namespace per directory.

Seen as [polluted scope in Doxygen docs](https://computationalradiationphysics.github.io/picongpu/annotated.html).