### PR TITLE
[WIP] Docs: Add ionization prediction plot

### DIFF
--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -73,7 +73,7 @@ Tunneling Ionization
 Tunneling ionization describes the process during which an initially bound electron quantum-mechanically tunnels through a potential barrier of finite height.
 
 Keldysh
-"""""""
+^^^^^^^
 
 .. math::
 
@@ -92,7 +92,7 @@ The Keldysh ionization rate has been implemented according to the equation (9) i
 
 
 Ammosov-Delone-Krainov (ADK)
-""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. math::
    :nowrap:
@@ -120,6 +120,14 @@ When we account for orbital structure in shielding of the ion charge :math:`Z` a
 One would expect much earlier ionization of Hydrogen due to lower ionization energy. The following image shows how this can be explained by the shape of the ion potential that is assumed in this model.
 
 .. plot:: models/field_ionization_effective_potentials.py
+
+Predicting Charge State Distributions
+-------------------------------------
+
+Especially for underdense targets it is possible to already give an estimate for how the laser pulse ionizes a certain target.
+Starting from an initially unionized state, calculating ionization rates for each charge state for a given electric field a Markovian approach of transition matrices yields the charge state population for each time.
+
+.. plot:: models/field_ionization_charge_state_prediction.py
 
 References
 ----------

--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -47,7 +47,7 @@ Overview: Implemented Models
     |                     | * ``ADKCircPol``            | * [DeloneKrainov]_        |
     +---------------------+-----------------------------+---------------------------+
     | Barrier Suppression | * ``BSI``                   | * [MulserBauer2010]_      |
-    |                     | * ``BSIEffectiveZ``         | * [ClementiRaimondi1963]_ |
+    |                     | * ``BSIEffectiveZ`` (R&D)   | * [ClementiRaimondi1963]_ |
     |                     |                             |   [ClementiRaimondi1967]_ |
     |                     | * ``BSIStarkShifted`` (R&D) | * [BauerMulser1999]_      |
     +---------------------+-----------------------------+---------------------------+
@@ -125,9 +125,13 @@ Predicting Charge State Distributions
 -------------------------------------
 
 Especially for underdense targets, it is possible to already give an estimate for how the laser pulse ionizes a specific target.
-Starting from an initially unionized state, calculating ionization rates for each charge state for a given electric field a Markovian_ approach of transition matrices yields the charge state population for each time.
+Starting from an initially unionized state, calculating ionization rates for each charge state for a given electric field via a Markovian_ approach of transition matrices yields the charge state population for each time.
 
 .. _Markovian: https://en.wikipedia.org/wiki/Markov_chain
+
+Here, we show an example of Neon gas ionized by a Gaussian laser pulse with maximum amplitude :math:`a_0 = 10` and pulse duration (FWHM intensity) of :math:`30\,\mathrm{fs}`.
+The figure shows the ionization rates and charge state population produced by the ``ADKLinPol`` model obtained from the pulse shape in the lower panel, as well as the step-like ionization produced by the ``BSI`` model.
+
 .. plot:: models/field_ionization_charge_state_prediction.py
 
 References

--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -134,6 +134,35 @@ The figure shows the ionization rates and charge state population produced by th
 
 .. plot:: models/field_ionization_charge_state_prediction.py
 
+You can test the implemented ionization models yourself with the corresponding module shipped in ``picongpu/lib/python``.
+
+.. code:: python
+
+    import numpy as np
+    import scipy.constants as sc
+    from picongpu.utils import FieldIonization
+
+    # instantiate class object that contains functions for
+    #   - ionization rates
+    #   - critical field strengths (BSI models)
+    #   - laser intensity conversion
+    FI = FieldIonization()
+
+    # dictionary with atomic units
+    AU = FI.atomic_unit
+
+    # residual charge state AFTER ionization
+    Z_H = 1
+    # hydrogen ionization energy (13.6 eV) converted to atomic units
+    E_H_AU = 13.6 * sc.electron_volt / AU['energy']
+    # output: 0.50
+    print("%.2f" % (E_H_AU))
+    # barrier suppression threshold field strength
+    F_BSI_H = FI.F_crit_BSI(Z=Z_H, E_Ip=E_H_AU)
+    # output: 3.21e+10 V/m
+    print("%.2e V/m" % (F_BSI_H * AU['electric field']))
+
+
 References
 ----------
 .. [DeloneKrainov]

--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -13,7 +13,7 @@ PIConGPU features an adaptable ionization framework for arbitrary and combinable
 .. note::
 
     Most of the calculations and formulae in this section of the docs are done in the **Atomic Units (AU)** system.
-    
+
 .. math::
 
     \hbar = \mathrm{e} = m_\mathrm{e} = 1
@@ -124,9 +124,10 @@ One would expect much earlier ionization of Hydrogen due to lower ionization ene
 Predicting Charge State Distributions
 -------------------------------------
 
-Especially for underdense targets it is possible to already give an estimate for how the laser pulse ionizes a certain target.
-Starting from an initially unionized state, calculating ionization rates for each charge state for a given electric field a Markovian approach of transition matrices yields the charge state population for each time.
+Especially for underdense targets, it is possible to already give an estimate for how the laser pulse ionizes a specific target.
+Starting from an initially unionized state, calculating ionization rates for each charge state for a given electric field a Markovian_ approach of transition matrices yields the charge state population for each time.
 
+.. _Markovian: https://en.wikipedia.org/wiki/Markov_chain
 .. plot:: models/field_ionization_charge_state_prediction.py
 
 References
@@ -154,7 +155,7 @@ References
         *Ionization in the field of a strong electromagnetic wave*,
         Soviet Physics JETP 20, 1307-1314 (1965),
         http://jetp.ac.ru/cgi-bin/dn/e_020_05_1307.pdf
-        
+
 .. [ClementiRaimondi1963]
         E. Clementi and D. Raimondi.
         *Atomic Screening Constant from SCF Functions*,

--- a/docs/source/models/field_ionization_charge_state_prediction.py
+++ b/docs/source/models/field_ionization_charge_state_prediction.py
@@ -39,7 +39,7 @@ params = {
 mpl.rcParams.update(params)
 
 
-def time_AU_to_SI(t_AU) -> float:
+def time_AU_to_SI(t_AU):
     """Convert time from AU to SI.
 
     :param t_AU: time in atomic units
@@ -49,7 +49,7 @@ def time_AU_to_SI(t_AU) -> float:
     return t_AU * AU_T
 
 
-def time_SI_to_AU(t_SI) -> float:
+def time_SI_to_AU(t_SI):
     """Convert time from SI to AU.
 
     :param t_SI: time in SI units
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     percent = 1e-2
     # femtosecond: for time conversion
     fs = 1e-15
-    # cm² in m²
+    # cm^2 in m^2
     cm2 = 1e-4
 
 # ============================================================================
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     # maximum electric field in a0
     E_max_a0 = 10
     # maximum intensity
-    I_max = FI.convert_a0_to_Intensity(E_in_a0=E_max_a0)  # W/m²
+    I_max = FI.convert_a0_to_Intensity(E_in_a0=E_max_a0)  # W/m^2
 
     intensity_fwhm = 30.e-15  # s
     intensity_sigma = intensity_fwhm / (2. * np.sqrt(2. * np.log(2)))  # s
@@ -193,7 +193,7 @@ if __name__ == "__main__":
     ylim_ax_rate = [1e-10, 1e3]  # 1 / AU of time
     ylim_ax_pop = [0, 100]
     ylim_ax_bsi = [0, 100]
-    ylim_ax_bsi_twin = [1e13, 1e21]  # W/cm²
+    ylim_ax_bsi_twin = [1e13, 1e21]  # W/cm^2
     yfill_range = np.linspace(ylim_ax_bsi[0], ylim_ax_bsi[1], 100)
 
     # customize the color scale
@@ -259,7 +259,7 @@ if __name__ == "__main__":
             )
 
     ax_bsi_twin = ax_bsi.twinx()
-    # plot intensity in W/cm²
+    # plot intensity in W/cm^2
     ax_bsi_twin.plot(time / fs, intensity_envelope_SI / 1e4, c="k")
 
     locs = np.array([0, 100])

--- a/docs/source/models/field_ionization_charge_state_prediction.py
+++ b/docs/source/models/field_ionization_charge_state_prediction.py
@@ -1,3 +1,11 @@
+"""Ionization prediction module and example.
+
+This file is part of the PIConGPU.
+Copyright 2019-2020 PIConGPU contributors
+Authors: Marco Garten
+License: GPLv3+
+"""
+
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 import numpy as np
@@ -18,17 +26,23 @@ mpl.rcParams.update(params)
 
 # dictionary of atomic units (AU) - values in SI units
 atomic_unit = {
-    'electric field' : sc.m_e**2 * sc.e**5 / (sc.hbar**4 * (4*sc.pi*sc.epsilon_0)**3),
-    'intensity' : sc.m_e**4 / (8 * sc.pi * sc.alpha * sc.hbar**9) * sc.e**12 / (4 * sc.pi * sc.epsilon_0)**6,
-    'energy' : sc.m_e*sc.e**4/(sc.hbar**2 * (4 * sc.pi * sc.epsilon_0)**2),
-    'time' : sc.hbar**3 * (4 * sc.pi * sc.epsilon_0)**2 / sc.m_e / sc.e**4
+    'electric field': sc.m_e**2 * sc.e**5 / (
+        sc.hbar**4 * (4 * sc.pi * sc.epsilon_0)**3
+        ),
+    'intensity': sc.m_e**4 / (
+        8 * sc.pi * sc.alpha * sc.hbar**9
+        ) * sc.e**12 / (4 * sc.pi * sc.epsilon_0)**6,
+    'energy': sc.m_e * sc.e**4 / (
+        sc.hbar**2 * (4 * sc.pi * sc.epsilon_0)**2
+        ),
+    'time': sc.hbar**3 * (
+        4 * sc.pi * sc.epsilon_0
+        )**2 / sc.m_e / sc.e**4
 }
 
-# (critical) barrier suppression field strength
-def F_crit(Z,E_Ip):
-    """
-    Classical barrier suppression field strength
 
+def F_crit(Z, E_Ip):
+    """Classical barrier suppression field strength.
 
     :param Z: charge state of the resulting ion
     :param E_Ip: ionization potential [unit: AU]
@@ -37,9 +51,9 @@ def F_crit(Z,E_Ip):
     """
     return E_Ip**2. / (4. * Z)
 
-def n_eff(Z,E_Ip):
-    """
-    Effective principal quantum number
+
+def n_eff(Z, E_Ip):
+    """Effective principal quantum number.
 
     :param Z: charge state of the resulting ion
     :param E_Ip: ionization potential [unit: AU]
@@ -48,162 +62,173 @@ def n_eff(Z,E_Ip):
     """
     return Z / np.sqrt(2. * E_Ip)
 
-def ADKRate(Z,E_Ip,F):
-    """
-    Ammosov-Delone-Krainov ionization rate simplified by Stirling's approximation and m=0
-    like in publication [DeloneKrainov1998].
+
+def ADKRate(Z, E_Ip, F):
+    """Ammosov-Delone-Krainov ionization rate.
+
+    A rate model, simplified by Stirling's approximation and setting the
+    magnetic quantum number m=0 like in publication [DeloneKrainov1998].
 
     :param Z: charge state of the resulting ion
     :param E_Ip: ionization potential [unit: AU]
     :param F: field strength [unit: AU]
     """
-    nEff = np.float64(n_eff(Z,E_Ip))
+    nEff = np.float64(n_eff(Z, E_Ip))
     D = ((4. * Z**3.) / (F * nEff**4.))**nEff
 
     rate = (np.sqrt((3. * nEff**3. * F) / (np.pi * Z**3.))
-          * (F * D**2.) / (8. * np.pi * Z)
-          * np.exp(-(2. * Z**3.)/(3. * nEff**3. * F)))
+            * (F * D**2.) / (8. * np.pi * Z)
+            * np.exp(-(2. * Z**3.) / (3. * nEff**3. * F)))
 
     # set nan values due to near-zero field strengths to zero
     rate = np.nan_to_num(rate)
 
     return rate
 
-def convert_a0_to_Intensity(E_in_a0,lambda_laser=800.e-9):
-    """
+
+def convert_a0_to_Intensity(E_in_a0, lambda_laser=800.e-9):
+    """Convert electric field in a0 to intensity in SI.
+
     :param E_in_a0: electric field [unit: a0]
     :param lambda_laser: laser wavelength [unit: m]
 
     :returns: intensity [unit: W/m²]
     """
+    E_in_SI = E_in_a0 \
+        * sc.m_e * sc.c * 2. * sc.pi * sc.c \
+        / (lambda_laser * sc.e)
 
-    return (E_in_a0 / (0.85 * lambda_laser * 1e6))**2 * 1e22
+    intensity = 0.5 * sc.c * sc.epsilon_0 * E_in_SI**2.
+
+    return intensity
 
 
 if __name__ == "__main__":
     """
-    On execution this file produces the image
+    On execution, this file produces the image
     `field_ionization_charge_state_prediction.svg`
     for the PIConGPU documentation.
     """
 
     # atomic units
-    AU_E_eV = atomic_unit['energy']/sc.electron_volt  # eV
+    AU_E_eV = atomic_unit['energy'] / sc.electron_volt  # eV
     AU_F = atomic_unit['electric field']  # V/m
     AU_I = atomic_unit['intensity']  # W/m^2
     AU_T = atomic_unit['time']  # s
 
     # proton number: Neon
     Z_max = 10
-    # array of possible charge states: Neon
-    Z = np.arange(Z_max) + np.int(1)
+    # array of ionized charge states: Neon
+    Z = np.arange(1, Z_max + 1, dtype=int)
     # array of ionization energies in eV for Neon
-    ionization_energies_eV  = np.array([
-    21.5645,
-    40.9630,
-    63.4233,
-    97.1900,
-    126.247,
-    157.934,
-    207.271,
-    239.0969,
-    1195.8078,
-    1362.1991
+    # taken from https://physics.nist.gov/cgi-bin/ASD/ie.pl
+    ionization_energies_eV = np.array([
+        21.5645,
+        40.9630,
+        63.4233,
+        97.1900,
+        126.247,
+        157.934,
+        207.271,
+        239.0969,
+        1195.8078,
+        1362.1991
     ])
 
     # convert ionization energies to atomic units
     i_pot_AU = ionization_energies_eV / AU_E_eV
 
-    """
-    Create the electric field distribution for our example.
-    """
-    #
+# ============================================================================
+#   Create the electric field distribution for our example.
+# ============================================================================
+    # laser wavelength [unit: m]
     lambda_laser = 800.e-9
-    # a0 in SI
-    a0 = np.float64(2*np.pi/lambda_laser * sc.m_e*sc.c**2 / sc.e)
     # maximum electric field in a0
     E_max_a0 = 10
     # maximum intensity
-    I_max = convert_a0_to_Intensity(E_in_a0=E_max_a0) # W/m²
+    I_max = convert_a0_to_Intensity(E_in_a0=E_max_a0)  # W/m²
 
-    intensity_fwhm  = 30.e-15 # s
-    intensity_sigma = intensity_fwhm / (2. * np.sqrt(2. * np.log(2))) # s
+    intensity_fwhm = 30.e-15  # s
+    intensity_sigma = intensity_fwhm / (2. * np.sqrt(2. * np.log(2)))  # s
 
     t_res = 10000
-    time = np.linspace(-200e-15,200e-15,t_res) # s
+    time = np.linspace(-200e-15, 200e-15, t_res)  # s
     intensity_envelope_SI = I_max * np.exp(- .5 * time**2 / intensity_sigma**2)
 
     intensity_envelope_AU = intensity_envelope_SI / AU_I
     e_field_envelope_AU = np.sqrt(intensity_envelope_AU)
 
-    """
-    Calculate the ADK rates for the electric field envelope and each charge
-    state.
-    """
-    rate_matrix = np.zeros([len(i_pot_AU),t_res])
+# =============================================================================
+#   Calculate the ADK rates for the electric field envelope and each charge
+#   state.
+# =============================================================================
+    rate_matrix = np.zeros([len(i_pot_AU), t_res])
 
-    for i,cs in enumerate(Z):
-        rate_matrix[i,:] = ADKRate(cs,i_pot_AU[i],e_field_envelope_AU)
+    for i, cs in enumerate(Z):
+        rate_matrix[i, :] = ADKRate(cs, i_pot_AU[i], e_field_envelope_AU)
 
-    """
-    Markovian approach for calculating the transition matrices of the problem.
-    """
+
+# =============================================================================
+#   Markovian approach for calculating the transition matrices of the problem.
+# =============================================================================
+
     # transition matrix
-    trans_mat_base = np.diag(np.ones([Z_max+1]))
+    trans_mat_base = np.diag(np.ones([Z_max + 1]))
     trans_mat_before = trans_mat_base
     # preparation of the transition matrix: Markov absorbing state CS = 10
-    trans_mat_base[Z_max,Z_max] = 1
-
+    trans_mat_base[Z_max, Z_max] = 1
 
     # prepare initial state
-    initState = np.zeros([Z_max+1])
+    initState = np.zeros([Z_max + 1])
     # all atoms are initially unionized
     initState[0] = 1
 
     # prepare expected charge distribution array
-    charge_dist = np.zeros([Z_max+1,t_res+1])
+    charge_dist = np.zeros([Z_max + 1, t_res + 1])
     # manipulate last entry for loop
-    charge_dist[:,-1] = initState
+    charge_dist[:, -1] = initState
 
     # time step of the Markov process
-    dt = (time[-1] - time[0])/ AU_T / t_res
+    dt = (time[-1] - time[0]) / AU_T / t_res
 
     # loop over steps
     for i in np.arange(t_res):
         # calculate the transition matrix of this step
         trans_mat = trans_mat_base
-        for k,cs in enumerate(Z):
+        for k, cs in enumerate(Z):
             # probability to stay bound
-            trans_mat[k,k] = np.exp(-rate_matrix[k,i] * dt)
+            trans_mat[k, k] = np.exp(-rate_matrix[k, i] * dt)
             # probability to ionize
-            trans_mat[k+1,k] = 1. - np.exp(-rate_matrix[k,i] * dt)
+            trans_mat[k + 1, k] = 1. - np.exp(-rate_matrix[k, i] * dt)
 
         # Markov step
-        charge_dist[:,i] = np.dot(charge_dist[:,i-1],trans_mat.T)
+        charge_dist[:, i] = np.dot(charge_dist[:, i - 1], trans_mat.T)
 
-    """
-    Barrier suppression field strength calculation.
-    """
-    electric_field_BSI = F_crit(Z,i_pot_AU)
+
+# =============================================================================
+#   Barrier suppression field strength calculation
+# =============================================================================
+    electric_field_BSI = F_crit(Z, i_pot_AU)
 
     # find times when BSI fields are exceeded
     time_BSI = np.zeros([Z_max])
-    for i,cs in enumerate(Z):
+    for i, cs in enumerate(Z):
         idx = np.where(e_field_envelope_AU > electric_field_BSI[i])[0][0]
-        time_BSI[i] = time[idx-1]
+        time_BSI[i] = time[idx - 1]
 
-    """
-    Plotting the ionization rates, the electric field and the charge state
-    population over time.
-    """
-    xlim = [-75,-0]
-    ylim_ax1 = [1e-10,1e2] # 1 / AU of time
+
+# =============================================================================
+#   Plotting the ionization rates, the electric field and the charge state
+#   population over time.
+# =============================================================================
+    xlim = [-75, -0]
+    ylim_ax1 = [1e-10, 1e2]  # 1 / AU of time
     ylim_ax2 = [0, 1]
-    ylim_ax3 = [1e13,1e21] # W/cm²
-    yfill_range = np.linspace(ylim_ax3[0],ylim_ax3[1], 100)
+    ylim_ax3 = [1e13, 1e21]  # W/cm²
+    yfill_range = np.linspace(ylim_ax3[0], ylim_ax3[1], 100)
 
     # customize the color scale
-    color = plt.cm.rainbow(np.linspace(0, 1, Z_max+1))[::-1]
+    color = plt.cm.rainbow(np.linspace(0, 1, Z_max + 1))[::-1]
 
     # creation of figure and axes
     fig = plt.figure()
@@ -213,26 +238,56 @@ if __name__ == "__main__":
     ax3 = fig.add_subplot(313, sharex=ax1)
 
     # plotting
-    ax1.axhline(y=1,ls="--",lw=1,c="k")
+    ax1.axhline(y=1, ls="--", lw=1, c="k")
     # plot intensity in W/cm²
     ax3.plot(time * 1e15, intensity_envelope_SI / 1e4, c="k")
 
-    for i in np.arange(Z_max+1):
+    for i in np.arange(Z_max + 1):
         if i < Z_max:
-            ax1.plot(time * 1e15, rate_matrix[i,:], label="{}+ to {}+".format(Z[i]-1,Z[i]),color=color[i])
-            ax3.axvline(time_BSI[i] * 1e15,label="{}+ to {}+".format(Z[i]-1,Z[i]),color=color[i])
+            ax1.plot(
+                time * 1e15, rate_matrix[i, :],
+                label="{}+ to {}+".format(
+                   Z[i] - 1, Z[i]), color=color[i]
+                )
+            ax3.axvline(
+                time_BSI[i] * 1e15,
+                label="{}+ to {}+".format(
+                    Z[i] - 1, Z[i]), color=color[i]
+                )
 
-        ax2.plot(time * 1e15,charge_dist[i,:-1],label="{}+".format(i),color=color[i])
-        ax2.fill_between(x=time * 1e15,y1=0,y2=charge_dist[i,:-1],color=color[i],alpha=.3)
+        ax2.plot(
+            time * 1e15, charge_dist[i, :-1],
+            label="{}+".format(i), color=color[i]
+            )
+        ax2.fill_between(
+            x=time * 1e15,
+            y1=0, y2=charge_dist[i, :-1],
+            color=color[i], alpha=.3
+            )
         # color the regions between charge state transitions in the BSI model
         if (i > 0 and i < Z_max):
-            ax3.fill_betweenx(y=yfill_range,x1=time_BSI[i-1]*1e15,x2=time_BSI[i]*1e15,color=color[i],alpha=.3)
-        # color the range between the earliest time and the first charge state transition
+            ax3.fill_betweenx(y=yfill_range,
+                              x1=time_BSI[i - 1] * 1e15,
+                              x2=time_BSI[i] * 1e15,
+                              color=color[i],
+                              alpha=.3)
+        # color the range between the earliest time and the first charge state
+        # transition
         if (i == 0):
-            ax3.fill_betweenx(y=yfill_range,x1=time[0]*1e15,x2=time_BSI[i]*1e15,color=color[i],alpha=.3)
-        # color the range between the last charge state transition and the latest time
+            ax3.fill_betweenx(
+                y=yfill_range,
+                x1=time[0] * 1e15,
+                x2=time_BSI[i] * 1e15,
+                color=color[i],
+                alpha=.3)
+        # color the range between the last charge state transition and the
+        # latest time
         if (i == Z_max):
-            ax3.fill_betweenx(y=yfill_range,x1=time_BSI[i-1]*1e15,x2=time[-1]*1e15,color=color[i],alpha=.3)
+            ax3.fill_betweenx(y=yfill_range,
+                              x1=time_BSI[i - 1] * 1e15,
+                              x2=time[-1] * 1e15,
+                              color=color[i],
+                              alpha=.3)
 
     # set plot limits
     ax1.set_xlim(xlim)
@@ -256,5 +311,3 @@ if __name__ == "__main__":
     plt.tight_layout(pad=0.4)
 
     plt.show()
-
-    

--- a/docs/source/models/field_ionization_charge_state_prediction.py
+++ b/docs/source/models/field_ionization_charge_state_prediction.py
@@ -1,0 +1,260 @@
+import matplotlib as mpl
+from matplotlib import pyplot as plt
+import numpy as np
+import scipy.constants as sc
+
+
+params = {
+    'font.size': 20,
+    'lines.linewidth': 3,
+    'legend.fontsize': 10,
+    'legend.frameon': True,
+    'xtick.labelsize': 20,
+    'ytick.labelsize': 20,
+    # RTD default textwidth: 800px
+    'figure.figsize': [10, 16]
+}
+mpl.rcParams.update(params)
+
+# dictionary of atomic units (AU) - values in SI units
+atomic_unit = {
+    'electric field' : sc.m_e**2 * sc.e**5 / (sc.hbar**4 * (4*sc.pi*sc.epsilon_0)**3),
+    'intensity' : sc.m_e**4 / (8 * sc.pi * sc.alpha * sc.hbar**9) * sc.e**12 / (4 * sc.pi * sc.epsilon_0)**6,
+    'energy' : sc.m_e*sc.e**4/(sc.hbar**2 * (4 * sc.pi * sc.epsilon_0)**2),
+    'time' : sc.hbar**3 * (4 * sc.pi * sc.epsilon_0)**2 / sc.m_e / sc.e**4
+}
+
+# (critical) barrier suppression field strength
+def F_crit(Z,E_Ip):
+    """
+    Classical barrier suppression field strength
+
+
+    :param Z: charge state of the resulting ion
+    :param E_Ip: ionization potential [unit: AU]
+
+    :returns: critical field strength [unit: AU]
+    """
+    return E_Ip**2. / (4. * Z)
+
+def n_eff(Z,E_Ip):
+    """
+    Effective principal quantum number
+
+    :param Z: charge state of the resulting ion
+    :param E_Ip: ionization potential [unit: AU]
+
+    :returns: effective principal quantum number
+    """
+    return Z / np.sqrt(2. * E_Ip)
+
+def ADKRate(Z,E_Ip,F):
+    """
+    Ammosov-Delone-Krainov ionization rate simplified by Stirling's approximation and m=0
+    like in publication [DeloneKrainov1998].
+
+    :param Z: charge state of the resulting ion
+    :param E_Ip: ionization potential [unit: AU]
+    :param F: field strength [unit: AU]
+    """
+    nEff = np.float64(n_eff(Z,E_Ip))
+    D = ((4. * Z**3.) / (F * nEff**4.))**nEff
+
+    rate = (np.sqrt((3. * nEff**3. * F) / (np.pi * Z**3.))
+          * (F * D**2.) / (8. * np.pi * Z)
+          * np.exp(-(2. * Z**3.)/(3. * nEff**3. * F)))
+
+    # set nan values due to near-zero field strengths to zero
+    rate = np.nan_to_num(rate)
+
+    return rate
+
+def convert_a0_to_Intensity(E_in_a0,lambda_laser=800.e-9):
+    """
+    :param E_in_a0: electric field [unit: a0]
+    :param lambda_laser: laser wavelength [unit: m]
+
+    :returns: intensity [unit: W/m²]
+    """
+
+    return (E_in_a0 / (0.85 * lambda_laser * 1e6))**2 * 1e22
+
+
+if __name__ == "__main__":
+    """
+    On execution this file produces the image
+    `field_ionization_charge_state_prediction.svg`
+    for the PIConGPU documentation.
+    """
+
+    # atomic units
+    AU_E_eV = atomic_unit['energy']/sc.electron_volt  # eV
+    AU_F = atomic_unit['electric field']  # V/m
+    AU_I = atomic_unit['intensity']  # W/m^2
+    AU_T = atomic_unit['time']  # s
+
+    # proton number: Neon
+    Z_max = 10
+    # array of possible charge states: Neon
+    Z = np.arange(Z_max) + np.int(1)
+    # array of ionization energies in eV for Neon
+    ionization_energies_eV  = np.array([
+    21.5645,
+    40.9630,
+    63.4233,
+    97.1900,
+    126.247,
+    157.934,
+    207.271,
+    239.0969,
+    1195.8078,
+    1362.1991
+    ])
+
+    # convert ionization energies to atomic units
+    i_pot_AU = ionization_energies_eV / AU_E_eV
+
+    """
+    Create the electric field distribution for our example.
+    """
+    #
+    lambda_laser = 800.e-9
+    # a0 in SI
+    a0 = np.float64(2*np.pi/lambda_laser * sc.m_e*sc.c**2 / sc.e)
+    # maximum electric field in a0
+    E_max_a0 = 10
+    # maximum intensity
+    I_max = convert_a0_to_Intensity(E_in_a0=E_max_a0) # W/m²
+
+    intensity_fwhm  = 30.e-15 # s
+    intensity_sigma = intensity_fwhm / (2. * np.sqrt(2. * np.log(2))) # s
+
+    t_res = 10000
+    time = np.linspace(-200e-15,200e-15,t_res) # s
+    intensity_envelope_SI = I_max * np.exp(- .5 * time**2 / intensity_sigma**2)
+
+    intensity_envelope_AU = intensity_envelope_SI / AU_I
+    e_field_envelope_AU = np.sqrt(intensity_envelope_AU)
+
+    """
+    Calculate the ADK rates for the electric field envelope and each charge
+    state.
+    """
+    rate_matrix = np.zeros([len(i_pot_AU),t_res])
+
+    for i,cs in enumerate(Z):
+        rate_matrix[i,:] = ADKRate(cs,i_pot_AU[i],e_field_envelope_AU)
+
+    """
+    Markovian approach for calculating the transition matrices of the problem.
+    """
+    # transition matrix
+    trans_mat_base = np.diag(np.ones([Z_max+1]))
+    trans_mat_before = trans_mat_base
+    # preparation of the transition matrix: Markov absorbing state CS = 10
+    trans_mat_base[Z_max,Z_max] = 1
+
+
+    # prepare initial state
+    initState = np.zeros([Z_max+1])
+    # all atoms are initially unionized
+    initState[0] = 1
+
+    # prepare expected charge distribution array
+    charge_dist = np.zeros([Z_max+1,t_res+1])
+    # manipulate last entry for loop
+    charge_dist[:,-1] = initState
+
+    # time step of the Markov process
+    dt = (time[-1] - time[0])/ AU_T / t_res
+
+    # loop over steps
+    for i in np.arange(t_res):
+        # calculate the transition matrix of this step
+        trans_mat = trans_mat_base
+        for k,cs in enumerate(Z):
+            # probability to stay bound
+            trans_mat[k,k] = np.exp(-rate_matrix[k,i] * dt)
+            # probability to ionize
+            trans_mat[k+1,k] = 1. - np.exp(-rate_matrix[k,i] * dt)
+
+        # Markov step
+        charge_dist[:,i] = np.dot(charge_dist[:,i-1],trans_mat.T)
+
+    """
+    Barrier suppression field strength calculation.
+    """
+    electric_field_BSI = F_crit(Z,i_pot_AU)
+
+    # find times when BSI fields are exceeded
+    time_BSI = np.zeros([Z_max])
+    for i,cs in enumerate(Z):
+        idx = np.where(e_field_envelope_AU > electric_field_BSI[i])[0][0]
+        time_BSI[i] = time[idx-1]
+
+    """
+    Plotting the ionization rates, the electric field and the charge state
+    population over time.
+    """
+    xlim = [-75,-0]
+    ylim_ax1 = [1e-10,1e2] # 1 / AU of time
+    ylim_ax2 = [0, 1]
+    ylim_ax3 = [1e13,1e21] # W/cm²
+    yfill_range = np.linspace(ylim_ax3[0],ylim_ax3[1], 100)
+
+    # customize the color scale
+    color = plt.cm.rainbow(np.linspace(0, 1, Z_max+1))[::-1]
+
+    # creation of figure and axes
+    fig = plt.figure()
+
+    ax1 = fig.add_subplot(311)
+    ax2 = fig.add_subplot(312, sharex=ax1)
+    ax3 = fig.add_subplot(313, sharex=ax1)
+
+    # plotting
+    ax1.axhline(y=1,ls="--",lw=1,c="k")
+    # plot intensity in W/cm²
+    ax3.plot(time * 1e15, intensity_envelope_SI / 1e4, c="k")
+
+    for i in np.arange(Z_max+1):
+        if i < Z_max:
+            ax1.plot(time * 1e15, rate_matrix[i,:], label="{}+ to {}+".format(Z[i]-1,Z[i]),color=color[i])
+            ax3.axvline(time_BSI[i] * 1e15,label="{}+ to {}+".format(Z[i]-1,Z[i]),color=color[i])
+
+        ax2.plot(time * 1e15,charge_dist[i,:-1],label="{}+".format(i),color=color[i])
+        ax2.fill_between(x=time * 1e15,y1=0,y2=charge_dist[i,:-1],color=color[i],alpha=.3)
+        # color the regions between charge state transitions in the BSI model
+        if (i > 0 and i < Z_max):
+            ax3.fill_betweenx(y=yfill_range,x1=time_BSI[i-1]*1e15,x2=time_BSI[i]*1e15,color=color[i],alpha=.3)
+        # color the range between the earliest time and the first charge state transition
+        if (i == 0):
+            ax3.fill_betweenx(y=yfill_range,x1=time[0]*1e15,x2=time_BSI[i]*1e15,color=color[i],alpha=.3)
+        # color the range between the last charge state transition and the latest time
+        if (i == Z_max):
+            ax3.fill_betweenx(y=yfill_range,x1=time_BSI[i-1]*1e15,x2=time[-1]*1e15,color=color[i],alpha=.3)
+
+    # set plot limits
+    ax1.set_xlim(xlim)
+    ax1.set_yscale("log")
+    ax1.set_ylim(ylim_ax1)
+    ax2.set_ylim(ylim_ax2)
+    ax3.set_yscale("log")
+    ax3.set_ylim(ylim_ax3)
+
+    # labels
+    ax1.set_ylabel(r"Ionization Rate $\Gamma\,\mathrm{(AU^{-1})}$")
+    ax2.set_ylabel(r"Rel. Population")
+    ax3.set_ylabel(r"Intensity $I\,\mathrm{(W/cm^2)}$")
+    ax3.set_xlabel(r"Time $t-t_\mathrm{max}\,\mathrm{(fs)}$")
+
+    ax1.legend(loc="lower right", fancybox=True, borderpad=1)
+    ax2.legend(loc="lower right", fancybox=True, borderpad=1)
+    ax3.legend(loc="lower right", fancybox=True, borderpad=1)
+
+    fig.align_labels()
+    plt.tight_layout(pad=0.4)
+
+    plt.show()
+
+    

--- a/docs/source/models/field_ionization_charge_state_prediction.py
+++ b/docs/source/models/field_ionization_charge_state_prediction.py
@@ -14,7 +14,10 @@ import numpy as np
 import scipy.constants as sc
 from importlib import import_module
 
-sys.path.insert(0, os.path.abspath('../../../lib/python/'))
+picongpu_package_path = os.path.abspath('../../../lib/python/')
+
+if picongpu_package_path not in sys.path:
+    sys.path.insert(0, picongpu_package_path)
 
 
 # import my own modules without having to write a 'noqa' comment because PEP8

--- a/docs/source/models/field_ionization_charge_state_prediction.py
+++ b/docs/source/models/field_ionization_charge_state_prediction.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
 # =============================================================================
 #   Barrier suppression field strength calculation
 # =============================================================================
-    electric_field_BSI = FI.F_crit(Z, i_pot_AU)
+    electric_field_BSI = FI.F_crit_BSI(Z, i_pot_AU)
 
     # find times when BSI fields are exceeded
     time_BSI = np.zeros([Z_max])

--- a/lib/python/picongpu/utils/__init__.py
+++ b/lib/python/picongpu/utils/__init__.py
@@ -1,8 +1,10 @@
 from .find_time import FindTime
 from .memory_calculator import MemoryCalculator
+from .field_ionization import FieldIonization
 
 
 __all__ = [
     "FindTime",
-    "MemoryCalculator"
+    "MemoryCalculator",
+    "FieldIonization"
 ]

--- a/lib/python/picongpu/utils/field_ionization.py
+++ b/lib/python/picongpu/utils/field_ionization.py
@@ -47,7 +47,7 @@ class FieldIonization:
 
     def F_crit_BSIStarkShifted(self,
                                E_Ip):
-        """Barrier suppression field strength according to
+        """Barrier suppression field strength according to \
         Bauer 2010 - High Power Laser Matter Interaction, p. 276, Eq. (7.45).
 
         :param E_Ip: ionization potential [unit: AU]
@@ -116,8 +116,6 @@ class FieldIonization:
 
         :returns: ionization rate [unit: 1/AU(time)]
         """
-
-
         # characteristic exponential function argument
         charExpArg = np.sqrt((2.*E_Ip)**3) / F
 
@@ -135,7 +133,7 @@ class FieldIonization:
         :param E_in_a0: electric field [unit: a0]
         :param lambda_laser: laser wavelength [unit: m]
 
-        :returns: intensity [unit: W/m²]
+        :returns: intensity [unit: W/m^2]
         """
         E_in_SI = E_in_a0 \
             * sc.m_e * sc.c * 2. * sc.pi * sc.c \

--- a/lib/python/picongpu/utils/field_ionization.py
+++ b/lib/python/picongpu/utils/field_ionization.py
@@ -1,0 +1,97 @@
+"""Field ionization models implemented in PIConGPU.
+
+This file is part of the PIConGPU.
+Copyright 2019-2020 PIConGPU contributors
+Authors: Marco Garten
+License: GPLv3+
+"""
+
+
+import numpy as np
+import scipy.constants as sc
+
+
+class FieldIonization:
+    """Field ionization class, containing methods and units.
+
+    A field ionization class that contains functions to calculate ionization
+    rates, threshold fields and atomic units.
+    """
+
+    # dictionary of atomic units (AU) - values in SI units
+    atomic_unit = {
+        'electric field': sc.m_e**2 * sc.e**5 / (
+            sc.hbar**4 * (4 * sc.pi * sc.epsilon_0)**3
+        ),
+        'intensity': sc.m_e**4 / (
+            8 * sc.pi * sc.alpha * sc.hbar**9
+        ) * sc.e**12 / (4 * sc.pi * sc.epsilon_0)**6,
+        'energy': sc.m_e * sc.e**4 / (
+            sc.hbar**2 * (4 * sc.pi * sc.epsilon_0)**2
+        ),
+        'time': sc.hbar**3 * (
+            4 * sc.pi * sc.epsilon_0
+        )**2 / sc.m_e / sc.e**4
+    }
+
+    def F_crit(self,
+               Z, E_Ip):
+        """Classical barrier suppression field strength.
+
+        :param Z: charge state of the resulting ion
+        :param E_Ip: ionization potential [unit: AU]
+
+        :returns: critical field strength [unit: AU]
+        """
+        return E_Ip**2. / (4. * Z)
+
+    def n_eff(self,
+              Z, E_Ip):
+        """Effective principal quantum number.
+
+        :param Z: charge state of the resulting ion
+        :param E_Ip: ionization potential [unit: AU]
+
+        :returns: effective principal quantum number
+        """
+        return Z / np.sqrt(2. * E_Ip)
+
+    def ADKRate(self,
+                Z, E_Ip, F):
+        """Ammosov-Delone-Krainov ionization rate.
+
+        A rate model, simplified by Stirling's approximation and setting the
+        magnetic quantum number m=0 like in publication [DeloneKrainov1998].
+
+        :param Z: charge state of the resulting ion
+        :param E_Ip: ionization potential [unit: AU]
+        :param F: field strength [unit: AU]
+        """
+        nEff = np.float64(self.n_eff(Z, E_Ip))
+        D = ((4. * Z**3.) / (F * nEff**4.))**nEff
+
+        rate = (np.sqrt((3. * nEff**3. * F) / (np.pi * Z**3.))
+                * (F * D**2.) / (8. * np.pi * Z)
+                * np.exp(-(2. * Z**3.) / (3. * nEff**3. * F)))
+
+        # set nan values due to near-zero field strengths to zero
+        rate = np.nan_to_num(rate)
+
+        return rate
+
+    @staticmethod
+    def convert_a0_to_Intensity(E_in_a0, lambda_laser=800.e-9):
+        """Convert electric field in a0 to intensity in SI.
+
+        :param E_in_a0: electric field [unit: a0]
+        :param lambda_laser: laser wavelength [unit: m]
+
+        :returns: intensity [unit: W/m²]
+        """
+        E_in_SI = E_in_a0 \
+            * sc.m_e * sc.c * 2. * sc.pi * sc.c \
+            / (lambda_laser * sc.e)
+
+        intensity = 0.5 * sc.c * sc.epsilon_0 * E_in_SI**2.
+
+        return intensity

--- a/lib/python/picongpu/utils/field_ionization.py
+++ b/lib/python/picongpu/utils/field_ionization.py
@@ -34,8 +34,8 @@ class FieldIonization:
         )**2 / sc.m_e / sc.e**4
     }
 
-    def F_crit(self,
-               Z, E_Ip):
+    def F_crit_BSI(self,
+                   Z, E_Ip):
         """Classical barrier suppression field strength.
 
         :param Z: charge state of the resulting ion
@@ -45,9 +45,22 @@ class FieldIonization:
         """
         return E_Ip**2. / (4. * Z)
 
+    def F_crit_BSIStarkShifted(self,
+                               E_Ip):
+        """Barrier suppression field strength according to
+        Bauer 2010 - High Power Laser Matter Interaction, p. 276, Eq. (7.45).
+
+        :param E_Ip: ionization potential [unit: AU]
+
+        :returns: critical field strength [unit: AU]
+        """
+        return (np.sqrt(2.) - 1.) * E_Ip**(3./2.)
+
     def n_eff(self,
               Z, E_Ip):
         """Effective principal quantum number.
+
+        Belongs to the ADK rate model.
 
         :param Z: charge state of the resulting ion
         :param E_Ip: ionization potential [unit: AU]
@@ -68,6 +81,8 @@ class FieldIonization:
         :param F: field strength [unit: AU]
         :param polarization: laser polarization
                              ['linear' (default), 'circular']
+
+        :returns: ionization rate [unit: 1/AU(time)]
         """
         pol = polarization
         if pol not in ["linear", "circular"]:
@@ -89,6 +104,27 @@ class FieldIonization:
 
         # set nan values due to near-zero field strengths to zero
         rate = np.nan_to_num(rate)
+
+        return rate
+
+    def KeldyshRate(self,
+                    E_Ip, F):
+        """Keldysh model ionization rate.
+
+        :param E_Ip: ionization potential [unit: AU]
+        :param F: field strength [unit: AU]
+
+        :returns: ionization rate [unit: 1/AU(time)]
+        """
+
+
+        # characteristic exponential function argument
+        charExpArg = np.sqrt((2.*E_Ip)**3) / F
+
+        # ionization rate
+        rate = np.sqrt(6.*np.pi) / 2**(5./4.) \
+            * E_Ip * np.sqrt(1./charExpArg) \
+            * np.exp(-2./3. * charExpArg)
 
         return rate
 

--- a/lib/python/picongpu/utils/field_ionization.py
+++ b/lib/python/picongpu/utils/field_ionization.py
@@ -57,7 +57,7 @@ class FieldIonization:
         return Z / np.sqrt(2. * E_Ip)
 
     def ADKRate(self,
-                Z, E_Ip, F):
+                Z, E_Ip, F, polarization="linear"):
         """Ammosov-Delone-Krainov ionization rate.
 
         A rate model, simplified by Stirling's approximation and setting the
@@ -66,13 +66,26 @@ class FieldIonization:
         :param Z: charge state of the resulting ion
         :param E_Ip: ionization potential [unit: AU]
         :param F: field strength [unit: AU]
+        :param polarization: laser polarization
+                             ['linear' (default), 'circular']
         """
+        pol = polarization
+        if pol not in ["linear", "circular"]:
+            raise NotImplementedError(
+                "Cannot interpret polarization='{}'.\n".format(pol) +
+                "So far, the only implemented options are: " +
+                "['linear', 'circular']"
+                )
+
         nEff = np.float64(self.n_eff(Z, E_Ip))
         D = ((4. * Z**3.) / (F * nEff**4.))**nEff
 
-        rate = (np.sqrt((3. * nEff**3. * F) / (np.pi * Z**3.))
-                * (F * D**2.) / (8. * np.pi * Z)
-                * np.exp(-(2. * Z**3.) / (3. * nEff**3. * F)))
+        rate = (F * D**2.) / (8. * np.pi * Z) \
+            * np.exp(-(2. * Z**3.) / (3. * nEff**3. * F))
+
+        if pol == 'linear':
+            rate = rate \
+                * np.sqrt((3. * nEff**3. * F) / (np.pi * Z**3.))
 
         # set nan values due to near-zero field strengths to zero
         rate = np.nan_to_num(rate)


### PR DESCRIPTION
This PR adds a python script that plots a charge state population prediction for Neon gas that is irradiated by a laser pulse of 30fs duration.
The maximum a0 is 10 and the pulse is only modeled as a Gaussian envelope.
A documentation section has been added as well.

- [x] relocate the main parts of the script to `lib/python/picongpu` so that users can easily benefit from it
- [x] rearrange the plot so that it is easily understandable
- [x] format the python code according to PEP8

At the moment the plot it creates in the docs looks like this:

- *top panel*: ionization rates for Neon in the ADK model calculated with the intensity shape given in the lower panel
- *middle panel*: relative charge state population of Neon based on the ADK model
- *lower panel*: temporal intensity distribution in black and BSI model predicted charge state population overlay in colored regions

![field_ionization_charge_state_prediction](https://user-images.githubusercontent.com/5416860/52111795-f5f96e00-2604-11e9-8671-5b2ffbeeaf6d.png)

