### PR TITLE
MemoryCalculator: fix example output for documentation

### DIFF
--- a/docs/source/usage/python/utils.rst
+++ b/docs/source/usage/python/utils.rst
@@ -6,14 +6,11 @@ Memory Calculator
 To aid you in the planning and setup of your simulation PIConGPU provides python tools for educated guesses on simulation parameters.
 They can be found under ``lib/python/picongpu/utils``.
 
-:ref:`Calculate the memory requirement per device <usage-workflows-memoryPerDevice>` with ``memory_calculator.py``
+:ref:`Calculate the memory requirement per device <usage-workflows-memoryPerDevice>`.
 
     .. code:: python
     
         from picongpu.utils import MemoryCalculator
-
-memory_calculator.py
-^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: picongpu.utils.memory_calculator.MemoryCalculator
    :members:

--- a/docs/source/usage/workflows/memoryPerDevice.rst
+++ b/docs/source/usage/workflows/memoryPerDevice.rst
@@ -16,6 +16,6 @@ The following paragraph shows the use of the ``MemoryCalculator`` for the ``4.cf
 
 This will give the following output:
 
-.. program-output:: ./usage/workflows/memoryPerDevice.py
+.. program-output:: bash -c "PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH ./usage/workflows/memoryPerDevice.py"
 
 If you have a machine or cluster node with NVIDIA GPUs you can find out the available memory size by typing ``nvidia-smi`` on a shell.


### PR DESCRIPTION
This commit fixes the documentation output of the `MemoryCalculator` example script.

![auswahl_047](https://user-images.githubusercontent.com/5416860/48952427-6c615c00-ef42-11e8-8099-77954d5f5498.png)

~~So far I cannot check this because my own `sys.path` contains `...lib/python/picongpu`.~~

I built the doxygen versions **1.8. .. 6, 13** and **14** and all of them fail building the picongpu docu on hypnos.
```
Generating XML output for class pmacc::DataBoxUnaryTransform
/home/garten70/src/picongpu/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp:34: warning: explicit link request to 'result' could not be resolved
Generating XML output for class pmacc::DataConnector
Segmentation fault (core dumped)
```

**Edit:**   
After being able to test it I can now say the fix does actually work