### PR TITLE
Params: float_X Constants to Literals

### DIFF
--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -55,7 +55,7 @@ namespace densityProfiles
      *
      *   takes `gasCenterLeft_SI      for y < gasCenterLeft_SI`,
      *         `gasCenterRight_SI     for y > gasCenterRight_SI`,
-     *   and `exponent = float_X(0.0) for gasCenterLeft_SI < y < gasCenterRight_SI`
+     *   and `exponent = 0.0 for gasCenterLeft_SI < y < gasCenterRight_SI`
      */
     PMACC_STRUCT(GaussianParam,
         /** ...
@@ -266,7 +266,7 @@ namespace densityProfiles
 
             /* triangle function example
              * for a density profile from 0 to 400 microns */
-            float_X s = float_X( 1.0 - 5.0 * math::abs( y - 0.2 ) );
+            float_X s = 1.0_X - 5.0_X * math::abs( y - 0.2_X );
 
             /* give it an empty/filled striping for every second cell */
             //s *= float_X( (y_cell_id % 2) == 0 );

--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -93,7 +93,7 @@ namespace manipulators
         template< typename T_Particle >
         DINLINE void operator()( T_Particle& particle )
         {
-            particle[weighting_] *= float_X(2.0);
+            particle[weighting_] *= 2.0_X;
         }
     };
 
@@ -106,7 +106,7 @@ namespace manipulators
         DINLINE void operator()( T_Rng& rng, T_Particle& particle )
         {
             // enable radiation for 10% of the particles
-            particle[ radiationMask_ ] = rng() < ( 0.1 );
+            particle[ radiationMask_ ] = rng() < 0.1_X;
         }
     };
 

--- a/include/picongpu/param/particleCalorimeter.param
+++ b/include/picongpu/param/particleCalorimeter.param
@@ -41,8 +41,10 @@ HDINLINE float2_X mapYawPitchToNormedRange(const float_X yaw,
                                            const float_X maxYaw,
                                            const float_X maxPitch)
 {
-    return float2_X(float_X(0.5) + float_X(0.5) * yaw / maxYaw,
-                    float_X(0.5) + float_X(0.5) * pitch / maxPitch);
+    return float2_X(
+        0.5_X + 0.5_X * yaw / maxYaw,
+        0.5_X + 0.5_X * pitch / maxPitch
+    );
 }
 
 } // namespace particleCalorimeter

--- a/include/picongpu/param/png.param
+++ b/include/picongpu/param/png.param
@@ -51,10 +51,10 @@ namespace picongpu
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
         // multiply highest undisturbed particle density with factor
-        constexpr float_X preParticleDens_opacity = 0.25;
-        constexpr float_X preChannel1_opacity = 1.0;
-        constexpr float_X preChannel2_opacity = 1.0;
-        constexpr float_X preChannel3_opacity = 1.0;
+        constexpr float_X preParticleDens_opacity = 0.25_X;
+        constexpr float_X preChannel1_opacity = 1.0_X;
+        constexpr float_X preChannel2_opacity = 1.0_X;
+        constexpr float_X preChannel3_opacity = 1.0_X;
 
         // specify color scales for each channel
         namespace preParticleDensCol = colorScales::red;
@@ -75,7 +75,7 @@ namespace picongpu
 
         DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
         {
-            return -float_X(1.0) * field_E.y();
+            return -1.0_X * field_E.y();
         }
     }
 }

--- a/include/picongpu/param/pngColorScales.param
+++ b/include/picongpu/param/pngColorScales.param
@@ -61,7 +61,7 @@ namespace picongpu
                       - opacity * float3_X( myChannel.x() * img.x(),
                                                myChannel.y() * img.y(),
                                                myChannel.z() * img.z() )
-                      + myChannel * (float_X(1.0) - value ) * opacity;
+                      + myChannel * ( 1.0_X - value ) * opacity;
             }
         }
 

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -80,14 +80,14 @@ namespace picongpu
     value_identifier(
         float3_X,
         momentumPrev1,
-        float3_X::create( 0. )
+        float3_X::create( 0._X )
     );
 
     //! weighting of the macro particle
     value_identifier(
         float_X,
         weighting,
-        float_X( 0. )
+        0._X
     );
 
     //! Voronoi cell of the macro particle
@@ -135,7 +135,7 @@ namespace picongpu
     value_identifier(
         float_X,
         boundElectrons,
-        float_X( 0. )
+        0._X
     );
 
     /** atomic superconfiguration

--- a/include/picongpu/param/speciesConstants.param
+++ b/include/picongpu/param/speciesConstants.param
@@ -36,7 +36,7 @@ namespace picongpu
      * high-precision formulas for relativistic and non-relativistic
      * use-cases, e.g. energy-binning algorithms.
      */
-    constexpr float_X GAMMA_THRESH = float_X(1.005);
+    constexpr float_X GAMMA_THRESH = 1.005_X;
 
     /** Threshold in radiation plugin between relativistic and non-relativistic regime
      *
@@ -46,7 +46,7 @@ namespace picongpu
      * With 0.18 the relative error between Taylor approximation and real value
      * will be below 0.001% = 1e-5 * for x=1/gamma^2 < 0.18
      */
-    constexpr float_X GAMMA_INV_SQUARE_RAD_THRESH = float_X(0.18);
+    constexpr float_X GAMMA_INV_SQUARE_RAD_THRESH = 0.18_X;
 
     namespace SI
     {

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/density.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/density.param
@@ -53,7 +53,10 @@ struct FoilFunctor
      *
      * @return float_X density [normalized to 1.0]
      */
-    HDINLINE float_X operator()(float2_64 pos, const float3_64& cellSize_SI)
+    HDINLINE float_X operator()(
+        float2_64 pos,
+        const float3_64& cellSize_SI
+    )
     {
         /* center point of foil */
         constexpr float_64 plateauPos = 4e-6;
@@ -64,19 +67,20 @@ struct FoilFunctor
 
         using namespace pmacc::algorithms::math;
 
-        if(abs(pos.y() - plateauPos) < plateauLength / 2.0)
+        if( abs( pos.y() - plateauPos) < plateauLength / 2.0 )
         {
-            return float_X(1.0);
+            return 1.0_X;
         }
-        const float_64 d = math::min(abs(pos.y() - plateauPos + plateauLength / 2.0),
-                               abs(pos.y() - plateauPos - plateauLength / 2.0));
-        return exp(-d*d / (2.0 * rampLength*rampLength));
+        const float_64 d = math::min(
+            abs( pos.y() - plateauPos + plateauLength / 2.0 ),
+            abs( pos.y() - plateauPos - plateauLength / 2.0 )
+        );
+        return float_X( exp( -d * d / ( 2.0_X * rampLength * rampLength ) ) );
     }
 };
 
-/* definition of free formula profile */
+//! definition of free formula profile
 using Foil = FreeFormulaImpl< FoilFunctor >;
 
-}//namespace densityProfiles
-
-} //namepsace picongpu
+} // namespace densityProfiles
+} // namepsace picongpu

--- a/share/picongpu/examples/Bunch/include/picongpu/param/png.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/png.param
@@ -74,7 +74,7 @@ DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, co
 
 DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
 {
-    return -float_X(1.0) * field_E.y();
+    return -1.0_X * field_E.y();
 }
 }
 }

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
@@ -76,7 +76,7 @@ namespace manipulators
         )
         {
             constexpr float_X protonNumber = GetAtomicNumbers< T_Particle >::type::numberOfProtons;
-            particle[ boundElectrons_ ] = protonNumber - float_X( 2. );
+            particle[ boundElectrons_ ] = protonNumber - 2._X;
         }
     };
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/png.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/png.param
@@ -69,12 +69,12 @@ namespace picongpu
 
         DINLINE float_X preChannel2 ( const float3_X& field_B, const float3_X& field_E, const float3_X& field_J )
         {
-            return -float_X(1.0) * field_B.z();
+            return -1.0_X * field_B.z();
         }
 
         DINLINE float_X preChannel3 ( const float3_X& field_B, const float3_X& field_E, const float3_X& field_J )
         {
-            return float_X(1.0);
+            return 1.0_X;
         }
     }
 

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/density.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/density.param
@@ -51,7 +51,7 @@ namespace densityProfiles
          *
          *   takes `gasCenterLeft_SI      for y < gasCenterLeft_SI`,
          *         `gasCenterRight_SI     for y > gasCenterRight_SI`,
-         *   and exponent = float_X(0.0)  for gasCenterLeft_SI < y < gasCenterRight_SI
+         *   and exponent = 0.0  for gasCenterLeft_SI < y < gasCenterRight_SI
          */
         (PMACC_C_VALUE(float_X, gasFactor, -1.0))
         (PMACC_C_VALUE(float_X, gasPower, 4.0))

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/png.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/png.param
@@ -74,7 +74,7 @@ DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, co
 
 DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
 {
-    return -float_X(1.0) * field_E.y();
+    return -1.0_X * field_E.y();
 }
 }
 }

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/particle.param
@@ -66,7 +66,7 @@ namespace manipulators
         {
             constexpr float_X ion1plus =
                 GetAtomicNumbers< T_Particle >::type::numberOfProtons -
-                float_X(1);
+                1._X;
 
             // set (Z - 1) bound electrons
             particle[boundElectrons_] = ion1plus;

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/png.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/png.param
@@ -74,7 +74,7 @@ namespace picongpu
 
         DINLINE float_X preChannel3 ( const float3_X& field_B, const float3_X& field_E, const float3_X& field_J )
         {
-            return float_X(1.0);
+            return 1.0_X;
         }
     }
 }


### PR DESCRIPTION
Increase readability of input `.param` files by using C++11 literals for constant numbers with suffix `_X` instead of `float_X( ... )`.

- [x] rebase after #2622