### PR TITLE
gnu::fallthough is GCC 7+

### DIFF
--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -261,12 +261,12 @@ enum AreaType
  *
  * Use [[fallthrough]] in C++17
  */
-#if BOOST_COMP_GNUC
+#if (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(7,0,0))
 #   define PMACC_FALLTHROUGH [[gnu::fallthrough]]
 #elif BOOST_COMP_CLANG
 #   define PMACC_FALLTHROUGH [[clang::fallthrough]]
 #else
-#   define PMACC_FALLTHROUGH
+#   define PMACC_FALLTHROUGH ( (void)0 )
 #endif
 
 } //namespace pmacc


### PR DESCRIPTION
Missed that this attribute is unknown prior to GCC 7 and causes a warning.
Replace with NOP in that case.

In clang it's in all supported versions (e.g. in [clang 3.7+](https://releases.llvm.org/3.7.0/tools/clang/docs/AttributeReference.html#fallthrough-clang-fallthrough))

Follow-up to #2665 