### PR TITLE
Python Tools: Incorporate sim_time into readers and visualizers

### DIFF
--- a/docs/source/dev/py_postprocessing.rst
+++ b/docs/source/dev/py_postprocessing.rst
@@ -15,7 +15,7 @@ Data Reader
 
 The data readers should reside in the ``lib/python/picongpu/plugins/data`` directory.
 There is a base class in ``base_reader.py`` defining the interface of a reader.
-Each reader class should derive from this class and needs to implement the following interface functions:
+Each reader class should derive from this class and implement the interface functions not implemented in this class.
 
 .. autoclass:: picongpu.plugins.data.base_reader.DataReader
    :members:

--- a/lib/python/picongpu/plugins/data/base_reader.py
+++ b/lib/python/picongpu/plugins/data/base_reader.py
@@ -75,9 +75,11 @@ class DataReader(object):
         an iteration and data for the iteration matching the time
         is returned.
 
-        time: float or np.array of float
+        time: float or np.array of float or None.
+            If None, data for all available times is returned.
 
-        iteration: int or np.array of int
+        iteration: int or np.array of int or None.
+            If None, data for all available iterations is returned.
 
         Returns
         -------
@@ -89,13 +91,22 @@ class DataReader(object):
                 "One of 'iteration' and 'time' parameters"
                 " has to be present!")
 
-        iteration = kwargs.get('iteration', None)
+        iteration = None
+        if 'iteration' in kwargs:
+            # remove the entry from kwargs since we pass that
+            # on
+            iteration = kwargs.pop('iteration')
 
-        time = kwargs.get('time', None)
-        if time is not None:
+        if 'time' in kwargs:
             # we have time and override the iteration
-            # so convert time to iteration
-            iteration = self.find_time.get_iteration(time)
+            # by the converted time
+            time = kwargs.pop('time')
+            if time is None:
+                # use all times that are available, i.e. all iterations
+                iteration = self.get_iterations(**kwargs)
+            else:
+                iteration = self.find_time.get_iteration(time)
+            print("got 'time'=", time, ", converting to iteration", iteration)
 
         return self._get_for_iteration(iteration, **kwargs)
 

--- a/lib/python/picongpu/plugins/data/base_reader.py
+++ b/lib/python/picongpu/plugins/data/base_reader.py
@@ -32,6 +32,23 @@ class DataReader(object):
         self.data_file_prefix = None
         self.data_file_suffix = None
 
+    def get_dt(self):
+        """
+        Return the timestep for the chosen simulation.
+        """
+        return self.find_time.get_dt()
+
+    def get_times(self, **kwargs):
+        """
+        Returns
+        -------
+        An array of floats of simulation time steps for which
+        data is available
+        """
+
+        iterations = np.array(self.get_iterations(**kwargs))
+        return self.find_time.get_time(iterations)
+
     def get_data_path(self, **kwargs):
         """
         Returns
@@ -48,22 +65,6 @@ class DataReader(object):
         data is available.
         """
         raise NotImplementedError
-
-    def get_dt(self):
-        """
-        """
-        return self.find_time.get_dt()
-
-    def get_times(self, **kwargs):
-        """
-        Returns
-        -------
-        An array of floats of simulation time steps for which
-        data is available
-        """
-
-        iterations = np.array(self.get_iterations(**kwargs))
-        return self.find_time.get_time(iterations)
 
     def get(self, **kwargs):
         """

--- a/lib/python/picongpu/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/plugins/data/energy_histogram.py
@@ -99,23 +99,23 @@ class EnergyHistogramData(DataReader):
                            delimiter=" ",
                            dtype=np.uint64).values[:, 0]
 
-    def get(self, species, species_filter="all", iteration=None,
-            include_overflow=False, **kwargs):
+    def _get_for_iteration(self, iteration, species, species_filter="all",
+                           include_overflow=False, **kwargs):
         """
-        Get a histogram.
+        Get a histogram for a given iteration.
 
         Parameters
         ----------
+        iteration : (unsigned) int [unitless]
+            The iteration at which to read the data.
+            A list of iterations is allowed as well.
+            ``None`` refers to the list of all available iterations.
         species : string
             short name of the particle species, e.g. 'e' for electrons
             (defined in ``speciesDefinition.param``)
         species_filter: string
             name of the particle species filter, default is 'all'
             (defined in ``particleFilters.param``)
-        iteration : (unsigned) int [unitless]
-            The iteration at which to read the data.
-            A list of iterations is allowed as well.
-            ``None`` refers to the list of all available iterations.
         include_overflow : boolean, default: False
             Include overflow and underflow bins as the first/last bins.
 

--- a/lib/python/picongpu/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/plugins/data/energy_histogram.py
@@ -106,9 +106,8 @@ class EnergyHistogramData(DataReader):
 
         Parameters
         ----------
-        iteration : (unsigned) int [unitless]
+        iteration : (unsigned) int [unitless] or list of int or None.
             The iteration at which to read the data.
-            A list of iterations is allowed as well.
             ``None`` refers to the list of all available iterations.
         species : string
             short name of the particle species, e.g. 'e' for electrons
@@ -123,8 +122,7 @@ class EnergyHistogramData(DataReader):
         -------
         counts : np.array of dtype float [unitless]
             count of particles in each bin
-            If iteration is a list, returns (ordered) dict with iterations as
-            its index.
+            If iteration is a list, returns a list of counts.
         bins : np.array of dtype float [keV]
             upper ranges of each energy bin
         """
@@ -179,9 +177,6 @@ class EnergyHistogramData(DataReader):
             del data['overflow']
 
         if len(iteration) > 1:
-            return collections.OrderedDict(zip(
-                    iteration,
-                    data.loc[iteration].values
-                )), bins
+            return data.loc[iteration].values, bins
         else:
             return data.loc[iteration].values[0, :], bins

--- a/lib/python/picongpu/plugins/data/phase_space.py
+++ b/lib/python/picongpu/plugins/data/phase_space.py
@@ -214,7 +214,7 @@ class PhaseSpaceData(DataReader):
         ps_meta :
             PhaseSpaceMeta object with meta information about the 2D histogram
 
-        @todo if iteration is a list, return a dict
+        @todo if iteration is a list, return a list of tuples
         """
         if iteration is None:
             raise ValueError('The iteration needs to be set!')

--- a/lib/python/picongpu/plugins/data/phase_space.py
+++ b/lib/python/picongpu/plugins/data/phase_space.py
@@ -187,13 +187,16 @@ class PhaseSpaceData(DataReader):
 
         return iterations
 
-    def get(self, species, species_filter='all', iteration=None, ps=None,
-            **kwargs):
+    def _get_for_iteration(self, iteration, species, species_filter='all',
+                           ps=None, **kwargs):
         """
         Get a phase space histogram.
 
         Parameters
         ----------
+        iteration : (unsigned) int [unitless]
+            The iteration at which to read the data.
+            @TODO also allow lists here
         species : string
             short name of the particle species, e.g. 'e' for electrons
             (defined in ``speciesDefinition.param``)
@@ -203,9 +206,6 @@ class PhaseSpaceData(DataReader):
         ps : string
             phase space selection in order: spatial, momentum component,
             e.g. 'ypy' or 'ypx'
-        iteration : (unsigned) int [unitless]
-            The iteration at which to read the data.
-            @TODO also allow lists here
 
         Returns
         -------

--- a/lib/python/picongpu/plugins/data/png.py
+++ b/lib/python/picongpu/plugins/data/png.py
@@ -7,6 +7,7 @@ License: GPLv3+
 """
 from .base_reader import DataReader
 
+import numpy as np
 import os
 from scipy import misc
 import collections
@@ -140,7 +141,7 @@ class PNGData(DataReader):
 
         Returns
         -------
-        A sorted list of unsigned integers.
+        A numpy array of sorted unsigned integers.
         """
         # get the available png files in the directory
         png_path = self.get_data_path(
@@ -151,7 +152,7 @@ class PNGData(DataReader):
         # split iteration number from the filenames
         iters = [int(f.split("_")[4].split(".")[0]) for f in png_files]
 
-        return sorted(iters)
+        return np.array(sorted(iters))
 
     def _get_for_iteration(self, iteration, species, species_filter='all',
                            axis=None, slice_point=None, **kwargs):
@@ -160,9 +161,9 @@ class PNGData(DataReader):
 
         Parameters
         ----------
-        iteration: int or list of ints
+        iteration: int or list of ints or None
             The iteration at which to read the data.
-            if set to 'None', then return images for all available iterations
+            if set to 'None', return images for all available iterations
         species : string
             short name of the particle species, e.g. 'e' for electrons
             (defined in ``speciesDefinition.param``)
@@ -177,8 +178,8 @@ class PNGData(DataReader):
 
         Returns
         -------
-        A dictionary mapping iteration number to numpy array representation of
-        the corresponding png file if multiple iterations were requested.
+        A list of numpy array representations of
+        the corresponding png files if multiple iterations were requested.
         Otherwise a single nump array representation for the requested\
         iteration.
         """
@@ -197,10 +198,10 @@ class PNGData(DataReader):
             # iteration is None, so we use all available data
             iteration = available_iterations
 
-        imgs = {it: misc.imread(
+        imgs = [misc.imread(
             self.get_data_path(species, species_filter, axis,
-                               slice_point, it)) for it in iteration}
+                               slice_point, it)) for it in iteration]
         if len(iteration) == 1:
-            return imgs[iteration[0]]
+            return imgs[0]
         else:
             return imgs

--- a/lib/python/picongpu/plugins/data/png.py
+++ b/lib/python/picongpu/plugins/data/png.py
@@ -153,13 +153,16 @@ class PNGData(DataReader):
 
         return sorted(iters)
 
-    def get(self, species, species_filter='all', iteration=None,
-            axis=None, slice_point=None, **kwargs):
+    def _get_for_iteration(self, iteration, species, species_filter='all',
+                           axis=None, slice_point=None, **kwargs):
         """
         Get an array representation of a PNG file.
 
         Parameters
         ----------
+        iteration: int or list of ints
+            The iteration at which to read the data.
+            if set to 'None', then return images for all available iterations
         species : string
             short name of the particle species, e.g. 'e' for electrons
             (defined in ``speciesDefinition.param``)
@@ -171,9 +174,6 @@ class PNGData(DataReader):
         slice_point: float
             relative offset in the third axis not given in the axis argument.\
             Should be between 0 and 1
-        iteration: int or list of ints
-            The iteration at which to read the data.
-            if set to 'None', then return images for all available iterations
 
         Returns
         -------

--- a/lib/python/picongpu/plugins/plot_mpl/energy_histogram_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/energy_histogram_visualizer.py
@@ -61,19 +61,17 @@ class Visualizer(BaseVisualizer):
                 (defined in ``speciesDefinition.param``)
             iteration: int
                 number of the iteration
+            time: float
+                simulation time.
+                Only one of 'iteration' or 'time' should be passed!
             species_filter: string
                 name of the particle species filter, default is 'all'
                 (defined in ``particleFilters.param``)
 
         """
-        iteration = kwargs.get('iteration')
-        species = kwargs.get('species')
-        if iteration is None or species is None:
-            raise ValueError("Iteration and species have to be provided as\
-            keyword arguments!")
-
         super().visualize(**kwargs)
 
+        species = kwargs['species']
         species_filter = kwargs.get('species_filter', 'all')
 
         self.ax.relim()

--- a/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
@@ -81,6 +81,9 @@ class Visualizer(BaseVisualizer):
         kwargs: dict with possible additional keyword args. Valid are:
             iteration: int
                 the iteration number for which data will be plotted.
+            time: float
+                simulation time.
+                Only one of 'iteration' or 'time' should be passed!
             species : string
                 short name of the particle species, e.g. 'e' for electrons
                 (defined in ``speciesDefinition.param``)

--- a/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
@@ -72,6 +72,9 @@ class Visualizer(BaseVisualizer):
                 The iteration at which to read the data.
                 if set to 'None', then return images for all available\
                     iterations
+            time: float
+                simulation time.
+                Only one of 'iteration' or 'time' should be passed!
         """
         super().visualize(**kwargs)
 


### PR DESCRIPTION
This PR makes use of the `FindTime` class and adds it to the data readers. This offers the possibility to query for simulation times directly instead of only query for iterations.

Besides, the readers now return an array of data items when multiple iterations are given in the `get` methods instead of dictionaries. This was done to allow reusing the same function for getting data regardless of whether `time` or `iteration` parameter were provided. 