### PR TITLE
fix hemera k80_restart.tpl

### DIFF
--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -34,10 +34,18 @@
 
 # required GPUs per node for the current job
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
-fi`
 
-#number of cores per parallel node / default is 2 cores (4 HT threads) per gpu on k80 queue
-.TBG_coresPerNode="$(( TBG_gpusPerNode * 2 ))"
+# host memory per gpu
+.TBG_memPerGPU="$((238000 / $TBG_gpusPerNode))"
+# host memory per node
+.TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
+
+# number of cores to block per GPU - we got 2 cpus per gpu
+#   and we will be accounted 2 CPUs per GPU anyway
+.TBG_coresPerGPU=2
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
 
 # use ceil to caculate nodes
 .TBG_nodes="$(( ( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
@@ -62,10 +70,10 @@ fi`
 #SBATCH --mail-user=!TBG_mailAddress
 #SBATCH --workdir=!TBG_dstPath
 
+# do not overwrite existing stderr and stdout files
+#SBATCH --open-mode=append
 #SBATCH -o stdout
 #SBATCH -e stderr
-
-echo 'Running program...' | tee -a output
 
 cd !TBG_dstPath
 
@@ -81,13 +89,16 @@ unset MODULES_NO_OUTPUT
 umask 0027
 
 mkdir simOutput 2> /dev/null
-cd simOutput
-ln -s ../stdout output
-
-
 sleep 1
+cd simOutput
 
-echo "----- automated restart routine -----" | tee -a output
+if [ ! -f output ]
+then
+    ln -s ../stdout output 2> /dev/null
+fi
+
+echo 'Running program...'
+echo "----- automated restart routine -----"
 
 #check whether last checkpoint is valid
 file=""
@@ -99,34 +110,39 @@ then
     fileEnding="bp"
 fi
 
-for file in `ls -t ./checkpoints/checkpoint_*.$fileEnding`
+for file in $(ls -t ./checkpoints/checkpoint_*.$fileEnding 2>/dev/null)
 do
-    echo -n "validate checkpoint $file: " | tee -a output
+    echo -n "validate checkpoint $file: "
     $fileEnding"ls" $file &> /dev/null
     if [ $? -eq 0 ]
     then
-        echo "OK" | tee -a output
+        echo "OK"
         break
     else
-        echo "FAILED" | tee -a output
+        echo "FAILED $?"
         file=""
     fi
 done
 
 #this sed call extracts the final simulation step from the cfg (assuming a standard cfg)
 finalStep=`echo !TBG_programParams | sed 's/.*-s[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
-echo "final step      = " $finalStep | tee -a output
+echo "final step      = " $finalStep
 #this sed call extracts the -s and --checkpoint flags
 programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9,:,\,]\+[^\s]//g'`
 #extract restart period
 restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9,:,\,]\+[^\s]\).*/\1/'`
-echo  "restart period = " $restartPeriod | tee -a output
+echo  "restart period = " $restartPeriod
 
 
 # ******************************************* #
 # need some magic, if the restart period is in new notation with the ':' and ','
 
-currentStep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
+if [ -z "$file" ]; then
+    currentStep=0
+else
+    currentStep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
+fi
+
 nextStep=$(nextstep_from_period.sh $restartPeriod $finalStep $currentStep)
 
 if [ -z "$file" ]; then
@@ -137,7 +153,7 @@ fi
 
 # ******************************************* #
 
-echo "--- end automated restart routine ---" | tee -a output
+echo "--- end automated restart routine ---"
 
 #wait that all nodes see ouput folder
 sleep 1
@@ -149,23 +165,21 @@ export OMPI_MCA_io=^ompio
 
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
-  mpiexec --prefix $MPIHOME -tag-output --display-map -x LIBRARY_PATH -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "no binary 'cuda_memtest' available or compute node is not exclusively allocated, skip GPU memory test" >&2
 fi
 
 if [ $? -eq 0 ] ; then
-  mpiexec --prefix $MPIHOME -x LIBRARY_PATH -tag-output --display-map -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/picongpu $stepSetup !TBG_author $programParams | tee -a output
+  mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu $stepSetup !TBG_author $programParams
 fi
-
-mpiexec --prefix $MPIHOME -x LIBRARY_PATH -npernode !TBG_gpusPerNode -n !TBG_tasks /usr/bin/env bash -c "killall -9 picongpu 2>/dev/null || true"
 
 if [ $nextStep -lt $finalStep ]
 then
-    ssh hemera4 "/usr/bin/sbatch !TBG_dstPath/tbg/submit.start"
+    /usr/bin/sbatch "!TBG_dstPath/tbg/submit.start"
     if [ $? -ne 0 ] ; then
-        echo "error during job submission" | tee -a output
+        echo "error during job submission"
     else
-        echo "job submitted" | tee -a output
+        echo "job submitted"
     fi
 fi


### PR DESCRIPTION
The restart template for hemera's k80 queue was not working.

- fix that stdout and stderr was always overwritten by the batch system
- fix that `tee` was used and all output was written twice into the log file
- fix re-submit (resubmit directly from the node)
- fix mpiexec command
- fix broken start of a simulation where the folder `checkpoint` not exists
- add missing required node memory calculation