### PR TITLE
fix fallthrough warning

### DIFF
--- a/include/picongpu/main.cpp
+++ b/include/picongpu/main.cpp
@@ -19,6 +19,7 @@
 
 #include "picongpu/ArgsParser.hpp"
 #include <pmacc/Environment.hpp>
+#include <pmacc/types.hpp>
 
 #include <picongpu/simulation_defines.hpp>
 
@@ -53,7 +54,7 @@ int main(int argc, char **argv)
             sim.load();
             sim.start();
             sim.unload();
-            /* missing `break` is voluntarily to set the error code to 0 */
+            PMACC_FALLTHROUGH;
         case ArgsParser::SUCCESS_EXIT:
             errorCode = 0;
             break;

--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -67,6 +67,7 @@
 
 // compatibility macros (compiler or C++ standard version specific)
 #include <boost/config.hpp>
+#include <boost/predef.h>
 
 #include <stdint.h>
 #include <stdexcept>
@@ -254,6 +255,18 @@ enum AreaType
 #   define PMACC_CONSTEXPR_CAPTURE static constexpr
 #else
 #   define PMACC_CONSTEXPR_CAPTURE constexpr
+#endif
+
+/** C++11 and C++14 explicit fallthrough in switch cases
+ *
+ * Use [[fallthrough]] in C++17
+ */
+#if BOOST_COMP_GNUC
+#   define PMACC_FALLTHROUGH [[gnu::fallthrough]]
+#elif BOOST_COMP_CLANG
+#   define PMACC_FALLTHROUGH [[clang::fallthrough]]
+#else
+#   define PMACC_FALLTHROUGH
 #endif
 
 } //namespace pmacc


### PR DESCRIPTION
Newer versions of GCC, such as gcc 7.1, throw a warning in `-Wextra` on fallthrough.
So let's explicitly try to annotate it.