### PR TITLE
One Position Init: Check Density Probes

### DIFF
--- a/include/picongpu/particles/startPosition/OnePositionImpl.hpp
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.hpp
@@ -122,6 +122,8 @@ namespace detail
                     m_weighting
                 );
 
+            result = realParticlesPerCell > 0.0_X ? result : 0.0_X;
+
             return result;
         }
 


### PR DESCRIPTION
Probe particles usually have no weighting. Our `startPosition::OnePosition` should still honor the density functor of the user as a binary mask.

Fix #2888.

cc @x113f can you verify this solves your issue?

Update: For upcoming `0.4.3` and current `dev`,  PR #2831 might already solve this issue.