### PR TITLE
HDF5 plugin: fix memory leak

### DIFF
--- a/include/picongpu/plugins/hdf5/HDF5Writer.hpp
+++ b/include/picongpu/plugins/hdf5/HDF5Writer.hpp
@@ -524,10 +524,12 @@ private:
 
     void closeH5File()
     {
-        if (mThreadParams.dataCollector != nullptr)
+        if (mThreadParams.dataCollector)
         {
             log<picLog::INPUT_OUTPUT > ("HDF5 close DataCollector");
             mThreadParams.dataCollector->close();
+            mThreadParams.dataCollector->finalize();
+            __delete(mThreadParams.dataCollector);
         }
     }
 


### PR DESCRIPTION
Fix missing free for ressources in HDF5 plugin.
The result can be that the simulation is running out of memory.