### PR TITLE
fix particle creation if density zero

### DIFF
--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -229,7 +229,10 @@ namespace picongpu
                         totalCellOffset
                     );
 
-                    float_X const realParticlesPerCell = realDensity * CELL_VOLUME;
+                    /** @bug volatile is required for CUDA 9.2 and sm_60 else the compiler will
+                     * optimize out `if(realParticlesPerCell > 0.0_X)` later on.
+                     */
+                    volatile float_X const realParticlesPerCell = realDensity * CELL_VOLUME;
 
                     // create an independent position functor for each cell in the supercell
                     positionFunctorCtx[ idx ] = positionFunctor(
@@ -238,8 +241,9 @@ namespace picongpu
                         WorkerCfg< cellsPerSupercell >{ linearIdx }
                     );
 
-                    numParsPerCellCtx[ idx ] =
-                        positionFunctorCtx[ idx ].template numberOfMacroParticles< ParticleType >( realParticlesPerCell );
+                    if(realParticlesPerCell > 0.0_X)
+                        numParsPerCellCtx[ idx ] =
+                            positionFunctorCtx[ idx ].template numberOfMacroParticles< ParticleType >( realParticlesPerCell );
 
                     if( numParsPerCellCtx[ idx ] > 0 )
                         nvidia::atomicAllExch(


### PR DESCRIPTION
fix #2823

In the case where the density functor is returning a density of zero or negative the functor which calculates the number of macro-particles (called `startPosition` functor) should not be called.
This avoids that the functor write e.g. the user who is using a free functor implementation must handle those edge cases.

changes:
 - do not call `startPosition` functor if density is `<= 0.0`


# Tests
- [x] test on hemera (P100)
- [x] test on hypnos (k80)