### PR TITLE
jobsystem no mail by default

### DIFF
--- a/etc/picongpu/draco-mpcdf/general.tpl
+++ b/etc/picongpu/draco-mpcdf/general.tpl
@@ -30,8 +30,6 @@
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --exclusive
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
@@ -44,7 +42,7 @@
 .TBG_queue="general"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/draco-mpcdf/picongpu.profile.example
+++ b/etc/picongpu/draco-mpcdf/picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 

--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -32,8 +32,6 @@
 #SBATCH --mem=!TBG_memPerNode
 # must be 1 else we can not use hyperthreading
 #SBATCH --threads-per-core=1
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
@@ -47,7 +45,7 @@
 .TBG_queue="defq"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"} # NONE, BEGIN, END, FAIL, REQUEUE, ALL
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -32,8 +32,6 @@
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem=!TBG_memPerNode
 #SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
@@ -47,7 +45,7 @@
 .TBG_queue="gpu"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"} # NONE, BEGIN, END, FAIL, REQUEUE, ALL
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 

--- a/etc/picongpu/hydra-hzdr/default.tpl
+++ b/etc/picongpu/hydra-hzdr/default.tpl
@@ -27,7 +27,6 @@
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
 #PBS -l mem=!TBG_globalMainMemStr
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -n

--- a/etc/picongpu/hypnos-hzdr/fermi.tpl
+++ b/etc/picongpu/hypnos-hzdr/fermi.tpl
@@ -26,7 +26,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/hypnos-hzdr/k20.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20.tpl
@@ -26,7 +26,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/hypnos-hzdr/k20_autoWait.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_autoWait.tpl
@@ -26,7 +26,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/hypnos-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_restart.tpl
@@ -45,7 +45,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/hypnos-hzdr/k20_vampir.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_vampir.tpl
@@ -26,7 +26,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/hypnos-hzdr/k20_wait.tpl
+++ b/etc/picongpu/hypnos-hzdr/k20_wait.tpl
@@ -26,7 +26,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/hypnos-hzdr/k80.tpl
+++ b/etc/picongpu/hypnos-hzdr/k80.tpl
@@ -26,7 +26,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/hypnos-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hypnos-hzdr/k80_restart.tpl
@@ -49,7 +49,6 @@ fi`
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 #PBS -o stdout

--- a/etc/picongpu/hypnos-hzdr/laser.tpl
+++ b/etc/picongpu/hypnos-hzdr/laser.tpl
@@ -26,7 +26,6 @@
 # Sets batch job's name
 #PBS -N !TBG_jobName
 #PBS -l nodes=!TBG_nodes:ppn=!TBG_coresPerNode
-# send me mails on job (b)egin, (e)nd, (a)bortion or (n)o mail
 #PBS -m !TBG_mailSettings -M !TBG_mailAddress
 #PBS -d !TBG_dstPath
 

--- a/etc/picongpu/lawrencium-lbnl/fermi.tpl
+++ b/etc/picongpu/lawrencium-lbnl/fermi.tpl
@@ -51,7 +51,7 @@
 .TBG_feature="mako_fermi"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/lawrencium-lbnl/k20.tpl
+++ b/etc/picongpu/lawrencium-lbnl/k20.tpl
@@ -51,7 +51,7 @@
 .TBG_feature="lr_kepler"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 

--- a/etc/picongpu/pizdaint-cscs/large.tpl
+++ b/etc/picongpu/pizdaint-cscs/large.tpl
@@ -30,8 +30,6 @@
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --ntasks-per-core=1
 #SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --constraint=gpu
@@ -44,7 +42,7 @@
 .TBG_queue="large"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"${SCRATCH}/picongpu.profile"}

--- a/etc/picongpu/pizdaint-cscs/normal.tpl
+++ b/etc/picongpu/pizdaint-cscs/normal.tpl
@@ -30,8 +30,6 @@
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --ntasks-per-core=1
 #SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --constraint=gpu
@@ -44,7 +42,7 @@
 .TBG_queue="normal"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"${SCRATCH}/picongpu.profile"}

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 

--- a/etc/picongpu/taurus-tud/k20x.tpl
+++ b/etc/picongpu/taurus-tud/k20x.tpl
@@ -31,8 +31,6 @@
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem-per-cpu=3000
 #SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
@@ -45,7 +43,7 @@
 .TBG_queue="gpu1"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 

--- a/etc/picongpu/taurus-tud/k80.tpl
+++ b/etc/picongpu/taurus-tud/k80.tpl
@@ -31,8 +31,6 @@
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem-per-cpu=2583
 #SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
@@ -45,7 +43,7 @@
 .TBG_queue="gpu2"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 

--- a/etc/picongpu/taurus-tud/knl.tpl
+++ b/etc/picongpu/taurus-tud/knl.tpl
@@ -29,8 +29,6 @@
 #SBATCH -N !TBG_nodes
 #SBATCH -c !TBG_coresPerAcc
 #SBATCH --mem=90000
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
@@ -43,7 +41,7 @@
 .TBG_queue="knl"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -3,9 +3,9 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 
 # User Information ######################################### (edit those lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 


### PR DESCRIPTION
To avoid that the user is sending mails to `someone@example.com` if he is not adding
his own mail address in the profile for the system the mail notification is disabled by default.

- remove mail option documentation in `tpl` (already docuemntated in the profile)
- slurm systems
  - document mail option `NONE`
  - set mail option `NONE` as default