### PR TITLE
Alpaka 0.3.3

### DIFF
--- a/thirdParty/alpaka/alpakaConfig.cmake
+++ b/thirdParty/alpaka/alpakaConfig.cmake
@@ -578,6 +578,7 @@ LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${_ALPAKA_LINK_LIBRARY}")
 
 # Add all the source and include files in all recursive subdirectories and group them accordingly.
 append_recursive_files_add_to_src_group("${_ALPAKA_SUFFIXED_INCLUDE_DIR}" "${_ALPAKA_SUFFIXED_INCLUDE_DIR}" "hpp" _ALPAKA_FILES_HEADER)
+append_recursive_files_add_to_src_group("${_ALPAKA_SUFFIXED_INCLUDE_DIR}" "${_ALPAKA_SUFFIXED_INCLUDE_DIR}" "h" _ALPAKA_FILES_HEADER)
 
 append_recursive_files_add_to_src_group("${_ALPAKA_ROOT_DIR}/script" "${_ALPAKA_ROOT_DIR}" "sh" _ALPAKA_FILES_SCRIPT)
 SET_SOURCE_FILES_PROPERTIES(${_ALPAKA_FILES_SCRIPT} PROPERTIES HEADER_FILE_ONLY TRUE)

--- a/thirdParty/alpaka/appveyor.yml
+++ b/thirdParty/alpaka/appveyor.yml
@@ -138,7 +138,7 @@ before_build:
     - cmd: if "%CONFIGURATION%"=="Release" set ALPAKA_BOOST_VARIANT=release
     # Select the libraries required.
     - cmd: set ALPAKA_BOOST_B2=--with-test
-    - cmd: if "%ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE%"=="ON" set ALPAKA_BOOST_B2=%ALPAKA_BOOST_B2% --with-fiber --with-context --with-thread --with-system --with-atomic --with-chrono --with-date_time
+    - cmd: if not "%ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE%"=="OFF" set ALPAKA_BOOST_B2=%ALPAKA_BOOST_B2% --with-fiber --with-context --with-thread --with-system --with-atomic --with-chrono --with-date_time
 
     - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" set ALPAKA_BOOST_TOOLSET=msvc-14.1
     - cmd: b2 -j2 --toolset=%ALPAKA_BOOST_TOOLSET% --layout=versioned %ALPAKA_BOOST_B2% architecture=x86 address-model=%ALPAKA_BOOST_ADDRESS_MODEL% variant=%ALPAKA_BOOST_VARIANT% link=static threading=multi runtime-link=shared define=_CRT_NONSTDC_NO_DEPRECATE define=_CRT_SECURE_NO_DEPRECATE define=_SCL_SECURE_NO_DEPRECAT define=BOOST_USE_WINFIBERS --stagedir="%ALPAKA_B2_STAGE_DIR%"

--- a/thirdParty/alpaka/include/alpaka/core/Unused.hpp
+++ b/thirdParty/alpaka/include/alpaka/core/Unused.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2016-2018 Erik Zenker, Benjamin Worpitz
+* Copyright 2018 Axel Huebl
 *
 * This file is part of alpaka.
 *
@@ -21,11 +21,29 @@
 
 #pragma once
 
-#include <boost/predef/version_number.h>
+#include <alpaka/core/Common.hpp>
 
-#define ALPAKA_VERSION_MAJOR 0
-#define ALPAKA_VERSION_MINOR 3
-#define ALPAKA_VERSION_PATCH 3
+#include <boost/config.hpp>
 
-//! The alpaka library version number
-#define ALPAKA_VERSION BOOST_VERSION_NUMBER(ALPAKA_VERSION_MAJOR, ALPAKA_VERSION_MINOR, ALPAKA_VERSION_PATCH)
+namespace alpaka
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template< typename... Ts >
+    BOOST_FORCEINLINE
+    BOOST_CXX14_CONSTEXPR
+    ALPAKA_FN_HOST_ACC
+    void
+    ignore_unused( Ts const& ... )
+    {}
+
+    ALPAKA_NO_HOST_ACC_WARNING
+    template< typename... Ts >
+    BOOST_FORCEINLINE
+    BOOST_CXX14_CONSTEXPR
+    ALPAKA_FN_HOST_ACC
+    void
+    ignore_unused()
+    {}
+
+} // namespace alpaka
+

--- a/thirdParty/alpaka/include/alpaka/rand/TinyMT/Engine.hpp
+++ b/thirdParty/alpaka/include/alpaka/rand/TinyMT/Engine.hpp
@@ -1,0 +1,95 @@
+/**
+* \file
+* Copyright 2018 Axel Huebl
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <alpaka/rand/TinyMT/tinymt32.h>
+
+#include <cstdint>
+
+
+namespace alpaka
+{
+namespace rand
+{
+namespace generator
+{
+namespace cpu
+{
+    //! Implementation of std::UniformRandomBitGenerator for TinyMT32
+    struct TinyMTengine
+    {
+        using result_type = std::uint32_t;
+
+        static constexpr result_type default_seed()
+        {
+            return 42u;
+        }
+
+        void seed( result_type value = default_seed() )
+        {
+            // parameters from TinyMT/jump/sample.c
+            prng.mat1 = 0x8f7011ee;
+            prng.mat2 = 0xfc78ff1f;
+            prng.tmat = 0x3793fdff;
+
+            tinymt32_init( &prng, value );
+        }
+
+        TinyMTengine( std::uint32_t const & seedValue )
+        {
+            seed( seedValue );
+        }
+
+        TinyMTengine()
+        {
+            std::uint32_t const magicSeed = 42u;
+            seed( magicSeed );
+        }
+
+        result_type operator()()
+        {
+            return tinymt32_generate_uint32( &prng );
+        }
+
+        static constexpr result_type min()
+        {
+            return 0u;
+        }
+
+        static constexpr result_type max()
+        {
+            return UINT32_MAX;
+        }
+
+        void discard( unsigned long long ) // z
+        {
+            // not implemented
+            // tinymt32_jump( &prng, z, z );
+        }
+
+        tinymt32_t prng;
+    };
+
+} // namespace cpu
+} // namespace generator
+} // namespace rand
+} // namespace alpaka

--- a/thirdParty/alpaka/include/alpaka/rand/TinyMT/LICENSE.txt
+++ b/thirdParty/alpaka/include/alpaka/rand/TinyMT/LICENSE.txt
@@ -1,0 +1,30 @@
+Copyright (c) 2011, 2013 Mutsuo Saito, Makoto Matsumoto,
+Hiroshima University and The University of Tokyo.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of the Hiroshima University nor the names of
+      its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/thirdParty/alpaka/include/alpaka/rand/TinyMT/tinymt32.h
+++ b/thirdParty/alpaka/include/alpaka/rand/TinyMT/tinymt32.h
@@ -1,0 +1,407 @@
+#ifndef TINYMT32_H
+#define TINYMT32_H
+/**
+ * @file tinymt32.h
+ *
+ * @brief Tiny Mersenne Twister only 127 bit internal state
+ *
+ * @author Mutsuo Saito (Hiroshima University)
+ * @author Makoto Matsumoto (University of Tokyo)
+ *
+ * Copyright (C) 2011 Mutsuo Saito, Makoto Matsumoto,
+ * Hiroshima University and The University of Tokyo.
+ * All rights reserved.
+ *
+ * The 3-clause BSD License is applied to this software, see
+ * LICENSE.txt
+ */
+
+#include <boost/predef.h>
+
+#include <cstdint>
+#include <cinttypes>
+
+#if BOOST_COMP_CLANG
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wold-style-cast"
+#   pragma clang diagnostic ignored "-Wsign-conversion"
+#endif
+#if BOOST_COMP_GNUC
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+#if BOOST_COMP_MSVC
+    #pragma warning(push)
+    #pragma warning(disable: 4100)  // tinymt32.h(60): warning C4100: 'random': unreferenced formal parameter
+#endif
+
+#define TINYMT32_MEXP 127
+#define TINYMT32_SH0 1
+#define TINYMT32_SH1 10
+#define TINYMT32_SH8 8
+#define TINYMT32_MASK UINT32_C(0x7fffffff)
+#define TINYMT32_MUL (1.0f / 16777216.0f)
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * tinymt32 internal state vector and parameters
+ */
+struct TINYMT32_T {
+    uint32_t status[4];
+    uint32_t mat1;
+    uint32_t mat2;
+    uint32_t tmat;
+};
+
+typedef struct TINYMT32_T tinymt32_t;
+
+inline void tinymt32_init(tinymt32_t * random, uint32_t seed);
+inline void tinymt32_init_by_array(tinymt32_t * random, uint32_t init_key[],
+                            int key_length);
+
+#if defined(__GNUC__)
+/**
+ * This function always returns 127
+ * @param random not used
+ * @return always 127
+ */
+inline static int tinymt32_get_mexp(
+    tinymt32_t * random  __attribute__((unused))) {
+    return TINYMT32_MEXP;
+}
+#else
+inline static int tinymt32_get_mexp(tinymt32_t * random) {
+    return TINYMT32_MEXP;
+}
+#endif
+
+/**
+ * This function changes internal state of tinymt32.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ */
+inline static void tinymt32_next_state(tinymt32_t * random) {
+    uint32_t x;
+    uint32_t y;
+
+    y = random->status[3];
+    x = (random->status[0] & TINYMT32_MASK)
+        ^ random->status[1]
+        ^ random->status[2];
+    x ^= (x << TINYMT32_SH0);
+    y ^= (y >> TINYMT32_SH0) ^ x;
+    random->status[0] = random->status[1];
+    random->status[1] = random->status[2];
+    random->status[2] = x ^ (y << TINYMT32_SH1);
+    random->status[3] = y;
+    random->status[1] ^= -((int32_t)(y & 1)) & random->mat1;
+    random->status[2] ^= -((int32_t)(y & 1)) & random->mat2;
+}
+
+/**
+ * This function outputs 32-bit unsigned integer from internal state.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ * @return 32-bit unsigned pseudorandom number
+ */
+inline static uint32_t tinymt32_temper(tinymt32_t * random) {
+    uint32_t t0, t1;
+    t0 = random->status[3];
+#if defined(LINEARITY_CHECK)
+    t1 = random->status[0]
+        ^ (random->status[2] >> TINYMT32_SH8);
+#else
+    t1 = random->status[0]
+        + (random->status[2] >> TINYMT32_SH8);
+#endif
+    t0 ^= t1;
+    t0 ^= -((int32_t)(t1 & 1)) & random->tmat;
+    return t0;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ * @return floating point number r (1.0 <= r < 2.0)
+ */
+inline static float tinymt32_temper_conv(tinymt32_t * random) {
+    uint32_t t0, t1;
+    union {
+        uint32_t u;
+        float f;
+    } conv;
+
+    t0 = random->status[3];
+#if defined(LINEARITY_CHECK)
+    t1 = random->status[0]
+        ^ (random->status[2] >> TINYMT32_SH8);
+#else
+    t1 = random->status[0]
+        + (random->status[2] >> TINYMT32_SH8);
+#endif
+    t0 ^= t1;
+    conv.u = ((t0 ^ (-((int32_t)(t1 & 1)) & random->tmat)) >> 9)
+              | UINT32_C(0x3f800000);
+    return conv.f;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ * @return floating point number r (1.0 < r < 2.0)
+ */
+inline static float tinymt32_temper_conv_open(tinymt32_t * random) {
+    uint32_t t0, t1;
+    union {
+        uint32_t u;
+        float f;
+    } conv;
+
+    t0 = random->status[3];
+#if defined(LINEARITY_CHECK)
+    t1 = random->status[0]
+        ^ (random->status[2] >> TINYMT32_SH8);
+#else
+    t1 = random->status[0]
+        + (random->status[2] >> TINYMT32_SH8);
+#endif
+    t0 ^= t1;
+    conv.u = ((t0 ^ (-((int32_t)(t1 & 1)) & random->tmat)) >> 9)
+              | UINT32_C(0x3f800001);
+    return conv.f;
+}
+
+/**
+ * This function outputs 32-bit unsigned integer from internal state.
+ * @param random tinymt internal status
+ * @return 32-bit unsigned integer r (0 <= r < 2^32)
+ */
+inline static uint32_t tinymt32_generate_uint32(tinymt32_t * random) {
+    tinymt32_next_state(random);
+    return tinymt32_temper(random);
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using multiplying by (1 / 2^24).
+ * floating point multiplication is faster than using union trick in
+ * my Intel CPU.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 <= r < 1.0)
+ */
+inline static float tinymt32_generate_float(tinymt32_t * random) {
+    tinymt32_next_state(random);
+    return (tinymt32_temper(random) >> 8) * TINYMT32_MUL;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using union trick.
+ * @param random tinymt internal status
+ * @return floating point number r (1.0 <= r < 2.0)
+ */
+inline static float tinymt32_generate_float12(tinymt32_t * random) {
+    tinymt32_next_state(random);
+    return tinymt32_temper_conv(random);
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using union trick.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 <= r < 1.0)
+ */
+inline static float tinymt32_generate_float01(tinymt32_t * random) {
+    tinymt32_next_state(random);
+    return tinymt32_temper_conv(random) - 1.0f;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function may return 1.0 and never returns 0.0.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 < r <= 1.0)
+ */
+inline static float tinymt32_generate_floatOC(tinymt32_t * random) {
+    tinymt32_next_state(random);
+    return 1.0f - tinymt32_generate_float(random);
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function returns neither 0.0 nor 1.0.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 < r < 1.0)
+ */
+inline static float tinymt32_generate_floatOO(tinymt32_t * random) {
+    tinymt32_next_state(random);
+    return tinymt32_temper_conv_open(random) - 1.0f;
+}
+
+/**
+ * This function outputs double precision floating point number from
+ * internal state. The returned value has 32-bit precision.
+ * In other words, this function makes one double precision floating point
+ * number from one 32-bit unsigned integer.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 <= r < 1.0)
+ */
+inline static double tinymt32_generate_32double(tinymt32_t * random) {
+    tinymt32_next_state(random);
+    return tinymt32_temper(random) * (1.0 / 4294967296.0);
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#define MIN_LOOP 8
+#define PRE_LOOP 8
+
+/**
+ * This function represents a function used in the initialization
+ * by init_by_array
+ * @param x 32-bit integer
+ * @return 32-bit integer
+ */
+static uint32_t ini_func1(uint32_t x) {
+    return (x ^ (x >> 27)) * UINT32_C(1664525);
+}
+
+/**
+ * This function represents a function used in the initialization
+ * by init_by_array
+ * @param x 32-bit integer
+ * @return 32-bit integer
+ */
+static uint32_t ini_func2(uint32_t x) {
+    return (x ^ (x >> 27)) * UINT32_C(1566083941);
+}
+
+/**
+ * This function certificate the period of 2^127-1.
+ * @param random tinymt state vector.
+ */
+static void period_certification(tinymt32_t * random) {
+    if ((random->status[0] & TINYMT32_MASK) == 0 &&
+	random->status[1] == 0 &&
+	random->status[2] == 0 &&
+	random->status[3] == 0) {
+	random->status[0] = 'T';
+	random->status[1] = 'I';
+	random->status[2] = 'N';
+	random->status[3] = 'Y';
+    }
+}
+
+/**
+ * This function initializes the internal state array with a 32-bit
+ * unsigned integer seed.
+ * @param random tinymt state vector.
+ * @param seed a 32-bit unsigned integer used as a seed.
+ */
+inline void tinymt32_init(tinymt32_t * random, uint32_t seed) {
+    random->status[0] = seed;
+    random->status[1] = random->mat1;
+    random->status[2] = random->mat2;
+    random->status[3] = random->tmat;
+    for (uint32_t i = 1; i < MIN_LOOP; i++) {
+	random->status[i & 3] ^= i + UINT32_C(1812433253)
+	    * (random->status[(i - 1) & 3]
+	       ^ (random->status[(i - 1) & 3] >> 30));
+    }
+    period_certification(random);
+    for (int i = 0; i < PRE_LOOP; i++) {
+	tinymt32_next_state(random);
+    }
+}
+
+/**
+ * This function initializes the internal state array,
+ * with an array of 32-bit unsigned integers used as seeds
+ * @param random tinymt state vector.
+ * @param init_key the array of 32-bit integers, used as a seed.
+ * @param key_length the length of init_key.
+ */
+inline void tinymt32_init_by_array(tinymt32_t * random, uint32_t init_key[],
+			    int key_length) {
+    const int lag = 1;
+    const int mid = 1;
+    const int size = 4;
+    uint32_t i;
+    int j;
+    int count;
+    uint32_t r;
+    uint32_t * st = &random->status[0];
+
+    st[0] = 0;
+    st[1] = random->mat1;
+    st[2] = random->mat2;
+    st[3] = random->tmat;
+    if (key_length + 1 > MIN_LOOP) {
+	count = key_length + 1;
+    } else {
+	count = MIN_LOOP;
+    }
+    r = ini_func1(st[0] ^ st[mid % size]
+		  ^ st[(size - 1) % size]);
+    st[mid % size] += r;
+    r += uint32_t(key_length);
+    st[(mid + lag) % size] += r;
+    st[0] = r;
+    count--;
+    for (i = 1, j = 0; (j < count) && (j < key_length); j++) {
+	r = ini_func1(st[i % size]
+		      ^ st[(i + mid) % size]
+		      ^ st[(i + size - 1) % size]);
+	st[(i + mid) % size] += r;
+	r += init_key[j] + i;
+	st[(i + mid + lag) % size] += r;
+	st[i % size] = r;
+	i = (i + 1) % size;
+    }
+    for (; j < count; j++) {
+	r = ini_func1(st[i % size]
+		      ^ st[(i + mid) % size]
+		      ^ st[(i + size - 1) % size]);
+	st[(i + mid) % size] += r;
+	r += i;
+	st[(i + mid + lag) % size] += r;
+	st[i % size] = r;
+	i = (i + 1) % size;
+    }
+    for (j = 0; j < size; j++) {
+	r = ini_func2(st[i % size]
+		      + st[(i + mid) % size]
+		      + st[(i + size - 1) % size]);
+	st[(i + mid) % size] ^= r;
+	r -= i;
+	st[(i + mid + lag) % size] ^= r;
+	st[i % size] = r;
+	i = (i + 1) % size;
+    }
+    period_certification(random);
+    for (i = 0; i < PRE_LOOP; i++) {
+	tinymt32_next_state(random);
+    }
+}
+
+#undef MIN_LOOP
+#undef PRE_LOOP
+
+#if BOOST_COMP_CLANG
+#   pragma clang diagnostic pop
+#endif
+#if BOOST_COMP_GNUC
+#   pragma GCC diagnostic pop
+#endif
+#if BOOST_COMP_MSVC
+#   pragma warning(pop)
+#endif
+
+#endif

--- a/thirdParty/alpaka/script/travis/install_clang.sh
+++ b/thirdParty/alpaka/script/travis/install_clang.sh
@@ -33,7 +33,7 @@ set -euo pipefail
 
 if [ -z "$(ls -A "${ALPAKA_CI_CLANG_DIR}")" ]
 then
-    if (( ALPAKA_CI_CLANG_VER_MAJOR >= 5 ))
+    if (( ALPAKA_CI_CLANG_VER_MAJOR == 5 ))
     then
         ALPAKA_CLANG_PKG_FILE_NAME=clang+llvm-${ALPAKA_CI_CLANG_VER}-linux-x86_64-ubuntu14.04.tar.xz
     else

--- a/thirdParty/alpaka/test/unit/stream/src/StreamTest.cpp
+++ b/thirdParty/alpaka/test/unit/stream/src/StreamTest.cpp
@@ -59,9 +59,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE_EQUAL(true, alpaka::stream::empty(f.m_stream));
 }
 
-// gcc 5.4 in combination with nvcc 8.0 fails to compile those tests when --expt-relaxed-constexpr is enabled
-// /usr/include/c++/5/tuple(484) (col. 17): error: calling a __host__ function("std::_Tuple_impl<(unsigned long)0ul,  :: > ::_Tuple_impl [subobject]") from a __device__ function("std::tuple< :: > ::tuple") is not allowed
-#if !((BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(5, 0, 0)) && (BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(8, 0, 0)) && (BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(9, 0, 0)))
 //-----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE_TEMPLATE(
     streamCallbackIsWorking,
@@ -123,6 +120,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE_EQUAL(true, alpaka::stream::empty(f.m_stream));
     BOOST_REQUIRE_EQUAL(true, CallbackFinished);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Improved Alpaka CPU RNG state. Fix #2653

Update alpaka from 

 - release  alpaka@0.3.2 (ComputationalRadiationPhysics/alpaka@847aed6 == [`0.3.2`](https://github.com/ComputationalRadiationPhysics/alpaka/tree/0.3.2) )
to
 - release  alpaka@0.3.3 (ComputationalRadiationPhysics/alpaka@172b9e2a4974a86e312cc4fb170556438e2dcc8e == [`0.3.3`](https://github.com/ComputationalRadiationPhysics/alpaka/tree/0.3.3) )

# Changes to Last Stable

- add CPU random number generators based on `std::random_device` and TinyMT32
- made TinyMT32 the default random number generator
- add `alpaka::ignore_unused`

# Used Update Command
```
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git subtree pull --prefix thirdParty/alpaka \
  git@github.com:ComputationalRadiationPhysics/alpaka.git 0.3.3 --squash
```