### PR TITLE
Plugin Notify: Debug

### DIFF
--- a/include/pmacc/pluginSystem/PluginConnector.hpp
+++ b/include/pmacc/pluginSystem/PluginConnector.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <list>
 #include <string>
+#include <iostream>
 
 
 namespace pmacc
@@ -81,6 +82,9 @@ namespace pmacc
             {
                 if (!(*iter)->isLoaded())
                 {
+                    std::cout << "Plugin load: "
+                              << (*iter)->pluginGetName()
+                              << std::endl;
                     (*iter)->load();
                 }
             }
@@ -164,6 +168,16 @@ namespace pmacc
                 )
                 {
                     INotify* notifiedObj = iter->first;
+                    IPlugin* plugin = dynamic_cast<IPlugin*>(notifiedObj);
+
+                    std::cout << "Plugin notify: "
+                              << notifiedObj << " | ";
+                    if( plugin )
+                        std::cout << plugin->pluginGetName();
+                    else
+                        std::cout << "[not a plugin]";
+
+                    std::cout << std::endl;
                     notifiedObj->notify(currentStep);
                     notifiedObj->setLastNotify(currentStep);
                 }
@@ -252,6 +266,7 @@ namespace pmacc
         }
 
         std::list<IPlugin*> plugins;
+        std::list<IPlugin*> notificationPlugins;
         NotificationList notificationList;
     };
 }


### PR DESCRIPTION
Just documenting a quick way to debug whenever the `PluginConnector` `load()` of an `IPlugin` and  `notify()` of an `INotify` object.

Most multi-plugins do, unfurtunately, not cast to `IPlugin` and can therefore not be identified by name.