### PR TITLE
ISAAC 1.3.3+

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -271,7 +271,7 @@ ADIOS
 
 ISAAC
 """""
-- 1.3.1+
+- 1.3.3+
 - requires *boost* (header only), *IceT*, *Jansson*, *libjpeg* (preferably *libjpeg-turbo*), *libwebsockets* (only for the ISAAC server, but not the plugin itself)
 - enables live in situ visualization, see more here `Plugin description <https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-ISAAC>`_
 - *Spack:* ``spack install isaac``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -271,7 +271,7 @@ ADIOS
 
 ISAAC
 """""
-- 1.3.0+
+- 1.3.1+
 - requires *boost* (header only), *IceT*, *Jansson*, *libjpeg* (preferably *libjpeg-turbo*), *libwebsockets* (only for the ISAAC server, but not the plugin itself)
 - enables live in situ visualization, see more here `Plugin description <https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-ISAAC>`_
 - *Spack:* ``spack install isaac``

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -97,7 +97,7 @@ touch "$thisDir"runGuard
             module load gcc/4.9.4 boost/1.62.0 cmake/3.10.0 cuda/8.0.44 openmpi/1.10.4
             module load libSplash/1.7.0 adios/1.13.1
             module load pngwriter/0.7.0
-            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.3.0
+            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.3.1
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/bin/pic-compile -l -q -j $cnf_numParallel \

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -97,7 +97,7 @@ touch "$thisDir"runGuard
             module load gcc/4.9.4 boost/1.62.0 cmake/3.10.0 cuda/8.0.44 openmpi/1.10.4
             module load libSplash/1.7.0 adios/1.13.1
             module load pngwriter/0.7.0
-            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.3.1
+            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.3.3
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/bin/pic-compile -l -q -j $cnf_numParallel \

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -312,7 +312,7 @@ endif(PNGwriter_FOUND)
 
 SET(ISAAC_CUDA OFF CACHE BOOL "Using CUDA")
 SET(ISAAC_ALPAKA ON CACHE BOOL "Using Alpaka")
-find_package(ISAAC 1.3.1 CONFIG QUIET)
+find_package(ISAAC 1.3.3 CONFIG QUIET)
 if(ISAAC_FOUND)
     message(STATUS "Found ISAAC: ${ISAAC_DIR}")
     SET(ISAAC_STEREO "No" CACHE STRING "Using stereoscopy")

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -312,7 +312,7 @@ endif(PNGwriter_FOUND)
 
 SET(ISAAC_CUDA OFF CACHE BOOL "Using CUDA")
 SET(ISAAC_ALPAKA ON CACHE BOOL "Using Alpaka")
-find_package(ISAAC 1.3.0 CONFIG QUIET)
+find_package(ISAAC 1.3.1 CONFIG QUIET)
 if(ISAAC_FOUND)
     message(STATUS "Found ISAAC: ${ISAAC_DIR}")
     SET(ISAAC_STEREO "No" CACHE STRING "Using stereoscopy")


### PR DESCRIPTION
Since ISAAC 1.3.0 forgot to bump the version define, CMake will not find it with required minimum versions.

1.3.1 fixed that.

Update: there seem to be more issues with ISAAC... hard to figure out after a year without a changelog and PRs. We will go for the latest release 1.3.3+.

ISSAC `${ISAAC_INCLUDE_DIRS}` is even in 1.3.3 broken and points to CMake dir instead of include dir: https://github.com/ComputationalRadiationPhysics/isaac/issues/68

Update: work-arounded both in spack recipe of PIConGPU and compile suite ISAAC module by explicitly setting `CPATH` to ISAAC include dir...

Going for ISAAC 1.3.3 since we fixed some boost and CUDA 9 issues AFAIR.