### PR TITLE
add MPI linking info in install documentation

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -234,7 +234,7 @@ HDF5
   - ``make``
   - *optional:* ``make test``
   - ``make install``
-  - if you encounter errors during ``./configure`` related to linking MPI you might try setting ``export CC=mpicc`` and ``export CXX=mpic++`` before running ``./configure``
+  - If you encounter errors related to linking MPI during ``./configure``, you might try setting ``export CC=mpicc`` and ``export CXX=mpic++`` before running ``./configure``.
 - *environment:* (assumes install from source in ``$HOME/lib/hdf5``)
 
   - ``export HDF5_ROOT=$HOME/lib/hdf5``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -234,6 +234,7 @@ HDF5
   - ``make``
   - *optional:* ``make test``
   - ``make install``
+  - if you encounter errors during ``./configure`` related to linking MPI you might try setting ``export CC=mpicc`` and ``export CXX=mpic++`` before running ``./configure``
 - *environment:* (assumes install from source in ``$HOME/lib/hdf5``)
 
   - ``export HDF5_ROOT=$HOME/lib/hdf5``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -234,7 +234,7 @@ HDF5
   - ``make``
   - *optional:* ``make test``
   - ``make install``
-  - If you encounter errors related to linking MPI during ``./configure``, you might try setting ``export CC=mpicc`` and ``export CXX=mpic++`` before running ``./configure``.
+  - If you encounter errors related to linking MPI during ``./configure``, you might try setting the compiler manually via ``./configure --enable-parallel --enable-shared --prefix $HOME/lib/hdf5/ CC=mpicc CXX=mpic++``.
 - *environment:* (assumes install from source in ``$HOME/lib/hdf5``)
 
   - ``export HDF5_ROOT=$HOME/lib/hdf5``


### PR DESCRIPTION
This pull request adds an additional bullet point for building hdf5 from source. Based on the discussion on #2667, it is a quite common issue to run into linking errors with MPI when configuring HDF5. This can be solved by specifying to use the MPI compilers instead of the default ones (set e.g. by the GCC/ICC module). This new bullet point adds this missing information. 