### PR TITLE
updata alpaka to release 0.3.0

### DIFF
--- a/thirdParty/alpaka/README.md
+++ b/thirdParty/alpaka/README.md
@@ -63,7 +63,7 @@ Supported Compilers
 
 This library uses C++11 (or newer when available).
 
-|Accelerator Back-end|gcc 4.9.2|gcc 5.4|gcc 6.3/7.2|clang 3.5/3.6|clang 3.7/3.8|clang 3.9|clang 4/5|MSVC 2015.3/2017.3|
+|Accelerator Back-end|gcc 4.9.2|gcc 5.4|gcc 6.3/7.2|clang 3.5/3.6|clang 3.7/3.8|clang 3.9|clang 4/5|MSVC 2017.5|
 |---|---|---|---|---|---|---|---|---|
 |Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|

--- a/thirdParty/alpaka/appveyor.yml
+++ b/thirdParty/alpaka/appveyor.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Benjamin Worpitz, Erik Zenker
+# Copyright 2015-2017 Benjamin Worpitz, Erik Zenker
 #
 # This file is part of alpaka.
 #
@@ -51,15 +51,9 @@ environment:
           OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: boost-1.65.1
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        #- OMP_NUM_THREADS: 4
-        #  ALPAKA_BOOST_BRANCH: boost-1.64.0
-        #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - OMP_NUM_THREADS: 3
-          ALPAKA_BOOST_BRANCH: boost-1.65.1
-          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-        - OMP_NUM_THREADS: 1
-          ALPAKA_BOOST_BRANCH: boost-1.62.0
-          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+        - OMP_NUM_THREADS: 4
+          ALPAKA_BOOST_BRANCH: boost-1.64.0
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 matrix:
     fast_finish: true
@@ -146,7 +140,6 @@ before_build:
     - cmd: set ALPAKA_BOOST_B2=--with-test
     - cmd: if "%ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE%"=="ON" set ALPAKA_BOOST_B2=%ALPAKA_BOOST_B2% --with-fiber --with-context --with-thread --with-system --with-atomic --with-chrono --with-date_time
 
-    - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" set ALPAKA_BOOST_TOOLSET=msvc-14.0
     - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" set ALPAKA_BOOST_TOOLSET=msvc-14.1
     - cmd: b2 -j2 --toolset=%ALPAKA_BOOST_TOOLSET% --layout=versioned %ALPAKA_BOOST_B2% architecture=x86 address-model=%ALPAKA_BOOST_ADDRESS_MODEL% variant=%ALPAKA_BOOST_VARIANT% link=static threading=multi runtime-link=shared define=_CRT_NONSTDC_NO_DEPRECATE define=_CRT_SECURE_NO_DEPRECATE define=_SCL_SECURE_NO_DEPRECAT define=BOOST_USE_WINFIBERS --stagedir="%ALPAKA_B2_STAGE_DIR%"
 
@@ -168,8 +161,6 @@ before_build:
     # Build the visual studio soultion from the cmake files.
     - cmd: cd C:\projects\alpaka
 
-    - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" set ALPAKA_CMAKE_GENERATOR=Visual Studio 14 2015
-    - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
     - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" set ALPAKA_CMAKE_GENERATOR=Visual Studio 15 2017
     - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
     - cmd: if "%PLATFORM%"=="x64" set ALPAKA_CMAKE_GENERATOR=%ALPAKA_CMAKE_GENERATOR% Win64

--- a/thirdParty/alpaka/include/alpaka/version.hpp
+++ b/thirdParty/alpaka/include/alpaka/version.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2016-2017 Erik Zenker, Benjamin Worpitz
+* Copyright 2016-2018 Erik Zenker, Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -24,7 +24,7 @@
 #include <boost/predef/version_number.h>
 
 #define ALPAKA_VERSION_MAJOR 0
-#define ALPAKA_VERSION_MINOR 2
+#define ALPAKA_VERSION_MINOR 3
 #define ALPAKA_VERSION_PATCH 0
 
 //! The alpaka library version number


### PR DESCRIPTION
Update alpaka from 
 - dev alpaka@develop (ComputationalRadiationPhysics/alpaka@9e3d274)
to
 - release  alpaka@master (ComputationalRadiationPhysics/alpaka@c0e1b3c56 == [`0.3.0`](https://github.com/ComputationalRadiationPhysics/alpaka/tree/0.3.0) )

# Changes to Last Stable

Bugs Fixed:
* fixed multiple bugs where CPU streams/events could deadlock or behaved different than the native CUDA events
* fixed a bug where the block synchronization of the Boost.Fiber backend crashed due to uninitialized variables

New Features / Enhancements:
* added support for stream callbacks allowing to enqueue arbitrary host code using `alpaka::stream::enqueue(stream, [&](){...});`
* added support for compiling for multiple architectures using e.g. `ALPAKA_CUDA_ARCH="20;35"`
* added support for using `__host__ constexpr` code within `__device__` code
* enhanced the CUDA error handling
* enhanced the documentation for [mapping CUDA to alpaka](https://github.com/ComputationalRadiationPhysics/alpaka/blob/0.3.0/doc/markdown/user/implementation/mapping/CUDA.md)

Compatibility Changes:
* added support for CUDA 9.0 and 9.1
* added support for CMake 3.9 and 3.10
* removed support for CMake 3.6 and older
* added support for boost-1.65.0
* removed support for boost-1.61.0 and older
* added support for gcc 7
* added support for clang 4 and 5
* removed support for VS2015

# Used Update Command
```
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git subtree pull --prefix thirdParty/alpaka \
  git@github.com:ComputationalRadiationPhysics/alpaka.git master --squash
```