### PR TITLE
Docker CUDA Image: Hwloc Default

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -59,7 +59,7 @@ RUN        spack install $PIC_PACKAGE && \
 
 # load spack & picongpu environment on login
 RUN        /bin/echo -e "source $SPACK_ROOT/share/spack/setup-env.sh\n" \
-                        "spack load $PIC_PACKAGE\n" \
+                        "spack load -r $PIC_PACKAGE\n" \
                         'if [ $(id -u) -eq 0 ]; then\n' \
                         '   function mpirun { $(which mpirun) --allow-run-as-root $@; }\n' \
                         '   export -f mpirun\n' \

--- a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
@@ -14,6 +14,8 @@ packages:
   openmpi:
     version: [3.1.3]
     variants: +cuda fabrics=verbs,ucx,libfabric
+  hwloc:
+    variants: +cuda
   all:
     providers:
       mpi: [openmpi]


### PR DESCRIPTION
Our currently shipped Docker image build for the CUDA backend with Spack. Due to a concretization issue in OpenMPI's package, we also need to specify the `hwloc` default variant to be with `+cuda`.

Follow-up to #2847.