### PR TITLE
remove current deposition in bunch example

### DIFF
--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
@@ -86,7 +86,6 @@ using ParticleFlagsElectrons = bmpl::vector<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
-    current< UsedParticleCurrentSolver >,
     massRatio< MassRatioElectrons >,
     chargeRatio< ChargeRatioElectrons >
 #if( ENABLE_SYNCHROTRON_PHOTONS == 1 )


### PR DESCRIPTION
This pull request fixes a bug in the bunch example.
Thank you @lehnertu for discovering it!

The current deposition should be deactivated for this example since otherwise the bunch gets pulled back by the remaining "virtual" ions. 