### PR TITLE
Revert Calorimeter Unit Fix

### DIFF
--- a/docs/source/usage/plugins/particleCalorimeter.rst
+++ b/docs/source/usage/plugins/particleCalorimeter.rst
@@ -103,7 +103,7 @@ The dataset has the following attributes:
 ================== =============================================
 Attribute          Description
 ================== =============================================
-``unitSI``         scaling factor for counts in calorimeter bins
+``unitSI``         scaling factor for energy in calorimeter bins
 ``maxYaw[deg]``    half of the opening angle yaw.
 ``maxPitch[deg]``  half of the opening angle pitch.
 ``posYaw[deg]``    yaw coordinate of the calorimeter.
@@ -113,6 +113,9 @@ Attribute          Description
 ``maxEnergy[keV]`` maximal detectable energy.
 ``logScale``       boolean indicating logarithmic scale.
 ================== =============================================
+
+The output in each bin is given in Joule.
+Divide by energy value of the bin for a unitless count per bin.
 
 .. note::
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -334,7 +334,7 @@ private:
                            "calorimeter",
                            &(*this->hBufTotalCalorimeter->origin()));
 
-        const float_64 unitSI = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+        const float_64 unitSI = particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * UNIT_ENERGY;
 
         hdf5DataFile.writeAttribute(currentStep,
                                     SplashType64,


### PR DESCRIPTION
The calorimeter trulys stores an energy per bin right now.

Revert https://github.com/ComputationalRadiationPhysics/picongpu/pull/2848 (only in `dev`)