### PR TITLE
Plugins: ADIOS & PhaseSpace Wterminate

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -204,7 +204,7 @@ namespace picongpu
         {
             // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
             __getTransactionEvent().waitForFinished();
-            MPI_CHECK(MPI_Comm_free( &commFileWriter ));
+            MPI_CHECK_NO_EXCEPT(MPI_Comm_free( &commFileWriter ));
         }
     }
 

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -840,7 +840,7 @@ public:
         {
             // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
             __getTransactionEvent().waitForFinished();
-            MPI_CHECK(MPI_Comm_free(&(mThreadParams.adiosComm)));
+            MPI_CHECK_NO_EXCEPT(MPI_Comm_free(&(mThreadParams.adiosComm)));
         }
     }
 


### PR DESCRIPTION
Silence the GCC 7.3 `-Wterminate` warning about `throws` of our `MPI_CHECK` macro in destructors.

Instead, write to `stderr`.