### PR TITLE
Core Particles: C++11 Using for Typedef

### DIFF
--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -48,8 +48,8 @@ struct FieldToParticleInterpolation
 
     static constexpr int lowerMargin = supp / 2 ;
     static constexpr int upperMargin = (supp + 1) / 2;
-    typedef typename pmacc::math::CT::make_Int<simDim,lowerMargin>::type LowerMargin;
-    typedef typename pmacc::math::CT::make_Int<simDim,upperMargin>::type UpperMargin;
+    using LowerMargin = typename pmacc::math::CT::make_Int<simDim,lowerMargin>::type;
+    using UpperMargin = typename pmacc::math::CT::make_Int<simDim,upperMargin>::type;
 
     PMACC_CASSERT_MSG(
         __FieldToParticleInterpolation_supercell_is_too_small_for_stencil,
@@ -81,7 +81,7 @@ struct FieldToParticleInterpolation
          * The following calls seperate the vector interpolation into
          * independent scalar interpolations.
          */
-        typedef typename pmacc::math::CT::make_Int<simDim,supp>::type Supports;
+        using Supports = typename pmacc::math::CT::make_Int<simDim,supp>::type;
 
         typename Cursor::ValueType result;
         for(uint32_t i = 0; i < Cursor::ValueType::dim; i++)
@@ -116,10 +116,10 @@ template<class AssignMethod, class InterpolationMethod>
 struct GetMargin<picongpu::FieldToParticleInterpolation<AssignMethod, InterpolationMethod> >
 {
 private:
-    typedef picongpu::FieldToParticleInterpolation<AssignMethod, InterpolationMethod> Interpolation;
+    using Interpolation = picongpu::FieldToParticleInterpolation<AssignMethod, InterpolationMethod>;
 public:
-    typedef typename Interpolation::LowerMargin LowerMargin;
-    typedef typename Interpolation::UpperMargin UpperMargin;
+    using LowerMargin = typename Interpolation::LowerMargin;
+    using UpperMargin = typename Interpolation::UpperMargin;
 };
 
 } //namespace traits

--- a/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
@@ -49,8 +49,8 @@ struct FieldToParticleInterpolationNative
 
     static constexpr int lowerMargin = supp / 2;
     static constexpr int upperMargin = (supp + 1) / 2;
-    typedef typename pmacc::math::CT::make_Int<simDim,lowerMargin>::type LowerMargin;
-    typedef typename pmacc::math::CT::make_Int<simDim,upperMargin>::type UpperMargin;
+    using LowerMargin = typename pmacc::math::CT::make_Int<simDim,lowerMargin>::type;
+    using UpperMargin = typename pmacc::math::CT::make_Int<simDim,upperMargin>::type;
 
     template<class Cursor, class VecVector_ >
     HDINLINE float3_X operator()(Cursor field, const floatD_X& particlePos,
@@ -92,10 +92,10 @@ template<class AssignMethod, class InterpolationMethod>
 struct GetMargin<picongpu::FieldToParticleInterpolationNative<AssignMethod, InterpolationMethod> >
 {
 private:
-    typedef picongpu::FieldToParticleInterpolationNative< AssignMethod, InterpolationMethod> Interpolation;
+    using Interpolation = picongpu::FieldToParticleInterpolationNative< AssignMethod, InterpolationMethod>;
 public:
-    typedef typename Interpolation::LowerMargin LowerMargin;
-    typedef typename Interpolation::UpperMargin UpperMargin;
+    using LowerMargin = typename Interpolation::LowerMargin;
+    using UpperMargin = typename Interpolation::UpperMargin;
 };
 
 } //namespace traits

--- a/include/picongpu/algorithms/LinearInterpolateWithUpper.hpp
+++ b/include/picongpu/algorithms/LinearInterpolateWithUpper.hpp
@@ -39,8 +39,8 @@ struct LinearInterpolateWithUpper
 {
     static constexpr uint32_t dim = T_Dim;
 
-    typedef typename pmacc::math::CT::make_Int<dim, 0>::type OffsetOrigin;
-    typedef typename pmacc::math::CT::make_Int<dim, 1>::type OffsetEnd;
+    using OffsetOrigin = typename pmacc::math::CT::make_Int<dim, 0>::type;
+    using OffsetEnd = typename pmacc::math::CT::make_Int<dim, 1>::type;
 
     /** calculate the linear interpolation for a given direction
      *

--- a/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
+++ b/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
@@ -97,8 +97,8 @@ struct ShiftCoordinateSystem
          *  and does not waste registers */
         const uint32_t dim = T_Vector::dim;
 
-        typedef boost::mpl::vector1 < boost::mpl::range_c<uint32_t, 0, dim > > Size;
-        typedef typename AllCombinations<Size>::type CombiTypes;
+        using Size = boost::mpl::vector1 < boost::mpl::range_c<uint32_t, 0, dim > >;
+        using CombiTypes = typename AllCombinations<Size>::type;
 
         ForEach<CombiTypes, AssignToDim<bmpl::_1, T_supports> > shift;
         shift(forward(cursor), forward(vector), fieldPos);

--- a/include/picongpu/initialization/ParserGridDistribution.hpp
+++ b/include/picongpu/initialization/ParserGridDistribution.hpp
@@ -36,7 +36,7 @@ namespace picongpu
 class ParserGridDistribution
 {
 private:
-    typedef std::vector<std::pair<uint32_t, uint32_t> > value_type;
+    using value_type = std::vector<std::pair<uint32_t, uint32_t> >;
 
 public:
     ParserGridDistribution( const std::string s )

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -101,13 +101,13 @@ struct CreateDensity
     using FrameType = typename SpeciesType::FrameType;
 
 
-    typedef typename bmpl::apply1<T_DensityFunctor, SpeciesType>::type UserDensityFunctor;
+    using UserDensityFunctor = typename bmpl::apply1<T_DensityFunctor, SpeciesType>::type;
     /* add interface for compile time interface validation*/
     using DensityFunctor = densityProfiles::IProfile<UserDensityFunctor>;
 
-    typedef typename bmpl::apply1<T_PositionFunctor, SpeciesType>::type UserPositionFunctor;
+    using UserPositionFunctor = typename bmpl::apply1<T_PositionFunctor, SpeciesType>::type;
     /* add interface for compile time interface validation*/
-    typedef manipulators::IUnary<UserPositionFunctor> PositionFunctor;
+    using PositionFunctor = manipulators::IUnary<UserPositionFunctor>;
 
     HINLINE void operator()( const uint32_t currentStep )
     {

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -110,7 +110,7 @@ class Particles : public ParticlesBase<
 {
 public:
 
-    typedef pmacc::ParticleDescription<
+    using SpeciesParticleDescription = pmacc::ParticleDescription<
         T_Name,
         SuperCellSize,
         T_Attributes,
@@ -137,11 +137,11 @@ public:
                 particles::boundary::CallPluginsAndDeleteParticles
             >
         >::type
-    > SpeciesParticleDescription;
-    typedef ParticlesBase<SpeciesParticleDescription, picongpu::MappingDesc, DeviceHeap> ParticlesBaseType;
-    typedef typename ParticlesBaseType::FrameType FrameType;
-    typedef typename ParticlesBaseType::FrameTypeBorder FrameTypeBorder;
-    typedef typename ParticlesBaseType::ParticlesBoxType ParticlesBoxType;
+    >;
+    using ParticlesBaseType = ParticlesBase<SpeciesParticleDescription, picongpu::MappingDesc, DeviceHeap>;
+    using FrameType = typename ParticlesBaseType::FrameType;
+    using FrameTypeBorder = typename ParticlesBaseType::FrameTypeBorder;
+    using ParticlesBoxType = typename ParticlesBaseType::ParticlesBoxType;
 
 
     Particles(const std::shared_ptr<DeviceHeap>& heap, picongpu::MappingDesc cellDescription, SimulationDataId datasetID);
@@ -243,11 +243,11 @@ namespace traits
        >
     >
     {
-        typedef typename picongpu::Particles<
+        using type = typename picongpu::Particles<
             T_Name,
             T_Attributes,
             T_Flags
-        >::ParticlesBoxType type;
+        >::ParticlesBoxType;
     };
 } //namespace traits
 } //namespace picongpu

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -307,11 +307,11 @@ struct PushAllSpecies
         EventList commEventList;
 
         /* push all species */
-        typedef typename pmacc::particles::traits::FilterByFlag
+        using VectorSpeciesWithPusher = typename pmacc::particles::traits::FilterByFlag
         <
             VectorAllSpecies,
             particlePusher<>
-        >::type VectorSpeciesWithPusher;
+        >::type;
         ForEach< VectorSpeciesWithPusher, particles::PushSpecies< bmpl::_1 > > pushSpecies;
         pushSpecies( currentStep, eventInt, forward(updateEventList) );
 

--- a/include/picongpu/particles/access/Cell2Particle.tpp
+++ b/include/picongpu/particles/access/Cell2Particle.tpp
@@ -51,8 +51,8 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
     constexpr lcellId_t maxParticlesInFrame = pmacc::math::CT::volume< typename TParticlesBox::FrameType::SuperCellSize >::type::value; \
     CellIndex superCellIdx = cellIndex / (CellIndex)SuperCellSize::toRT(); \
     \
-    typedef typename TParticlesBox::FramePtr FramePtr; \
-    typedef typename TParticlesBox::FrameType Frame; \
+    using FramePtr = typename TParticlesBox::FramePtr; \
+    using Frame = typename TParticlesBox::FrameType; \
     PMACC_SMEM( acc, frame, FramePtr ); \
     PMACC_SMEM( acc, particlesInSuperCell, uint16_t ); \
     ForEachIdx< \

--- a/include/picongpu/particles/boundary/CallPluginsAndDeleteParticles.hpp
+++ b/include/picongpu/particles/boundary/CallPluginsAndDeleteParticles.hpp
@@ -48,7 +48,7 @@ namespace boundary
             int32_t const direction
         ) const
         {
-            typedef std::list<pmacc::IPlugin*> Plugins;
+            using Plugins = std::list<pmacc::IPlugin*>;
             Plugins plugins = Environment<>::get().PluginConnector().getAllPlugins();
 
             for( Plugins::iterator iter = plugins.begin(); iter != plugins.end(); iter++ )

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -66,24 +66,24 @@ struct Bremsstrahlung
     using FrameType = typename ElectronSpecies::FrameType;
 
     /* specify field to particle interpolation scheme */
-    typedef typename pmacc::traits::Resolve<
+    using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
         typename GetFlagType<FrameType,interpolation<> >::type
-        >::type Field2ParticleInterpolation;
+    >::type;
 
     /* margins around the supercell for the interpolation of the field on the cells */
-    typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
-    typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+    using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;
+    using UpperMargin = typename GetMargin<Field2ParticleInterpolation>::UpperMargin;
 
     /* relevant area of a block */
-    typedef SuperCellDescription<
+    using BlockArea = SuperCellDescription<
         typename MappingDesc::SuperCellSize,
         LowerMargin,
         UpperMargin
-        > BlockArea;
+    >;
 
     BlockArea BlockDescription;
 
-    typedef MappingDesc::SuperCellSize TVec;
+    using TVec = MappingDesc::SuperCellSize;
 
     using ValueTypeIonDensity = FieldTmp::ValueType;
 
@@ -100,9 +100,9 @@ private:
     PMACC_ALIGN(photonMom, float3_X);
 
     /* random number generator */
-    typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
-    typedef pmacc::random::distributions::Uniform<float_X> Distribution;
-    typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
+    using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
+    using Distribution = pmacc::random::distributions::Uniform<float_X>;
+    using RandomGen = typename RNGFactory::GetRandomType<Distribution>::type;
     RandomGen randomGen;
 
 public:

--- a/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -56,9 +56,10 @@ namespace detail
  */
 struct GetPhotonAngleFunctor
 {
-    typedef typename ::pmacc::result_of::Functor<
+    using LinInterpCursor = typename ::pmacc::result_of::Functor<
         ::pmacc::cursor::tools::LinearInterp<float_X>,
-        ::pmacc::cursor::BufferCursor<float_X, DIM2> >::type LinInterpCursor;
+        ::pmacc::cursor::BufferCursor<float_X, DIM2>
+    >::type;
 
     using type = float_X;
 
@@ -115,7 +116,7 @@ struct GetPhotonAngle
 
 private:
 
-    typedef boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM2> > MyBuf;
+    using MyBuf = boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM2> >;
     MyBuf dBufTheta;
 
     /** probability density at polar angle theta.
@@ -159,7 +160,7 @@ private:
         {
             namespace odeint = boost::numeric::odeint;
 
-            typedef boost::array<float_64, 1> state_type;
+            using state_type = boost::array<float_64, 1>;
 
             state_type integral_result = {0.0};
             const float_64 lowerLimit = 0.0;

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -58,9 +58,10 @@ namespace detail
  */
 struct LookupTableFunctor
 {
-    typedef typename ::pmacc::result_of::Functor<
+    using LinInterpCursor = typename ::pmacc::result_of::Functor<
         ::pmacc::cursor::tools::LinearInterp<float_X>,
-        ::pmacc::cursor::BufferCursor<float_X, DIM2> >::type LinInterpCursor;
+        ::pmacc::cursor::BufferCursor<float_X, DIM2>
+    >::type;
 
     using type = float_X;
 
@@ -101,7 +102,7 @@ public:
     using LookupTableFunctor = detail::LookupTableFunctor;
 private:
 
-    typedef boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM2> > MyBuf;
+    using MyBuf = boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM2> >;
     MyBuf dBufScaledSpectrum;
     MyBuf dBufStoppingPower;
 

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -145,7 +145,7 @@ void ScaledSpectrum::init(const float_64 targetZ)
     const float_64 lnEMin = math::log(electron::MIN_ENERGY);
     const float_64 lnEMax = math::log(electron::MAX_ENERGY);
 
-    typedef boost::array<float_64, 1> state_type;
+    using state_type = boost::array<float_64, 1>;
 
     for(uint32_t EkinIdx = 0; EkinIdx < electron::NUM_SAMPLES_EKIN; EkinIdx++)
     {

--- a/include/picongpu/particles/creation/creation.hpp
+++ b/include/picongpu/particles/creation/creation.hpp
@@ -51,7 +51,7 @@ void createParticlesFromSpecies(T_SourceSpecies& sourceSpecies,
                                 T_ParticleCreator particleCreator,
                                 T_CellDescription* cellDesc)
 {
-    typedef typename MappingDesc::SuperCellSize SuperCellSize;
+    using SuperCellSize = typename MappingDesc::SuperCellSize;
     const pmacc::math::Int<simDim> coreBorderGuardSuperCells = cellDesc->getGridSuperCells();
     const pmacc::math::Int<simDim> guardSuperCells = cellDesc->getGuardingSuperCells();
     const pmacc::math::Int<simDim> coreBorderSuperCells = coreBorderGuardSuperCells - 2 * guardSuperCells;

--- a/include/picongpu/particles/densityProfiles/FromHDF5Impl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromHDF5Impl.hpp
@@ -39,12 +39,12 @@ namespace densityProfiles
 template<typename T_ParamClass>
 struct FromHDF5Impl : public T_ParamClass
 {
-    typedef T_ParamClass ParamClass;
+    using ParamClass = T_ParamClass;
 
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef FromHDF5Impl<ParamClass> type;
+        using type = FromHDF5Impl<ParamClass>;
     };
 
     HINLINE FromHDF5Impl(uint32_t currentStep)
@@ -181,7 +181,7 @@ private:
             }
 
             /* allocate temporary buffer for hdf5 data */
-            typedef typename FieldTmp::ValueType::type ValueType;
+            using ValueType = typename FieldTmp::ValueType::type;
             ValueType *tmpBfr = nullptr;
 
             size_t accessSize = accessSpace.productOfComponents();
@@ -207,7 +207,7 @@ private:
                 /* get the databox of the host buffer */
                 auto dataBox = fieldBuffer.getHostBuffer().getDataBox();
                 /* get a 1D access object to the databox */
-                typedef DataBoxDim1Access< typename FieldTmp::DataBoxType > D1Box;
+                using D1Box = DataBoxDim1Access< typename FieldTmp::DataBoxType >;
                 DataSpace<simDim> guards = fieldBuffer.getGridLayout().getGuard();
                 D1Box d1RAccess(dataBox.shift(guards + accessOffset), accessSpace);
 

--- a/include/picongpu/particles/densityProfiles/HomogenousImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/HomogenousImpl.hpp
@@ -32,7 +32,7 @@ struct HomogenousImpl
     template<typename T_SpeciesType>
     struct apply
     {
-        typedef HomogenousImpl type;
+        using type = HomogenousImpl;
     };
 
     HINLINE HomogenousImpl(uint32_t currentStep)

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -86,20 +86,20 @@ namespace ionization
         using FrameType = typename SrcSpecies::FrameType;
 
         /* specify field to particle interpolation scheme */
-        typedef typename pmacc::traits::Resolve<
+        using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
             typename GetFlagType<FrameType,interpolation<> >::type
-        >::type Field2ParticleInterpolation;
+        >::type;
 
         /* margins around the supercell for the interpolation of the field on the cells */
-        typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
-        typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+        using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;
+        using UpperMargin = typename GetMargin<Field2ParticleInterpolation>::UpperMargin;
 
         /* relevant area of a block */
-        typedef SuperCellDescription<
+        using BlockArea = SuperCellDescription<
             typename MappingDesc::SuperCellSize,
             LowerMargin,
             UpperMargin
-            > BlockArea;
+        >;
 
         BlockArea BlockDescription;
 
@@ -109,12 +109,12 @@ namespace ionization
             using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
-            typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
-            typedef pmacc::random::distributions::Uniform<float_X> Distribution;
-            typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
+            using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
+            using Distribution = pmacc::random::distributions::Uniform<float_X>;
+            using RandomGen = typename RNGFactory::GetRandomType<Distribution>::type;
             RandomGen randomGen;
 
-            typedef MappingDesc::SuperCellSize TVec;
+            using TVec = MappingDesc::SuperCellSize;
 
             using ValueType_E = FieldE::ValueType;
             using ValueType_B = FieldB::ValueType;

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -71,20 +71,20 @@ namespace ionization
         using FrameType = typename SrcSpecies::FrameType;
 
         /* specify field to particle interpolation scheme */
-        typedef typename pmacc::traits::Resolve<
+        using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
             typename GetFlagType<FrameType,interpolation<> >::type
-        >::type Field2ParticleInterpolation;
+        >::type;
 
         /* margins around the supercell for the interpolation of the field on the cells */
-        typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
-        typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+        using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;
+        using UpperMargin = typename GetMargin<Field2ParticleInterpolation>::UpperMargin;
 
         /* relevant area of a block */
-        typedef SuperCellDescription<
+        using BlockArea = SuperCellDescription<
             typename MappingDesc::SuperCellSize,
             LowerMargin,
             UpperMargin
-            > BlockArea;
+        >;
 
         BlockArea BlockDescription;
 
@@ -93,7 +93,7 @@ namespace ionization
             /* define ionization ALGORITHM (calculation) for ionization MODEL */
             using IonizationAlgorithm = T_IonizationAlgorithm;
 
-            typedef MappingDesc::SuperCellSize TVec;
+            using TVec = MappingDesc::SuperCellSize;
 
             using ValueType_E = FieldE::ValueType;
             /* global memory EM-field device databoxes */

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -87,20 +87,20 @@ namespace ionization
         using FrameType = typename SrcSpecies::FrameType;
 
         /* specify field to particle interpolation scheme */
-        typedef typename pmacc::traits::Resolve<
+        using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
             typename GetFlagType<FrameType,interpolation<> >::type
-        >::type Field2ParticleInterpolation;
+        >::type;
 
         /* margins around the supercell for the interpolation of the field on the cells */
-        typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
-        typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+        using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;
+        using UpperMargin = typename GetMargin<Field2ParticleInterpolation>::UpperMargin;
 
         /* relevant area of a block */
-        typedef SuperCellDescription<
+        using BlockArea = SuperCellDescription<
             typename MappingDesc::SuperCellSize,
             LowerMargin,
             UpperMargin
-            > BlockArea;
+        >;
 
         BlockArea BlockDescription;
 
@@ -110,12 +110,12 @@ namespace ionization
             using IonizationAlgorithm = T_IonizationAlgorithm;
 
             /* random number generator */
-            typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
-            typedef pmacc::random::distributions::Uniform<float_X> Distribution;
-            typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
+            using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
+            using Distribution = pmacc::random::distributions::Uniform<float_X>;
+            using RandomGen = typename RNGFactory::GetRandomType<Distribution>::type;
             RandomGen randomGen;
 
-            typedef MappingDesc::SuperCellSize TVec;
+            using TVec = MappingDesc::SuperCellSize;
 
             using ValueType_E = FieldE::ValueType;
             using ValueType_B = FieldB::ValueType;

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -61,8 +61,8 @@ namespace particleToGrid
 
         static constexpr int lowerMargin = supp / 2;
         static constexpr int upperMargin = (supp + 1) / 2;
-        typedef typename pmacc::math::CT::make_Int<simDim, lowerMargin>::type LowerMargin;
-        typedef typename pmacc::math::CT::make_Int<simDim, upperMargin>::type UpperMargin;
+        using LowerMargin = typename pmacc::math::CT::make_Int<simDim, lowerMargin>::type;
+        using UpperMargin = typename pmacc::math::CT::make_Int<simDim, upperMargin>::type;
 
         HDINLINE ComputeGridValuePerFrame()
         {

--- a/include/picongpu/particles/pusher/particlePusherAxel.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAxel.hpp
@@ -42,8 +42,8 @@ namespace picongpu
             /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
              * for particle positions outside the super cell in one push
              */
-            typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
-            typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
+            using LowerMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
+            using UpperMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
 
             enum coords
             {

--- a/include/picongpu/particles/pusher/particlePusherBoris.hpp
+++ b/include/picongpu/particles/pusher/particlePusherBoris.hpp
@@ -35,8 +35,8 @@ struct Push
     /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
      * for particle positions outside the super cell in one push
      */
-    typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
-    typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
+    using LowerMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
+    using UpperMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
 
     template< typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Particle, typename T_Pos >
     HDINLINE void operator()(

--- a/include/picongpu/particles/pusher/particlePusherFree.hpp
+++ b/include/picongpu/particles/pusher/particlePusherFree.hpp
@@ -34,8 +34,8 @@ namespace picongpu
             /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
              * for particle positions outside the super cell in one push
              */
-            typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
-            typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
+            using LowerMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
+            using UpperMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
 
             template< typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Particle, typename T_Pos >
             HDINLINE void operator()(

--- a/include/picongpu/particles/pusher/particlePusherPhoton.hpp
+++ b/include/picongpu/particles/pusher/particlePusherPhoton.hpp
@@ -33,8 +33,8 @@ namespace picongpu
             /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
              * for particle positions outside the super cell in one push
              */
-            typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
-            typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
+            using LowerMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
+            using UpperMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
 
             template< typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Particle, typename T_Pos >
             HDINLINE void operator()(

--- a/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -47,8 +47,8 @@ struct Push
   /* this is an optional extention for sub-sampling pushes that enables grid to particle interpolation
    * for particle positions outside the super cell in one push
    */
-  typedef typename pmacc::math::CT::make_Int<simDim,1>::type LowerMargin;
-  typedef typename pmacc::math::CT::make_Int<simDim,1>::type UpperMargin;
+  using LowerMargin = typename pmacc::math::CT::make_Int<simDim,1>::type;
+  using UpperMargin = typename pmacc::math::CT::make_Int<simDim,1>::type;
 
   template<
     typename T_FunctorFieldE,
@@ -81,7 +81,7 @@ struct Push
     const float_X deltaT = DELTA_T;
     const uint32_t dimMomentum = GetNComponents<TypeMomentum>::value;
     // the transver data type adjust to 3D3V, 2D3V, 2D2V, ...
-    typedef pmacc::math::Vector< picongpu::float_X, simDim + dimMomentum > VariableType;
+    using VariableType = pmacc::math::Vector< picongpu::float_X, simDim + dimMomentum >;
     VariableType var;
 
     // transfer position
@@ -92,7 +92,7 @@ struct Push
     for(uint32_t i=0; i<dimMomentum; ++i)
       var[simDim + i] = mom[i];
 
-    typedef DiffEquation<VariableType, float_X, TypeEFieldFunctor, TypeBFieldFunctor, TypePosition, TypeMomentum, TypeMass, TypeCharge, TypeWeighting, Velocity, Gamma> DiffEqType;
+    using DiffEqType = DiffEquation<VariableType, float_X, TypeEFieldFunctor, TypeBFieldFunctor, TypePosition, TypeMomentum, TypeMass, TypeCharge, TypeWeighting, Velocity, Gamma>;
     DiffEqType diffEq(functorEField, functorBField, mass, charge, weighting);
 
     VariableType varNew = pmacc::math::RungeKutta4()(diffEq, var, float_X(0.0), deltaT);

--- a/include/picongpu/particles/pusher/particlePusherVay.hpp
+++ b/include/picongpu/particles/pusher/particlePusherVay.hpp
@@ -35,8 +35,8 @@ struct Push
     /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
      * for particle positions outside the super cell in one push
      */
-    typedef typename pmacc::math::CT::make_Int<simDim,0>::type LowerMargin;
-    typedef typename pmacc::math::CT::make_Int<simDim,0>::type UpperMargin;
+    using LowerMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
+    using UpperMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
 
     template<
         typename T_FunctorFieldE,

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -78,25 +78,25 @@ struct PhotonCreator
     using FrameType = typename ElectronSpecies::FrameType;
 
     /* specify field to particle interpolation scheme */
-    typedef typename pmacc::particles::traits::ResolveAliasFromSpecies<
+    using Field2ParticleInterpolation = typename pmacc::particles::traits::ResolveAliasFromSpecies<
         ElectronSpecies,
         interpolation<>
-    >::type Field2ParticleInterpolation;
+    >::type;
 
     /* margins around the supercell for the interpolation of the field on the cells */
-    typedef typename GetMargin<Field2ParticleInterpolation>::LowerMargin LowerMargin;
-    typedef typename GetMargin<Field2ParticleInterpolation>::UpperMargin UpperMargin;
+    using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;
+    using UpperMargin = typename GetMargin<Field2ParticleInterpolation>::UpperMargin;
 
     /* relevant area of a block */
-    typedef SuperCellDescription<
+    using BlockArea = SuperCellDescription<
         typename MappingDesc::SuperCellSize,
         LowerMargin,
         UpperMargin
-        > BlockArea;
+    >;
 
     BlockArea BlockDescription;
 
-    typedef MappingDesc::SuperCellSize TVec;
+    using TVec = MappingDesc::SuperCellSize;
 
     using ValueType_E = FieldE::ValueType;
     using ValueType_B = FieldB::ValueType;
@@ -115,9 +115,9 @@ private:
     PMACC_ALIGN(photon_mom, float3_X);
 
     /* random number generator */
-    typedef pmacc::random::RNGProvider<simDim, random::Generator> RNGFactory;
-    typedef pmacc::random::distributions::Uniform<float_X> Distribution;
-    typedef typename RNGFactory::GetRandomType<Distribution>::type RandomGen;
+    using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
+    using Distribution = pmacc::random::distributions::Uniform<float_X>;
+    using RandomGen = typename RNGFactory::GetRandomType<Distribution>::type;
     RandomGen randomGen;
 
 public:

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -45,9 +45,10 @@ namespace detail
  */
 struct MapToLookupTable
 {
-    typedef typename ::pmacc::result_of::Functor<
+    using LinInterpCursor = typename ::pmacc::result_of::Functor<
         ::pmacc::cursor::tools::LinearInterp<float_X>,
-        ::pmacc::cursor::BufferCursor<float_X, DIM1> >::type LinInterpCursor;
+        ::pmacc::cursor::BufferCursor<float_X, DIM1>
+    >::type;
 
     using type = float_X;
 
@@ -68,10 +69,11 @@ struct MapToLookupTable
     HDINLINE float_X operator()(const float_X x) const;
 };
 
-typedef ::pmacc::cursor::Cursor<
+using SyncFuncCursor = ::pmacc::cursor::Cursor<
     MapToLookupTable,
     ::pmacc::cursor::PlusNavigator,
-    float_X> SyncFuncCursor;
+    float_X
+>;
 
 } // namespace detail
 
@@ -86,7 +88,7 @@ public:
     using SyncFuncCursor = detail::SyncFuncCursor;
 private:
 
-    typedef boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM1> > MyBuf;
+    using MyBuf = boost::shared_ptr<pmacc::container::DeviceBuffer<float_X, DIM1> >;
     MyBuf dBuf_SyncFuncs[2]; // two synchrotron functions
 
     struct BesselK

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -77,7 +77,7 @@ float_64 SynchrotronFunctions::F_1(const float_64 x) const
         return float_64(0.0);
 
     using namespace boost::numeric::odeint;
-    typedef boost::array<float_64, 1> state_type;
+    using state_type = boost::array<float_64, 1>;
 
     state_type integral_result = {0.0};
     const float_64 upper_bound(SYNC_FUNCS_F1_INTEGRAL_BOUND);

--- a/include/picongpu/particles/traits/GetAtomicNumbers.hpp
+++ b/include/picongpu/particles/traits/GetAtomicNumbers.hpp
@@ -34,12 +34,12 @@ struct GetAtomicNumbers
 {
     using FrameType = typename T_Species::FrameType;
 
-    typedef typename HasFlag<FrameType, atomicNumbers<> >::type hasAtomicNumbers;
+    using hasAtomicNumbers = typename HasFlag<FrameType, atomicNumbers<> >::type;
     /* throw static assert if species has no protons or neutrons */
     PMACC_CASSERT_MSG(This_species_has_no_atomic_numbers,hasAtomicNumbers::value==true);
 
-    typedef typename GetFlagType<FrameType,atomicNumbers<> >::type FoundAtomicNumbersAlias;
-    typedef typename pmacc::traits::Resolve<FoundAtomicNumbersAlias >::type type;
+    using FoundAtomicNumbersAlias = typename GetFlagType<FrameType,atomicNumbers<> >::type;
+    using type = typename pmacc::traits::Resolve<FoundAtomicNumbersAlias >::type;
 };
 } //namespace traits
 

--- a/include/picongpu/particles/traits/GetCurrentSolver.hpp
+++ b/include/picongpu/particles/traits/GetCurrentSolver.hpp
@@ -30,9 +30,9 @@ namespace traits
 template<typename T_Species>
 struct GetCurrentSolver
 {
-    typedef typename pmacc::traits::Resolve<
+    using type = typename pmacc::traits::Resolve<
         typename GetFlagType<typename T_Species::FrameType, current<> >::type
-    >::type type;
+    >::type;
 };
 } //namespace traits
 

--- a/include/picongpu/particles/traits/GetInterpolation.hpp
+++ b/include/picongpu/particles/traits/GetInterpolation.hpp
@@ -31,9 +31,9 @@ namespace traits
 template<typename T_Species>
 struct GetInterpolation
 {
-    typedef typename pmacc::traits::Resolve<
+    using type = typename pmacc::traits::Resolve<
         typename GetFlagType<typename T_Species::FrameType, interpolation<> >::type
-    >::type type;
+    >::type;
 };
 } //namespace traits
 

--- a/include/picongpu/particles/traits/GetIonizationEnergies.hpp
+++ b/include/picongpu/particles/traits/GetIonizationEnergies.hpp
@@ -35,13 +35,13 @@ struct GetIonizationEnergies
     using SpeciesType = T_Species;
     using FrameType = typename SpeciesType::FrameType;
 
-    typedef typename HasFlag<FrameType, ionizationEnergies<> >::type hasIonizationEnergies;
+    using hasIonizationEnergies = typename HasFlag<FrameType, ionizationEnergies<> >::type;
     /* throw static assert if species has no protons or neutrons */
     PMACC_CASSERT_MSG(No_ionization_energies_are_defined_for_this_species,hasIonizationEnergies::value==true);
 
-    typedef typename GetFlagType<FrameType,ionizationEnergies<> >::type FoundIonizationEnergiesAlias;
+    using FoundIonizationEnergiesAlias = typename GetFlagType<FrameType,ionizationEnergies<> >::type;
     /* Extract ionization energy vector from AU namespace */
-    typedef typename pmacc::traits::Resolve<FoundIonizationEnergiesAlias >::type type;
+    using type = typename pmacc::traits::Resolve<FoundIonizationEnergiesAlias >::type;
 
     static constexpr int protonNumber = static_cast<int>(GetAtomicNumbers<SpeciesType>::type::numberOfProtons);
     /* length of the ionization energy vector */

--- a/include/picongpu/particles/traits/GetMarginPusher.hpp
+++ b/include/picongpu/particles/traits/GetMarginPusher.hpp
@@ -33,17 +33,17 @@ namespace traits
 template<typename T_Species>
 struct GetMarginPusher
 {
-    typedef pmacc::math::CT::add<
+    using AddLowerMargins = pmacc::math::CT::add<
         GetLowerMargin< GetInterpolation< bmpl::_1 > >,
         GetLowerMargin< GetPusher< bmpl::_1 > >
-    > AddLowerMargins;
-    typedef typename bmpl::apply<AddLowerMargins, T_Species>::type LowerMargin;
+    >;
+    using LowerMargin = typename bmpl::apply<AddLowerMargins, T_Species>::type;
 
-    typedef pmacc::math::CT::add<
+    using AddUpperMargins = pmacc::math::CT::add<
         GetUpperMargin< GetInterpolation< bmpl::_1 > >,
         GetUpperMargin< GetPusher< bmpl::_1 > >
-    > AddUpperMargins;
-    typedef typename bmpl::apply<AddUpperMargins, T_Species>::type UpperMargin;
+    >;
+    using UpperMargin = typename bmpl::apply<AddUpperMargins, T_Species>::type;
 };
 
 template<typename T_Species>

--- a/include/picongpu/particles/traits/GetPusher.hpp
+++ b/include/picongpu/particles/traits/GetPusher.hpp
@@ -31,9 +31,9 @@ namespace traits
 template<typename T_Species>
 struct GetPusher
 {
-    typedef typename pmacc::traits::Resolve<
+    using type = typename pmacc::traits::Resolve<
         typename GetFlagType<typename T_Species::FrameType, particlePusher<> >::type
-      >::type type;
+      >::type;
 };
 
 }// namespace traits

--- a/include/picongpu/particles/traits/GetShape.hpp
+++ b/include/picongpu/particles/traits/GetShape.hpp
@@ -31,9 +31,9 @@ namespace traits
 template<typename T_Species>
 struct GetShape
 {
-    typedef typename pmacc::traits::Resolve<
+    using type = typename pmacc::traits::Resolve<
         typename GetFlagType<typename T_Species::FrameType, shape<> >::type
-    >::type type;
+    >::type;
 };
 
 } //namespace traits

--- a/include/picongpu/particles/traits/GetSpeciesFlagName.hpp
+++ b/include/picongpu/particles/traits/GetSpeciesFlagName.hpp
@@ -47,12 +47,12 @@ namespace traits
     struct
     GetSpeciesFlagName
     {
-        typedef typename pmacc::traits::Resolve<
+        using SpeciesFlag = typename pmacc::traits::Resolve<
             typename GetFlagType<
                 typename T_Species::FrameType,
                 T_Flag
             >::type
-        >::type SpeciesFlag;
+        >::type;
 
         std::string operator()() const
         {

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -317,10 +317,14 @@ public:
         currentBGField = new cellwiseOperation::CellwiseOperation < CORE + BORDER > (*cellDescription);
 
         // Initialize random number generator and synchrotron functions, if there are synchrotron or bremsstrahlung Photons
-        typedef typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies,
-                                                                synchrotronPhotons<> >::type AllSynchrotronPhotonsSpecies;
-        typedef typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies,
-                                                                bremsstrahlungPhotons<> >::type AllBremsstrahlungPhotonsSpecies;
+        using AllSynchrotronPhotonsSpecies = typename pmacc::particles::traits::FilterByFlag<
+            VectorAllSpecies,
+            synchrotronPhotons<>
+        >::type;
+        using AllBremsstrahlungPhotonsSpecies = typename pmacc::particles::traits::FilterByFlag<
+            VectorAllSpecies,
+            bremsstrahlungPhotons<>
+        >::type;
 
         // create factory for the random number generator
         const uint32_t userSeed = random::seed::ISeed< random::SeedGenerator >{}();
@@ -523,11 +527,11 @@ public:
     {
         namespace nvfct = pmacc::nvidia::functors;
 
-        typedef typename pmacc::particles::traits::FilterByIdentifier
+        using VectorSpeciesWithMementumPrev1 = typename pmacc::particles::traits::FilterByIdentifier
         <
             VectorAllSpecies,
             momentumPrev1
-        >::type VectorSpeciesWithMementumPrev1;
+        >::type;
 
         /* copy attribute momentum to momentumPrev1 */
         ForEach<
@@ -566,8 +570,10 @@ public:
         populationKinetics( currentStep );
 
         /* call the synchrotron radiation module for each radiating species (normally electrons) */
-        typedef typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies,
-                                                                synchrotronPhotons<> >::type AllSynchrotronPhotonsSpecies;
+        using AllSynchrotronPhotonsSpecies = typename pmacc::particles::traits::FilterByFlag<
+            VectorAllSpecies,
+            synchrotronPhotons<>
+        >::type;
 
         ForEach<
             AllSynchrotronPhotonsSpecies,
@@ -577,11 +583,11 @@ public:
 
 #if( PMACC_CUDA_ENABLED == 1 )
         /* Bremsstrahlung */
-        typedef typename pmacc::particles::traits::FilterByFlag
+        using VectorSpeciesWithBremsstrahlung = typename pmacc::particles::traits::FilterByFlag
         <
             VectorAllSpecies,
             bremsstrahlungIons<>
-        >::type VectorSpeciesWithBremsstrahlung;
+        >::type;
         ForEach<
             VectorSpeciesWithBremsstrahlung,
             particles::CallBremsstrahlung< bmpl::_1 >
@@ -621,11 +627,11 @@ public:
         (*currentBGField)(fieldJ, nvfct::Add(), FieldBackgroundJ(fieldJ->getUnit()),
                           currentStep, FieldBackgroundJ::activated);
 
-        typedef typename pmacc::particles::traits::FilterByFlag
+        using VectorSpeciesWithCurrentSolver = typename pmacc::particles::traits::FilterByFlag
         <
             VectorAllSpecies,
             current<>
-        >::type VectorSpeciesWithCurrentSolver;
+        >::type;
         ForEach<
             VectorSpeciesWithCurrentSolver,
             ComputeCurrent<

--- a/include/picongpu/simulationControl/SimulationStarter.hpp
+++ b/include/picongpu/simulationControl/SimulationStarter.hpp
@@ -41,7 +41,7 @@ namespace picongpu
     class SimulationStarter : public ISimulationStarter
     {
     private:
-        typedef std::list<boost::program_options::options_description> BoostOptionsList;
+        using BoostOptionsList = std::list<boost::program_options::options_description>;
 
         SimulationClass* simulationClass;
         InitClass* initClass;


### PR DESCRIPTION
replace `typedef` in examples with modern C++11 `using`.
Commited as tools user.