### PR TITLE
CFL Static Assert: new grid.param

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -69,14 +69,14 @@ namespace dirSplitting
          * A workaround is to add a template dependency to the expression.
          * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
          */
-        PMACC_CASSERT_MSG(DirectionSplitting_Set_dX_equal_dt_times_c____check_your_gridConfig_param_file,
+        PMACC_CASSERT_MSG(DirectionSplitting_Set_dX_equal_dt_times_c____check_your_grid_param_file,
                           (SI::SPEED_OF_LIGHT_SI * SI::DELTA_T_SI) == SI::CELL_WIDTH_SI &&
                           (sizeof(T_Dummy) != 0));
-        PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_gridConfig_param_file,
+        PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_grid_param_file,
                           SI::CELL_HEIGHT_SI == SI::CELL_WIDTH_SI &&
                           (sizeof(T_Dummy) != 0));
 #if (SIMDIM == DIM3)
-        PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_gridConfig_param_file,
+        PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_grid_param_file,
                           SI::CELL_DEPTH_SI == SI::CELL_WIDTH_SI &&
                           (sizeof(T_Dummy) != 0));
 #endif

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -51,7 +51,7 @@ namespace none
     >
     {
         /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
-        PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_gridConfig_param_file,
+        PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
             (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
     };
 } // namespace none

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -62,7 +62,7 @@ namespace maxwellSolver
         void updateE()
         {
             /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
-            PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_gridConfig_param_file,
+            PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
                 (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
 
             typedef SuperCellDescription<


### PR DESCRIPTION
Fix the reference to `grid.param` in our static asserts for the CFL of the Maxwell solvers.