### PR TITLE
Fix Python EnergyHistogramData: skip of first iteration

### DIFF
--- a/lib/python/picongpu/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/plugins/data/energy_histogram.py
@@ -94,7 +94,6 @@ class EnergyHistogramData(DataReader):
 
         # the first column contains the iterations
         return pd.read_csv(data_file_path,
-                           skiprows=1,
                            usecols=(0,),
                            delimiter=" ",
                            dtype=np.uint64).values[:, 0]
@@ -135,7 +134,6 @@ class EnergyHistogramData(DataReader):
         # read whole file as pandas.DataFrame
         data = pd.read_csv(
             data_file_path,
-            skiprows=1,
             delimiter=" "
         )
         # upper range of each bin in keV
@@ -168,7 +166,7 @@ class EnergyHistogramData(DataReader):
         if not set(iteration).issubset(data.index.values):
             raise IndexError('Iteration {} is not available!\n'
                              'List of available iterations: \n'
-                             '{}'.format(iteration, data['iteration']))
+                             '{}'.format(iteration, data.index.values))
 
         # remove unused columns
         del data['sum']


### PR DESCRIPTION
Fixes #2798.
Also fixes an issue with the exception thrown when an invalid iteration is requested. Since the iterations are the index of the `pd.DataFrame` they are not regular columns anymore and can not be indexed by `data['iteration']`