### PR TITLE
PMacc: refactor RNG method interface

### DIFF
--- a/include/pmacc/random/distributions/distributions.hpp
+++ b/include/pmacc/random/distributions/distributions.hpp
@@ -1,0 +1,25 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/random/distributions/Uniform.hpp"
+#include "pmacc/random/distributions/Normal.hpp"

--- a/include/pmacc/random/methods/AlpakaRand.hpp
+++ b/include/pmacc/random/methods/AlpakaRand.hpp
@@ -30,7 +30,7 @@ namespace random
 namespace methods
 {
 
-    template< typename T_Acc >
+    template< typename T_Acc = cupla::Acc>
     class AlpakaRand
     {
     public:

--- a/include/pmacc/random/methods/MRG32k3aMin.hpp
+++ b/include/pmacc/random/methods/MRG32k3aMin.hpp
@@ -40,11 +40,11 @@ namespace methods
 
 #if( PMACC_CUDA_ENABLED != 1 )
     //! fallback to alpaka RNG if a cpu accelerator is used
-    template< typename T_Acc >
+    template< typename T_Acc = cupla::Acc>
     using MRG32k3aMin = AlpakaRand< T_Acc >;
 #else
     //! Mersenne-Twister random number generator with a reduced state
-    template< typename T_Acc >
+    template< typename T_Acc = cupla::Acc>
     class MRG32k3aMin
     {
     public:

--- a/include/pmacc/random/methods/XorMin.hpp
+++ b/include/pmacc/random/methods/XorMin.hpp
@@ -40,11 +40,11 @@ namespace methods
 
 #if( PMACC_CUDA_ENABLED != 1 )
     //! fallback to alpaka RNG if a cpu accelerator is used
-    template< typename T_Acc >
+    template< typename T_Acc = cupla::Acc>
     using XorMin = AlpakaRand< T_Acc >;
 #else
     //! Uses the CUDA XORWOW RNG but does not store state members required for normal distribution
-    template< typename T_Acc >
+    template< typename T_Acc = cupla::Acc>
     class XorMin
     {
     public:

--- a/include/pmacc/random/methods/methods.hpp
+++ b/include/pmacc/random/methods/methods.hpp
@@ -1,0 +1,26 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/random/methods/AlpakaRand.hpp"
+#include "pmacc/random/methods/MRG32k3aMin.hpp"
+#include "pmacc/random/methods/XorMin.hpp"


### PR DESCRIPTION
- add `cupla::Acc` as default accelerator (template interface)
- add a accumulative include for random `methods` and `distributions`

Because of the reason that PMacc is depending on `cupla` and mostly used with one accelerator the interface for defining a random number method from the user side looks much more easier if the method is by default specialized for the accelerator activated in cupla.
This change is a requirement to expose the used random number generator method in PIConGPU to the user.