### PR TITLE
Calorimeter: Fix unitSI

### DIFF
--- a/docs/source/usage/plugins/particleCalorimeter.rst
+++ b/docs/source/usage/plugins/particleCalorimeter.rst
@@ -100,10 +100,10 @@ Depending on whether energy binning is enabled the dataset is two or three dimen
 The dataset has the following attributes:
 
 
-================== ==================================================
+================== =============================================
 Attribute          Description
-================== ==================================================
-``unitSI``         conversion factor from calorimeter value to Joule.
+================== =============================================
+``unitSI``         scaling factor for counts in calorimeter bins
 ``maxYaw[deg]``    half of the opening angle yaw.
 ``maxPitch[deg]``  half of the opening angle pitch.
 ``posYaw[deg]``    yaw coordinate of the calorimeter.
@@ -112,7 +112,7 @@ Attribute          Description
 ``minEnergy[keV]`` minimal detectable energy.
 ``maxEnergy[keV]`` maximal detectable energy.
 ``logScale``       boolean indicating logarithmic scale.
-================== ==================================================
+================== =============================================
 
 .. note::
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -334,7 +334,7 @@ private:
                            "calorimeter",
                            &(*this->hBufTotalCalorimeter->origin()));
 
-        const float_64 unitSI = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * UNIT_ENERGY;
+        const float_64 unitSI = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
 
         hdf5DataFile.writeAttribute(currentStep,
                                     SplashType64,


### PR DESCRIPTION
The unitSI in the particle calorimeter plugin should scale the bins (counts). This is not a scaling to energy but just a normalization during data reduction (and still a count).

Energy and opening angles are on the axes of the recorded mesh.