### PR TITLE
add support for more cpu alpaka accelerators

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -39,7 +39,7 @@ help()
     echo "                       (default is <inputDirectory>)"
     echo "-b | --backend       - set compute backend and optionally the architecture"
     echo "                       syntax: backend[:architecture]"
-    echo "                       supported backends: cuda, omp2b"
+    echo "                       supported backends: cuda, omp2b, serial, tbb"
     echo "                       (e.g.: \"cuda:20;35;37;52;60\" or \"omp2b:native\" or \"omp2b\")"
     echo "                       default: \"cuda\" if not set via environment variable PIC_BACKEND"
     echo "                       note: architecture names are compiler dependent"
@@ -64,6 +64,16 @@ get_backend_flags()
         fi
     elif [ "${backend_cfg[0]}" == "omp2b" ] ; then
         result+=" -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON"
+        if [ $num_options -eq 2 ] ; then
+            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+        fi
+    elif [ "${backend_cfg[0]}" == "serial" ] ; then
+        result+=" -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON"
+        if [ $num_options -eq 2 ] ; then
+            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+        fi
+    elif [ "${backend_cfg[0]}" == "tbb" ] ; then
+        result+=" -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi

--- a/include/pmacc/traits/GetNumWorkers.hpp
+++ b/include/pmacc/traits/GetNumWorkers.hpp
@@ -59,5 +59,31 @@ namespace traits
         static constexpr uint32_t value = 1u;
     };
 #endif
+#if( ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED == 1 )
+    template<
+        uint32_t T_maxWorkers,
+        typename ... T_Args
+    >
+    struct GetNumWorkers<
+        T_maxWorkers,
+        alpaka::acc::AccCpuSerial< T_Args... >
+    >
+    {
+        static constexpr uint32_t value = 1u;
+    };
+#endif
+#if( ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED == 1 )
+    template<
+        uint32_t T_maxWorkers,
+        typename ... T_Args
+    >
+    struct GetNumWorkers<
+        T_maxWorkers,
+        alpaka::acc::AccCpuTbbBlocks< T_Args... >
+    >
+    {
+        static constexpr uint32_t value = 1u;
+    };
+#endif
 } // namespace traits
 } // namespace pmacc


### PR DESCRIPTION
This PR allows to use more cpu accelerators. To simplify debugging it often helps to run the program serial, which is now supported.

- add accelerator `serial` == `ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE`
- add accelerator  `tbb` == `ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE`
- update `pic-configure`