### PR TITLE
fix memory leaks PMacc/PIConGPU

### DIFF
--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -38,6 +38,8 @@
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/memory/boxes/PitchedBox.hpp>
 
+#include <memory>
+
 
 namespace picongpu
 {
@@ -132,8 +134,8 @@ namespace picongpu
 
     private:
 
-        GridBuffer<ValueType, simDim> *fieldTmp;
-        GridBuffer<ValueType, simDim>* fieldTmpRecv;
+        std::unique_ptr< GridBuffer<ValueType, simDim> > fieldTmp;
+        std::unique_ptr< GridBuffer<ValueType, simDim> > fieldTmpRecv;
 
         uint32_t m_slotId;
 

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -55,8 +55,6 @@ namespace picongpu
         uint32_t slotId
     ) :
         SimulationFieldHelper<MappingDesc>( cellDescription ),
-        fieldTmp( nullptr ),
-        fieldTmpRecv( nullptr ),
         m_slotId( slotId )
     {
         m_commTagScatter =
@@ -65,10 +63,14 @@ namespace picongpu
         m_commTagGather = ++pmacc::traits::detail::GetUniqueTypeId< uint8_t >::counter +
             SPECIES_FIRSTTAG;
 
-        fieldTmp = new GridBuffer <ValueType, simDim >( cellDescription.getGridLayout( ) );
+        fieldTmp.reset(
+            new GridBuffer <ValueType, simDim >( cellDescription.getGridLayout( ) )
+        );
 
         if( fieldTmpSupportGatherCommunication )
-            fieldTmpRecv = new GridBuffer< ValueType, simDim >( fieldTmp->getDeviceBuffer(), cellDescription.getGridLayout( ) );
+            fieldTmpRecv.reset(
+                new GridBuffer< ValueType, simDim >( fieldTmp->getDeviceBuffer(), cellDescription.getGridLayout( ) )
+            );
 
         /** \todo The exchange has to be resetted and set again regarding the
          *  temporary "Fill-"Functor we want to use.
@@ -185,7 +187,6 @@ namespace picongpu
 
     FieldTmp::~FieldTmp( )
     {
-        __delete( fieldTmp );
     }
 
     template<uint32_t AREA, class FrameSolver, class ParticlesClass>

--- a/include/pmacc/memory/buffers/ExchangeIntern.hpp
+++ b/include/pmacc/memory/buffers/ExchangeIntern.hpp
@@ -129,9 +129,7 @@ namespace pmacc
             return result;
         }
 
-        virtual ~ExchangeIntern()
-        {
-        }
+        virtual ~ExchangeIntern() = default;
 
         DataSpace<DIM> exchangeTypeToOffset(uint32_t exchange, GridLayout<DIM> &memoryLayout,
                                             DataSpace<DIM> guardingCells, uint32_t area) const

--- a/include/pmacc/memory/buffers/ExchangeIntern.hpp
+++ b/include/pmacc/memory/buffers/ExchangeIntern.hpp
@@ -33,6 +33,8 @@
 #include "pmacc/assert.hpp"
 #include "pmacc/types.hpp"
 
+#include <memory>
+
 
 namespace pmacc
 {
@@ -47,7 +49,7 @@ namespace pmacc
 
         ExchangeIntern(DeviceBuffer<TYPE, DIM>& source, GridLayout<DIM> memoryLayout, DataSpace<DIM> guardingCells, uint32_t exchange,
                        uint32_t communicationTag, uint32_t area = BORDER, bool sizeOnDevice = false) :
-        Exchange<TYPE, DIM>(exchange, communicationTag), deviceDoubleBuffer(nullptr)
+        Exchange<TYPE, DIM>(exchange, communicationTag)
         {
 
             PMACC_ASSERT(!guardingCells.isOneDimensionGreaterThan(memoryLayout.getGuard()));
@@ -67,31 +69,41 @@ namespace pmacc
 
             /*This is only a pointer to other device data
              */
-            this->deviceBuffer = new DeviceBufferIntern<TYPE, DIM > (source, tmp_size,
-                                                                     exchangeTypeToOffset(exchange, memoryLayout, guardingCells, area),
-                                                                     sizeOnDevice);
+            deviceBuffer.reset(
+                new DeviceBufferIntern<TYPE, DIM >(
+                    source,
+                    tmp_size,
+                    exchangeTypeToOffset(
+                        exchange,
+                        memoryLayout,
+                        guardingCells,
+                        area
+                    ),
+                    sizeOnDevice
+                )
+            );
             if (DIM > DIM1)
             {
                 /*create double buffer on gpu for faster memory transfers*/
-                this->deviceDoubleBuffer = new DeviceBufferIntern<TYPE, DIM > (tmp_size, false, true);
+                deviceDoubleBuffer.reset( new DeviceBufferIntern<TYPE, DIM > (tmp_size, false, true) );
             }
 
-            this->hostBuffer = new HostBufferIntern<TYPE, DIM > (tmp_size);
+            hostBuffer.reset( new HostBufferIntern<TYPE, DIM > (tmp_size) );
         }
 
         ExchangeIntern(DataSpace<DIM> exchangeDataSpace, uint32_t exchange,
                        uint32_t communicationTag, bool sizeOnDevice = false) :
-        Exchange<TYPE, DIM>(exchange, communicationTag), deviceDoubleBuffer(nullptr)
+        Exchange<TYPE, DIM>(exchange, communicationTag)
         {
-            this->deviceBuffer = new DeviceBufferIntern<TYPE, DIM > (exchangeDataSpace, sizeOnDevice);
+            deviceBuffer.reset( new DeviceBufferIntern<TYPE, DIM > (exchangeDataSpace, sizeOnDevice) );
            //  this->deviceBuffer = new DeviceBufferIntern<TYPE, DIM > (exchangeDataSpace, sizeOnDevice,true);
             if (DIM > DIM1)
             {
                 /*create double buffer on gpu for faster memory transfers*/
-               this->deviceDoubleBuffer = new DeviceBufferIntern<TYPE, DIM > (exchangeDataSpace, false, true);
+               deviceDoubleBuffer.reset( new DeviceBufferIntern<TYPE, DIM > (exchangeDataSpace, false, true) );
             }
 
-            this->hostBuffer = new HostBufferIntern<TYPE, DIM > (exchangeDataSpace);
+            hostBuffer.reset( new HostBufferIntern<TYPE, DIM > (exchangeDataSpace) );
         }
 
         /**
@@ -119,9 +131,6 @@ namespace pmacc
 
         virtual ~ExchangeIntern()
         {
-            __delete(hostBuffer);
-            __delete(deviceBuffer);
-            __delete(deviceDoubleBuffer);
         }
 
         DataSpace<DIM> exchangeTypeToOffset(uint32_t exchange, GridLayout<DIM> &memoryLayout,
@@ -225,12 +234,11 @@ namespace pmacc
         }
 
     protected:
-        HostBufferIntern<TYPE, DIM> *hostBuffer;
+        std::unique_ptr< HostBufferIntern<TYPE, DIM> > hostBuffer;
 
-        /*! This buffer is a vector which is used as message buffer for faster memcopy
-         */
-        DeviceBufferIntern<TYPE, DIM> *deviceDoubleBuffer;
-        DeviceBufferIntern<TYPE, DIM> *deviceBuffer;
+        //! This buffer is a vector which is used as message buffer for faster memcopy
+        std::unique_ptr< DeviceBufferIntern<TYPE, DIM> > deviceDoubleBuffer;
+        std::unique_ptr< DeviceBufferIntern<TYPE, DIM> > deviceBuffer;
 
     };
 


### PR DESCRIPTION
Fix a memory leak found with valgrind in:
  - `ExchangeIntern.hpp`
  - `FieldTmp`

Use `std::unique_ptr` instead of native pointers to avoid memory leaks.