### PR TITLE
cuda_memtest usage on hypnos

### DIFF
--- a/etc/picongpu/hypnos-hzdr/fermi.tpl
+++ b/etc/picongpu/hypnos-hzdr/fermi.tpl
@@ -29,7 +29,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr
@@ -45,8 +44,11 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=4
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 .TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
@@ -76,11 +78,11 @@ cd simOutput
 #wait that all nodes see ouput folder
 sleep 1
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
-  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k20.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20.tpl
@@ -29,7 +29,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr
@@ -44,8 +43,11 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=4
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 .TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
@@ -75,11 +77,11 @@ cd simOutput
 #wait that all nodes see ouput folder
 sleep 1
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
-  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k20_autoWait.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_autoWait.tpl
@@ -29,7 +29,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
 
 #PBS -W depend=afterany:!TBG_waitJob
 
@@ -49,8 +48,11 @@
 # get the ID of the last job of the submitting user waiting in the k20 queue
 .TBG_waitJob=`qstat -u $(whoami) | grep $TBG_queue | tail -n 1 | awk '{print $1}'`
 
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=4
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 .TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
@@ -80,11 +82,11 @@ cd simOutput
 #wait that all nodes see ouput folder
 sleep 1
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
-  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_restart.tpl
@@ -48,7 +48,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr
@@ -128,11 +127,11 @@ echo "--- end automated restart routine ---" | tee -a output
 #wait that all nodes see ouput folder
 sleep 1
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
-  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k20_wait.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_wait.tpl
@@ -29,7 +29,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
 
 #PBS -W depend=afterany:!TBG_waitJob
 
@@ -46,8 +45,11 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 4 gpus per node if we need more than 4 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 4 ] ; then echo 4; else echo $TBG_tasks; fi`
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=4
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 .TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
@@ -77,11 +79,11 @@ cd simOutput
 #wait that all nodes see ouput folder
 sleep 1
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
-  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k80.tpl
+++ b/etc/picongpu/hypnos-hzdr/k80.tpl
@@ -29,7 +29,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr
@@ -44,8 +43,11 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=8
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 #number of cores per parallel node / default is 2 cores per gpu on k20 queue
 .TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
@@ -75,11 +77,11 @@ cd simOutput
 #wait that all nodes see ouput folder
 sleep 1
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
-  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k80_restart.tpl
@@ -28,8 +28,12 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 8 gpus per node if we need more than 8 gpus else same count as TBG_tasks
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=8
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
+fi`
 
 #number of cores per parallel node / default is 2 cores (4 HT threads) per gpu on k80 queue
 .TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
@@ -48,8 +52,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
-
 #PBS -o stdout
 #PBS -e stderr
 
@@ -129,11 +131,11 @@ echo "--- end automated restart routine ---" | tee -a output
 #wait that all nodes see ouput folder
 sleep 1
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
-  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then

--- a/etc/picongpu/hypnos-hzdr/laser.tpl
+++ b/etc/picongpu/hypnos-hzdr/laser.tpl
@@ -29,7 +29,6 @@
 # send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
-#PBS -n
 
 #PBS -o stdout
 #PBS -e stderr


### PR DESCRIPTION
`cuda_memtest` can currently only be used if the node is exclusive allocated by the user and no other job is running on it.
All hypnos template files for hypnos supports that the user can allocate only a subset of a node. In this case `cuda_memtest` will crash if an other user/job is already using gpu zero.
This PR will disable the GPU memory test if the job has not alloacted all GPUs.

- remove PBS option `-n` (exclusive node usage) because it is not working on hypnos
- disable the test `cuda_memtest` if node is not exclusive allocated

It would be possible to mark this PR as `bug` because the way how `cuda_memtest` is used is wrong.


# Tests

- [x] job allocates all GPUs
- [x] job allocate only the half node