### PR TITLE
Fix k80.tpl and k80_restart.tpl for Hemera

### DIFF
--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -24,7 +24,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=$proj
+#SBATCH --account=!proj
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -47,7 +47,7 @@ fi`
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=$proj
+#SBATCH --account=!proj
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName


### PR DESCRIPTION
Of course environment variables are not replaced in the sbatch script if they are called with a dollar sign in front. 
The right way with TBG is to use an exclamation mark.
This PR fixes #2931.

Thanks @finnolec for reporting this.
**CC'ing** @wany12 