### PR TITLE
Taurus: Power9 V100 Templates

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -168,18 +168,19 @@ Queue: ml (NVIDIA V100 GPUs on Power9 nodes)
 For this profile, you additionally need to compile and install everything for the power9-architecture including your own :ref:`boost <install-dependencies>`, :ref:`HDF5 <install-dependencies>`, c-blosc and :ref:`ADIOS <install-dependencies>`.
 
 Install script for `c-blosc`
-```
-cd $SOURCE_DIR
-git clone -b v1.12.1 https://github.com/Blosc/c-blosc.git \
-    $SOURCE_DIR/c-blosc
-mkdir c-blosc-build
-cd c-blosc-build
-cmake -DCMAKE_INSTALL_PREFIX=$BLOSC_ROOT \
-    -DPREFER_EXTERNAL_ZLIB=ON \
-    $SOURCE_DIR/c-blosc
-make -j4
-make install
-```
+
+.. code-block:: bash
+
+   cd $SOURCE_DIR
+   git clone -b v1.12.1 https://github.com/Blosc/c-blosc.git \
+       $SOURCE_DIR/c-blosc
+   mkdir c-blosc-build
+   cd c-blosc-build
+   cmake -DCMAKE_INSTALL_PREFIX=$BLOSC_ROOT \
+       -DPREFER_EXTERNAL_ZLIB=ON \
+       $SOURCE_DIR/c-blosc
+   make -j4
+   make install
 
 .. literalinclude:: profiles/taurus-tud/V100_picongpu.profile.example
    :language: bash

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -161,6 +161,28 @@ For this profile, you additionally need to install your own :ref:`boost <install
 
 .. literalinclude:: profiles/taurus-tud/knl_picongpu.profile.example
    :language: bash
+   
+Queue: ml (NVIDIA V100 GPUs on Power9 nodes)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this profile, you additionally need to compile and install everything for the power9-architecture including your own :ref:`boost <install-dependencies>`, :ref:`HDF5 <install-dependencies>`, c-blosc and :ref:`ADIOS <install-dependencies>`.
+
+Install script for `c-blosc`
+```
+cd $SOURCE_DIR
+git clone -b v1.12.1 https://github.com/Blosc/c-blosc.git \
+    $SOURCE_DIR/c-blosc
+mkdir c-blosc-build
+cd c-blosc-build
+cmake -DCMAKE_INSTALL_PREFIX=$BLOSC_ROOT \
+    -DPREFER_EXTERNAL_ZLIB=ON \
+    $SOURCE_DIR/c-blosc
+make -j4
+make install
+```
+
+.. literalinclude:: profiles/taurus-tud/V100_picongpu.profile.example
+   :language: bash
 
 Lawrencium (LBNL)
 -----------------

--- a/etc/picongpu/taurus-tud/V100.tpl
+++ b/etc/picongpu/taurus-tud/V100.tpl
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Copyright 2013-2019 Axel Huebl, Richard Pausch, Alexander Debus
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for taurus' SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-cpu=1511
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="ml"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# 6 gpus per node
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 6 ] ; then echo 6; else echo $TBG_tasks; fi`
+
+# number of cores to block per GPU - we got 6 cpus per gpu
+#   and we will be accounted 6 CPUs per GPU anyway
+.TBG_coresPerGPU=28
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to calculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+# Due to missing SLURM integration of the current MPI libraries
+# we have to create a suitable machinefile.
+rm -f machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+# we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
+#   support ticket [Ticket:2014052241001186] srun: mpi mca flags
+#   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
+export OMPI_MCA_mpi_leave_pinned=0
+
+# test if cuda_memtest binary is available
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+  # Run CUDA memtest to check GPU's health
+  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi
+

--- a/etc/picongpu/taurus-tud/V100.tpl
+++ b/etc/picongpu/taurus-tud/V100.tpl
@@ -83,12 +83,10 @@ umask 0027
 # Due to missing SLURM integration of the current MPI libraries
 # we have to create a suitable machinefile.
 rm -f machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+for i in `seq !TBG_gpusPerNode`
+do
+    scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+done
 
 mkdir simOutput 2> /dev/null
 cd simOutput
@@ -97,6 +95,9 @@ cd simOutput
 #   support ticket [Ticket:2014052241001186] srun: mpi mca flags
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
+# Use ROMIO for IO
+# according to ComputationalRadiationPhysics/picongpu#2857
+export OMPI_MCA_io=^ompio
 
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -1,0 +1,80 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ######################################### (edit those lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# Modules #####################################################################
+#
+module purge
+module load modenv/ml
+# similar to foss/2018a, but also includes SpectrumMPI which basically is just a OpenMPI-fork of IBM
+module load gsolf/2018a
+module load GCC/6.4.0-2.28
+module load CMake/3.10.2-GCCcore-6.4.0
+# CUDA is no module in the current enviroment!
+#module load CUDA/9.2.88  # gcc <= 7, intel 15-17
+# OpenMPI is already loaded
+#module load OpenMPI/2.1.2-GCC-6.4.0-2.28
+module load git/2.18.0-GCCcore-6.4.0
+module load zlib/1.2.11-GCCcore-6.4.0
+
+# Self-Build Software #########################################################
+#
+# needs to be compiled by the user
+export PIC_LIBS="/scratch/p_electron/debus/power9/lib"
+export BOOST_ROOT=$PIC_LIBS/boost-1.69.0-Power9
+export PNG_ROOT=$PIC_LIBS/libpng-1.6.34-Power9
+export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0-Power9
+export ADIOS_ROOT=$PIC_LIBS/adios-1.13.1-Power9
+export Splash_DIR=$PIC_LIBS/splash-Power9
+export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
+export HDF5_ROOT=$PIC_LIBS/hdf5-Power9
+export BLOSC_ROOT=$PIC_LIBS/blosc-1.12.1-Power9
+
+export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
+export LIBRARY_PATH=$BOOST_ROOT/lib:$LIBRARY_PATH
+export LD_LIBRARY_PATH=$PNG_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PNGwriter_DIR/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$Splash_DIR/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
+
+export PATH=$PNG_ROOT/bin:$PATH
+export PATH=$ADIOS_ROOT/bin:$PATH
+
+export CMAKE_PREFIX_PATH=$PNG_ROOT:$CMAKE_PREFIX_PATH
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:60"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+# python not included yet
+#export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# This is necessary in order to make alpaka compile.
+# The workaround is from Axel Huebl according to alpaka PR #702.
+export CXXFLAGS="-Dlinux"
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "gpu2" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/taurus-tud/V100.tpl"
+
+alias getNode='srun -p ml --gres=gpu:6 -n 6 --pty --mem-per-cpu=10000 -t 2:00:00 bash'
+

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -31,7 +31,7 @@ module load zlib/1.2.11-GCCcore-6.4.0
 # Self-Build Software #########################################################
 #
 # needs to be compiled by the user
-export PIC_LIBS="/scratch/p_electron/debus/power9/lib"
+export PIC_LIBS="$HOME/lib"
 export BOOST_ROOT=$PIC_LIBS/boost-1.69.0-Power9
 export PNG_ROOT=$PIC_LIBS/libpng-1.6.34-Power9
 export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0-Power9

--- a/etc/picongpu/taurus-tud/V100_restart.tpl
+++ b/etc/picongpu/taurus-tud/V100_restart.tpl
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Copyright 2013-2019 Axel Huebl, Richard Pausch, Alexander Debus
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for taurus' SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+# Maximum memory setting the SLURM queue "ml" accepts.
+#SBATCH --mem-per-cpu=1511
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --workdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="ml"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# 6 gpus per node
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 6 ] ; then echo 6; else echo $TBG_tasks; fi`
+
+# number of cores to block per GPU - we got 6 cpus per gpu
+#   and we will be accounted 6 CPUs per GPU anyway
+.TBG_coresPerGPU=28
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to calculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+# Due to missing SLURM integration of the current MPI libraries
+# we have to create a suitable machinefile.
+rm -f machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+# we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
+#   support ticket [Ticket:2014052241001186] srun: mpi mca flags
+#   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
+export OMPI_MCA_mpi_leave_pinned=0
+
+sleep 1
+
+echo "----- automated restart routine -----" | tee -a output
+
+#check whether last checkpoint is valid
+file=""
+# ADIOS restart files take precedence over HDF5 files
+fileEnding="h5"
+hasADIOS=$(ls ./checkpoints/checkpoint_*.bp 2>/dev/null | wc -w)
+if [ $hasADIOS -gt 0 ]
+then
+    fileEnding="bp"
+fi
+
+for file in `ls -t ./checkpoints/checkpoint_*.$fileEnding`
+do
+    echo -n "validate checkpoint $file: " | tee -a output
+    $fileEnding"ls" $file &> /dev/null
+    if [ $? -eq 0 ]
+    then
+        echo "OK" | tee -a output
+        break
+    else
+        echo "FAILED" | tee -a output
+        file=""
+    fi
+done
+
+#this sed call extracts the final simulation step from the cfg (assuming a standard cfg)
+finalStep=`echo !TBG_programParams | sed 's/.*-s[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
+echo "final step      = " $finalStep | tee -a output
+#this sed call extracts the -s and --checkpoint flags
+programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9,:,\,]\+[^\s]//g'`
+#extract restart period
+restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9,:,\,]\+[^\s]\).*/\1/'`
+echo  "restart period = " $restartPeriod | tee -a output
+
+
+# ******************************************* #
+# need some magic, if the restart period is in new notation with the ':' and ','
+
+currentStep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
+nextStep=$(nextstep_from_period.sh $restartPeriod $finalStep $currentStep)
+
+if [ -z "$file" ]; then
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod"
+else
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod --checkpoint.restart --checkpoint.restart.step $currentStep"
+fi
+
+# ******************************************* #
+
+echo "--- end automated restart routine ---" | tee -a output
+
+#wait that all nodes see output folder
+sleep 1
+
+# test if cuda_memtest binary is available
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+  # Run CUDA memtest to check GPU's health
+  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/picongpu $stepSetup !TBG_author !TBG_programParams | tee output
+fi
+
+mpiexec -hostfile ../machinefile.txt /usr/bin/env bash -c "killall -9 picongpu 2>/dev/null || true"
+
+if [ $nextStep -lt $finalStep ]
+then
+    ssh tauruslogin6 "/usr/bin/sbatch !TBG_dstPath/tbg/submit.start"
+    if [ $? -ne 0 ] ; then
+        echo "error during job submission" | tee -a output
+    else
+        echo "job submitted" | tee -a output
+    fi
+fi
+

--- a/etc/picongpu/taurus-tud/V100_restart.tpl
+++ b/etc/picongpu/taurus-tud/V100_restart.tpl
@@ -84,12 +84,10 @@ umask 0027
 # Due to missing SLURM integration of the current MPI libraries
 # we have to create a suitable machinefile.
 rm -f machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+for i in `seq !TBG_gpusPerNode`
+do
+    scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+done
 
 mkdir simOutput 2> /dev/null
 cd simOutput
@@ -98,6 +96,9 @@ cd simOutput
 #   support ticket [Ticket:2014052241001186] srun: mpi mca flags
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
+# Use ROMIO for IO
+# according to ComputationalRadiationPhysics/picongpu#2857
+export OMPI_MCA_io=^ompio
 
 sleep 1
 


### PR DESCRIPTION
PIConGPU now runs on the Power9 nodes on Taurus. On the `ml`-partition there are 22 nodes with each 6 V100 GPUs.

A working and tested configuration of the V100-profile, as well as the suitable templates with and without restarting can be found in this pull request.

Boost, HDF5, PNG, pngwriter, c-blosc, adios and splash were required to be self-built. The hint from ComputationalRadiationPhysics/alpaka#702 was used as a workaround to make the code compile. The current MPI-version for the Power9 machines is currently not integrated with SLURM. For this reason we created and used machinefiles in the V100-template V100.tpl.

Now PIConGPU runs and both ADIOS and HDF5-output work. However, the "real-life" HDF5-output for larger files (~100GB) is abysmally slow. Hence, use ADIOS for the heavy-lifting and HDF5 for smaller output (phase-space) etc. .

As a test case, an LWFA production run was used on 108 GPUs and so far produced nice output. Initial crashs seemed to have arisen by an unstable filesystem and so far could not be reproduced. However, the restarting capabilities do work.

At the moment this `ml`-partition is still in the testing phase and will go live by Februrary 1, 2019. The current maximum walltime is 8h.

Enjoy! 😃 