### PR TITLE
Fix sliceFieldReader

### DIFF
--- a/lib/python/picongpu/plugins/sliceFieldReader.py
+++ b/lib/python/picongpu/plugins/sliceFieldReader.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 Richard Pausch
+# Copyright 2014-2018 Richard Pausch, Klaus Steiniger
 #
 # This file is part of PIConGPU.
 #
@@ -42,7 +42,7 @@ def readFieldSlices(File):
     elif type(File) is str:
         theFile = open(File, 'r')
     else:
-        # if neither trow arrow
+        # if neither throw error
         raise IOError("the argument - {} - is not a file".format(File))
 
     # determine size of slice:
@@ -77,7 +77,7 @@ def readFieldSlices(File):
         # go through all valid field vectors
         for x in range(N_x):
             fieldValue = line[x]
-            data[y, x, :] = map(float, fieldValue[1:-1].split(','))
+            data[y, x, :] = [ float(x) for x in fieldValue[1:-1].split(',') ]
     return data
 
 

--- a/lib/python/picongpu/plugins/sliceFieldReader.py
+++ b/lib/python/picongpu/plugins/sliceFieldReader.py
@@ -77,7 +77,7 @@ def readFieldSlices(File):
         # go through all valid field vectors
         for x in range(N_x):
             fieldValue = line[x]
-            data[y, x, :] = [ float(x) for x in fieldValue[1:-1].split(',') ]
+            data[y, x, :] = [float(x) for x in fieldValue[1:-1].split(',')]
     return data
 
 


### PR DESCRIPTION
Use of `map()` changed from Python 2 to 3 which results in an error when using the function now. This PR avoids the map function but uses a (more pythonic) list comprehension which is also version independent.

A grammar error in a comment is corrected as well.