### PR TITLE
Docker & Singularity Updates

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -62,13 +62,19 @@ RUN        /bin/echo -e "source $SPACK_ROOT/share/spack/setup-env.sh\n" \
                         "spack load $PIC_PACKAGE\n" \
                         'if [ $(id -u) -eq 0 ]; then\n' \
                         '   function mpirun { $(which mpirun) --allow-run-as-root $@; }\n' \
+                        '   export -f mpirun\n' \
                         'fi\n' \
-                        'export -f mpirun\n' \
                         'if [ $(id -u) -eq 0 ]; then\n' \
                         '   function mpiexec { $(which mpiexec) --allow-run-as-root $@; }\n' \
+                        '   export -f mpiexec\n' \
                         'fi\n' \
-                        'export -f mpiexec\n' \
                > /etc/profile.d/picongpu.sh
+
+# force the use of a login shell
+RUN        /bin/echo -e '#!/bin/bash -l\n' \
+                        'exec "$@"\n' \
+               > /etc/entrypoint.sh
+RUN        chmod a+x /etc/entrypoint.sh
 
 # build example for out-of-the-box usage: LWFA
 RUN        /bin/bash -l -c ' \
@@ -105,4 +111,6 @@ COPY       start_khi_4.sh /usr/bin/bench4
 COPY       start_khi_8.sh /usr/bin/bench8
 COPY       start_foil_4.sh /usr/bin/foil4
 COPY       start_foil_8.sh /usr/bin/foil8
-CMD        /bin/bash -l
+
+ENTRYPOINT ["/etc/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -89,6 +89,10 @@ RUN        /bin/bash -l -c ' \
                pic-build -b "cuda:30;35;37;50;60;70" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
                rm -rf .build'
 
+# make input directories readable and files executable for all users
+RUN        chmod a+x /opt/picInputs/*/bin/* && \
+           chmod a+r -R /opt/picInputs/* && \
+           find /opt/picInputs -type d -exec chmod a+rx {} \;
 
 COPY       start_lwfa.sh /usr/bin/lwfa
 COPY       start_lwfa_4.sh /usr/bin/lwfa4

--- a/share/picongpu/dockerfiles/ubuntu-1604/modules.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/modules.yaml
@@ -2,25 +2,18 @@ modules:
   enable::
     - tcl
   tcl:
-    # Note on OpenMPI in Docker
-    # We should be able to use the latest MPI with
-    # `OMPI_MCA_btl_vader_single_copy_mechanism=none`
-    # to avoid disabling vader alltogether:
-    # https://github.com/open-mpi/ompi/issues/4948#issuecomment-377341406
+    # vader in docker: https://github.com/open-mpi/ompi/issues/4948
+    # ompio bugs: https://github.com/open-mpi/ompi/issues/6285
     openmpi:
       environment:
         set:
-          OMPI_MCA_mpi_leave_pinned: '0'
-          OMPI_MCA_btl: '^vader'
+          OMPI_MCA_btl_vader_single_copy_mechanism: 'none'
+          OMPI_MCA_io: '^ompio'
     # This anonymous spec selects any package that
     # depends on openmpi. The double colon at the
     # end clears the set of rules that matched so far.
     ^openmpi::
       environment:
         set:
-          OMPI_MCA_mpi_leave_pinned: '0'
-          OMPI_MCA_btl: '^vader'
-    icet:
-      environment:
-        prepend_path:
-          CMAKE_PREFIX_PATH: '${PREFIX}/lib'
+          OMPI_MCA_btl_vader_single_copy_mechanism: 'none'
+          OMPI_MCA_io: '^ompio'

--- a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
@@ -12,7 +12,8 @@ packages:
       python@2.7.12%gcc@5.4.0 arch=linux-ubuntu16-x86_64: /usr
     buildable: False
   openmpi:
-    version: [2.1.2]
+    version: [3.1.3]
+    variants: +cuda fabrics=verbs,ucx,libfabric
   all:
     providers:
       mpi: [openmpi]


### PR DESCRIPTION
OpenMPI Vader fix:
- instead of disabling vader alltogether, disable the non-functioning copy-mechanism in Docker and allow OpenMPI 3+ usage

OpenMPI fabrics with spack:
- build all possible fabrics, do not rely on auto-detection which will never have IB (psm, psm2 and mxm do not build without actual HW drivers detected during OpenMPI configure time)

OpenMPI parallel IO work-around:
- crashes and data corruption in releases 2.0-4.0, fallback to ROMIO #2857 

OpenMPI CUDA:
- enable CUDA awareness

IceT:
- buggy CMake install path corrected in `package.py` (spack mainline) https://github.com/spack/spack/pull/5014

Docker/Singularity:
- fix access rights to example dirs for non-root users

A big thank you to @AdamSimpson for provided feedback and improvements! :rocket: :sparkles: 