### PR TITLE
 PMAcc functor: const on device functor factory

### DIFF
--- a/include/picongpu/particles/filter/All.hpp
+++ b/include/picongpu/particles/filter/All.hpp
@@ -84,7 +84,7 @@ namespace acc
             T_Acc const & acc,
             DataSpace< simDim > const &,
             T_WorkerCfg const &
-        )
+        ) const
         {
             return acc::All{ };
 

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -144,7 +144,7 @@ namespace acc
             T_Acc const & acc,
             DataSpace< simDim > const & localSuperCellOffset,
             T_WorkerCfg const &
-        )
+        ) const
         {
             return acc::RelativeGlobalDomainPosition< Params >(
                 localDomainOffset,

--- a/include/picongpu/particles/filter/generic/Free.hpp
+++ b/include/picongpu/particles/filter/generic/Free.hpp
@@ -115,9 +115,9 @@ namespace acc
             T_Acc const &,
             DataSpace< simDim > const &,
             T_WorkerCfg const &
-        )
+        ) const
         {
-            return acc::Free< Functor >( *static_cast< Functor * >( this ) );
+            return acc::Free< Functor >( *static_cast< Functor const * >( this ) );
         }
 
         static

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -146,13 +146,13 @@ namespace acc
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
-        )
+        ) const
         -> acc::FreeRng<
             Functor,
             RngType
         >
         {
-            RngType const rng = ( *static_cast< RngGenerator * >( this ) )(
+            RngType const rng = ( *static_cast< RngGenerator const * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -162,7 +162,7 @@ namespace acc
                 Functor,
                 RngType
             >(
-                *static_cast< Functor * >( this ),
+                *static_cast< Functor const * >( this ),
                 rng
             );
         }

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -139,9 +139,9 @@ namespace acc
         )
         -> acc::FreeTotalCellOffset< Functor >
         {
-            auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor * >( this );
+            auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor const * >( this );
             return acc::FreeTotalCellOffset< Functor >(
-                *static_cast< Functor * >( this ),
+                *static_cast< Functor const * >( this ),
                 cellOffsetFunctor(
                     acc,
                     localSupercellOffset,

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -96,20 +96,20 @@ namespace misc
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
-        )
+        ) const
         {
             namespace nvrng = nvidia::rng;
 
             using FrameType = typename SpeciesType::FrameType;
             using SuperCellSize = typename FrameType::SuperCellSize;
-
-            rngHandle.init(
+            RngHandle tmp( rngHandle );
+            tmp.init(
                 localSupercellOffset * SuperCellSize::toRT() +
                 DataSpaceOperations< simDim >::template map< SuperCellSize >( workerCfg.getWorkerIdx( ) )
             );
             return RandomGen(
                 acc,
-                rngHandle.applyDistribution< Distribution >()
+                tmp.applyDistribution< Distribution >()
             );
         }
 

--- a/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
+++ b/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
@@ -66,7 +66,7 @@ namespace misc
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const &
-        )
+        ) const
         {
             DataSpace< simDim > const superCellToLocalOriginCellOffset(
                 localSupercellOffset * SuperCellSize::toRT( )

--- a/include/picongpu/particles/manipulators/generic/Free.hpp
+++ b/include/picongpu/particles/manipulators/generic/Free.hpp
@@ -111,9 +111,9 @@ namespace acc
             T_Acc const &,
             DataSpace< simDim > const &,
             T_WorkerCfg const &
-        )
+        ) const
         {
-            return acc::Free< Functor >( *static_cast< Functor * >( this ) );
+            return acc::Free< Functor >( *static_cast< Functor const * >( this ) );
         }
 
         //! get the name of the functor

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -148,13 +148,13 @@ namespace acc
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
-        )
+        ) const
         -> acc::FreeRng<
             Functor,
             RngType
         >
         {
-            RngType const rng = ( *static_cast< RngGenerator * >( this ) )(
+            RngType const rng = ( *static_cast< RngGenerator const * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -164,7 +164,7 @@ namespace acc
                 Functor,
                 RngType
             >(
-                *static_cast< Functor * >( this ),
+                *static_cast< Functor const * >( this ),
                 rng
             );
         }

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
@@ -134,9 +134,9 @@ namespace acc
         )
         -> acc::FreeTotalCellOffset< Functor >
         {
-            auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor * >( this );
+            auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor const * >( this );
             return acc::FreeTotalCellOffset< Functor >(
-                *static_cast< Functor * >( this ),
+                *static_cast< Functor const * >( this ),
                 cellOffsetFunctor(
                     acc,
                     localSupercellOffset,

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -155,9 +155,9 @@ namespace acc
             T_Acc const & acc,
             T const &,
             T_WorkerCfg const &
-        )
+        ) const
         {
-            return acc::Free< Functor >( *static_cast< Functor * >( this ) );
+            return acc::Free< Functor >( *static_cast< Functor const * >( this ) );
         }
     };
 

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -190,13 +190,13 @@ namespace acc
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
-        )
+        ) const
         -> acc::FreeRng<
             Functor,
             RngType
         >
         {
-            RngType const rng = ( *static_cast< RngGenerator * >( this ) )(
+            RngType const rng = ( *static_cast< RngGenerator const * >( this ) )(
                 acc,
                 localSupercellOffset,
                 workerCfg
@@ -206,7 +206,7 @@ namespace acc
                 Functor,
                 RngType
             >(
-                *static_cast< Functor * >( this ),
+                *static_cast< Functor const * >( this ),
                 rng
             );
         }

--- a/include/pmacc/functor/Filtered.hpp
+++ b/include/pmacc/functor/Filtered.hpp
@@ -207,7 +207,7 @@ namespace acc
             T_Acc const & acc,
             T_OffsetType const & domainOffset,
             mappings::threads::WorkerCfg< T_numWorkers > const & workerCfg
-        )
+        ) const
         -> acc::Filtered<
             T_FilterOperator,
             decltype(
@@ -243,12 +243,12 @@ namespace acc
                     )
                 )
             >(
-                ( *static_cast< Filter * >( this ) )(
+                ( *static_cast< Filter const * >( this ) )(
                     acc,
                     domainOffset,
                     workerCfg
                 ),
-                ( *static_cast< Functor * >( this ) )(
+                ( *static_cast< Functor const * >( this ) )(
                     acc,
                     domainOffset,
                     workerCfg

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -213,7 +213,7 @@ namespace detail
             T_Acc const & acc,
             T_OffsetType const & domainOffset,
             mappings::threads::WorkerCfg< T_numWorkers > const & workerCfg
-        )
+        ) const
         -> acc::Interface<
             decltype(
                 alpaka::core::declval< UserFunctor >( )(
@@ -226,7 +226,7 @@ namespace detail
             T_ReturnType
         >
         {
-            return ( *static_cast< UserFunctor * >( this ) )(
+            return ( *static_cast< UserFunctor const * >( this ) )(
                 acc,
                 domainOffset,
                 workerCfg


### PR DESCRIPTION
fix: RNG segfault first seen in #2554 

## Problem Description

We call the `rng` init several times with virtual workers.
The `rngHandle` generates a table of states on which is one selected on `RngHandle::init()`.

By copying the handle first, we make sure that each virtual worker starts from the same initial `rngHandle`, which avoids double-shifts which result in out-of-memory access.

## Changes

Set functor interface to create the on device functor of an host functor to `const` to avoid side effects if an worker in lockstep programming is deriving the device functor multiple times from the same base host functor.

- PMacc functor interface change: const on device functor factory
- PIConGPU: const functor on device factory
  - `Rng.hpp`: create a copy of the RNG handle before calling `init()`
  - const-ify the factory method to fulfill the interface

Bug was introduced in #2447
**note** Previous releases are not effected by this bug.
It looks like the bug has no influence on the CUDA backend.