### PR TITLE
Python: param_parser for JSON parameter files

### DIFF
--- a/lib/python/picongpu/utils/param_parser.py
+++ b/lib/python/picongpu/utils/param_parser.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+This file is part of the PIConGPU.
+
+Copyright 2017-2018 PIConGPU contributors
+Authors: Sebastian Starke
+License: GPLv3+
+"""
+
+import os
+import json
+import getopt
+import sys
+
+
+def read_range_file(file, values_only=True):
+    """
+    Read a json file for a PIC scan or simulation. Such files are generated
+    by the python jupyter UI and have the following structure:
+    PARAMETER_NAME: {
+        "type": run (or compile)
+        "values": [v1, v2]
+    }
+
+    assumed to
+    Parameters
+    ----------
+    file: str
+        path to a parameter json file to read (either from a scan
+        or a single simulation)
+
+    values_only: bool
+        Flag to discard everything but the 'values' attribute for
+        each parameter contained in the json file
+
+    Returns
+    -------
+    A dictionary with keys = parameter names.
+    Values are either a dictionary with 'values', 'type' and 'macro_name'
+    keys for each parameter if 'values_only' is False.
+    Or simply a list of values for this parameter when 'values_only' is
+    True.
+    """
+    if not os.path.isfile(file):
+        raise IOError("File {} does not exist".format(file))
+
+    with open(file, 'r') as json_file:
+        range_dict = json.load(json_file)
+    if values_only:
+        filtered_range_dict = dict()
+        for name, attrs in range_dict.items():
+            filtered_range_dict[name] = attrs['values']
+
+        return filtered_range_dict
+    else:
+        return range_dict
+
+
+def to_macro_name(name):
+    """
+    Convert a parameter name to the corresponding name in the picongpu
+    compiler-define.
+    """
+    if not name.startswith("_"):
+        return "PARAM_" + name.upper()
+    else:
+        return "PARAM" + name.upper()
+
+
+def parse(file, ptype):
+    """
+    parses json files of scans or simulations for their parameters
+    type (either compiletime or runtime, coded as compile/run) and
+    values.
+
+    Returns
+    -------
+    an argument string which is further processed by
+    pic-configure with -c option for compile time parameters
+    or by tbg for runtime parameters.
+    """
+    range_dict = read_range_file(file, values_only=False)
+    # filter for correct ptype
+    filtered_dict = dict()
+    for param_name, attrs in range_dict.items():
+        if attrs['type'] == ptype:
+            # name, value mapping
+            filtered_dict[param_name] = attrs['values'][0]
+
+    # construct the statement passed to picongpu
+    if ptype == "compile":
+        ostr = [to_macro_name(name) + "=" + str(value)
+                for name, value in filtered_dict.items()]
+        cxx_defines = ";".join(map(lambda s: "-D" + s, ostr))
+        return "-DPARAM_OVERWRITES:LIST='" + cxx_defines + "'"
+
+    elif ptype == "run":
+        ostr = [str(name) + "=" + str(value)
+                for name, value in filtered_dict.items()]
+        if not ostr:
+            return ""
+        else:
+            return "-o " + "'" + " ".join(ostr) + "'"
+
+
+if __name__ == '__main__':
+
+    # parse command line params
+    type = ''
+    file = ''
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "ht:i:", ["type=", "ifile="])
+    except getopt.GetoptError:
+        print("paramParser.py -t <parameterType -i <inputfile>")
+        sys.exit(2)
+
+    #print("opts = ", opts)
+    #print("args = ", args)
+
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            print("paramParser.py -t <parameterType -i <inputfile>")
+        elif opt in ("-t", "--type"):
+            type = arg
+        elif opt in ("-i", "--ifile"):
+            file = arg
+
+    if(type in ["compile", "run"]):
+        print(parse(file, type))
+    else:
+        print("-t option not understood! Either choose 'compile' or 'run'!")
+        sys.exit(2)

--- a/lib/python/picongpu/utils/param_parser.py
+++ b/lib/python/picongpu/utils/param_parser.py
@@ -105,7 +105,6 @@ def parse(file, ptype):
 
 if __name__ == '__main__':
 
-    # parse command line params
     type = ''
     file = ''
 
@@ -114,9 +113,6 @@ if __name__ == '__main__':
     except getopt.GetoptError:
         print("paramParser.py -t <parameterType -i <inputfile>")
         sys.exit(2)
-
-    #print("opts = ", opts)
-    #print("args = ", args)
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):


### PR DESCRIPTION
This PR adds a python script that can be used from the command line.
It allows to read and filter JSON files as generated by the jupyter notebook UI  based on their status (either compile-time or runtime parameter).
It returns CMAKE define strings that can be further processed by pic-configure to define the given parameter values in the picongpu simulation.

The JSON file structure is assumed to be like here:
```
{
  "_A0": {
    "type": "compile",
    "values": [
      41.69166666666667
    ]
  },
  "WAVE_LENGTH_SI": {
    "type": "compile",
    "values": [
      8.000000000000001e-07
    ]
  },
  "PULSE_LENGTH_SI": {
    "type": "compile",
    "values": [
      5.000000000000001e-15
    ]
  },
  "BASE_DENSITY_SI": {
    "type": "compile",
    "values": [
      9.99539589003089e+24
    ]
  },
  "TBG_STEPS": {
    "type": "run",
    "values": [
      7841
    ]
  }
}
```
At the moment we use this script for automatic job submissions as part of the `compile_laser.tpl` file in the following way:
```bash
PARAM_PARSER="$EUPRAXIA_BASE_DIR/bin/param_parser.py"
DEFINES="$( python $PARAM_PARSER -t compile -i params.json )"
pic-configure "$DEFINES" !TBG_dstPath/inputs

OPTIONS="$( python $PARAM_PARSER -t run -i ../params.json )"
tbg -s -c etc/picongpu/4_gui.cfg -t etc/picongpu/hypnos-hzdr/k20.tpl $DEST_DIR $OPTIONS

```