### PR TITLE
Limit Supported GCC with nvcc 8.0-9.1

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -31,7 +31,11 @@ Mandatory
 
 gcc
 """
-- 4.9 to 5.X (depends on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
+- 4.9 - 7 (if you want to build of Nvidia GPUs, supported compilers depend on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
+
+  - CUDA 8.0: Use gcc 4.9
+  - CUDA 9.0 - 9.1: Use gcc 4.9 - 5
+  - CUDA 9.2: Use gcc 4.9 - 7
 - *note:* be sure to build all libraries/dependencies with the *same* gcc version
 - *Debian/Ubuntu:*
   

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -322,6 +322,25 @@ if( ("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc") AND
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_NOEXCEPT")
 endif()
 
+# GCC's C++11 tuples are broken in "supported" NVCC versions
+if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        if(CUDA_VERSION VERSION_EQUAL 8.0)
+            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 5.0)
+                message(FATAL_ERROR "NVCC 8.0 does not support the std::tuple "
+                        "implementation in GCC 5+. Please use GCC 4.9!")
+            endif()
+        elseif(
+            (CUDA_VERSION VERSION_EQUAL 9.0) OR
+            (CUDA_VERSION VERSION_EQUAL 9.1))
+            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 6.0)
+                message(FATAL_ERROR "NVCC 9.0-9.1 do not support the std::tuple "
+                        "implementation in GCC 6+. Please use GCC 4.9 or 5!")
+            endif()
+        endif()
+    endif()
+endif()
+
 
 ################################################################################
 # Find OpenMP


### PR DESCRIPTION
Sadly, the truly working GCC range is smaller than the official CUDA support. This is caused by missing support of `std::tuple` which is pulled easily in dependencies such as boost.

The latest NVCC 9.2 is supposedly good as it adds official `std::tuple` support and even support for GCC 7.

Close #2388