### PR TITLE
fix missing include

### DIFF
--- a/include/pmacc/mappings/simulation/EnvironmentController.hpp
+++ b/include/pmacc/mappings/simulation/EnvironmentController.hpp
@@ -22,14 +22,12 @@
 #pragma once
 
 #include "pmacc/memory/dataTypes/Mask.hpp"
-
+#include "pmacc/Environment.def"
 #include "pmacc/communication/ICommunicator.hpp"
+
 
 namespace pmacc
 {
-
-template<unsigned DIM>
-class Environment;
 
 class EnvironmentController
 {


### PR DESCRIPTION
`friend struct detail::Environment;` can  not be used if the namespace `detail` is not known in the file.

- include `pmacc/Environment.def`
- remove forward declaration