### PR TITLE
seed generator for RNG

### DIFF
--- a/include/picongpu/param/random.param
+++ b/include/picongpu/param/random.param
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include "picongpu/random/seed/Seed.hpp"
+
 #include <pmacc/random/methods/methods.hpp>
 
 
@@ -43,22 +45,16 @@ namespace random
      */
     using Generator =  pmacc::random::methods::XorMin< >;
 
-    /** global seed
+    /** random number start seed
      *
-     *  global seed to derive GPU local seeds from
-     *  - vary it to shuffle pseudo random generators for exactly same simulation
-     *  - note: even when kept constant, highly parallel simulations do not ensure
-     *          100% deterministic simulations on the floating point level
+     * Generator to create a seed for the random number generator.
+     * Depending of the generator the seed is reproducible or
+     * or changed with each program execution.
+     *
+     *   - seed::Value< 42 >
+     *   - seed::FromTime
+     *   - seed::FromEnvironment
      */
-    struct GlobalSeed
-    {
-        uint32_t
-        operator()()
-        {
-            /** to vary (binary) identical simulations, use a combination of
-             *  time(nullptr) from \see <ctime> (precision: seconds) */
-            return 42;
-        }
-    };
+    using SeedGenerator = seed::Value< 42 > ;
 } // namespace random
 } // namespace picongpu

--- a/include/picongpu/random/seed/ISeed.hpp
+++ b/include/picongpu/random/seed/ISeed.hpp
@@ -1,0 +1,51 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/random/seed/Seed.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace random
+{
+namespace seed
+{
+    /** seed generator interface wrapper
+     *
+     * Generated seed is equal on all ranks and can be used together with an
+     * rank unique seed to initialize a random number generator.
+     * Depending of the generator T_SeedFunctor the seed is reproducible or
+     * or changed with each program execution.
+     */
+    template< typename T_SeedFunctor = seed::Value< 42 > >
+    struct ISeed
+    {
+        uint32_t
+        operator()() const
+        {
+            return T_SeedFunctor{}();
+        }
+    };
+} // namespace seed
+} // namespace random
+} // namespace picongpu

--- a/include/picongpu/random/seed/Seed.cpp
+++ b/include/picongpu/random/seed/Seed.cpp
@@ -1,0 +1,67 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picongpu/random/seed/Seed.hpp"
+
+#include <mpi.h>
+#include <chrono>
+#include <cstdlib>
+
+
+namespace picongpu
+{
+namespace random
+{
+namespace seed
+{
+
+    uint32_t
+    FromTime::operator()() const
+    {
+        auto now = std::chrono::system_clock::now();
+        uint32_t now_ms = std::chrono::time_point_cast< std::chrono::milliseconds >( now ).
+            time_since_epoch().count();
+
+        // receive time from rank zero
+        MPI_Bcast(
+            &now_ms,
+            1,
+            MPI_UINT32_T,
+            0,
+            MPI_COMM_WORLD
+        );
+
+        return now_ms;
+    }
+
+    uint32_t
+    FromEnvironment::operator()() const
+    {
+        char* seedStr = nullptr;
+        uint32_t seed = 0;
+        seedStr = std::getenv( "PIC_SEED" );
+        if( seedStr )
+            seed = std::stoi( seedStr );
+
+        return seed;
+    }
+
+} // namespace seed
+} // namespace random
+} // namespace picongpu

--- a/include/picongpu/random/seed/Seed.hpp
+++ b/include/picongpu/random/seed/Seed.hpp
@@ -1,0 +1,70 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace random
+{
+namespace seed
+{
+
+    /** constant seed
+     *
+     * The seed is equal on each program program start.
+     */
+    template< uint32_t T_constSeedValue >
+    struct Value
+    {
+        uint32_t
+        operator()() const
+        {
+            return T_constSeedValue;
+        }
+    };
+
+    /** time dependant seed
+     *
+     * The seed is derived from the current system time.
+     * The seed is different with each program start.
+     */
+    struct FromTime
+    {
+        uint32_t
+        operator()() const;
+    };
+
+    /** read the seed from the environment
+     *
+     * Read the seed from the environment variable `PIC_SEED`.
+     * If `PIC_SEED` is not defined zero will be returned.
+     */
+    struct FromEnvironment
+    {
+        uint32_t
+        operator()() const;
+    };
+
+} // namespace seed
+} // namespace random
+} // namespace picongpu


### PR DESCRIPTION
In some cases it is useful to initialize the random number generator
always with the same value to increase the reproducibility of different
simulation runs. IN some cases the opposit is required.

- re-enable the possibility to choose the seed
- add different seed generators:
  - seed::Value<...>
  - seed::FromEnvironment
  - seed::FromTime

**The seed generators can be moved into `PMacc` as soon as we remove the requirement that PMacc must be header only.**

# Todo

- [x] rebase against #2605 
- [x] rebase against #2608 to solve compile issues