### PR TITLE
fix namespace issue in default GaussLaguerre  laser

### DIFF
--- a/include/picongpu/fields/laserProfiles/GaussianBeam.def
+++ b/include/picongpu/fields/laserProfiles/GaussianBeam.def
@@ -106,8 +106,8 @@ namespace defaults
          */
         static constexpr float_X LASER_PHASE = 0.0;
 
-        using LAGUERREMODES_t = LAGUERREMODES_t;
-        static constexpr uint32_t MODENUMBER = MODENUMBER;
+        using LAGUERREMODES_t = defaults::LAGUERREMODES_t;
+        static constexpr uint32_t MODENUMBER = defaults::MODENUMBER;
 
         /** Available polarisation types
          */


### PR DESCRIPTION
With the refactoring of the laser code (#2587), a bug was introduced that only appears when using a CPU back-end. (According the @psychocoderHPC, the `nvcc` does not check this not-used code, thus the error is not thrown.) 

This pull request fixes this issue by adding the `default::` namespace to the Laguerre mode attributes set before.  

The error occurs when compiling the `LaserWakefield` example using the `etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example`.

Thanks @psychocoderHPC for all your explanations on that issue. 