### PR TITLE
Update modules and memory in gpu_picongpu.profile

### DIFF
--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2019 Axel Huebl, Richard Pausch, Rene Widera
+# Copyright 2013-2019 Axel Huebl, Richard Pausch, Rene Widera, Marco Garten
 #
 # This file is part of PIConGPU.
 #
@@ -19,7 +19,7 @@
 #
 
 
-# PIConGPU batch script for hemera' SLURM batch system
+# PIConGPU batch script for hemera's SLURM batch system
 
 #SBATCH --partition=!TBG_queue
 #SBATCH --time=!TBG_wallTime
@@ -34,7 +34,6 @@
 #SBATCH --gres=gpu:!TBG_gpusPerNode
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
 #SBATCH --workdir=!TBG_dstPath
 
 #SBATCH -o stdout
@@ -57,7 +56,7 @@
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per gpu
-.TBG_memPerGPU="$((360000 / $TBG_gpusPerNode))"
+.TBG_memPerGPU="$((378000 / $TBG_gpusPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
 

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -18,8 +18,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load gcc/7.3.0
 module load cmake/3.11.3
-module load cuda/9.2
-module load openmpi/2.1.2-cuda92
+module load cuda/10.0
+module load openmpi/2.1.2-cuda100
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -27,9 +27,9 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load adios/1.13.1-cuda92
-module load hdf5-parallel/1.8.20-cuda92
-module load libsplash/1.7.0-cuda92
+module load adios/1.13.1-cuda100
+module load hdf5-parallel/1.8.20-cuda100
+module load libsplash/1.7.0-cuda100
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0
@@ -62,7 +62,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=360000 -p gpu --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=378000 -p gpu --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -78,5 +78,5 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=$((6 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((90000 * numGPUs)) -p gpu --pty bash
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p gpu --pty bash
 }


### PR DESCRIPTION
Updated the hemera cluster gpu_picongpu.profile
- updated the modules to builds based on cuda/10.0
- updated the memory requirement to leave only 2GB free on a node, not 20GB