### PR TITLE
Manual: Plugin & Particle Sections, Map

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,7 +65,6 @@ Usage
    usage/reference
    usage/basics
    usage/param
-   usage/particles
    usage/plugins
    usage/tbg
    usage/examples

--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -114,9 +114,9 @@ particle.param
    :path: include/picongpu/param/particle.param
    :no-link:
 
-More details on the order of initialization of particles inside a particle species :ref:`can be found here <usage-particles>`.
+More details on the order of initialization of particles inside a particle species :ref:`can be found here <usage-params-core-particles>`.
 
-:ref:`List of all pre-defined particle manipulators <usage-particles-manipulation>`.
+:ref:`List of all pre-defined particle manipulators <usage-params-core-particles-manipulation>`.
 
 unit.param
 ^^^^^^^^^^
@@ -134,7 +134,7 @@ particleFilters.param
    :path: include/picongpu/simulation_defines/param/particleFilters.param
    :no-link:
 
-:ref:`List of all pre-defined particle filters <usage-particles-filters>`.
+:ref:`List of all pre-defined particle filters <usage-params-core-particles-filters>`.
 
 speciesInitialization.param
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ speciesInitialization.param
    :path: include/picongpu/param/speciesInitialization.param
    :no-link:
 
-:ref:`List of all initialization methods for particle species <usage-particles-init>`.
+:ref:`List of all initialization methods for particle species <usage-params-core-particles-init>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -75,7 +75,7 @@ speciesAttributes.param
    :path: include/picongpu/param/speciesAttributes.param
    :no-link:
 
-The following species attributes are defined by pmacc and always stored with a particle:
+The following species attributes are defined by PMacc and always stored with a particle:
 
 .. doxygenfile:: Identifier.hpp
    :project: PIConGPU
@@ -114,8 +114,12 @@ particle.param
    :path: include/picongpu/param/particle.param
    :no-link:
 
+More details on the order of initialization of particles inside a particle species :ref:`can be found here <usage-particles>`.
+
+:ref:`List of all pre-defined particle manipulators <usage-particles-manipulation>`.
+
 unit.param
-^^^^^^^^^^^^^^
+^^^^^^^^^^
 
 .. doxygenfile:: unit.param
    :project: PIConGPU
@@ -130,6 +134,8 @@ particleFilters.param
    :path: include/picongpu/simulation_defines/param/particleFilters.param
    :no-link:
 
+:ref:`List of all pre-defined particle filters <usage-particles-filters>`.
+
 speciesInitialization.param
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -137,3 +143,11 @@ speciesInitialization.param
    :project: PIConGPU
    :path: include/picongpu/param/speciesInitialization.param
    :no-link:
+
+:ref:`List of all initialization methods for particle species <usage-particles-init>`.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   particles/init.rst

--- a/docs/source/usage/param/particles/init.rst
+++ b/docs/source/usage/param/particles/init.rst
@@ -1,7 +1,7 @@
 .. _usage-particles:
 
 Particles
-=========
+"""""""""
 
 Particles are defined in modular steps.
 First, species need to be generally defined in :ref:`speciesDefinition.param <usage-params-core>`.
@@ -12,34 +12,34 @@ The following operations can be applied in the ``picongpu::particles::InitPipeli
 .. _usage-particles-init:
 
 Initialization
---------------
+''''''''''''''
 
 CreateDensity
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::CreateDensity
    :project: PIConGPU
 
 Derive
-^^^^^^
+~~~~~~
 
 .. doxygenstruct:: picongpu::particles::Derive
    :project: PIConGPU
 
 Manipulate
-^^^^^^^^^^
+~~~~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::Manipulate
    :project: PIConGPU
 
 ManipulateDerive
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::ManipulateDerive
    :project: PIConGPU
 
 FillAllGaps
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::FillAllGaps
    :project: PIConGPU
@@ -47,67 +47,67 @@ FillAllGaps
 .. _usage-particles-manipulation:
 
 Manipulation Functors
----------------------
+'''''''''''''''''''''
 
 Some of the particle operations above can take the following functors as arguments to manipulate attributes of particle species.
 A particle filter (see following section) is used to only manipulated selected particles of a species with a functor.
 
 Free
-^^^^
+~~~~
 
 .. doxygenstruct:: picongpu::particles::manipulators::generic::Free
    :project: PIConGPU
 
 FreeRng
-^^^^^^^
+~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::manipulators::generic::FreeRng
    :project: PIConGPU
 
 FreeTotalCellOffset
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::manipulators::unary::FreeTotalCellOffset
    :project: PIConGPU
 
 CopyAttribute
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 .. doxygentypedef:: picongpu::particles::manipulators::unary::CopyAttribute
    :project: PIConGPU
 
 Drift
-^^^^^
+~~~~~
 
 .. doxygentypedef:: picongpu::particles::manipulators::unary::Drift
    :project: PIConGPU
 
 RandomPosition
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 .. doxygentypedef:: picongpu::particles::manipulators::unary::RandomPosition
    :project: PIConGPU
 
 Temperature
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 .. doxygentypedef:: picongpu::particles::manipulators::unary::Temperature
    :project: PIConGPU
 
 Assign
-^^^^^^
+~~~~~~
 
 .. doxygentypedef:: picongpu::particles::manipulators::binary::Assign
    :project: PIConGPU
 
 DensityWeighting
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 .. doxygentypedef:: picongpu::particles::manipulators::binary::DensityWeighting
    :project: PIConGPU
 
 ProtonTimesWeighting
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 
 .. doxygentypedef:: picongpu::particles::manipulators::binary::ProtonTimesWeighting
    :project: PIConGPU
@@ -115,37 +115,37 @@ ProtonTimesWeighting
 .. _usage-particles-filters:
 
 Manipulation Filters
---------------------
+''''''''''''''''''''
 
 Most of the particle functors shall operate on all valid particles, where ``filter::All`` is the default assumption.
 One can limit the domain or subset of particles with filters such as the ones below (or define new ones).
 
 All
-^^^
+~~~
 
 .. doxygenstruct:: picongpu::particles::filter::All
    :project: PIConGPU
 
 RelativeGlobalDomainPosition
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::filter::RelativeGlobalDomainPosition
    :project: PIConGPU
 
 Free
-^^^^
+~~~~
 
 .. doxygenstruct:: picongpu::particles::filter::generic::Free
    :project: PIConGPU
 
 FreeRng
-^^^^^^^
+~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::filter::generic::FreeRng
    :project: PIConGPU
 
 FreeTotalCellOffset
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 .. doxygenstruct:: picongpu::particles::filter::generic::FreeTotalCellOffset
    :project: PIConGPU

--- a/docs/source/usage/param/particles/init.rst
+++ b/docs/source/usage/param/particles/init.rst
@@ -1,4 +1,4 @@
-.. _usage-particles:
+.. _usage-params-core-particles:
 
 Particles
 """""""""
@@ -9,7 +9,7 @@ Second, species are initialized with particles in :ref:`speciesInitialization.pa
 
 The following operations can be applied in the ``picongpu::particles::InitPipeline`` of the latter:
 
-.. _usage-particles-init:
+.. _usage-params-core-particles-init:
 
 Initialization
 ''''''''''''''
@@ -44,7 +44,7 @@ FillAllGaps
 .. doxygenstruct:: picongpu::particles::FillAllGaps
    :project: PIConGPU
 
-.. _usage-particles-manipulation:
+.. _usage-params-core-particles-manipulation:
 
 Manipulation Functors
 '''''''''''''''''''''
@@ -112,7 +112,7 @@ ProtonTimesWeighting
 .. doxygentypedef:: picongpu::particles::manipulators::binary::ProtonTimesWeighting
    :project: PIConGPU
 
-.. _usage-particles-filters:
+.. _usage-params-core-particles-filters:
 
 Manipulation Filters
 ''''''''''''''''''''

--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -36,7 +36,7 @@ Plugin name                                                                     
    plugins/*
 
 Period Syntax
-=============
+-------------
 
 Most plugins allow to define a period on how often a plugin shall be executed (notified).
 Its simple syntax is: ``<period>`` with a simple number.
@@ -52,7 +52,7 @@ Additionally, the following syntax allows to define intervals for periods:
 Multiple intervals can be combined via a comma separated list.
 
 Examples
---------
+^^^^^^^^
 
 * ``42`` every 42th time step
 * ``::`` equal to just writing ``1``, every time step from start (0) to the end of the simulation
@@ -62,7 +62,7 @@ Examples
 * ``5,10``: at steps 0 5 10 15 20 25 ... (only executed once per step in overlapping intervals)
 
 Python Postprocessing
-=====================
+---------------------
 
 In order to further work with the data produced by a plugin during a simulation run, PIConGPU provides python tools that can be used for reading data and visualization.
 They can be found under ``lib/python/picongpu/plugins``.

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -10,7 +10,7 @@ The acceptance of particles for counting in the energy histogram can be adjusted
 ^^^^^^^^^^^
 
 The :ref:`particleFilters.param <usage-params-core>` file allows to define accepted particles for the energy histogram.
-A typical :ref:`filter <usage-particles-filters>` could select particles within a specified :ref:`opening angle in forward direction <usage-workflows-particleFilters>`.
+A typical :ref:`filter <usage-params-core-particles-filters>` could select particles within a specified :ref:`opening angle in forward direction <usage-workflows-particleFilters>`.
 
 .cfg files
 ^^^^^^^^^^

--- a/docs/source/usage/reference.rst
+++ b/docs/source/usage/reference.rst
@@ -46,3 +46,7 @@ We therefore *rely on you* to show our community, diversity and usefulness, e.g.
     Please consider adding yourself to our `community map <https://github.com/ComputationalRadiationPhysics/picongpu-communitymap>`_!
 
 Thank you and enjoy PIConGPU and our community!
+
+.. raw:: html
+
+   <iframe src="https://computationalradiationphysics.github.io/picongpu-communitymap/" style="width:100%; height: 650px;" frameborder="0"></iframe>

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -72,7 +72,7 @@ and add ``ParticlesForwardPinhole`` to the ``AllParticleFilters`` list:
 Limiting Filters to Eligible Species
 """"""""""""""""""""""""""""""""""""
 
-Besides :ref:`the list of pre-defined filters <usage-particles-filters>` with parametrization, users can also define generic, "free" implementations as shown above.
+Besides :ref:`the list of pre-defined filters <usage-params-core-particles-filters>` with parametrization, users can also define generic, "free" implementations as shown above.
 All filters are added to ``AllParticleFilters`` and then *combined with all available species* from ``VectorAllSpecies`` (see :ref:`speciesDefinition.param <usage-params-core>`).
 
 In the case of user-defined free filters we can now check if each species in ``VectorAllSpecies`` fulfills the requirements of the filter.

--- a/include/picongpu/param/speciesInitialization.param
+++ b/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesInitialization.param
@@ -20,12 +20,10 @@
 /** @file
  *
  * Initialize particles inside particle species. This is the final step in
- * setting up particles (defined in speciesDefinition.param) via density profiles
- * (defined in density.param). One can then further derive particles from one
- * species to an other and manipulate attributes with "manipulators" and "filters"
- * (defined in particle.param and particleFilters.param).
- *
- * For a full list of options, see the user manual section "Usage" - "Particles".
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
  */
 
 #pragma once


### PR DESCRIPTION
The headlines and section level for plugins was wrong. Lower period syntax and general post-processing infos.

Also cleans up the particle doc structure in Usage.

Also adds user map in HTML version as iframe.