### PR TITLE
split `ParserGridDistribution` into `hpp/cpp` file

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -89,9 +89,9 @@ zlib
 
 boost
 """""
-- 1.62.0 - 1.68.0 (``program_options``, ``regex`` , ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
+- 1.62.0 - 1.68.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``,  ``regex``)
 - *note:* for CUDA 9+ support, use boost 1.65.1 or newer
-- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
+- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev libboost-regex-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
 - *from source:*

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -165,10 +165,10 @@ endif()
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options regex filesystem
+find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options filesystem
                                               system math_tr1 serialization)
 if(TARGET Boost::program_options)
-    set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex
+    set(LIBS ${LIBS} Boost::boost Boost::program_options
                      Boost::filesystem Boost::system Boost::math_tr1
                      Boost::serialization)
 else()

--- a/include/picongpu/initialization/ParserGridDistribution.cpp
+++ b/include/picongpu/initialization/ParserGridDistribution.cpp
@@ -1,0 +1,142 @@
+/* Copyright 2013-2019 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picongpu/initialization/ParserGridDistribution.hpp"
+
+#include <pmacc/verify.hpp>
+#include <cstdint>
+#include <vector>   // std::vector
+#include <string>   // std::string
+#include <iterator> // std::distance
+
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+namespace picongpu
+{
+
+    ParserGridDistribution::ParserGridDistribution( std::string const s )
+    {
+        parsedInput = parse( s );
+    }
+
+    uint32_t
+    ParserGridDistribution::getOffset( uint32_t const devicePos, uint32_t const maxCells ) const
+    {
+        value_type::const_iterator iter = parsedInput.begin();
+        // go to last device of these n subdomains extent{n}
+        uint32_t i = iter->count - 1u;
+        uint32_t sum = 0u;
+
+        while( i < devicePos )
+        {
+            // add last subdomain
+            sum += iter->extent * iter->count;
+
+            ++iter;
+            // go to last device of these n subdomains extent{n}
+            i += iter->count;
+        }
+
+        // add part of this subdomain that is before me
+        sum += iter->extent * ( devicePos + iter->count - i - 1u );
+
+        // check total number of cells
+        uint32_t sumTotal = 0u;
+        for( iter = parsedInput.begin(); iter != parsedInput.end(); ++iter )
+            sumTotal += iter->extent * iter->count;
+
+        PMACC_VERIFY( sumTotal == maxCells );
+
+        return sum;
+    }
+
+    uint32_t
+    ParserGridDistribution::getLocalSize( uint32_t const devicePos ) const
+    {
+        value_type::const_iterator iter = parsedInput.begin();
+        // go to last device of these n subdomains extent{n}
+        uint32_t i = iter->count - 1u;
+
+        while( i < devicePos )
+        {
+            ++iter;
+            // go to last device of these n subdomains extent{n}
+            i += iter->count;
+        }
+
+        return iter->extent;
+    }
+
+    void
+    ParserGridDistribution::verifyDevices( uint32_t const numDevices ) const
+    {
+        uint32_t numSubdomains = 0u;
+        for( SubdomainPair const & p : parsedInput )
+            numSubdomains += p.count;
+
+        PMACC_VERIFY( numSubdomains == numDevices );
+    }
+
+    ParserGridDistribution::value_type
+    ParserGridDistribution::parse( std::string const s ) const
+    {
+        boost::regex regFind( "[0-9]+(\\{[0-9]+\\})*",
+                              boost::regex_constants::perl );
+
+        boost::sregex_token_iterator iter( s.begin( ), s.end( ),
+                                           regFind, 0 );
+        boost::sregex_token_iterator end;
+
+        value_type newInput;
+        newInput.reserve( std::distance( iter, end ) );
+
+        for(; iter != end; ++iter )
+        {
+            std::string pM = *iter;
+
+            // find count n and extent b of b{n}
+            boost::regex regCount(
+                "(.*\\{)|(\\})",
+                boost::regex_constants::perl
+            );
+            std::string count = boost::regex_replace( pM, regCount, "" );
+
+            boost::regex regExtent(
+                "\\{.*\\}",
+                boost::regex_constants::perl
+            );
+            std::string extent = boost::regex_replace( pM, regExtent, "" );
+
+            // no count {n} given (implies one)
+            if( count == *iter )
+                count = "1";
+
+            const SubdomainPair g = {
+                boost::lexical_cast< uint32_t > ( extent ),
+                boost::lexical_cast< uint32_t > ( count )
+            };
+            newInput.emplace_back( g );
+        }
+
+        return newInput;
+    }
+
+} // namespace picongpu

--- a/include/picongpu/initialization/ParserGridDistribution.cpp
+++ b/include/picongpu/initialization/ParserGridDistribution.cpp
@@ -25,8 +25,7 @@
 #include <string>   // std::string
 #include <iterator> // std::distance
 
-#include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
+#include <regex>
 
 
 namespace picongpu
@@ -98,12 +97,14 @@ namespace picongpu
     ParserGridDistribution::value_type
     ParserGridDistribution::parse( std::string const s ) const
     {
-        boost::regex regFind( "[0-9]+(\\{[0-9]+\\})*",
-                              boost::regex_constants::perl );
+        std::regex regFind(
+            R"([0-9]+(\{[0-9]+})*)",
+            std::regex::egrep
+        );
 
-        boost::sregex_token_iterator iter( s.begin( ), s.end( ),
+        std::sregex_token_iterator iter( s.begin( ), s.end( ),
                                            regFind, 0 );
-        boost::sregex_token_iterator end;
+        std::sregex_token_iterator end;
 
         value_type newInput;
         newInput.reserve( std::distance( iter, end ) );
@@ -113,25 +114,25 @@ namespace picongpu
             std::string pM = *iter;
 
             // find count n and extent b of b{n}
-            boost::regex regCount(
-                "(.*\\{)|(\\})",
-                boost::regex_constants::perl
+            std::regex regCount(
+                R"((.*\{)|(}))",
+                std::regex::egrep
             );
-            std::string count = boost::regex_replace( pM, regCount, "" );
+            std::string count = std::regex_replace( pM, regCount, "" );
 
-            boost::regex regExtent(
-                "\\{.*\\}",
-                boost::regex_constants::perl
+            std::regex regExtent(
+                R"(\{.*})",
+                std::regex::egrep
             );
-            std::string extent = boost::regex_replace( pM, regExtent, "" );
+            std::string extent = std::regex_replace( pM, regExtent, "" );
 
             // no count {n} given (implies one)
             if( count == *iter )
                 count = "1";
 
             const SubdomainPair g = {
-                boost::lexical_cast< uint32_t > ( extent ),
-                boost::lexical_cast< uint32_t > ( count )
+                static_cast< uint32_t > ( std::stoul(extent) ),
+                static_cast< uint32_t > ( std::stoul(count) )
             };
             newInput.emplace_back( g );
         }

--- a/include/pmacc/debug/abortWithError.hpp
+++ b/include/pmacc/debug/abortWithError.hpp
@@ -28,6 +28,7 @@
 
 namespace pmacc
 {
+namespace{
     /** abort program with an exception
      *
      * This function always throws a `runtime_error`.
@@ -55,4 +56,5 @@ namespace pmacc
             msg
         );
     }
+}
 }


### PR DESCRIPTION
hopefully, fix #2898

- Split the grid parser into an interface file `hpp` and the implementation `cpp` to avoid that boost regex is parsed by nvcc. Boost regex is very often the root of compile issues because nvcc is not able to split the host and device part correctly.
- Define `abortWithError` static to allow the usage in multiple object files without creating the linker error ` multiple definitions of ...
- remove `boost::regex` by `std::regex`
- remove `boost::lexical_cast`
