### PR TITLE
splash2txt: fix file name trimming

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -89,9 +89,9 @@ zlib
 
 boost
 """""
-- 1.62.0 - 1.68.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``,  ``regex``)
+- 1.62.0 - 1.68.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
 - *note:* for CUDA 9+ support, use boost 1.65.1 or newer
-- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev libboost-regex-dev``
+- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
 - *from source:*
@@ -99,7 +99,7 @@ boost
   - ``curl -Lo boost_1_65_1.tar.gz https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz``
   - ``tar -xzf boost_1_65_1.tar.gz``
   - ``cd boost_1_65_1``
-  - ``./bootstrap.sh --with-libraries=atomic,chrono,context,date_time,fiber,filesystem,math,program_options,regex,serialization,system,thread --prefix=$HOME/lib/boost``
+  - ``./bootstrap.sh --with-libraries=atomic,chrono,context,date_time,fiber,filesystem,math,program_options,serialization,system,thread --prefix=$HOME/lib/boost``
   - ``./b2 cxxflags="-std=c++11" -j4 && ./b2 install``
 - *environment:* (assumes install from source in ``$HOME/lib/boost``)
 
@@ -257,7 +257,7 @@ HDF5
 
 splash2txt
 """"""""""
-- requires *libSplash* and *boost* ``program_options``, ``regex``
+- requires *libSplash* and *boost* ``program_options``
 - converts slices in dumped hdf5 files to plain txt matrices
 - assume you [downloaded](#requirements) PIConGPU to `PICSRC=$HOME/src/picongpu`
 - ``mkdir -p ~/build && cd ~/build``

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -136,9 +136,9 @@ endif(ADIOS_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options regex)
+find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
 if(TARGET Boost::program_options)
-    set(LIBS ${LIBS} Boost::boost Boost::program_options Boost::regex)
+    set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
     set(LIBS ${LIBS} ${Boost_LIBRARIES})

--- a/src/tools/splash2txt/include/splash2txt.hpp
+++ b/src/tools/splash2txt/include/splash2txt.hpp
@@ -35,7 +35,6 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/cmdline.hpp>
 #include <boost/program_options/variables_map.hpp>
-#include <boost/regex.hpp>
 #include <iomanip>
 
 class Dims

--- a/src/tools/splash2txt/splash2txt.cpp
+++ b/src/tools/splash2txt/splash2txt.cpp
@@ -27,6 +27,8 @@
 #include "tools_adios_parallel.hpp"
 #endif
 
+#include <regex>
+
 namespace po = boost::program_options;
 
 const size_t numAllowedSlices = 3;
@@ -101,10 +103,9 @@ bool parseOptions( int argc, char** argv, ProgramOptions &options )
 #endif
         // re-parse wrong typed input files to valid format, if possible
         //   find _X.h5 with syntax at the end and delete it
-        boost::regex filePattern( "_.*\\.h5",
-                                  boost::regex_constants::icase |
-                                  boost::regex_constants::perl );
-        options.inputFile = boost::regex_replace( options.inputFile, filePattern, "" );
+        std::regex filePattern( "\\(_[[:digit:]]\\)*\\.h5",
+                                  std::regex::egrep );
+        options.inputFile = std::regex_replace( options.inputFile, filePattern, "" );
 
         // set various flags
         options.verbose = vm.count( "verbose" ) != 0;


### PR DESCRIPTION
- fix file pattern to prepare the file name for libsplash
  example for a not supported path: `buildPIC/khi_cpu/bin/h5/data_0.h5`
  The `_` in `khi_cpu` was misinterpreted an the file path was set to `buildPIC/khi`
- remove `boost::regex` with `std::regex`
- update documentation: remove requirement of `boost::regex` ￼(this step was already mentioned in [#2899](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2899#issuecomment-467798314) )

Note: I marked this PR as bug because due to the original regex pattern used to trimm the file name it could result into the bug that the file is not exists.