### PR TITLE
re-enable CUDA 8.0 and gcc 5.0 - 5.3 support

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -33,7 +33,7 @@ gcc
 """
 - 4.9 - 7 (if you want to build of Nvidia GPUs, supported compilers depend on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
 
-  - CUDA 8.0: Use gcc 4.9
+  - CUDA 8.0: Use gcc 4.9 - 5.3
   - CUDA 9.0 - 9.1: Use gcc 4.9 - 5
   - CUDA 9.2: Use gcc 4.9 - 7 (not yet supported)
 - *note:* be sure to build all libraries/dependencies with the *same* gcc version

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -326,9 +326,9 @@ endif()
 if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         if(CUDA_VERSION VERSION_EQUAL 8.0)
-            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 5.0)
+            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 5.4)
                 message(FATAL_ERROR "NVCC 8.0 does not support the std::tuple "
-                        "implementation in GCC 5+. Please use GCC 4.9!")
+                        "implementation in GCC 5.4+. Please use GCC 4.9 - 5.3!")
             endif()
         elseif(
             (CUDA_VERSION VERSION_EQUAL 9.0) OR


### PR DESCRIPTION
Allow to use CUDA 8.0 together with gcc 5.0 to 5.3.
The support for this compiler combination was removed with #2628.


Note: I used `gcc/5.3.0` and `cuda/8.0` together since over a year and have no issues.