### PR TITLE
Spack: Improve Bootstrap

### DIFF
--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -24,14 +24,14 @@ First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html
    # get spack
    git clone https://github.com/spack/spack.git $HOME/src/spack
 
+   # build spack's dependencies via spack :)
+   $HOME/src/spack/bin/spack bootstrap
+
    # activate the spack environment
    source $HOME/src/spack/share/spack/setup-env.sh
 
-   # build spack's dependencies via spack :)
-   spack bootstrap
-
    # install a supported compiler
-   spack compiler list | grep gcc@7.3.0 | spack install gcc@7.3.0 && spack load gcc@7.3.0 && spack compiler add
+   spack compiler list | grep gcc@7.3.0 1>/dev/null && spack install gcc@7.3.0 && spack load gcc@7.3.0 && spack compiler add
 
    # add the PIConGPU repository
    git clone https://github.com/ComputationalRadiationPhysics/spack-repo.git $HOME/src/spack-repo


### PR DESCRIPTION
If the bootstrap pulls in environment modules, these need to be activated. Improve command order to avoid sourcing twice.

Fix #2770 

- [x] WIP: do not merge until checkbox is checked