### PR TITLE
Hypnos: CMake 3.13.4

### DIFF
--- a/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k20_picongpu.profile.example
@@ -22,7 +22,7 @@ then
 
         # Core Dependencies
         module load gcc/4.9.2
-        module load cmake/3.10.1
+        module load cmake/3.13.4
         module load boost/1.62.0
         module load cuda/8.0
         module load openmpi/2.1.2.cuda80

--- a/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/k80_picongpu.profile.example
@@ -22,7 +22,7 @@ then
 
         # Core Dependencies
         module load gcc/4.9.2
-        module load cmake/3.10.1
+        module load cmake/3.13.4
         module load boost/1.62.0
         module load cuda/8.0
         module load openmpi/2.1.2.cuda80

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -22,7 +22,7 @@ then
 
         # Core Dependencies
         module load gcc/5.3.0
-        module load cmake/3.10.1
+        module load cmake/3.13.4
         module load boost/1.62.0
         module load openmpi/1.8.6
         module load numactl


### PR DESCRIPTION
Use a newer CMake on Hypnos.

For recent builds of openPMD-api and Alpaka a CMake 3.11+ is recommended, saving later troubles for users in post-processing.

### To Do

- [x] verify module works (first version: broken)