### PR TITLE
Fix missing exponent in fieldIonization.rst

### DIFF
--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -98,7 +98,7 @@ Ammosov-Delone-Krainov (ADK)
    :nowrap:
 
     \begin{align}
-        \Gamma_\mathrm{ADK} &= \underbrace{\sqrt{\frac{3 n^{*3} F}{\pi Z^3}}}_\text{lin. pol.} \frac{F D^2}{8 \pi Z} \exp\left(-\frac{2Z}{3n^{*3}F}\right) \\
+        \Gamma_\mathrm{ADK} &= \underbrace{\sqrt{\frac{3 n^{*3} F}{\pi Z^3}}}_\text{lin. pol.} \frac{F D^2}{8 \pi Z} \exp\left(-\frac{2Z^3}{3n^{*3}F}\right) \\
         D &\equiv \left( \frac{4 \mathrm{e} Z^3}{F n^{*4}} \right)^{n^*} \hspace{2cm} n^* \equiv \frac{Z}{\sqrt{2 E_\mathrm{ip}}}
     \end{align}
 


### PR DESCRIPTION
In the documentation (*not in the actual code*) an exponent was missing in the ADK ionization rate (last exponential function term).

This is a screenshot of the equation from the original publication that is referenced in the file
![auswahl_042](https://user-images.githubusercontent.com/5416860/48080564-3b68f380-e1ee-11e8-8f1d-7e83c83f2186.png)
