### PR TITLE
Manual: Updates for 0.4.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -31,7 +31,7 @@ Mandatory
 
 gcc
 """
-- 4.9 - 7 (if you want to build of Nvidia GPUs, supported compilers depend on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
+- 4.9 - 7 (if you want to build for Nvidia GPUs, supported compilers depend on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
 
   - CUDA 8.0: Use gcc 4.9 - 5.3
   - CUDA 9.0 - 9.1: Use gcc 4.9 - 5.5
@@ -89,13 +89,16 @@ zlib
 
 boost
 """""
-- 1.62.0-1.64.0 (``program_options``, ``regex`` , ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
-- download from `http://www.boost.org <http://sourceforge.net/projects/boost/files/boost/1.62.0/boost_1_62_0.tar.gz/download>`_
+- 1.62.0 - 1.68.0 (``program_options``, ``regex`` , ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
+- *note:* for CUDA 9 support, use boost 1.65.1 or newer
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
 - *from source:*
 
+  - ``curl -Lo boost_1_65_1.tar.gz https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz``
+  - ``tar -xzf boost_1_65_1.tar.gz``
+  - ``cd boost_1_65_1``
   - ``./bootstrap.sh --with-libraries=atomic,chrono,context,date_time,fiber,filesystem,math,program_options,regex,serialization,system,thread --prefix=$HOME/lib/boost``
   - ``./b2 cxxflags="-std=c++11" -j4 && ./b2 install``
 - *environment:* (assumes install from source in ``$HOME/lib/boost``)
@@ -116,7 +119,7 @@ rsync
 - *Arch Linux:* ``sudo pacman --sync rsync``
 - *Spack:* ``spack install rsync``
 
-alpaka 0.3.2
+alpaka 0.3.3
 """"""""""""
 - `alpaka <https://github.com/ComputationalRadiationPhysics/alpaka>`_ is included in the PIConGPU source code
 
@@ -160,7 +163,7 @@ CUDA
 - at least one **CUDA** capable **GPU**
 - *compute capability*: ``sm_20`` or higher (for CUDA 9+: ``sm_30`` or higher)
 - `full list <https://developer.nvidia.com/cuda-gpus>`_ of CUDA GPUs and their *compute capability*
-- `More <http://www.olcf.ornl.gov/titan/>`_ is always `better <http://www.cscs.ch/computers/piz_daint/index.html>`_. Especially, if we are talking GPUs :-)
+- `More <http://www.olcf.ornl.gov/summit/>`_ is always `better <http://www.cscs.ch/computers/piz_daint/index.html>`_. Especially, if we are talking GPUs :-)
 - *environment:*
 
   - ``export CUDA_ROOT=<CUDA_INSTALL>``
@@ -224,8 +227,8 @@ HDF5
   - ``cd ~/src``
   - download hdf5 source code from `release list of the HDF5 group <https://www.hdfgroup.org/ftp/HDF5/releases/>`_, for example:
 
-  - ``wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.20/src/hdf5-1.8.20.tar.gz``
-  - ``tar -xvzf hdf5-1.8.20.tar.gz``
+  - ``curl -Lo hdf5-1.8.20.tar.gz https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.20/src/hdf5-1.8.20.tar.gz``
+  - ``tar -xzf hdf5-1.8.20.tar.gz``
   - ``cd hdf5-1.8.20``
   - ``./configure --enable-parallel --enable-shared --prefix $HOME/lib/hdf5/``
   - ``make``
@@ -275,8 +278,8 @@ ADIOS
 
   - ``mkdir -p ~/src ~/build ~/lib``
   - ``cd ~/src``
-  - ``wget http://users.nccs.gov/~pnorbert/adios-1.13.1.tar.gz``
-  - ``tar -xvzf adios-1.13.1.tar.gz``
+  - ``curl -Lo adios-1.13.1.tar.gz http://users.nccs.gov/~pnorbert/adios-1.13.1.tar.gz``
+  - ``tar -xzf adios-1.13.1.tar.gz``
   - ``cd adios-1.13.1``
   - ``CFLAGS="-fPIC" ./configure --enable-static --enable-shared --prefix=$HOME/lib/adios --with-mpi=$MPI_ROOT --with-zlib=/usr``
   - ``make``
@@ -303,8 +306,8 @@ VampirTrace
 
   - ``mkdir -p ~/src ~/build ~/lib``
   - ``cd ~/src``
-  - ``wget -O VampirTrace-5.14.4.tar.gz "http://wwwpub.zih.tu-dresden.de/~mlieber/dcount/dcount.php?package=vampirtrace&get=VampirTrace-5.14.4.tar.gz"``
-  - ``tar -xvzf VampirTrace-5.14.4.tar.gz``
+  - ``curl -Lo VampirTrace-5.14.4.tar.gz "http://wwwpub.zih.tu-dresden.de/~mlieber/dcount/dcount.php?package=vampirtrace&get=VampirTrace-5.14.4.tar.gz"``
+  - ``tar -xzf VampirTrace-5.14.4.tar.gz``
   - ``cd VampirTrace-5.14.4``
   - ``./configure --prefix=$HOME/lib/vampirtrace --with-cuda-dir=<CUDA_ROOT>``
   - ``make all -j``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -89,7 +89,7 @@ zlib
 
 boost
 """""
-- 1.62.0 - 1.68.0 (``program_options``, ``regex`` , ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
+- 1.62.0 - 1.67.0 (``program_options``, ``regex`` , ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
 - *note:* for CUDA 9 support, use boost 1.65.1 or newer
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -46,19 +46,20 @@ Step-by-Step
    # switch to your input directory
    cd $HOME/picInputs/myLWFA
 
-PIConGPU is controlled via two kinds of input sets: compile-time options and runtime options.
+PIConGPU is controlled via two kinds of textual input sets: compile-time options and runtime options.
 
-Edit the :ref:`.param files <usage-params>` inside ``include/picongpu/param/``.
-Initially and when options are changed, PIConGPU *requires a re-compile*.
+Compile-time :ref:`.param files <usage-params>` reside in ``include/picongpu/param/`` and define the physics case and deployed numerics.
+After creation and whenever options are changed, PIConGPU *requires a re-compile*.
+Feel free to take a look now, but we will later come back on how to :ref:`edit those files <usage-params-edit>`.
 
-Now edit the :ref:`runtime (command line) arguments <usage-cfg>` in ``etc/picongpu/*.cfg``.
-These options do *not* require a re-compile when changed (e.g. simulation size, number of GPUs, plugins, ...).
+:ref:`Runtime (command line) arguments <usage-cfg>` are set in ``etc/picongpu/*.cfg`` files.
+These options do *not* require a re-compile when changed (e.g. simulation size, number of devices, plugins, ...).
 
 2. Compile Simulation
 """""""""""""""""""""
 
-In our input, ``.param`` files are build directly into the PIConGPU binary for performance reasons.
-Changing or initially adding those requires a compile.
+In our input, ``.param`` files are build directly into the PIConGPU binary for :ref:`performance reasons <usage-params-rationale>`.
+A compile is required after changing or initially adding those files.
 
 In this step you can optimize the simulation for the specific hardware you want to run on.
 By default, we compile for Nvidia GPUs with the CUDA backend, targeting the oldest compatible `architecture <https://developer.nvidia.com/cuda-gpus>`_.
@@ -71,6 +72,8 @@ By default, we compile for Nvidia GPUs with the CUDA backend, targeting the olde
 This step will take a few minutes.
 Time for a coffee or a `sword fight <https://xkcd.com/303/>`_!
 
+We explain in the :ref:`details section <usage-basics-build>` below how to set further options, e.g. CPU targets or tuning for newer GPU architectures.
+
 3. Run Simulation
 """""""""""""""""
 
@@ -80,31 +83,39 @@ While you are still in ``$HOME/picInputs/myLWFA``, start your simulation on one 
    :emphasize-lines: 2
    
    # example run for an interactive simulation on the same machine
-   tbg -s bash -c etc/picongpu/0001gpus.cfg -t etc/picongpu/bash/mpiexec.tpl $SCRATCH/runs/lwfa_001
+   tbg -s bash -c etc/picongpu/1.cfg -t etc/picongpu/bash/mpiexec.tpl $SCRATCH/runs/lwfa_001
 
 This will create the directory ``$SCRATCH/runs/lwfa_001`` where all simulation output will be written to.
 ``tbg`` will further create a subfolder ``input/`` in the directory of the run with the same structure as ``myLWFA`` to archive your input files.
 
-Further Reading
----------------
+Details on the Commands Above
+-----------------------------
 
-Individual input files, their syntax and usage are explained in the following sections.
+.. _usage-basics-tbg:
 
-See ``tbg --help`` :ref:`for more information <usage-tbg>` about the ``tbg`` tool.
+tbg
+"""
 
-For example, if you want to run on the HPC System `"Hypnos" at HZDR <https://www.hzdr.de/db/Cms?pOid=12231>`_, your tbg submit command would just change to:
+The ``tbg`` tool is explained in detail :ref:`in its own section <usage-tbg>`.
+Its primary purpose is to abstract the options in runtime ``.cfg`` files from the technical details on how to run on various supercomputers.
+
+For example, if you want to run on the HPC System `"Hypnos" at HZDR <https://www.hzdr.de/db/Cms?pOid=12231>`_, your ``tbg`` submit command would just change to:
 
 .. code-block:: bash
    :emphasize-lines: 2
 
    # request 16 GPUs from the PBS batch system and run on the queue k20
-   tbg -s qsub -c etc/picongpu/0016gpus.cfg -t etc/picongpu/hypnos-hzdr/k20.tpl $SCRATCH/runs/lwfa_002
+   tbg -s qsub -c etc/picongpu/1.cfg -t etc/picongpu/hypnos-hzdr/k20.tpl $SCRATCH/runs/lwfa_002
+
+Note that we can use the same ``1.cfg`` file, your input set is *portable*.
+
+.. _usage-basics-create:
 
 pic-create
 """"""""""
 
 This tool is just a short-hand to create a new set of input files.
-It does a copy from an already existing set of input files (e.g. our examples or a previous simulation) and adds additional default files.
+It does a copy from an already existing set of input files (e.g. our examples or a previous simulation) and adds additional helper files.
 
 See ``pic-create --help`` for more options during input set creation:
 
@@ -115,6 +126,8 @@ A run simulation can also be reused to create derived input sets via ``pic-creat
 .. code-block:: bash
 
    pic-create $SCRATCH/runs/lwfa_001/input $HOME/picInputs/mySecondLWFA
+
+.. _usage-basics-build:
 
 pic-build
 """""""""
@@ -138,7 +151,7 @@ In detail, it does:
    # - make install copies resulting binaries to input set
    make -j install
 
-``pic-build`` accepts the same command line flags as ``pic-configure``.
+``pic-build`` accepts the same command line flags as :ref:`pic-configure <usage-basics-configure>`.
 For example, if you want to build for running on CPUs instead of a GPUs, call:
 
 .. code-block:: bash
@@ -151,12 +164,16 @@ Its full documentation from ``pic-build --help`` reads:
 
 .. program-output:: ../../bin/pic-build --help
 
+.. _usage-basics-configure:
+
 pic-configure
 """""""""""""
 
-The tools is just a convenient wrapper for a call to `CMake <https://cmake.org>`_.
-It is executed from an empty build directory.
-You will likely not use this tool directly when using ``pic-build`` from above.
+This tool is just a convenient wrapper for a call to `CMake <https://cmake.org>`_.
+It is executed from an :ref:`empty build directory <install-source>`.
+
+You will likely not use this tool directly.
+Instead, :ref:`pic-build <usage-basics-build>` from above calls ``pic-configure`` for you, forwarding its arguments.
 
 We *strongly recommend* to set the appropriate target compute backend via ``-b`` for optimal performance.
 For Nvidia CUDA GPUs, set the `compute capability <https://developer.nvidia.com/cuda-gpus>`_ of your GPU:
@@ -186,6 +203,6 @@ See ``pic-configure --help`` for more options during input set configuration:
 .. program-output:: ../../bin/pic-configure --help
 
 After running configure you can run ``ccmake .`` to set additional compile options (optimizations, debug levels, hardware version, etc.).
-This will influence your build done via ``make``.
+This will influence your build done via ``make install``.
 
 You can pass further options to configure PIConGPU directly instead of using ``ccmake .``, by passing ``-c "-DOPTION1=VALUE1 -DOPTION2=VALUE2"``.

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -104,8 +104,11 @@ For example, if you want to run on the HPC System `"Hypnos" at HZDR <https://www
 .. code-block:: bash
    :emphasize-lines: 2
 
-   # request 16 GPUs from the PBS batch system and run on the queue k20
+   # request 1 GPU from the PBS batch system and run on the queue "k20"
    tbg -s qsub -c etc/picongpu/1.cfg -t etc/picongpu/hypnos-hzdr/k20.tpl $SCRATCH/runs/lwfa_002
+
+   # run again, this time on 16 GPUs
+   tbg -s qsub -c etc/picongpu/16.cfg -t etc/picongpu/hypnos-hzdr/k20.tpl $SCRATCH/runs/lwfa_003
 
 Note that we can use the same ``1.cfg`` file, your input set is *portable*.
 

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -118,7 +118,7 @@ pic-create
 """"""""""
 
 This tool is just a short-hand to create a new set of input files.
-It does a copy from an already existing set of input files (e.g. our examples or a previous simulation) and adds additional helper files.
+It copies from an already existing set of input files (e.g. our examples or a previous simulation) and adds additional helper files.
 
 See ``pic-create --help`` for more options during input set creation:
 

--- a/docs/source/install/instructions/docker.rst
+++ b/docs/source/install/instructions/docker.rst
@@ -17,6 +17,7 @@ Preparation
 ^^^^^^^^^^^
 
 First `install nvidia-docker <https://github.com/NVIDIA/nvidia-docker>`_ for your distribution.
+Use version 2 or newer.
 
 Install
 ^^^^^^^
@@ -25,7 +26,7 @@ The download of a pre-configured image with the latest version of PIConGPU is no
 
 .. code-block:: bash
 
-   nvidia-docker pull ax3l/picongpu
+   docker pull ax3l/picongpu
 
 Use PIConGPU
 ^^^^^^^^^^^^
@@ -34,14 +35,14 @@ Start a pre-configured LWFA live-simulation with
 
 .. code-block:: bash
 
-   nvidia-docker run -p 2459:2459 -t ax3l/picongpu:0.3.0 /bin/bash -lc start_lwfa
+   docker run --runtime=nvidia -p 2459:2459 -t ax3l/picongpu /bin/bash -lc start_lwfa
    # open firefox and isaac client
 
 or just open the container and run your own:
 
 .. code-block:: bash
 
-   nvidia-docker run -it ax3l/picongpu
+   docker run --runtime=nvidia -it ax3l/picongpu
 
 .. note::
 

--- a/docs/source/install/instructions/source.rst
+++ b/docs/source/install/instructions/source.rst
@@ -49,7 +49,7 @@ An example could look like this
 
 .. code-block:: bash
 
-   # go to an empty, temporary build project
+   # go to an empty, temporary build directory
    cd $HOME/build
    rm -rf ../build/*
    

--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -4,6 +4,11 @@
 
    You will need to understand how to use `the terminal <http://www.ks.uiuc.edu/Training/Tutorials/Reference/unixprimer.html>`_.
 
+.. warning::
+
+   Our spack package is still in beta state and is continuously improved.
+   Please feel free to report any issues that you might encounter.
+
 Spack
 -----
 
@@ -26,7 +31,7 @@ First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html
    spack bootstrap
 
    # install a supported compiler
-   spack compiler list | grep gcc@5.4.0 || spack install gcc@5.4.0 && spack load gcc@5.4.0 && spack compiler add
+   spack compiler list | grep gcc@5.4.0 | spack install gcc@5.4.0 && spack load gcc@5.4.0 && spack compiler add
 
    # add the PIConGPU repository
    git clone https://github.com/ComputationalRadiationPhysics/spack-repo.git $HOME/src/spack-repo
@@ -56,7 +61,7 @@ PIConGPU can now be loaded with
 
 .. code-block:: bash
 
-   spack load picongpu %gcc@5.4.0
+   spack load picongpu
 
 For more information on *variants* of the ``picongpu`` package in spack run ``spack info picongpu`` and refer to the `official spack documentation <https://spack.readthedocs.io/>`_.
 
@@ -67,5 +72,5 @@ For more information on *variants* of the ``picongpu`` package in spack run ``sp
    
    .. code-block:: bash
 
-      spack install picongpu backend=omp2b %gcc@5.4.0
-      spack load picongpu backend=omp2b %gcc@5.4.0
+      spack install picongpu backend=omp2b
+      spack load picongpu backend=omp2b

--- a/docs/source/usage/param.rst
+++ b/docs/source/usage/param.rst
@@ -8,6 +8,8 @@
 Parameter files, ``*.param`` placed in ``include/picongpu/param/`` are used to set all **compile-time options** for a PIConGPU simulation.
 This includes most fundamental options such as numerical solvers, floating precision, memory usage due to attributes and super-cell based algorithms, density profiles, initial conditions etc.
 
+.. _usage-params-edit:
+
 Editing
 -------
 
@@ -25,6 +27,8 @@ For example, if you want to edit the *grid* and time step resolution, *file outp
 See ``pic-edit --help`` for all available files:
 
 .. program-output:: ../../bin/pic-edit --help
+
+.. _usage-params-rationale:
 
 Rationale
 ---------

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -14,9 +14,10 @@ Scheduling on today's supercomputers is usually done via *batch systems* that de
 An unfortunate aspect about batch systems from a user's perspective is, that their usage varies a lot.
 And naturally, different systems have different resources in queues that need to be described.
 
-We abstract the description of queues, resource acquisition and job submission away from PIConGPU user input via *template files* (``.tpl``).
-For example, the ``.cfg`` file defines how many *devices* shall be used for computation, but the ``.tpl`` file calculates how many *physical nodes* will be requested.
-Also, the ``.tpl`` file takes care of how to spawn a process when scheduled, e.g. with ``mpiexec`` and which flags for networking details need to be passed.
+PIConGPU runtime options are described in *configuration files* (``.cfg``).
+We abstract the description of queues, resource acquisition and job submission via *template files* (``.tpl``).
+For example, a ``.cfg`` file defines how many *devices* shall be used for computation, but a ``.tpl`` file calculates how many *physical nodes* will be requested.
+Also, ``.tpl`` files takes care of how to spawn a process when scheduled, e.g. with ``mpiexec`` and which flags for networking details need to be passed.
 After combining the *machine independent* (portable) ``.cfg`` file from user input with the *machine dependent* ``.tpl`` file, ``tbg`` can submit the requested job to the batch system.
 
 Last but not least, one usually wants to store the input of a simulation with its output.

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -16,7 +16,7 @@ And naturally, different systems have different resources in queues that need to
 
 We abstract the description of queues, resource acquisition and job submission away from PIConGPU user input via *template files* (``.tpl``).
 For example, the ``.cfg`` file defines how many *devices* shall be used for computation, but the ``.tpl`` file calculates how many *physical nodes* will be requested.
-Also, the ``.tpl`` file takes care off how to spawn a process when scheduled, e.g. with ``mpiexec`` and which flags for networking details need to be passed.
+Also, the ``.tpl`` file takes care of how to spawn a process when scheduled, e.g. with ``mpiexec`` and which flags for networking details need to be passed.
 After combining the *machine independent* (portable) ``.cfg`` file from user input with the *machine dependent* ``.tpl`` file, ``tbg`` can submit the requested job to the batch system.
 
 Last but not least, one usually wants to store the input of a simulation with its output.

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -3,15 +3,29 @@
 TBG
 ===
 
-.. sectionauthor:: Axel Huebl, Richard Pausch
+.. sectionauthor:: Axel Huebl
 .. moduleauthor:: René Widera
 
-todo: explain idea and use case
+Our tool *template batch generator* (``tbg``) abstracts program runtime options from technical details of supercomputers.
+On a desktop PC, one can just execute a command interactively and instantaneously.
+Contrarily on a supercomputer, resources need to be shared between different users efficiently via *job scheduling*.
+Scheduling on today's supercomputers is usually done via *batch systems* that define various queues of resources.
 
-- what is a batch system
-- cfg files
-- tpl files
-- behaviour (existing dirs, submission, environment)
+An unfortunate aspect about batch systems from a user's perspective is, that their usage varies a lot.
+And naturally, different systems have different resources in queues that need to be described.
+
+We abstract the description of queues, resource acquisition and job submission away from PIConGPU user input via *template files* (``.tpl``).
+For example, the ``.cfg`` file defines how many *devices* shall be used for computation, but the ``.tpl`` file calculates how many *physical nodes* will be requested.
+Also, the ``.tpl`` file takes care off how to spawn a process when scheduled, e.g. with ``mpiexec`` and which flags for networking details need to be passed.
+After combining the *machine independent* (portable) ``.cfg`` file from user input with the *machine dependent* ``.tpl`` file, ``tbg`` can submit the requested job to the batch system.
+
+Last but not least, one usually wants to store the input of a simulation with its output.
+``tbg`` conveniently automates this task before submission.
+
+In summary, PIConGPU runtime options in ``.cfg`` files are portable to any machine.
+When accessing a machine for the first time, one needs to write template ``.tpl`` files, abstractly describing how to run PIConGPU on the specific queue(s) of the batch system.
+We ship such template files already for a set of supercomputers, interactive execution and many common batch systems.
+See ``$PICSRC/etc/picongpu/`` and :ref:`our list of systems with .profile files <install-profile>` for details.
 
 
 Usage
@@ -24,13 +38,15 @@ Usage
 .cfg File Macros
 ^^^^^^^^^^^^^^^^
 
-Feel free to copy & paste sections of the files below into your `.cfg`, e.g. to configure complex plugins:
+Feel free to copy & paste sections of the files below into your ``.cfg``, e.g. to configure complex plugins:
 
 .. literalinclude:: ../../TBG_macros.cfg
    :language: bash
 
 Batch System Examples
 ^^^^^^^^^^^^^^^^^^^^^
+
+.. sectionauthor:: Axel Huebl, Richard Pausch
 
 Slurm
 """""

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -365,6 +365,17 @@ if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
     endif()
 endif()
 
+# Boost predef headers for NVCC are broken in Boost 1.68.0
+#   Alpaka 0.3.3 does not include a work-around yet
+#   `pmacc/types.hpp` does not include a work-around yet
+#   https://github.com/ComputationalRadiationPhysics/alpaka/pull/606
+if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
+    if(Boost_VERSION EQUAL 106800)
+        message(FATAL_ERROR "Boost 1.68.0 has broken CUDA NVCC detection in "
+                "boost/predef.h Please use Boost 1.65.1 - 1.67.0")
+    endif()
+endif()
+
 # Newer CUDA releases: probably troublesome, warn at least
 if(CUDA_VERSION VERSION_GREATER 9.2)
     message(WARNING "Untested CUDA release! Maybe use a newer PIConGPU?")


### PR DESCRIPTION
- add `tbg` section
- update "basic usage" section:
  - fix outdated .cfg file names
  - improve clarity and structure
- update install instructions:
  - refresh version ranges
  - update min. alpaka
  - add notes, e.g. to spack and use nvidia docker 2+
  - replace wget with more widespread curl command (linux/osx)
  - remove untar verbosity

Greetings from Toronto Airport!