### PR TITLE
Plugin PhaseSpace: fix momentum meta information

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2018 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *
@@ -301,9 +301,7 @@ namespace picongpu
          *   \see PhaseSpaceMulti::pluginLoad( )
          */
         float_64 const pRange_unit =
-            float_64( frame::getMass< typename Species::FrameType >() ) *
-            float_64( SPEED_OF_LIGHT ) *
-            ( UNIT_MASS * float_64( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE ) ) *
+            UNIT_MASS *
             UNIT_SPEED;
 
         DumpHBuffer dumpHBuffer;


### PR DESCRIPTION
In `PhaseSpace.tpp` both the `axis_p_range` as well as the `pRange_unit` contain the factor m_species (species mass in electron masses). That resulted in the momentum range being too large for all ions when later momentum values are multiplied by this `pRange_unit`.
This commit fixes that issue.

Now the momentum range in the plots created e.g. with the [script from the plugin documentation](https://picongpu.readthedocs.io/en/latest/usage/plugins/phaseSpace.html?highlight=phase%20space#analysis) are correct as well and correspond to the momentum limits from the `cfg` file.

**FoilLCT example: `4.cfg`**
```Shell
# longitudinal phase space: in m_<species> c
TBG_e_PSypy="... --e_phaseSpace.min -2.0 --e_phaseSpace.max 2.0"
TBG_H_PSypy="... --H_phaseSpace.min -0.04 --H_phaseSpace.max 0.04"
TBG_C_PSypy="... --C_phaseSpace.min -0.02 --C_phaseSpace.max 0.02"
TBG_N_PSypy="... --N_phaseSpace.min -0.02 --N_phaseSpace.max 0.02"
```
*electrons*
![ps_e](https://user-images.githubusercontent.com/5416860/43320487-e7dad1f6-91a8-11e8-936f-e8c0260f63fb.png)
*Hydrogen*
![ps_h](https://user-images.githubusercontent.com/5416860/43320503-f2032566-91a8-11e8-9dd3-abb545ee3751.png)
*Carbon*
![ps_c](https://user-images.githubusercontent.com/5416860/43320511-f6f5d640-91a8-11e8-8246-83c3cfafb77b.png)
*Nitrogen*
![ps_n](https://user-images.githubusercontent.com/5416860/43320515-fb87bc50-91a8-11e8-8a0e-4d875c293cb5.png)
