### PR TITLE
[WIP] Jupyter widgets: automatic update of plot options 

### DIFF
--- a/lib/python/picongpu/plugins/data/base_reader.py
+++ b/lib/python/picongpu/plugins/data/base_reader.py
@@ -121,3 +121,38 @@ class DataReader(object):
         dependent format and type.
         """
         raise NotImplementedError
+
+    # NOTE: this can be hard to define abstractly since we should make each
+    # parameter query dependent on all other possible choices of parameters
+    # thus requiring kwargs?!
+
+    # e.g. get all species strings for defined values of filter, iteration
+    # and other parameters
+    def get_species(self, iteration=None, species_filter=None):
+        """
+        Get the available species abbreviations for which data exists.
+        Optionally specific iterations and/or filters can be given.
+
+
+        Returns
+        -------
+        A list of species abbreviation strings for which data exists.
+        In case iteration or species_filter are not None, only species
+        are returned that match iteration and species_filter.
+        """
+        raise NotImplementedError
+
+    def get_species_filters(self, iteration=None, species=None):
+        raise NotImplementedError
+
+    def get_options(self, iteration=None, species=None, species_filter=None):
+        """
+        Returns
+        -------
+        a dictionary mapping keywords that a visualizer might use
+        to the values for which data is present.
+        """
+        return {
+            'species': self.get_species(iteration, species_filter),
+            'species_filter': self.get_species_filters(iteration, species)
+        }

--- a/lib/python/picongpu/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/plugins/data/energy_histogram.py
@@ -182,3 +182,9 @@ class EnergyHistogramData(DataReader):
             return data.loc[iteration].values, bins, iteration, dt
         else:
             return data.loc[iteration].values[0, :], bins, iteration, dt
+
+    def get_species(self, iteration=None, species_filter=None):
+        raise NotImplementedError
+
+    def get_species_filters(self):
+        raise NotImplementedError

--- a/lib/python/picongpu/plugins/data/phase_space.py
+++ b/lib/python/picongpu/plugins/data/phase_space.py
@@ -288,3 +288,22 @@ class PhaseSpaceData(DataReader):
             return ret[0]
         else:
             return ret
+
+    def get_species(self, iteration=None, species_filter=None):
+        raise NotImplementedError
+
+    def get_species_filters(self, iteration=None, species=None):
+        raise NotImplementedError
+
+    def get_ps(self, iteration=None, species=None, species_filter=None):
+        raise NotImplementedError
+
+    def get_options(self, iteration=None, species=None, species_filter=None):
+
+        # the options for species and species_filter
+        d = super().get_options()
+
+        # also append options for ps
+        d['ps'] = self.get_ps()
+
+        return d

--- a/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
@@ -232,6 +232,16 @@ class BaseWidget(widgets.VBox):
         #    (without triggering the callback)
         self._update_available_sim_times()
 
+        # TODO: update the widgets that allow choosing of parameter
+        # vaues for plotting with the options that are common to
+        # a) the selected simulations and
+        # b) to the selected simulation time
+        # BUT: is this enough to update the options only on choice of
+        # simulations? shouldn't this also be updated when
+        # a) some other option changes
+        # and
+        # b) the simulation time changes?
+
     def _handle_run_dir_selection_callback(self, change):
         """
         Callback function when user selects a subset of the


### PR DESCRIPTION
At the moment the options of each jupyter widget (like 'species' or 'species_filter') are hardcoded to a single option (see screenshot). 
![widget](https://user-images.githubusercontent.com/31093529/53556712-b7dc6500-3b44-11e9-80a0-3ec4937938ce.png)


This PR will improve this situation by dynamically adapting those options based on the values common to the selected simulations.



Before implementing something we should discuss the following:
a) is it sufficient to update those parameters only when the selected simulations change? Or do we also update them when the selected simulation time changes or when any of the other options changes?

b) Should the query for available species, filters, and other options be implemented in the data classes or in the widget classes? 

