### PR TITLE
Fix docs for radiation in 2D

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -326,8 +326,6 @@ Tool                           Description
 Known Issues
 ^^^^^^^^^^^^
 
-Currently, the radiation plugin does not support 2D simulations. 
-This should be fixed with `issue #289 <https://github.com/ComputationalRadiationPhysics/picongpu/issues/289>`_ .
 The plugin supports multiple radiation species but spectra (frequencies and observation directions) are the same for all species. 
 
 


### PR DESCRIPTION
This fixes the documentation of the radiation plugin for 2D simulations.
(re-) close https://github.com/ComputationalRadiationPhysics/picongpu/issues/289