### PR TITLE
Small update for python visualizers

### DIFF
--- a/lib/python/picongpu/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/plugins/data/energy_histogram.py
@@ -124,6 +124,10 @@ class EnergyHistogramData(DataReader):
             If iteration is a list, returns a list of counts.
         bins : np.array of dtype float [keV]
             upper ranges of each energy bin
+        iteration: np.array of dtype int
+            the iteration numbers that data is retrieved for
+        dt: float
+            the timestep between consecutive iterations
         """
         if iteration is not None:
             if not isinstance(iteration, collections.Iterable):

--- a/lib/python/picongpu/plugins/data/png.py
+++ b/lib/python/picongpu/plugins/data/png.py
@@ -176,10 +176,10 @@ class PNGData(DataReader):
 
         Returns
         -------
-        A list of numpy array representations of
-        the corresponding png files if multiple iterations were requested.
-        Otherwise a single nump array representation for the requested\
-        iteration.
+        A 4d numpy array representations of
+        the corresponding png files of shape n x height x width x 3
+        if multiple iterations were requested, otherwise a 3d array
+        of shape height x width x 3.
         """
         available_iterations = self.get_iterations(
             species, species_filter, axis, slice_point)
@@ -199,7 +199,5 @@ class PNGData(DataReader):
         imgs = [misc.imread(
             self.get_data_path(species, species_filter, axis,
                                slice_point, it)) for it in iteration]
-        if len(iteration) == 1:
-            return imgs[0]
-        else:
-            return imgs
+
+        return np.array(imgs).squeeze()


### PR DESCRIPTION
This PR fixes the docstring for the return types of the `EnergyHistogramData` s `_get_for_iteration` method.

It also changes the return type of the `PNGData` class to always output the pngs as numpy arrays (3d or 4d)