### PR TITLE
deactivate current in Bunch example

### DIFF
--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
@@ -86,7 +86,6 @@ using ParticleFlagsElectrons = bmpl::vector<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
-    current< UsedParticleCurrentSolver >,
     massRatio< MassRatioElectrons >,
     chargeRatio< ChargeRatioElectrons >
 #if( ENABLE_SYNCHROTRON_PHOTONS == 1 )


### PR DESCRIPTION
With the new version, the current deposition is activated in the bunch example.
This however breaks the electron propagation due to a wrong (non charge neutral) initialization. 

Thanks @lehnertu for finding this bug!