### PR TITLE
Further improve wording in docs

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,7 +21,7 @@ Overview
    :alt: overview of PIConGPU library dependencies
 
    Overview of inter-library dependencies for parallel execution of PIConGPU on a typical HPC system. Due to common binary incompatibilities between compilers, MPI and boost versions, we recommend to organize software with a version-aware package manager such as `spack <https://github.com/spack/spack>`_ and to deploy a hierarchical module system such as `lmod <https://github.com/TACC/Lmod>`_.
-   A Lmod example setup can be found `here <https://github.com/ComputationalRadiationPhysics/compileNode>`_.
+   An Lmod example setup can be found `here <https://github.com/ComputationalRadiationPhysics/compileNode>`_.
 
 Requirements
 ------------
@@ -217,7 +217,7 @@ libSplash
 HDF5
 """"
 - 1.8.6+
-- standard shared version (no c++, enable parallel)
+- standard shared version (no C++, enable parallel)
 - *Debian/Ubuntu:* ``sudo apt-get install libhdf5-openmpi-dev``
 - *Arch Linux:* ``sudo pacman --sync hdf5-openmpi``
 - *Spack:* ``spack install hdf5~fortran``
@@ -260,7 +260,7 @@ splash2txt
 png2gas
 """""""
 - requires *libSplash*, *pngwriter* and *boost* ``program_options``)
-- converts png files to hdf5 files that can be used as an input for a species initial density profiles
+- converts png files to hdf5 files that can be used as an input for species initial density profiles
 - compile and install exactly as *splash2txt* above
 
 ADIOS

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,16 +9,16 @@
 
 *Particle-in-Cell Simulations for the Exascale Era*
 
-PIConGPU is a fully relativistic, manycore, 3D3V particle-in-cell (PIC) code.
+PIConGPU is a fully relativistic, manycore, 3D3V and 2D3V particle-in-cell (PIC) code.
 The PIC algorithm is a central tool in plasma physics.
-It describes the dynamics of a plasma by computing the motion of electrons and ions in the plasma based on Maxwell's equations.
+It describes the dynamics of a plasma by computing the motion of electrons and ions in the plasma based on the Vlasov-Maxwell system of equations.
 
 How to Read This Document
 -------------------------
 
-Generally, **follow the manual pages in-order** to get started.
-Individual chapters are based on the information of the chapters before.
-In case you are already fluent in compiling C++ projects and HPC, running PIC simulations or scientific data analysis feel free to jump the respective sections.
+Generally, to get started **follow the manual pages in order**.
+Individual chapters are based on the information in the chapters before.
+In case you are already fluent in compiling C++ projects and HPC, running PIC simulations or scientific data analysis, feel free to jump the respective sections.
 
 .. only:: html
 

--- a/docs/source/install/instructions/source.rst
+++ b/docs/source/install/instructions/source.rst
@@ -13,7 +13,7 @@ From Source
 
 .. sectionauthor:: Axel Huebl
 
-Don't be afraid young physicist, self-compiling C/C++ projects is easy, fun and profitable!
+Don't be afraid, young physicist, self-compiling C/C++ projects is easy, fun and profitable!
 
 Compiling a project from source essentially requires three steps:
 

--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -39,7 +39,7 @@ First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html
 
 .. note::
 
-   When you next time open a terminal or log back into the machine, make sure to activate the spack environment again via:
+   When you open a terminal next time or log back into the machine, make sure to activate the spack environment again via:
 
    .. code-block:: bash
 
@@ -68,7 +68,7 @@ For more information on *variants* of the ``picongpu`` package in spack run ``sp
 .. note::
 
    PIConGPU can also run *without a GPU*!
-   For example for our OpenMP backend, just specify the backend with ``backend=omp2b`` for the two commands above:
+   For example, to use our OpenMP backend, just add ``backend=omp2b`` to the two commands above:
    
    .. code-block:: bash
 

--- a/docs/source/install/path.rst
+++ b/docs/source/install/path.rst
@@ -6,15 +6,15 @@ Introduction
 .. sectionauthor:: Axel Huebl
 
 Installing PIConGPU means :ref:`installing C++ libraries <install-dependencies>` that PIConGPU depends on and :ref:`setting environment variables <install-profile>` to find those dependencies.
-The first part is usually the job of a system administrator while the second part needs to be configured on the user-side.
+The first part is usually the job of a system administrator while the second part needs to be configured on the user side.
 
 Depending on your experience, role, computing environment and expectations for optimal hardware utilization, you have several ways to install and select PIConGPU's dependencies.
-Choose your favorite *install and environment management method* below, young padavan, and follow the corresponding sections of the next chapters.
+Choose your favorite *install and environment management method* below, young padawan, and follow the corresponding sections of the next chapters.
 
 Ways to Install
 ---------------
 
-Choose *one* of the install methods below to get started:
+Choose *one* of the installation methods below to get started.
 
 Load Modules
 ^^^^^^^^^^^^
@@ -25,13 +25,13 @@ It loads according modules and sets :ref:`helper environment variables <install-
 
 .. important::
 
-   For many HPC systems we already prepared and maintain an environment for you which will run out-of-the-box.
-   See if yours is :ref:`in the list <install-profile>` so you can skip the installation completely!
+   For many HPC systems we have already prepared and maintain an environment which will run out of the box.
+   See if your system is :ref:`in the list <install-profile>` so you can skip the installation completely!
 
 Spack
 ^^^^^
 
-[Spack]_ is a flexible package manager that can build and organize software dependencies for you.
+[Spack]_ is a flexible package manager that can build and organize software dependencies.
 It can be configured once for your hardware architecture to create optimally tuned binaries and provides modulefile support (e.g. [modules]_, [Lmod]_).
 Those auto-build modules manage your environment variables and allow easy switching between versions, configurations and compilers.
 
@@ -40,21 +40,21 @@ Build from Source
 
 You choose a supported C++ compiler and configure, compile and install all missing dependencies from source.
 You are responsible to manage the right versions and configurations.
-Performance will be ideal if architecture is chosen correctly (and/or if build directly on your hardware).
+Performance will be ideal if architecture is chosen correctly (and/or if built directly on your hardware).
 You then set environment variables to find those installs.
 
 Conda
 ^^^^^
 
 We currently do not have an official conda install (yet).
-Due to pre-build binaries, performance will be sub-ideal and HPC cluster support (e.g. MPI) might be very limited.
+Due to pre-build binaries, performance could be not ideal and HPC cluster support (e.g. MPI) might be very limited.
 Useful for small desktop or single-node runs.
 
 Nvidia-Docker
 ^^^^^^^^^^^^^
 
-Not yet officially supported but we already provide a ``Dockerfile`` to get started.
-Performance might be sub-ideal if the image is not build for the specific local hardware again.
+Not yet officially supported, but we already provide a ``Dockerfile`` to get started.
+Performance might be not ideal if the image is not built for the specific local hardware again.
 Useful for small desktop or single-node runs.
 We are also working on `Singularity <http://singularity.lbl.gov/>`_ images.
 

--- a/docs/source/usage/reference.rst
+++ b/docs/source/usage/reference.rst
@@ -5,7 +5,7 @@ Reference
 
 .. sectionauthor:: Axel Huebl
 
-PIConGPU is a year-long, scientific project with many people contributing to it.
+PIConGPU is an almost decade-long scientific project with many people contributing to it.
 In order to credit the work of others, we expect you to cite our latest paper describing PIConGPU when publishing and/or presenting scientific results.
 
 In addition to that and out of good scientific practice, you should document the version of PIConGPU that was used and any modifications you applied.


### PR DESCRIPTION
A little inspired by #2705 , I've read a little portion of the docs as a bedtime literature (no PIC-related dreams, in case someone was wondering) and made some notes.

A short comment on some of the fixes: the installation guide had an absurd amount of `you` and `yours`, reduced somewhat, also 'sub-ideal' is not a word (although would be useful).

In addition to the fixes in the PR, here are things I found strange, but not sure whether or how to fix.

In 'How to Read This Document':
- It says the code is 3D3V, should 2D3V be added?
- `It describes the dynamics of a plasma by computing the motion of electrons and ions in the plasma based on Maxwell’s equations.` is confusing to me. Firstly, one might get an impression the particles move due to Maxwell's equations. Secondly, the grid or fields are not mentioned at all.
- Is it on purpose that bold and italic are both used for highlighting? If so, I don't see an obvious distinction.

In INSTALL.rst: broken or incorrectly formated link in splash2txt section.

I plan to gradually continue, so WIP.