### PR TITLE
fix EveryNthCellImpl

### DIFF
--- a/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
@@ -67,7 +67,7 @@ namespace densityProfiles
 
             // is this cell populated with a probe particle?
             bool const isPopulated(
-                isThisCellWithProbe.productOfComponents() == 0
+                isThisCellWithProbe == DataSpace< simDim >::create( 0 )
             );
 
             /* every how many (volumentric) cells do we set a particle:


### PR DESCRIPTION
fix #2763

The number of skipped cells for the functor is due to a bug always dominated by the dimension with the smallest value. If one dimension is one than each cell is used even if other dimensions has a larger value.