### PR TITLE
Doc: CUDA 9.2 not yet supported

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -35,7 +35,7 @@ gcc
 
   - CUDA 8.0: Use gcc 4.9
   - CUDA 9.0 - 9.1: Use gcc 4.9 - 5
-  - CUDA 9.2: Use gcc 4.9 - 7
+  - CUDA 9.2: Use gcc 4.9 - 7 (not yet supported)
 - *note:* be sure to build all libraries/dependencies with the *same* gcc version
 - *Debian/Ubuntu:*
   
@@ -152,7 +152,7 @@ Optional Libraries
 
 CUDA
 """"
-- `8.0+ <https://developer.nvidia.com/cuda-downloads>`_
+- `8.0 - 9.1 <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -341,6 +341,18 @@ if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
     endif()
 endif()
 
+# CUDA 9.2 is not yet supported by alpaka
+if(CUDA_VERSION VERSION_EQUAL 9.2)
+    if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
+        message(FATAL_ERROR "NVCC 9.2 is not yet supported by alpaka!")
+    endif()
+endif()
+
+# Newer CUDA releases: probably troublesome, warn at least
+if(CUDA_VERSION VERSION_GREATER 9.2)
+    message(WARNING "Untested CUDA release! Maybe use a newer PIConGPU?")
+endif()
+
 
 ################################################################################
 # Find OpenMP


### PR DESCRIPTION
CUDA 9.2 will not yet run as alpaka first has to support it.

Know alpaka 0.3.1 issue:
- https://github.com/ComputationalRadiationPhysics/alpaka/issues/525

Tested alpaka 0.3.1 CUDA releases are 7.0 - 9.1:
- https://github.com/ComputationalRadiationPhysics/alpaka/blob/0.3.1/.travis.yml#L54

PIConGPU currently works with CUDA 8.0+ (and 7.5 in some limited cases, we removed official support).