### PR TITLE
remove duplicated definition of `BOOST_MPL_LIMIT_VECTOR_SIZE`

### DIFF
--- a/include/pmacc/particles/boostExtension/InheritGenerators.hpp
+++ b/include/pmacc/particles/boostExtension/InheritGenerators.hpp
@@ -21,7 +21,9 @@
 
 #pragma once
 
+#include "pmacc/types.hpp"
 #include "pmacc/particles/memory/frames/NullFrame.hpp"
+
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/deref.hpp>
 #include <boost/mpl/pop_front.hpp>
@@ -32,7 +34,6 @@
 #include <boost/mpl/front.hpp>
 #include <boost/mpl/empty.hpp>
 
-#define BOOST_MPL_LIMIT_VECTOR_SIZE 20
 
 namespace pmacc
 {


### PR DESCRIPTION
PMacc  `types.hpp` is defining `BOOST_MPL_LIMIT_VECTOR_SIZE`.
A duplicated definition is  available in `InheritGenerators.hpp`.

@sbastrakov and me spotted it during investigating #2871

Since 0.4.X is not developed anymore this should be no problem and a backport is not required.