### PR TITLE
fix out of host memory during HDF5 dumping

### DIFF
--- a/include/pmacc/memory/buffers/MappedBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/MappedBufferIntern.hpp
@@ -55,7 +55,11 @@ public:
     DeviceBuffer<TYPE, DIM>(size, size),
     pointer(nullptr), ownPointer(true)
     {
-        CUDA_CHECK(cudaMallocHost(&pointer, size.productOfComponents() * sizeof (TYPE), cudaHostAllocMapped));
+#if( PMACC_CUDA_ENABLED == 1 )
+        CUDA_CHECK((cuplaError_t)cudaHostAlloc(&pointer, size.productOfComponents() * sizeof (TYPE), cudaHostAllocMapped));
+#else
+        pointer = new TYPE[size.productOfComponents()];
+#endif
         reset(false);
     }
 
@@ -69,7 +73,25 @@ public:
 
         if (pointer && ownPointer)
         {
-            CUDA_CHECK(cudaFreeHost(pointer));
+#if( PMACC_CUDA_ENABLED == 1 )
+/* cupla 0.1.0 does not support the function cudaHostAlloc to create mapped memory.
+ * Therefore we need to call the native CUDA function cudaFreeHost to free memory.
+ * Due to the renaming of cuda functions with cupla via macros we need to remove
+ * the renaming to get access to the native cuda function.
+ * @todo this is a workaround please fix me. We need to investigate if
+ * it is possible to have mapped/unified memory in alpaka.
+ *
+ * corresponding alpaka issues:
+ *   https://github.com/ComputationalRadiationPhysics/alpaka/issues/296
+ *   https://github.com/ComputationalRadiationPhysics/alpaka/issues/612
+ */
+#   undef cudaFreeHost
+            CUDA_CHECK((cuplaError_t)cudaFreeHost(pointer));
+// re-introduce the cupla macro
+#   define cudaFreeHost(...) cuplaFreeHost(__VA_ARGS__)
+#else
+            __deleteArray(pointer);
+#endif
         }
     }
 


### PR DESCRIPTION
For HDF5 checkpoints and normal dumps we use CUDA mapped memory to transfere the particles to the host memory. Due to the usage of cupla and the reason that mapped memory is not supported by cupla and alpaka we fall back to native CUDA functions. To free mapped memory the function `cudaFreeHost`. This function is also used to free normal host memory allocated with `cudaMallocHost` which is supported by cupla.
The cupla internal macros rename `cudaFreeHost` to `cuplaFreeHost` and fall back to alpaka functionallity to free the memory. In the case where we allocated the memory without the knowledge of cupla, cupla is trowing an error and `cudaFreeHost` will never be called.
The result in PIConGPU is that with each particle dump the host memory footprint grows until we run out of memory.

- fix broken memory freeing
- `MappedBufferIntern`
  - fix that wrong function is used to allocate mapped memory
  - add workaround to free mapped memory
  - add fallpack if an CPU accelerator is used

Note: `MappedBufferIntern` is not used for long time therefore the wrong allocation call was not seen by any user of PMacc


This bugfix ~~should~~ solve: #2504

# Tests

- [x] KHI with 192x512x64 cells on 1  GPU

CC-ing: @PrometheusPi  @steindev @HighIander  @BeyondEspresso 