### PR TITLE
ISAAC: 1.4.0+

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -288,7 +288,7 @@ ADIOS
 
 ISAAC
 """""
-- 1.3.3+
+- 1.4.0+
 - requires *boost* (header only), *IceT*, *Jansson*, *libjpeg* (preferably *libjpeg-turbo*), *libwebsockets* (only for the ISAAC server, but not the plugin itself)
 - enables live in situ visualization, see more here `Plugin description <https://github.com/ComputationalRadiationPhysics/picongpu/wiki/Plugin%3A-ISAAC>`_
 - *Spack:* ``spack install isaac``

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -97,7 +97,7 @@ touch "$thisDir"runGuard
             module load gcc/4.9.4 boost/1.62.0 cmake/3.10.0 cuda/8.0.44 openmpi/1.10.4
             module load libSplash/1.7.0 adios/1.13.1
             module load pngwriter/0.7.0
-            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.3.3
+            module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.4.0
 
             # compile all examples, fetch output and return code
             $cnf_gitdir/bin/pic-compile -l -q -j $cnf_numParallel \

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -312,7 +312,7 @@ endif(PNGwriter_FOUND)
 
 SET(ISAAC_CUDA OFF CACHE BOOL "Using CUDA")
 SET(ISAAC_ALPAKA ON CACHE BOOL "Using Alpaka")
-find_package(ISAAC 1.3.3 CONFIG QUIET)
+find_package(ISAAC 1.4.0 CONFIG QUIET)
 if(ISAAC_FOUND)
     message(STATUS "Found ISAAC: ${ISAAC_DIR}")
     SET(ISAAC_STEREO "No" CACHE STRING "Using stereoscopy")


### PR DESCRIPTION
Require the latest ISAAC release for PIConGPU.

This release fixes a CMake install issue and several rendering artifacts in border regions.

For details please refer to:
https://github.com/ComputationalRadiationPhysics/isaac/releases/tag/v1.4.0

I updated the compile suite with the new release.