### PR TITLE
CompileSuite: Update Plugins

### DIFF
--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -95,9 +95,9 @@ touch "$thisDir"runGuard
             export PIC_BACKEND="cuda"
             . /etc/profile
             module load gcc/4.9.4 boost/1.62.0 cmake/3.10.0 cuda/8.0.44 openmpi/1.10.4
-            module load libSplash/1.6.0 adios/1.13.1
-            module load pngwriter/0.7.0 rivlib/1.0.2
-            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.1.0
+            module load libSplash/1.7.0 adios/1.13.1
+            module load pngwriter/0.7.0
+            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.3.0
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/bin/pic-compile -l -q -j $cnf_numParallel \


### PR DESCRIPTION
Update the following plugins to their minimum version for the compile suite:
- libSplash 1.7.0
- ISAAC 1.3.0

Remove rivlib (used in our first 3D in situ render plugin before ISAAC).