### PR TITLE
fix error message:  missing restart step

### DIFF
--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -442,7 +442,7 @@ public:
             initialiserController->printInformation();
             if (this->restartRequested)
             {
-                /* we do not require --restart.step if a master checkpoint file is found */
+                /* we do not require '--checkpoint.restart.step' if a master checkpoint file is found */
                 if (this->restartStep < 0)
                 {
                     std::vector<uint32_t> checkpoints = readCheckpointMasterFile();
@@ -450,7 +450,7 @@ public:
                     if (checkpoints.empty())
                     {
                         throw std::runtime_error(
-                            "Restart failed. You must provide the '--restart.step' argument. See picongpu --help."
+                            "Restart failed. You must provide the '--checkpoint.restart.step' argument. See picongpu --help."
                         );
                     } else
                         this->restartStep = checkpoints.back();


### PR DESCRIPTION
The old parameter `--restart.step` is shown in the error message if the master
checkpoint file is not available.

- add correct parameter `--checkpoint.restart.step` to the error message
- fix in code documentation string