### PR TITLE
accelerator `threads`

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -39,7 +39,7 @@ help()
     echo "                       (default is <inputDirectory>)"
     echo "-b | --backend       - set compute backend and optionally the architecture"
     echo "                       syntax: backend[:architecture]"
-    echo "                       supported backends: cuda, omp2b, serial, tbb"
+    echo "                       supported backends: cuda, omp2b, serial, tbb, threads"
     echo "                       (e.g.: \"cuda:20;35;37;52;60\" or \"omp2b:native\" or \"omp2b\")"
     echo "                       default: \"cuda\" if not set via environment variable PIC_BACKEND"
     echo "                       note: architecture names are compiler dependent"
@@ -74,6 +74,11 @@ get_backend_flags()
         fi
     elif [ "${backend_cfg[0]}" == "tbb" ] ; then
         result+=" -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON"
+        if [ $num_options -eq 2 ] ; then
+            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+        fi
+    elif [ "${backend_cfg[0]}" == "threads" ] ; then
+        result+=" -DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi


### PR DESCRIPTION
fix #2694

Allow the PIConGPU user to select the alpaka accelerator `ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE`.
This accelerator is called in PIConGPU `threads`.

- add `threads` to the `-b` option of `pic-configure`
- update help of `pic-configure`