### PR TITLE
avoid two slides

### DIFF
--- a/include/picongpu/simulationControl/MovingWindow.hpp
+++ b/include/picongpu/simulationControl/MovingWindow.hpp
@@ -180,7 +180,8 @@ private:
      */
     void incrementSlideCounter(const uint32_t currentStep)
     {
-        if (slidingWindowActive==true && lastSlideStep != currentStep)
+        // do not slide twice in one simulation step
+        if (slidingWindowActive==true && lastSlideStep < currentStep)
         {
             slideCounter++;
             lastSlideStep = currentStep;


### PR DESCRIPTION
If someone is querying the moving window class with a time step which is less than
the current simulation step it can happen that the window is sliding.

- only allow sliding if the time step is larger than the last slide point