### PR TITLE
hemera tbg templates

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -18,6 +18,23 @@ Ideally, store that file directly in your ``$HOME/`` and source it after connect
 
 We listed some example ``picongpu.profile`` files below which can be used to set up PIConGPU's dependencies on various HPC systems.
 
+Hemera (HZDR)
+-------------
+
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` manually.
+
+Queue: defq (2x Intel Xeon Gold 6148, 20 Cores + 20 HyperThreads/CPU)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/hemera-hzdr/defq_picongpu.profile.example
+   :language: bash
+
+Queue: gpu (4x NVIDIA P100 16GB)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/hemera-hzdr/gpu_picongpu.profile.example
+   :language: bash
+
 Hypnos (HZDR)
 -------------
 

--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Copyright 2013-2018 Axel Huebl, Richard Pausch, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for hemera' SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_devicesPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerCPU
+#SBATCH --mem=!TBG_memPerNode
+# must be 1 else we can not use hyperthreading
+#SBATCH --threads-per-core=1
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+#SBATCH --workdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="defq"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"} # NONE, BEGIN, END, FAIL, REQUEUE, ALL
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of available/hosted devices per node in the system
+.TBG_numHostedDevicesPerNode=2
+
+# 2 devices per node
+.TBG_devicesPerNode=`if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi`
+
+# host memory per device
+.TBG_memPerCPU="$((360000 / $TBG_numHostedDevicesPerNode))"
+# host memory per node
+.TBG_memPerNode="$((TBG_memPerCPU * TBG_devicesPerNode))"
+
+# number of cores to block per device - we got 20 cpus per device
+.TBG_coresPerCPU=20
+
+# We only start 1 MPI task per device
+.TBG_mpiTasksPerNode="$(( TBG_devicesPerNode * 1 ))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_devicesPerNode - 1 ) / TBG_devicesPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  mpiexec --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -1,0 +1,81 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# General modules #############################################################
+#
+module purge
+module load gcc/7.3.0
+module load cmake/3.11.3
+module load openmpi/2.1.2
+module load boost/1.68.0
+
+# Other Software ##############################################################
+#
+module load zlib/1.2.11
+module load c-blosc/1.14.4
+
+module load adios/1.13.1
+module load hdf5-parallel/1.8.20
+module load libsplash/1.7.0
+
+module load libpng/1.6.35
+module load pngwriter/0.7.0
+
+# Environment #################################################################
+#
+#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_LIB
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="omp2b:skylake-avx512"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "defq" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/hemera-hzdr/defq.tpl"
+
+# allocate an interactive shell for one hour
+#   getNode 2  # allocates to interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    srun --time=1:00:00 --nodes=$numNodes --ntasks-per-node=2 --cpus-per-task=20  --mem=360000 -p defq --pty bash
+}
+
+# allocate an interactive shell for one hour
+#   getDevice 2  # allocates to interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numDevices=1
+    else
+        if [ "$1" -gt 2 ] ; then
+            echo "The maximal number of devices per node is 2." 1>&2
+            return 1
+        else
+            numDevices=$1
+        fi
+    fi
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=$((20 * $numDevices)) --mem=$((1800000 * numDevices)) -p defq --pty bash
+}

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Copyright 2013-2018 Axel Huebl, Richard Pausch, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for hemera' SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_gpusPerNode
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem=!TBG_memPerNode
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+#SBATCH --workdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="gpu"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"} # NONE, BEGIN, END, FAIL, REQUEUE, ALL
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=4
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
+
+# host memory per gpu
+.TBG_memPerGPU="$((360000 / $TBG_gpusPerNode))"
+# host memory per node
+.TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
+
+# number of cores to block per GPU - we got 6 cpus per gpu
+#   and we will be accounted 6 CPUs per GPU anyway
+.TBG_coresPerGPU=6
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode - 1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+  # Run CUDA memtest to check GPU's health
+  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -1,0 +1,82 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# General modules #############################################################
+#
+module purge
+module load gcc/7.3.0
+module load cmake/3.11.3
+module load cuda/9.2
+module load openmpi/2.1.2-cuda92
+module load boost/1.68.0
+
+# Other Software ##############################################################
+#
+module load zlib/1.2.11
+module load c-blosc/1.14.4
+
+module load adios/1.13.1-cuda92
+module load hdf5-parallel/1.8.20-cuda92
+module load libsplash/1.7.0-cuda92
+
+module load libpng/1.6.35
+module load pngwriter/0.7.0
+
+# Environment #################################################################
+#
+#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_LIB
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:60"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "gpu" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/hemera-hzdr/gpu.tpl"
+
+# allocate an interactive shell for one hour
+#   getNode 2  # allocates to interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=360000 -p gpu --pty bash
+}
+
+# allocate an interactive shell for one hour
+#   getDevice 2  # allocates to interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numGPUs=1
+    else
+        if [ "$1" -gt 4 ] ; then
+            echo "The maximal number of devices per node is 4." 1>&2
+            return 1
+        else
+            numGPUs=$1
+        fi
+    fi
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=$((6 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((90000 * numGPUs)) -p gpu --pty bash
+}


### PR DESCRIPTION
- add tbg templates for hemera (HZDR) cluster CPU/GPU
- add hemera profiles

Note: PIConGPU will not compile on hemera until https://github.com/ComputationalRadiationPhysics/picongpu/pull/2685/files#diff-d1fb8e3eeab4d2001da0932360713480R373 is removed. We can remove it as soon as PIConGPU based on alpaka 0.3.4

# Tests

- [x] cpu queue (named defq)
- [x] qpu queue (named gpu)