### PR TITLE
Visualizers: axes passed on startup

### DIFF
--- a/lib/python/picongpu/plugins/plot_mpl/base_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/base_visualizer.py
@@ -18,6 +18,9 @@ class Visualizer(object):
         _create_data_reader(self, run_directory)
         _create_plt_obj(self, ax)
         _update_plt_obj(self)
+
+    Note: When using classes derived from this within jupyter notebooks, use
+    %matplotlib notebook mode.
     """
 
     def __init__(self, run_directory, ax=None):

--- a/lib/python/picongpu/plugins/plot_mpl/base_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/base_visualizer.py
@@ -20,7 +20,7 @@ class Visualizer(object):
         _update_plt_obj(self)
     """
 
-    def __init__(self, run_directory):
+    def __init__(self, run_directory, ax=None):
         """
         Initialize the reader and data as member parameters.
 
@@ -29,6 +29,7 @@ class Visualizer(object):
         run_directory : string
             path to the run directory of PIConGPU
             (the path before ``simOutput/``)
+        ax: matplotlib.axes
         """
         if run_directory is None:
             raise ValueError('The run_directory parameter can not be None!')
@@ -36,6 +37,10 @@ class Visualizer(object):
         self.plt_obj = None
         self.data_reader = self._create_data_reader(run_directory)
         self.data = None
+
+        if ax is None:
+            print("Warning: No axes was given, using plt.gca() instead!")
+        self.ax = plt.gca() if ax is None else ax
 
     def _create_data_reader(self, run_directory):
         """
@@ -45,16 +50,12 @@ class Visualizer(object):
         """
         raise NotImplementedError
 
-    def _create_plt_obj(self, ax):
+    def _create_plt_obj(self):
         """
         Sets 'self.plt_obj' to an instance of a matplotlib.artist.Artist
-        object (or derived classes) which can be updated
-        by feeding new data into it.
+        object (or derived classes) created by using 'self.ax'
+        which can later be updated by feeding new data into it.
         Only called on the first call for visualization.
-
-        Parameters
-        ----------
-        ax: matplotlib.axes.Axes instance
         """
         raise NotImplementedError
 
@@ -65,32 +66,15 @@ class Visualizer(object):
         """
         raise NotImplementedError
 
-    def _ax_or_gca(self, ax):
-        """
-        Returns the passed ax if it is not None or the current
-        matplotlib axes object otherwise.
-
-        Parameters
-        ----------
-        ax: None or matplotlib.axes.Axes instance
-        Returns
-        -------
-        A matplotlib.axes.Axes instance
-        """
-
-        return ax or plt.gca()
-
-    def visualize(self, ax=None, **kwargs):
+    def visualize(self, **kwargs):
         """
         1. Creates the 'plt_obj' if it does not exist
         2. Fills the 'data' parameter by using the reader
         3. Updates the 'plt_obj' with the new data.
         """
-        if ax is None:
-            raise ValueError("A matplotlib axes object needs to be passed!")
 
         self.data = self.data_reader.get(**kwargs)
         if self.plt_obj is None:
-            self._create_plt_obj(ax)
+            self._create_plt_obj()
         else:
             self._update_plt_obj()

--- a/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
@@ -8,7 +8,7 @@ License: GPLv3+
 
 from picongpu.plugins.png import PNG
 from picongpu.plugins.plot_mpl.base_visualizer import Visualizer as\
-    BaseVisualizer, plt
+    BaseVisualizer
 
 
 class Visualizer(BaseVisualizer):
@@ -16,15 +16,16 @@ class Visualizer(BaseVisualizer):
     Class for providing a plot of a PNG file using matplotlib.
     """
 
-    def __init__(self, run_directory):
+    def __init__(self, run_directory, ax=None):
         """
         Parameters
         ----------
         run_directory: string
             path to the run directory of PIConGPU
             (the path before ``simOutput/``)
+        ax: matplotlib.axes
         """
-        super(Visualizer, self).__init__(run_directory)
+        super().__init__(run_directory, ax)
 
     def _create_data_reader(self, run_directory):
         """
@@ -33,12 +34,12 @@ class Visualizer(BaseVisualizer):
 
         return PNG(run_directory)
 
-    def _create_plt_obj(self, ax):
+    def _create_plt_obj(self):
         """
         Implementation of base class function.
         Turns 'self.plt_obj' into a matplotlib.image.AxesImage object.
         """
-        self.plt_obj = ax.imshow(self.data)
+        self.plt_obj = self.ax.imshow(self.data)
 
     def _update_plt_obj(self):
         """
@@ -46,15 +47,13 @@ class Visualizer(BaseVisualizer):
         """
         self.plt_obj.set_data(self.data)
 
-    def visualize(self, ax=None, **kwargs):
+    def visualize(self, **kwargs):
         """
         Creates a plot on the provided axes object for
         the PNG file of the given iteration using matpotlib.
 
         Parameters
         ----------
-        ax: matplotlib axes object
-            the part of the figure where this plot will be shown.
         kwargs: dict
             additional keyword args. Necessary are the following:
             species : string
@@ -74,8 +73,7 @@ class Visualizer(BaseVisualizer):
                 if set to 'None', then return images for all available\
                     iterations
         """
-        ax = self._ax_or_gca(ax)
-        super(Visualizer, self).visualize(ax, **kwargs)
+        super().visualize(**kwargs)
 
 
 if __name__ == '__main__':
@@ -84,6 +82,7 @@ if __name__ == '__main__':
 
         import sys
         import getopt
+        import matplotlib.pyplot as plt
 
         def usage():
             print("usage:")
@@ -143,10 +142,10 @@ if __name__ == '__main__':
         if slice_point is None:
             print("Offset was not given, will determine from file")
 
-        fig, ax = plt.subplots(1, 1)
-        Visualizer(path).visualize(ax, iteration=iteration, species=species,
-                                   species_filter=filtr, axis=axis,
-                                   slice_point=slice_point)
+        _, ax = plt.subplots(1, 1)
+        Visualizer(path, ax).visualize(iteration=iteration, species=species,
+                                       species_filter=filtr, axis=axis,
+                                       slice_point=slice_point)
         plt.show()
 
     main()


### PR DESCRIPTION
This PR makes the API of the visualizers a bit clearer by passing the matplotlib axes on creation instead of only passing it in the `visualize(ax,...)` call. 

So far this API kind of suggested that it is possible to switch the figures between multiple visualization calls which in fact does not happen since the `self.plt_obj` is still tied to the previous axes.
Now there should be no ambiguity anymore.

Please merge this before #2691 since this still makes use of the API that is currently used.