### PR TITLE
expose random number method to the user

### DIFF
--- a/docs/source/usage/param/misc.rst
+++ b/docs/source/usage/param/misc.rst
@@ -11,12 +11,12 @@ starter.param
    :path: include/picongpu/param/starter.param
    :no-link:
 
-seed.param
-^^^^^^^^^^
+random.param
+^^^^^^^^^^^^
 
-.. doxygenfile:: seed.param
+.. doxygenfile:: random.param
    :project: PIConGPU
-   :path: include/picongpu/param/seed.param
+   :path: include/picongpu/param/random.param
    :no-link:
 
 physicalConstants.param

--- a/include/picongpu/_defaultParam.loader
+++ b/include/picongpu/_defaultParam.loader
@@ -30,7 +30,7 @@
 #   include "picongpu/param/mallocMC.param"
 #endif
 #include "picongpu/param/memory.param"
-#include "picongpu/param/seed.param"
+#include "picongpu/param/random.param"
 #include "picongpu/param/precision.param"
 #include "picongpu/param/physicalConstants.param"
 #include "picongpu/param/flylite.param"

--- a/include/picongpu/param/random.param
+++ b/include/picongpu/param/random.param
@@ -17,11 +17,23 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
+#include <pmacc/random/methods/methods.hpp>
+
 
 namespace picongpu
 {
+    /** Random number generation methods
+     *
+     * It is not allowed to change the method and restart an already existing checkpoint.
+     *
+     *  - pmacc::random::methods::XorMin
+     *  - pmacc::random::methods::MRG32k3aMin
+     *  - pmacc::random::methods::AlpakaRand
+     */
+    using RandomGenrator =  pmacc::random::methods::XorMin< >;
+
     /** global seed
      *
      *  global seed to derive GPU local seeds from
@@ -38,15 +50,6 @@ namespace picongpu
              *  time(nullptr) from \see <ctime> (precision: seconds) */
             return 42;
         }
-    };
-
-    /* seed for randomization of different particle attributes */
-    enum Seeds
-    {
-        TEMPERATURE_SEED = 255845,
-        POSITION_SEED = 854666252,
-        IONIZATION_SEED = 431630977,
-        FREERNG_SEED = 99991
     };
 
 } /* namespace picongpu */

--- a/include/picongpu/param/random.param
+++ b/include/picongpu/param/random.param
@@ -24,6 +24,8 @@
 
 namespace picongpu
 {
+namespace random
+{
     /** Random number generation methods
      *
      * It is not allowed to change the method and restart an already existing checkpoint.
@@ -32,7 +34,7 @@ namespace picongpu
      *  - pmacc::random::methods::MRG32k3aMin
      *  - pmacc::random::methods::AlpakaRand
      */
-    using RandomGenrator =  pmacc::random::methods::XorMin< >;
+    using Generator =  pmacc::random::methods::XorMin< >;
 
     /** global seed
      *
@@ -51,5 +53,5 @@ namespace picongpu
             return 42;
         }
     };
-
-} /* namespace picongpu */
+} // namespace random
+} // namespace picongpu

--- a/include/picongpu/param/random.param
+++ b/include/picongpu/param/random.param
@@ -17,6 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file
+ *
+ * Configure the pseudorandom number generator (PRNG).
+ * Allows to select method and global seeds in order to vary the
+ * initial state of the parallel PRNG.
+ */
+
 #pragma once
 
 #include <pmacc/random/methods/methods.hpp>

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -24,7 +24,7 @@
 #include "PhotonEmissionAngle.hpp"
 #include "picongpu/fields/FieldTmp.hpp"
 
-#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
@@ -100,7 +100,7 @@ private:
     PMACC_ALIGN(photonMom, float3_X);
 
     /* random number generator */
-    typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
+    typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
     typedef pmacc::random::distributions::Uniform<float_X> Distribution;
     typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
     RandomGen randomGen;

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -26,7 +26,7 @@
 #include <pmacc/nvidia/rng/methods/Xor.hpp>
 #include <pmacc/mpi/SeedPerRank.hpp>
 #include <pmacc/traits/GetUniqueTypeId.hpp>
-#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
 #include <utility>
@@ -59,7 +59,7 @@ namespace misc
         using SpeciesType = T_SpeciesType;
         using RNGFactory = pmacc::random::RNGProvider<
             simDim,
-            pmacc::random::methods::XorMin< cupla::Acc >
+            random::Generator
         >;
         using RngHandle = typename RNGFactory::Handle;
         using RandomGen = RngWrapper<

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -29,7 +29,7 @@
 #include "picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def"
 #include "picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp"
 
-#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
@@ -118,7 +118,7 @@ namespace ionization
             using IonizationAlgorithm =  T_IonizationAlgorithm;
 
             /* random number generator */
-            using RNGFactory = pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>>;
+            using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
             using Distribution = pmacc::random::distributions::Uniform<float_X>;
             using RandomGen = typename RNGFactory::GetRandomType<Distribution>::type;
             RandomGen randomGen;

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -31,7 +31,7 @@
 #include "picongpu/particles/ionization/byField/ADK/ADK.def"
 #include "picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp"
 
-#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
@@ -109,7 +109,7 @@ namespace ionization
             using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
-            typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
+            typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
             typedef pmacc::random::distributions::Uniform<float_X> Distribution;
             typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
             RandomGen randomGen;

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -29,7 +29,7 @@
 #include "picongpu/particles/ionization/byField/Keldysh/Keldysh.def"
 #include "picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp"
 
-#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
@@ -110,7 +110,7 @@ namespace ionization
             using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
-            typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
+            typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
             typedef pmacc::random::distributions::Uniform<float_X> Distribution;
             typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
             RandomGen randomGen;

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -36,7 +36,7 @@
 #include "picongpu/fields/MaxwellSolver/Solvers.hpp"
 #include "picongpu/traits/FieldPosition.hpp"
 
-#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
@@ -115,7 +115,7 @@ private:
     PMACC_ALIGN(photon_mom, float3_X);
 
     /* random number generator */
-    typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
+    typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
     typedef pmacc::random::distributions::Uniform<float_X> Distribution;
     typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
     RandomGen randomGen;

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -55,7 +55,7 @@
 #include "picongpu/particles/manipulators/manipulators.hpp"
 #include "picongpu/particles/filter/filter.hpp"
 #include "picongpu/particles/flylite/NonLTE.tpp"
-#include <pmacc/random/methods/XorMin.hpp>
+#include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
 #if( PMACC_CUDA_ENABLED == 1 )
@@ -317,7 +317,7 @@ public:
                                                                 bremsstrahlungPhotons<> >::type AllBremsstrahlungPhotonsSpecies;
 
         // create factory for the random number generator
-        using RNGFactory = pmacc::random::RNGProvider< simDim, pmacc::random::methods::XorMin< cupla::Acc> >;
+        using RNGFactory = pmacc::random::RNGProvider< simDim, random::Generator >;
         auto rngFactory = new RNGFactory( Environment<simDim>::get().SubGrid().getLocalDomain().size );
 
         // init and share random number generator


### PR DESCRIPTION
Remove the hard coded `XorMin` method with the user changeable `RandomGenerator` from `random.param`

- rename `seed.param` into `random.param`
- remove unused seeds for particles, temperatures, ...
- add type definition `RandomGenerator` (can be changed by the user)

- [x] merge after #2604 (included in this PR as first commit)