### PR TITLE
Update taurus-tud profiles for the `ml` partition

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -167,20 +167,14 @@ Queue: ml (NVIDIA V100 GPUs on Power9 nodes)
 
 For this profile, you additionally need to compile and install everything for the power9-architecture including your own :ref:`boost <install-dependencies>`, :ref:`HDF5 <install-dependencies>`, c-blosc and :ref:`ADIOS <install-dependencies>`.
 
-Install script for `c-blosc`
+.. note::
 
-.. code-block:: bash
+   Please find a `Taurus ml quick start here <https://gist.github.com/steindev/cc02eae81f465833afa27fc8880f3473>`_.
 
-   cd $SOURCE_DIR
-   git clone -b v1.12.1 https://github.com/Blosc/c-blosc.git \
-       $SOURCE_DIR/c-blosc
-   mkdir c-blosc-build
-   cd c-blosc-build
-   cmake -DCMAKE_INSTALL_PREFIX=$BLOSC_ROOT \
-       -DPREFER_EXTERNAL_ZLIB=ON \
-       $SOURCE_DIR/c-blosc
-   make -j4
-   make install
+.. note::
+   
+   You need to compile the libraries and PIConGPU on an ``ml`` node since
+   only nodes in the ``ml`` queue are Power9 systems.
 
 .. literalinclude:: profiles/taurus-tud/V100_picongpu.profile.example
    :language: bash

--- a/etc/picongpu/taurus-tud/V100.tpl
+++ b/etc/picongpu/taurus-tud/V100.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2019 Axel Huebl, Richard Pausch, Alexander Debus
+# Copyright 2013-2019 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
 #
 # This file is part of PIConGPU.
 #
@@ -31,8 +31,6 @@
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem-per-cpu=1511
 #SBATCH --gres=gpu:!TBG_gpusPerNode
-# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
-# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
@@ -53,8 +51,8 @@
 # 6 gpus per node
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 6 ] ; then echo 6; else echo $TBG_tasks; fi`
 
-# number of cores to block per GPU - we got 6 cpus per gpu
-#   and we will be accounted 6 CPUs per GPU anyway
+# number of cores to block per GPU - we got 28 cpus per gpu
+#   and we will be accounted 28 CPUs per GPU anyway
 .TBG_coresPerGPU=28
 
 # We only start 1 MPI task per GPU
@@ -80,35 +78,30 @@ unset MODULES_NO_OUTPUT
 # set user rights to u=rwx;g=r-x;o=---
 umask 0027
 
-# Due to missing SLURM integration of the current MPI libraries
-# we have to create a suitable machinefile.
-rm -f machinefile.txt
-for i in `seq !TBG_gpusPerNode`
-do
-    scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
-done
-
 mkdir simOutput 2> /dev/null
 cd simOutput
+ln -s ../stdout output
 
 # we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
 #   support ticket [Ticket:2014052241001186] srun: mpi mca flags
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
-# Use ROMIO for IO
-# according to ComputationalRadiationPhysics/picongpu#2857
+
+# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
+# fallback ROMIO backend instead.
+#   see bug https://github.com/open-mpi/ompi/issues/6285
 export OMPI_MCA_io=^ompio
 
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   # Run CUDA memtest to check GPU's health
-  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/cuda_memtest.sh
+  srun -K1 !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "no binary 'cuda_memtest' available, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi
 

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -1,11 +1,11 @@
 # Name and Path of this Script ############################### (DO NOT change!)
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
 
-# User Information ######################################### (edit those lines)
+# User Information ######################################### (edit the following lines)
 #   - automatically add your name and contact to output file meta data
-#   - send me a mail on batch system jobs: BEGIN, END, FAIL, REQUEUE, ALL,
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="ALL"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
@@ -17,43 +17,45 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module purge
 module load modenv/ml
-# similar to foss/2018a, but also includes SpectrumMPI which basically is just a OpenMPI-fork of IBM
-module load gsolf/2018a
-module load GCC/6.4.0-2.28
-module load CMake/3.10.2-GCCcore-6.4.0
-# CUDA is no module in the current enviroment!
-#module load CUDA/9.2.88  # gcc <= 7, intel 15-17
-# OpenMPI is already loaded
-#module load OpenMPI/2.1.2-GCC-6.4.0-2.28
+
+# load CUDA/9.2.88-GCC-7.3.0-2.30, also loads GCC/7.3.0-2.30, zlib, OpenMPI and others
+module load fosscuda/2018b
+module load CMake/3.11.4-GCCcore-7.3.0
 module load git/2.18.0-GCCcore-6.4.0
-module load zlib/1.2.11-GCCcore-6.4.0
+module load libpng/1.6.34-GCCcore-7.3.0
+
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+printf "@ Note: You need to compile picongpu on a node. @\n"
+printf "@       Likewise for building the libraries.    @\n"
+printf "@       Get a node with the getNode command.    @\n"
+printf "@       Then source %s again.@\n" "$(basename $PIC_PROFILE)"
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
 
 # Self-Build Software #########################################################
 #
 # needs to be compiled by the user
-export PIC_LIBS="$HOME/lib"
-export BOOST_ROOT=$PIC_LIBS/boost-1.69.0-Power9
-export PNG_ROOT=$PIC_LIBS/libpng-1.6.34-Power9
+# Check the install script at
+# https://gist.github.com/steindev/cc02eae81f465833afa27fc8880f3473#file-picongpu_0-4-3_taurus-tud-sh
+#
+export PIC_LIBS=$HOME/lib/power9
+export BOOST_ROOT=$PIC_LIBS/boost-1.68.0-Power9
 export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0-Power9
 export ADIOS_ROOT=$PIC_LIBS/adios-1.13.1-Power9
+export HDF5_ROOT=$PIC_LIBS/hdf5-1.8.20-Power9
 export Splash_DIR=$PIC_LIBS/splash-Power9
-export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
-export HDF5_ROOT=$PIC_LIBS/hdf5-Power9
-export BLOSC_ROOT=$PIC_LIBS/blosc-1.12.1-Power9
+export BLOSC_ROOT=$PIC_LIBS/blosc-1.16.2-Power9
 
 export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
-export LIBRARY_PATH=$BOOST_ROOT/lib:$LIBRARY_PATH
-export LD_LIBRARY_PATH=$PNG_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$PNGwriter_DIR/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$Splash_DIR/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$Splash_DIR/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
 
-export PATH=$PNG_ROOT/bin:$PATH
 export PATH=$ADIOS_ROOT/bin:$PATH
 
-export CMAKE_PREFIX_PATH=$PNG_ROOT:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$HDF5_ROOT:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
@@ -64,7 +66,7 @@ export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin
 
 # python not included yet
-#export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
 # This is necessary in order to make alpaka compile.
 # The workaround is from Axel Huebl according to alpaka PR #702.
@@ -72,7 +74,7 @@ export CXXFLAGS="-Dlinux"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)
-#   - "gpu2" queue
+#   - "ml" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/V100.tpl"
 


### PR DESCRIPTION
New modules where installed for the `ml` partition.
Among other things, the MPI machinefile became unnecessary.
I updated the respective `V100_picongpu.profile.example` and `V100.tpl`.
Furthermore, I compiled a script from @ax3l's older scripts
which installs the libraries on which picongpu depends.
The script can be found at (https://gist.github.com/steindev/cc02eae81f465833afa27fc8880f3473#file-picongpu_0-4-3_taurus-tud-sh).
I included the link in the `V100_picongpu.profile.example` as well.