### PR TITLE
fix that guard size must be one

### DIFF
--- a/include/picongpu/fields/FieldManipulator.kernel
+++ b/include/picongpu/fields/FieldManipulator.kernel
@@ -94,6 +94,8 @@ namespace detail
 
             uint32_t const workerIdx = threadIdx.x;
 
+            auto const numGuardSuperCells = mapper.getGuardingSuperCells();
+
             // cell index of the supercell within the local domain (incl. the guards)
             DataSpace< simDim > const localDomainCells = mapper.getGridSuperCells() * SuperCellSize::toRT();
 
@@ -118,17 +120,17 @@ namespace detail
 
                     do
                     {
-                        cell[ axis ] += SuperCellSize::toRT()[ axis ] * -1 * relExchangeDir[ axis ];
+                        cell[ axis ] += numGuardSuperCells * SuperCellSize::toRT()[ axis ] * -relExchangeDir[ axis ];
                         int factor(0);
 
                         if( relExchangeDir[ axis ] < 0 )
                         {
-                            factor = SuperCellSize::toRT()[ axis ] - cell[ axis ] +
+                            factor = numGuardSuperCells * SuperCellSize::toRT()[ axis ] - cell[ axis ] +
                                 thickness - 1;
                         }
                         else
                         {
-                            factor = SuperCellSize::toRT()[ axis ] + cell[ axis ] -
+                            factor = numGuardSuperCells * SuperCellSize::toRT()[ axis ] + cell[ axis ] -
                                 localDomainCells[ axis ] + thickness;
                         }
 

--- a/include/picongpu/plugins/IntensityPlugin.hpp
+++ b/include/picongpu/plugins/IntensityPlugin.hpp
@@ -84,7 +84,7 @@ struct KernelIntensity
         );
 
         int y = blockIdx.y * SuperCellSize::y::value + threadIdx.y;
-        int yGlobal = y + SuperCellSize::y::value;
+        int yGlobal = y + GUARD_SIZE * SuperCellSize::y::value;
         const DataSpace<DIM2> threadId(threadIdx);
 
         if (threadId.x() == 0)

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -231,7 +231,7 @@ public:
 
         SimulationHelper<simDim>::pluginLoad();
 
-        GridLayout<SIMDIM> layout(gridSizeLocal, MappingDesc::SuperCellSize::toRT());
+        GridLayout<SIMDIM> layout(gridSizeLocal, GUARD_SIZE * MappingDesc::SuperCellSize::toRT());
         cellDescription = new MappingDesc(layout.getDataSpace(), GUARD_SIZE, GUARD_SIZE);
 
         checkGridConfiguration(global_grid_size, cellDescription->getGridLayout());

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -93,7 +93,7 @@ protected:
         particlesBuffer = new BufferType(
             deviceHeap,
             description.getGridLayout().getDataSpace(),
-            description.getGridLayout().getGuard()
+            MappingDesc::SuperCellSize::toRT()
         );
     }
 


### PR DESCRIPTION
A few algorithms in PMacc and PIConGPU was not able to handle more than one guard supercell.
This algorithm assumes always one supercell as guard.

Fix:
 - take in account the number of used guarding super cells
 - `MySimulation.hpp`: fix grid layout initialization.
 - `ParticlesBase.hpp`: fix that guarding cells are passed as parameter into `ParticlesBuffer` instead of the supercell size

**Note** The latest release is also effected by this issue that the guard size must be always one. Since the change of the number guard supercells is more than less a feature we should not back port this fix.

Other bugfixes those are needed to solve the ssumtion that the guard size is always one: #2613