### PR TITLE
Contributor name typo in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,7 +7,7 @@ Sergei Bastrakov, Florian Berninger, Heiko Burau, Michael Bussmann,
 Alexander Debus, Robert Dietrich, Carlchristian Eckert, Wen Fu, Marco Garten,
 Ilja Goethel, Alexander Grund, Sebastian Hahn, Anton Helm, Wolfgang Hoehnig,
 Axel Huebl, Jeffrey Kelling, Maximilian Knespel, Remi Lehe, Alexander Matthes,
-Richard Pausch, Rophie Rudat, Felix Schmitt, Conrad Schumann,
+Richard Pausch, Sophie Rudat, Felix Schmitt, Conrad Schumann,
 Benjamin Schneider, Joseph Schuchart, Sebastian Starke, Klaus Steiniger,
 Rene Widera, Benjamin Worpitz
 


### PR DESCRIPTION
Sorry, @kossag14 your name was wrong in our `LICENSE.md`. 
