### PR TITLE
Change link to CRP group @ HZDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ PIConGPU was one of the **finalists** of the 2013
 [Gordon Bell Prize](http://sc13.supercomputing.org/content/acm-gordon-bell-prize).
 
 PIConGPU is developed and maintained by the
-[Computational Radiation Physics Group](http://www.hzdr.de/db/Cms?pNid=132&pOid=30354)
+[Computational Radiation Physics Group](https://www.hzdr.de/db/Cms?pNid=2097)
 at the [Institute for Radiation Physics](http://www.hzdr.de/db/Cms?pNid=132)
 at [HZDR](http://www.hzdr.de/) in close collaboration with the Center
 for Information Services and High Performance Computing


### PR DESCRIPTION
I propose to change the link to the Computational Radiation Physics group at HZDR.
The new link still leads to the same page as the old but will avoid possible issues with doxygen that I encountered.
In some cases the ampersand in the link will not be automatically escaped by doxygen and this causes and invalid token in the XML file.

I hope that this is fine since this change doesn't fix the actual problem with doxygen but it rather avoids it.