### PR TITLE
ADIOS: No adios_set_max_buffer_size

### DIFF
--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -1444,12 +1444,8 @@ private:
         writeIdProviderStartId.prepare(*threadParams, idProviderState.maxNumProc);
         writeIdProviderNextId.prepare(*threadParams);
 
-        /* allocate buffer in MB according to our current group size */
-        /* `1 + mem` minimum 1 MiB that we can write attributes on empty GPUs */
-        size_t writeBuffer_in_MiB=1+threadParams->adiosGroupSize / 1024 / 1024;
-        /* value `1.1` is the secure factor if we miss to count some small buffers*/
-        size_t buffer_mem=static_cast<size_t>(1.1 * static_cast<float_64>(writeBuffer_in_MiB));
-        adios_set_max_buffer_size(buffer_mem);
+        // in the past, we had to explicitly estiamte our buffers.
+        // this is now done automatically by ADIOS on `adios_write()`
         threadParams->adiosBufferInitialized = true;
 
         /* open adios file. all variables need to be defined at this point */


### PR DESCRIPTION
There is no need to set `adios_set_max_buffer_size`. It sets the maximum ADIOS is allowed to allocate in its buffers (but this call does not pre-allocate things).

But the actual buffer is since ADIOS 1.10.0 already dynamically allocated (#1639) and the default for maximum allocation is a large default. If we later on want to control host-side memory, we can just set a ratio of free host mem, but ADIOS will only allocate what it actually needs until then.

See
  https://github.com/ornladios/ADIOS/commit/9fae0d12fea535a4366e81c0c04d7a3be54c3179

Fix #2656 (Crashes reported in some cases since our buffer estimate was not precise enough.)