### PR TITLE
fix tbg error message

### DIFF
--- a/bin/tbg
+++ b/bin/tbg
@@ -275,14 +275,14 @@ help()
 initCall="$0 $*"
 projectPath="."
 
-pathToegetopt=`which egetopt`
+pathToegetopt=$(which egetopt 2>/dev/null)
 if [ $? -eq 0 ] ; then
     pathToegetopt=`dirname $pathToegetopt`
 else
     pathToegetopt=`dirname $0`
 fi
 
-egetoptTool=`which $pathToegetopt/egetopt`
+egetoptTool=$(which $pathToegetopt/egetopt 2>/dev/null)
 if [ $? -ne 0 ] ; then
     echo "Cannot find program egetopt" >&2
     exit 1


### PR DESCRIPTION
If the path to `egetopt` is not in the environment variable `PATH` tbg falls back to use the `egetopt` in the same location as `tbg` itself. In that case the command `which` is throwing a long error message that egetopt can not be found.
This PR hide the error message and create an own error message if needed.