### PR TITLE
fix compile with boost 1.68.0

### DIFF
--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -37,11 +37,7 @@
 #include <boost/preprocessor/arithmetic/inc.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
-#if( BOOST_VERSION < 106700 )
-#   include <boost/math/common_factor_rt.hpp>
-#else
-#   include <boost/integer/common_factor_rt.hpp>
-#endif
+#include <boost/integer/common_factor_rt.hpp>
 
 #include "pmacc/eventSystem/tasks/TaskKernel.hpp"
 #include "pmacc/eventSystem/events/kernelEvents.hpp"
@@ -112,7 +108,7 @@ math::Size_t<DIM3> getBestCudaBlockDim(const math::Size_t<dim> gridDimension)
         MaxCudaBlockDim<dim>::type::toRT(); /* max threads per axis */
     for(int i = 0; i < dim; i++)
     {
-        result[i] = boost::math::gcd(gridDimension[i], maxThreads[i]);
+        result[i] = boost::integer::gcd(gridDimension[i], maxThreads[i]);
     }
 
     return result;

--- a/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -31,11 +31,7 @@
 
 #include <pmacc/cuSTL/algorithm/functor/AssignValue.hpp>
 
-#if( BOOST_VERSION < 106700 )
-#   include <boost/math/common_factor_rt.hpp>
-#else
-#   include <boost/integer/common_factor_rt.hpp>
-#endif
+#include <boost/integer/common_factor_rt.hpp>
 #include <boost/mpl/placeholders.hpp>
 
 #include <stdint.h>
@@ -68,7 +64,7 @@ struct DeviceMemAssigner
         size_t maxValues[] = {16, 16, 4}; // maximum values for each dimension
         for(int i = 0; i < dim; i++)
         {
-            blockSize[i] = boost::math::gcd(buffer->size()[i], maxValues[dim-1]);
+            blockSize[i] = boost::integer::gcd(buffer->size()[i], maxValues[dim-1]);
         }
         /* the maximum number of threads per block for devices with
          * compute capability > 2.0 is 1024 */


### PR DESCRIPTION
Boost 1.68.0 is not allowed since #2685 but after we will integrate the next alapak release we will end in compile issues.
The reason is #2707. The definition of `boost::math::gcd` is not available if `boost/integer/common_factor_rt.hpp` is included.

This PR fixes the behaviour be using always `boost/integer/common_factor_rt.hpp` and use `boost::integer::gcd` within PMacc.

# Tested with

- [ ] boost 1.62.0
- [ ] boost 1.68.0