### PR TITLE
memory.param: GUARD_SIZE docs

### DIFF
--- a/include/picongpu/param/memory.param
+++ b/include/picongpu/param/memory.param
@@ -46,6 +46,20 @@ namespace picongpu
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize >;
 
+    /** define the size of the core, border and guard area
+     *
+     * PIConGPU uses spatial domain-decomposition for parallelization
+     * over multiple devices with non-shared memory architecture.
+     * The global spatial domain is organized per device in three
+     * sections: the GUARD area contains copies of neighboring
+     * devices (also known as "halo"/"ghost").
+     * The BORDER area is the outermost layer of cells of a device,
+     * equally to what neighboring devices see as GUARD area.
+     * The CORE area is the innermost area of a device. In union with
+     * the BORDER area it defines the "active" spatial domain on a device.
+     *
+     * GUARD_SIZE is defined in units of SuperCellSize.
+     */
     constexpr uint32_t GUARD_SIZE = 1;
 
     /** bytes reserved for species exchange buffer

--- a/include/picongpu/param/memory.param
+++ b/include/picongpu/param/memory.param
@@ -17,6 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
 #pragma once
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
@@ -33,7 +42,7 @@ namespace picongpu
     constexpr size_t reservedGpuMemorySize = 350 *1024*1024;
 
     /* short namespace*/
-    namespace mCT=pmacc::math::CT;
+    namespace mCT = pmacc::math::CT;
     /** size of a superCell
      *
      * volume of a superCell must be <= 1024
@@ -44,7 +53,7 @@ namespace picongpu
     >::type;
 
     /** define mapper which is used for kernel call mappings */
-    using MappingDesc = MappingDescription<simDim, SuperCellSize >;
+    using MappingDesc = MappingDescription< simDim, SuperCellSize >;
 
     /** define the size of the core, border and guard area
      *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
@@ -17,6 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
 #pragma once
 
 #include <pmacc/math/Vector.hpp>

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
@@ -44,6 +44,20 @@ namespace picongpu
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription< simDim, SuperCellSize >;
 
+    /** define the size of the core, border and guard area
+     *
+     * PIConGPU uses spatial domain-decomposition for parallelization
+     * over multiple devices with non-shared memory architecture.
+     * The global spatial domain is organized per device in three
+     * sections: the GUARD area contains copies of neighboring
+     * devices (also known as "halo"/"ghost").
+     * The BORDER area is the outermost layer of cells of a device,
+     * equally to what neighboring devices see as GUARD area.
+     * The CORE area is the innermost area of a device. In union with
+     * the BORDER area it defines the "active" spatial domain on a device.
+     *
+     * GUARD_SIZE is defined in units of SuperCellSize.
+     */
     constexpr uint32_t GUARD_SIZE = 1;
 
     /** bytes reserved for species exchange buffer

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
@@ -17,6 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
 #pragma once
 
 #include <pmacc/math/Vector.hpp>

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
@@ -47,6 +47,20 @@ using SuperCellSize = typename mCT::shrinkTo<
 /** define the object for mapping superCells to cells*/
 using MappingDesc = MappingDescription< simDim, SuperCellSize >;
 
+/** define the size of the core, border and guard area
+ *
+ * PIConGPU uses spatial domain-decomposition for parallelization
+ * over multiple devices with non-shared memory architecture.
+ * The global spatial domain is organized per device in three
+ * sections: the GUARD area contains copies of neighboring
+ * devices (also known as "halo"/"ghost").
+ * The BORDER area is the outermost layer of cells of a device,
+ * equally to what neighboring devices see as GUARD area.
+ * The CORE area is the innermost area of a device. In union with
+ * the BORDER area it defines the "active" spatial domain on a device.
+ *
+ * GUARD_SIZE is defined in units of SuperCellSize.
+ */
 constexpr uint32_t GUARD_SIZE = 1;
 
 /** bytes reserved for species exchange buffer

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
@@ -17,6 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
 #pragma once
 
 #include <pmacc/math/Vector.hpp>

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
@@ -47,6 +47,20 @@ using SuperCellSize = typename mCT::shrinkTo<
 /** define the object for mapping superCells to cells*/
 using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 
+/** define the size of the core, border and guard area
+ *
+ * PIConGPU uses spatial domain-decomposition for parallelization
+ * over multiple devices with non-shared memory architecture.
+ * The global spatial domain is organized per device in three
+ * sections: the GUARD area contains copies of neighboring
+ * devices (also known as "halo"/"ghost").
+ * The BORDER area is the outermost layer of cells of a device,
+ * equally to what neighboring devices see as GUARD area.
+ * The CORE area is the innermost area of a device. In union with
+ * the BORDER area it defines the "active" spatial domain on a device.
+ *
+ * GUARD_SIZE is defined in units of SuperCellSize.
+ */
 constexpr uint32_t GUARD_SIZE = 1;
 
 /** bytes reserved for species exchange buffer

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
@@ -46,6 +46,21 @@ using SuperCellSize = typename mCT::shrinkTo<
 
 /** define the object for mapping superCells to cells*/
 using MappingDesc = MappingDescription< simDim, SuperCellSize >;
+
+/** define the size of the core, border and guard area
+ *
+ * PIConGPU uses spatial domain-decomposition for parallelization
+ * over multiple devices with non-shared memory architecture.
+ * The global spatial domain is organized per device in three
+ * sections: the GUARD area contains copies of neighboring
+ * devices (also known as "halo"/"ghost").
+ * The BORDER area is the outermost layer of cells of a device,
+ * equally to what neighboring devices see as GUARD area.
+ * The CORE area is the innermost area of a device. In union with
+ * the BORDER area it defines the "active" spatial domain on a device.
+ *
+ * GUARD_SIZE is defined in units of SuperCellSize.
+ */
 constexpr uint32_t GUARD_SIZE = 1;
 
 /** bytes reserved for species exchange buffer

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
@@ -17,6 +17,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
 
 #pragma once
 


### PR DESCRIPTION
Add a doxygen string explaining the `GUARD_SIZE` parameter. The runtime error from PMACC_VERIFY we throw in `MySimulation.hpp` did otherwise not make sense to users.

Other resources: *Docs » Workflows » Setting the Number of Cells* in the [manual](https://picongpu.readthedocs.io/en/latest/usage/workflows/numberOfCells.html).

Thx to @HighIander for the hint docs were missing.

Related to #1982.