### PR TITLE
Update Piz-Daint installation script

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -69,7 +69,7 @@ For this profile to work, you need to download the :ref:`PIConGPU source code <i
 
 .. note::
 
-   Please find a `Piz Daint quick start from December 2017 here <https://gist.github.com/ax3l/68cb4caa597df3def9b01640959ea56b>`_.
+   Please find a `Piz Daint quick start from December 2017 here <https://gist.github.com/n01r/20dacc20987b75d1858db5261d5d0205>`_.
 
 .. literalinclude:: profiles/pizdaint-cscs/picongpu.profile.example
    :language: bash

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -69,7 +69,7 @@ For this profile to work, you need to download the :ref:`PIConGPU source code <i
 
 .. note::
 
-   Please find a `Piz Daint quick start from December 2017 here <https://gist.github.com/n01r/20dacc20987b75d1858db5261d5d0205>`_.
+   Please find a `Piz Daint quick start from August 2018 here <https://gist.github.com/ax3l/68cb4caa597df3def9b01640959ea56b>`_.
 
 .. literalinclude:: profiles/pizdaint-cscs/picongpu.profile.example
    :language: bash

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -48,14 +48,14 @@ module load cray-hdf5-parallel/1.10.0.3
 # Self-Build Software #########################################################
 #
 # needs to be compiled by the user
-export PICLIB="$HOME/lib"
-export BOOST_ROOT=$PICLIB/boost-1.62.0
-export ZLIB_ROOT=$PICLIB/zlib-1.2.11
-export PNG_ROOT=$PICLIB/libpng-1.6.34
-export BLOSC_ROOT=$PICLIB/blosc-1.12.1
-export PNGwriter_DIR=$PICLIB/pngwriter-0.7.0
-export ADIOS_ROOT=$PICLIB/adios-1.13.1
-export Splash_DIR=$PICLIB/splash-1.7.0
+export PIC_LIBS="$HOME/lib"
+export BOOST_ROOT=$PIC_LIBS/boost-1.62.0
+export ZLIB_ROOT=$PIC_LIBS/zlib-1.2.11
+export PNG_ROOT=$PIC_LIBS/libpng-1.6.34
+export BLOSC_ROOT=$PIC_LIBS/blosc-1.12.1
+export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0
+export ADIOS_ROOT=$PIC_LIBS/adios-1.13.1
+export Splash_DIR=$PIC_LIBS/splash-1.7.0
 
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$ZLIB_ROOT/lib:$LD_LIBRARY_PATH

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -48,13 +48,14 @@ module load cray-hdf5-parallel/1.10.0.3
 # Self-Build Software #########################################################
 #
 # needs to be compiled by the user
-export BOOST_ROOT=$SCRATCH/lib/boost-1.62.0
-export ZLIB_ROOT=$SCRATCH/lib/zlib-1.2.11
-export PNG_ROOT=$SCRATCH/lib/libpng-1.6.34
-export BLOSC_ROOT=$SCRATCH/lib/blosc-1.12.1
-export PNGwriter_DIR=$SCRATCH/lib/pngwriter-0.7.0
-export ADIOS_ROOT=$SCRATCH/lib/adios-1.13.1
-export Splash_DIR=$SCRATCH/lib/splash-1.7.0
+export PICLIB="$HOME/lib"
+export BOOST_ROOT=$PICLIB/boost-1.62.0
+export ZLIB_ROOT=$PICLIB/zlib-1.2.11
+export PNG_ROOT=$PICLIB/libpng-1.6.34
+export BLOSC_ROOT=$PICLIB/blosc-1.12.1
+export PNGwriter_DIR=$PICLIB/pngwriter-0.7.0
+export ADIOS_ROOT=$PICLIB/adios-1.13.1
+export Splash_DIR=$PICLIB/splash-1.7.0
 
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$ZLIB_ROOT/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Marco's script takes into account the limited quota on $HOME and builds the libraries in `/dev/shm`. I just tested it and it runs fine.