### PR TITLE
Containers: Update 0.4.0

### DIFF
--- a/share/picongpu/dockerfiles/README.rst
+++ b/share/picongpu/dockerfiles/README.rst
@@ -56,19 +56,20 @@ You can also push the result to dockerhub and singularity-hub (you need an accou
     cd ubuntu-1604
 
     # docker image
-    docker build -t ax3l/picongpu:0.3.0 .
+    docker build -t ax3l/picongpu:0.4.0 .
     # optional: push to dockerhub (needed for singularity bootstrap)
     docker login
-    docker push ax3l/picongpu:0.3.0
+    docker push ax3l/picongpu:0.4.0
     # optional: mark as latest release
-    docker tag ax3l/picongpu:0.3.0 ax3l/picongpu:latest
+    docker tag ax3l/picongpu:0.4.0 ax3l/picongpu:latest
     docker push ax3l/picongpu:latest
 
     # singularity image
     singularity create -s 4096 picongpu.img
     sudo singularity bootstrap picongpu.img Singularity
-    # optional: push to singularity-hub
-    singularity push picongpu.img --name ax3l/picongpu --tag 0.3.0
+    # optional: push to a singularity registry
+    # setup your $HOME/.sregistry first
+    sregistry push picongpu.img --name ax3l/picongpu --tag 0.4.0
 
 Recipes
 -------

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -6,7 +6,7 @@ ENV        DEBIAN_FRONTEND=noninteractive \
            FORCE_UNSAFE_CONFIGURE=1 \
            SPACK_ROOT=/usr/local \
            SPACK_EXTRA_REPO=/usr/local/share/spack-repo \
-           PIC_PACKAGE='picongpu@0.4.0-rc4+isaac backend=cuda'
+           PIC_PACKAGE='picongpu@0.4.0+isaac backend=cuda'
 
 # install minimal spack dependencies
 #   - adds gfortran for spack's openmpi package

--- a/share/picongpu/dockerfiles/ubuntu-1604/Singularity
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Singularity
@@ -1,10 +1,10 @@
 Bootstrap: docker
-From: ax3l/picongpu:0.3.0
+From: ax3l/picongpu:0.4.0
 
 
 %labels
 Maintainer Axel Huebl <a.huebl@hzdr.de>
-Version 0.3.0
+Version 0.4.0
 
 
 %runscript


### PR DESCRIPTION
Update docs for containers to latest release. Update singularity registry usage: no public registry anymore unless used with github-controlled builders. Use own registry instead.