### PR TITLE
fix possible deadlock in blocking MPI ops

### DIFF
--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -89,7 +89,7 @@ public:
 
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
 
-        /* avoid deadlock between not finished pmacc tasks and MPI_Barrier */
+        // avoid deadlock between not finished pmacc tasks and MPI_Barrier
         __getTransactionEvent().waitForFinished();
         /* can be spared for better scalings, but guarantees the user
          * that the restart was successful */

--- a/include/picongpu/plugins/IntensityPlugin.hpp
+++ b/include/picongpu/plugins/IntensityPlugin.hpp
@@ -259,6 +259,8 @@ private:
         float_32* integretedAllTmp = new float_32[yLocalSize * gpus];
         memset(integretedAll, 0, sizeof (float_32) *yGlobalSize);
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Gather(&yOffset, 1, MPI_INT, yOffsetsAll, 1,
                              MPI_INT, 0, MPI_COMM_WORLD));
 

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -90,6 +90,11 @@ class TFieldSource
             typename FieldType::DataBoxType dataBox = pField->getDeviceDataBox();
             shifted = dataBox.shift( guarding );
             dc.releaseData( FieldType::getName() );
+            /* avoid deadlock between not finished pmacc tasks and potential blocking operations
+             * within ISAAC
+             */
+            __getTransactionEvent().waitForFinished();
+
         }
 
         ISAAC_NO_HOST_DEVICE_WARNING

--- a/include/picongpu/plugins/PhaseSpace/DumpHBufferSplashP.hpp
+++ b/include/picongpu/plugins/PhaseSpace/DumpHBufferSplashP.hpp
@@ -152,6 +152,9 @@ namespace picongpu
             /** write local domain ********************************************/
             typename PICToSplash<Type>::type ctPhaseSpace;
 
+            // avoid deadlock between not finished pmacc tasks and mpi calls in HDF5
+            __getTransactionEvent().waitForFinished();
+
             pdc.writeDomain( currentStep,
                              /* global domain and my local offset within it */
                              globalPhaseSpace_size,

--- a/include/picongpu/plugins/adios/ADIOSCountParticles.hpp
+++ b/include/picongpu/plugins/adios/ADIOSCountParticles.hpp
@@ -119,6 +119,8 @@ public:
         uint64_t globalNumParticles = 0;
         uint64_t myParticleOffset = 0;
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Allgather(
                 &myNumParticles, 1, MPI_UNSIGNED_LONG_LONG,
                 allNumParticles, 1, MPI_UNSIGNED_LONG_LONG,

--- a/include/picongpu/plugins/adios/NDScalars.hpp
+++ b/include/picongpu/plugins/adios/NDScalars.hpp
@@ -141,6 +141,9 @@ struct ReadNDScalars
 
         ADIOS_SELECTION* fSel = adios_selection_boundingbox(varInfo->ndim, start, count);
 
+        // avoid deadlock between not finished pmacc tasks and mpi calls in adios
+        __getTransactionEvent().waitForFinished();
+
         /* specify what we want to read, but start reading at below at `adios_perform_reads` */
         /* magic parameters (0, 1): `from_step` (not used in streams), `nsteps` to read (must be 1 for stream) */
         log<picLog::INPUT_OUTPUT > ("ADIOS: Schedule read skalar %1%)") % datasetName;

--- a/include/picongpu/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/include/picongpu/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -101,6 +101,8 @@ struct LoadParticleAttributesFromADIOS
              *        ADIOS method and can therefore be skipped for empty reads */
             if( elements > 0 )
             {
+                // avoid deadlock between not finished pmacc tasks and mpi calls in adios
+                __getTransactionEvent().waitForFinished();
                 ADIOS_CMD(adios_schedule_read( params->fp,
                                                sel,
                                                datasetName.str().c_str(),

--- a/include/picongpu/plugins/adios/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/adios/restart/LoadSpecies.hpp
@@ -115,6 +115,8 @@ public:
         uint64_t count = 5; // ADIOSCountParticles: uint64_t
         ADIOS_SELECTION* piSel = adios_selection_boundingbox( 1, &start, &count );
 
+        // avoid deadlock between not finished pmacc tasks and mpi calls in adios
+        __getTransactionEvent().waitForFinished();
         ADIOS_CMD(adios_schedule_read( params->fp,
                                        piSel,
                                        (particlePath + std::string("particles_info")).c_str(),
@@ -132,6 +134,8 @@ public:
 
         uint64_t fullParticlesInfo[gc.getGlobalSize()];
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Allgather( particlesInfo, 1, MPI_UINT64_T,
                                  fullParticlesInfo, 1, MPI_UINT64_T,
                                  gc.getCommunicator().getMPIComm() ));

--- a/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
@@ -115,6 +115,9 @@ public:
             /* magic parameters (0, 1): `from_step` (not used in streams), `nsteps` to read (must be 1 for stream) */
             log<picLog::INPUT_OUTPUT > ("ADIOS: Schedule read from field (%1%, %2%, %3%, %4%)") %
                                         params->fp % fSel % datasetName.str() % (void*)field_container;
+
+            // avoid deadlock between not finished pmacc tasks and mpi calls in adios
+            __getTransactionEvent().waitForFinished();
             ADIOS_CMD(adios_schedule_read( params->fp, fSel, datasetName.str().c_str(), 0, 1, (void*)field_container ));
 
             /* start a blocking read of all scheduled variables */

--- a/include/picongpu/plugins/hdf5/NDScalars.hpp
+++ b/include/picongpu/plugins/hdf5/NDScalars.hpp
@@ -58,6 +58,9 @@ struct WriteNDScalars
 
         Dimensions localSize(1, 1, 1);
 
+        // avoid deadlock between not finished pmacc tasks and mpi calls in adios
+        __getTransactionEvent().waitForFinished();
+
         typename traits::PICToSplash<T_Scalar>::type splashType;
         params.dataCollector->writeDomain(params.currentStep,            /* id == time step */
                                            globalSize,                   /* total size of dataset over all processes */
@@ -105,6 +108,9 @@ struct ReadNDScalars
         Dimensions domain_offset(0, 0, 0);
         for (uint32_t d = 0; d < simDim; ++d)
             domain_offset[d] = Environment<simDim>::get().GridController().getPosition()[d];
+
+        // avoid deadlock between not finished pmacc tasks and mpi calls in adios
+        __getTransactionEvent().waitForFinished();
 
         DomainCollector::DomDataClass data_class;
         DataContainer *dataContainer =

--- a/include/picongpu/plugins/hdf5/WriteSpecies.hpp
+++ b/include/picongpu/plugins/hdf5/WriteSpecies.hpp
@@ -278,6 +278,8 @@ public:
         uint64_t numParticlesOffset = 0;
         uint64_t numParticlesGlobal = 0;
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Allgather(
             myParticlePatch, 2, MPI_UINT64_T,
             &(*particleCounts.begin()), 2, MPI_UINT64_T,

--- a/include/picongpu/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
+++ b/include/picongpu/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
@@ -80,6 +80,10 @@ struct LoadParticleAttributesFromHDF5
             tmpArray = new ComponentType[elements];
 
         ParallelDomainCollector* dataCollector = params->dataCollector;
+
+        // avoid deadlock between not finished pmacc tasks and mpi calls in splash/HDF5
+        __getTransactionEvent().waitForFinished();
+
         for (uint32_t d = 0; d < components; d++)
         {
             OpenPMDName<T_Identifier> openPMDName;

--- a/include/picongpu/plugins/hdf5/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/hdf5/restart/LoadSpecies.hpp
@@ -118,6 +118,9 @@ public:
             speciesSubGroup + std::string("particlePatches/")
         );
 
+        // avoid deadlock between not finished pmacc tasks and mpi calls in splash/HDF5
+        __getTransactionEvent().waitForFinished();
+
         // read particle patches
         openPMD::PatchReader patchReader;
 

--- a/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -79,6 +79,9 @@ public:
         for (uint32_t d = 0; d < simDim; ++d)
             local_domain_size[d] = params->window.localDimensions.size[d];
 
+        // avoid deadlock between not finished pmacc tasks and mpi calls in splash/HDF5
+        __getTransactionEvent().waitForFinished();
+
         auto destBox = field.getHostBuffer().getDataBox();
         for (uint32_t i = 0; i < numComponents; ++i)
         {

--- a/include/picongpu/plugins/hdf5/writer/Field.hpp
+++ b/include/picongpu/plugins/hdf5/writer/Field.hpp
@@ -142,6 +142,8 @@ struct Field
                 sizeSrcData[d] = field_no_guard[d];
             }
 
+            // avoid deadlock between not finished pmacc tasks and mpi calls in splash/HDF5
+            __getTransactionEvent().waitForFinished();
             params->dataCollector->writeDomain(params->currentStep,             /* id == time step */
                                                splashGlobalDomainSize,          /* total size of dataset over all processes */
                                                splashGlobalOffsetFile,          /* write offset for this process */

--- a/include/picongpu/plugins/hdf5/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/hdf5/writer/ParticleAttribute.hpp
@@ -142,6 +142,8 @@ struct ParticleAttribute
                 tmpArray[i] = ((ComponentValueType*)dataPtr)[i * components + d];
             }
 
+            // avoid deadlock between not finished pmacc tasks and mpi calls in splash/HDF5
+            __getTransactionEvent().waitForFinished();
             threadParams->dataCollector->writeDomain(
                 threadParams->currentStep,
                 /* Dimensions for global collective buffer */

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -255,6 +255,9 @@ private:
 
         size_t* ptr = localResult->getHostBuffer().getPointer();
 
+        // avoid deadlock between not finished pmacc tasks and mpi calls in adios
+        __getTransactionEvent().waitForFinished();
+
         dataCollector->writeDomain(currentStep,                     /* id == time step */
                                    splashGlobalSize,                /* total size of dataset over all processes */
                                    splashGlobalOffset,              /* write offset for this process */

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -138,6 +138,8 @@ public:
                                               DivideInPlace<float_X>(float_X(numRanks)));
         }
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_Bcast(&(*hBufLeftParsCalorimeter.origin()),
                   hBufLeftParsCalorimeter.size().productOfComponents() * sizeof(float_X),
                   MPI_CHAR,

--- a/include/pmacc/mpi/MPIReduce.hpp
+++ b/include/pmacc/mpi/MPIReduce.hpp
@@ -104,6 +104,8 @@ struct MPIReduce
         if (!isActive)
             mpiRank = -1;
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Allgather(&mpiRank, 1, MPI_INT, &reduceRank[0], 1, MPI_INT, MPI_COMM_WORLD));
 
         for (int i = 0; i < countRanks; ++i)

--- a/include/pmacc/mpi/reduceMethods/AllReduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/AllReduce.hpp
@@ -44,6 +44,8 @@ struct AllReduce
     template<class Functor, typename Type >
     HINLINE void operator()(Functor, Type* dest, Type* src, const size_t count, MPI_Datatype type, MPI_Op op, MPI_Comm comm) const
     {
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Allreduce((void*) src,
                                 (void*) dest,
                                 count,

--- a/include/pmacc/mpi/reduceMethods/Reduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/Reduce.hpp
@@ -44,6 +44,9 @@ struct Reduce
     template<class Functor, typename Type >
     HINLINE void operator()(Functor, Type* dest, Type* src, const size_t count, MPI_Datatype type, MPI_Op op, MPI_Comm comm) const
     {
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
+
         MPI_CHECK(MPI_Reduce((void*) src,
                              (void*) dest,
                              count,

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -154,7 +154,7 @@ public:
             CUDA_CHECK(cudaDeviceSynchronize());
             CUDA_CHECK(cudaGetLastError());
 
-            /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+            // avoid deadlock between not finished PMacc tasks and MPI_Barrier
             __getTransactionEvent().waitForFinished();
 
             GridController<DIM> &gc = Environment<DIM>::get().GridController();

--- a/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -104,6 +104,8 @@ struct GatherSlice
         if (!isActive)
             mpiRank = -1;
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Allgather(&mpiRank, 1, MPI_INT, &gatherRanks[0], 1, MPI_INT, MPI_COMM_WORLD));
 
         for (int i = 0; i < countRanks; ++i)
@@ -115,6 +117,8 @@ struct GatherSlice
             }
         }
 
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_Group group;
         MPI_Group newgroup;
         MPI_CHECK(MPI_Comm_group(MPI_COMM_WORLD, &group));
@@ -151,7 +155,8 @@ struct GatherSlice
         if (fullData == nullptr && mpiRank == 0)
             fullData = (char*) new ValueType[header.nodeSize.productOfComponents() * numRanks];
 
-
+        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+        __getTransactionEvent().waitForFinished();
         MPI_CHECK(MPI_Gather(fakeHeader, sizeof(MessageHeader), MPI_CHAR, recvHeader, sizeof(MessageHeader),
                              MPI_CHAR, 0, comm));
 


### PR DESCRIPTION
Our event system in PMacc is not running in a separate threads. If we call a blocking operation e.g. MPI_Barrier or MPI collective operations and there are open tasks in the event system queue it could be that the full simulation is freezing. The reason is that it is possible that a MPI process `1` is waiting for a MPI operation which is never opened from the peer rank `2` because the peer is hanging in an other blocking operation those can not be finsihed until the rank `1` starting the corresponding counter part operation.
Parts of the bugs was already fixed in #1659 but we missed that this is a behavior with all blocking operations e.g. MPI blocking operations, MPI blocking collectives and parallel file system operations those mostly also use MPI blocking collectives.