### PR TITLE
Python Regex: r Literals

### DIFF
--- a/docs/source/models/field_ionization_comparison_c_ii_ionization.py
+++ b/docs/source/models/field_ionization_comparison_c_ii_ionization.py
@@ -77,27 +77,27 @@ if __name__ == "__main__":
     p_H = plt.plot(fields, H, label="ADK H")
 
     p_Csimple = plt.plot(fields, Csimple,
-                         label="ADK C  $ \quad Z = 2\mathrm{+}$")
+                         label=r"ADK C  $ \quad Z = 2\mathrm{+}$")
     p_Ceff = plt.plot(fields, Ceff,
-                      label="ADK C (eff) $ \quad Z = 3.136 = Z_\mathrm{eff}$")
+                      label=r"ADK C (eff) $ \quad Z = 3.136 = Z_\mathrm{eff}$")
     plt.vlines(E_H**2./(4*1), ymin, ymax,
                colors="{}".format(p_H[0].get_color()),
-               label="$F_\mathrm{BSI}$ H", linestyles="--")
+               label=r"$F_\mathrm{BSI}$ H", linestyles="--")
 
     plt.vlines(E_C[1]**2. / (4*2), ymin, ymax,
                colors="{}".format(p_Csimple[0].get_color()),
-               label="$F_\mathrm{BSI}$ C", linestyles="--")
+               label=r"$F_\mathrm{BSI}$ C", linestyles="--")
     plt.vlines(E_C[1]**2. / (4*3.136), ymin, ymax,
                colors="{}".format(p_Ceff[0].get_color()),
-               label="$F_\mathrm{BSI}$ C (eff)", linestyles="--")
+               label=r"$F_\mathrm{BSI}$ C (eff)", linestyles="--")
 
     plt.title("Comparison of ADK ionization rates for\nCarbon-II and Hydrogen")
     plt.ylim([ymin, ymax])
     plt.xlim([1e-2, 1e1])
     plt.yscale("log")
     plt.xscale("log")
-    plt.ylabel("ionization rate $\Gamma$ [s$^{-1}$]")
-    plt.xlabel("field strength $F$ [AU = 5.1422$\cdot 10^{11}$ V/m]")
+    plt.ylabel(r"ionization rate $\Gamma$ [s$^{-1}$]")
+    plt.xlabel(r"field strength $F$ [AU = 5.1422$\cdot 10^{11}$ V/m]")
     plt.legend(loc="best")
 
     plt.show()

--- a/docs/source/models/field_ionization_effective_potentials.py
+++ b/docs/source/models/field_ionization_effective_potentials.py
@@ -78,8 +78,8 @@ if __name__ == "__main__":
     plt.hlines(-E_CII, xmin, xmax)
 
     # add the legend and format the plot
-    plt.title("Effective atomic potentials of Carbon-II and Hydrogen in\n"
-              "homogeneous electric field $F_\mathrm{BSI}$ (C-II)")
+    plt.title(r"Effective atomic potentials of Carbon-II and Hydrogen in\n"
+              r"homogeneous electric field $F_\mathrm{BSI}$ (C-II)")
     plt.legend(loc="best")
     plt.text(xmin+1, -E_H+.05, r"$E_\mathrm{i}$ H")
     plt.text(xmin+1, -E_CII+.05, r"$E_\mathrm{i}$ C-II (Z_eff)")
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     plt.text(xmin+1, -2.6, r"$\mathrm{\ with\ } F = F_\mathrm{BSI}$(C-II)")
     plt.xlim([-10., 10.])
     plt.ylim([-3., 1.])
-    plt.ylabel("$V_\mathrm{eff}$ [AU = Rydberg]")
-    plt.xlabel("$x$ [AU = Bohr radii]")
+    plt.ylabel(r"$V_\mathrm{eff}$ [AU = Rydberg]")
+    plt.xlabel(r"$x$ [AU = Bohr radii]")
 
     plt.show()

--- a/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
@@ -59,7 +59,7 @@ class Visualizer(BaseVisualizer):
         self.cbar = plt.colorbar(self.plt_obj, ax=self.ax)
         self.cbar.set_label(
             r'$Q / \mathrm{d}r \mathrm{d}p$ [$\mathrm{C s kg^{-1} m^{-2}}$] ')
-        self.ax.set_xlabel(r'${0}$ [${1}$]'.format(meta.r, "\mathrm{\mu m}"))
+        self.ax.set_xlabel(r'${0}$ [${1}$]'.format(meta.r, r'\mathrm{\mu m}'))
         self.ax.set_ylabel(r'$p_{0}$ [$\beta\gamma$]'.format(meta.p))
 
     def _update_plt_obj(self):

--- a/lib/python/picongpu/utils/find_time.py
+++ b/lib/python/picongpu/utils/find_time.py
@@ -66,13 +66,13 @@ class FindTime(object):
         data_file_path = self.get_data_path()
 
         # matches floats and scientific floats
-        rg_flt = "([-\+[0-9]+\.[0-9]*[Ee]*[\+-]*[0-9]*)"
+        rg_flt = r"([-\+[0-9]+\.[0-9]*[Ee]*[\+-]*[0-9]*)"
 
         # our UNIT_TIME is scaled to dt
         dt = np.fromregex(
             data_file_path,
-            "\s+UNIT_TIME " +
-            rg_flt + "\n",
+            r"\s+UNIT_TIME " +
+            rg_flt + r"\n",
             dtype=np.dtype([('dt', 'float')])
         )
 

--- a/src/tools/bin/plot_chargeConservation.py
+++ b/src/tools/bin/plot_chargeConservation.py
@@ -122,8 +122,8 @@ def plotError(h5file, slice_pos=[0.5, 0.5, 0.5]):
                vmin=-limit, vmax=+limit,
                aspect='auto',
                cmap=plt.cm.bwr)
-    plt.xlabel("$x\,[\Delta x]$", fontsize=20)
-    plt.ylabel("$y\,[\Delta y]$", fontsize=20)
+    plt.xlabel(r"$x\,[\Delta x]$", fontsize=20)
+    plt.ylabel(r"$y\,[\Delta y]$", fontsize=20)
     plt.xticks(fontsize=16)
     plt.yticks(fontsize=16)
     set_colorbar(plt.colorbar(orientation='horizontal',
@@ -138,8 +138,8 @@ def plotError(h5file, slice_pos=[0.5, 0.5, 0.5]):
                vmin=-limit, vmax=+limit,
                aspect='auto',
                cmap=plt.cm.bwr)
-    plt.xlabel("$x\,[\Delta x]$", fontsize=20)
-    plt.ylabel("$z\,[\Delta z]$", fontsize=20)
+    plt.xlabel(r"$x\,[\Delta x]$", fontsize=20)
+    plt.ylabel(r"$z\,[\Delta z]$", fontsize=20)
     plt.xticks(fontsize=16)
     plt.yticks(fontsize=16)
     set_colorbar(plt.colorbar(orientation='horizontal',
@@ -154,8 +154,8 @@ def plotError(h5file, slice_pos=[0.5, 0.5, 0.5]):
                vmin=-limit, vmax=+limit,
                aspect='auto',
                cmap=plt.cm.bwr)
-    plt.xlabel("$y\,[\Delta y]$", fontsize=20)
-    plt.ylabel("$z\,[\Delta z]$", fontsize=20)
+    plt.xlabel(r"$y\,[\Delta y]$", fontsize=20)
+    plt.ylabel(r"$z\,[\Delta z]$", fontsize=20)
     plt.xticks(fontsize=16)
     plt.yticks(fontsize=16)
     set_colorbar(plt.colorbar(orientation='horizontal',

--- a/src/tools/bin/plot_chargeConservation_overTime.py
+++ b/src/tools/bin/plot_chargeConservation_overTime.py
@@ -65,7 +65,7 @@ def get_list_of_hdf5_files(base_directory):
 
     for filename in os.listdir(h5_dir):
         if os.path.isfile(h5_dir+filename):
-            if re.search(".+_[0-9]+\.h5", filename):
+            if re.search(r".+_[0-9]+\.h5", filename):
                 h5_list.append(h5_dir + filename)
     return h5_list
 


### PR DESCRIPTION
Python regular expressions need a `r''` literal.
Fix a recently introduced flake8/pycodestyle warning (that let's the CI fail).