### PR TITLE
PhaseSpace: Unit Colorbar 2D3V

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -297,7 +297,7 @@ namespace picongpu
         /** \todo communicate GUARD and add it to the two neighbors BORDER */
 
         /* write to file */
-        const float_64 UNIT_VOLUME = math::pow( UNIT_LENGTH, (int)simDim );
+        const float_64 UNIT_VOLUME = UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH;
         const float_64 unit = UNIT_CHARGE / UNIT_VOLUME;
 
         /* (momentum) p range: unit is m_species * c


### PR DESCRIPTION
Fix the unit for the phase space volume in the phase space plugin for 2D3V simulations.

Since we properly switched for 2D3V simulations to represent periodic, one-cell 3D3V scalings, every quantity is properly "volumetric". Before this change, calculating a density by integrating the phase space in p direction was weird and needed (for known species filter volume) an additional division by our normalized length. This fixes it.