### PR TITLE
ADIOS: 1.13.1

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -244,7 +244,7 @@ png2gas
 
 ADIOS
 """""
-- 1.10.0+ (requires *MPI* and *zlib*)
+- 1.13.1+ (requires *MPI* and *zlib*)
 - *Debian/Ubuntu:* ``sudo apt-get install libadios-dev libadios-bin``
 - *Arch Linux* using an `AUR helper <https://wiki.archlinux.org/index.php/AUR_helpers>`_: ``pacaur --sync libadios``
 - *Arch Linux* using the `AUR <https://wiki.archlinux.org/index.php/Arch_User_Repository>`_ manually:
@@ -258,9 +258,9 @@ ADIOS
 
   - ``mkdir -p ~/src ~/build ~/lib``
   - ``cd ~/src``
-  - ``wget http://users.nccs.gov/~pnorbert/adios-1.10.0.tar.gz``
-  - ``tar -xvzf adios-1.10.0.tar.gz``
-  - ``cd adios-1.10.0``
+  - ``wget http://users.nccs.gov/~pnorbert/adios-1.13.1.tar.gz``
+  - ``tar -xvzf adios-1.13.1.tar.gz``
+  - ``cd adios-1.13.1``
   - ``CFLAGS="-fPIC" ./configure --enable-static --enable-shared --prefix=$HOME/lib/adios --with-mpi=$MPI_ROOT --with-zlib=/usr``
   - ``make``
   - ``make install``

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -95,7 +95,7 @@ touch "$thisDir"runGuard
             export PIC_BACKEND="cuda"
             . /etc/profile
             module load gcc/4.9.4 boost/1.62.0 cmake/3.10.0 cuda/8.0.44 openmpi/1.10.4
-            module load libSplash/1.6.0 adios/1.10.0
+            module load libSplash/1.6.0 adios/1.13.1
             module load pngwriter/0.7.0 rivlib/1.0.2
             module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.1.0
 

--- a/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
+++ b/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
@@ -32,7 +32,7 @@ then
         module load hdf5-parallel/1.8.15 libsplash/1.7.0
 
         # either use libSplash or ADIOS for file I/O
-        #module load adios/1.10.0
+        #module load adios/1.13.1
 
         # Debug Tools
         #module load gdb

--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -33,7 +33,7 @@ then
         module load hdf5-parallel/1.8.20 libsplash/1.7.0
 
         # either use libSplash or ADIOS for file I/O
-        #module load adios/1.10.0
+        #module load adios/1.13.1
 
         # Debug Tools
         #module load gdb

--- a/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
@@ -33,7 +33,7 @@ then
         module load hdf5-parallel/1.8.20 libsplash/1.7.0
 
         # either use libSplash or ADIOS for file I/O
-        #module load adios/1.10.0
+        #module load adios/1.13.1
 
         # Debug Tools
         #module load gdb

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -33,7 +33,7 @@ then
         module load hdf5-parallel/1.8.15 libsplash/1.7.0
 
         # either use libSplash or ADIOS for file I/O
-        #module load adios/1.10.0
+        #module load adios/1.13.1
 
         # Debug Tools
         #module load gdb

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -53,7 +53,7 @@ export ZLIB_ROOT=$SCRATCH/lib/zlib-1.2.11
 export PNG_ROOT=$SCRATCH/lib/libpng-1.6.34
 export BLOSC_ROOT=$SCRATCH/lib/blosc-1.12.1
 export PNGwriter_DIR=$SCRATCH/lib/pngwriter-0.7.0
-export ADIOS_ROOT=$SCRATCH/lib/adios-1.13.0
+export ADIOS_ROOT=$SCRATCH/lib/adios-1.13.1
 export Splash_DIR=$SCRATCH/lib/splash-1.7.0
 
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH

--- a/etc/picongpu/titan-ornl/picongpu.profile.example
+++ b/etc/picongpu/titan-ornl/picongpu.profile.example
@@ -67,7 +67,7 @@ export MPI_ROOT=$MPICH_DIR
 
 # plugins (optional) ##########################################################
 module load cray-hdf5-parallel/1.8.14
-module load adios/1.10.0
+module load adios/1.13.1
 export HDF5_ROOT=$HDF5_DIR
 #export ADIOS_ROOT=$ADIOS_DIR
 #export DATASPACES_ROOT=$DATASPACES_DIR

--- a/etc/picongpu/titan-ornl/pythonOnRhea.profile.example
+++ b/etc/picongpu/titan-ornl/pythonOnRhea.profile.example
@@ -22,7 +22,7 @@ module load python_scipy
 export IPYTHONDIR=$PROJWORK/$proj/ipython
 
 # ADIOS
-export ADIOS_ROOT=$PROJWORK/$proj/lib/adios-1.10.0-rhea
+export ADIOS_ROOT=$PROJWORK/$proj/lib/adios-1.13.1-rhea
 export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
 export PATH=$ADIOS_ROOT/bin:$PATH
 
@@ -38,7 +38,7 @@ source $PROJWORK/$proj/python-venv/rhea/bin/activate
 #
 # first install adios
 #   LDFLAGS="-fPIC -pthread" CFLAGS="-fPIC -g -O2" CXXFLAGS="-fPIC -g -O2" \
-#     ./configure --prefix=$PROJWORK/$proj/lib/adios-1.10.0-rhea \
+#     ./configure --prefix=$PROJWORK/$proj/lib/adios-1.13.1-rhea \
 #     --with-zlib --with-mpi --enable-static --enable-shared \
 #     --without-dataspaces
 #   make -j

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -227,7 +227,7 @@ add_definitions(-DPIC_VERBOSE_LVL=${PIC_VERBOSE})
 
 # find adios installation
 #   set(ADIOS_USE_STATIC_LIBS ON) # force static linking
-find_package(ADIOS 1.10.0)
+find_package(ADIOS 1.13.1)
 
 if(ADIOS_FOUND)
     add_definitions(-DENABLE_ADIOS=1)

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -1312,15 +1312,8 @@ private:
         DataSpace<simDim> particleOffset(localDomain.offset);
         particleOffset.y() -= threadParams->window.globalDimensions.offset.y();
 
-        /* ADIOS API change:
-         * <= 1.10.0: `enum ADIOS_FLAG`
-         * >= 1.11.0: `enum ADIOS_STATISTICS_FLAG`
-         */
-#if ( ( ADIOS_VERSION_MAJOR * 100 + ADIOS_VERSION_MINOR ) >= 111 )
+        // do not generate statistics for variables on the fly
         ADIOS_STATISTICS_FLAG noStatistics = adios_stat_no;
-#else
-        ADIOS_FLAG noStatistics = adios_flag_no;
-#endif
 
         /* create adios group for fields without statistics */
         ADIOS_CMD(adios_declare_group(&(threadParams->adiosGroupHandle),

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -111,7 +111,7 @@ message(STATUS "Found Splash: ${Splash_DIR}")
 
 # find adios installation
 #   set(ADIOS_USE_STATIC_LIBS ON) # force static linking
-find_package(ADIOS 1.10.0)
+find_package(ADIOS 1.13.1)
 
 if(ADIOS_FOUND)
     add_definitions(-DENABLE_ADIOS=1)


### PR DESCRIPTION
ADIOS 1.13.1 fixes several issues with zero-sized block reading and writing when compression transports are used.

This mostly shows up in PIConGPU with simulations on which some GPUs hold zero particles, e.g. in ion acceleration.

Close #2562