### PR TITLE
RTD: Sphinx 1.7

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx_rtd_theme>=0.3.1
 recommonmark
-sphinx
+sphinx==1.7
 breathe>=4.5
 sphinxcontrib.programoutput
 pygments


### PR DESCRIPTION
Fix readthedocs sphinx to version 1.7 since the latest
1.8 release line has a bug rendering overloaded C++ code with breathe.

Upstream issue: https://github.com/sphinx-doc/sphinx/issues/5496