### PR TITLE
fix missing const quallifier

### DIFF
--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -136,7 +136,7 @@ namespace acc
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
-        )
+        ) const
         -> acc::FreeTotalCellOffset< Functor >
         {
             auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor const * >( this );

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
@@ -131,7 +131,7 @@ namespace acc
             T_Acc const & acc,
             DataSpace< simDim > const & localSupercellOffset,
             T_WorkerCfg const & workerCfg
-        )
+        ) const
         -> acc::FreeTotalCellOffset< Functor >
         {
             auto & cellOffsetFunctor = *static_cast< CellOffsetFunctor const * >( this );


### PR DESCRIPTION
Functor and filter `FreeTotalCellOffset` can not be used (code is not compiling) because the factory method is missing the const quallifier.