### PR TITLE
fix plotting tool for numerical heating

### DIFF
--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -25,7 +25,7 @@ __doc__ = '''
 This program compares the energy evolution of two PIConGPU runs.
 Just give the directory of two PIConGPU runs and this program will
 get all values needed if they are available.
-You should activate `--energy_fields` and any `--energy_X` (X any species)
+You should activate `--fields_energy` and any `--<species>_energy` (for any species)
 for both simulation runs with the same dumping period.
 A different number of particle species between both simulations
 is possible.
@@ -119,7 +119,7 @@ for sim in directories:
     mydir = sim+simDir
     # get relevant files with energy
     files = [f for f in os.listdir(mydir)
-             if os.path.isfile(os.path.join(mydir, f)) and re.search('^.*_energy_all.dat', f)]
+             if os.path.isfile(os.path.join(mydir, f)) and (re.search('^.*_energy_all.dat', f) or re.search('^.fields_energy.dat', f))]
     # check if file list is empty
     if len(files) == 0:
         sys.exit("There were no energy files in \"{}\".".format(mydir))


### PR DESCRIPTION
fix: #2687

The field energy is ignored/not used in the tool `plotNumericalHeating`.
This results into a wrong heating plot.

- add usage of `fields_energy.dat`
- fix documentation