### PR TITLE
Boost: Deprecated Math Header

### DIFF
--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -37,7 +37,11 @@
 #include <boost/preprocessor/arithmetic/inc.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
-#include <boost/math/common_factor_rt.hpp>
+#if( BOOST_VERSION < 106700 )
+#   include <boost/math/common_factor_rt.hpp>
+#else
+#   include <boost/integer/common_factor_rt.hpp>
+#endif
 
 #include "pmacc/eventSystem/tasks/TaskKernel.hpp"
 #include "pmacc/eventSystem/events/kernelEvents.hpp"

--- a/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -31,7 +31,11 @@
 
 #include <pmacc/cuSTL/algorithm/functor/AssignValue.hpp>
 
-#include <boost/math/common_factor_rt.hpp>
+#if( BOOST_VERSION < 106700 )
+#   include <boost/math/common_factor_rt.hpp>
+#else
+#   include <boost/integer/common_factor_rt.hpp>
+#endif
 #include <boost/mpl/placeholders.hpp>
 
 #include <stdint.h>


### PR DESCRIPTION
Deprecation warning in Boost 1.67+

```
include/boost/math/common_factor_rt.hpp:13:93:
  note: #pragma message: This header is deprecated.
  Use <boost/integer/common_factor_rt.hpp> instead.

BOOST_HEADER_DEPRECATED("<boost/integer/common_factor_rt.hpp>");
```

https://github.com/boostorg/math/blob/boost-1.67.0/include/boost/math/common_factor_rt.hpp