### PR TITLE
PMacc Tests: Add Missing Namespaces

### DIFF
--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -276,7 +276,7 @@ namespace exec
  *
  * @param ... instance of kernel functor
  */
-#define PMACC_KERNEL( ... ) pmacc::exec::kernel( __VA_ARGS__, __FILE__,  static_cast< size_t >( __LINE__ ) )
+#define PMACC_KERNEL( ... ) ::pmacc::exec::kernel( __VA_ARGS__, __FILE__,  static_cast< size_t >( __LINE__ ) )
 
 
 #include "pmacc/eventSystem/events/kernelEvents.tpp"

--- a/include/pmacc/test/PMaccFixture.hpp
+++ b/include/pmacc/test/PMaccFixture.hpp
@@ -25,6 +25,12 @@
 #include <pmacc/Environment.hpp>
 #include <pmacc/dimensions/DataSpace.hpp>
 
+
+namespace pmacc
+{
+namespace test
+{
+
 /** Fixture that initializes PMacc for a given dimensionality */
 template<unsigned T_dim>
 struct PMaccFixture
@@ -43,5 +49,8 @@ struct PMaccFixture
     }
 };
 
-typedef PMaccFixture<2> PMaccFixture2D;
-typedef PMaccFixture<3> PMaccFixture3D;
+using PMaccFixture2D = PMaccFixture< 2 >;
+using PMaccFixture3D = PMaccFixture< 3 >;
+
+} // namespace test
+} // namespace pmacc

--- a/include/pmacc/test/memory/HostBufferIntern/copyFrom.hpp
+++ b/include/pmacc/test/memory/HostBufferIntern/copyFrom.hpp
@@ -23,6 +23,16 @@
 
 /* #includes in "test/memoryUT.cu" */
 
+
+namespace pmacc
+{
+namespace test
+{
+namespace memory
+{
+namespace HostBufferIntern
+{
+
 /**
  * Checks if data is copied correctly from device to
  * host.
@@ -32,9 +42,10 @@ struct CopyFromTest {
     template<typename T_Dim>
     void exec(T_Dim)
     {
+        using Data = uint8_t ;
+        using Extents = size_t;
 
-        typedef uint8_t Data;
-        typedef size_t Extents;
+        using ::pmacc::test::memory::getElementsPerDim;
 
         std::vector<size_t> nElementsPerDim = getElementsPerDim<T_Dim>();
 
@@ -72,7 +83,13 @@ struct CopyFromTest {
     }
 };
 
-BOOST_AUTO_TEST_CASE( copyFrom ){
-    ::boost::mpl::for_each< Dims >( CopyFromTest() );
+} // namespace HostBufferIntern
+} // namespace memory
+} // namespace test
+} // namespace pmacc
 
+BOOST_AUTO_TEST_CASE( copyFrom )
+{
+    using namespace pmacc::test::memory::HostBufferIntern;
+    ::boost::mpl::for_each< Dims >( CopyFromTest() );
 }

--- a/include/pmacc/test/memory/HostBufferIntern/reset.hpp
+++ b/include/pmacc/test/memory/HostBufferIntern/reset.hpp
@@ -23,6 +23,16 @@
 
 /* #includes in "test/memoryUT.cu" */
 
+
+namespace pmacc
+{
+namespace test
+{
+namespace memory
+{
+namespace HostBufferIntern
+{
+
 /**
  * Checks if the HostBufferIntern is reseted correctly to zero.
  */
@@ -31,9 +41,10 @@ struct ResetTest {
     template<typename T_Dim>
     void exec(T_Dim)
     {
+        using Data = uint8_t ;
+        using Extents = size_t;
 
-        typedef uint8_t Data;
-        typedef size_t Extents;
+        using ::pmacc::test::memory::getElementsPerDim;
 
         std::vector<size_t> nElementsPerDim = getElementsPerDim<T_Dim>();
 
@@ -60,7 +71,13 @@ struct ResetTest {
     }
 };
 
-BOOST_AUTO_TEST_CASE( reset ){
-    ::boost::mpl::for_each< Dims >( ResetTest() );
+} // namespace HostBufferIntern
+} // namespace memory
+} // namespace test
+} // namespace pmacc
 
+BOOST_AUTO_TEST_CASE( reset )
+{
+    using namespace pmacc::test::memory::HostBufferIntern;
+    ::boost::mpl::for_each< Dims >( ResetTest() );
 }

--- a/include/pmacc/test/memory/HostBufferIntern/setValue.hpp
+++ b/include/pmacc/test/memory/HostBufferIntern/setValue.hpp
@@ -23,6 +23,16 @@
 
 /* #includes in "test/memoryUT.cu" */
 
+
+namespace pmacc
+{
+namespace test
+{
+namespace memory
+{
+namespace HostBufferIntern
+{
+
 /**
  * Checks if the HostBufferIntern is set to a constant value.
  */
@@ -32,9 +42,10 @@ struct setValueTest
     template<typename T_Dim>
     void exec(T_Dim)
     {
+        using Data = uint8_t ;
+        using Extents = size_t;
 
-        typedef uint8_t Data;
-        typedef size_t Extents;
+        using ::pmacc::test::memory::getElementsPerDim;
 
         std::vector<size_t> nElementsPerDim = getElementsPerDim<T_Dim>();
 
@@ -64,8 +75,13 @@ struct setValueTest
     }
 };
 
+} // namespace HostBufferIntern
+} // namespace memory
+} // namespace test
+} // namespace pmacc
+
 BOOST_AUTO_TEST_CASE( setValue )
 {
+    using namespace pmacc::test::memory::HostBufferIntern;
     ::boost::mpl::for_each< Dims >( setValueTest() );
-
 }

--- a/include/pmacc/test/memory/memoryUT.cpp
+++ b/include/pmacc/test/memory/memoryUT.cpp
@@ -46,10 +46,16 @@
 #include "pmacc/types.hpp" /* DIM1,DIM2,DIM3 */
 
 
+namespace pmacc
+{
+namespace test
+{
+namespace memory
+{
+
 /*******************************************************************************
  * Configuration
  ******************************************************************************/
-
 
 /**
  * Defines for which numbers of elements a
@@ -75,6 +81,9 @@ std::vector<size_t> getElementsPerDim(){
     return nElementsPerDim;
 }
 
+} // namespace memory
+} // namespace test
+} // namespace pmacc
 
 /**
  * Definition of a list of dimension types. This
@@ -82,16 +91,16 @@ std::vector<size_t> getElementsPerDim(){
  * each dimension setup automatically. For this
  * purpose boost::mpl::for_each is used.
  */
-typedef ::boost::mpl::list<boost::mpl::int_<DIM1>,
-                           boost::mpl::int_<DIM2>,
-                           boost::mpl::int_<DIM3> > Dims;
-
+using Dims = ::boost::mpl::list< boost::mpl::int_< DIM1 >,
+                                 boost::mpl::int_< DIM2 >,
+                                 boost::mpl::int_< DIM3 > >;
 
 /*******************************************************************************
  * Test Suites
  ******************************************************************************/
-typedef PMaccFixture<TEST_DIM> MyPMaccFixture;
-BOOST_GLOBAL_FIXTURE(MyPMaccFixture);
+using MyPMaccFixture = pmacc::test::PMaccFixture< TEST_DIM >;
+
+BOOST_GLOBAL_FIXTURE( MyPMaccFixture );
 
 BOOST_AUTO_TEST_SUITE( memory )
 

--- a/include/pmacc/test/particles/particlesUT.cpp
+++ b/include/pmacc/test/particles/particlesUT.cpp
@@ -20,12 +20,16 @@
  */
 
 #include "pmacc/test/PMaccFixture.hpp"
+
 #include <boost/test/unit_test.hpp>
 
+
 #if TEST_DIM == 2
-    BOOST_GLOBAL_FIXTURE(PMaccFixture2D);
+    using pmacc::test::PMaccFixture2D;
+    BOOST_GLOBAL_FIXTURE( PMaccFixture2D );
 #else
-    BOOST_GLOBAL_FIXTURE(PMaccFixture3D);
+    using pmacc::test::PMaccFixture3D;
+    BOOST_GLOBAL_FIXTURE( PMaccFixture3D );
 #endif
 
 #include "IdProvider.hpp"

--- a/include/pmacc/test/random/2DDistribution.cpp
+++ b/include/pmacc/test/random/2DDistribution.cpp
@@ -32,13 +32,22 @@
 #include "pmacc/dataManagement/ISimulationData.hpp"
 #include "pmacc/Environment.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
+
 #include <stdint.h>
 #include <iostream>
 #include <fstream>
 #include <limits>
 
-typedef pmacc::DataSpace<DIM2> Space2D;
-typedef pmacc::DataSpace<DIM3> Space3D;
+
+namespace pmacc
+{
+namespace test
+{
+namespace random
+{
+
+using Space2D = pmacc::DataSpace< DIM2 >;
+using Space3D = pmacc::DataSpace< DIM3 >;
 
 template<
     uint32_t T_numWorkers,
@@ -319,14 +328,21 @@ void runTest(uint32_t numSamples)
     std::cout << " std. dev: " << stdDev << std::endl;
 }
 
+} // namespace random
+} // namespace test
+} // namespace pmacc
+
 int main(int argc, char** argv)
 {
-    pmacc::Environment<2>::get().initDevices(Space2D::create(1), Space2D::create(0));
+    using namespace pmacc;
+    using namespace test::random;
+
+    Environment<2>::get().initDevices(Space2D::create(1), Space2D::create(0));
 
     const uint32_t numSamples = (argc > 1) ? atoi(argv[1]) : 100;
 
-    runTest< pmacc::random::methods::AlpakaRand< cupla::Acc> >(numSamples);
+    runTest< random::methods::AlpakaRand< cupla::Acc> >(numSamples);
 
     /* finalize the pmacc context */
-    pmacc::Environment<>::get().finalize();
+    Environment<>::get().finalize();
 }


### PR DESCRIPTION
Add missing namespace to PMacc tests. Related to #2577