### PR TITLE
fix outdated derive species

### DIFF
--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
@@ -50,7 +50,7 @@ namespace particles
         >
 #   if( PARAM_IONS == 1 )
         ,
-        DeriveSpecies<
+        Derive<
             PIC_Electrons,
             PIC_Ions
         >


### PR DESCRIPTION
This syntax is obsolete with the new version (0.4.0). 
Since it was not captured by the compile suite, this case is probably never checked. 
Should we add it to the compile suite?