### PR TITLE
remove unused species template signature

### DIFF
--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -39,7 +39,6 @@ namespace generic
      *
      * @tparam T_Functor user defined unary functor
      * @tparam T_Distribution pmacc::random::distributions, random number distribution
-     * @tparam T_SpeciesType type of the species that shall be manipulated
      *
      * example for `particleFilters.param`: get every second particle
      *                                      (random sample of 50%)
@@ -68,8 +67,7 @@ namespace generic
      */
     template<
         typename T_Functor,
-        typename T_Distribution,
-        typename T_SpeciesType = boost::mpl::_1
+        typename T_Distribution
     >
     struct FreeRng;
 

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -96,26 +96,28 @@ namespace acc
 
     template<
         typename T_Functor,
-        typename T_Distribution,
-        typename T_SpeciesType
+        typename T_Distribution
     >
     struct FreeRng :
     protected functor::User< T_Functor >,
         private picongpu::particles::functor::misc::Rng<
-            T_Distribution,
-            T_SpeciesType
+            T_Distribution
         >
     {
+        template< typename T_SpeciesType >
+        struct apply
+        {
+            using type = FreeRng;
+        };
+
         using RngGenerator = picongpu::particles::functor::misc::Rng<
-            T_Distribution,
-            T_SpeciesType
+            T_Distribution
         >;
 
         using RngType = typename RngGenerator::RandomGen;
 
         using Functor = functor::User< T_Functor >;
         using Distribution = T_Distribution;
-        using SpeciesType = T_SpeciesType;
 
         /** constructor
          *

--- a/include/picongpu/particles/functor/misc/Rng.def
+++ b/include/picongpu/particles/functor/misc/Rng.def
@@ -37,11 +37,9 @@ namespace misc
     /** provide a random number generator
      *
      * @tparam T_Distribution pmacc::random::distributions, random number distribution
-     * @tparam T_SpeciesType type of the species that shall be manipulated
      */
     template<
-        typename T_Distribution,
-        typename T_SpeciesType = boost::mpl::_1
+        typename T_Distribution
     >
     struct Rng;
 

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -45,18 +45,13 @@ namespace misc
     /** call simple free user defined functor and provide a random number generator
      *
      * @tparam T_Distribution random number distribution
-     * @tparam T_SpeciesType type of the species that shall used to generate a unique
-     *                       seed to initialize the random number generator
      */
     template<
-        typename T_Distribution,
-        typename T_SpeciesType
+        typename T_Distribution
     >
     struct Rng
     {
-
         using Distribution = T_Distribution;
-        using SpeciesType = T_SpeciesType;
         using RNGFactory = pmacc::random::RNGProvider<
             simDim,
             random::Generator
@@ -100,8 +95,6 @@ namespace misc
         {
             namespace nvrng = nvidia::rng;
 
-            using FrameType = typename SpeciesType::FrameType;
-            using SuperCellSize = typename FrameType::SuperCellSize;
             RngHandle tmp( rngHandle );
             tmp.init(
                 localSupercellOffset * SuperCellSize::toRT() +

--- a/include/picongpu/particles/manipulators/generic/FreeRng.def
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.def
@@ -39,7 +39,6 @@ namespace generic
      *
      * @tparam T_Functor user defined unary functor
      * @tparam T_Distribution pmacc::random::distributions, random number distribution
-     * @tparam T_SpeciesType type of the species that shall be manipulated
      *
      * example for `particle.param`: add
      *   @code{.cpp}
@@ -68,8 +67,7 @@ namespace generic
      */
     template<
         typename T_Functor,
-        typename T_Distribution,
-        typename T_SpeciesType = boost::mpl::_1
+        typename T_Distribution
     >
     struct FreeRng;
 

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -98,26 +98,29 @@ namespace acc
 
     template<
         typename T_Functor,
-        typename T_Distribution,
-        typename T_SpeciesType
+        typename T_Distribution
     >
     struct FreeRng :
     protected functor::User< T_Functor >,
         private picongpu::particles::functor::misc::Rng<
-            T_Distribution,
-            T_SpeciesType
+            T_Distribution
         >
     {
+
+        template< typename T_SpeciesType >
+        struct apply
+        {
+            using type = FreeRng;
+        };
+
         using RngGenerator = picongpu::particles::functor::misc::Rng<
-            T_Distribution,
-            T_SpeciesType
+            T_Distribution
         >;
 
         using RngType = typename RngGenerator::RandomGen;
 
         using Functor = functor::User< T_Functor >;
         using Distribution = T_Distribution;
-        using SpeciesType = T_SpeciesType;
 
         /** constructor
          *

--- a/include/picongpu/particles/startPosition/generic/FreeRng.def
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.def
@@ -39,12 +39,10 @@ namespace generic
      *
      * @tparam T_Functor user defined unary functor
      * @tparam T_Distribution pmacc::random::distributions, random number distribution
-     * @tparam T_SpeciesType type of the species that shall be manipulated
      */
     template<
         typename T_Functor,
-        typename T_Distribution,
-        typename T_SpeciesType = boost::mpl::_1
+        typename T_Distribution
     >
     struct FreeRng;
 

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -104,26 +104,28 @@ namespace acc
 
     template<
         typename T_Functor,
-        typename T_Distribution,
-        typename T_SpeciesType
+        typename T_Distribution
     >
     struct FreeRng :
         protected T_Functor,
         private picongpu::particles::functor::misc::Rng<
-            T_Distribution,
-            T_SpeciesType
+            T_Distribution
         >
     {
+        template< typename T_SpeciesType >
+        struct apply
+        {
+            using type = FreeRng;
+        };
+
         using RngGenerator = picongpu::particles::functor::misc::Rng<
-            T_Distribution,
-            T_SpeciesType
+            T_Distribution
         >;
 
         using RngType = typename RngGenerator::RandomGen;
 
         using Functor = T_Functor;
         using Distribution = T_Distribution;
-        using SpeciesType = T_SpeciesType;
 
         /** constructor
          *


### PR DESCRIPTION
PIConGPU RNG functors, filters and startPosition functors have the species type in the tempate signature. This type is not needed. 
The species was a left over from the old random number generator.

- remove unused template species signature from RNG functors