### PR TITLE
PS & Calorimeter Plugins: Filter Docs

### DIFF
--- a/docs/source/usage/plugins/particleCalorimeter.rst
+++ b/docs/source/usage/plugins/particleCalorimeter.rst
@@ -32,7 +32,7 @@ PIConGPU command line option       Description
 ``--ph_calorimeter.period``        The ouput periodicity of the plugin.
                                    A value of ``100`` would mean an output at simulation time step *0, 100, 200, ...*.
 ``--ph_calorimeter.file``          Output file prefix. Files will be stored in the folder ``ph_calorimeter``
-``--ph_energy.filter``             Use filtered particles. All available filters will be shown with ``picongpu --help``
+``--ph_calorimeter.filter``        Use filtered particles. All available filters will be shown with ``picongpu --help``
 ``--ph_calorimeter.numBinsYaw``    Specifies the number of bins used for the yaw axis of the calorimeter.
                                    Defaults to ``64``.
 ``--ph_calorimeter.numBinsPitch``  Specifies the number of bins used for the pitch axis of the calorimeter.
@@ -121,8 +121,8 @@ Attribute          Description
 
    .. code-block:: bash
 
-      --ph_calorimeter.period 128 --ph_calorimeter.file calo1 
-      --ph_calorimeter.period 1000 --ph_calorimeter.file calo2 --ph_calorimeter.logScale 1 --ph_calorimeter.minEnergy 1
+      --ph_calorimeter.period 128 --ph_calorimeter.file calo1 --ph_calorimeter.filter all
+      --ph_calorimeter.period 1000 --ph_calorimeter.file calo2 --ph_calorimeter.filter all --ph_calorimeter.logScale 1 --ph_calorimeter.minEnergy 1
 
    creates two plugins:
  

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -19,7 +19,7 @@ Example for *y-pz* phase space for the *electron* species (``.cfg`` file macro):
 
    # Calculate a 2D phase space
    # - momentum range in m_e c
-   TGB_ePSypz="--e_phaseSpace.period 10 --e_phaseSpace.space y --e_phaseSpace.momentum pz --e_phaseSpace.min -1.0 --e_phaseSpace.max 1.0"
+   TGB_ePSypz="--e_phaseSpace.period 10 --e_phaseSpace.filter all --e_phaseSpace.space y --e_phaseSpace.momentum pz --e_phaseSpace.min -1.0 --e_phaseSpace.max 1.0"
 
 
 The distinct options are (assuming a species ``e`` for electrons):


### PR DESCRIPTION
Fix outdated and missing filter flags in examples of the phase space and particle calorimeter plugin.

Discovered by @kossag14, thx!