### PR TITLE
fix stencil conditions

### DIFF
--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -53,8 +53,8 @@ struct FieldToParticleInterpolation
 
     PMACC_CASSERT_MSG(
         __FieldToParticleInterpolation_supercell_is_to_small_for_stencil,
-        pmacc::math::CT::min< SuperCellSize >::type::value >= lowerMargin &&
-        pmacc::math::CT::min< SuperCellSize >::type::value >= upperMargin
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= lowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= upperMargin
     );
 
     /*(supp + 1) % 2 is 1 for even supports else 0*/

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -46,8 +46,8 @@ struct EmZ
 
     PMACC_CASSERT_MSG(
         __EmZ_supercell_is_to_small_for_stencil,
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentUpperMargin
     );
 
 

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -50,8 +50,8 @@ struct Esirkepov<T_ParticleShape, DIM3>
 
     PMACC_CASSERT_MSG(
         __Esirkepov_supercell_is_to_small_for_stencil,
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentUpperMargin
     );
 
     float_X charge;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -57,8 +57,8 @@ struct Esirkepov<T_ParticleShape, DIM2>
 
     PMACC_CASSERT_MSG(
         __Esirkepov2D_supercell_is_to_small_for_stencil,
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentUpperMargin
     );
 
     static constexpr int begin = -currentLowerMargin + 1;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -57,8 +57,8 @@ struct EsirkepovNative
 
     PMACC_CASSERT_MSG(
         __EsirkepovNative_supercell_is_to_small_for_stencil,
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentUpperMargin
     );
 
     /* iterate over all grid points */

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -274,7 +274,7 @@ struct GetMargin<picongpu::currentSolver::VillaBune<T_ParticleShape> >
 
     PMACC_CASSERT_MSG(
         __VillaBune_supercell_is_to_small_for_stencil,
-        pmacc::math::CT::min< SuperCellSize >::type::value >= 2
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= 2
     );
 };
 

--- a/include/picongpu/fields/currentDeposition/ZigZag/ZigZag.hpp
+++ b/include/picongpu/fields/currentDeposition/ZigZag/ZigZag.hpp
@@ -162,8 +162,8 @@ struct ZigZag
 
     PMACC_CASSERT_MSG(
         __ZigZag_supercell_is_to_small_for_stencil,
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min< SuperCellSize >::type::value >= currentUpperMargin
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentLowerMargin &&
+        pmacc::math::CT::min< SuperCellSize >::type::value * GUARD_SIZE >= currentUpperMargin
     );
 
     /* calculate grid point where we calculate the assigned values


### PR DESCRIPTION
The current stencil condition checks assume that the number of guard supercells `GUARD_SIZE` can be only one. A stencil can only read and write to margins those fits into the guard and can be send/receive by PMacc.

Fix: Take number of guard supercells in account to validate if the stencil margins fits into the guard.

**Note:** There are a lot of other bugs which not allows to increase the `GUARD_SIZE` therefore a back port to the latest release is not strongly required.