### PR TITLE
More fixes for MSVC capturing constexpr in lambdas

### DIFF
--- a/include/picongpu/fields/LaserPhysics.hpp
+++ b/include/picongpu/fields/LaserPhysics.hpp
@@ -66,7 +66,7 @@ namespace fields
             );
 
             constexpr uint32_t planeSize = pmacc::math::CT::volume< LaserPlaneSizeInSuperCell >::type::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
+            PMACC_CONSTEXPR_CAPTURE uint32_t numWorkers = T_numWorkers;
 
             const uint32_t workerIdx = threadIdx.x;
 

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -118,7 +118,7 @@ namespace picongpu
             using namespace mappings::threads;
 
             constexpr uint32_t frameSize = pmacc::math::CT::volume< SuperCellSize >::type::value;
-            constexpr uint32_t cellsPerSupercell = pmacc::math::CT::volume< SuperCellSize >::type::value;
+            PMACC_CONSTEXPR_CAPTURE uint32_t cellsPerSupercell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
 
             uint32_t const workerIdx = threadIdx.x;


### PR DESCRIPTION
This issue has been fixed by #2522, apply the same fix to newer code.