### PR TITLE
Fix Python param parser case

### DIFF
--- a/lib/python/picongpu/utils/param_parser.py
+++ b/lib/python/picongpu/utils/param_parser.py
@@ -95,7 +95,7 @@ def parse(file, ptype):
         return "-DPARAM_OVERWRITES:LIST='" + cxx_defines + "'"
 
     elif ptype == "run":
-        ostr = [str(name) + "=" + str(value)
+        ostr = [str(name).upper() + "=" + str(value)
                 for name, value in filtered_dict.items()]
         if not ostr:
             return ""


### PR DESCRIPTION
Runtime parameters names are not converted to uppercase by the `param_parser.py` at the moment which is fixed in this pull request.