### PR TITLE
Add getter for omega and n to python module

### DIFF
--- a/lib/python/picongpu/plugins/data/radiation.py
+++ b/lib/python/picongpu/plugins/data/radiation.py
@@ -105,3 +105,16 @@ class RadiationData:
         omega_h = self.h5_file[("/data/{}/DetectorMesh/" +
                                 "DetectorFrequency/omega").format(self.timestep)]
         return omega_h[0, :, 0] * omega_h.attrs['unitSI']
+
+    def get_vector_n(self):
+        """Returns the unit vector 'n' of the observation directions."""
+        n_h = self.h5_file[("/data/{}/DetectorMesh/" +
+                            "DetectorDirection/").format(self.timestep)]
+        n_x = n_h['x'][:, 0, 0] * n_h['x'].attrs['unitSI']
+        n_y = n_h['y'][:, 0, 0] * n_h['y'].attrs['unitSI']
+        n_z = n_h['z'][:, 0, 0] * n_h['z'].attrs['unitSI']
+        n_vec = np.empty((len(n_x), 3))
+        n_vec[:, 0] = n_x
+        n_vec[:, 1] = n_y
+        n_vec[:, 2] = n_z
+        return n_vec

--- a/lib/python/picongpu/plugins/data/radiation.py
+++ b/lib/python/picongpu/plugins/data/radiation.py
@@ -102,14 +102,14 @@ class RadiationData:
 
     def get_omega(self):
         """Returns frequency 'omega' of spectrum in [s^-1]."""
-        omega_h = self.h5_file[("/data/{}/DetectorMesh/" +
-                                "DetectorFrequency/omega").format(self.timestep)]
+        omega_h = self.h5_file["/data/{}/".format(self.timestep) +
+                               "DetectorMesh/DetectorFrequency/omega"]
         return omega_h[0, :, 0] * omega_h.attrs['unitSI']
 
     def get_vector_n(self):
         """Returns the unit vector 'n' of the observation directions."""
-        n_h = self.h5_file[("/data/{}/DetectorMesh/" +
-                            "DetectorDirection/").format(self.timestep)]
+        n_h = self.h5_file["/data/{}/".format(self.timestep) +
+                           "DetectorMesh/DetectorDirection/"]
         n_x = n_h['x'][:, 0, 0] * n_h['x'].attrs['unitSI']
         n_y = n_h['y'][:, 0, 0] * n_h['y'].attrs['unitSI']
         n_z = n_h['z'][:, 0, 0] * n_h['z'].attrs['unitSI']

--- a/lib/python/picongpu/plugins/data/radiation.py
+++ b/lib/python/picongpu/plugins/data/radiation.py
@@ -99,3 +99,9 @@ class RadiationData:
     def get_Polarization_Z(self):
         """Returns real spectra for z-polarization in [Js]."""
         return np.abs(self.get_Amplitude_z())**2
+
+    def get_omega(self):
+        """Returns frequency 'omega' of spectrum in [s^-1]."""
+        omega_h = self.h5_file[("/data/{}/DetectorMesh/" +
+                                "DetectorFrequency/omega").format(self.timestep)]
+        return omega_h[0, :, 0] * omega_h.attrs['unitSI']


### PR DESCRIPTION
This pull request closes issue #2759 by adding the missing getters for frequency (omega) and observation direction (n) . It still does not make it compatible to the standard iteration oriented interface. 