### PR TITLE
stop moving window after N steps

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -90,6 +90,10 @@ TBG_periodic="--periodic 1 0 1"
 # Enables moving window (sliding) in your simulation
 TBG_movingWindow="-m"
 
+
+# stop the moving window after given simulation step
+TBG_stopWindow="--stopWindow 1337"
+
 ################################################################################
 ## Placeholder for multi data plugins:
 ##

--- a/include/picongpu/fields/FieldManipulator.hpp
+++ b/include/picongpu/fields/FieldManipulator.hpp
@@ -83,7 +83,7 @@ public:
                 }
 
                 /* if sliding window is active we disable absorber on bottom side*/
-                if (MovingWindow::getInstance().isSlidingWindowActive() && i == BOTTOM) continue;
+                if (MovingWindow::getInstance().isSlidingWindowActive(currentStep) && i == BOTTOM) continue;
 
                 ExchangeMapping<GUARD, MappingDesc> mapper(cellDescription, i);
                 constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -374,7 +374,7 @@ private:
         {
             MPI_Comm_rank(MPI_COMM_WORLD, &rank);
             MPI_Comm_size(MPI_COMM_WORLD, &numProc);
-            if ( MovingWindow::getInstance().isSlidingWindowActive() )
+            if ( MovingWindow::getInstance().isEnabled() )
                 movingWindow = true;
             float_X minCellSize = math::min( cellSize[0], math::min( cellSize[1], cellSize[2] ) );
             float3_X cellSizeFactor = cellSize / minCellSize;

--- a/include/picongpu/plugins/PngPlugin.hpp
+++ b/include/picongpu/plugins/PngPlugin.hpp
@@ -128,13 +128,14 @@ namespace picongpu
                                                            charToAxisNumber(getValue(axis, i)[1])
                                                            );
                                 /* if simulation run in 2D ignore all xz, yz slices (we had no z direction)*/
-                                const bool isAllowed2DSlice= (simDim==DIM3) || (transpose.x()!=2 && transpose.y()!=2);
-                                const bool isSlidingWindowActive=MovingWindow::getInstance().isSlidingWindowActive();
+                                const bool isAllowed2DSlice = (simDim == DIM3) || (transpose.x() != 2 && transpose.y() != 2);
+                                const bool isSlidingWindowEnabled = MovingWindow::getInstance().isEnabled();
                                 /* if sliding window is active we are not allowed to create pngs from xz slice
                                  * This means one dimension in transpose must contain 1 (y direction)
                                  */
-                                const bool isAllowedMovingWindowSlice=!isSlidingWindowActive ||
-                                                                      (transpose.x()==1 || transpose.y()==1);
+                                const bool isAllowedMovingWindowSlice =
+                                    !isSlidingWindowEnabled ||
+                                    (transpose.x() == 1 || transpose.y() == 1);
                                 if( isAllowed2DSlice && isAllowedMovingWindowSlice )
                                 {
                                     VisType* tmp = new VisType(pluginName, pngCreator, period, transpose, getValue(slicePoints, i));

--- a/include/picongpu/plugins/adios/WriteSpecies.hpp
+++ b/include/picongpu/plugins/adios/WriteSpecies.hpp
@@ -126,7 +126,7 @@ public:
             typedef typename FilterFactory<usedFilters>::FilterType MyParticleFilter;
             MyParticleFilter filter;
             /* activate filter pipeline if moving window is activated */
-            filter.setStatus(MovingWindow::getInstance().isSlidingWindowActive());
+            filter.setStatus(MovingWindow::getInstance().isEnabled());
             filter.setWindowPosition(params->localWindowToDomainOffset,
                                      params->window.localDimensions.size);
 

--- a/include/picongpu/plugins/hdf5/WriteSpecies.hpp
+++ b/include/picongpu/plugins/hdf5/WriteSpecies.hpp
@@ -210,7 +210,7 @@ public:
             typedef typename FilterFactory<usedFilters>::FilterType MyParticleFilter;
             MyParticleFilter filter;
             /* activate filter pipeline if moving window is activated */
-            filter.setStatus(MovingWindow::getInstance().isSlidingWindowActive());
+            filter.setStatus(MovingWindow::getInstance().isEnabled());
             filter.setWindowPosition(params->localWindowToDomainOffset,
                                      params->window.localDimensions.size);
 


### PR DESCRIPTION
Sometimes for bunch-bunch or bunch-target collision it could be useful to allow to stop the
moving windows. This option is now available via `stopWindow`.

- add cli option `stopWindow`
- refactor `MovingWindow`: add method `setEndSlideOnStep` and `isEnabled`

# Tests

- [x] LWFA with `-m`
- [x] LWFA `-m --stopWindow 2000`
- [x] LWFA no sliding window