### PR TITLE
fix compile splash2txt

### DIFF
--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -104,6 +104,11 @@ if(MPI_CXX_FOUND)
     set(LIBS ${LIBS} ${MPI_CXX_LIBRARIES})
 endif(MPI_CXX_FOUND)
 
+################################################################################
+# Find zlib
+################################################################################
+
+find_package(ZLIB REQUIRED)
 
 ################################################################################
 # libSplash (+ hdf5 due to required headers)
@@ -160,6 +165,8 @@ add_executable(splash2txt
      ${SRCFILES}
      )
 
+target_link_libraries(splash2txt Splash::Splash)
+target_link_libraries(splash2txt ZLIB::ZLIB)
 target_link_libraries(splash2txt m ${LIBS})
 
 

--- a/src/tools/splash2txt/tools_splash_parallel.cpp
+++ b/src/tools/splash2txt/tools_splash_parallel.cpp
@@ -309,7 +309,7 @@ void ToolsSplashParallel::convertToText()
         {
             try
             {
-                dc.readAttribute(m_options.step, iter->c_str(), "unitSI").read(&(excontainer.unit), sizeof(excontainer.unit));
+                dc.readAttributeInfo(m_options.step, iter->c_str(), "unitSI").read(&(excontainer.unit), sizeof(excontainer.unit));
             } catch (const DCException&)
             {
                 if (m_options.verbose)


### PR DESCRIPTION
- fix broken compile due to a wrong interface usage introduced with #2520
- cmake missing include/dependency
  - add splash to the cmake target `splash2txt`
  - add splash dependency `zlib` to the `splash2txt` target