### PR TITLE
auto domain adjustment

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -53,6 +53,8 @@ TBG_gridSize="128 256 128"
 # Number of simulation steps/iterations as "N"
 TBG_steps="100"
 
+# disable grid size auto adjustment
+TBG_disableGridAutoAdjustment="--autoAdjustGrid off"
 
 ################################################################################
 ## Section: Optional Variables

--- a/docs/source/usage/workflows/numberOfCells.rst
+++ b/docs/source/usage/workflows/numberOfCells.rst
@@ -8,10 +8,14 @@ Setting the Number of Cells
 Together with the grid resolution in :ref:`grid.param <usage-params-core>`, the number of cells in our :ref:`.cfg files <usage-tbg>` determine the overall size of a simulation (box).
 The following rules need to be applied when setting the number of cells:
 
-Each GPU needs to:
+Each device needs to:
 
 #. contain an integer *multiple* of supercells
 #. at least *three* supercells
+#. for non periodic boundary conditions, the number of absorbing boundary cells for devices at the simulation boundary (see :ref:`grid.param <usage-params-core>`) must fit into the local volume
+
+The grid size will be automatically adjusted if the conditions above are not fulfilled. 
+This behavior can be disabled by using the command line option ``--autoAdjustGrid off``
 
 Supercell sizes in terms of number of cells are set in :ref:`memory.param <usage-params-memory>` and are by default ``8x8x4`` for 3D3V simulations on GPUs.
 For 2D3V simulations, ``16x16`` is usually a good supercell size, however the default is simply cropped to ``8x8``, so make sure to change it to get more performance.

--- a/include/picongpu/simulationControl/DomainAdjuster.hpp
+++ b/include/picongpu/simulationControl/DomainAdjuster.hpp
@@ -1,0 +1,369 @@
+/* Copyright 2018 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/mpi/reduceMethods/Reduce.hpp>
+#include <pmacc/mpi/MPIReduce.hpp>
+#include <pmacc/nvidia/functors/Add.hpp>
+#include <pmacc/nvidia/functors/Max.hpp>
+#include <pmacc/nvidia/functors/Min.hpp>
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/mpi/GetMPI_StructAsArray.hpp>
+
+#include <array>
+
+
+namespace picongpu
+{
+    /** adjust domain sizes
+     *
+     * Extend the local offset, the local and global domain size to fulfill all
+     * PIConGPU/PMacc conditions.
+     */
+    class DomainAdjuster
+    {
+
+    public:
+        /** constructor
+         *
+         * @param numDevices number of devices [per dimension]
+         * @param mpiPosition the position of the local device [per dimension]
+         * @param isPeriodic if the outer simulation boundaries are periodic [per dimension]
+         *                   1 is meaning periodic else 0
+         * @param movingWindowEnabled if moving window is enabled
+         */
+        DomainAdjuster(
+            DataSpace< simDim > const & numDevices,
+            DataSpace< simDim > const & mpiPosition,
+            DataSpace< simDim > const & isPeriodic,
+            bool const movingWindowEnabled
+        ) :
+            m_numDevices( numDevices),
+            m_mpiPosition( mpiPosition ),
+            m_isPeriodic( isPeriodic ),
+            m_movingWindowEnabled( movingWindowEnabled ),
+            m_isMaster( mpiPosition == DataSpace< simDim >::create( 0 ) )
+        {
+        }
+
+        /** adjust the domain size
+         *
+         * This method is a MPI collective operation and must be called from all MPI ranks.
+         *
+         * @param[in,out] globalDomainSize size of the global volume [in cells]
+         * @param[in,out] localDomainSize size of the local volume [in cells]
+         * @param[out] localDomainOffset local offset [in cells] relative to the origin of the global domain
+         */
+        void operator()(
+            DataSpace< simDim > & globalDomainSize,
+            DataSpace< simDim > & localDomainSize,
+            DataSpace< simDim > & localDomainOffset
+        )
+        {
+            m_globalDomainSize = globalDomainSize;
+            m_localDomainSize = localDomainSize;
+
+            for( uint32_t d = 0; d < simDim; ++d )
+            {
+                multipleOfSuperCell( d );
+                minThreeSuperCells( d );
+                greaterEqualThanAbsorber( d );
+                deriveGlobalDomainSize( d );
+                updateLocalDomainOffset( d );
+            }
+
+            if( globalDomainSize != m_globalDomainSize || localDomainSize != m_localDomainSize )
+            {
+                std::cout << " new grid size (global|local|offset): " <<
+                    m_globalDomainSize.toString() << "|" <<
+                    m_localDomainSize.toString() << "|" <<
+                    m_localDomainOffset.toString() << std::endl;
+            }
+
+            // write results back
+            globalDomainSize = m_globalDomainSize;
+            localDomainSize = m_localDomainSize;
+            localDomainOffset = m_localDomainOffset;
+        }
+
+    private:
+
+        /** update local domain offset
+         *
+         * Share the local domain size with all MPI ranks and calculate the offset of the
+         * local domain [in cells] relative to the origin of the global domain.
+         *
+         * @param dim dimension to update
+         */
+        void updateLocalDomainOffset( size_t const dim )
+        {
+            pmacc::GridController< simDim > & gc = pmacc::Environment< simDim >::get( ).GridController( );
+
+            int mpiPos( gc.getPosition( )[ dim ] );
+            int numMpiRanks = gc.getGlobalSize();
+
+            // gather mpi position in the direction we are checking
+            std::vector< int > mpiPositions( numMpiRanks );
+            MPI_CHECK( MPI_Allgather(
+                &mpiPos,
+                1,
+                MPI_INT,
+                mpiPositions.data(),
+                1,
+                MPI_INT,
+                gc.getCommunicator().getMPIComm()
+            ));
+
+            // gather local sizes in the direction we are checking
+            std::vector< uint64_t > allLocalSizes( numMpiRanks );
+            uint64_t lSize = static_cast< uint64_t >( m_localDomainSize[ dim ] );
+            MPI_CHECK( MPI_Allgather(
+                &lSize,
+                1,
+                MPI_UINT64_T,
+                allLocalSizes.data(),
+                1,
+                MPI_UINT64_T,
+                gc.getCommunicator().getMPIComm()
+            ));
+
+            uint64_t offset = 0u;
+            for( size_t i = 0u; i < mpiPositions.size(); ++i )
+            {
+                if( mpiPositions[ i ] < mpiPos )
+                    offset += allLocalSizes[ i ];
+            }
+
+            /* since we are not doing independent reduces per slice we need
+             * to adjust the offset result by dividing with the number of
+             * MPI ranks in all other dimensions.
+             */
+            offset /= static_cast< uint64_t >( m_numDevices.productOfComponents() / m_numDevices[ dim ] );
+            m_localDomainOffset[ dim ] = static_cast< int >( offset );
+
+        }
+
+        /** ensure that the local size is a multiple of the supercell size
+         *
+         * @param dim dimension to update
+         */
+        void multipleOfSuperCell( size_t const dim )
+        {
+            int const sCellSize = SuperCellSize::toRT()[ dim ];
+            // round up to full supercells
+            int const validLocalSize =
+                ( ( m_localDomainSize[ dim ] + sCellSize - 1 ) / sCellSize ) *
+                sCellSize;
+
+            if( validLocalSize != m_localDomainSize[ dim ] )
+            {
+                std::cout << "Dimension " << dimNames[ dim ] <<
+                    ": local grid size is not a multiple of supercell size. Adjust from " <<
+                    m_localDomainSize[ dim ] << " to " <<  validLocalSize << std::endl;
+
+                m_localDomainSize[ dim ] = validLocalSize;
+            }
+        }
+
+        /** ensure that we have a CORE and BORDER region
+         *
+         * Each region must have the size of at least one supercell.
+         *
+         * @param dim dimension to update
+         */
+        void minThreeSuperCells( size_t const  dim )
+        {
+            int numSuperCells = m_localDomainSize[ dim ] / SuperCellSize::toRT()[ dim ];
+
+            if( numSuperCells < 3 )
+            {
+                int newLocalDomainSize = 3 * SuperCellSize::toRT()[ dim ];
+                std::cout << "Dimension " << dimNames[ dim ] <<
+                    ": local grid size is not containing at least 3 supercells. Adjust from " <<
+                    m_localDomainSize[ dim ] << " to " <<  newLocalDomainSize << std::endl;
+
+                m_localDomainSize[ dim ] = newLocalDomainSize;
+            }
+        }
+
+        /** ensure that the absorber fits into the local domain
+         *
+         * The methods checks the local domain size only if the absorber for the
+         * given dimension is enabled.
+         *
+         * @param dim dimension to update
+         */
+        void greaterEqualThanAbsorber( size_t const dim )
+        {
+            int validLocalSize = m_localDomainSize[ dim ];
+
+            bool const isAbsorberEnabled = !m_isPeriodic[ dim ];
+            bool const isBoundaryDevice = ( m_mpiPosition[ dim ] == 0 || m_mpiPosition[ dim ] == m_numDevices[ dim ] - 1 );
+            if( isAbsorberEnabled && isBoundaryDevice )
+            {
+                size_t boundary = m_mpiPosition[ dim ] == 0u ? 0u : 1u;
+                int maxAbsorberCells = ABSORBER_CELLS[ dim ][ boundary ];
+
+                if( m_movingWindowEnabled && dim == 1u )
+                {
+                    /* since the device changes their position during the simulation
+                     * the negative and positive absorber cells must fit into the domain
+                     */
+                    maxAbsorberCells = static_cast< int >(
+                        std::max(
+                            ABSORBER_CELLS[ dim ][ 0 ],
+                            ABSORBER_CELLS[ dim ][ 1 ]
+                        )
+                    );
+                }
+
+                if( m_localDomainSize[ dim ] < maxAbsorberCells )
+                {
+                    int const sCellSize = SuperCellSize::toRT()[ dim ];
+                    // round up to full supercells
+                    validLocalSize =
+                        ( ( maxAbsorberCells + sCellSize - 1 ) / sCellSize ) *
+                        sCellSize;
+                }
+
+                if( validLocalSize != m_localDomainSize[ dim ] )
+                {
+                    std::cout << "Dimension " << dimNames[ dim ] <<
+                        ": local grid size must be greater or equal than the largest absorber. Adjust from " <<
+                        m_localDomainSize[ dim ] << " to " <<  validLocalSize << std::endl;
+                    
+                    m_localDomainSize[ dim ] = validLocalSize;
+                }
+            }
+        }
+
+        /** derive the local domain size
+         *
+         * Calculate the local domain size.
+         * This function takes into account that the local domain size must be
+         * equal for all domains if moving window is activated.
+         *
+         * @param dim dimension to update
+         */
+        void deriveLocalDomainSize( size_t const dim )
+        {
+            if( m_movingWindowEnabled && dim == 1u )
+            {
+
+                pmacc::mpi::MPIReduce mpiReduce;
+
+                int globalMax;
+                mpiReduce(
+                    pmacc::nvidia::functors::Max(),
+                    &globalMax,
+                    &m_localDomainSize[ dim ],
+                    1,
+                    pmacc::mpi::reduceMethods::AllReduce()
+                );
+
+                int globalMin;
+                mpiReduce(
+                    pmacc::nvidia::functors::Min(),
+                    &globalMin,
+                    &m_localDomainSize[ dim ],
+                    1,
+                    pmacc::mpi::reduceMethods::AllReduce()
+                );
+
+                // local size must be equal for all devices in y direction
+                if( m_isMaster && globalMax != globalMin )
+                {
+                    std::cout << "Dimension " << dimNames[ dim ] <<
+                        ": local grid size must be equal for all devices because moving window is enabled. Adjust from " <<
+                        m_localDomainSize[ dim ] << " to " <<  globalMax << std::endl;
+                }
+
+                m_localDomainSize[ dim ] = globalMax;
+            }
+        }
+
+        /** derive the global domain size
+         *
+         * Calculate the global domain size.
+         *
+         * @param dim dimension to update
+         */
+        void deriveGlobalDomainSize( size_t const dim )
+        {
+            uint64_t validGlobalGridSize = 0u;
+
+            deriveLocalDomainSize( dim );
+
+            if( m_movingWindowEnabled && dim == 1u )
+            {
+                // the local sizes in slide direction must be equal sized
+                validGlobalGridSize = static_cast< uint64_t >( m_localDomainSize[ dim ] * m_numDevices[ dim ] );
+            }
+            else
+            {
+                uint64_t localDomainSize = static_cast< uint64_t >( m_localDomainSize[ dim ] );
+                pmacc::mpi::MPIReduce mpiReduce;
+                mpiReduce(
+                    pmacc::nvidia::functors::Add(),
+                    &validGlobalGridSize,
+                    &localDomainSize,
+                    1,
+                    pmacc::mpi::reduceMethods::AllReduce()
+                );
+                /* since we are not doing independent reduces per slice we need
+                 * to adjust the reduce result by dividing the sizes of all other dimensions
+                 * we are not check within the method call
+                 */
+                validGlobalGridSize /= static_cast< uint64_t >(
+                    m_numDevices.productOfComponents() / m_numDevices[ dim ]
+                );
+
+            }
+
+            if( m_isMaster && validGlobalGridSize != static_cast< uint64_t >( m_globalDomainSize[ dim ] ) )
+            {
+                    std::cout << "Dimension " << dimNames[ dim ] <<
+                        ": global grid size adjusted from " <<
+                        m_globalDomainSize[ dim ] << " to " <<  validGlobalGridSize << std::endl;
+            }
+
+            m_globalDomainSize[ dim ] = static_cast< int >( validGlobalGridSize );
+        }
+
+        DataSpace< simDim > m_globalDomainSize;
+        DataSpace< simDim > m_localDomainSize;
+        DataSpace< simDim > m_localDomainOffset;
+        DataSpace< simDim > const m_numDevices;
+        DataSpace< simDim > const m_mpiPosition;
+        DataSpace< simDim > const m_isPeriodic;
+        bool const m_movingWindowEnabled;
+        bool const m_isMaster;
+        /**! lookup table to translate a dimension index into a name
+         *
+         * \warning `= { { ... } }` is not required by the c++11 standard but
+         * is necessary for g++ 4.9
+         */
+        std::array< char, 3 > dimNames = { { 'x', 'y', 'z' } };
+    };
+
+} // namespace picongpu

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -148,7 +148,9 @@ public:
             ("moving,m", po::value<bool>(&slidingWindow)->zero_tokens(), "enable sliding/moving window")
             ("stopWindow", po::value<int32_t>(&endSlidingOnStep)->default_value(-1),
                 "stops the window at stimulation step, "
-                "-1 means that window is never stopping");
+                "-1 means that window is never stopping")
+            ("autoAdjustGrid", po::value<bool>(&autoAdjustGrid)->default_value(true),
+                "auto adjust the grid size if PIConGPU conditions are not fulfilled");
     }
 
     std::string pluginGetName() const
@@ -233,6 +235,10 @@ public:
             isPeriodic,
             slidingWindow
         );
+
+        if(!autoAdjustGrid)
+            domainAdjuster.validateOnly();
+
         domainAdjuster(gridSizeGlobal, gridSizeLocal, gridOffset);
 
         Environment<simDim>::get().initGrids(gridSizeGlobal, gridSizeLocal, gridOffset);
@@ -787,6 +793,7 @@ protected:
     bool slidingWindow;
     int32_t endSlidingOnStep;
     bool showVersionOnce;
+    bool autoAdjustGrid = true;
 };
 } /* namespace picongpu */
 

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -56,6 +56,7 @@
 #include "picongpu/particles/manipulators/manipulators.hpp"
 #include "picongpu/particles/filter/filter.hpp"
 #include "picongpu/particles/flylite/NonLTE.tpp"
+#include "picongpu/simulationControl/DomainAdjuster.hpp"
 #include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 
@@ -184,13 +185,13 @@ public:
             std::cerr << "Invalid configuration. Can't use moving window with one device in Y direction" << std::endl;
         }
 
-        DataSpace<simDim> global_grid_size;
+        DataSpace<simDim> gridSizeGlobal;
         DataSpace<simDim> gpus;
         DataSpace<simDim> isPeriodic;
 
         for (uint32_t i = 0; i < simDim; ++i)
         {
-            global_grid_size[i] = gridSize[i];
+            gridSizeGlobal[i] = gridSize[i];
             gpus[i] = devices[i];
             isPeriodic[i] = periodic[i];
         }
@@ -217,16 +218,24 @@ public:
 
             // calculate local grid points & offset
             gridSizeLocal[dim] = parserGD.getLocalSize(myGPUpos[dim]);
-            gridOffset[dim] = parserGD.getOffset(myGPUpos[dim], global_grid_size[dim]);
         }
         // by default: use an equal distributed box for all omitted params
         for (uint32_t dim = gridDistribution.size(); dim < simDim; ++dim)
         {
-            gridSizeLocal[dim] = global_grid_size[dim] / gpus[dim];
-            gridOffset[dim] = gridSizeLocal[dim] * myGPUpos[dim];
+            gridSizeLocal[dim] = gridSizeGlobal[dim] / gpus[dim];
         }
 
-        Environment<simDim>::get().initGrids(global_grid_size, gridSizeLocal, gridOffset);
+        DataSpace<simDim> gridOffset;
+
+        DomainAdjuster domainAdjuster(
+            gpus,
+            myGPUpos,
+            isPeriodic,
+            slidingWindow
+        );
+        domainAdjuster(gridSizeGlobal, gridSizeLocal, gridOffset);
+
+        Environment<simDim>::get().initGrids(gridSizeGlobal, gridSizeLocal, gridOffset);
 
         if (slidingWindow)
             MovingWindow::getInstance().setEndSlideOnStep(endSlidingOnStep);
@@ -241,30 +250,12 @@ public:
         GridLayout<simDim> layout(gridSizeLocal, GuardSize::toRT() * SuperCellSize::toRT());
         cellDescription = new MappingDesc(layout.getDataSpace(), DataSpace<simDim>(GuardSize::toRT()));
 
-        checkGridConfiguration(global_grid_size, cellDescription->getGridLayout());
-
         if (gc.getGlobalRank() == 0)
         {
             if (MovingWindow::getInstance().isEnabled())
                 log<picLog::PHYSICS > ("Sliding Window is ON");
             else
                 log<picLog::PHYSICS > ("Sliding Window is OFF");
-        }
-
-        for (uint32_t i = 0; i < simDim; ++i)
-        {
-
-            /*
-             * absorber must be smaller than local gridsize if direction is periodic.
-             * absorber can't go over more than one device.
-             */
-            if (isPeriodic[i] == 0)
-            {
-                /*negativ direction*/
-                PMACC_VERIFY((int) ABSORBER_CELLS[i][0] <= (int) cellDescription->getGridLayout().getDataSpaceWithoutGuarding()[i]);
-                /*positiv direction*/
-                PMACC_VERIFY((int) ABSORBER_CELLS[i][1] <= (int) cellDescription->getGridLayout().getDataSpaceWithoutGuarding()[i]);
-            }
         }
     }
 
@@ -757,25 +748,6 @@ public:
         return cellDescription;
     }
 
-private:
-
-    template<uint32_t DIM>
-    void checkGridConfiguration(DataSpace<DIM> globalGridSize, GridLayout<DIM>)
-    {
-
-        for(uint32_t i=0;i<simDim;++i)
-        {
-            // global size must be a devisor of supercell size
-            // note: this is redundant, while using the local condition below
-            PMACC_VERIFY(globalGridSize[i] % MappingDesc::SuperCellSize::toRT()[i] == 0);
-            // local size must be a devisor of supercell size
-            PMACC_VERIFY(gridSizeLocal[i] % MappingDesc::SuperCellSize::toRT()[i] == 0);
-            // local size must be at least 2 supercells (1x core + 2x border)
-            // note: size of border = guard_size (in supercells)
-            PMACC_VERIFY(gridSizeLocal[i] / MappingDesc::SuperCellSize::toRT()[i] >= 2 * GuardSize::toRT()[i] + 1);
-        }
-    }
-
 protected:
     std::shared_ptr<DeviceHeap> deviceHeap;
 
@@ -808,7 +780,6 @@ protected:
     std::vector<uint32_t> gridSize;
     /** Without guards */
     DataSpace<simDim> gridSizeLocal;
-    DataSpace<simDim> gridOffset;
     std::vector<uint32_t> periodic;
 
     std::vector<std::string> gridDistribution;


### PR DESCRIPTION
Add helper to calculate/adjust the domain sizes and offset of the simulation.

- add class `AdjustDomainSize`
- remove domain validation from `MySimulation`
- add new command line parameter `--autoAdjustGrid`


If the domain is automatically adjusted the changes will be logged on `stdout`. I know that this is not optimal but since we are lacking a logger this is the best way.