### PR TITLE
(compile issue) fix random seed

### DIFF
--- a/include/picongpu/random/seed/Seed.cpp
+++ b/include/picongpu/random/seed/Seed.cpp
@@ -20,6 +20,7 @@
 #include "picongpu/random/seed/Seed.hpp"
 
 #include <mpi.h>
+#include <string>
 #include <chrono>
 #include <cstdlib>
 


### PR DESCRIPTION
It is currently not possible to compile PIConGPU due to a compiler error (Tested with gcc 5.3.0):
```
include/picongpu/random/seed/Seed.cpp:60:20: error: ‘stoi’ is not a member of ‘std’
             seed = std::stoi( seedStr );
```

- add missing include `<string>`

This bug was introduced with #2607