### PR TITLE
Docs: openPMD Update

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ recommonmark
 sphinx==1.7
 breathe>=4.5
 sphinxcontrib.programoutput
-sphinxcontrib.napoleon>=1.8.1
+sphinxcontrib-napoleon>=0.7
 pygments
 # generate plots
 matplotlib

--- a/docs/source/postprocessing/openPMD.rst
+++ b/docs/source/postprocessing/openPMD.rst
@@ -11,10 +11,12 @@ If you hear of it for the first time you can find a quick `online tutorial <http
 
 As a user of PIConGPU, you will be mainly interested in our :ref:`python tools <pp-python>` and readers, that can read openPMD, e.g. into:
 
-* Numpy reader and Jupyter notebook GUI via `openPMD-viewer <https://github.com/openPMD/openPMD-viewer>`_ (`tutorial <https://github.com/openPMD/openPMD-viewer/tree/master/tutorials>`_)
+* read & write data: `openPMD-api <https://github.com/openPMD/openPMD-api>`_ (`manual <https://openpmd-api.readthedocs.io/>`_)
+* visualization and analysis, including an exploratory Jupyter notebook GUI: `openPMD-viewer <https://github.com/openPMD/openPMD-viewer>`_ (`tutorial <https://github.com/openPMD/openPMD-viewer/tree/master/tutorials>`_)
 * `yt-project <http://yt-project.org/doc/examining/loading_data.html#openpmd-data>`_ (`tutorial <https://gist.github.com/C0nsultant/5808d5f61b271b8f969d5c09f5ca91dc>`_)
 * :ref:`ParaView <pp-paraview>`
 * `VisIt <https://github.com/openPMD/openPMD-visit-plugin>`_
+* converter tools: `openPMD-converter <https://github.com/openPMD/openPMD-converter>`_
 * full list of `projects using openPMD <https://github.com/openPMD/openPMD-projects>`_
 
 If you intend to write your own post-processing routines, make sure to check out our `example files <https://github.com/openPMD/openPMD-example-datasets>`_, the `formal, open standard <https://github.com/openPMD/openPMD-standard>`_ on openPMD and a `list of projects <https://github.com/openPMD/openPMD-projects>`_ that already support openPMD.

--- a/docs/source/postprocessing/python.rst
+++ b/docs/source/postprocessing/python.rst
@@ -39,12 +39,22 @@ https://jupyter.readthedocs.io
 openPMD-viewer
 --------------
 
-A library that reads and visualizes data in our HDF5 files thanks to their :ref:`openPMD markup <pp-openPMD>`.
-Provides an API to correctly convert units to SI, interpret iteration steps correctly, annotate axis and much more.
+An exploratory framework that visualizes and analyzes data in our HDF5 files thanks to their :ref:`openPMD markup <pp-openPMD>`.
+Automatically converts units to SI, interprets iteration steps as time series, annotates axes and provides some domain specific analysis, e.g. for LWFA.
 Also provides an interactive GUI for fast exploration via Jupyter notebooks.
 
 * `Project Homepage <https://github.com/openPMD/openPMD-viewer>`_
 * `Tutorial <https://github.com/openPMD/openPMD-viewer/tree/master/tutorials>`_
+
+
+openPMD-api
+-----------
+
+A data library that reads (and writes) data in our openPMD files (HDF5 and ADIOS) to and from Numpy data structures.
+Provides an API to correctly convert units to SI, interprets iteration steps correctly, etc.
+
+* `Manual <https://openpmd-api.readthedocs.io/>`_
+* `Examples <https://github.com/openPMD/openPMD-api/tree/dev/examples>`_
 
 
 yt-project


### PR DESCRIPTION
Update projects around openPMD and link openPMD-api.

Also corrects the `docs/requirements.txt` to fix the failing RTD build introduced in #2726.