### PR TITLE
Lasers: float_X Constants to Literals

### DIFF
--- a/include/picongpu/fields/LaserPhysics.hpp
+++ b/include/picongpu/fields/LaserPhysics.hpp
@@ -112,7 +112,7 @@ namespace fields
         void operator()(uint32_t currentStep) const
         {
             /* The laser can be initialized in the plane of the first cell or
-             * any later x-y plane inside the simulation. Initializing the
+             * any later x-z plane inside the simulation. Initializing the
              * laser in planes inside the simulation corresponds to an
              * evaluation of the field at negatively shifted time.
              */

--- a/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
@@ -50,8 +50,8 @@ namespace expRampWithPrepulse
         static constexpr float_64 TIME_1 = float_64( Params::TIME_POINT_1_SI / UNIT_TIME );
         static constexpr float_64 TIME_2 = float_64( Params::TIME_POINT_2_SI / UNIT_TIME );
         static constexpr float_64 TIME_3 = float_64( Params::TIME_POINT_3_SI / UNIT_TIME );
-        static constexpr float_X endUpramp = TIME_PEAKPULSE - 0.5 * LASER_NOFOCUS_CONSTANT;
-        static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5 * LASER_NOFOCUS_CONSTANT;
+        static constexpr float_X endUpramp = TIME_PEAKPULSE - 0.5_X * LASER_NOFOCUS_CONSTANT;
+        static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5_X * LASER_NOFOCUS_CONSTANT;
 
         static constexpr float_X INIT_TIME = float_X( ( TIME_PEAKPULSE + Params::RAMP_INIT * PULSE_LENGTH ) / UNIT_TIME );
 
@@ -62,28 +62,28 @@ namespace expRampWithPrepulse
         );
 
         // some prerequisites for check of intensities (approximate check, because I can't use exp and log)
-        static constexpr float ratio_dt = ( endUpramp - TIME_3 ) / ( TIME_3 - TIME_2 ); // ratio of time intervals
-        static constexpr float ri1 = Params::INT_RATIO_POINT_3 / Params::INT_RATIO_POINT_2; // first intensity ratio
-        static constexpr float ri2 = 0.2 / Params::INT_RATIO_POINT_3; // second intensity ratio (0.2 is an arbitrary upper border for the intensity of the exp ramp)
+        static constexpr float_X ratio_dt = ( endUpramp - TIME_3 ) / ( TIME_3 - TIME_2 ); // ratio of time intervals
+        static constexpr float_X ri1 = Params::INT_RATIO_POINT_3 / Params::INT_RATIO_POINT_2; // first intensity ratio
+        static constexpr float_X ri2 = 0.2_X / Params::INT_RATIO_POINT_3; // second intensity ratio (0.2 is an arbitrary upper border for the intensity of the exp ramp)
 
         /* Approximate check, if ri1 ^ ratio_dt > ri2. That would mean, that the exponential curve through (time2, int2) and (time3, int3) lies above (endUpramp, 0.2)
          * the power function is emulated by "rounding" the exponent to a rational number and expanding both sides by the common denominator, to get integer powers, see below
          * for this, the range for ratio_dt is split into parts; the checked condition is "rounded down", i.e. it's weaker in every point of those ranges except one.
          */
         static constexpr bool intensity_too_big =
-            ( ratio_dt >= 3.   && ri1 * ri1 * ri1 > ri2) ||
-            ( ratio_dt >= 2.   && ri1 * ri1 > ri2) ||
-            ( ratio_dt >= 1.5  && ri1 * ri1 * ri1 > ri2 * ri2) ||
-            ( ratio_dt >= 1.   && ri1 > ri2) ||
-            ( ratio_dt >= 0.8  && ri1 * ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
-            ( ratio_dt >= 0.75 && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 ) ||
-            ( ratio_dt >= 0.67 && ri1 * ri1 > ri2 * ri2 * ri2 ) ||
-            ( ratio_dt >= 0.6  && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
-            ( ratio_dt >= 0.5  && ri1 > ri2 * ri2 ) ||
-            ( ratio_dt >= 0.4  && ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
-            ( ratio_dt >= 0.33 && ri1 > ri2 * ri2 * ri2 ) ||
-            ( ratio_dt >= 0.25 && ri1 > ri2 * ri2 * ri2 * ri2 ) ||
-            ( ratio_dt >= 0.2  && ri1 > ri2 * ri2 * ri2 * ri2 * ri2 );
+            ( ratio_dt >= 3._X   && ri1 * ri1 * ri1 > ri2) ||
+            ( ratio_dt >= 2._X   && ri1 * ri1 > ri2) ||
+            ( ratio_dt >= 1.5_X  && ri1 * ri1 * ri1 > ri2 * ri2) ||
+            ( ratio_dt >= 1._X   && ri1 > ri2) ||
+            ( ratio_dt >= 0.8_X  && ri1 * ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.75_X && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.67_X && ri1 * ri1 > ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.6_X  && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.5_X  && ri1 > ri2 * ri2 ) ||
+            ( ratio_dt >= 0.4_X  && ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.33_X && ri1 > ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.25_X && ri1 > ri2 * ri2 * ri2 * ri2 ) ||
+            ( ratio_dt >= 0.2_X  && ri1 > ri2 * ri2 * ri2 * ri2 * ri2 );
         static_assert(
             !intensity_too_big,
             "The intensities of the ramp are very large - the extrapolation to the time of the main pulse would give more than half of the pulse amplitude. This is not a Gaussian pulse at all anymore - probably some of the parameters are different from what you think!?"
@@ -169,7 +169,7 @@ namespace acc
             auto const exp_compos( pos_trans * pos_trans / ( w0 * w0 ) );
             float_X const exp_arg( exp_compos.sumOfComponents() );
 
-            m_elong *= math::exp( float_X( -1.0 ) * exp_arg );
+            m_elong *= math::exp( -1.0_X * exp_arg );
 
             if( Unitless::initPlaneY != 0 ) // compile time if
             {
@@ -181,7 +181,7 @@ namespace acc
                  *
                  * The `correctionFactor` assume that the wave is moving in y direction.
                  */
-                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * float_X( 2. );
+                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * 2._X;
 
                 // jump over the guard of the electric field
                 m_dataBoxE( localCell + SuperCellSize::toRT() * GuardSize::toRT() ) +=  correctionFactor * m_elong;
@@ -213,7 +213,7 @@ namespace acc
         gauss( float_X const t )
         {
             float_X const exponent = t / float_X( Unitless::PULSE_LENGTH );
-            return math::exp( float_X( -0.25 ) * exponent * exponent );
+            return math::exp( -0.25_X * exponent * exponent );
         }
 
         /** get value of exponential curve through two points at given t
@@ -276,7 +276,7 @@ namespace acc
                     );
                 }
 
-                env += Unitless::AMPLITUDE * ( float_X( 1. ) - ramp_when_peakpulse ) *
+                env += Unitless::AMPLITUDE * ( 1._X - ramp_when_peakpulse ) *
                     gauss( runTime - Unitless::endUpramp );
                 env += AMP_PREPULSE * gauss( runTime - Unitless::TIME_PREPULSE );
                 if( during_first_exp )
@@ -342,16 +342,16 @@ namespace acc
 
             if( Unitless::Polarisation == Unitless::LINEAR_X )
             {
-                elong.x() = float_X( envelope * ( math::sin( phase ) ) );
+                elong.x() = envelope * math::sin( phase );
             }
             else if( Unitless::Polarisation == Unitless::LINEAR_Z )
             {
-                elong.z() = float_X( envelope * ( math::sin( phase ) ) );
+                elong.z() = envelope * math::sin( phase );
             }
             else if( Unitless::Polarisation == Unitless::CIRCULAR )
             {
-                elong.x() = float_X( envelope / math::sqrt( 2.0 ) * ( math::sin( phase ) ) );
-                elong.z() = float_X( envelope / math::sqrt( 2.0 ) * ( math::cos( phase ) ) );
+                elong.x() = envelope / math::sqrt( 2.0_X ) * math::sin( phase );
+                elong.z() = envelope / math::sqrt( 2.0_X ) * math::cos( phase );
             }
         }
 

--- a/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
@@ -78,15 +78,15 @@ namespace acc
         HDINLINE float_X simpleLaguerre( const uint32_t n, const float_X x )
         {
             //Result for special case n == 0
-            if (n == 0) return float_X(1.0);
+            if (n == 0) return 1.0_X;
             uint32_t currentN = 1;
-            float_X laguerreNMinus1 = float_X(1.0);
-            float_X laguerreN = float_X(1.0) - x;
-            float_X laguerreNPlus1 = float_X(0.0);
+            float_X laguerreNMinus1 = 1.0_X;
+            float_X laguerreN = 1.0_X - x;
+            float_X laguerreNPlus1( 0.0_X );
             while (currentN < n)
             {
                 //Core statement of the algorithm
-                laguerreNPlus1 = ( ( float_X(2.0) * float_X(currentN) + float_X(1.0) - x) * laguerreN - float_X(currentN) * laguerreNMinus1 ) / float_X(currentN + 1);
+                laguerreNPlus1 = ( ( 2.0_X * float_X(currentN) + 1.0_X - x) * laguerreN - float_X(currentN) * laguerreNMinus1 ) / float_X(currentN + 1u);
                 //Advance by one order
                 laguerreNMinus1 = laguerreN;
                 laguerreN = laguerreNPlus1;
@@ -142,8 +142,8 @@ namespace acc
             // @todo add half-cells via traits::FieldPosition< Solver::NumicalCellType, FieldE >()
 
             // transversal position only
-            floatD_X planeNoNormal = floatD_X::create( 1.0 );
-            planeNoNormal[ planeNormalDir ] = 0.0;
+            floatD_X planeNoNormal = floatD_X::create( 1.0_X );
+            planeNoNormal[ planeNormalDir ] = 0.0_X;
             float_X const r2 = math::abs2( pos * planeNoNormal );
 
             // calculate focus position relative to the laser initialization plane
@@ -153,11 +153,11 @@ namespace acc
             float_X const y_R = float_X( PI ) * Unitless::W0 * Unitless::W0 / Unitless::WAVE_LENGTH;
 
             // the radius of curvature of the beam's  wavefronts
-            float_X const R_y = -focusPos * ( float_X(1.0) + ( y_R / focusPos )*( y_R / focusPos ) );
+            float_X const R_y = -focusPos * ( 1.0_X + ( y_R / focusPos )*( y_R / focusPos ) );
 
             // initialize temporary variables
-            float_X etrans = float_X( 0.0 );
-            float_X etrans_norm = float_X( 0.0 );
+            float_X etrans( 0.0_X );
+            float_X etrans_norm( 0.0_X );
             PMACC_CASSERT_MSG(
                 MODENUMBER_must_be_smaller_than_number_of_entries_in_LAGUERREMODES_vector,
                 Unitless::MODENUMBER < Unitless::LAGUERREMODES_t::dim
@@ -166,7 +166,7 @@ namespace acc
                 etrans_norm += typename Unitless::LAGUERREMODES_t{}[m];
 
             // beam waist in the near field: w_y(y=0) == W0
-            float_X const w_y = Unitless::W0 * algorithms::math::sqrt( float_X(1.0) + ( focusPos / y_R )*( focusPos / y_R ) );
+            float_X const w_y = Unitless::W0 * algorithms::math::sqrt( 1.0_X + ( focusPos / y_R )*( focusPos / y_R ) );
             //! the Gouy phase shift
             float_X const xi_y = algorithms::math::atan( -focusPos / y_R );
 
@@ -174,11 +174,11 @@ namespace acc
             {
                 for( uint32_t m = 0 ; m <= Unitless::MODENUMBER ; ++m )
                 {
-                    etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
-                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + m_phase )
-                        * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                              *( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * Unitless::PULSE_LENGTH ) / ( float_X(2.0) * Unitless::PULSE_LENGTH ) );
+                    etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre( m, 2.0_X * r2 / w_y / w_y )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / 2.0_X / R_y + ( 2._X * float_X( m ) + 1._X ) * xi_y + m_phase )
+                        * math::exp( -( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                              *( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( 2.0_X * Unitless::PULSE_LENGTH ) / ( 2.0_X * Unitless::PULSE_LENGTH ) );
                 }
                 m_elong *= etrans / etrans_norm;
             }
@@ -186,22 +186,22 @@ namespace acc
             {
                 for( uint32_t m = 0 ; m <= Unitless::MODENUMBER ; ++m )
                 {
-                    etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
-                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + m_phase )
-                        * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                              *( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * Unitless::PULSE_LENGTH ) / ( float_X(2.0) * Unitless::PULSE_LENGTH ) );
+                    etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre( m, 2.0_X * r2 / w_y / w_y )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / 2.0_X / R_y + ( 2._X * float_X( m ) + 1._X ) * xi_y + m_phase )
+                        * math::exp( -( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                              *( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( 2.0_X * Unitless::PULSE_LENGTH ) / ( 2.0_X * Unitless::PULSE_LENGTH ) );
                 }
                 m_elong.x() *= etrans / etrans_norm;
                 m_phase += float_X( PI / 2.0 );
-                etrans = float_X(0.0);
+                etrans = 0.0_X;
                 for( uint32_t m = 0 ; m <= Unitless::MODENUMBER ; ++m )
                 {
-                    etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre( m, float_X(2.0) * r2 / w_y / w_y )
-                        * math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / float_X(2.0) / R_y + ( 2*m + 1 ) * xi_y + m_phase )
-                        * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                              *( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * Unitless::PULSE_LENGTH ) / ( float_X(2.0) * Unitless::PULSE_LENGTH ) );
+                    etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre( m, 2.0_X * r2 / w_y / w_y )
+                        * math::exp( -r2 / w_y / w_y ) * math::cos( 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / 2.0_X / R_y + ( 2._X * float_X( m ) + 1._X ) * xi_y + m_phase )
+                        * math::exp( -( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                              *( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                              / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( 2.0_X * Unitless::PULSE_LENGTH ) / ( 2.0_X * Unitless::PULSE_LENGTH ) );
                 }
                 m_elong.z() *= etrans / etrans_norm;
                 // reminder: if you want to use phase below, substract pi/2
@@ -218,7 +218,7 @@ namespace acc
                  *
                  * The `correctionFactor` assume that the wave is moving in y direction.
                  */
-                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * float_X( 2. );
+                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * 2._X;
 
                 // jump over the guard of the electric field
                 m_dataBoxE( localCell + SuperCellSize::toRT() * GuardSize::toRT() ) +=  correctionFactor * m_elong;
@@ -272,10 +272,10 @@ namespace acc
             // calculate focus position relative to the laser initialization plane
             float_X const focusPos = Unitless::FOCUS_POS - Unitless::initPlaneY * CELL_HEIGHT;
 
-            elong = float3_X::create( 0.0 );
+            elong = float3_X::create( 0.0_X );
 
             // This check is done here on HOST, since std::numeric_limits<float_X>::epsilon() does not compile on laserTransversal(), which is on DEVICE.
-            float_X etrans_norm = float_X( 0.0 );
+            float_X etrans_norm( 0.0_X );
 
             PMACC_CASSERT_MSG(
                 MODENUMBER_must_be_smaller_than_number_of_entries_in_LAGUERREMODES_vector,
@@ -317,11 +317,11 @@ namespace acc
             }
             else if( Unitless::Polarisation == Unitless::CIRCULAR )
             {
-                elong.x() = float_X( envelope / math::sqrt( 2.0 ) );
-                elong.z() = float_X( envelope / math::sqrt( 2.0 ) );
+                elong.x() = float_X( envelope ) / math::sqrt( 2.0_X );
+                elong.z() = float_X( envelope ) / math::sqrt( 2.0_X );
             }
 
-            phase = float_X( 2.0 ) * float_X( PI ) * float_X( Unitless::f ) * ( runTime - float_X( mue ) - focusPos / SPEED_OF_LIGHT ) + Unitless::LASER_PHASE;
+            phase = 2.0_X * float_X( PI ) * float_X( Unitless::f ) * ( runTime - float_X( mue ) - focusPos / SPEED_OF_LIGHT ) + Unitless::LASER_PHASE;
         }
 
         /** create device manipulator functor

--- a/include/picongpu/fields/laserProfiles/None.hpp
+++ b/include/picongpu/fields/laserProfiles/None.hpp
@@ -41,7 +41,7 @@ namespace none
         static constexpr float_X WAVE_LENGTH = float_X( Params::WAVE_LENGTH_SI / UNIT_LENGTH ); // unit: meter
         static constexpr float_X PULSE_LENGTH = float_X( Params::PULSE_LENGTH_SI / UNIT_TIME ); // unit: seconds (1 sigma)
         static constexpr float_X AMPLITUDE = float_X( Params::AMPLITUDE_SI / UNIT_EFIELD ); // unit: Volt /meter
-        static constexpr float_X INIT_TIME = float_X( 0.0 ); // unit: seconds (no initialization time)
+        static constexpr float_X INIT_TIME = 0.0_X; // unit: seconds (no initialization time)
     };
 } // namespace none
 namespace acc

--- a/include/picongpu/fields/laserProfiles/PlaneWave.hpp
+++ b/include/picongpu/fields/laserProfiles/PlaneWave.hpp
@@ -113,7 +113,7 @@ namespace acc
                  *
                  * The `correctionFactor` assume that the wave is moving in y direction.
                  */
-                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * float_X( 2. );
+                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * 2._X;
 
                 // jump over the guard of the electric field
                 m_dataBoxE( localCell + SuperCellSize::toRT() * GuardSize::toRT() ) +=  correctionFactor * m_elong;
@@ -142,7 +142,7 @@ namespace acc
          * @param currentStep current simulation time step
          */
         HINLINE PlaneWave( uint32_t currentStep ) :
-            phase( float_X( 0.0 ) )
+            phase( 0.0_X )
         {
             // get data
             DataConnector & dc = Environment< >::get( ).DataConnector( );

--- a/include/picongpu/fields/laserProfiles/Polynom.hpp
+++ b/include/picongpu/fields/laserProfiles/Polynom.hpp
@@ -121,7 +121,7 @@ namespace acc
             auto const exp_compos( pos_trans * pos_trans / ( w0 * w0 ) );
             float_X const exp_arg( exp_compos.sumOfComponents() );
 
-            m_elong *= math::exp( float_X( -1.0 ) * exp_arg );
+            m_elong *= math::exp( -1.0_X * exp_arg );
 
             if( Unitless::initPlaneY != 0 ) // compile time if
             {
@@ -133,7 +133,7 @@ namespace acc
                  *
                  * The `correctionFactor` assume that the wave is moving in y direction.
                  */
-                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * float_X( 2. );
+                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * 2._X;
 
                 // jump over the guard of the electric field
                 m_dataBoxE( localCell + SuperCellSize::toRT() * GuardSize::toRT() ) +=  correctionFactor * m_elong;
@@ -160,11 +160,11 @@ namespace acc
         HDINLINE float_X
         Tpolynomial( float_X const tau )
         {
-            float_X result( 0.0 );
-            if( tau >= float_X( 0.0 ) && tau <= float_X( 1.0 ) )
-                result = tau * tau * tau * (float_X( 10.0 ) - float_X( 15.0 ) * tau + float_X( 6.0 ) * tau * tau);
-            else if( tau > float_X( 1.0 ) && tau <= float_X( 2.0 ) )
-                result = (float_X( 2.0 ) - tau) * (float_X( 2.0 ) - tau) * (float_X( 2.0 ) - tau) * (float_X( 4.0 ) - float_X( 9.0 ) * tau + float_X( 6.0 ) * tau * tau);
+            float_X result( 0.0_X );
+            if( tau >= 0.0_X && tau <= 1.0_X )
+                result = tau * tau * tau * ( 10.0_X - 15.0_X * tau + 6.0_X * tau * tau );
+            else if( tau > 1.0_X && tau <= 2.0_X )
+                result = ( 2.0_X - tau ) * ( 2.0_X - tau ) * ( 2.0_X - tau ) * ( 4.0_X - 9.0_X * tau + 6.0_X * tau * tau );
 
             return result;
         }
@@ -174,7 +174,7 @@ namespace acc
          * @param currentStep current simulation time step
          */
         HINLINE Polynom( uint32_t currentStep ) :
-            phase( float_X( 0.0 ) )
+            phase( 0.0_X )
         {
             // get data
             DataConnector & dc = Environment< >::get( ).DataConnector( );
@@ -197,7 +197,7 @@ namespace acc
 
             float_64 const runTime = DELTA_T * currentStep - Unitless::laserTimeShift;
 
-            elong = float3_X::create( 0.0 );
+            elong = float3_X::create( 0.0_X );
 
             /* a symmetric pulse will be initialized at position z=0
              * the laser amplitude rises  for t_rise
@@ -205,10 +205,10 @@ namespace acc
              * making the laser pulse 2*t_rise long
              */
 
-            const float_X t_rise = float_X( 0.5 ) * Unitless::PULSE_LENGTH;
+            const float_X t_rise = 0.5_X * Unitless::PULSE_LENGTH;
             const float_X tau = runTime / t_rise;
 
-            const float_X omegaLaser = float_X( 2.0 ) * PI * Unitless::f;
+            const float_X omegaLaser = 2.0_X * PI * Unitless::f;
 
             if( Unitless::Polarisation == Unitless::LINEAR_X )
             {
@@ -222,9 +222,9 @@ namespace acc
             }
             else if( Unitless::Polarisation == Unitless::CIRCULAR )
             {
-                elong.x() = Unitless::AMPLITUDE * Tpolynomial( tau ) / math::sqrt( 2.0 ) *
+                elong.x() = Unitless::AMPLITUDE * Tpolynomial( tau ) / math::sqrt( 2.0_X ) *
                     math::sin( omegaLaser * ( runTime - t_rise ) + Unitless::LASER_PHASE );
-                elong.z() = Unitless::AMPLITUDE * Tpolynomial( tau ) / math::sqrt( 2.0 ) *
+                elong.z() = Unitless::AMPLITUDE * Tpolynomial( tau ) / math::sqrt( 2.0_X ) *
                     math::cos( omegaLaser * ( runTime - t_rise ) + Unitless::LASER_PHASE );
             }
         }

--- a/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
+++ b/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
@@ -119,7 +119,7 @@ namespace acc
             // calculate focus position relative to the laser initialization plane
             float_X const focusPos = Unitless::FOCUS_POS - pos.y();
 
-            float_X const timeShift = m_phase / ( float_X( 2.0 ) * float_X( PI ) * float_X( Unitless::f ) ) + focusPos / SPEED_OF_LIGHT;
+            float_X const timeShift = m_phase / ( 2.0_X * float_X( PI ) * float_X( Unitless::f ) ) + focusPos / SPEED_OF_LIGHT;
             float_X const local_tilt_x = Unitless::TILT_X;
             float_X const spaceShift_x = SPEED_OF_LIGHT * algorithms::math::tan( local_tilt_x ) * timeShift / cellSize.y();
 
@@ -137,33 +137,33 @@ namespace acc
             float_X const y_R = float_X( PI ) * Unitless::W0 * Unitless::W0 / Unitless::WAVE_LENGTH;
 
             // the radius of curvature of the beam's  wavefronts
-            float_X const R_y = -focusPos * ( float_X(1.0) + ( y_R / focusPos )*( y_R / focusPos ) );
+            float_X const R_y = -focusPos * ( 1.0_X + ( y_R / focusPos )*( y_R / focusPos ) );
 
             // beam waist in the near field: w_y(y=0) == W0
-            float_X const w_y = Unitless::W0 * algorithms::math::sqrt( float_X(1.0) + ( focusPos / y_R )*( focusPos / y_R ) );
+            float_X const w_y = Unitless::W0 * algorithms::math::sqrt( 1.0_X + ( focusPos / y_R )*( focusPos / y_R ) );
             //! the Gouy phase shift
             float_X const xi_y = algorithms::math::atan( -focusPos / y_R );
 
             if( Unitless::Polarisation == Unitless::LINEAR_X || Unitless::Polarisation == Unitless::LINEAR_Z )
             {
-                m_elong *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + m_phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * Unitless::PULSE_LENGTH ) / ( float_X(2.0) * Unitless::PULSE_LENGTH ) );
+                m_elong *= math::exp( -r2 / w_y / w_y ) * math::cos( 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / 2.0_X / R_y + xi_y + m_phase )
+                    * math::exp( -( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                          *( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( 2.0_X * Unitless::PULSE_LENGTH ) / ( 2.0_X * Unitless::PULSE_LENGTH ) );
             }
             else if( Unitless::Polarisation == Unitless::CIRCULAR )
             {
-                m_elong.x() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + m_phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * Unitless::PULSE_LENGTH ) / ( float_X(2.0) * Unitless::PULSE_LENGTH ) );
-                m_phase += float_X( PI / 2.0 );
-                m_elong.z() *= math::exp( -r2 / w_y / w_y ) * math::cos( float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - float_X(2.0) * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / float_X(2.0) / R_y + xi_y + m_phase )
-                    * math::exp( -( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::WAVE_LENGTH )
-                          *( r2 / float_X(2.0) / R_y - focusPos - m_phase / float_X(2.0) / float_X( PI ) * Unitless::Unitless::WAVE_LENGTH )
-                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( float_X(2.0) * Unitless::PULSE_LENGTH ) / ( float_X(2.0) * Unitless::PULSE_LENGTH ) );
+                m_elong.x() *= math::exp( -r2 / w_y / w_y ) * math::cos( 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / 2.0_X / R_y + xi_y + m_phase )
+                    * math::exp( -( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                          *( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( 2.0_X * Unitless::PULSE_LENGTH ) / ( 2.0_X * Unitless::PULSE_LENGTH ) );
+                m_phase += float_X( PI ) / 2.0_X;
+                m_elong.z() *= math::exp( -r2 / w_y / w_y ) * math::cos( 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * focusPos - 2.0_X * float_X( PI ) / Unitless::WAVE_LENGTH * r2 / 2.0_X / R_y + xi_y + m_phase )
+                    * math::exp( -( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::WAVE_LENGTH )
+                          *( r2 / 2.0_X / R_y - focusPos - m_phase / 2.0_X / float_X( PI ) * Unitless::Unitless::WAVE_LENGTH )
+                          / SPEED_OF_LIGHT / SPEED_OF_LIGHT / ( 2.0_X * Unitless::PULSE_LENGTH ) / ( 2.0_X * Unitless::PULSE_LENGTH ) );
                 // reminder: if you want to use phase below, substract pi/2
-                // m_phase -= float_X( PI / 2.0 );
+                // m_phase -= float_X( PI ) / 2.0_X;
             }
 
             if( Unitless::initPlaneY != 0 ) // compile time if
@@ -176,7 +176,7 @@ namespace acc
                  *
                  * The `correctionFactor` assume that the wave is moving in y direction.
                  */
-                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * float_X( 2. );
+                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * 2._X;
 
                 // jump over the guard of the electric field
                 m_dataBoxE( localCell + SuperCellSize::toRT() * GuardSize::toRT() ) +=  correctionFactor * m_elong;
@@ -260,11 +260,11 @@ namespace acc
             }
             else if( Unitless::Polarisation == Unitless::CIRCULAR )
             {
-                elong.x() = float_X( envelope / math::sqrt( 2.0 ) );
-                elong.z() = float_X( envelope / math::sqrt( 2.0 ) );
+                elong.x() = float_X( envelope ) / math::sqrt( 2.0_X );
+                elong.z() = float_X( envelope ) / math::sqrt( 2.0_X );
             }
 
-            phase = float_X( 2.0 ) * float_X( PI ) * float_X( Unitless::f ) * ( runTime - float_X( mue ) - focusPos / SPEED_OF_LIGHT ) + Unitless::LASER_PHASE;
+            phase = 2.0_X * float_X( PI ) * float_X( Unitless::f ) * ( runTime - float_X( mue ) - focusPos / SPEED_OF_LIGHT ) + Unitless::LASER_PHASE;
         }
 
         /** create device manipulator functor

--- a/include/picongpu/fields/laserProfiles/Wavepacket.hpp
+++ b/include/picongpu/fields/laserProfiles/Wavepacket.hpp
@@ -46,8 +46,8 @@ namespace wavepacket
         static constexpr float_X W0_X = float_X( Params::W0_X_SI / UNIT_LENGTH ); // unit: meter
         static constexpr float_X W0_Z = float_X( Params::W0_Z_SI / UNIT_LENGTH ); // unit: meter
         static constexpr float_X INIT_TIME = float_X( Params::PULSE_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT ); // unit: seconds (full initialization length)
-        static constexpr float_X endUpramp = float_X( -0.5 * LASER_NOFOCUS_CONSTANT ); // unit: seconds
-        static constexpr float_X startDownramp = float_X( 0.5 * LASER_NOFOCUS_CONSTANT ); // unit: seconds
+        static constexpr float_X endUpramp = -0.5_X * LASER_NOFOCUS_CONSTANT; // unit: seconds
+        static constexpr float_X startDownramp = 0.5_X * LASER_NOFOCUS_CONSTANT; // unit: seconds
 
         /* initialize the laser not in the first cell is equal to a negative shift
          * in time
@@ -119,13 +119,13 @@ namespace acc
             // @todo add half-cells via traits::FieldPosition< Solver::NumicalCellType, FieldE >()
 
             // transversal position only
-            float3_X const w0_3D( Unitless::W0_X, 0., Unitless::W0_Z );
+            float3_X const w0_3D( Unitless::W0_X, 0._X, Unitless::W0_Z );
             auto const w0( w0_3D.shrink< simDim >().remove< planeNormalDir >() );
             auto const pos_trans( pos.remove< planeNormalDir >() );
             auto const exp_compos( pos_trans * pos_trans / ( w0 * w0 ) );
             float_X const exp_arg( exp_compos.sumOfComponents() );
 
-            m_elong *= math::exp( float_X( -1.0 ) * exp_arg );
+            m_elong *= math::exp( -1.0_X * exp_arg );
 
             if( Unitless::initPlaneY != 0 ) // compile time if
             {
@@ -137,7 +137,7 @@ namespace acc
                  *
                  * The `correctionFactor` assume that the wave is moving in y direction.
                  */
-                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * float_X( 2. );
+                auto const correctionFactor = ( SPEED_OF_LIGHT * DELTA_T ) / CELL_HEIGHT * 2._X;
 
                 // jump over the guard of the electric field
                 m_dataBoxE( localCell + SuperCellSize::toRT() * GuardSize::toRT() ) +=  correctionFactor * m_elong;
@@ -194,10 +194,10 @@ namespace acc
 
             float_64 const runTime = DELTA_T * currentStep - Unitless::laserTimeShift - mue;
 
-            elong = float3_X::create( 0.0 );
+            elong = float3_X::create( 0.0_X );
             float_X envelope = float_X( Unitless::AMPLITUDE );
 
-            const float_64 tau = Unitless::PULSE_LENGTH * math::sqrt( 2.0 );
+            const float_64 tau = Unitless::PULSE_LENGTH * math::sqrt( 2.0_X );
 
             float_64 correctionFactor = 0.0;
 
@@ -213,8 +213,8 @@ namespace acc
             else if( runTime < Unitless::endUpramp )
             {
                 // upramp = start
-                const float_64 exponent = ( ( runTime - Unitless::endUpramp ) / Unitless::PULSE_LENGTH / math::sqrt( 2.0 ) );
-                envelope *= math::exp( -0.5 * exponent * exponent );
+                const float_X exponent = ( ( runTime - Unitless::endUpramp ) / Unitless::PULSE_LENGTH / math::sqrt( 2.0_X ) );
+                envelope *= math::exp( -0.5_X * exponent * exponent );
                 correctionFactor = ( runTime - Unitless::endUpramp ) / ( tau * tau * Unitless::w );
             }
 
@@ -222,16 +222,16 @@ namespace acc
 
             if( Unitless::Polarisation == Unitless::LINEAR_X )
             {
-                elong.x() = float_X( envelope * ( math::sin( phase ) + correctionFactor * math::cos( phase ) ) );
+                elong.x() = envelope * ( math::sin( phase ) + correctionFactor * math::cos( phase ) );
             }
             else if( Unitless::Polarisation == Unitless::LINEAR_Z )
             {
-                elong.z() = float_X( envelope * ( math::sin( phase ) + correctionFactor * math::cos( phase ) ) );
+                elong.z() = envelope * ( math::sin( phase ) + correctionFactor * math::cos( phase ) );
             }
             else if( Unitless::Polarisation == Unitless::CIRCULAR )
             {
-                elong.x() = float_X( envelope / math::sqrt( 2.0 ) * ( math::sin( phase ) + correctionFactor * math::cos( phase ) ) );
-                elong.z() = float_X( envelope / math::sqrt( 2.0 ) * ( math::cos( phase ) + correctionFactor * math::sin( phase ) ) );
+                elong.x() = envelope / math::sqrt( 2.0_X ) * ( math::sin( phase ) + correctionFactor * math::cos( phase ) );
+                elong.z() = envelope / math::sqrt( 2.0_X ) * ( math::cos( phase ) + correctionFactor * math::sin( phase ) );
             }
         }
 


### PR DESCRIPTION
Increase readability of laser profile implementations by using C++11 literals for constant numbers with suffix `_X` instead of `float_X( ... )`.

- [x] rebase after #2622