### PR TITLE
Slurm: Link stdout live

### DIFF
--- a/etc/picongpu/draco-mpcdf/general.tpl
+++ b/etc/picongpu/draco-mpcdf/general.tpl
@@ -79,11 +79,12 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 #wait that all nodes see ouput folder
 sleep 1
 
 # Run PIConGPU
-srun -K1 !TBG_dstPath/tbg/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+srun -K1 !TBG_dstPath/tbg/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 
 

--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -89,8 +89,9 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  mpiexec --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  mpiexec --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -90,6 +90,7 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
@@ -101,5 +102,5 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/lawrencium-lbnl/fermi.tpl
+++ b/etc/picongpu/lawrencium-lbnl/fermi.tpl
@@ -90,6 +90,7 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # openmpi/1.6.5 is not GPU aware and handles pinned memory correctly incorrectly
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
@@ -105,5 +106,5 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  mpirun !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  mpirun !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/lawrencium-lbnl/k20.tpl
+++ b/etc/picongpu/lawrencium-lbnl/k20.tpl
@@ -88,6 +88,7 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # openmpi/1.6.5 is not GPU aware and handles pinned memory correctly incorrectly
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
@@ -104,5 +105,5 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  mpirun !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  mpirun !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/pizdaint-cscs/large.tpl
+++ b/etc/picongpu/pizdaint-cscs/large.tpl
@@ -76,6 +76,7 @@ unset MODULES_NO_OUTPUT
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then

--- a/etc/picongpu/pizdaint-cscs/normal.tpl
+++ b/etc/picongpu/pizdaint-cscs/normal.tpl
@@ -76,6 +76,7 @@ unset MODULES_NO_OUTPUT
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # the next three lines were recommended by Cray to avoid warnings
 export PMI_MMAP_SYNC_WAIT_TIME=300

--- a/etc/picongpu/taurus-tud/k20x.tpl
+++ b/etc/picongpu/taurus-tud/k20x.tpl
@@ -80,6 +80,7 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
 #   support ticket [Ticket:2014052241001186] srun: mpi mca flags
@@ -96,6 +97,6 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi
 

--- a/etc/picongpu/taurus-tud/k80.tpl
+++ b/etc/picongpu/taurus-tud/k80.tpl
@@ -80,6 +80,7 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
 #   support ticket [Ticket:2014052241001186] srun: mpi mca flags
@@ -96,6 +97,6 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi
 

--- a/etc/picongpu/taurus-tud/knl.tpl
+++ b/etc/picongpu/taurus-tud/knl.tpl
@@ -80,6 +80,7 @@ umask 0027
 
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # Run PIConGPU
-NUMA_HW_THREADS_PER_PHYSICAL_CORE=!TBG_hardwareThreadsPerCore mpiexec !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+NUMA_HW_THREADS_PER_PHYSICAL_CORE=!TBG_hardwareThreadsPerCore mpiexec !TBG_dstPath/input/etc/picongpu/cpuNumaStarter.sh !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams


### PR DESCRIPTION
Since the `stdout` files are cached and created live by Slurm during the run, we can just symlink `simOutput/output` onto it for scripts and spare the IO latency load of small little writes.

Should fix the problem reported in #2830 on Slurm systems for tools that check e.g. for constants in our output files. Suggested by @psychocoderHPC [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2830#issuecomment-444410184).

Note that links can be created even before a file they point to exists.