### PR TITLE
Use _X syntax in OnceIonized manipulator

### DIFF
--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
@@ -62,7 +62,7 @@ namespace manipulators
         )
         {
             constexpr float_X protonNumber = GetAtomicNumbers< T_Particle >::type::numberOfProtons;
-            particle[ boundElectrons_ ] = protonNumber - 1;
+            particle[ boundElectrons_ ] = protonNumber - 1.0_X;
         }
     };
     using OnceIonized = generic::Free< OnceIonizedImpl >;


### PR DESCRIPTION
The `_X` syntax was missing in the `OnceIonized` manipulator in the `FoilLCT` example
It now matches the `TwiceIonized` manipulator and also has the correct data type for `protonNumber`.