### PR TITLE
Plugin Docs: Python Tools & Matplotlib

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ recommonmark
 sphinx==1.7
 breathe>=4.5
 sphinxcontrib.programoutput
+sphinxcontrib.napoleon>=1.8.1
 pygments
 # generate plots
 matplotlib

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,8 +19,9 @@
 import os
 import subprocess
 from recommonmark.parser import CommonMarkParser
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+python_libs = os.path.abspath('../../lib/python')
+sys.path.insert(0, python_libs)
 
 
 # -- General configuration ------------------------------------------------
@@ -38,12 +39,16 @@ show_authors = True
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.mathjax',
+              'sphinx.ext.napoleon',
               'breathe',
               'sphinxcontrib.programoutput',
               'matplotlib.sphinxext.plot_directive']
 
 if not on_rtd:
     extensions.append('sphinx.ext.githubpages')
+
+# napoleon autodoc config
+napoleon_include_init_with_doc = True
 
 # breathe config
 breathe_projects = {'PIConGPU': '../xml'}

--- a/docs/source/dev/py_postprocessing.rst
+++ b/docs/source/dev/py_postprocessing.rst
@@ -1,0 +1,69 @@
+.. _development-pytools:
+
+Python Postprocessing Tool Structure
+====================================
+
+Each plugin should implement at least the following Python classes.
+
+1. A data reader class responsible for loading the data from the simulation directory
+2. A visualizer class that outputs a matplotlib plot
+
+The repository directory for PIConGPU Python modules for plugins is ``lib/python/picongpu/plugins/``.
+
+Data Reader
+~~~~~~~~~~~
+
+The data readers should reside in the ``lib/python/picongpu/plugins/data`` directory.
+There is a base class in ``base_reader.py`` defining the interface of a reader.
+Each reader class should derive from this class and needs to implement the following interface functions:
+
+.. autoclass:: picongpu.plugins.data.base_reader.DataReader
+   :members:
+   :private-members:
+
+To shorten the import statements for the readers, please also add an entry in the ``__init__.py`` file of the ``data`` directory.
+
+Visualizer
+~~~~~~~~~~
+
+The visualizers should reside in the ``lib/python/picongpu/plugins/plot_mpl/`` directory.
+The module names should end on ``_visualizer.py`` and the class name should only be ``Visualizer``.
+
+To shorten the import statements for the visualizers, please also add an entry in the ``__init__.py`` file of the ``plot_mpl`` directory.
+
+There is a base class for visualization found in ``base_visualizer.py`` which already handles the plotting logic.
+It uses the data reader classes for accessing the data.
+After getting the data, it ensures that (for performance reasons) a matplotlib artist is created only for the first plot and later only gets updated with fresh data.
+
+.. autoclass:: picongpu.plugins.plot_mpl.base_visualizer.Visualizer
+   :members:
+   :private-members:
+
+The complete implementation logic of the ``visualize`` function is pretty simple.
+
+.. code:: python
+
+   def visualize(self, **kwargs):
+        self.data = self.data_reader.get(**kwargs)
+        if self.plt_obj is None:
+            self._create_plt_obj()
+        else:
+            self._update_plt_obj()
+
+All new plugins should derive from this class.
+
+When implementing a new visualizer you have to perform the following steps:
+
+1. Let your visualizer class inherit from the ``Visualizer`` class in ``base visualizer.py``.
+
+2. Implement the ``_create_data_reader(self, run_directory)`` function.
+This function should return a data reader object (see above) for this plugin's data.
+
+3. Implement the ``_create_plt_obj(self)`` function.
+This function needs to access the plotting data from the ``self.data`` member (this is the data structure as returned by the data readers ``.get(...)`` function, create some kind of matplotlib artist by storing it in the ``self.plt_obj`` member variable and set up other plotting details (e.g. a colorbar).
+
+4. Implement the ``_update_plt_obj(self)`` function.
+This is called only after a valid ``self.plt_obj`` was created.
+It updates the matplotlib artist with new data.
+Therefore it again needs to access the plotting data from the ``self.data`` member and call the data update API for the matplotlib artist (normally via ``.set_data(...)``.
+

--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -61,6 +61,19 @@ Examples
 * ``42,30:50:10``: at steps 30 40 42 50 84 126 168 ...
 * ``5,10``: at steps 0 5 10 15 20 25 ... (only executed once per step in overlapping intervals)
 
+Python Postprocessing
+=====================
+
+In order to further work with the data produced by a plugin during a simulation run, PIConGPU provides python tools that can be used for reading data and visualization.
+They can be found under ``lib/python/picongpu/plugins``.
+
+It is our goal to provide at least two modules for each plugin to make postprocessing as convenient as possible:
+1. a data reader (inside the ``data`` subdirectory)
+2. a matplotlib visualizer (inside the ``plot_mpl`` subdirectory)
+
+Further information on how to use these tools can be found at each plugin page.
+
+If you would like to help in developing those classes for a plugin of your choice, please read :ref:`python postprocessing <development-pytools>`.
 
 .. rubric:: Footnotes
 

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -26,7 +26,7 @@ PIConGPU command line option                description
                                             A value of ``100`` would mean an output at simulation time step *0, 100, 200, ...*.
                                             If set to a non-zero value, the energy histogram of all **electrons** is computed.
                                             By default, the value is ``0`` and no histogram for the electrons is computed.
-``--e_energy.filter``                       Use filtered particles. Available filters are set up in 
+``--e_energy.filter``                       Use filtered particles. Available filters are set up in
                                             :ref:`particleFilters.param <usage-params-core>`.
 ``--e_energyHistogram.binCount``            Specifies the number of bins used for the **electron** histogram.
                                             Default is ``1024``.
@@ -39,10 +39,10 @@ PIConGPU command line option                description
 
 .. note::
 
-   This plugin is a multi plugin. 
+   This plugin is a multi plugin.
    Command line parameter can be used multiple times to create e.g. dumps with different dumping period.
    In the case where an optional parameter with a default value is explicitly defined the parameter will be always passed to the instance of the multi plugin where the parameter is not set.
-   e.g. 
+   For example,
 
    .. code-block:: bash
 
@@ -50,7 +50,7 @@ PIConGPU command line option                description
       --e_energyHistogram.period 100 --e_energyHistogram.filter all --e_energyHistogram.maxEnergy 20 --e_energyHistogram.binCount 512
 
    creates two plugins:
- 
+
    #. create an electron histogram **with 512 bins** each 128th time step.
    #. create an electron histogram **with 1024 bins** (this is the default) each 100th time step.
 
@@ -74,50 +74,73 @@ The histograms are stored in ASCII files in the ``simOutput/`` directory.
 
 The file for the electron histogram is named ``e_energyHistogram.dat`` and for all other species ``<species>_energyHistogram.dat`` likewise.
 The first line of these files does not contain histogram data and is commented-out using ``#``.
-It describes the energy binning that needed to interpret the following data. 
-It can be seen as the head of the following data table. 
-The first column is an integer value describing the simulation time step. 
-The second column counts the number of real particles below the minimum energy value used for the histogram. 
-The following columns give the real electron count of the particles in the specific bin described by the first line/header. 
+It describes the energy binning that needed to interpret the following data.
+It can be seen as the head of the following data table.
+The first column is an integer value describing the simulation time step.
+The second column counts the number of real particles below the minimum energy value used for the histogram.
+The following columns give the real electron count of the particles in the specific bin described by the first line/header.
 The second last column gives the number of real particles that have a higher energy than the maximum energy used for the histogram.
-The last column gives the total number of particles. 
+The last column gives the total number of particles.
 In total there are 4 columns more than the number of bins specified with command line arguments.
 Each row describes another simulation time step.
 
 Analysis Tools
 ^^^^^^^^^^^^^^
 
-You can quickly plot the data in Python with:
+Data Reader
+"""""""""""
+You can quickly load and interact with the data in Python with:
 
 .. code:: python
 
    from picongpu.plugins.data import EnergyHistogramData
-   import matplotlib.pyplot as plt
+
 
    # load data
-   energy_histogram = EnergyHistogramData('/home/axel/runs/lwfa_001')
-   counts, bins = energy_histogram.get('e', species_filter='all', iteration=2000)
+   eh_data = EnergyHistogramData('/home/axel/runs/lwfa_001')
+   counts, bins_keV = eh_data.get('e', species_filter='all', iteration=2000)
 
-   # unit conversion
-   MeV = 1.e-3  # keV to MeV
+Matplotlib Visualizer
+"""""""""""""""""""""
 
-   # plotting
-   plt.plot(bins * MeV, counts)
+You can quickly plot the data in Python with:
 
-   # range
-   ax = plt.gca()
-   # log scale example
-   # ax.set_yscale('log')
-   # ax.set_ylim([1.e7, 1.e12])
+.. code:: python
 
-   # annotations
-   ax.set_xlabel(r'E$_\mathrm{kin}$ [MeV]')
-   ax.set_ylabel(r'count [arb.u.]')
+   from picongpu.plugins.plot_mpl import EnergyHistogramMPL
+   import matplotlib.pyplot as plt
+
+
+   # create a figure and axes
+   fig, ax = plt.subplots(1, 1)
+
+   # create the visualizer
+   eh_vis = EnergyHistogramMPL('path/to/run_dir', ax)
+
+   eh_vis.visualize(iteration=200, species='e')
 
    plt.show()
 
+The visualizer can also be used from the command line by writing
 
-Alternatively, PIConGPU comes with a command line analysis tool for the energy histograms. 
+ .. code:: bash
+
+    python energy_histogram_visualizer.py
+
+with the following command line options
+
+================================     ======================================================
+Options                              Value
+================================     ======================================================
+-p                                   Path to the run directory of a simulation.
+-i                                   An iteration number
+-s (optional, defaults to 'e')       Particle species abbreviation (e.g. 'e' for electrons)
+-f (optional, defaults to 'all')     Species filter string
+================================     ======================================================
+
+
+
+Alternatively, PIConGPU comes with a command line analysis tool for the energy histograms.
 It is based on *gnuplot* and requires that gnuplot is available via command line.
 The tool can be found in ``src/tools/bin/`` and is called ``BinEnergyPlot.sh``.
 It accesses the gnuplot script ``BinEnergyPlot.gnuplot`` in ``src/tools/share/gnuplot/``.

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -58,48 +58,71 @@ A file is created per species, phasespace selection and time step.
 Values are given as *charge density* per phase space bin.
 In order to scale to a simpler *charge of particles* per :math:`\mathrm{d}r_i` and :math:`\mathrm{d}p_i` -bin multiply by the cell volume ``dV``.
 
-Analysis
-^^^^^^^^
+Analysis Tools
+^^^^^^^^^^^^^^
 
-The easiest way is to load the data in Python:
+Data Reader
+"""""""""""
+You can quickly load and interact with the data in Python with:
 
 .. code:: python
 
    from picongpu.plugins.data import PhaseSpaceData
-   import matplotlib.pyplot as plt
-   from matplotlib.colors import LogNorm
    import numpy as np
 
 
    # load data
-   phase_space = PhaseSpaceData('/home/axel/runs/foil_001')
-   e_ps, e_ps_meta = phase_space.get('e', species_filter='all', iteration=1000, ps='ypy')
+   ps_data = PhaseSpaceData('/home/axel/runs/lwfa_001')
+   ps, meta = ps_data.get(species='e', species_filter='all', ps='ypy', iteration=2000)
 
    # unit conversion from SI
    mu = 1.e6  # meters to microns
    e_mc_r = 1. / (9.109e-31 * 2.9979e8)  # electrons: kg * m / s to beta * gamma
 
-   # plotting
-   plt.imshow(
-       np.abs(e_ps).T * e_ps_meta.dV,
-       extent = e_ps_meta.extent * [mu, mu, e_mc_r, e_mc_r],
-       interpolation = 'nearest',
-       aspect = 'auto',
-       origin='lower',
-       norm = LogNorm()
-   )
+   Q_dr_dp = np.abs(e_ps) * e_ps_meta.dV  # C s kg^-1 m^-2
+   extent = e_ps_meta.extent * [mu, mu, e_mc_r, e_mc_r]  # spatial: microns, momentum: beta*gamma
 
-   # annotations
-   cbar = plt.colorbar()
-   cbar.set_label(r'$Q / \mathrm{d}r \mathrm{d}p$ [$\mathrm{C s kg^{-1} m^{-2}}$]')
+Note that the spatial extent of the output over time might change when running a moving window simulation.
 
-   ax = plt.gca()
-   ax.set_xlabel(r'${0}$'.format(e_ps_meta.r) + r' [$\mathrm{\mu m}$]')
-   ax.set_ylabel(r'$p_{0}$ [$\beta\gamma$]'.format(e_ps_meta.p))
+Matplotlib Visualizer
+"""""""""""""""""""""
+
+You can quickly plot the data in Python with:
+
+.. code:: python
+
+   from picongpu.plugins.plot_mpl import PhaseSpaceMPL
+   import matplotlib.pyplot as plt
+
+
+   # create a figure and axes
+   fig, ax = plt.subplots(1, 1)
+
+   # create the visualizer
+   ps_vis = PhaseSpaceMPL('path/to/run_dir', ax)
+
+   # plot
+   ps_vis.visualize(iteration=200, species='e')
 
    plt.show()
 
-Note that the spatial extent of the output over time might change when running a moving window simulation.
+The visualizer can also be used from the command line by writing
+
+ .. code:: bash
+
+    python phase_space_visualizer.py
+
+with the following command line options
+
+================================     =======================================================
+Options                              Value
+================================     =======================================================
+-p                                   Path and filename to the run directory of a simulation.
+-i                                   An iteration number
+-s (optional, defaults to 'e')       Particle species abbreviation (e.g. 'e' for electrons)
+-f (optional, defaults to 'all')     Species filter string
+-m (optional, defaults to 'ypy')     Momentum string to specify the phase space
+================================     =======================================================
 
 Out-of-Range Behavior
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -6,7 +6,7 @@ PNG
 This plugin generates **images in the png format** for slices through the simulated volume.
 It allows to draw a **species density** together with electric, magnetic and/or current field values.
 The exact field values, their coloring and their normalization can be set using ``*.param`` files.
-It is a very rudimentary and useful tool to get a first impression on what happens in the simulation and to verify that the parameter set chosen leads to  the desired physics. 
+It is a very rudimentary and useful tool to get a first impression on what happens in the simulation and to verify that the parameter set chosen leads to the desired physics.
 
 .. note::
 
@@ -20,7 +20,7 @@ The plugin is available as soon as the :ref:`PNGwriter library <install-dependen
 .cfg file
 ^^^^^^^^^
 
-For **electrons** (``e``) the following table describes the command line arguments used for the visualization. 
+For **electrons** (``e``) the following table describes the command line arguments used for the visualization.
 
 ====================== ==========================================================================================================
 Command line option    Description
@@ -38,14 +38,14 @@ Command line option    Description
 ====================== ==========================================================================================================
 
 These flags use ``boost::program_options``'s ``multitoken()``.
-Therefore, **several setups** can be specified e.g. to draw different slices. 
+Therefore, **several setups** can be specified e.g. to draw different slices.
 The order of the flags is important in this case.
 E.g. in the following example, two different slices are visualized and stored in different directories:
 
 .. code:: bash
 
    picongpu [more args]
-     # first 
+     # first
      --e_png.period 100
      --e_png.axis xy
      --e_png.slicePoint 0.5
@@ -63,10 +63,10 @@ The two param files :ref:`png.param <usage-params-plugins>` and :ref:`pngColorSc
 
 **Specifying the field values using** ``png.param``
 
-Depending on the used prefix in the command line flags, electron and/or ion density is drawn. 
+Depending on the used prefix in the command line flags, electron and/or ion density is drawn.
 Additionally to that, three field values can be visualized together with the particle density.
 In order to set up the visualized field values, the ``png.param`` needs to be changed.
-In this file, a variety of other parameters used for the PngModule can be specified. 
+In this file, a variety of other parameters used for the PngModule can be specified.
 
 The ratio of the image can be set.
 
@@ -78,14 +78,14 @@ The ratio of the image can be set.
    /* if true image is scaled if cellsize is not quadratic, else no scale */
    const bool scale_to_cellsize = true;
 
-In order to scale the image, ``scale_to_cellsize`` needs to be set to ``true`` and ``scale_image`` needs to specify the reduction ratio of the image. 
+In order to scale the image, ``scale_to_cellsize`` needs to be set to ``true`` and ``scale_image`` needs to specify the reduction ratio of the image.
 
 .. note::
 
    For a 2D simulation, even a 2D image can be a quite heavy output.
    Make sure to reduce the preview size!
 
-It  is possible to draw the borders between the GPUs used as white lines. 
+It is possible to draw the borders between the GPUs used as white lines.
 This can be done by setting the parameter ``white_box_per_GPU`` in ``png.param`` to ``true``
 
 .. code:: cpp
@@ -94,7 +94,7 @@ This can be done by setting the parameter ``white_box_per_GPU`` in ``png.param``
 
 There are three field values that can be drawn: ``CHANNEL1``, ``CHANNEL2`` and ``CHANNEL3``.
 
-Since an adequate color scaling is essential, there several option the user can choose from. 
+Since an adequate color scaling is essential, there several option the user can choose from.
 
 .. code:: cpp
 
@@ -137,27 +137,27 @@ and add different coloring:
    namespace preChannel2Col = colorScales::green;    /* draw channel 2 in green */
    namespace preChannel3Col = colorScales::none;     /* do not draw channel 3 */
 
-The colors available are defined in ``pngColorScales.param`` and their usage is described below. 
+The colors available are defined in ``pngColorScales.param`` and their usage is described below.
 If ``colorScales::none`` is used, the channel is not drawn.
 
 
-In order to specify what the three channels represent, three functions can be defined in ``png.param``. 
+In order to specify what the three channels represent, three functions can be defined in ``png.param``.
 The define the values computed for the png visualization.
-The data structures used are those available in PIConGPU. 
+The data structures used are those available in PIConGPU.
 
 .. code:: cpp
 
    /* png preview settings for each channel */
    DINLINE float_X preChannel1( float3_X const & field_B, float3_X const & field_E, float3_X const & field_J )
    {
-       /* Channel1 
+       /* Channel1
         * computes the absolute value squared of the electric current */
        return math::abs2(field_J);
    }
 
    DINLINE float_X preChannel2( float3_X const & field_B, float3_X const & field_E, float3_X const & field_J )
    {
-       /* Channel2 
+       /* Channel2
         * computes the square of the x-component of the electric field */
        return field_E.x() * field_E.x();
    }
@@ -170,8 +170,8 @@ The data structures used are those available in PIConGPU.
        return -float_X(1.0) * field_E.y();
    }
 
-Only positive values are drawn. Negative values are clipped to zero. 
-In the above example, this feature is used for ``preChannel3``. 
+Only positive values are drawn. Negative values are clipped to zero.
+In the above example, this feature is used for ``preChannel3``.
 
 
 **Defining coloring schemes in** ``pngColorScales.param``
@@ -200,12 +200,12 @@ But the user can also specify his or her own color scheme by defining a namespac
             * In this example, the color yellow (RGB=1,1,0) is used. */
            const float3_X myChannel( 1.0, 1.0, 0.0 );
 
-           /* here, the previously calculated image (in case, other channels have already 
+           /* here, the previously calculated image (in case, other channels have already
             * contributed to the png) is changed.
             * First of all, the total image intensity is reduced by the opacity of this
             * channel, but only in the color channels specified by this color "NameOfColor".
-            * Then, the actual values are added with the correct color (myChannel) and opacity. */ 
-           img = img 
+            * Then, the actual values are added with the correct color (myChannel) and opacity. */
+           img = img
                  - opacity * float3_X( myChannel.x() * img.x(),
                                        myChannel.y() * img.y(),
                                        myChannel.z() * img.z() )
@@ -241,8 +241,73 @@ The pngs follow a naming convention:
 
    <species>_png_yx_0.5_002000.png
 
-First, either ``<species>`` names the particle type. 
+First, either ``<species>`` names the particle type.
 Following the 2nd underscore, the drawn dimensions are given.
 Then the slice ratio, specified by ``--e_png.slicePoint`` or ``--i_png.slicePoint``, is stated in the file name.
-The last part of the file name is a 6 digit number, specifying the simulation time step, at which the picture was created. 
+The last part of the file name is a 6 digit number, specifying the simulation time step, at which the picture was created.
 This naming convention allows to put all pngs in one directory and still be able to identify them correctly if necessary.
+
+Analysis Tools
+^^^^^^^^^^^^^^
+
+Data Reader
+"""""""""""
+
+You can quickly load and interact with the data in Python with:
+
+.. code:: python
+
+   from picongpu.plugins.data import PNGData
+
+
+   png_data = PNGData('path/to/run_dir')
+
+   # get the available iterations for which output exists
+   iters = png_data.get_iterations(species="e", axis="yx")
+
+   # pngs as numpy arrays
+   pngs = png_data.get(species="e", axis="yx", iteration=iters[:3])
+
+   pngs[iters[0]].shape
+
+Matplotlib Visualizer
+"""""""""""""""""""""
+
+If you are only interested in visualizing the generated png files it is
+even easier since you don't have to load the data manually.
+
+.. code:: python
+
+   from picongpu.plugins.plot_mpl import PNGMPL
+   import matplotlib.pyplot as plt
+
+
+   # create a figure and axes
+   fig, ax = plt.subplots(1, 1)
+
+   # create the visualizer
+   png_vis = PNGMPL('path/to/run_dir', ax)
+
+   # plot
+   png_vis.visualize(iteration=200, species='e', axis='yx')
+
+   plt.show()
+
+The visualizer can also be used from the command line by writing
+
+ .. code:: bash
+
+    python png_visualizer.py
+
+with the following command line options
+
+=================================  ==================================================================
+Options                            Value
+=================================  ==================================================================
+-p                                 Path and to the run directory of a simulation.
+-i                                 An iteration number
+-s                                 Particle species abbreviation (e.g. 'e' for electrons)
+-f (optional, defaults to 'e')     Species filter string
+-a (optional, defaults to 'yx')    Axis string (e.g. 'yx' or 'xy')
+-o (optional, defaults to 'None')  A float between 0 and 1 for slice offset along the third dimension
+=================================  ==================================================================


### PR DESCRIPTION
Adds sections on how to develop and use the new python tools.

~~It already includes documentation for the jupyter_widgets as well (see #2691)~~

- [x] update with changes from #2727 
- [x] update with changes from #2728 
- [x] update with changes from #2730 
- [x] move all widget additions to #2691