### PR TITLE
Boost 1.67.0+ Template Aliases

### DIFF
--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -320,19 +320,15 @@ endif()
 message(STATUS "Boost: result_of with TR1 style and decltype fallback")
 set(PMacc_DEFINITIONS ${PMacc_DEFINITIONS} -DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
 
-# Boost >= 1.60.0 and CUDA != 7.5 failed when used with C++11
-# seen with Boost 1.60.0 - 1.62.0 (maybe later) and CUDA 7.0 and 8.0
-# CUDA 7.5 works without a workaround
-# CUDA 8.0.44 bug reappeared, but work-around was mainlined in 1.63.0+
-# CUDA 9.0 unknown, likely fixed
-# CUDA 9.1.85-3 and above fixed
+# Boost >= 1.60.0 and CUDA 8.0 fail to compile on mp_defer
+# seen with Boost 1.60.0 - 1.63.0 (latter got config work-around below)
+# CUDA 9.0+ fixed
 if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
     if( (Boost_VERSION GREATER 105999) AND
-        (NOT CUDA_VERSION VERSION_EQUAL 7.5) AND
-        (CUDA_VERSION VERSION_LESS 9.1) )
+        (CUDA_VERSION VERSION_EQUAL 8.0) )
         # Boost Bug https://svn.boost.org/trac/boost/ticket/11897
-        message(STATUS "Boost: Disable template aliases")
-        set(PMacc_DEFINITIONS ${PMacc_DEFINITIONS} -DBOOST_NO_CXX11_TEMPLATE_ALIASES)
+        message(STATUS "Boost: Disable variadic templates")
+        set(PMacc_DEFINITIONS ${PMacc_DEFINITIONS} -DBOOST_NO_CXX11_VARIADIC_TEMPLATES)
     endif()
 endif()
 


### PR DESCRIPTION
Enable boost template aliases. Fix #2907

Boost 1.67.0+ uses `boost::void_t` even though it is only conditionally defined (controlled via `BOOST_NO_CXX11_TEMPLATE_ALIASES`): https://github.com/boostorg/type_traits/issues/113

https://www.boost.org/doc/libs/1_67_0/boost/type_traits/detail/has_binary_operator.hpp

This section in our config was originally designed to work-around https://svn.boost.org/trac10/ticket/11897
The NVCC bug appeared in CUDA 7.0, was fixed in 7.5 and re-appeared in 8.0. During transition to CUDA 8, the work-around was switched from disabling variadic templates to disabling template aliases, as it also excludes boost `mp_defer` code of the original issues. Nevertheless, there seems to be no reason why we would need boost variadic templates with CUDA 8.0 (at least no details were given in #1603 where this would fail and only indicates stylistic reasons). As the specific usage of variadic templates in boost `mp_defer` are the actual problem with CUDA 8.0, use the original work-around again.

CI will test CUDA 8.0.44 + Boost 1.62.0 .
Boost [1.63.0+](https://github.com/boostorg/config/blob/boost-1.63.0/include/boost/config/compiler/nvcc.hpp) applies the same work-around in its configs for CUDA 8.0 (`BOOST_NO_CXX11_VARIADIC_TEMPLATES`).