### PR TITLE
enhance taurus gpu setup

### DIFF
--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -26,23 +26,22 @@ module load git/2.18.0-GCCcore-6.4.0
 module load gnuplot/5.2.4-foss-2018a
 
 module load Boost/1.66.0-foss-2018a
-# currently not linking correctly:
-#module load HDF5/1.10.1-foss-2018a
+# currently not linking correctly - thus clean LIBRARY_PATH later:
+module load HDF5/1.10.1-foss-2018a
 module load zlib/1.2.11-GCCcore-6.4.0
 
 # module system does not export cmake prefix path:
 export CMAKE_PREFIX_PATH=$EBROOTLIBPNG:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$EBROOTZLIB:$CMAKE_PREFIX_PATH
 
+# clean LIBRARY_PATH due to hdf5 linking error
+export LIBRARY_PATH=""
+
 # Environment #################################################################
 #
 
 # path to own libraries:
 export ownLibs=$HOME
-# workaround HDF5:
-export HDF5_ROOT=$ownLibs/lib/hdf5
-export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
-export CMAKE_PREFIX_PATH=$HDF5_ROOT:$CMAKE_PREFIX_PATH
 
 # pngwriter needs to be built by the user:
 export PNGwriter_DIR=$ownLibs/lib/pngwriter
@@ -50,7 +49,7 @@ export CMAKE_PREFIX_PATH=$PNGwriter_DIR:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGwriter_DIR/lib/
 
 # splash needs to be built by the user:
-export Splash_DIR=$ownLibs/lib/splashModule2
+export Splash_DIR=$ownLibs/lib/splash
 export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Splash_DIR/lib/
 

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -26,13 +26,16 @@ module load git/2.18.0-GCCcore-6.4.0
 module load gnuplot/5.2.4-foss-2018a
 
 module load Boost/1.66.0-foss-2018a
-# currently not linking correctly:
-#module load HDF5/1.10.1-foss-2018a
+# currently not linking correctly - thus clean LIBRARY_PATH later:
+module load HDF5/1.10.1-foss-2018a
 module load zlib/1.2.11-GCCcore-6.4.0
 
 # module system does not export cmake prefix path:
 export CMAKE_PREFIX_PATH=$EBROOTLIBPNG:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$EBROOTZLIB:$CMAKE_PREFIX_PATH
+
+# clean LIBRARY_PATH due to hdf5 linking error
+export LIBRARY_PATH=""
 
 # Environment #################################################################
 #
@@ -40,18 +43,13 @@ export CMAKE_PREFIX_PATH=$EBROOTZLIB:$CMAKE_PREFIX_PATH
 # path to own libraries:
 export ownLibs=$HOME
 
-# workaround HDF5:
-export HDF5_ROOT=$ownLibs/lib/hdf5
-export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
-export CMAKE_PREFIX_PATH=$HDF5_ROOT:$CMAKE_PREFIX_PATH
-
 # pngwriter needs to be built by the user:
 export PNGwriter_DIR=$ownLibs/lib/pngwriter
 export CMAKE_PREFIX_PATH=$PNGwriter_DIR:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGwriter_DIR/lib/
 
 # splash needs to be built by the user:
-export Splash_DIR=$ownLibs/lib/splashModule2
+export Splash_DIR=$ownLibs/lib/splash
 export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Splash_DIR/lib/
 


### PR DESCRIPTION
This pull request removes the self-compiled hdf5 library and solves the previous linking issue by removing the variable `LIBRARY_PATH`. 

Thanks @psychocoderHPC for pointing out this solution. 

PIConGPU compiles and a LWFA run time test with hdf5 output was successful (using 32 GPUs) and another using just 4 GPUs and both hdf5 output and phase ppace output failed with an error:
```
[taurusi2100:21122:0] Caught signal 11 (Segmentation fault)
[taurusi2100:21123:0] Caught signal 11 (Segmentation fault)
[taurusi2100:21124:0] Caught signal 11 (Segmentation fault)
==== backtrace ====
 2 0x00000000000687bc mxm_handle_error()  /var/tmp/OFED_topdir/BUILD/mxm-3.6.3104/src/mxm/util/debug/debug.c:641
 3 0x0000000000068d0c mxm_error_signal_handler()  /var/tmp/OFED_topdir/BUILD/mxm-3.6.3104/src/mxm/util/debug/debug.c:616
 4 0x0000000000035270 killpg()  ??:0
 5 0x00000000000375e7 ADIOI_Flatten()  ??:0
 6 0x00000000000386b3 ADIOI_Flatten_datatype()  ??:0
 7 0x000000000002cebd ADIO_Set_view()  ??:0
 8 0x00000000000118a6 mca_io_romio314_dist_MPI_File_set_view()  ??:0
 9 0x000000000000b792 mca_io_romio314_file_set_view()  ??:0
10 0x000000000008c24d MPI_File_set_view()  ??:0
11 0x0000000000311047 H5FD_mpio_write()  H5FDmpio.c:0
12 0x0000000000111d58 H5FD_write()  ??:0
13 0x00000000000f6e5c H5F__accum_write()  ??:0
14 0x00000000001f5f10 H5PB_write()  ??:0
15 0x00000000000fa5bb H5F_block_write()  ??:0
16 0x00000000000a8c72 H5D__chunk_allocate()  ??:0
17 0x00000000000b9ed0 H5D__init_storage()  H5Dint.c:0
18 0x00000000000bed8f H5D__alloc_storage()  ??:0
19 0x00000000000c5629 H5D__layout_oh_create()  ??:0
20 0x00000000000bb2e6 H5D__create()  ??:0
21 0x00000000000c68bc H5O__dset_create()  H5Doh.c:0
22 0x000000000018ba34 H5O_obj_create()  ??:0
23 0x00000000001743c1 H5L_link_cb()  H5L.c:0
24 0x000000000014710d H5G_traverse_real()  H5Gtraverse.c:0
25 0x00000000001475ff H5G_traverse()  ??:0
26 0x000000000017591f H5L_link_object()  ??:0
27 0x00000000000ba985 H5D__create_named()  ??:0
28 0x0000000000095d47 H5Dcreate2()  ??:0
29 0x00000000008f9b9f _ZN6splash9DCDataSet6createERKNS_14CollectionTypeElNS_10DimensionsEjbb()  ??:0
30 0x00000000008d6d3b _ZN6splash21ParallelDataCollector12writeDataSetElNS_10DimensionsES1_RKNS_14CollectionTypeEjNS_9SelectionEPKcPKv()  ??:0
31 0x00000000008dbf87 _ZN6splash21ParallelDataCollector5writeEiNS_10DimensionsES1_RKNS_14CollectionTypeEjNS_9SelectionEPKcPKv()  ??:0
32 0x00000000008345d1 _ZN8picongpu4hdf510HDF5Writer9writeHDF5EPv()  ??:0
33 0x0000000000838de5 _ZN8picongpu4hdf510HDF5Writer8dumpDataEj()  ??:0
34 0x000000000083934f _ZN8picongpu4hdf510HDF5Writer6notifyEj()  ??:0
35 0x0000000000738f20 _ZN5pmacc16SimulationHelperILj3EE11dumpOneStepEj()  ??:0
36 0x00000000008008c9 _ZN5pmacc16SimulationHelperILj3EE15startSimulationEv()  ??:0
37 0x0000000000801680 _ZN8picongpu17SimulationStarterINS_21InitialiserControllerENS_16PluginControllerENS_12MySimulationEE5startEv()  ??:0
38 0x00000000006c50cb main()  ??:0
39 0x0000000000021c05 __libc_start_main()  ??:0
40 0x00000000006c655f _start()  ??:0
===================
==== backtrace ====
 2 0x00000000000687bc mxm_handle_error()  /var/tmp/OFED_topdir/BUILD/mxm-3.6.3104/src/mxm/util/debug/debug.c:641
 3 0x0000000000068d0c mxm_error_signal_handler()  /var/tmp/OFED_topdir/BUILD/mxm-3.6.3104/src/mxm/util/debug/debug.c:616
 4 0x0000000000035270 killpg()  ??:0
 5 0x00000000000375e7 ADIOI_Flatten()  ??:0
 6 0x00000000000386b3 ADIOI_Flatten_datatype()  ??:0
 7 0x000000000002cebd ADIO_Set_view()  ??:0
 8 0x00000000000118a6 mca_io_romio314_dist_MPI_File_set_view()  ??:0
 9 0x000000000000b792 mca_io_romio314_file_set_view()  ??:0
10 0x000000000008c24d MPI_File_set_view()  ??:0
11 0x0000000000311047 H5FD_mpio_write()  H5FDmpio.c:0
12 0x0000000000111d58 H5FD_write()  ??:0
13 0x00000000000f6e5c H5F__accum_write()  ??:0
14 0x00000000001f5f10 H5PB_write()  ??:0
15 0x00000000000fa5bb H5F_block_write()  ??:0
16 0x00000000000a8c72 H5D__chunk_allocate()  ??:0
17 0x00000000000b9ed0 H5D__init_storage()  H5Dint.c:0
18 0x00000000000bed8f H5D__alloc_storage()  ??:0
19 0x00000000000c5629 H5D__layout_oh_create()  ??:0
20 0x00000000000bb2e6 H5D__create()  ??:0
21 0x00000000000c68bc H5O__dset_create()  H5Doh.c:0
22 0x000000000018ba34 H5O_obj_create()  ??:0
23 0x00000000001743c1 H5L_link_cb()  H5L.c:0
24 0x000000000014710d H5G_traverse_real()  H5Gtraverse.c:0
25 0x00000000001475ff H5G_traverse()  ??:0
26 0x000000000017591f H5L_link_object()  ??:0
27 0x00000000000ba985 H5D__create_named()  ??:0
28 0x0000000000095d47 H5Dcreate2()  ??:0
29 0x00000000008f9b9f _ZN6splash9DCDataSet6createERKNS_14CollectionTypeElNS_10DimensionsEjbb()  ??:0
30 0x00000000008d6d3b _ZN6splash21ParallelDataCollector12writeDataSetElNS_10DimensionsES1_RKNS_14CollectionTypeEjNS_9SelectionEPKcPKv()  ??:0
31 0x00000000008dbf87 _ZN6splash21ParallelDataCollector5writeEiNS_10DimensionsES1_RKNS_14CollectionTypeEjNS_9SelectionEPKcPKv()  ??:0
32 0x00000000008345d1 _ZN8picongpu4hdf510HDF5Writer9writeHDF5EPv()  ??:0
33 0x0000000000838de5 _ZN8picongpu4hdf510HDF5Writer8dumpDataEj()  ??:0
34 0x000000000083934f _ZN8picongpu4hdf510HDF5Writer6notifyEj()  ??:0
35 0x0000000000738f20 _ZN5pmacc16SimulationHelperILj3EE11dumpOneStepEj()  ??:0
36 0x00000000008008c9 _ZN5pmacc16SimulationHelperILj3EE15startSimulationEv()  ??:0
37 0x0000000000801680 _ZN8picongpu17SimulationStarterINS_21InitialiserControllerENS_16PluginControllerENS_12MySimulationEE5startEv()  ??:0
38 0x00000000006c50cb main()  ??:0
39 0x0000000000021c05 __libc_start_main()  ??:0
40 0x00000000006c655f _start()  ??:0
===================
==== backtrace ====
 2 0x00000000000687bc mxm_handle_error()  /var/tmp/OFED_topdir/BUILD/mxm-3.6.3104/src/mxm/util/debug/debug.c:641
 3 0x0000000000068d0c mxm_error_signal_handler()  /var/tmp/OFED_topdir/BUILD/mxm-3.6.3104/src/mxm/util/debug/debug.c:616
 4 0x0000000000035270 killpg()  ??:0
 5 0x00000000000375e7 ADIOI_Flatten()  ??:0
 6 0x00000000000386b3 ADIOI_Flatten_datatype()  ??:0
 7 0x000000000002cebd ADIO_Set_view()  ??:0
 8 0x00000000000118a6 mca_io_romio314_dist_MPI_File_set_view()  ??:0
 9 0x000000000000b792 mca_io_romio314_file_set_view()  ??:0
10 0x000000000008c24d MPI_File_set_view()  ??:0
11 0x0000000000311047 H5FD_mpio_write()  H5FDmpio.c:0
12 0x0000000000111d58 H5FD_write()  ??:0
13 0x00000000000f6e5c H5F__accum_write()  ??:0
14 0x00000000001f5f10 H5PB_write()  ??:0
15 0x00000000000fa5bb H5F_block_write()  ??:0
16 0x00000000000a8c72 H5D__chunk_allocate()  ??:0
17 0x00000000000b9ed0 H5D__init_storage()  H5Dint.c:0
18 0x00000000000bed8f H5D__alloc_storage()  ??:0
19 0x00000000000c5629 H5D__layout_oh_create()  ??:0
20 0x00000000000bb2e6 H5D__create()  ??:0
21 0x00000000000c68bc H5O__dset_create()  H5Doh.c:0
22 0x000000000018ba34 H5O_obj_create()  ??:0
23 0x00000000001743c1 H5L_link_cb()  H5L.c:0
24 0x000000000014710d H5G_traverse_real()  H5Gtraverse.c:0
25 0x00000000001475ff H5G_traverse()  ??:0
26 0x000000000017591f H5L_link_object()  ??:0
27 0x00000000000ba985 H5D__create_named()  ??:0
28 0x0000000000095d47 H5Dcreate2()  ??:0
29 0x00000000008f9b9f _ZN6splash9DCDataSet6createERKNS_14CollectionTypeElNS_10DimensionsEjbb()  ??:0
30 0x00000000008d6d3b _ZN6splash21ParallelDataCollector12writeDataSetElNS_10DimensionsES1_RKNS_14CollectionTypeEjNS_9SelectionEPKcPKv()  ??:0
31 0x00000000008dbf87 _ZN6splash21ParallelDataCollector5writeEiNS_10DimensionsES1_RKNS_14CollectionTypeEjNS_9SelectionEPKcPKv()  ??:0
32 0x00000000008345d1 _ZN8picongpu4hdf510HDF5Writer9writeHDF5EPv()  ??:0
33 0x0000000000838de5 _ZN8picongpu4hdf510HDF5Writer8dumpDataEj()  ??:0
34 0x000000000083934f _ZN8picongpu4hdf510HDF5Writer6notifyEj()  ??:0
35 0x0000000000738f20 _ZN5pmacc16SimulationHelperILj3EE11dumpOneStepEj()  ??:0
36 0x00000000008008c9 _ZN5pmacc16SimulationHelperILj3EE15startSimulationEv()  ??:0
37 0x0000000000801680 _ZN8picongpu17SimulationStarterINS_21InitialiserControllerENS_16PluginControllerENS_12MySimulationEE5startEv()  ??:0
38 0x00000000006c50cb main()  ??:0
39 0x0000000000021c05 __libc_start_main()  ??:0
40 0x00000000006c655f _start()  ??:0
===================
srun: error: taurusi2100: task 3: Segmentation fault
srun: Terminating job step 3586557.1
srun: error: taurusi2100: tasks 1-2: Segmentation fault
slurmstepd: error: *** STEP 3586557.1 ON taurusi2100 CANCELLED AT 2018-11-07T10:35:00 ***
srun: Job step aborted: Waiting up to 32 seconds for job step to finish.
srun: error: taurusi2100: task 0: Killed
```
during initialization. 

Any ideas what might cause this strange behavior for 4 GPUs? 