### PR TITLE
Restart TPLs: new checkpoints.period syntax

### DIFF
--- a/etc/picongpu/hypnos-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_restart.tpl
@@ -104,25 +104,24 @@ done
 finalStep=`echo !TBG_programParams | sed 's/.*-s[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
 echo "final step      = " $finalStep | tee -a output
 #this sed call extracts the -s and --checkpoint flags
-programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9]\+[^\s]//g'`
+programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9,:,\,]\+[^\s]//g'`
 #extract restart period
-restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
+restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9,:,\,]\+[^\s]\).*/\1/'`
 echo  "restart period = " $restartPeriod | tee -a output
 
-if [ "" != "$file" ]
-then
-    cptimestep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
-    echo "start time      = " $cptimestep | tee -a output
+# ******************************************* #
+# need some magic, if the restart period is in new notation with the ':' and ','
 
-    endTime="$(($cptimestep + $restartPeriod ))"
-    echo "end time        = " $endTime | tee -a output
+currentStep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
+nextStep=$(nextstep_from_period.sh $restartPeriod $finalStep $currentStep)
 
-    stepSetup=$(echo -s $endTime "--checkpoint.restart --checkpoint.restart.step" $cptimestep "--checkpoint.period" $restartPeriod )
+if [ -z "$file" ]; then
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod"
 else
-    echo "no checkpoint found" | tee -a output
-    endTime=$restartPeriod
-    stepSetup=$(echo " -s " $endTime "--checkpoint.period" $restartPeriod )
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod --checkpoint.restart --checkpoint.restart.step $currentStep"
 fi
+
+# ******************************************* #
 
 echo "--- end automated restart routine ---" | tee -a output
 
@@ -142,7 +141,7 @@ fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks /usr/bin/env bash -c "killall -9 picongpu 2>/dev/null || true"
 
-if [ $endTime -lt $finalStep ]
+if [ $nextStep -lt $finalStep ]
 then
     ssh hypnos4 "/opt/torque/bin/qsub !TBG_dstPath/tbg/submit.start"
     if [ $? -ne 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k80_restart.tpl
@@ -99,30 +99,31 @@ do
         file=""
     fi
 done
+file
 
 #this sed call extracts the final simulation step from the cfg (assuming a standard cfg)
 finalStep=`echo !TBG_programParams | sed 's/.*-s[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
 echo "final step      = " $finalStep | tee -a output
 #this sed call extracts the -s and --checkpoint flags
-programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9]\+[^\s]//g'`
+programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9,:,\,]\+[^\s]//g'`
 #extract restart period
-restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
+restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9,:,\,]\+[^\s]\).*/\1/'`
 echo  "restart period = " $restartPeriod | tee -a output
 
-if [ "" != "$file" ]
-then
-    cptimestep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
-    echo "start time      = " $cptimestep | tee -a output
 
-    endTime="$(($cptimestep + $restartPeriod ))"
-    echo "end time        = " $endTime | tee -a output
+# ******************************************* #
+# need some magic, if the restart period is in new notation with the ':' and ','
 
-    stepSetup=$(echo -s $endTime "--checkpoint.restart --checkpoint.restart.step" $cptimestep "--checkpoint.period" $restartPeriod )
+currentStep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
+nextStep=$(nextstep_from_period.sh $restartPeriod $finalStep $currentStep)
+
+if [ -z "$file" ]; then
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod"
 else
-    echo "no checkpoint found" | tee -a output
-    endTime=$restartPeriod
-    stepSetup=$(echo " -s " $endTime "--checkpoint.period" $restartPeriod )
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod --checkpoint.restart --checkpoint.restart.step $currentStep"
 fi
+
+# ******************************************* #
 
 echo "--- end automated restart routine ---" | tee -a output
 
@@ -142,7 +143,7 @@ fi
 
 mpiexec --prefix $MPIHOME -x LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks /usr/bin/env bash -c "killall -9 picongpu 2>/dev/null || true"
 
-if [ $endTime -lt $finalStep ]
+if [ $nextStep -lt $finalStep ]
 then
     ssh hypnos4 "/opt/torque/bin/qsub !TBG_dstPath/tbg/submit.start"
     if [ $? -ne 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k80_restart.tpl
@@ -99,7 +99,6 @@ do
         file=""
     fi
 done
-file
 
 #this sed call extracts the final simulation step from the cfg (assuming a standard cfg)
 finalStep=`echo !TBG_programParams | sed 's/.*-s[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`

--- a/src/tools/bin/nextstep_from_period.sh
+++ b/src/tools/bin/nextstep_from_period.sh
@@ -39,8 +39,8 @@ helpText()
 
 for p in $@; do
     if [ "$p" = "-h" ] || [ "$p" = "--help" ]; then
-	    helpText
-	    exit 0
+        helpText
+        exit 0
     fi
 done
 

--- a/src/tools/bin/nextstep_from_period.sh
+++ b/src/tools/bin/nextstep_from_period.sh
@@ -77,9 +77,16 @@ splitSections()
 }
 expandPeriods()
 {
-    # split a string on occurences of ':' and always return a 3-tuple
-    # with some default values if there were less than two ':' - also
-    # breaks, if there were more than two ':'
+    # split a string on occurences of ':' and transform it into a
+    # sequence of checkpoint timesteps. Reads the global variable
+    # $lastStep to determine the end of the sequence if not given
+    # otherwise
+    #   input syntax:
+    #       period  or
+    #       start:end[:period]
+    #   examples: 5:20:5 -> 5 10 15 20
+    #             3      -> 0 3 6 9   (with $lastStep == 10)
+    #             3:5    -> 3 4 5
     IFS=':'
     input=($1)
     len=${#input[@]}

--- a/src/tools/bin/nextstep_from_period.sh
+++ b/src/tools/bin/nextstep_from_period.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017-2018 Axel Huebl, Ilja Goethel
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+set -euf -o pipefail
+
+helpText()
+{
+    echo "
+    Usage: $0 period lastStep [currentStep]
+
+    Script returns next timestep specified by the period syntax
+    Takes three positional arguments:
+     - a string representing period-syntax, like 3000,12000:15000:1000,1337:1337
+     - and the final timestep (convertible to int)
+     - the current timestep (convertible to int)
+
+    and prints the next timestep to stdout"
+}
+
+# now we parse cmd params: first look for -h, then case depending on $#
+
+for p in $@; do
+    if [ "$p" = "-h" ] || [ "$p" = "--help" ]; then
+	    helpText
+	    exit 0
+    fi
+done
+
+case $# in
+    0 | 1)
+        printf "\n *** Not enough arguments! *** \n"
+        helpText
+        exit 1
+    ;;
+    2)
+        period="$1"
+        lastStep="$2"
+        currentStep=0
+    ;;
+    3)
+        period="$1"
+        lastStep="$2"
+        currentStep="$3"
+    ;;
+    *)
+        printf "\n *** Too many arguments! *** \n"
+        helpText
+        exit 1
+    ;;
+esac
+
+splitSections()
+{
+    # split a string on occurences of ','
+    IFS=','
+    for s in $1; do
+        echo $s
+    done
+}
+expandPeriods()
+{
+    # split a string on occurences of ':' and always return a 3-tuple
+    # with some default values if there were less than two ':' - also
+    # breaks, if there were more than two ':'
+    IFS=':'
+    input=($1)
+    len=${#input[@]}
+    case $len in
+        1)
+            seq 0 $1 $lastStep
+        ;;
+        2)
+            seq ${input[0]} 1 ${input[1]}
+        ;;
+        3)
+            seq ${input[0]} ${input[2]} ${input[1]}
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+}
+
+sections=$(splitSections "$period")
+steps=()
+for s in $sections; do
+    newSteps=($(expandPeriods $s))
+    steps+=(${newSteps[@]})
+done
+
+steps=($(printf "%s\n" "${steps[@]}" | sort -u -g))
+
+for step in "${steps[@]}"; do
+    if [ $step -gt $currentStep ]; then
+        echo $step
+        break
+    fi
+done


### PR DESCRIPTION
Write a script for computing next step from the new-style period syntax.
Necessary for restart.tpl, which has to extract the parameters for the next restart. 