### PR TITLE
fix V100 deadlock

### DIFF
--- a/include/pmacc/nvidia/atomic.hpp
+++ b/include/pmacc/nvidia/atomic.hpp
@@ -90,7 +90,7 @@ namespace nvidia
             {
                 /* Get a bitmask with 1 for each thread in the warp, that executes this */
 #if(__CUDACC_VER_MAJOR__ >= 9)
-                const int mask = __ballot_sync(0xFFFFFFFF, 1);
+                const int mask = __activemask();
 #else
                 const int mask = __ballot(1);
 #endif
@@ -101,7 +101,7 @@ namespace nvidia
                 /* Get the start value for this warp */
                 if (laneId == leader)
                     result = ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc,ptr, static_cast<T_Type>(__popc(mask)), hierarchy);
-                result = warpBroadcast(result, leader, static_cast< uint32_t >(mask));
+                result = warpBroadcast(result, leader);
                 /* Add offset per thread */
                 return result + static_cast<T_Type>(__popc(mask & ((1 << laneId) - 1)));
             }
@@ -185,7 +185,7 @@ atomicAllExch(const T_Acc& acc, T_Type* ptr, const T_Type value, const T_Hierarc
 {
 #if (__CUDA_ARCH__ >= 200)
 #   if(__CUDACC_VER_MAJOR__ >= 9)
-    const int mask = __ballot_sync(0xFFFFFFFF, 1);
+    const int mask = __activemask();
 #   else
     const int mask = __ballot(1);
 #   endif

--- a/include/pmacc/nvidia/warp.hpp
+++ b/include/pmacc/nvidia/warp.hpp
@@ -52,23 +52,22 @@ DINLINE uint32_t getLaneId()
  *
  * @param data value to broadcast
  * @param srcLaneId lane id of the source thread
- * @param laneMask lane mask with participating thread
  * @return value send by the source thread
  *
  * \{
  */
 //! broadcast a 32bit integer
-DINLINE int32_t warpBroadcast(const int32_t data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
+DINLINE int32_t warpBroadcast(const int32_t data, const int32_t srcLaneId)
 {
 #if(__CUDACC_VER_MAJOR__ >= 9)
-    return  __shfl_sync(laneMask, data, srcLaneId);
+    return  __shfl_sync(__activemask(), data, srcLaneId);
 #else
     return  __shfl(data, srcLaneId);
 #endif
 }
 
 //! Broadcast a 64bit integer by using 2 32bit broadcasts
-DINLINE int64_cu warpBroadcast(int64_cu data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
+DINLINE int64_cu warpBroadcast(int64_cu data, const int32_t srcLaneId)
 {
     int32_t* const pData = reinterpret_cast<int32_t*>(&data);
     pData[0] = warpBroadcast(pData[0], srcLaneId);
@@ -77,7 +76,7 @@ DINLINE int64_cu warpBroadcast(int64_cu data, const int32_t srcLaneId, const uin
 }
 
 //! Broadcast a 32bit unsigned int
-DINLINE uint32_t warpBroadcast(const uint32_t data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
+DINLINE uint32_t warpBroadcast(const uint32_t data, const int32_t srcLaneId)
 {
     return static_cast<uint32_t>(
         warpBroadcast(static_cast<int32_t>(data), srcLaneId)
@@ -85,7 +84,7 @@ DINLINE uint32_t warpBroadcast(const uint32_t data, const int32_t srcLaneId, con
 }
 
 //!Broadcast a 64bit unsigned int
-DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
+DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId)
 {
     return static_cast<uint64_cu>(
         warpBroadcast(static_cast<int64_cu>(data), srcLaneId)
@@ -93,17 +92,17 @@ DINLINE uint64_cu warpBroadcast(const uint64_cu data, const int32_t srcLaneId, c
 }
 
 //! Broadcast a 32bit float
-DINLINE float warpBroadcast(const float data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
+DINLINE float warpBroadcast(const float data, const int32_t srcLaneId)
 {
 #if(__CUDACC_VER_MAJOR__ >= 9)
-    return  __shfl_sync(laneMask, data, srcLaneId);
+    return  __shfl_sync(__activemask(), data, srcLaneId);
 #else
     return  __shfl(data, srcLaneId);
 #endif
 }
 
 //! Broadcast a 64bit float by using 2 32bit broadcasts
-DINLINE double warpBroadcast(double data, const int32_t srcLaneId, const uint32_t laneMask = 0xFFFFFFFF)
+DINLINE double warpBroadcast(double data, const int32_t srcLaneId)
 {
     float* const pData = reinterpret_cast<float*>(&data);
     pData[0] = warpBroadcast(pData[0], srcLaneId);


### PR DESCRIPTION
fix #2514

If NVIDIA TESLA V100 is used with a CUDA9.X the gpu is deadlocking.
The reason for the deadlock is the wrong usage `__ballot_sync`.

Solved by using `__activemask()` to call for active lanes in the warp.

- change interface of `warpBroadcast`: remove `laneMask`