### PR TITLE
Update mallocMC to 2.3.0crp

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -120,8 +120,8 @@ cupla 0.1.0
 """""""""""
 - `cupla <https://github.com/ComputationalRadiationPhysics/cupla>`_ is included in the PIConGPU source code
 
-mallocMC 2.3.0crp-dev
-"""""""""""""""""""""
+mallocMC 2.3.0crp
+"""""""""""""""""
 - only required for CUDA backend
 - `mallocMC <https://github.com/ComputationalRadiationPhysics/mallocMC>`_ is included in the PIConGPU source code
 

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -116,12 +116,12 @@ endif()
 # Find mallocMC
 ################################################################################
 if(ALPAKA_ACC_GPU_CUDA_ENABLE)
-    find_package(mallocMC 2.2.0 QUIET)
+    find_package(mallocMC 2.3.0 QUIET)
 
     if(NOT mallocMC_FOUND)
         message(STATUS "Using mallocMC from thirdParty/ directory")
         set(MALLOCMC_ROOT "${PIConGPUapp_SOURCE_DIR}/../../thirdParty/mallocMC")
-        find_package(mallocMC 2.2.0 REQUIRED)
+        find_package(mallocMC 2.3.0 REQUIRED)
     endif(NOT mallocMC_FOUND)
 
     include_directories(SYSTEM ${mallocMC_INCLUDE_DIRS})

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -338,12 +338,12 @@ endif()
 ################################################################################
 
 if(ALPAKA_ACC_GPU_CUDA_ENABLE)
-    find_package(mallocMC 2.2.0 QUIET)
+    find_package(mallocMC 2.3.0 QUIET)
 
     if(NOT mallocMC_FOUND)
         message(STATUS "Using mallocMC from thirdParty/ directory")
         set(MALLOCMC_ROOT "${PMacc_DIR}/../../thirdParty/mallocMC")
-        find_package(mallocMC 2.2.0 REQUIRED)
+        find_package(mallocMC 2.3.0 REQUIRED)
     endif(NOT mallocMC_FOUND)
 
     set(PMacc_INCLUDE_DIRS ${PMacc_INCLUDE_DIRS} ${mallocMC_INCLUDE_DIRS})

--- a/thirdParty/mallocMC/CHANGELOG.md
+++ b/thirdParty/mallocMC/CHANGELOG.md
@@ -1,6 +1,42 @@
 Change Log / Release Log for mallocMC
 ================================================================
 
+2.3.0crp
+--------
+**Date:** 2018-06-11
+
+This release adds support for CUDA 9 and clang's -x cuda frontend and fixes several bugs.
+Global objects have been refactored to separate objects on host and device.
+
+### Changes to mallocMC 2.2.0crp
+
+**Features**
+ - CUDA 9 support #144 #145
+ - clang++ -x cuda support #133
+ - add `destructiveResize` method #136
+ - heap as separate object on host and device, no more globals #116
+ - use `BOOST_STATIC_CONSTEXPR` where possible #109
+
+**Bug fixes**
+ - fix uninitialized pointers #110 #112
+ - fix crash in getAvailableSlots #106 #107
+ - Fix `uint32_t` cstdint #104 #105
+ - fix missing boost include #142
+ - fix includes from C headers #121
+ - fix missing local size change in `finalizeHeap()` #135
+ - check heap pointer in Scatter creation policy #126
+
+**Misc:**
+ - better link usage and install docs #141
+ - self consistent allocator #140
+ - rename some shadowed variables in C++11 mode #108
+ - properly enforce `-Werror` in Travis-CI #128
+ - update Travis-CI image #119
+ - improved docs #125 #127
+
+Thanks to Carlchristian Eckert, René Widera, Axel Huebl and Alexander Grund for contributing to this release!
+
+
 2.2.0crp
 -------------
 **Date:** 2015-09-25

--- a/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -619,7 +619,7 @@ namespace ScatterKernelDetail{
         void* res = 0;
         for(
 #if(__CUDACC_VER_MAJOR__ >= 9)
-          unsigned int __mask = __ballot_sync(0xFFFFFFFF, 1),
+          unsigned int __mask = __activemask(),
 #else
           unsigned int __mask = __ballot(1),
 #endif
@@ -936,7 +936,7 @@ namespace ScatterKernelDetail{
         int wId = threadIdx.x >> 5; //do not use warpid-function, since this value is not guaranteed to be stable across warp lifetime
 
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        uint32 activeThreads  = __popc(__ballot_sync(0xFFFFFFFF, true));
+        uint32 activeThreads  = __popc(__activemask());
 #else
         uint32 activeThreads  = __popc(__ballot(true));
 #endif

--- a/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -101,7 +101,7 @@ namespace DistributionPolicies{
         //necessary for offset calculation
         bool coalescible = bytes > 0 && bytes < (pagesize / 32);
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        threadcount = __popc(__ballot_sync(0xFFFFFFFF, coalescible));
+        threadcount = __popc(__ballot_sync(__activemask(), coalescible));
 #else
         threadcount = __popc(__ballot(coalescible));
 #endif

--- a/thirdParty/mallocMC/src/include/mallocMC/version.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/version.hpp
@@ -38,7 +38,7 @@
 
 /** the mallocMC version: major API changes should be reflected here */
 #define MALLOCMC_VERSION_MAJOR 2
-#define MALLOCMC_VERSION_MINOR 2
+#define MALLOCMC_VERSION_MINOR 3
 #define MALLOCMC_VERSION_PATCH 0
 
 /** the mallocMC flavor is used to differentiate the releases of the


### PR DESCRIPTION
Updates mallocMC:
- Fix V100 Active Lanes in Warp [#145](https://github.com/ComputationalRadiationPhysics/mallocMC/pull/145)

From
- `mallocMC@dev` (https://github.com/ComputationalRadiationPhysics/mallocMC/commit/3531c29c0d2a88be45508a789eab624cb0dd4fc5)
to
- `mallocMC@2.3.0crp` (https://github.com/ComputationalRadiationPhysics/mallocMC/tree/4b779a34cd8ba073b24f69435d71022f3988d42e == [2.3.0crp](https://github.com/ComputationalRadiationPhysics/mallocMC/tree/2.3.0crp))

## Used Commands

```bash
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git subtree pull --prefix thirdParty/mallocMC \
  git@github.com:ComputationalRadiationPhysics/mallocMC.git 2.3.0crp --squash
```