### PR TITLE
cleanup `pmacc/types.hpp`

### DIFF
--- a/include/pmacc/attribute/Constexpr.hpp
+++ b/include/pmacc/attribute/Constexpr.hpp
@@ -1,0 +1,49 @@
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+/**
+ * Visual Studio has a bug with constexpr variables being captured in lambdas as
+ * non-constexpr variables, causing build errors. The issue has been verified
+ * for versions 14.0 and 15.5 (latest at the moment) and is also reported in
+ * https://stackoverflow.com/questions/28763375/using-lambda-captured-constexpr-value-as-an-array-dimension
+ * and related issue
+ * https://developercommunity.visualstudio.com/content/problem/1997/constexpr-not-implicitely-captured-in-lambdas.html
+ *
+ * As a workaround (until this is fixed in VS) add a new PMACC_CONSTEXPR_CAPTURE
+ * macro for declaring constexpr variables that are captured in lambdas and have
+ * to remain constexpr inside a lambda e.g., used as a template argument. Such
+ * variables have to be declared with PMACC_CONSTEXPR_CAPTURE instead of
+ * constexpr. The macro will be replaced with just constexpr for other compilers
+ * and for Visual Studio with static constexpr, which makes it capture properly.
+ *
+ * Note that this macro is to be used only in very few cases, where not only a
+ * constexpr is captured, but also it has to remain constexpr inside a lambda.
+ */
+#ifdef _MSC_VER
+#   define PMACC_CONSTEXPR_CAPTURE static constexpr
+#else
+#   define PMACC_CONSTEXPR_CAPTURE constexpr
+#endif

--- a/include/pmacc/attribute/Fallthrough.hpp
+++ b/include/pmacc/attribute/Fallthrough.hpp
@@ -1,4 +1,6 @@
-/* Copyright 2013-2019 Rene Widera
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of PMacc.
  *
@@ -21,38 +23,23 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
+// compatibility macros (compiler or C++ standard version specific)
+#include <boost/config.hpp>
+// work-around for Boost 1.68.0
+//   fixed in https://github.com/boostorg/predef/pull/84
+//   see https://github.com/ComputationalRadiationPhysics/alpaka/pull/606
+// include <boost/predef.h>
+#include <alpaka/core/BoostPredef.hpp>
 
-#include <stdint.h>
 
-#ifndef PMACC_VERBOSE_LVL
-#define PMACC_VERBOSE_LVL 0
+/** C++11 and C++14 explicit fallthrough in switch cases
+ *
+ * Use [[fallthrough]] in C++17
+ */
+#if (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(7,0,0))
+#   define PMACC_FALLTHROUGH [[gnu::fallthrough]]
+#elif BOOST_COMP_CLANG
+#   define PMACC_FALLTHROUGH [[clang::fallthrough]]
+#else
+#   define PMACC_FALLTHROUGH ( (void)0 )
 #endif
-
-namespace pmacc
-{
-
-    /*create verbose class*/
-    DEFINE_VERBOSE_CLASS(PMaccVerbose)
-    (
-        /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0,NOTHING);
-        DEFINE_LOGLVL(1,MEMORY);
-        DEFINE_LOGLVL(2,INFO);
-        DEFINE_LOGLVL(4,CRITICAL);
-        DEFINE_LOGLVL(8,MPI);
-        DEFINE_LOGLVL(16,CUDA_RT);
-        DEFINE_LOGLVL(32,COMMUNICATION);
-        DEFINE_LOGLVL(64,EVENT);
-    )
-    /*set default verbose lvl (integer number)*/
-    (NOTHING::lvl|PMACC_VERBOSE_LVL);
-
-    //short name for access verbose types of PMacc
-    using ggLog = PMaccVerbose;
-
-}
-
-
-

--- a/include/pmacc/attribute/FunctionSpecifier.hpp
+++ b/include/pmacc/attribute/FunctionSpecifier.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cupla/types.hpp>
+
+
+#define HDINLINE ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE
+#define DINLINE ALPAKA_FN_ACC ALPAKA_FN_INLINE
+#define DEVICEONLY ALPAKA_FN_ACC
+#define HINLINE ALPAKA_FN_HOST ALPAKA_FN_INLINE
+
+/**
+ * CUDA architecture version (aka PTX ISA level)
+ * 0 for host compilation
+ */
+#ifndef __CUDA_ARCH__
+#   define PMACC_CUDA_ARCH 0
+#else
+#   define PMACC_CUDA_ARCH __CUDA_ARCH__
+#endif
+
+/** PMacc global identifier for CUDA kernel */
+#define PMACC_GLOBAL_KEYWORD DINLINE
+
+/*
+ * Disable nvcc warning:
+ * calling a __host__ function from __host__ __device__ function.
+ *
+ * Usage:
+ * PMACC_NO_NVCC_HDWARNING
+ * HDINLINE function_declaration()
+ *
+ * It is not possible to disable the warning for a __host__ function
+ * if there are calls of virtual functions inside. For this case use a wrapper
+ * function.
+ * WARNING: only use this method if there is no other way to create runable code.
+ * Most cases can solved by #ifdef __CUDA_ARCH__ or #ifdef __CUDACC__.
+ */
+#if defined(__CUDACC__)
+#   define PMACC_NO_NVCC_HDWARNING _Pragma("hd_warning_disable")
+#else
+#   define PMACC_NO_NVCC_HDWARNING
+#endif

--- a/include/pmacc/cuplaHelper/ValidateCall.hpp
+++ b/include/pmacc/cuplaHelper/ValidateCall.hpp
@@ -1,0 +1,57 @@
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cuda_to_cupla.hpp>
+#include <iostream>
+#include <stdexcept>
+
+namespace pmacc
+{
+
+/**
+ * Print a cuda error message including file/line info to stderr
+ */
+#define PMACC_PRINT_CUDA_ERROR(msg) \
+    std::cerr << "[CUDA] Error: <" << __FILE__ << ">:" << __LINE__ << " " << msg << std::endl
+
+/**
+ * Print a cuda error message including file/line info to stderr and raises an exception
+ */
+#define PMACC_PRINT_CUDA_ERROR_AND_THROW(cudaError, msg) \
+    PMACC_PRINT_CUDA_ERROR(msg);                         \
+    throw std::runtime_error(std::string("[CUDA] Error: ") + std::string(cudaGetErrorString(cudaError)))
+
+/**
+ * Captures CUDA errors and prints messages to stdout, including line number and file.
+ *
+ * @param cmd command with cudaError_t return value to check
+ */
+#define CUDA_CHECK(cmd) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR_AND_THROW(error, ""); }}
+
+#define CUDA_CHECK_MSG(cmd,msg) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR_AND_THROW(error, msg); }}
+
+#define CUDA_CHECK_NO_EXCEPT(cmd) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR(""); }}
+
+} // namespace pmacc

--- a/include/pmacc/debug/VerboseLog.hpp
+++ b/include/pmacc/debug/VerboseLog.hpp
@@ -22,14 +22,13 @@
 #pragma once
 
 #include "pmacc/debug/VerboseLogMakros.hpp"
-#include "pmacc/types.hpp"
 
 #include <boost/format.hpp>
 
 #include <string>
 #include <iostream>
 #include <sstream>
-#include <stdint.h>
+#include <cstdint>
 
 namespace pmacc
 {

--- a/include/pmacc/dimensions/Definition.hpp
+++ b/include/pmacc/dimensions/Definition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2019 Rene Widera
+/* Copyright 2019 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -21,38 +21,8 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
 
-#include <stdint.h>
-
-#ifndef PMACC_VERBOSE_LVL
-#define PMACC_VERBOSE_LVL 0
-#endif
-
-namespace pmacc
-{
-
-    /*create verbose class*/
-    DEFINE_VERBOSE_CLASS(PMaccVerbose)
-    (
-        /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0,NOTHING);
-        DEFINE_LOGLVL(1,MEMORY);
-        DEFINE_LOGLVL(2,INFO);
-        DEFINE_LOGLVL(4,CRITICAL);
-        DEFINE_LOGLVL(8,MPI);
-        DEFINE_LOGLVL(16,CUDA_RT);
-        DEFINE_LOGLVL(32,COMMUNICATION);
-        DEFINE_LOGLVL(64,EVENT);
-    )
-    /*set default verbose lvl (integer number)*/
-    (NOTHING::lvl|PMACC_VERBOSE_LVL);
-
-    //short name for access verbose types of PMacc
-    using ggLog = PMaccVerbose;
-
-}
-
-
-
+//! Defines number of dimensions (1-3)
+#define DIM1 1u
+#define DIM2 2u
+#define DIM3 3u

--- a/include/pmacc/eventSystem/EventType.hpp
+++ b/include/pmacc/eventSystem/EventType.hpp
@@ -1,4 +1,6 @@
-/* Copyright 2013-2019 Rene Widera
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of PMacc.
  *
@@ -21,38 +23,33 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
+#include <cstdint>
 
-#include <stdint.h>
-
-#ifndef PMACC_VERBOSE_LVL
-#define PMACC_VERBOSE_LVL 0
-#endif
 
 namespace pmacc
 {
+namespace eventSystem
+{
 
-    /*create verbose class*/
-    DEFINE_VERBOSE_CLASS(PMaccVerbose)
-    (
-        /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0,NOTHING);
-        DEFINE_LOGLVL(1,MEMORY);
-        DEFINE_LOGLVL(2,INFO);
-        DEFINE_LOGLVL(4,CRITICAL);
-        DEFINE_LOGLVL(8,MPI);
-        DEFINE_LOGLVL(16,CUDA_RT);
-        DEFINE_LOGLVL(32,COMMUNICATION);
-        DEFINE_LOGLVL(64,EVENT);
-    )
-    /*set default verbose lvl (integer number)*/
-    (NOTHING::lvl|PMACC_VERBOSE_LVL);
+    /**
+     * Internal event/task type used for notifications in the event system.
+     */
+    enum EventType
+    {
+        FINISHED,
+        COPYHOST2DEVICE,
+        COPYDEVICE2HOST,
+        COPYDEVICE2DEVICE,
+        SENDFINISHED,
+        RECVFINISHED,
+        LOGICALAND,
+        SETVALUE,
+        GETVALUE,
+        KERNEL
+    };
 
-    //short name for access verbose types of PMacc
-    using ggLog = PMaccVerbose;
+} // namespace type
 
-}
-
-
-
+    // for backward compatibility pull all definitions into the pmacc namespace
+    using namespace eventSystem;
+} // namespace pmacc

--- a/include/pmacc/memory/Align.hpp
+++ b/include/pmacc/memory/Align.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/ppFunctions.hpp"
+
+/** calculate and set the optimal alignment for data
+  *
+  * you must align all arrays and structs that are used on the device
+  * @param byte size of data in bytes
+  */
+#define __optimal_align__(byte)                                                \
+    alignas(                                                                 \
+        /** \bug avoid bug if alignment is >16 byte                            \
+         * https://github.com/ComputationalRadiationPhysics/picongpu/issues/1563 \
+         */                                                                    \
+        PMACC_MIN(PMACC_ROUND_UP_NEXT_POW2(byte),16)                           \
+    )
+
+#define PMACC_ALIGN( var, ... ) __optimal_align__( sizeof( __VA_ARGS__ ) ) __VA_ARGS__ var
+#define PMACC_ALIGN8( var, ... ) alignas( 8 ) __VA_ARGS__ var

--- a/include/pmacc/memory/Delete.hpp
+++ b/include/pmacc/memory/Delete.hpp
@@ -1,4 +1,6 @@
-/* Copyright 2013-2019 Rene Widera
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of PMacc.
  *
@@ -21,38 +23,6 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
 
-#include <stdint.h>
-
-#ifndef PMACC_VERBOSE_LVL
-#define PMACC_VERBOSE_LVL 0
-#endif
-
-namespace pmacc
-{
-
-    /*create verbose class*/
-    DEFINE_VERBOSE_CLASS(PMaccVerbose)
-    (
-        /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0,NOTHING);
-        DEFINE_LOGLVL(1,MEMORY);
-        DEFINE_LOGLVL(2,INFO);
-        DEFINE_LOGLVL(4,CRITICAL);
-        DEFINE_LOGLVL(8,MPI);
-        DEFINE_LOGLVL(16,CUDA_RT);
-        DEFINE_LOGLVL(32,COMMUNICATION);
-        DEFINE_LOGLVL(64,EVENT);
-    )
-    /*set default verbose lvl (integer number)*/
-    (NOTHING::lvl|PMACC_VERBOSE_LVL);
-
-    //short name for access verbose types of PMacc
-    using ggLog = PMaccVerbose;
-
-}
-
-
-
+#define __delete( var ) if( ( var ) ) { delete( var ); ( var ) = nullptr; }
+#define __deleteArray( var ) if( ( var ) ) { delete[ ]( var ); ( var ) = nullptr; }

--- a/include/pmacc/type/Area.hpp
+++ b/include/pmacc/type/Area.hpp
@@ -1,4 +1,6 @@
-/* Copyright 2013-2019 Rene Widera
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of PMacc.
  *
@@ -21,38 +23,26 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
-
-#include <stdint.h>
-
-#ifndef PMACC_VERBOSE_LVL
-#define PMACC_VERBOSE_LVL 0
-#endif
 
 namespace pmacc
 {
+namespace type
+{
 
-    /*create verbose class*/
-    DEFINE_VERBOSE_CLASS(PMaccVerbose)
-    (
-        /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0,NOTHING);
-        DEFINE_LOGLVL(1,MEMORY);
-        DEFINE_LOGLVL(2,INFO);
-        DEFINE_LOGLVL(4,CRITICAL);
-        DEFINE_LOGLVL(8,MPI);
-        DEFINE_LOGLVL(16,CUDA_RT);
-        DEFINE_LOGLVL(32,COMMUNICATION);
-        DEFINE_LOGLVL(64,EVENT);
-    )
-    /*set default verbose lvl (integer number)*/
-    (NOTHING::lvl|PMACC_VERBOSE_LVL);
+    /*! area which is calculated
+     *
+     * CORE is the inner area of a grid
+     * BORDER is the border of a grid (my own border, not the neighbor part)
+     */
+    enum AreaType
+    {
+        CORE = 1u,
+        BORDER = 2u,
+        GUARD = 4u
+    };
 
-    //short name for access verbose types of PMacc
-    using ggLog = PMaccVerbose;
+} // namespace type
 
-}
-
-
-
+    // for backward compatibility pull all definitions into the pmacc namespace
+    using namespace type;
+} // namespace pmacc

--- a/include/pmacc/type/Exchange.hpp
+++ b/include/pmacc/type/Exchange.hpp
@@ -1,0 +1,86 @@
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+
+namespace pmacc
+{
+namespace type
+{
+
+    /**
+     * Bitmask which describes the direction of communication.
+     *
+     * Bitmasks may be combined logically, e.g. LEFT+TOP = TOPLEFT.
+     * It is not possible to combine complementary masks (e.g. FRONT and BACK),
+     * as a bitmask always defines one direction of communication (send or receive).
+     *
+     * Axis index relation:
+     *   right & left are in X
+     *   bottom & top are in Y
+     *   back & front are in Z
+     */
+    enum ExchangeType
+    {
+        RIGHT = 1u,
+        LEFT = 2u,
+        BOTTOM = 3u,
+        TOP = 6u,
+        BACK = 9u,
+        FRONT = 18u // 3er-System
+    };
+
+    struct ExchangeTypeNames
+    {
+        std::string operator[]( const uint32_t exchange ) const
+        {
+            if( exchange >= 27 )
+                return std::string("unknown exchange type: ") + std::to_string(exchange);
+
+            const char* names[27] = {
+                "none",
+                "right", "left", "bottom",
+                "right-bottom", "left-bottom",
+                "top",
+                "right-top", "left-top",
+                "back",
+                "right-back", "left-back",
+                "bottom-back", "right-bottom-back", "left-bottom-back",
+                "top-back", "right-top-back", "left-top-back",
+                "front",
+                "right-front", "left-front",
+                "bottom-front", "right-bottom-front", "left-bottom-front",
+                "top-front", "right-top-front", "left-top-front"
+            };
+            return names[exchange];
+        }
+    };
+
+} // namespace type
+
+    // for backward compatibility pull all definitions into the pmacc namespace
+    using namespace type;
+} // namespace pmacc

--- a/include/pmacc/type/Integral.hpp
+++ b/include/pmacc/type/Integral.hpp
@@ -1,4 +1,6 @@
-/* Copyright 2013-2019 Rene Widera
+/* Copyright 2013-2019 Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Wolfgang Hoenig, Benjamin Worpitz,
+ *                     Alexander Grund
  *
  * This file is part of PMacc.
  *
@@ -21,38 +23,20 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
+#include <cstdint>
 
-#include <stdint.h>
-
-#ifndef PMACC_VERBOSE_LVL
-#define PMACC_VERBOSE_LVL 0
-#endif
 
 namespace pmacc
 {
+namespace type
+{
 
-    /*create verbose class*/
-    DEFINE_VERBOSE_CLASS(PMaccVerbose)
-    (
-        /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0,NOTHING);
-        DEFINE_LOGLVL(1,MEMORY);
-        DEFINE_LOGLVL(2,INFO);
-        DEFINE_LOGLVL(4,CRITICAL);
-        DEFINE_LOGLVL(8,MPI);
-        DEFINE_LOGLVL(16,CUDA_RT);
-        DEFINE_LOGLVL(32,COMMUNICATION);
-        DEFINE_LOGLVL(64,EVENT);
-    )
-    /*set default verbose lvl (integer number)*/
-    (NOTHING::lvl|PMACC_VERBOSE_LVL);
+    using id_t = uint64_t;
+    using uint64_cu = unsigned long long int;
+    using int64_cu = long long int;
 
-    //short name for access verbose types of PMacc
-    using ggLog = PMaccVerbose;
+} // namespace type
 
-}
-
-
-
+    // for backward compatibility pull all definitions into the pmacc namespace
+    using namespace type;
+} // namespace pmacc

--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -23,6 +23,10 @@
 
 #pragma once
 
+
+#define BOOST_MPL_LIMIT_VECTOR_SIZE 20
+#define BOOST_MPL_LIMIT_MAP_SIZE 20
+
 #include <cupla/types.hpp>
 
 #ifndef PMACC_CUDA_ENABLED
@@ -59,23 +63,21 @@
 #include "pmacc/debug/PMaccVerbose.hpp"
 #include "pmacc/ppFunctions.hpp"
 
-#define BOOST_MPL_LIMIT_VECTOR_SIZE 20
-#define BOOST_MPL_LIMIT_MAP_SIZE 20
+#include "pmacc/dimensions/Definition.hpp"
+#include "pmacc/type/Area.hpp"
+#include "pmacc/type/Integral.hpp"
+#include "pmacc/type/Exchange.hpp"
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+#include "pmacc/attribute/Constexpr.hpp"
+#include "pmacc/attribute/Fallthrough.hpp"
+#include "pmacc/eventSystem/EventType.hpp"
+#include "pmacc/cuplaHelper/ValidateCall.hpp"
+#include "pmacc/memory/Align.hpp"
+#include "pmacc/memory/Delete.hpp"
+
 #include <boost/typeof/std/utility.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/filesystem.hpp>
-
-// compatibility macros (compiler or C++ standard version specific)
-#include <boost/config.hpp>
-// work-around for Boost 1.68.0
-//   fixed in https://github.com/boostorg/predef/pull/84
-//   see https://github.com/ComputationalRadiationPhysics/alpaka/pull/606
-// include <boost/predef.h>
-#include <alpaka/core/BoostPredef.hpp>
-
-#include <stdint.h>
-#include <stdexcept>
-#include <string>
 
 
 namespace pmacc
@@ -83,198 +85,5 @@ namespace pmacc
 
 namespace bmpl = boost::mpl;
 namespace bfs = boost::filesystem;
-
-//short name for access verbose types of PMacc
-typedef PMaccVerbose ggLog;
-
-typedef uint64_t id_t;
-typedef unsigned long long int uint64_cu;
-typedef long long int int64_cu;
-
-#define HDINLINE ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE
-#define DINLINE ALPAKA_FN_ACC ALPAKA_FN_INLINE
-#define DEVICEONLY ALPAKA_FN_ACC
-#define HINLINE ALPAKA_FN_HOST ALPAKA_FN_INLINE
-
-/**
- * CUDA architecture version (aka PTX ISA level)
- * 0 for host compilation
- */
-#ifndef __CUDA_ARCH__
-#   define PMACC_CUDA_ARCH 0
-#else
-#   define PMACC_CUDA_ARCH __CUDA_ARCH__
-#endif
-
-/** PMacc global identifier for CUDA kernel */
-#define PMACC_GLOBAL_KEYWORD DINLINE
-
-/*
- * Disable nvcc warning:
- * calling a __host__ function from __host__ __device__ function.
- *
- * Usage:
- * PMACC_NO_NVCC_HDWARNING
- * HDINLINE function_declaration()
- *
- * It is not possible to disable the warning for a __host__ function
- * if there are calls of virtual functions inside. For this case use a wrapper
- * function.
- * WARNING: only use this method if there is no other way to create runable code.
- * Most cases can solved by #ifdef __CUDA_ARCH__ or #ifdef __CUDACC__.
- */
-#if defined(__CUDACC__)
-#define PMACC_NO_NVCC_HDWARNING _Pragma("hd_warning_disable")
-#else
-#define PMACC_NO_NVCC_HDWARNING
-#endif
-
-/**
- * Bitmask which describes the direction of communication.
- *
- * Bitmasks may be combined logically, e.g. LEFT+TOP = TOPLEFT.
- * It is not possible to combine complementary masks (e.g. FRONT and BACK),
- * as a bitmask always defines one direction of communication (send or receive).
- *
- * Axis index relation:
- *   right & left are in X
- *   bottom & top are in Y
- *   back & front are in Z
- */
-enum ExchangeType
-{
-    RIGHT = 1u, LEFT = 2u, BOTTOM = 3u, TOP = 6u, BACK = 9u, FRONT = 18u // 3er-System
-};
-
-struct ExchangeTypeNames
-{
-    std::string operator[]( const uint32_t exchange ) const
-    {
-        if( exchange >= 27 )
-            return std::string("unknown exchange type: ") + std::to_string(exchange);
-
-        const char* names[27] = {
-            "none",
-            "right", "left", "bottom",
-            "right-bottom", "left-bottom",
-            "top",
-            "right-top", "left-top",
-            "back",
-            "right-back", "left-back",
-            "bottom-back", "right-bottom-back", "left-bottom-back",
-            "top-back", "right-top-back", "left-top-back",
-            "front",
-            "right-front", "left-front",
-            "bottom-front", "right-bottom-front", "left-bottom-front",
-            "top-front", "right-top-front", "left-top-front"
-        };
-        return names[exchange];
-    }
-};
-
-/**
- * Defines number of dimensions (1-3)
- */
-
-#define DIM1 1u
-#define DIM2 2u
-#define DIM3 3u
-
-/**
- * Internal event/task type used for notifications in the event system.
- */
-enum EventType
-{
-    FINISHED, COPYHOST2DEVICE, COPYDEVICE2HOST, COPYDEVICE2DEVICE, SENDFINISHED, RECVFINISHED, LOGICALAND, SETVALUE, GETVALUE, KERNEL
-};
-
-/**
- * Print a cuda error message including file/line info to stderr
- */
-#define PMACC_PRINT_CUDA_ERROR(msg) \
-    std::cerr << "[CUDA] Error: <" << __FILE__ << ">:" << __LINE__ << " " << msg << std::endl
-
-/**
- * Print a cuda error message including file/line info to stderr and raises an exception
- */
-#define PMACC_PRINT_CUDA_ERROR_AND_THROW(cudaError, msg) \
-    PMACC_PRINT_CUDA_ERROR(msg);                         \
-    throw std::runtime_error(std::string("[CUDA] Error: ") + std::string(cudaGetErrorString(cudaError)))
-
-/**
- * Captures CUDA errors and prints messages to stdout, including line number and file.
- *
- * @param cmd command with cudaError_t return value to check
- */
-#define CUDA_CHECK(cmd) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR_AND_THROW(error, ""); }}
-
-#define CUDA_CHECK_MSG(cmd,msg) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR_AND_THROW(error, msg); }}
-
-#define CUDA_CHECK_NO_EXCEPT(cmd) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR(""); }}
-
-/** calculate and set the optimal alignment for data
-  *
-  * you must align all arrays and structs that are used on the device
-  * @param byte size of data in bytes
-  */
-#define __optimal_align__(byte)                                                \
-    alignas(                                                                 \
-        /** \bug avoid bug if alignment is >16 byte                            \
-         * https://github.com/ComputationalRadiationPhysics/picongpu/issues/1563 \
-         */                                                                    \
-        PMACC_MIN(PMACC_ROUND_UP_NEXT_POW2(byte),16)                           \
-    )
-
-#define PMACC_ALIGN(var,...) __optimal_align__(sizeof(__VA_ARGS__)) __VA_ARGS__ var
-#define PMACC_ALIGN8( var, ... ) alignas( 8 ) __VA_ARGS__ var
-
-/*! area which is calculated
- *
- * CORE is the inner area of a grid
- * BORDER is the border of a grid (my own border, not the neighbor part)
- */
-enum AreaType
-{
-    CORE = 1u, BORDER = 2u, GUARD = 4u
-};
-
-#define __delete(var) if((var)) { delete (var); var=nullptr; }
-#define __deleteArray(var) if((var)) { delete[] (var); var=nullptr; }
-
-/**
- * Visual Studio has a bug with constexpr variables being captured in lambdas as
- * non-constexpr variables, causing build errors. The issue has been verified
- * for versions 14.0 and 15.5 (latest at the moment) and is also reported in
- * https://stackoverflow.com/questions/28763375/using-lambda-captured-constexpr-value-as-an-array-dimension
- * and related issue
- * https://developercommunity.visualstudio.com/content/problem/1997/constexpr-not-implicitely-captured-in-lambdas.html
- *
- * As a workaround (until this is fixed in VS) add a new PMACC_CONSTEXPR_CAPTURE
- * macro for declaring constexpr variables that are captured in lambdas and have
- * to remain constexpr inside a lambda e.g., used as a template argument. Such
- * variables have to be declared with PMACC_CONSTEXPR_CAPTURE instead of
- * constexpr. The macro will be replaced with just constexpr for other compilers
- * and for Visual Studio with static constexpr, which makes it capture properly.
- *
- * Note that this macro is to be used only in very few cases, where not only a
- * constexpr is captured, but also it has to remain constexpr inside a lambda.
- */
-#ifdef _MSC_VER
-#   define PMACC_CONSTEXPR_CAPTURE static constexpr
-#else
-#   define PMACC_CONSTEXPR_CAPTURE constexpr
-#endif
-
-/** C++11 and C++14 explicit fallthrough in switch cases
- *
- * Use [[fallthrough]] in C++17
- */
-#if (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(7,0,0))
-#   define PMACC_FALLTHROUGH [[gnu::fallthrough]]
-#elif BOOST_COMP_CLANG
-#   define PMACC_FALLTHROUGH [[clang::fallthrough]]
-#else
-#   define PMACC_FALLTHROUGH ( (void)0 )
-#endif
 
 } //namespace pmacc


### PR DESCRIPTION
Cleanup the misc header `pmacc/types.hpp` ([our eierlegende Wollmilchsau](https://de.wikipedia.org/wiki/Eierlegende_Wollmilchsau)) to support later refactorings of other classes to support compiling in independent compile units.

Move all definitions from types.hpp in independant files.

This PR is not changing the implementations and is fully backward compatible. To support the backwards compatibility all definitions within a hierarchical namespace is pulled into the pmacc namespace.