### PR TITLE
Python visualizers as jupyter widgets

### DIFF
--- a/docs/source/dev/py_postprocessing.rst
+++ b/docs/source/dev/py_postprocessing.rst
@@ -24,46 +24,32 @@ Each reader class should derive from this class and implement the interface func
 
 To shorten the import statements for the readers, please also add an entry in the ``__init__.py`` file of the ``data`` directory.
 
-Visualizer
-~~~~~~~~~~
+Matplotlib visualizer
+~~~~~~~~~~~~~~~~~~~~~
 
 The visualizers should reside in the ``lib/python/picongpu/plugins/plot_mpl/`` directory.
 The module names should end on ``_visualizer.py`` and the class name should only be ``Visualizer``.
 
-To shorten the import statements for the visualizers, please also add an entry in the ``__init__.py`` file of the ``plot_mpl`` directory.
+To shorten the import statements for the visualizers, please also add an entry in the ``__init__.py`` file of the ``plot_mpl`` directory with an alias that ends on "MPL".
 
 There is a base class for visualization found in ``base_visualizer.py`` which already handles the plotting logic.
-It uses the data reader classes for accessing the data.
+It uses (possibly multiple) instances of the data reader classes for accessing the data. Visualizing data simultaneously for more than one scan is supported by creating as many readers and plot objects as there are simulations for visualization.
 After getting the data, it ensures that (for performance reasons) a matplotlib artist is created only for the first plot and later only gets updated with fresh data.
 
 .. autoclass:: picongpu.plugins.plot_mpl.base_visualizer.Visualizer
    :members:
    :private-members:
 
-The complete implementation logic of the ``visualize`` function is pretty simple.
-
-.. code:: python
-
-   def visualize(self, **kwargs):
-        self.data = self.data_reader.get(**kwargs)
-        if self.plt_obj is None:
-            self._create_plt_obj()
-        else:
-            self._update_plt_obj()
-
 All new plugins should derive from this class.
 
 When implementing a new visualizer you have to perform the following steps:
 
-1. Let your visualizer class inherit from the ``Visualizer`` class in ``base visualizer.py``.
+1. Let your visualizer class inherit from the ``Visualizer`` class in ``base visualizer.py`` and call the base class constructor with the correct data reader class.
 
-2. Implement the ``_create_data_reader(self, run_directory)`` function.
-This function should return a data reader object (see above) for this plugin's data.
+2. Implement the ``_create_plt_obj(self, idx)`` function.
+This function needs to access the plotting data from the ``self.data`` member (this is the data structure as returned by the data readers ``.get(...)`` function, create some kind of matplotlib artist by storing it in the ``self.plt_obj`` member variable at the correct index specified by the idx variable (which corresponds to the data of the simulation at position idx that is passed in construction.
 
-3. Implement the ``_create_plt_obj(self)`` function.
-This function needs to access the plotting data from the ``self.data`` member (this is the data structure as returned by the data readers ``.get(...)`` function, create some kind of matplotlib artist by storing it in the ``self.plt_obj`` member variable and set up other plotting details (e.g. a colorbar).
-
-4. Implement the ``_update_plt_obj(self)`` function.
+3. Implement the ``_update_plt_obj(self, idx)`` function.
 This is called only after a valid ``self.plt_obj`` was created.
 It updates the matplotlib artist with new data.
 Therefore it again needs to access the plotting data from the ``self.data`` member and call the data update API for the matplotlib artist (normally via ``.set_data(...)``.
@@ -80,87 +66,58 @@ The module names should end on ``_widget.py``.
 To shorten the import statements for the widgets, please also add an entry in the ``__init__.py`` file of the ``jupyter_widget`` directory.
 
 There is a base class for visualization found in ``base_widget.py`` which already handles most of the widget logic.
-It also implements widgets for scan, simulation and iteration selection.
 
 .. autoclass:: picongpu.plugins.jupyter_widgets.base_widget.BaseWidget
    :members:
    :private-members:
 
-When created with an ``experiment_path`` argument, it assumes that there will be a number of subdirectories containing scan results named ``scan_<nr>``.
-Within each such directory it further assumes one or many PIConGPU simulation output directories named ``sim_<nr>``.
-The base class provides functionality to easily allow switching between visualizations for different scans or simulations.
+It allows to switch between visualizations for different simulation times (iterations) and different simulations.
 
 When implementing a new widget you have to perform the following steps:
 
-1. Let the widget class inherit from the base visualizer
+1. Let the widget class inherit from the ``BaseWidget`` class in ``base_widget.py`` and call the base class constructor with the correct matplotlib visualizer class.
 
 .. code:: python
 
-   from .base_visualizer import BaseWidget
+   from .base_widget import BaseWidget
 
    class NewPluginWidget(BaseWidget):
 
-2. In the constructor, call the base class constructor with the matplotlib visualizer class as ``pic_vis_cls`` keyword.
+2. In the constructor, call the base class constructor with the matplotlib visualizer class as ``plot_mpl_cls`` keyword.
 
    The base class will then create an instance of the visualizer class and delegate the plotting job to it.
 
 .. code:: python
 
-   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_visualizer.py
-   from .base_visualizer import BaseWidget
+   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
+   from .base_widget import BaseWidget
    from picongpu.plugins.plot_mpl import EnergyHistogramMPL
 
    class EnergyHistogramWidget(BaseWidget):
-       def __init__(self, experiment_path, fig=None, your_additional_args):
+       def __init__(self, run_dir_options, fig=None, **kwargs):
 
-           BaseWidget.__init__(
-               self,
-               experiment_path,
-               pic_vis_cls=EnergyHistogramMPL,
-               fig=fig)
-           # do stuff with your_additional_args
+            BaseWidget.__init__(self,
+                                EnergyHistogramMPL,
+                                run_dir_options,
+                                fig,
+                                **kwargs)
 
-
-3. (optional) adjust the ``_basic_ui_elements(self)`` function.
-    The base class already creates dropdown widgets for interactive selection of scan and simulation directories as well as a slider to adjust the simulation time (i.e. the iteration).
-    If your class does not need some of those widgets, feel free to override this function.
-    It needs to return a list of widgets.
-    Note that scan and simulation dropdowns should probably be returned in any case to allow switching between different simulations.
-
-4. implement the  ``_extra_ui_elements(self)`` function.
+3. implement the  ``_create_widgets_for_vis_args(self)`` function.
 
     This function has to define jupyter widgets as member variables of the class to allow interactive manipulation of parameters the underlying matplotlib visualizer is capable of handling.
-    It needs to return a list of those widgets.
+    It needs to return a dictionary using the parameter names the matplotlib visualizer accepts as keys and the widget members that correspond to these parameters as values.
 
 .. code:: python
 
-   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_visualizer.py
-   def _extra_ui_elements(self):
-       """
-       Create and return as a list the individual widgets that are necessary
-       for this special visualizer.
-       """
-       self.species = widgets.Dropdown(description="Species",
-                                       options=["e"],
-                                       value='e')
-       self.species_filter = widgets.Dropdown(description="Species_filter",
-                                              options=['all'],
-                                              value="all")
-       return [self.species, self.species_filter]
+   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
+    def _create_widgets_for_vis_args(self):
+        # widgets for the input parameters
+        self.species = widgets.Dropdown(description="Species",
+                                        options=["e"],
+                                        value='e')
+        self.species_filter = widgets.Dropdown(description="Species_filter",
+                                               options=['all'],
+                                               value="all")
 
-5. implement the ``_extra_ui_elements_value(self)`` function.
-
-    This function acts as the connection between the widgets specified above and transfering their values to the underlying matplotlib visualizer instance.
-    It therefore needs to return a dictionary with an entry for every widget specified in 4.
-    The keys must be the parameter names that the matplotlib visualizer accepts in its call to the ``visualize`` function.
-    The values will be the corresponding values of the widget elements for this parameter.
-
-.. code:: python
-
-   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_visualizer.py
-   def _extra_ui_elements_value(self):
-       """
-       Map widget values to parameter names for the plot_mpl visualizer.
-       """
-       return {'species': self.species.value,
-               'species_filter': self.species_filter.value}
+        return {'species': self.species,
+                'species_filter': self.species_filter}

--- a/docs/source/dev/py_postprocessing.rst
+++ b/docs/source/dev/py_postprocessing.rst
@@ -7,6 +7,7 @@ Each plugin should implement at least the following Python classes.
 
 1. A data reader class responsible for loading the data from the simulation directory
 2. A visualizer class that outputs a matplotlib plot
+3. A jupyter-widget class that exposes the parameters of the matplotlib visualizer to the user via other widgets.
 
 The repository directory for PIConGPU Python modules for plugins is ``lib/python/picongpu/plugins/``.
 
@@ -67,3 +68,99 @@ This is called only after a valid ``self.plt_obj`` was created.
 It updates the matplotlib artist with new data.
 Therefore it again needs to access the plotting data from the ``self.data`` member and call the data update API for the matplotlib artist (normally via ``.set_data(...)``.
 
+Jupyter Widget
+~~~~~~~~~~~~~~
+
+The widget is essentially only a wrapper around the matplotlib visualizer that allows dynamical adjustment of the parameters the visualizer accepts for plotting.
+This allows to adjust e.g. species, filter and other plugin-dependent options without having to write new lines of Python code.
+
+The widgets should reside in the ``lib/python/picongpu/plugins/jupyter_widgets/`` directory.
+The module names should end on ``_widget.py``.
+
+To shorten the import statements for the widgets, please also add an entry in the ``__init__.py`` file of the ``jupyter_widget`` directory.
+
+There is a base class for visualization found in ``base_widget.py`` which already handles most of the widget logic.
+It also implements widgets for scan, simulation and iteration selection.
+
+.. autoclass:: picongpu.plugins.jupyter_widgets.base_widget.BaseWidget
+   :members:
+   :private-members:
+
+When created with an ``experiment_path`` argument, it assumes that there will be a number of subdirectories containing scan results named ``scan_<nr>``.
+Within each such directory it further assumes one or many PIConGPU simulation output directories named ``sim_<nr>``.
+The base class provides functionality to easily allow switching between visualizations for different scans or simulations.
+
+When implementing a new widget you have to perform the following steps:
+
+1. Let the widget class inherit from the base visualizer
+
+.. code:: python
+
+   from .base_visualizer import BaseWidget
+
+   class NewPluginWidget(BaseWidget):
+
+2. In the constructor, call the base class constructor with the matplotlib visualizer class as ``pic_vis_cls`` keyword.
+
+   The base class will then create an instance of the visualizer class and delegate the plotting job to it.
+
+.. code:: python
+
+   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_visualizer.py
+   from .base_visualizer import BaseWidget
+   from picongpu.plugins.plot_mpl import EnergyHistogramMPL
+
+   class EnergyHistogramWidget(BaseWidget):
+       def __init__(self, experiment_path, fig=None, your_additional_args):
+
+           BaseWidget.__init__(
+               self,
+               experiment_path,
+               pic_vis_cls=EnergyHistogramMPL,
+               fig=fig)
+           # do stuff with your_additional_args
+
+
+3. (optional) adjust the ``_basic_ui_elements(self)`` function.
+    The base class already creates dropdown widgets for interactive selection of scan and simulation directories as well as a slider to adjust the simulation time (i.e. the iteration).
+    If your class does not need some of those widgets, feel free to override this function.
+    It needs to return a list of widgets.
+    Note that scan and simulation dropdowns should probably be returned in any case to allow switching between different simulations.
+
+4. implement the  ``_extra_ui_elements(self)`` function.
+
+    This function has to define jupyter widgets as member variables of the class to allow interactive manipulation of parameters the underlying matplotlib visualizer is capable of handling.
+    It needs to return a list of those widgets.
+
+.. code:: python
+
+   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_visualizer.py
+   def _extra_ui_elements(self):
+       """
+       Create and return as a list the individual widgets that are necessary
+       for this special visualizer.
+       """
+       self.species = widgets.Dropdown(description="Species",
+                                       options=["e"],
+                                       value='e')
+       self.species_filter = widgets.Dropdown(description="Species_filter",
+                                              options=['all'],
+                                              value="all")
+       return [self.species, self.species_filter]
+
+5. implement the ``_extra_ui_elements_value(self)`` function.
+
+    This function acts as the connection between the widgets specified above and transfering their values to the underlying matplotlib visualizer instance.
+    It therefore needs to return a dictionary with an entry for every widget specified in 4.
+    The keys must be the parameter names that the matplotlib visualizer accepts in its call to the ``visualize`` function.
+    The values will be the corresponding values of the widget elements for this parameter.
+
+.. code:: python
+
+   # taken from lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_visualizer.py
+   def _extra_ui_elements_value(self):
+       """
+       Map widget values to parameter names for the plot_mpl visualizer.
+       """
+       return {'species': self.species.value,
+               'species_filter': self.species_filter.value}

--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -68,9 +68,10 @@ Python Postprocessing
 In order to further work with the data produced by a plugin during a simulation run, PIConGPU provides python tools that can be used for reading data and visualization.
 They can be found under ``lib/python/picongpu/plugins``.
 
-It is our goal to provide at least two modules for each plugin to make postprocessing as convenient as possible:
+It is our goal to provide at least three modules for each plugin to make postprocessing as convenient as possible:
 1. a data reader (inside the ``data`` subdirectory)
 2. a matplotlib visualizer (inside the ``plot_mpl`` subdirectory)
+3. a jupyter widget visualizer (inside the ``jupyter_widgets`` subdirectory) for usage in jupyter-notebooks
 
 Further information on how to use these tools can be found at each plugin page.
 

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -153,3 +153,34 @@ Argument Value
 2nd      Simulation time step (needs to exist)
 3rd      Label for particle count used in the graph that this tool produces.
 ======== ===================================================================
+
+
+
+Jupyter Widget
+""""""""""""""
+
+If you want more interactive visualization, then start a jupyter notebook and make
+sure that ``ipywidgets`` and ``ìpympl`` are installed.
+
+Since this widget makes most sense in cases where many simulations were run and
+ordered in so called 'scans' it is assumed that there exists an output directory
+which contains directories ``scan_1``, ..., ``scan_N`` and each such directory
+contains one or many simulation directories ``sim_1`` to ``sim_M``.
+Of course visualizing iterations of a single simulation is also possible, but please
+adhere to the directory structure explained above.
+
+After starting the notebook server write the following
+
+.. code:: python
+
+   %matplotlib widget
+   import matplotlib.pyplot as plt
+   plt.ioff()
+
+   from IPython.display import display
+   from picongpu.plugins.jupyter_widgets import EnergyHistogramVisualizer
+
+   v = EnergyHistogramVisualizer(experiment_path="path/to/scan/outputs")
+   display(v)
+
+and then interact with the displayed widgets.

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -95,10 +95,23 @@ You can quickly load and interact with the data in Python with:
 
    from picongpu.plugins.data import EnergyHistogramData
 
-
-   # load data
    eh_data = EnergyHistogramData('/home/axel/runs/lwfa_001')
+
+   # show available iterations
+   eh_data.get_iterations(species='e')
+
+   # show available simulation times
+   eh_data.get_times(species='e')
+
+   # load data for a given iteration
    counts, bins_keV = eh_data.get('e', species_filter='all', iteration=2000)
+
+   # load data for a given time
+   counts, bins_keV = eh_data.get('e', species_filter='all', time=1.3900e-14)
+
+   # get data for multiple iterations
+   d, bins, iteration, dt = eh_data.get(species='e', iteration=[200, 400, 8000])
+
 
 Matplotlib Visualizer
 """""""""""""""""""""
@@ -121,7 +134,22 @@ You can quickly plot the data in Python with:
 
    plt.show()
 
-The visualizer can also be used from the command line by writing
+   # specifying simulation time is also possible (granted there is a matching iteration for that time)
+   eh_vis.visualize(time=2.6410e-13, species='e')
+
+   plt.show()
+
+   # plotting histogram data for multiple simulations simultaneously also works:
+   eh_vis = EnergyHistogramMPL([
+        ("sim1", "path/to/sim1"),
+        ("sim2", "path/to/sim2"),
+        ("sim3", "path/to/sim3")], ax)
+    eh_vis.visualize(species="e", iteration=10000)
+
+    plt.show()
+
+
+The visualizer can also be used from the command line (for a single simulation only) by writing
 
  .. code:: bash
 
@@ -162,25 +190,24 @@ Jupyter Widget
 If you want more interactive visualization, then start a jupyter notebook and make
 sure that ``ipywidgets`` and ``ìpympl`` are installed.
 
-Since this widget makes most sense in cases where many simulations were run and
-ordered in so called 'scans' it is assumed that there exists an output directory
-which contains directories ``scan_1``, ..., ``scan_N`` and each such directory
-contains one or many simulation directories ``sim_1`` to ``sim_M``.
-Of course visualizing iterations of a single simulation is also possible, but please
-adhere to the directory structure explained above.
-
 After starting the notebook server write the following
 
 .. code:: python
 
+   # this is required!
    %matplotlib widget
    import matplotlib.pyplot as plt
    plt.ioff()
 
    from IPython.display import display
-   from picongpu.plugins.jupyter_widgets import EnergyHistogramVisualizer
+   from picongpu.plugins.jupyter_widgets import EnergyHistogramWidget
 
-   v = EnergyHistogramVisualizer(experiment_path="path/to/scan/outputs")
-   display(v)
+   # provide the paths to the simulations you want to be able to choose from
+   # together with labels that will be used in the plot legends so you still know
+   # which data belongs to which simulation
+   w = EnergyHistogramWidget(run_dir_options=[
+           ("scan1/sim4", scan1_sim4),
+           ("scan1/sim5", scan1_sim5)])
+   display(w)
 
 and then interact with the displayed widgets.

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -71,9 +71,14 @@ You can quickly load and interact with the data in Python with:
    import numpy as np
 
 
-   # load data
    ps_data = PhaseSpaceData('/home/axel/runs/lwfa_001')
-   # a list of iterations is also possible
+   # show available iterations
+   ps_data.get_iterations(ps="xpx", species="e", species_filter='all')
+
+   # show available simulation times
+   ps_data.get_times(ps="xpx", species="e", species_filter='all')
+
+   # load data for a given iteration
    ps, meta = ps_data.get(ps='ypy', species='e', species_filter='all', iteration=2000)
 
    # unit conversion from SI
@@ -82,6 +87,17 @@ You can quickly load and interact with the data in Python with:
 
    Q_dr_dp = np.abs(ps) * meta.dV  # C s kg^-1 m^-2
    extent = meta.extent * [mu, mu, e_mc_r, e_mc_r]  # spatial: microns, momentum: beta*gamma
+
+   # load data for a given time
+   ps, ps_meta = ps_data.get(ps="xpx", species="e", species_filter='all', time=1.3900e-14)
+
+   # load data for multiple iterations
+   ret = ps_data.get(ps="xpx", species="e", species_filter='all', iteration=[2000, 4000])
+
+   # data and metadata for iteration 2000
+   # (data is in same order as the value passed to the 'iteration' parameter)
+   ps, meta = ret[0]
+
 
 Note that the spatial extent of the output over time might change when running a moving window simulation.
 
@@ -107,7 +123,22 @@ You can quickly plot the data in Python with:
 
    plt.show()
 
-The visualizer can also be used from the command line by writing
+   # specifying simulation time is also possible (granted there is a matching iteration for that time)
+   ps_vis.visualize(time=2.6410e-13, species='e')
+
+   plt.show()
+
+   # plotting data for multiple simulations simultaneously also works:
+   ps_vis = PhaseSpaceMPL([
+        ("sim1", "path/to/sim1"),
+        ("sim2", "path/to/sim2"),
+        ("sim3", "path/to/sim3")], ax)
+    ps_vis.visualize(species="e", iteration=10000)
+
+    plt.show()
+
+
+The visualizer can also be used from the command line (for a single simulation only) by writing
 
  .. code:: bash
 
@@ -131,26 +162,25 @@ Jupyter Widget
 If you want more interactive visualization, then start a jupyter notebook and make
 sure that ``ipywidgets`` and ``ìpympl`` are installed.
 
-Since this widget makes most sense in cases where many simulations were run and
-ordered in so called 'scans' it is assumed that there exists an output directory
-which contains directories ``scan_1``, ..., ``scan_N`` and each such directory
-contains one or many simulation directories ``sim_1`` to ``sim_M``.
-Of course visualizing iterations of a single simulation is also possible, but please
-adhere to the directory structure explained above.
-
 After starting the notebook server write the following
 
 .. code:: python
-
+   # this is required!
    %matplotlib widget
    import matplotlib.pyplot as plt
    plt.ioff()
 
    from IPython.display import display
-   from picongpu.plugins.jupyter_widgets import PhaseSpaceVisualizer
+   from picongpu.plugins.jupyter_widgets import PhaseSpaceWidget
 
-   v = PhaseSpaceVisualizer(experiment_path="path/to/scan/outputs")
-   display(v)
+   # provide the paths to the simulations you want to be able to choose from
+   # together with labels that will be used in the plot legends so you still know
+   # which data belongs to which simulation
+   w = PhaseSpaceWidget(run_dir_options=[
+           ("scan1/sim4", scan1_sim4),
+           ("scan1/sim5", scan1_sim5)])
+   display(w)
+
 
 and then interact with the displayed widgets.
 

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -125,6 +125,36 @@ Options                              Value
 -m (optional, defaults to 'ypy')     Momentum string to specify the phase space
 ================================     =======================================================
 
+Jupyter Widget
+""""""""""""""
+
+If you want more interactive visualization, then start a jupyter notebook and make
+sure that ``ipywidgets`` and ``ìpympl`` are installed.
+
+Since this widget makes most sense in cases where many simulations were run and
+ordered in so called 'scans' it is assumed that there exists an output directory
+which contains directories ``scan_1``, ..., ``scan_N`` and each such directory
+contains one or many simulation directories ``sim_1`` to ``sim_M``.
+Of course visualizing iterations of a single simulation is also possible, but please
+adhere to the directory structure explained above.
+
+After starting the notebook server write the following
+
+.. code:: python
+
+   %matplotlib widget
+   import matplotlib.pyplot as plt
+   plt.ioff()
+
+   from IPython.display import display
+   from picongpu.plugins.jupyter_widgets import PhaseSpaceVisualizer
+
+   v = PhaseSpaceVisualizer(experiment_path="path/to/scan/outputs")
+   display(v)
+
+and then interact with the displayed widgets.
+
+
 Out-of-Range Behavior
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -265,10 +265,14 @@ You can quickly load and interact with the data in Python with:
    # get the available iterations for which output exists
    iters = png_data.get_iterations(species="e", axis="yx")
 
-   # pngs as numpy arrays
+   # get the available simulation times for which output exists
+   times = png_data.get_times(species="e", axis="yx")
+
+   # pngs as numpy arrays for multiple iterations (times would also work)
    pngs = png_data.get(species="e", axis="yx", iteration=iters[:3])
 
-   pngs[iters[0]].shape
+   for png in pngs:
+       print(png.shape)
 
 Matplotlib Visualizer
 """""""""""""""""""""
@@ -318,26 +322,25 @@ Jupyter Widget
 If you want more interactive visualization, then start a jupyter notebook and make
 sure that ``ipywidgets`` and ``ìpympl`` are installed.
 
-Since this widget makes most sense in cases where many simulations were run and
-ordered in so called 'scans' it is assumed that there exists an output directory
-which contains directories ``scan_1``, ..., ``scan_N`` and each such directory
-contains one or many simulation directories ``sim_1`` to ``sim_M``.
-Of course visualizing iterations of a single simulation is also possible, but please
-adhere to the directory structure explained above.
-
 After starting the notebook server write the following
 
 .. code:: python
 
+   # this is required!
    %matplotlib widget
    import matplotlib.pyplot as plt
    # deactivate interactive mode
    plt.ioff()
 
    from IPython.display import display
-   from picongpu.plugins.jupyter_widgets import PNGVisualizer
+   from picongpu.plugins.jupyter_widgets import PNGWidget
 
-   v = PNGVisualizer(experiment_path="path/to/scan/outputs")
-   display(v)
+   # provide the paths to the simulations you want to be able to choose from
+   # together with labels that will be used in the plot legends so you still know
+   # which data belongs to which simulation
+   w = PNGWidget(run_dir_options=[
+           ("scan1/sim4", scan1_sim4),
+           ("scan1/sim5", scan1_sim5)])
+   display(w)
 
 and then interact with the displayed widgets.

--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -311,3 +311,33 @@ Options                            Value
 -a (optional, defaults to 'yx')    Axis string (e.g. 'yx' or 'xy')
 -o (optional, defaults to 'None')  A float between 0 and 1 for slice offset along the third dimension
 =================================  ==================================================================
+
+Jupyter Widget
+""""""""""""""
+
+If you want more interactive visualization, then start a jupyter notebook and make
+sure that ``ipywidgets`` and ``ìpympl`` are installed.
+
+Since this widget makes most sense in cases where many simulations were run and
+ordered in so called 'scans' it is assumed that there exists an output directory
+which contains directories ``scan_1``, ..., ``scan_N`` and each such directory
+contains one or many simulation directories ``sim_1`` to ``sim_M``.
+Of course visualizing iterations of a single simulation is also possible, but please
+adhere to the directory structure explained above.
+
+After starting the notebook server write the following
+
+.. code:: python
+
+   %matplotlib widget
+   import matplotlib.pyplot as plt
+   # deactivate interactive mode
+   plt.ioff()
+
+   from IPython.display import display
+   from picongpu.plugins.jupyter_widgets import PNGVisualizer
+
+   v = PNGVisualizer(experiment_path="path/to/scan/outputs")
+   display(v)
+
+and then interact with the displayed widgets.

--- a/lib/python/picongpu/plugins/jupyter_widgets/__init__.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/__init__.py
@@ -1,0 +1,7 @@
+from .energy_histogram_widget import EnergyHistogramWidget
+from .phase_space_widget import PhaseSpaceWidget
+from .png_widget import PNGWidget
+
+__all__ = ["EnergyHistogramWidget",
+           "PhaseSpaceWidget",
+           "PNGWidget"]

--- a/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2018 PIConGPU contributors
+Copyright 2017-2019 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
@@ -1,0 +1,442 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2017-2018 PIConGPU contributors
+Authors: Sebastian Starke
+License: GPLv3+
+"""
+
+import matplotlib.pyplot as plt
+
+from ipywidgets import widgets
+from datetime import datetime
+from warnings import warn
+
+
+class BaseWidget(widgets.VBox):
+    """
+    Basic widget class that wraps a corresponding plot_mpl visualizer.
+    It handles selection of scans, simulations and iterations.
+    It also allows to expose the parameters of the
+    corresponding plot_mpl visualizer via jupyter widgets to the user.
+    Only classes derived from this base class should be used!
+
+    Note: In order to work, those objects should be used in %matplotlib widget
+    mode and interactive plotting should be switched off (by using plt.ioff()).
+    """
+    def __init__(self, plot_mpl_cls, run_dir_options=None, fig=None, **kwargs):
+        """
+        Parameters
+        ----------
+        run_dir_options: list
+            list of tuples with label and filepath
+        plot_mpl_cls: a valid plot_mpl class handle (not string!)
+            Specifies the underlying plot_mpl visualizer that will be used.
+        fig: a matplotlib figure instance.(optional)
+            If no figure is provided, the widget will create its own figure.
+            Otherwise the widget will draw into the provided figure and will
+            not create its own.
+        kwargs: options for plotting, passed on to matplotlib commands.
+        """
+        widgets.VBox.__init__(self)
+        # if no figure is given, we create one and add it to children
+        # if one is given, we don't add it as part of children
+        add_fig_to_children = fig is None
+        # setting of figure and ax
+        self.fig = None
+        self.ax = None
+        self._init_fig_and_ax(fig, **kwargs)
+
+        # create the PIConGPU visualizer instance but do not set
+        # any run directories yet
+        self.plot_mpl = plot_mpl_cls(None, ax=self.ax)
+
+        self.label_path_lut = None
+        self._create_label_path_lookup(run_dir_options)
+
+        # widgets for selecting the simulation and the simulation step
+        # dependent on the derived class which widget it should be
+        # use the simulation labels of the plot_mpl visualizer from picongpu
+        self.sim_drop = self._create_sim_dropdown(
+            sorted(list(self.label_path_lut.keys())))
+        self.sim_drop.observe(
+            self._handle_run_dir_selection_callback, names='value')
+
+        self.sim_time_slider = widgets.SelectionSlider(
+            description='Time [s]',
+            options=[""],
+            continuous_update=False,
+            # layout=widgets.Layout(width='65%', height='10%'))
+        )
+        self.sim_time_slider.observe(self._visualize_callback, names='value')
+
+        # widgets that this specific widget might need
+        # to expose the parameters of the plot_mpl object.
+        self.widgets_for_vis_args = \
+            self._create_widgets_for_vis_args()
+        # Its changes will result in changes to the plot
+        for _, widg in self.widgets_for_vis_args.items():
+            widg.observe(self._visualize_callback, names='value')
+
+        # register the ui elements that will be displayed
+        # as children of this object.
+        vis_widgets = widgets.VBox(
+            children=[
+                self.sim_drop,
+                widgets.VBox(
+                    children=list(self.widgets_for_vis_args.values()))])
+        if add_fig_to_children:
+            top = widgets.HBox(children=[vis_widgets, self.fig.canvas])
+        else:
+            top = vis_widgets
+        bottom = self.sim_time_slider
+        self.children = [top, bottom]
+
+    def _create_label_path_lookup(self, run_dir_options):
+        """
+        Creates the lookup table from simulation labels to their paths.
+
+        Parameters
+        ----------
+        run_dir_options: str or list of str or list of tuples of (str, str)
+                         with a label and the path to the simulation.
+        """
+        # conversion from single element to list
+        if not isinstance(run_dir_options, list):
+            run_dir_options = [run_dir_options]
+
+        if len(run_dir_options) < 1:
+            warn("Empty run_dir_options list was passed!")
+            lut = {}
+        else:
+            if isinstance(run_dir_options[0], str):
+                # enumeration as labels
+                lut = {str(i): path for i, path in enumerate(run_dir_options)}
+            else:
+                # assume run_dir_options is a list of tuples of length two
+                lut = {label: path for label, path in run_dir_options}
+
+        # lookup table from label strings to paths
+        self.label_path_lut = lut
+
+    def _show_run_dir_options_in_dropdown(self):
+        """
+        Make the labels of the run_dir_options lookup table available for
+        selection as options for the dropdown.
+        """
+        sim_options = sorted(list(self.label_path_lut.keys()))
+        self.sim_drop.unobserve(
+            self._handle_run_dir_selection_callback, names='value')
+        # set the UI
+        self.sim_drop.options = sim_options
+        # re-enable the callback functions
+        self.sim_drop.observe(
+            self._handle_run_dir_selection_callback, names='value')
+
+    def set_run_dir_options(self, run_dir_options):
+        """
+        Re-set the selectable simulations and everything that is affected
+        by it in the dropdown menu.
+
+        Parameters
+        ----------
+        run_dir_options: list
+            list of tuples of length two with
+            a label and a path to a PIConGPU simulation
+        """
+        # renew the lookup table
+        self._create_label_path_lookup(run_dir_options)
+        # set the options in the dropdown
+        self._show_run_dir_options_in_dropdown()
+
+    def _init_fig_and_ax(self, fig, **kwargs):
+        """
+        Creates the figure and the ax as members.
+        """
+        if fig is None:
+            # create a new figure and add them to the plot
+            self.fig, self.ax = plt.subplots(1, 1, **kwargs)
+        else:
+            # Take the figure and do NOT add it to the children list but
+            # instead just draw straight into it.
+            # This way other elements can compose figure
+            # and this widget in any way they like.
+
+            # still clear the figure first to get rid of stuff that
+            # still might be there
+            # from some other plotting
+            fig.clear()
+            self.fig = fig
+            # provide unique label so new axes are always created
+            lab = (str(type(self)) +
+                   "_" + datetime.now().strftime("%Y%m%d%H%M%S"))
+            self.ax = fig.add_subplot(111, label=lab)
+
+# interface functions that can be overridden
+    def _create_sim_dropdown(self, options):
+        """
+        Provide the widget for selection of simulations.
+        Can be overridden in derived classes if some of those widgets
+        are not necessary.
+        Note: Make sure that no value of the widget is selected initially
+        since otherwise initial plotting after creation of the widget might
+        not work (since the constructor sets the value to the first available
+        which leads to the visualization callback being triggered.)
+
+        Returns
+        -------
+        a jupyter widget that allows selection of value(s)
+        """
+        sim_drop = widgets.SelectMultiple(
+            description="Sims", options=options, value=())
+
+        return sim_drop
+
+    def _create_widgets_for_vis_args(self):
+        """
+        Provide additional UI widget elements that expose the parameters
+        of the underlying plot_mpl visualizer instance that the user should
+        be able to modify.
+
+        Returns
+        -------
+        a dict mapping keyword argument names of the PIC visualizer
+        to the widgets that are used for adjusting those values.
+        Those widgets should be created in this function as well.
+
+        Note: no callback for plotting needs to be registered, this is done
+        automatically during construction.
+        """
+        return {}
+
+    def _get_widget_args(self):
+        """
+        Returns
+        -------
+        a dict mapping keyword argument names of the PIC visualizer
+        to the values of the corresponding widget elements.
+        """
+        return {arg: widg.value
+                for arg, widg in self.widgets_for_vis_args.items()}
+
+# functions that should NOT be overridden
+    def _handle_run_dir_selection(self, run_dir_selection):
+        """
+        Update the run_directories and the common simulation times.
+        """
+        # 1. need to set the run directories
+        self._update_plot_mpl_run_dir(run_dir_selection)
+
+        # 2. need to compute the simulation time common to all selected
+        #    simulations and set the slider value to one of those values
+        #    (without triggering the callback)
+        self._update_available_sim_times()
+
+    def _handle_run_dir_selection_callback(self, change):
+        """
+        Callback function when user selects a subset of the
+        available simulations.
+        """
+        selected_sims_labels = change['new']
+
+        self._handle_run_dir_selection(selected_sims_labels)
+
+        # 3. visualize
+        self.visualize()
+
+    def _update_plot_mpl_run_dir(self, selected_sims):
+        """
+        Passes the selected simulations to the
+        visualizer instance.
+
+        Parameters
+        ----------
+        selected_sims: list
+            list of simulation labels which will be translated to their path.
+        """
+        if isinstance(selected_sims, tuple):
+            # handle the case for a single selected value from
+            # a widgets.Dropdown instance
+            selected_sims = list(selected_sims)
+
+        if not isinstance(selected_sims, list):
+            selected_sims = [selected_sims]
+
+        # print("in _update_plot_mpl_run_dir, selected_sims =", selected_sims)
+
+        run_dirs = [self.label_path_lut[label] for label in selected_sims]
+        # prepare nicer labels for run_dirs in the plots
+        run_dirs = list(zip(selected_sims, run_dirs))
+
+        self.plot_mpl.set_run_directories(run_dirs)
+
+    def _update_available_sim_times(self):
+        """
+        Computes the intersection of simulation times that are present
+        in all simulations currently selected.
+        It automatically plots the iteration step that best matches the
+        specified simulation time.
+        """
+        # get the available iterations for every simulation
+        # and build the intersection
+        all_sim_times = []  # list of sets
+        for reader in self.plot_mpl.data_reader:
+            # query the reader for the available sim_times
+            try:
+                vis_params = self._get_widget_args()
+                times_avail = reader.get_times(
+                    **vis_params)
+            except IOError as e:
+                print("Getting times failed!", e)
+                raise e
+            # print(reader.run_directory, ":", times_avail)
+            all_sim_times.append(set(times_avail))
+
+        # the simulation times shared by all selected simulations
+        common_sim_times = sorted(list(set.intersection(*all_sim_times)))
+        if len(common_sim_times) == 0:
+            common_sim_times = [""]
+        # print("common_sim_times = ", common_sim_times)
+        # Note: this would trigger the callback function of the
+        # iteration slider and we deactivate it here first
+        self.sim_time_slider.unobserve(self._visualize_callback,
+                                       names='value')
+        # changing the option might silently also
+        # adjust the .value attribute!
+        self.sim_time_slider.options = common_sim_times
+        last_selected_val = self.sim_time_slider.value
+        # if the previously used iteration is available, use it as value
+        # otherwise start from first available
+        if last_selected_val in self.sim_time_slider.options:
+            self.sim_time_slider.value = last_selected_val
+        else:
+            print("last selected time {0} not present with newly"
+                  " selected sim_times, set to {1}".format(
+                        last_selected_val, common_sim_times[0]))
+            self.sim_time_slider.value = common_sim_times[0]
+
+        # re-enable the callback
+        self.sim_time_slider.observe(self._visualize_callback,
+                                     names='value')
+
+    def _visualize_callback(self, change):
+        """
+        Callback that is executed when one of the extra_ui_elements
+        changes or the iteration changes."""
+        self.visualize()
+
+    def visualize(self, **kwargs):
+        """
+        Draw the plot by getting all necessary parameter values from the
+        exposed widgets.
+
+        Parameters
+        ----------
+        kwargs: dict
+            Ignored at the moment.
+        """
+        time = self.sim_time_slider.value
+
+        # the case where no valid iteration is provided
+        if time is None or time is "":
+            return
+
+        # print("{} called visualize for time {} and run_dirs {}".format(
+        #     type(self), time,
+        #     [reader.run_directory for reader in self.plot_mpl.data_reader]))
+
+        vis_params = self._get_widget_args()
+        try:
+            self.plot_mpl.visualize(time=time,
+                                    **vis_params)
+        except Exception as e:
+            warn("{}: visualization failed! Reason: {} ".format(type(self), e))
+            # raise e
+
+        # since interactive mode should be turned off, we have
+        # to update the figure explicitely
+        try:
+            self.fig.canvas.draw()
+            self.fig.canvas.flush_events()
+        except ValueError as e:
+            warn("{}: drawing the plot failed! Reason: {}".format(
+                type(self), e))
+            # raise e
+
+    def _make_drop_val_compatible(self, val):
+        """
+        Depending on the type of self.sim_drop we have to
+        assign a single value or a tuple to the self.sim_drop.value.
+        This function converts the 'val' in a way to be compatible
+        with the expected type.
+        """
+        # handle conversion from SelectMultiple which expects
+        # tuples to ordinary dropdown which accepts a single value
+        if isinstance(self.sim_drop, widgets.Dropdown):
+            # handle SelectMultiple -> Dropdown
+            if isinstance(val, tuple):
+                val = val[0]
+        elif isinstance(self.sim_drop, widgets.SelectMultiple):
+            # handle Dropdown -> SelectMultiple
+            if not isinstance(val, tuple):
+                val = (val,)
+
+        return val
+
+    def _use_options_from_other(self, other):
+        """
+        Uses the options from another instance derived from this class
+        to instantly set e.g. the simulation time or the selected simulation.
+
+        This should only be used when switching the visualizer but keeping
+        the run_dir_options as they are.
+        """
+        other_sim = other.sim_drop.value
+        # skip this if other_sim is None (when coming from Dropdown)
+        # or empty (when coming from a SelectMultiple)
+        if other_sim is None or len(other_sim) == 0:
+            return
+
+        # setting the previously selected simulations
+        # (without executing callback)
+        self.sim_drop.unobserve(
+            self._handle_run_dir_selection_callback, names='value')
+        self.sim_drop.value = self._make_drop_val_compatible(other_sim)
+        self.sim_drop.observe(
+            self._handle_run_dir_selection_callback, names='value')
+
+        # manually update the run directories and the simulation times.
+        # Needed since we deactivated the callback to prevent plotting
+        self._handle_run_dir_selection(self.sim_drop.value)
+
+        other_time = other.sim_time_slider.value
+        # check if other_time is available before setting it
+        # this also triggers visualization
+        self.sim_time_slider.unobserve(
+            self._visualize_callback, names='value')
+
+        if other_time in self.sim_time_slider.options:
+            self.sim_time_slider.value = other_time
+        else:
+            # we dont have the selected time of the other widget
+            # so we choose the first available
+            self.sim_time_slider.value = self.sim_time_slider.options[0]
+
+        self.sim_time_slider.observe(
+            self._visualize_callback, names='value')
+
+        # species, filter and other stuff (extra_ui_elements)
+        for arg, other_widget in other.widgets_for_vis_args.items():
+            # if the keyword matches, we assign the value
+            # of the other widget to our widget
+            if arg in self.widgets_for_vis_args:
+                other_value = other_widget.value
+                own_widget = self.widgets_for_vis_args[arg]
+                # prevent triggering the callback each time
+                # but defer it until all args are set
+                own_widget.unobserve(self._visualize_callback, names='value')
+                own_widget.value = other_value
+                own_widget.observe(self._visualize_callback, names='value')
+
+    def _clean_ax(self):
+        self.plot_mpl._clean_ax()

--- a/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
@@ -1,0 +1,55 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2017-2018 PIConGPU contributors
+Authors: Sebastian Starke
+License: GPLv3+
+"""
+
+from .base_widget import BaseWidget
+from picongpu.plugins.plot_mpl import EnergyHistogramMPL
+
+from ipywidgets import widgets
+
+
+class EnergyHistogramWidget(BaseWidget):
+    """
+    From within jupyter notebook this widget can be used in the following way:
+
+        %matplotlib widget
+        import matplotlib.pyplot as plt
+        plt.ioff() # deactivating instant plotting is necessary!
+
+        from picongpu.plugins.jupyter_widgets import EnergyHistogramWidget
+
+        display(EnergyHistogramWidget(run_dir_options="path/to/outputs"))
+    """
+    def __init__(self, run_dir_options, fig=None, **kwargs):
+
+        BaseWidget.__init__(self,
+                            EnergyHistogramMPL,
+                            run_dir_options,
+                            fig,
+                            **kwargs)
+
+    def _create_widgets_for_vis_args(self):
+        """
+        Create the widgets that are necessary for adjusting the
+        visualization parameters of this special visualizer.
+
+        Returns
+        -------
+        a dict mapping keyword argument names of the PIC visualizer
+        to the jupyter widgets responsible for adjusting those values.
+        """
+        # widgets for the input parameters
+        # widgets for the input parameters
+        self.species = widgets.Dropdown(description="Species",
+                                        options=["e"],
+                                        value='e')
+        self.species_filter = widgets.Dropdown(description="Species_filter",
+                                               options=['all'],
+                                               value="all")
+
+        return {'species': self.species,
+                'species_filter': self.species_filter}

--- a/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2018 PIConGPU contributors
+Copyright 2017-2019 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """
@@ -42,8 +42,6 @@ class EnergyHistogramWidget(BaseWidget):
         a dict mapping keyword argument names of the PIC visualizer
         to the jupyter widgets responsible for adjusting those values.
         """
-        # widgets for the input parameters
-        # widgets for the input parameters
         self.species = widgets.Dropdown(description="Species",
                                         options=["e"],
                                         value='e')

--- a/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
@@ -1,0 +1,57 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2017-2018 PIConGPU contributors
+Authors: Sebastian Starke
+License: GPLv3+
+"""
+
+from .base_widget import BaseWidget
+from picongpu.plugins.plot_mpl import PhaseSpaceMPL
+
+from ipywidgets import widgets
+
+
+class PhaseSpaceWidget(BaseWidget):
+    """
+    From within jupyter notebook this widget can be used in the following way:
+
+        %matplotlib widget
+        import matplotlib.pyplot as plt
+        plt.ioff() # deactivate instant plotting is necessary!
+
+        from picongpu.plugins.jupyter_widgets import PhaseSpaceWidget
+
+        display(PhaseSpaceWidget(run_dir_options="path/to/outputs"))
+    """
+    def __init__(self, run_dir_options, fig=None, **kwargs):
+
+        BaseWidget.__init__(self,
+                            PhaseSpaceMPL,
+                            run_dir_options,
+                            fig,
+                            **kwargs)
+
+    def _create_widgets_for_vis_args(self):
+        """
+        Create the widgets that are necessary for adjusting the
+        visualization parameters of this special visualizer.
+
+        Returns
+        -------
+        a dict mapping keyword argument names of the PIC visualizer
+        to the jupyter widgets responsible for adjusting those values.
+        """
+        self.species = widgets.Dropdown(description="Species",
+                                        options=["e"],
+                                        value='e')
+        self.species_filter = widgets.Dropdown(description="Species_filter",
+                                               options=['all'],
+                                               value="all")
+        self.ps = widgets.Dropdown(description="ps",
+                                   options=['ypy'],
+                                   value='ypy')
+
+        return {'species': self.species,
+                'species_filter': self.species_filter,
+                'ps': self.ps}

--- a/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2018 PIConGPU contributors
+Copyright 2017-2019 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2018 PIConGPU contributors
+Copyright 2017-2019 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
@@ -1,0 +1,68 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2017-2018 PIConGPU contributors
+Authors: Sebastian Starke
+License: GPLv3+
+"""
+
+from .base_widget import BaseWidget
+from picongpu.plugins.plot_mpl import PNGMPL
+
+from ipywidgets import widgets
+
+
+class PNGWidget(BaseWidget):
+    """
+    From within jupyter notebook this widget can be used in the following way:
+
+        %matplotlib widget
+        import matplotlib.pyplot as plt
+        plt.ioff() # deactivate instant plotting is necessary!
+
+        from picongpu.plugins.jupyter_widgets import PNGWidget
+
+        display(PNGWidget(run_dir_options="path/to/outputs"))
+    """
+    def __init__(self, run_dir_options, fig=None, **kwargs):
+
+        BaseWidget.__init__(self,
+                            PNGMPL,
+                            run_dir_options,
+                            fig,
+                            **kwargs)
+
+    def _create_sim_dropdown(self, options):
+        """
+        The widget for displaying the available simulations.
+        This should be a Dropdown since the underlying
+        visualizer can not deal with multiple run_directories!
+        """
+        sim_drop = widgets.Dropdown(
+            description="Sims", options=options, value=None)
+
+        return sim_drop
+
+    def _create_widgets_for_vis_args(self):
+        """
+        Create the widgets that are necessary for adjusting the
+        visualization parameters of this special visualizer.
+
+        Returns
+        -------
+        a dict mapping keyword argument names of the PIC visualizer
+        to the jupyter widgets responsible for adjusting those values.
+        """
+        self.species = widgets.Dropdown(description="Species",
+                                        options=["e"],
+                                        value='e')
+        self.species_filter = widgets.Dropdown(description="Species_filter",
+                                               options=['all'],
+                                               value="all")
+        self.axis = widgets.Dropdown(description="Axis",
+                                     options=["yx", "yz"],
+                                     value="yx")
+
+        return {'species': self.species,
+                'species_filter': self.species_filter,
+                'axis': self.axis}

--- a/lib/python/picongpu/plugins/jupyter_widgets/requirements.txt
+++ b/lib/python/picongpu/plugins/jupyter_widgets/requirements.txt
@@ -1,0 +1,3 @@
+ipywidgets
+ipympl
+-r ../plot_mpl/requirements.txt

--- a/lib/python/picongpu/plugins/jupyter_widgets/utils.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/utils.py
@@ -1,0 +1,33 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2017-2018 PIConGPU contributors
+Authors: Sebastian Starke
+License: GPLv3+
+"""
+
+import os
+
+
+def get_all_dirs_with_prefix(path, prefix):
+    """
+    Returns all directories starting with a given prefix within the given
+    path
+    """
+    dirs = [d for d in os.listdir(
+        path) if os.path.isdir(os.path.join(path, d))]
+
+    prefix_filtered = [d for d in dirs if d.startswith(prefix)]
+    return sorted(prefix_filtered)
+
+
+def get_all_scans(path):
+    """
+    """
+    return get_all_dirs_with_prefix(path, "scan_")
+
+
+def get_all_sims(path):
+    """
+    """
+    return get_all_dirs_with_prefix(path, "sim_")


### PR DESCRIPTION
This PR provides another wrapping layer around the plot_mpl visualizer classes that makes them regular jupyter widgets. 
The advantage here is that all the additional visualization options can be exposed via dropdowns, radio buttons or something like this.

Note: The axis is passed in the constructor, which is atm not done in the plot_mpl widgets but which will be put in another PR.

In a jupyter notebook, simply write the following
```python
import matplotlib.pyplot as plt

from IPython.display import display
from picongpu.plugins.jupyter_widgets import PhaseSpaceWidget

fig, ax = plt.subplots(1, 1)
run_dir = "path/to/simulation/run"

ps_widget = PhaseSpaceWidget(run_dir, ax)
display(ps_widget)

# the iteration has to be set manually at the moment
vis.iteration = 2000


```
- [x] rebase after #2728 is merged
- [x] rebase after  #2726 is merged