### PR TITLE
Early Normalized Speed of Light

### DIFF
--- a/include/picongpu/param/physicalConstants.param
+++ b/include/picongpu/param/physicalConstants.param
@@ -73,6 +73,10 @@ namespace picongpu
         constexpr float_64 N_AVOGADRO = 6.02214076e23;
     }
 
+    /** Unit of speed */
+    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
+    constexpr float_X SPEED_OF_LIGHT = float_X( SI::SPEED_OF_LIGHT_SI / UNIT_SPEED );
+
     // converts
     //
     // UNIT_A to UNIT_B

--- a/include/picongpu/param/unit.param
+++ b/include/picongpu/param/unit.param
@@ -29,8 +29,6 @@
 
 namespace picongpu
 {
-    /** Unit of Speed */
-    constexpr float_64 UNIT_SPEED = SI::SPEED_OF_LIGHT_SI;
     /** Unit of time */
     constexpr float_64 UNIT_TIME = SI::DELTA_T_SI;
     /** Unit of length */

--- a/include/picongpu/unitless/physicalConstants.unitless
+++ b/include/picongpu/unitless/physicalConstants.unitless
@@ -22,9 +22,6 @@
 
 namespace picongpu
 {
-
-    constexpr float_X SPEED_OF_LIGHT = float_X(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-
     //! reduced Planck constant
     constexpr float_X HBAR = (float_X) (SI::HBAR_SI / UNIT_ENERGY / UNIT_TIME);
 


### PR DESCRIPTION
We need the speed of light and its normalization very
early in other `.param` files, e.g. to define energy filters.

This work-arounds this by defining it earlier than `unit.param`

Close #2585