### PR TITLE
typo fix in Send/receive buffer warning

### DIFF
--- a/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
@@ -117,7 +117,7 @@ namespace pmacc
             {
                 std::cerr << "Send/receive buffer for species " <<
                     ParBase::FrameType::getName() <<
-                    " is to small (max: " << maxSize <<
+                    " is too small (max: " << maxSize <<
                     ", direction: " << exchange <<
                     ", retries: " << retryCounter <<
                     ")" << std::endl;


### PR DESCRIPTION
Another revolutionary typo fix

By the way, in order for a user to react to this warning, how you define the _direction_? Foe example, if i get a warning:
```Send/receive buffer for species e is to small (max: 49152, direction: 3, retries: 1)```
should I increase `BYTES_EXCHANGE_Z` or there could be other possibilities?