### PR TITLE
pic-configure: add `--force/-f` option

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -46,6 +46,7 @@ help()
     echo "-c | --cmake         - overwrite options for cmake"
     echo "                       (e.g.: \"-DPIC_VERBOSE=21 -DCMAKE_BUILD_TYPE=Debug\")"
     echo "-t <presetNumber>    - configure this preset from cmakeFlags"
+    echo "-f | --force         - clear the cmake file cache and scan for new param files"
     echo "-h | --help          - show this help message"
 }
 
@@ -92,7 +93,7 @@ get_backend_flags()
 }
 
 # options may be followed by one colon to indicate they have a required argument
-OPTS=`getopt -o i:b:c:p:t:h -l install:,backend:,cmake:,params:,help -- "$@"`
+OPTS=`getopt -o i:b:c:p:t:hf -l install:,backend:,cmake:,params:,help,force -- "$@"`
 if [ $? != 0 ] ; then
     # something went wrong, getopt will put out an error message for us
     exit 1
@@ -128,6 +129,9 @@ while true ; do
         -h|--help)
             echo -e "$(help)"
             exit 0
+            ;;
+       -f|--force)
+            force="true"
             ;;
         -c|--cmake)
             cmake_options="$2"
@@ -177,6 +181,11 @@ if [ -z "$alpaka_backend" ] ; then
     echo "(Use -b|--backend or export PIC_BACKEND)" >&2
 fi
 
+if [ "$force" == "true" ] && [ -f "CMakeCache.txt" ] ; then
+    clean_cmd="cmake --build . --target clean"
+    echo -e "\033[32mforce clean the build directory:\033[0m $clean_cmd"
+    eval $clean_cmd
+fi
 own_command="cmake $cmake_flags $install_path $cmake_extension_param $cmake_options $alpaka_backend $picongpu_prefix/include/picongpu"
 echo -e "\033[32mcmake command:\033[0m $own_command"
 eval $own_command

--- a/etc/picongpu/submitAction.sh
+++ b/etc/picongpu/submitAction.sh
@@ -27,6 +27,7 @@ then
   (>&2 echo "WARNING: $numNewerFiles input file(s) in include/")
   (>&2 echo "         have been modified since the last compile!")
   (>&2 echo "         Did you forget to recompile?")
+  (>&2 echo "         Run 'pic-build -f' to recompile with the modified files.")
   (>&2 echo "List of modified files:")
   (>&2 echo -e "$newerFiles")
 fi


### PR DESCRIPTION
In the case where new parameter files are added to the input parameter into a already compiled parameter set, cmake will ignore the new files.
The option `-f` allows to enforce that cmake flushes the cache and rescans for new files.

This option is required in the following workflow:
- create an input set where e.g `particlesFilter.param` is missing
- run `pic-build`
- run `pic-edit particlesFilter`
- add a new filter
- run `pic-build`
- run `./bin/picongpu --help`

The last command will not show the new filter in the hdf5 source or everywhere else where filters will be used. A way to trigger a full rescan of cmake is to delete the folder `.build` or the new option `-f`.

The option `-f` has the advantage that all changes which were made with `ccmake` will still be in.  This is very often required for a developer.

In our workflow an explicit cleanup of the cmake cache is also required if `pic-edit` is copying a new param file into the input set else the new file will not be used by cmake. Since `pic-edit` is not aware that the build folder is `.build` I did not add this feature into `pic-edit`. Never the less we should do it.