### PR TITLE
Params: remove `boost::vector<>` usage

### DIFF
--- a/docs/source/usage/plugins/adios.rst
+++ b/docs/source/usage/plugins/adios.rst
@@ -22,7 +22,7 @@ One can e.g. disable the output of particles by setting:
    /* output all species */
    using FileOutputParticles = VectorAllSpecies;
    /* disable */
-   using FileOutputParticles = bmpl::vector0< >;
+   using FileOutputParticles = MakeSeq_t< >;
 
 .cfg file
 ^^^^^^^^^

--- a/docs/source/usage/plugins/hdf5.rst
+++ b/docs/source/usage/plugins/hdf5.rst
@@ -38,7 +38,7 @@ One can e.g. disable the output of particles by setting:
    /* output all species */
    using FileOutputParticles = VectorAllSpecies;
    /* disable */
-   using FileOutputParticles = bmpl::vector0< >;
+   using FileOutputParticles = MakeSeq_t< >;
 
 .cfg file
 ^^^^^^^^^

--- a/docs/source/usage/workflows/probeParticles.rst
+++ b/docs/source/usage/workflows/probeParticles.rst
@@ -20,7 +20,7 @@ Workflow
 
 .. code-block:: cpp
 
-    using ParticleFlagsProbes = bmpl::vector<
+    using ParticleFlagsProbes = MakeSeq_t<
         particlePusher< particles::pusher::Probe >,
         shape< UsedParticleShape >,
         interpolation< UsedField2Particle >
@@ -84,7 +84,7 @@ and add it to ``VectorAllSpecies``:
 
 .. code-block:: cpp
 
-   using InitPipeline = mpl::vector<
+   using InitPipeline = MakeSeq_t<
        // ... ,
        CreateDensity<
            densityProfiles::ProbeEveryFourthCell,

--- a/docs/source/usage/workflows/quasiNeutrality.rst
+++ b/docs/source/usage/workflows/quasiNeutrality.rst
@@ -15,7 +15,7 @@ For fully ionized ions, just use ``ManipulateDeriveSpecies`` in :ref:`speciesIni
 
 .. code-block:: cpp
 
-   using InitPipeline = mpl::vector<
+   using InitPipeline = MakeSeq_t<
        /* density profile from density.param and
         *     start position from particle.param */
        CreateDensity<
@@ -72,7 +72,7 @@ Then again in :ref:`speciesInitialization.param <usage-params-core>` set your in
 
 .. code-block:: cpp
 
-   using InitPipeline = mpl::vector<
+   using InitPipeline = MakeSeq_t<
        /* density profile from density.param and
         *     start position from particle.param */
        CreateDensity<

--- a/include/picongpu/param/fileOutput.param
+++ b/include/picongpu/param/fileOutput.param
@@ -111,7 +111,7 @@ namespace picongpu
     /** FileOutputParticles: Groups all Species that shall be dumped **********
      *
      * hint: to disable particle output set to
-     *   using FileOutputParticles = bmpl::vector0< >;
+     *   using FileOutputParticles = MakeSeq_t< >;
      */
     using FileOutputParticles = VectorAllSpecies;
 

--- a/include/picongpu/param/speciesDefinition.param
+++ b/include/picongpu/param/speciesDefinition.param
@@ -62,7 +62,7 @@ using DefaultParticleAttributes = MakeSeq_t<
 value_identifier( float_X, MassRatioPhotons, 0.0 );
 value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
-using ParticleFlagsPhotons = bmpl::vector<
+using ParticleFlagsPhotons = MakeSeq_t<
     particlePusher< particles::pusher::Photon >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -83,7 +83,7 @@ using PIC_Photons = Particles<
 value_identifier( float_X, MassRatioElectrons, 1.0 );
 value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -111,7 +111,7 @@ value_identifier( float_X, ChargeRatioIons, -1.0 );
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioIons, 1.0 );
 
-using ParticleFlagsIons = bmpl::vector<
+using ParticleFlagsIons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,

--- a/include/picongpu/param/speciesInitialization.param
+++ b/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<>;
+    using InitPipeline = MakeSeq_t<>;
 
 } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
@@ -55,7 +55,7 @@ using DefaultParticleAttributes = MakeSeq_t<
 value_identifier( float_X, MassRatioPhotons, 0.0 );
 value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
-using ParticleFlagsPhotons = bmpl::vector<
+using ParticleFlagsPhotons = MakeSeq_t<
     particlePusher< particles::pusher::Photon >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -78,7 +78,7 @@ value_identifier(float_X, MassRatioIons, 359100);
 value_identifier(float_X, ChargeRatioIons, -79.0);
 value_identifier(float_X, DensityRatioIons, 1.0);
 
-using ParticleFlagsIons = bmpl::vector<
+using ParticleFlagsIons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -104,7 +104,7 @@ value_identifier( float_X, MassRatioElectrons, 1.0 );
 value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 value_identifier( float_X, DensityRatioElectrons, 79.0 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
         CreateDensity<
             densityProfiles::Foil,
             startPosition::Quiet1ppc,

--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
@@ -61,7 +61,7 @@ using DefaultParticleAttributes = MakeSeq_t<
 value_identifier( float_X, MassRatioPhotons, 0.0 );
 value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
-using ParticleFlagsPhotons = bmpl::vector<
+using ParticleFlagsPhotons = MakeSeq_t<
     particlePusher< particles::pusher::Photon >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -82,7 +82,7 @@ using PIC_Photons = Particles<
 value_identifier( float_X, MassRatioElectrons, 1.0 );
 value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,

--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
 #ifdef PARAM_SINGLE_PARTICLE
         CreateDensity<
             densityProfiles::FreeFormula,

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
@@ -70,7 +70,7 @@ using IonParticleAttributes = MakeSeq_t<
 value_identifier( float_X, MassRatioElectrons, 1.0 );
 value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -95,7 +95,7 @@ value_identifier( float_X, ChargeRatioHydrogen, -1.0 );
 /* ratio relative to BASE_DENSITY (n_e) */
 value_identifier( float_X, DensityRatioHydrogen, 25. / 158. );
 
-using ParticleFlagsHydrogen = bmpl::vector<
+using ParticleFlagsHydrogen = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -131,7 +131,7 @@ value_identifier( float_X, ChargeRatioCarbon, -6.0 );
 /* ratio relative to BASE_DENSITY (n_e) */
 value_identifier( float_X, DensityRatioCarbon, 21. / 158. );
 
-using ParticleFlagsCarbon = bmpl::vector<
+using ParticleFlagsCarbon = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -167,7 +167,7 @@ value_identifier( float_X, ChargeRatioNitrogen, -7.0 );
 /* ratio relative to BASE_DENSITY (n_e) */
 value_identifier( float_X, DensityRatioNitrogen, 1. / 158. );
 
-using ParticleFlagsNitrogen = bmpl::vector<
+using ParticleFlagsNitrogen = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -196,7 +196,7 @@ using Nitrogen = Particles<
 
 /*--------------------------- Probe Particles -------------------------------*/
 
-using ParticleFlagsProbes = bmpl::vector<
+using ParticleFlagsProbes = MakeSeq_t<
     particlePusher< particles::pusher::Probe >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesInitialization.param
@@ -42,7 +42,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
         CreateDensity<
             densityProfiles::FlatFoilWithRamp,
             startPosition::Random6ppc,

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
@@ -60,7 +60,7 @@ using DefaultParticleAttributes = MakeSeq_t<
 value_identifier( float_X, MassRatioElectrons, 1.0 );
 value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -85,7 +85,7 @@ value_identifier( float_X, ChargeRatioIons, -1.0 );
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioIons, -1.0 );
 
-using ParticleFlagsIons = bmpl::vector<
+using ParticleFlagsIons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
         CreateDensity<
             densityProfiles::Homogenous,
             startPosition::Quiet25ppc,

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
@@ -61,7 +61,7 @@ using AttributeSeqIons = MakeSeq_t<
 value_identifier( float_X, MassRatioElectrons, 1.0 );
 value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,
@@ -83,7 +83,7 @@ using PIC_Electrons = Particles<
 value_identifier( float_X, MassRatioIons, 1836.152672 );
 value_identifier( float_X, ChargeRatioIons, -1.0 );
 
-using ParticleFlagsIons = bmpl::vector<
+using ParticleFlagsIons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
     interpolation< UsedField2Particle >,

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
 #if( PARAM_IONIZATION == 0 )
         CreateDensity<
             densityProfiles::Gaussian,

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fileOutput.param
@@ -94,7 +94,7 @@ namespace picongpu
     /** FileOutputParticles: Groups all Species that shall be dumped **********
      *
      * hint: to disable particle output set to
-     *   using FileOutputParticles = bmpl::vector0< >;
+     *   using FileOutputParticles = MakeSeq_t< >;
      */
     using FileOutputParticles = VectorAllSpecies;
 

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
@@ -58,7 +58,7 @@ using DefaultParticleAttributes = MakeSeq_t<
 value_identifier(float_X, MassRatioElectrons, 1.0);
 value_identifier(float_X, ChargeRatioElectrons, 1.0);
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
 /* enable the pusher only if PARAM_ENABLEPUSHER is defined as one `1` */
 #if( PARAM_ENABLEPUSHER == 1 )
     particlePusher<UsedParticlePusher>,

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
         CreateDensity<
             densityProfiles::FreeFormula,
             startPosition::OnePosition,

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
         CreateDensity<
             densityProfiles::Homogenous,
             startPosition::Random16ppc,

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
@@ -60,7 +60,7 @@ using DefaultParticleAttributes = MakeSeq_t<
 value_identifier( float_X, MassRatioPhotons, 0.0 );
 value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
-using ParticleFlagsPhotons = bmpl::vector<
+using ParticleFlagsPhotons = MakeSeq_t<
 #if( PARAM_ENABLE_PUSHER == 1 )
     particlePusher< particles::pusher::Photon >,
 #endif
@@ -94,7 +94,7 @@ value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 value_identifier( float_X, DensityRatioBulkElectrons, 0.999 );
 value_identifier( float_X, DensityRatioPromptElectrons, 0.001 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
 #if( PARAM_ENABLE_PUSHER == 1 )
     particlePusher< UsedParticlePusher >,
 #endif
@@ -136,7 +136,7 @@ value_identifier( float_X, ChargeRatioCopper, -29.0 );
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioCopper, 1.0 );
 
-using ParticleFlagsCopper = bmpl::vector<
+using ParticleFlagsCopper = MakeSeq_t<
 #if( PARAM_ENABLE_PUSHER == 1 )
     particlePusher< UsedParticlePusher >,
 #endif

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesInitialization.param
@@ -42,7 +42,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
         // Generate Densities
         CreateDensity<
             densityProfiles::Homogenous,

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
@@ -52,7 +52,7 @@ using DefaultParticleAttributes = MakeSeq_t<
 value_identifier( float_X, MassRatioElectrons, 1.0 );
 value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
-using ParticleFlagsElectrons = bmpl::vector<
+using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher<UsedParticlePusher>,
     shape<UsedParticleShape>,
     interpolation<UsedField2Particle>,
@@ -77,7 +77,7 @@ value_identifier( float_X, ChargeRatioIons, -1.0 );
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioIons, 1.0 );
 
-using ParticleFlagsIons = bmpl::vector<
+using ParticleFlagsIons = MakeSeq_t<
     particlePusher<UsedParticlePusher>,
     shape<UsedParticleShape>,
     interpolation<UsedField2Particle>,

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace particles
      *
      * the functors are called in order (from first to last functor)
      */
-    using InitPipeline = mpl::vector<
+    using InitPipeline = MakeSeq_t<
         CreateDensity<
             densityProfiles::Homogenous,
             startPosition::Quiet4ppc,


### PR DESCRIPTION
Remove the usage of `boost::mpl::vector` by `MakeSeq_t`.
This will be much easier for the user and will avoid confusion.