### PR TITLE
Fix pyflakes str/bytes/int compares

### DIFF
--- a/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
@@ -338,7 +338,7 @@ class BaseWidget(widgets.VBox):
         time = self.sim_time_slider.value
 
         # the case where no valid iteration is provided
-        if time is None or time is "":
+        if time is None or time == "":
             return
 
         # print("{} called visualize for time {} and run_dirs {}".format(

--- a/src/tools/bin/smooth.py
+++ b/src/tools/bin/smooth.py
@@ -64,10 +64,10 @@ def makeOddNumber(number, larger=True):
     returns next odd number
 
     """
-    if number % 2 is 1:
+    if number % 2 == 1:
         # in case number is odd
         return number
-    elif number % 2 is 0:
+    elif number % 2 == 0:
         # in case number is even
         if larger:
             return number + 1


### PR DESCRIPTION
Fix pyflakes:
```
use ==/!= to compare str, bytes, and int literals
```