### PR TITLE
fix gameOfLife

### DIFF
--- a/include/pmacc/mappings/kernel/MappingDescription.hpp
+++ b/include/pmacc/mappings/kernel/MappingDescription.hpp
@@ -57,7 +57,7 @@ public:
      * @param guardingSuperCells number of **supercells** within the guard
      */
     MappingDescription(
-        DataSpace<DIM> localGridCells = DataSpace<DIM> (),
+        DataSpace<DIM> localGridCells,
         DataSpace<DIM> guardingSuperCells = DataSpace<DIM>::create(0)
     ) :
         gridSuperCells(localGridCells / SuperCellSize::toRT()), /*block count per dimension*/

--- a/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -151,7 +151,7 @@ public:
          * MappingDesc stores the layout regarding Core, Border and Guard     *
          * in units of SuperCells.                                            *
          * This is saved by init to be used by the kernel to identify itself. */
-        evo.init(MappingDesc(layout.getDataSpace(), Space::create(1)));
+        evo.init(layout.getDataSpace(), Space::create(1));
 
         buff1 = new Buffer(layout, false);
         buff2 = new Buffer(layout, false);


### PR DESCRIPTION
The game of life example has a runtime issue that the mapping description verification
to check the number of supercells is always twrowing an error. The reason it that the
not existing default constructor is `MappingDescription` is used.
Please do not ask me why the code before is compiling. The class `MappingDescription` has no default constructor but is a not initialized member of the class `Evolution<>` which means by definition the default constructor should be called. Due to the fact that there is a user defined constructor there should be no default constructor available. 

Error message:
```
./gameOfLife -d  1 1  -g 128 128 -p 1 1 -r 23/3 -s 100
newborn if=3 stay alive if=23 mask=4108
terminate called after throwing an instance of 'std::runtime_error'
  what():  expression (( guardingSuperCells[ d ] == 0 && gridSuperCells[ d ] >= 1) || gridSuperCells[ d ] >= 2 * guardingSuperCells[ d ] + 1) failed in file (/include/pmacc/mappings/kernel/MappingDescription.hpp:82) : 
Aborted
```

- create the object for mapping description inside the init method of `Evolution`
- change interface of `Evolution<...>::init()`
- remove the default constructor for `MappingDescription` (it make no sense to allow a mapping with zero cells)

