### PR TITLE
fix 2D case of single electron init (via density)

### DIFF
--- a/share/picongpu/examples/Bunch/include/picongpu/param/density.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/density.param
@@ -109,7 +109,7 @@ namespace densityProfiles
                 precisionCast< uint64_t >(
                     math::floor(
                         position_start_SI.shrink< simDim >() /
-                        cellSize_SI
+                        cellSize_SI.shrink< simDim >()
                     )
                 )
             );


### PR DESCRIPTION
The single electron case should also work in 2D, but one vector reduction (to 2 dimensions) is missing and causes a compile error. This pull request fixes this bug. 