### PR TITLE
precision.param: file doxygen

### DIFF
--- a/include/picongpu/param/precision.param
+++ b/include/picongpu/param/precision.param
@@ -17,6 +17,17 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Define the precision of typically used floating point types in the
+ * simulation.
+ *
+ * PIConGPU normalizes input automatically, allowing to use single-precision by
+ * default for the core algorithms. Note that implementations of various
+ * algorithms (usually plugins or non-core components) might still decide to
+ * hard-code a different (mixed) precision for some critical operations.
+ */
+
 #pragma once
 
 
@@ -38,7 +49,7 @@ namespace precisionPIConGPU      = precision32Bit;
  */
 namespace precisionSqrt          = precisionPIConGPU;
 namespace precisionExp           = precisionPIConGPU;
-namespace precisionTrigonemetric = precisionPIConGPU;
+namespace precisionTrigonometric = precisionPIConGPU;
 
 
 } // namespace picongpu

--- a/include/picongpu/unitless/precision.unitless
+++ b/include/picongpu/unitless/precision.unitless
@@ -69,6 +69,6 @@ namespace picongpu
     using sqrt_X = precisionSqrt::precisionType;
     using exp_X = precisionExp::precisionType;
     // trigonometric functions
-    using trigo_X = precisionTrigonemetric::precisionType;
+    using trigo_X = precisionTrigonometric::precisionType;
 
 } // namespace picongpu

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/precision.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/precision.param
@@ -17,6 +17,17 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Define the precision of typically used floating point types in the
+ * simulation.
+ *
+ * PIConGPU normalizes input automatically, allowing to use single-precision by
+ * default for the core algorithms. Note that implementations of various
+ * algorithms (usually plugins or non-core components) might still decide to
+ * hard-code a different (mixed) precision for some critical operations.
+ */
+
 #pragma once
 
 
@@ -41,7 +52,7 @@ namespace precisionPIConGPU      = PARAM_PRECISION;
  */
 namespace precisionSqrt          = precisionPIConGPU;
 namespace precisionExp           = precisionPIConGPU;
-namespace precisionTrigonemetric = precisionPIConGPU;
+namespace precisionTrigonometric = precisionPIConGPU;
 
 
 } // namespace picongpu


### PR DESCRIPTION
Add a file doxygen comment for the precision input file. Will be automatically be shown in the manual.

Also fixes a typo in `trigonometric`.

Related to #1982.