### PR TITLE
fix gcc compile of IsaacPlugin

### DIFF
--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -147,7 +147,7 @@ class TFieldSource< FieldTmpOperation< FrameSolver, ParticleType > >
                 auto particles = dc.get< ParticleType >( ParticleType::FrameType::getName(), true );
 
                 fieldTmp->getGridBuffer().getDeviceBuffer().setValue( FieldTmp::ValueType(0.0) );
-                fieldTmp->computeValue < CORE + BORDER, FrameSolver > (*particles, *currentStep);
+                fieldTmp->template computeValue < CORE + BORDER, FrameSolver > (*particles, *currentStep);
                 EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
 
                 __setTransactionEvent(fieldTmpEvent);


### PR DESCRIPTION
With gcc 5.4 PIConGPU combined with ISACC is not compiling.
The reason is that the compile needs a hint that a method it templated.


Bug found by @FelixTUD