### PR TITLE
Piz Daint: avoid pmi_alps warnings

### DIFF
--- a/etc/picongpu/pizdaint-cscs/normal.tpl
+++ b/etc/picongpu/pizdaint-cscs/normal.tpl
@@ -79,6 +79,11 @@ unset MODULES_NO_OUTPUT
 mkdir simOutput 2> /dev/null
 cd simOutput
 
+# the next three lines were recommended by Cray to avoid warnings
+export PMI_MMAP_SYNC_WAIT_TIME=300
+export PMI_NO_FORK=1
+export PMI_NO_PREINITIALIZE=1
+
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   srun  -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh


### PR DESCRIPTION
On Piz Daint I received strange warnings in `stderr` after their maintenance and after
we changed the worlkflow to use some of their modules (`cmake` and the `daint-gpu` module) instead of building the code ourselves.

Example:
```Shell
Mon Apr  9 19:34:23 2018: [unset]:_pmi_alps_get_apid:alps response not OKAY
Mon Apr  9 19:34:23 2018: [unset]:_pmi_init:_pmi_alps_init returned -1
Mon Apr  9 19:35:49 2018: [unset]:_pmi_alps_get_apid:alps response not OKAY
Mon Apr  9 19:35:49 2018: [unset]:_pmi_init:_pmi_alps_init returned -1
```

I reported these warnings which at least didn't seem to have any malicious
consequence and the CSCS support reached out to Cray.
After setting three different environment variables the warnings disappeared.

They apparently appeared once for each call of `srun`.
I found the same thing reported at https://www.nersc.gov/assets/Uploads/slurm-cug2016-slides.pdf on slide 5.

The corresponding ticket ID at CSCS' support ticket system is **[cscs.ch #31059]**. If you encounter this behavior again, feel free to prepend this string to your subject line when writing to help@cscs.ch. 