### PR TITLE
Particle pusher acceleration

### DIFF
--- a/include/picongpu/param/pusher.param
+++ b/include/picongpu/param/pusher.param
@@ -28,6 +28,31 @@
 
 namespace picongpu
 {
+    struct particlePusherAccelerationParam
+    {
+        /** Define strength of constant and homogeneous acclerating
+         *  electric field in SI per dimension.
+         */
+
+        /** unit: Volt / meter */
+        static constexpr float_64 AMPLITUDEx_SI= 0.0;
+
+        /**
+         * The moving window propagation direction
+         * unit: Volt / meter
+         * (1e11 V/m = 1 GV/cm)
+         */
+        static constexpr float_64 AMPLITUDEy_SI= -1.e11;
+
+        /** unit: Volt / meter */
+        static constexpr float_64 AMPLITUDEz_SI= 0.0;
+
+        /** Acceleration Duration
+         *  unit: second
+         */
+        static constexpr float_64 ACCELERATION_TIME_SI= 10000.0 * ::picongpu::SI::DELTA_T_SI;
+    };
+
     namespace particlePusherVay
     {
         /** Precision of the square roots during the push step
@@ -56,6 +81,7 @@ namespace picongpu
         struct Vay;
         struct Boris;
         struct Photon;
+        struct Acceleration;
         struct Free;
         struct Probe;
         struct ReducedLandauLifshitz;

--- a/include/picongpu/param/pusher.param
+++ b/include/picongpu/param/pusher.param
@@ -30,7 +30,7 @@ namespace picongpu
 {
     struct particlePusherAccelerationParam
     {
-        /** Define strength of constant and homogeneous acclerating
+        /** Define strength of constant and homogeneous accelerating
          *  electric field in SI per dimension.
          */
 
@@ -47,7 +47,7 @@ namespace picongpu
         /** unit: Volt / meter */
         static constexpr float_64 AMPLITUDEz_SI= 0.0;
 
-        /** Acceleration Duration
+        /** Acceleration duration
          *  unit: second
          */
         static constexpr float_64 ACCELERATION_TIME_SI= 10000.0 * ::picongpu::SI::DELTA_T_SI;

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -76,6 +76,7 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *                                              with classical radiation reaction
  *
  * For diagnostics & modeling: ------------------------------------------------
+ * - particles::pusher::Acceleration : constant force on particles for acceleration
  * - particles::pusher::Free : free propagation, ignore fields
  *                             (= free stream model)
  * - particles::pusher::Photon : propagate with c in direction of normalized mom.

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -76,7 +76,7 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *                                              with classical radiation reaction
  *
  * For diagnostics & modeling: ------------------------------------------------
- * - particles::pusher::Acceleration : constant force on particles for acceleration
+ * - particles::pusher::Acceleration : Accelerate particles by applying a constant electric field
  * - particles::pusher::Free : free propagation, ignore fields
  *                             (= free stream model)
  * - particles::pusher::Photon : propagate with c in direction of normalized mom.

--- a/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
@@ -1,0 +1,99 @@
+/* Copyright 2013-2018 Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Klaus Steiniger
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/attribute/GetMass.hpp"
+#include "picongpu/traits/attribute/GetCharge.hpp"
+
+
+namespace picongpu
+{
+namespace particlePusherAcceleration
+{
+
+struct UnitlessParam : public particlePusherAccelerationParam
+{
+    /** Normalize input values from `pusher.param` to PIC units */
+    static constexpr float_X AMPLITUDEx = float_X(AMPLITUDEx_SI / UNIT_EFIELD); // unit: Volt / meter
+    static constexpr float_X AMPLITUDEy = float_X(AMPLITUDEy_SI / UNIT_EFIELD); // unit: Volt / meter
+    static constexpr float_X AMPLITUDEz = float_X(AMPLITUDEz_SI / UNIT_EFIELD); // unit: Volt / meter
+
+    static constexpr float_X ACCELERATION_TIME =  float_X(ACCELERATION_TIME_SI / UNIT_TIME); // unit: second
+
+};
+
+template<class Velocity, class Gamma>
+struct Push
+{
+    /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+     * for particle positions outside the super cell in one push
+     */
+    typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
+    typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
+
+    template< typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Particle, typename T_Pos >
+    HDINLINE void operator()(
+        const T_FunctorFieldB,
+        const T_FunctorFieldE,
+        T_Particle & particle,
+        T_Pos & pos,
+        const uint32_t currentStep
+    )
+    {
+        using UnitlessParam = ::picongpu::particlePusherAcceleration::UnitlessParam;
+
+        float_X const weighting = particle[ weighting_ ];
+        float_X const mass = attribute::getMass( weighting, particle );
+        float_X const charge = attribute::getCharge( weighting, particle );
+
+        using MomType = momentum::type;
+        MomType new_mom = particle[ momentum_ ];
+
+        const float_X deltaT = DELTA_T;
+
+        // normalize input SI values to
+        const float3_X eField(UnitlessParam::AMPLITUDEx, UnitlessParam::AMPLITUDEy, UnitlessParam::AMPLITUDEz);
+
+        /* Maybe refactor later to ensure a smooth and slow incease */
+        if ( currentStep * DELTA_T <= UnitlessParam::ACCELERATION_TIME )
+            new_mom += charge * eField * deltaT;
+
+        particle[ momentum_ ] = new_mom;
+
+        Velocity velocity;
+        const float3_X vel = velocity(new_mom, mass);
+
+        for(uint32_t d=0;d<simDim;++d)
+        {
+            pos[d] += (vel[d] * deltaT) / cellSize[d];
+        }
+
+    }
+
+    static pmacc::traits::StringProperty getStringProperties()
+    {
+        pmacc::traits::StringProperty propList( "name", "Acceleration" );
+        return propList;
+    }
+};
+} // namespace particlePusherBoris
+} // namespace picongpu

--- a/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
@@ -73,18 +73,20 @@ struct Push
         // normalize input SI values to
         const float3_X eField(UnitlessParam::AMPLITUDEx, UnitlessParam::AMPLITUDEy, UnitlessParam::AMPLITUDEz);
 
-        /* Maybe refactor later to ensure a smooth and slow incease */
+        /* ToDo: Refactor to ensure a smooth and slow increase of eField with time
+         * which may help to reduce radiation due to acceleration, if present.
+         */
         if ( currentStep * DELTA_T <= UnitlessParam::ACCELERATION_TIME )
             new_mom += charge * eField * deltaT;
 
         particle[ momentum_ ] = new_mom;
 
         Velocity velocity;
-        const float3_X vel = velocity(new_mom, mass);
+        const float3_X vel = velocity( new_mom, mass );
 
-        for(uint32_t d=0;d<simDim;++d)
+        for( uint32_t d = 0; d < simDim; ++d )
         {
-            pos[d] += (vel[d] * deltaT) / cellSize[d];
+            pos[d] += ( vel[d] * deltaT ) / cellSize[d];
         }
 
     }
@@ -95,5 +97,5 @@ struct Push
         return propList;
     }
 };
-} // namespace particlePusherBoris
+} // namespace particlePusherAcceleration
 } // namespace picongpu

--- a/include/picongpu/unitless/pusher.unitless
+++ b/include/picongpu/unitless/pusher.unitless
@@ -22,6 +22,7 @@
 #include "picongpu/algorithms/Gamma.hpp"
 #include "picongpu/algorithms/Velocity.hpp"
 
+#include "picongpu/particles/pusher/particlePusherAcceleration.hpp"
 #include "picongpu/particles/pusher/particlePusherBoris.hpp"
 #include "picongpu/particles/pusher/particlePusherVay.hpp"
 #include "picongpu/particles/pusher/particlePusherFree.hpp"
@@ -43,6 +44,11 @@ namespace particles
 {
 namespace pusher
 {
+
+struct Acceleration :
+public particlePusherAcceleration::Push<Velocity, Gamma<> >
+{
+};
 
 #if(SIMDIM==DIM3)
 


### PR DESCRIPTION
Implements a particle pusher which accelerates particles by a constant force. This resembles the idealized situation of accelerating in the electric field of a planar capacitor.
The electric field strength and duration of acceleration can be adjusted in the `pusher.param`. The pusher was tested by initializing a `gaussianCloud` electron gas and accelerating at a field strength of `1GeV/cm` for 518fs(=2225 DT).
![image](https://user-images.githubusercontent.com/26382442/47019691-f6eeb880-d157-11e8-91e3-9fa781e86e9e.png)

If requested, I can upload an example setup for its use.