### PR TITLE
Log: per device instead of GPU

### DIFF
--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -143,7 +143,7 @@ public:
                 log<picLog::PHYSICS >("y-cells per wavelength: %1%") %
                                      (fields::laserProfiles::Selected::WAVE_LENGTH / CELL_HEIGHT);
             const int localNrOfCells = cellDescription->getGridLayout().getDataSpaceWithoutGuarding().productOfComponents();
-            log<picLog::PHYSICS >("macro particles per gpu: %1%") %
+            log<picLog::PHYSICS >("macro particles per device: %1%") %
                                  (localNrOfCells * particles::TYPICAL_PARTICLES_PER_CELL * (bmpl::size<VectorAllSpecies>::type::value));
             log<picLog::PHYSICS >("typical macro particle weighting: %1%") % (particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
 

--- a/include/picongpu/plugins/hdf5/WriteSpecies.hpp
+++ b/include/picongpu/plugins/hdf5/WriteSpecies.hpp
@@ -175,7 +175,7 @@ public:
 
         // enforce that the filter interface is fulfilled
         particles::filter::IUnary< typename T_SpeciesFilter::Filter > particleFilter{ params->currentStep };
-        /* at this point we cast to uint64_t, before we assume that per GPU
+        /* at this point we cast to uint64_t, before we assume that per device
          * less then 1e9 (int range) particles will be counted
          */
         numParticles = uint64_t( pmacc::CountParticles::countOnDevice< CORE + BORDER >(
@@ -214,7 +214,7 @@ public:
             filter.setWindowPosition(params->localWindowToDomainOffset,
                                      params->window.localDimensions.size);
 
-            /* int: assume < 2e9 particles per GPU */
+            /* int: assume < 2e9 particles per device */
             GridBuffer<int, DIM1> counterBuffer(DataSpace<DIM1>(1));
             AreaMapping < CORE + BORDER, MappingDesc > mapper(*(params->cellDescription));
 


### PR DESCRIPTION
Change the "GPU" naming to "device" naming. A device can be a multi-core CPU, a GPU or similar.