### PR TITLE
pic-edit: clean cmake file cache if new param added

### DIFF
--- a/bin/pic-edit
+++ b/bin/pic-edit
@@ -142,6 +142,9 @@ do
         defaults_path="$picongpu_prefix/$file_prefix/$file_name"
         if [ -f "$defaults_path" ]
         then
+            if [ -f ".build/CMakeCache.txt" ] ; then
+                cmake --build .build --target clean
+            fi
             cp $defaults_path $file_path
         else
             echo "ERROR: input '$input' does not exist!" >&2


### PR DESCRIPTION
follow up of #2901

If a param file is copied to the input set of the user the cmake cache file cache fill be cleaned to avoid that the new param file is not taken into account during the compile.

Note: I added no output to the terminal that the cmake cache is cleared. I think it will only confuse the user at this place.  

- [x] merge after #2901