### PR TITLE
Syntax Highlighting: Fix RTD Theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
-sphinx_rtd_theme
+sphinx_rtd_theme>=0.3.1
 recommonmark
 sphinx
 breathe>=4.5
 sphinxcontrib.programoutput
+pygments
 # generate plots
 matplotlib
 scipy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,7 +111,7 @@ language = None
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False


### PR DESCRIPTION
The syntax highlighting with pygments was broken in the readthedocs theme.

Also changes the pygments style to `default` since the `"sphinx"` style has a weird green background that does not go well with the rtd theme.

Fixed in sphinx_rtd_theme 0.3.0+, so we just install a newer version of it in the rtd instance: https://github.com/rtfd/sphinx_rtd_theme/pull/448