### PR TITLE
RTD: Mock Sphinx Imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,12 @@ if not on_rtd:
 
 # napoleon autodoc config
 napoleon_include_init_with_doc = True
+autodoc_mock_imports = [
+    'h5py',
+    'pandas',
+    'ipywidgets',
+    'ipympl',
+]
 
 # breathe config
 breathe_projects = {'PIConGPU': '../xml'}

--- a/lib/python/picongpu/plugins/data/requirements.txt
+++ b/lib/python/picongpu/plugins/data/requirements.txt
@@ -2,4 +2,3 @@ numpy
 pandas>=0.21.0
 h5py
 scipy
--r plot_mpl/requirements.txt


### PR DESCRIPTION
Mock imports during sphinx build that are not essential. Allows to parse doc strings without the need of accessing and installing otherwise unneeded third-party Python modules.