### PR TITLE
Include int16 and uint16 types as traits for ADIOS

### DIFF
--- a/include/picongpu/traits/AdiosToPIC.tpp
+++ b/include/picongpu/traits/AdiosToPIC.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2019 Axel Huebl, Felix Schmitt
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -29,6 +29,18 @@ namespace picongpu
 
 namespace traits
 {
+
+    template<>
+    struct AdiosToPIC<adios_short>
+    {
+        typedef int16_t type;
+    };
+
+    template<>
+    struct AdiosToPIC<adios_unsigned_short>
+    {
+        typedef uint16_t type;
+    };
 
     template<>
     struct AdiosToPIC<adios_integer>

--- a/include/picongpu/traits/PICToAdios.tpp
+++ b/include/picongpu/traits/PICToAdios.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2019 Axel Huebl, Felix Schmitt
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -43,6 +43,24 @@ namespace traits
             sizeof(bool) == 1,
             ADIOS_Plugin__Can_not_find_a_one_byte_representation_of_bool
         );
+    };
+
+    template<>
+    struct PICToAdios<int16_t>
+    {
+        ADIOS_DATATYPES type;
+
+        PICToAdios() :
+        type(adios_short) {}
+    };
+
+    template<>
+    struct PICToAdios<uint16_t>
+    {
+        ADIOS_DATATYPES type;
+
+        PICToAdios() :
+        type(adios_unsigned_short) {}
     };
 
     template<>


### PR DESCRIPTION
Based on the discussion #2928 this PR fixes a bug, in which picongpu fails to compile when both ADIOS and particle merging are activated. Hence `int16` and `uint16` are now included as traits for ADIOS.
