### PR TITLE
supercell particle counter

### DIFF
--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -172,6 +172,11 @@ public:
     /** copy guard particles to intermediate exchange buffer
      *
      * Copy all particles from the guard of a direction to the device exchange buffer.
+     *  @warning This method resets the number of particles in the processed supercells even
+     * if there are particles left in the supercell and not fulfill the rule that the
+     * last frame is contiguous filled.
+     * Call KernelFillGaps afterwards if you need a valid number of particles
+     * and a contiguous filled last frame.
      */
     void copyGuardToExchange(uint32_t exchangeType);
 

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -172,11 +172,11 @@ public:
     /** copy guard particles to intermediate exchange buffer
      *
      * Copy all particles from the guard of a direction to the device exchange buffer.
-     *  @warning This method resets the number of particles in the processed supercells even
-     * if there are particles left in the supercell and not fulfill the rule that the
-     * last frame is contiguous filled.
-     * Call KernelFillGaps afterwards if you need a valid number of particles
-     * and a contiguous filled last frame.
+     * @warning This method resets the number of particles in the processed supercells even
+     * if there are particles left in the supercell and does not guarantee that the last frame is
+     * contiguous filled.
+     * Call fillAllGaps afterwards if you need a valid number of particles
+     * and a contiguously filled last frame.
      */
     void copyGuardToExchange(uint32_t exchangeType);
 

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -968,10 +968,10 @@ struct KernelDeleteParticles
 /** copy particles from the guard to an exchange buffer
  *
  * @warning This kernel resets the number of particles in the processed supercells even
- * if there are particles left in the supercell and not fulfill the rule that the
- * last frame is contiguous filled.
+ * if there are particles left in the supercell and does not guarantee that the last frame is
+ * contiguous filled.
  * Call KernelFillGaps afterwards if you need a valid number of particles
- * and a contiguous filled last frame.
+ * and a contiguously filled last frame.
  *
  * @tparam T_numWorkers number of workers
  */

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -229,17 +229,21 @@ struct KernelFillGapsLastFrame
                 uint32_t const
             )
             {
-                if( lastFrame.isValid() && counterParticles == 0 )
+                // there is no need to add a zero to the global memory
+                if( counterParticles != 0 )
                 {
-                    lastFrame = getPreviousFrameAndRemoveLastFrame(lastFrame, pb, superCellIdx);
-                    /* if there is a previous valid frame then this frame is fully filled and
-                     * now the last frame
-                     */
-                    if( lastFrame.isValid() )
-                        counterParticles = frameSize;
+                    auto & superCell = pb.getSuperCell( superCellIdx );
+                    superCell.setNumParticles(
+                        superCell.getNumParticles() + counterParticles
+                    );
                 }
-
-                pb.getSuperCell( superCellIdx ).setSizeLastFrame( counterParticles );
+                else
+                {
+                    /* The last frame is empty therefore it must be removed.
+                     * It is save to call this method even if there is no last frame.
+                     */
+                    pb.removeLastFrame( superCellIdx );
+                }
             }
         );
     }
@@ -320,6 +324,8 @@ struct KernelFillGaps
             counterParticles,
             int
         );
+
+        uint32_t numParticlesPerSuperCell = 0u;
 
         ForEachIdx<
             IdxConfig<
@@ -438,6 +444,7 @@ struct KernelFillGaps
                     {
                         if( counterGaps < counterParticles )
                         {
+                            numParticlesPerSuperCell += frameSize;
                             // any gap in the first frame is filled
                             firstFrame = pb.getNextFrame( firstFrame );
                         }
@@ -460,6 +467,7 @@ struct KernelFillGaps
                             );
                             if( lastFrame.isValid( ) && lastFrame != firstFrame )
                             {
+                                numParticlesPerSuperCell += frameSize;
                                 firstFrame = pb.getNextFrame( firstFrame );
                             }
                         }
@@ -475,6 +483,7 @@ struct KernelFillGaps
                         uint32_t const
                     )
                     {
+                        numParticlesPerSuperCell += frameSize;
                         firstFrame = pb.getNextFrame( firstFrame );
                     }
                 );
@@ -483,6 +492,20 @@ struct KernelFillGaps
             __syncthreads( );
 
         }
+
+        onlyMaster(
+            [&](
+                uint32_t const,
+                uint32_t const
+            )
+            {
+                /* numParticlesPerSuperCell is the number of particles in the
+                 * supercell except the particles in the last frame
+                 */
+                auto & superCell = pb.getSuperCell( superCellIdx );
+                superCell.setNumParticles( numParticlesPerSuperCell );
+            }
+        );
 
         // fill all gaps in the last frame of the supercell
         KernelFillGapsLastFrame< numWorkers >{ }(
@@ -595,9 +618,9 @@ struct KernelShiftParticles
         >;
 
         memory::CtxArray<
-            uint32_t,
+            int,
             ExchangeDomCfg
-        > lastFrameSizeCtx( 0 );
+        > newParticleInFrame( 0 );
 
         memory::CtxArray<
             DataSpace< dim >,
@@ -633,12 +656,13 @@ struct KernelShiftParticles
 
                 if ( tmpFrame.isValid() )
                 {
-                    lastFrameSizeCtx[ idx ] = pb.getSuperCell( relativeCtx[ idx ] ).getSizeLastFrame( );
+                    uint32_t particlesInFrame = pb.getSuperCell( relativeCtx[ idx ] ).getSizeLastFrame( );
                     // do not use the neighbor's last frame if it is full
-                    if ( lastFrameSizeCtx[ idx ] < frameSize )
+                    if ( particlesInFrame < frameSize )
                     {
+                        newParticleInFrame[ idx ] = -particlesInFrame;
                         destFrames[ linearIdx ] = tmpFrame;
-                        destFramesCounter[ linearIdx ] = lastFrameSizeCtx[ idx ];
+                        destFramesCounter[ linearIdx ] = particlesInFrame;
                     }
                 }
             }
@@ -702,7 +726,6 @@ struct KernelShiftParticles
                      */
                     if ( destFramesCounter[ linearIdx ] > 0 )
                     {
-                        lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ];
                         /* if we had no `low frame` we load a new empty one */
                         if ( !destFrames[ linearIdx ].isValid( ) )
                         {
@@ -717,7 +740,6 @@ struct KernelShiftParticles
                         /* check if a `high frame` is needed */
                         if ( destFramesCounter[ linearIdx ] > frameSize )
                         {
-                            lastFrameSizeCtx[ idx ] = destFramesCounter[ linearIdx ] - frameSize;
                             FramePtr tmpFrame( pb.getEmptyFrame( ) );
                             destFrames[ linearIdx + numExchanges ] = tmpFrame;
                             pb.setAsLastFrame(
@@ -770,7 +792,7 @@ struct KernelShiftParticles
             forEachExchange(
                 [&](
                     uint32_t const linearIdx,
-                    uint32_t const
+                    uint32_t const idx
                 )
                 {
                     /* if the `low frame` is full, each master thread
@@ -779,6 +801,7 @@ struct KernelShiftParticles
                      */
                     if ( destFramesCounter[ linearIdx ] >= frameSize )
                     {
+                        newParticleInFrame[ idx ] += frameSize;
                         destFramesCounter[ linearIdx ] -= frameSize;
                         destFrames[ linearIdx ] = destFrames[ linearIdx + numExchanges ];
                         destFrames[ linearIdx + numExchanges ] = FramePtr( );
@@ -794,14 +817,23 @@ struct KernelShiftParticles
 
         forEachExchange(
             [&](
-                uint32_t const,
+                uint32_t const linearIdx,
                 uint32_t const idx
             )
             {
-                /* each master thread updates the number of particles in the last frame
-                 * of the neighbors supercell
-                 */
-                pb.getSuperCell( relativeCtx[ idx ] ).setSizeLastFrame( lastFrameSizeCtx[ idx ] );
+                newParticleInFrame[ idx ] += destFramesCounter[ linearIdx ];
+                if( newParticleInFrame[ idx ] > 0 )
+                {
+                    /* Each master thread updates the number of particles
+                     * for the neighbor frame. The number of particles in the neighbor
+                     * frame must be correct because fill gaps is only called on the
+                     * current used supercell.
+                     */
+                    auto & superCell = pb.getSuperCell( relativeCtx[ idx ] );
+                    superCell.setNumParticles(
+                        superCell.getNumParticles() + newParticleInFrame[ idx ]
+                    );
+                }
             }
         );
 
@@ -926,16 +958,20 @@ struct KernelDeleteParticles
                 uint32_t const
             )
             {
-                /* all frames and particles are removed, set counter for particles
-                 * in the last frame to zero
-                 */
-                pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
+                // all frames and particles are removed
+                pb.getSuperCell( superCellIdx ).setNumParticles( 0 );
             }
         );
     }
 };
 
 /** copy particles from the guard to an exchange buffer
+ *
+ * @warning This kernel resets the number of particles in the processed supercells even
+ * if there are particles left in the supercell and not fulfill the rule that the
+ * last frame is contiguous filled.
+ * Call KernelFillGaps afterwards if you need a valid number of particles
+ * and a contiguous filled last frame.
  *
  * @tparam T_numWorkers number of workers
  */
@@ -1146,7 +1182,10 @@ struct KernelCopyGuardToExchange
                 uint32_t const
             )
             {
-                pb.getSuperCell( superCellIdx ).setSizeLastFrame( 0 );
+                /* Mark supercell as empty even if there are particles left.
+                 * This kernel not depends on the correct number particles in the supercell.
+                 */
+                pb.getSuperCell( superCellIdx ).setNumParticles( 0 );
             }
         );
 

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -22,6 +22,8 @@
 #pragma once
 
 #include "pmacc/types.hpp"
+#include "pmacc/math/vector/compile-time/Vector.hpp"
+
 
 namespace pmacc
 {
@@ -32,10 +34,10 @@ class SuperCell
 public:
 
     HDINLINE SuperCell() :
-    firstFramePtr(nullptr),
-    lastFramePtr(nullptr),
-    mustShiftVal(false),
-    sizeLastFrame(0)
+        firstFramePtr(nullptr),
+        lastFramePtr(nullptr),
+        numParticles(0),
+        mustShiftVal(false)
     {
     }
 
@@ -69,23 +71,30 @@ public:
         mustShiftVal = value;
     }
 
-    HDINLINE lcellId_t getSizeLastFrame()
+    HDINLINE uint32_t getSizeLastFrame()
     {
-        return sizeLastFrame;
+        constexpr uint32_t frameSize = math::CT::volume<
+            typename TYPE::SuperCellSize
+        >::type::value;
+            return numParticles ? ( ( numParticles - 1u ) % frameSize + 1u ) : 0u;
     }
 
-    HDINLINE void setSizeLastFrame(lcellId_t size)
+    HDINLINE uint32_t getNumParticles()
     {
-        sizeLastFrame = size;
+        return numParticles;
     }
 
+    HDINLINE void setNumParticles(uint32_t size)
+    {
+        numParticles = size;
+    }
 
-private:
-    PMACC_ALIGN(mustShiftVal, bool);
-    PMACC_ALIGN(sizeLastFrame, lcellId_t);
 public:
     PMACC_ALIGN(firstFramePtr, TYPE*);
     PMACC_ALIGN(lastFramePtr, TYPE*);
+private:
+    PMACC_ALIGN(numParticles, uint32_t);
+    PMACC_ALIGN(mustShiftVal, bool);
 };
 
-} //end namespace
+} //namespace pmacc

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -56,7 +56,7 @@ namespace pmacc
             return firstFramePtr;
         }
 
-        HDINLINE T_FrameType const*  LastFramePtr() const
+        HDINLINE T_FrameType const *  LastFramePtr() const
         {
             return lastFramePtr;
         }

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -28,73 +28,85 @@
 namespace pmacc
 {
 
-template <class TYPE>
-class SuperCell
-{
-public:
-
-    HDINLINE SuperCell() :
-        firstFramePtr(nullptr),
-        lastFramePtr(nullptr),
-        numParticles(0),
-        mustShiftVal(false)
+    template< class T_FrameType >
+    class SuperCell
     {
-    }
+    public:
 
-    HDINLINE TYPE* FirstFramePtr()
-    {
-        return firstFramePtr;
-    }
+        HDINLINE SuperCell() :
+            firstFramePtr( nullptr ),
+            lastFramePtr( nullptr ),
+            numParticles( 0 ),
+            mustShiftVal( false )
+        {
+        }
 
-    HDINLINE TYPE* LastFramePtr()
-    {
-        return lastFramePtr;
-    }
+        HDINLINE T_FrameType * FirstFramePtr()
+        {
+            return firstFramePtr;
+        }
 
-    HDINLINE const TYPE* FirstFramePtr() const
-    {
-        return firstFramePtr;
-    }
+        HDINLINE T_FrameType * LastFramePtr()
+        {
+            return lastFramePtr;
+        }
 
-    HDINLINE const TYPE* LastFramePtr() const
-    {
-        return lastFramePtr;
-    }
+        HDINLINE T_FrameType const * FirstFramePtr() const
+        {
+            return firstFramePtr;
+        }
 
-    HDINLINE bool mustShift()
-    {
-        return mustShiftVal;
-    }
+        HDINLINE T_FrameType const*  LastFramePtr() const
+        {
+            return lastFramePtr;
+        }
 
-    HDINLINE void setMustShift(bool value)
-    {
-        mustShiftVal = value;
-    }
+        HDINLINE bool mustShift() const
+        {
+            return mustShiftVal;
+        }
 
-    HDINLINE uint32_t getSizeLastFrame()
-    {
-        constexpr uint32_t frameSize = math::CT::volume<
-            typename TYPE::SuperCellSize
-        >::type::value;
+        HDINLINE void setMustShift( bool const value )
+        {
+            mustShiftVal = value;
+        }
+
+        HDINLINE uint32_t getSizeLastFrame() const
+        {
+            constexpr uint32_t frameSize = math::CT::volume<
+                typename T_FrameType::SuperCellSize
+            >::type::value;
             return numParticles ? ( ( numParticles - 1u ) % frameSize + 1u ) : 0u;
-    }
+        }
 
-    HDINLINE uint32_t getNumParticles()
-    {
-        return numParticles;
-    }
+        HDINLINE uint32_t getNumParticles() const
+        {
+            return numParticles;
+        }
 
-    HDINLINE void setNumParticles(uint32_t size)
-    {
-        numParticles = size;
-    }
+        HDINLINE void setNumParticles( uint32_t const size )
+        {
+            numParticles = size;
+        }
 
-public:
-    PMACC_ALIGN(firstFramePtr, TYPE*);
-    PMACC_ALIGN(lastFramePtr, TYPE*);
-private:
-    PMACC_ALIGN(numParticles, uint32_t);
-    PMACC_ALIGN(mustShiftVal, bool);
-};
+    public:
+        PMACC_ALIGN(
+            firstFramePtr,
+            T_FrameType*
+        );
+        PMACC_ALIGN(
+            lastFramePtr,
+            T_FrameType*
+        );
+    private:
+        PMACC_ALIGN(
+            numParticles,
+            uint32_t
+        );
+        PMACC_ALIGN(
+            mustShiftVal,
+            bool
+        );
+    };
 
 } //namespace pmacc

--- a/include/pmacc/test/particles/memory/SuperCell.hpp
+++ b/include/pmacc/test/particles/memory/SuperCell.hpp
@@ -1,0 +1,115 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/particles/memory/dataTypes/SuperCell.hpp>
+
+
+namespace pmacc
+{
+namespace test
+{
+namespace particles
+{
+namespace memory
+{
+
+template< typename T_SuperCell >
+struct TestNumParticlesLastFrame
+{
+    struct FrameTypeDummy
+    {
+        using SuperCellSize = T_SuperCell;
+    };
+
+    /** test a combination
+     *
+     * @param numParticlesPerCell number of particles within the test supercell
+     * @param particleLastFrame the assumed result with the given number of particles
+     *                          and T_SuperCell
+     */
+    HDINLINE void operator()(
+        uint32_t numParticlesPerCell,
+        uint32_t particleLastFrame
+    )
+    {
+        pmacc::SuperCell< FrameTypeDummy > superCell;
+        superCell.setNumParticles( numParticlesPerCell );
+
+        BOOST_CHECK_EQUAL(
+            superCell.getSizeLastFrame(),
+            particleLastFrame
+        );
+    }
+};
+
+} // namespace memory
+} // namespace particles
+} // namespace test
+} // namespace pmacc
+
+/* The supercell test is always performed with a 3 dimensional supercell
+ * because the supercell is agnostic about the number of dimensions.
+ */
+BOOST_AUTO_TEST_CASE( copyFrom )
+{
+    using namespace pmacc::test::particles::memory;
+    TestNumParticlesLastFrame<
+        pmacc::math::CT::Int<
+            8,
+            8,
+            4
+        >
+    > cell256{};
+
+    // no particles in the supercell
+    cell256( 0u, 0u );
+    // one full frame
+    cell256( 256u, 256u );
+    // two full frames
+    cell256( 512u, 256u );
+    // edge cases
+    cell256( 255u, 255u );
+    cell256( 257u, 1u );
+    cell256( 1u, 1u );
+
+    using namespace pmacc::test::particles::memory;
+    TestNumParticlesLastFrame<
+        pmacc::math::CT::Int<
+            3,
+            3,
+            3
+        >
+    > cell27{};
+
+    // no particles in the supercell
+    cell27( 0u, 0u );
+    // one full frame
+    cell27( 27u, 27u );
+    // two full frames
+    cell27( 54u, 27u );
+    // edge cases
+    cell27( 26u, 26u );
+    cell27( 28u, 1u );
+    cell27( 1u, 1u );
+
+}

--- a/include/pmacc/test/particles/particlesUT.cpp
+++ b/include/pmacc/test/particles/particlesUT.cpp
@@ -33,3 +33,4 @@
 #endif
 
 #include "IdProvider.hpp"
+#include "memory/SuperCell.hpp"


### PR DESCRIPTION
Extent the supercell to be aware about the number current number of particles.

- SuperCell:
  - add method `getNumParticles()`
  - remove method `setSizeLastFrame()`
  - add method `setNumParticles()`
  - re-format SuperCell to the new code style
  - add const to read only methods
- ParticleBase
  - update documentation
  - count number of particles during `KernelShiftParticles` and fill gaps kernel
- add unit test to test the supercell method `getSizeLastFrame()`

The second commit contains only the code style changes and add const to read only methods  of the supercell.

I am not sure if we should put this PR into 0.4.0 or wait until we opened the release branch.

- [x] rebase against #2649