### PR TITLE
fix misspelled words in plugin documentation

### DIFF
--- a/docs/source/usage/plugins/countParticles.rst
+++ b/docs/source/usage/plugins/countParticles.rst
@@ -11,7 +11,7 @@ Only in case of constant particle density, where each macro particle describes t
 ^^^^^^^^^
 
 The *CountParticles* plugin is always complied for all species.
-By specifying the perodicity of the output using the comand line argument ``--e_macroParticlesCount.period`` (here for an electron species called ``e``) with picongpu, the plugin is enabled.
+By specifying the periodicity of the output using the command line argument ``--e_macroParticlesCount.period`` (here for an electron species called ``e``) with picongpu, the plugin is enabled.
 Setting ``--e_macroParticlesCount.period 100`` adds the number of all electron like macro particles to the file `ElectronsCount.dat` for every 100th time step of the simulation.
 
 Memory Complexity
@@ -33,7 +33,7 @@ Output
 In the output file ``e_macroParticlesCount.dat``, there are three columns.
 The first is the integer number of the time step.
 The second is the number of macro particles as integer - useful for exact counts.
-And the third is the number of macro particles in scintific floating point notation - provides better human readability.
+And the third is the number of macro particles in scientific floating point notation - provides better human readability.
 
 Known Issues
 ^^^^^^^^^^^^

--- a/docs/source/usage/plugins/countParticles.rst
+++ b/docs/source/usage/plugins/countParticles.rst
@@ -12,7 +12,7 @@ Only in case of constant particle density, where each macro particle describes t
 
 The *CountParticles* plugin is always complied for all species.
 By specifying the periodicity of the output using the command line argument ``--e_macroParticlesCount.period`` (here for an electron species called ``e``) with picongpu, the plugin is enabled.
-Setting ``--e_macroParticlesCount.period 100`` adds the number of all electron like macro particles to the file `ElectronsCount.dat` for every 100th time step of the simulation.
+Setting ``--e_macroParticlesCount.period 100`` adds the number of all electron macro particles to the file `ElectronsCount.dat` for every 100th time step of the simulation.
 
 Memory Complexity
 ^^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ negligible.
 Output
 ^^^^^^
 
-In the output file ``e_macroParticlesCount.dat``, there are three columns.
+In the output file ``e_macroParticlesCount.dat`` there are three columns.
 The first is the integer number of the time step.
 The second is the number of macro particles as integer - useful for exact counts.
 And the third is the number of macro particles in scientific floating point notation - provides better human readability.

--- a/docs/source/usage/plugins/countPerSupercell.rst
+++ b/docs/source/usage/plugins/countPerSupercell.rst
@@ -14,8 +14,8 @@ The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <insta
 .cfg files
 ^^^^^^^^^^
 
-By specifying the periodicity of the output using the command line argument ``--e_macroParticlesPerSuperCell.period`` (here for an electron species ``e``) with picongpu, the plugin is enabled.
-Setting ``--e_macroParticlesPerSuperCell.period 100`` adds the number of all electron like macro particles to the file ``e_macroParticlesCount.dat`` for every 100th time step of the simulation.
+By specifying the periodicity of the output using the command line argument ``--e_macroParticlesPerSuperCell.period`` (here for an electron species ``e``) with picongpu the plugin is enabled.
+Setting ``--e_macroParticlesPerSuperCell.period 100`` adds the number of all electron macro particles to the file ``e_macroParticlesCount.dat`` for every 100th time step of the simulation.
 
 Accelerator
 """""""""""

--- a/docs/source/usage/plugins/countPerSupercell.rst
+++ b/docs/source/usage/plugins/countPerSupercell.rst
@@ -3,7 +3,7 @@
 Count per Supercell
 -------------------
 
-This plugin counts the total number of *macro particles of a species* for each super cell and sstores the result in an hdf5 file. 
+This plugin counts the total number of *macro particles of a species* for each super cell and stores the result in an hdf5 file. 
 Only in case of constant particle density, where each macro particle describes the same number of real particles (weighting), conclusions on the plasma density can be drawn.
 
 External Dependencies
@@ -14,7 +14,7 @@ The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <insta
 .cfg files
 ^^^^^^^^^^
 
-By specifying the perodicity of the output using the comand line argument ``--e_macroParticlesPerSuperCell.period`` (here for an electron species ``e``) with picongpu, the plugin is enabled.
+By specifying the periodicity of the output using the command line argument ``--e_macroParticlesPerSuperCell.period`` (here for an electron species ``e``) with picongpu, the plugin is enabled.
 Setting ``--e_macroParticlesPerSuperCell.period 100`` adds the number of all electron like macro particles to the file ``e_macroParticlesCount.dat`` for every 100th time step of the simulation.
 
 Accelerator

--- a/docs/source/usage/plugins/countPerSupercell.rst
+++ b/docs/source/usage/plugins/countPerSupercell.rst
@@ -4,7 +4,7 @@ Count per Supercell
 -------------------
 
 This plugin counts the total number of *macro particles of a species* for each super cell and stores the result in an hdf5 file. 
-Only in case of constant particle density, where each macro particle describes the same number of real particles (weighting), conclusions on the plasma density can be drawn.
+Only in case of constant particle weighting, where each macro particle describes the same number of real particles, conclusions on the plasma density can be drawn.
 
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -22,8 +22,8 @@ Currently, the plugin can be set *once for each species*.
 =========================================== =====================================================================================
 PIConGPU command line option                description
 =========================================== =====================================================================================
-``--e_energyHistogram.period``              The ouput periodicity of the **electron** histogram.
-                                            A value of ``100`` would mean aoutput at simulation time step *0, 100, 200, ...*.
+``--e_energyHistogram.period``              The output periodicity of the **electron** histogram.
+                                            A value of ``100`` would mean an output at simulation time step *0, 100, 200, ...*.
                                             If set to a non-zero value, the energy histogram of all **electrons** is computed.
                                             By default, the value is ``0`` and no histogram for the electrons is computed.
 ``--e_energy.filter``                       Use filtered particles. Available filters are set up in 

--- a/docs/source/usage/plugins/hdf5.rst
+++ b/docs/source/usage/plugins/hdf5.rst
@@ -12,7 +12,7 @@ What is the format of the created HDF5 files?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We write our fields and particles in an open markup called **openPMD**.
-You can investigate your files via a large collection of `tools and frameworks <https://github.com/openPMD/openPMD-projects>`_ or your use the native HDF5 bindings of your `favourite programming language <https://en.wikipedia.org/wiki/Hierarchical_Data_Format#Interfaces>`_.
+You can investigate your files via a large collection of `tools and frameworks <https://github.com/openPMD/openPMD-projects>`_ or your use the native HDF5 bindings of your `favorite programming language <https://en.wikipedia.org/wiki/Hierarchical_Data_Format#Interfaces>`_.
 
 **Resources for a quick-start:**
 

--- a/docs/source/usage/plugins/hdf5.rst
+++ b/docs/source/usage/plugins/hdf5.rst
@@ -12,7 +12,7 @@ What is the format of the created HDF5 files?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We write our fields and particles in an open markup called **openPMD**.
-You can investigate your files via a large collection of `tools and frameworks <https://github.com/openPMD/openPMD-projects>`_ or your use the native HDF5 bindings of your `favorite programming language <https://en.wikipedia.org/wiki/Hierarchical_Data_Format#Interfaces>`_.
+You can investigate your files via a large collection of `tools and frameworks <https://github.com/openPMD/openPMD-projects>`_ or use the native HDF5 bindings of your `favorite programming language <https://en.wikipedia.org/wiki/Hierarchical_Data_Format#Interfaces>`_.
 
 **Resources for a quick-start:**
 

--- a/docs/source/usage/plugins/intensity.rst
+++ b/docs/source/usage/plugins/intensity.rst
@@ -3,7 +3,7 @@
 Intensity
 ---------
 
-The maximum amplitude of the electric field for each cell in y-cell-position in **V/m** and the integrated amplitude of the electric field (integrated over the entirer x- and z-extent of the simulated volume and given for each y-cell-position).
+The maximum amplitude of the electric field for each cell in y-cell-position in **V/m** and the integrated amplitude of the electric field (integrated over the entire x- and z-extent of the simulated volume and given for each y-cell-position).
 
 
 .. attention::

--- a/docs/source/usage/plugins/particleCalorimeter.rst
+++ b/docs/source/usage/plugins/particleCalorimeter.rst
@@ -64,7 +64,7 @@ Coordinate System
 
 Yaw and pitch are `Euler angles <https://en.wikipedia.org/wiki/Euler_angles>`_ defining a point on a sphere's surface, where ``(0,0)`` points to the ``+y`` direction here. In the vicinity of ``(0,0)``, yaw points to ``+x`` and pitch to ``+z``.
 
-**Orientation detail:** Since the calorimeters's three-dimensional orientation is given by just two parameters (``posYaw`` and ``posPitch``) there is one degree of freedom left which has to be fixed.
+**Orientation detail:** Since the calorimeters' three-dimensional orientation is given by just two parameters (``posYaw`` and ``posPitch``) there is one degree of freedom left which has to be fixed.
 Here, this is achieved by eliminating the Euler angle roll.
 However, when ``posPitch`` is exactly ``+90`` or ``-90`` degrees, the choice of roll is ambiguous, depending on the yaw angle one approaches the singularity.
 Here we assume an approach from ``yaw = 0``.

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -111,7 +111,7 @@ Known Limitations
 ^^^^^^^^^^^^^^^^^
 
 - only one range per selected space-momentum-pair possible right now (naming collisions)
-- charge deposition uses the counter shape for now (would need one more write to neighbours to get it correct to the shape)
+- charge deposition uses the counter shape for now (would need one more write to neighbors to get it correct to the shape)
 - the user has to define the momentum range in advance
 - the resolution is fixed to ``1024 bins`` in momentum and the number of cells in the selected spatial dimension
 - this plugin does not yet use :ref:`openPMD markup <pp-openPMD>`.

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -111,7 +111,7 @@ Known Limitations
 ^^^^^^^^^^^^^^^^^
 
 - only one range per selected space-momentum-pair possible right now (naming collisions)
-- charge deposition uses the counter shape for now (would need one more write to neighbors to get it correct to the shape)
+- charge deposition uses the counter shape for now (would need one more write to neighbors to evaluate it correctly according to the shape)
 - the user has to define the momentum range in advance
 - the resolution is fixed to ``1024 bins`` in momentum and the number of cells in the selected spatial dimension
 - this plugin does not yet use :ref:`openPMD markup <pp-openPMD>`.

--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -113,7 +113,7 @@ Since an adequate color scaling is essential, there several option the user can 
    #define EM_FIELD_SCALE_CHANNEL3 -1
 
 In the above example, all channels are set to **auto scale**.
-**Be careful**, when using another normalization than auto scale, because depending on your set up, the normalization might fail due to parameters not set by PIConGPU.
+**Be careful**, when using a normalization other than auto-scale, depending on your setup, the normalization might fail due to parameters not set by PIConGPU.
 *Use the other normalization options only in case of the specified scenarios or if you know, how the scaling is computed.*
 
 

--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -31,7 +31,7 @@ Command line option    Description
                        If flags are not set, no pngs are created.
 ``--e_png.axis``       Set 2D slice through 3D volume that will be drawn.
                        Combine two of the three dimensions ``x``, ``y``and ``z``, the define a slice.
-                       E.g. setting ``--e_png.axis yz`` draws both the y and z dimension and performes a slice in x-direction.
+                       E.g. setting ``--e_png.axis yz`` draws both the y and z dimension and performs a slice in x-direction.
 ``--e_png.slicePoint`` Specifies at what ratio of the total depth of the remaining dimension, the slice should be performed.
                        The value given should lie between ``0.0`` and ``1.0``.
 ``--e_png.folder``     Name of the folder, where all pngs for the above setup should be stored.
@@ -113,7 +113,7 @@ Since an adequate color scaling is essential, there several option the user can 
    #define EM_FIELD_SCALE_CHANNEL3 -1
 
 In the above example, all channels are set to **auto scale**.
-**Be careful**, when using other normalizations than auto scale, because depending on your set up, the normalization might fail due to parameters not set by PIConGPU.
+**Be careful**, when using another normalization than auto scale, because depending on your set up, the normalization might fail due to parameters not set by PIConGPU.
 *Use the other normalization options only in case of the specified scenarios or if you know, how the scaling is computed.*
 
 

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -164,7 +164,7 @@ In order to do that, the radiating particle species needs the attribute ``radiat
 .. note::
 
    The reduction of the total intensity is not considered in the output.
-   The intensity will be (in the incoherent case) by the fraction of marked particles smaller than in the case of selecting all particles.
+   The intensity will be (in the incoherent case) will be smaller by the fraction of marked to all particles.
 
 .. note::
 

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -16,7 +16,7 @@ Variable                       Meaning
 ============================== ================================================================================
 :math:`\vec r_k(t)`            The position of particle *k* at time *t*.
 :math:`\vec \beta_k(t)`        The normalized speed of particle *k* at time *t*.
-                               (Speed devided by the speed of light)
+                               (Speed divided by the speed of light)
 :math:`\dot{\vec{\beta}}_k(t)` The normalized acceleration of particle *k* at time *t*.
                                (Time derivative of the normalized speed.)
 :math:`t`                      Time
@@ -26,7 +26,7 @@ Variable                       Meaning
 :math:`k`                      Running index of the particles.
 ============================== ================================================================================
 
-Currently this allows to predict the emitted radiation from plasmas if it can be described by classical means.
+Currently this allows to predict the emitted radiation from plasma if it can be described by classical means.
 Not considered are emissions from ionization, Compton scattering or any bremsstrahlung that originate from scattering on scales smaller than the PIC cell size. 
 
 External Dependencies
@@ -125,7 +125,7 @@ By default, it should be switched off by setting ``__COHERENTINCOHERENTWEIGHTING
 
 .. code:: cpp
 
-   // corect treatment of coherent and incoherent radiation from macroparticles
+   // correct treatment of coherent and incoherent radiation from macroparticles
    // 1 = on (slower and more memory, but correct quantitative treatment)
    // 0 = off (faster but macroparticles are treated as highly charged, point-like particle)
    #define __COHERENTINCOHERENTWEIGHTING__ 0
@@ -164,7 +164,7 @@ In order to do that, the radiating particle species needs the attribute ``radiat
 .. note::
 
    The reduction of the total intensity is not considered in the output.
-   The intensity will be (in the incoherent case) by the fraction of marked marticles smaller than in the case of selecting all particles.
+   The intensity will be (in the incoherent case) by the fraction of marked particles smaller than in the case of selecting all particles.
 
 .. note::
 
@@ -300,7 +300,7 @@ Command line flag                        Output description
 ``--radiation_<species>.lastRadiation``  has the same format as the output of *totalRadiation*.
                                          The spectral intensity is only summed over the last radiation `dump` period.
 ``--radiation_<species>.radPerGPU``      Same output as *totalRadiation* but only summed over each GPU. 
-                                         ecause each GPU specifies a spatial region, the origin of radiation signatures can be distinguished.
+                                         Because each GPU specifies a spatial region, the origin of radiation signatures can be distinguished.
 *radiationHDF5*                          In the folder  ``radiationHDF5``, hdf5 files for each radiation dump and species are stored.
                                          These are complex amplitudes in units used by *PIConGPU*.
                                          These are for restart purposes and for more complex data analysis.
@@ -318,7 +318,7 @@ Tool                           Description
                                This is a python script that has its own help.
                                Run ``plotRadiation --help`` for more information.
 ``radiationSyntheticDetector`` Reads *ASCII* radiation data and statistically analysis the spectra for a user specified region of observation angles and frequencies.
-                               This is a python script that has its own help. Run ``radiationSyntheticDetector --help`` for more informations.
+                               This is a python script that has its own help. Run ``radiationSyntheticDetector --help`` for more information.
 *smooth.py*                    Python module needed by `plotRadiation`.
 ============================== ======================================================================================================================================
 

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -77,7 +77,7 @@ namespace radiationNyquist
 ///////////////////////////////////////////////////
 
 
-  // corect treatment of coherent and incoherent  radiation from macroparticles
+  // correct treatment of coherent and incoherent  radiation from macroparticles
   /* Choose different form factors in order to consider different  particle shapes for radiation
    *  - radFormFactor_CIC_3D ... CIC charge distribution
    *  - radFormFactor_TSC_3D ... TSC charge distribution

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -77,7 +77,7 @@ namespace radiationNyquist
 ///////////////////////////////////////////////////
 
 
-  // correct treatment of coherent and incoherent  radiation from macroparticles
+  // correct treatment of coherent and incoherent radiation from macroparticles
   /* Choose different form factors in order to consider different  particle shapes for radiation
    *  - radFormFactor_CIC_3D ... CIC charge distribution
    *  - radFormFactor_TSC_3D ... TSC charge distribution

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -80,7 +80,7 @@ namespace radiationNyquist
 ///////////////////////////////////////////////////
 
 
-  // corect treatment of coherent and incoherent  radiation from macroparticles
+  // correct treatment of coherent and incoherent  radiation from macroparticles
   /* Choose different form factors in order to consider different  particle shapes for radiation
    *  - radFormFactor_CIC_3D ... CIC charge distribution
    *  - radFormFactor_TSC_3D ... TSC charge distribution


### PR DESCRIPTION
This pull request fixes various misspelled words in the read-the-docs plugin documentation.

Some errors pointed to further mistakes in the radiation plugin, which have been fixed too.