### PR TITLE
PlotMPL: fix run_directory arg into run_directories

### DIFF
--- a/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
@@ -23,12 +23,16 @@ class Visualizer(BaseVisualizer):
     Class for creating a matplotlib plot of phase space diagrams.
     """
 
-    def __init__(self, run_directory=None, ax=None):
+    def __init__(self, run_directories=None, ax=None):
         """
         Parameters
         ----------
-        run_directory : string
-            path to the run directory of PIConGPU
+        run_directories: list of tuples of length 2
+            or single tuple of length 2.
+            Each tuple is of the following form (sim_name, sim_path)
+            and consists of strings.
+            sim_name is a short string used e.g. in plot legends.
+            sim_path leads to the run directory of PIConGPU
             (the path before ``simOutput/``).
             If None, the user is responsible for providing run_directories
             later on via set_run_directories() before calling visualize().
@@ -43,7 +47,7 @@ class Visualizer(BaseVisualizer):
         # the separate colorbar axes
         self.colorbar_axes = None
 
-        super().__init__(PhaseSpaceData, run_directory, ax)
+        super().__init__(PhaseSpaceData, run_directories, ax)
 
     def _init_members(self, run_directories):
         """

--- a/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
@@ -16,18 +16,22 @@ class Visualizer(BaseVisualizer):
     Class for providing a plot of a PNG file using matplotlib.
     """
 
-    def __init__(self, run_directory=None, ax=None):
+    def __init__(self, run_directories=None, ax=None):
         """
         Parameters
         ----------
-        run_directory: string
-            path to the run directory of a PIConGPU simulation
+        run_directories: list of tuples of length 2
+            or single tuple of length 2.
+            Each tuple is of the following form (sim_name, sim_path)
+            and consists of strings.
+            sim_name is a short string used e.g. in plot legends.
+            sim_path leads to the run directory of PIConGPU
             (the path before ``simOutput/``).
             If None, the user is responsible for providing run_directories
             later on via set_run_directories() before calling visualize().
         ax: matplotlib.axes
         """
-        super().__init__(PNGData, run_directory, ax)
+        super().__init__(PNGData, run_directories, ax)
 
     def _check_and_fix_run_dirs(self, run_directories):
         """


### PR DESCRIPTION
The visualizers for phase space and png still had the `run_directory` parameter instead of its renamed and current version `run_directories` as the base class and energy histogram already had.