### PR TITLE
remove usage of pure `float` with `float_X`

### DIFF
--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -101,7 +101,7 @@ private:
 
     /* random number generator */
     typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
-    typedef pmacc::random::distributions::Uniform<float> Distribution;
+    typedef pmacc::random::distributions::Uniform<float_X> Distribution;
     typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
     RandomGen randomGen;
 

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -119,7 +119,7 @@ namespace ionization
 
             /* random number generator */
             using RNGFactory = pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>>;
-            using Distribution = pmacc::random::distributions::Uniform<float>;
+            using Distribution = pmacc::random::distributions::Uniform<float_X>;
             using RandomGen = typename RNGFactory::GetRandomType<Distribution>::type;
             RandomGen randomGen;
 

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -110,7 +110,7 @@ namespace ionization
 
             /* random number generator */
             typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
-            typedef pmacc::random::distributions::Uniform<float> Distribution;
+            typedef pmacc::random::distributions::Uniform<float_X> Distribution;
             typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
             RandomGen randomGen;
 

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -111,7 +111,7 @@ namespace ionization
 
             /* random number generator */
             typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
-            typedef pmacc::random::distributions::Uniform<float> Distribution;
+            typedef pmacc::random::distributions::Uniform<float_X> Distribution;
             typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
             RandomGen randomGen;
 

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -116,7 +116,7 @@ private:
 
     /* random number generator */
     typedef pmacc::random::RNGProvider<simDim, pmacc::random::methods::XorMin< cupla::Acc>> RNGFactory;
-    typedef pmacc::random::distributions::Uniform<float> Distribution;
+    typedef pmacc::random::distributions::Uniform<float_X> Distribution;
     typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
     RandomGen randomGen;
 


### PR DESCRIPTION
Within PIConGPU the random numbers generated are set hard to `float`. The user is allowed to change the precision in `precision.param` thus also the random numbers should have the user defined precision.

- remove the usage of `float` with `float_X`

**Note:** The latest release is also effected by this bug but due to the missing `double` precision implementation for the used random number generator in `0.3.X`  it is not easy fixable.