### PR TITLE
[WIP] Update hemera-hzdr/gpu.tpl

### DIFF
--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -63,7 +63,7 @@
 
 # number of cores to block per GPU - we got 6 cpus per gpu
 #   and we will be accounted 6 CPUs per GPU anyway
-.TBG_coresPerGPU=6
+.TBG_coresPerGPU=3
 
 # We only start 1 MPI task per GPU
 .TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"


### PR DESCRIPTION
During a recent maintenance on the hemera cluster at HZDR Hyperthreading was disabled. Therefore, we need to allocate less cores per gpu in order to comply with resource handling by the SLURM scheduler.