### PR TITLE
remove empty last frame

### DIFF
--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -229,6 +229,16 @@ struct KernelFillGapsLastFrame
                 uint32_t const
             )
             {
+                if( lastFrame.isValid() && counterParticles == 0 )
+                {
+                    lastFrame = getPreviousFrameAndRemoveLastFrame(lastFrame, pb, superCellIdx);
+                    /* if there is a previous valid frame then this frame is fully filled and
+                     * now the last frame
+                     */
+                    if( lastFrame.isValid() )
+                        counterParticles = frameSize;
+                }
+
                 pb.getSuperCell( superCellIdx ).setSizeLastFrame( counterParticles );
             }
         );


### PR DESCRIPTION
By definition our last frame is allowed to not be fully filled with particles.
To reduce the memory foot print the last frame, it should never be empty after all gaps are filled.
This is currently not always the case.

Remove the last frame in the a supercell in `KernelFillGapsLastFrame` if it is empty.

# Tests

- [x] runtime tests

@theZiz thx for helping me to find this issue with your graphical debugging tool [ISAAC](https://github.com/ComputationalRadiationPhysics/isaac) :-)