### PR TITLE
Remove unused ABSORBER_FADE_IN_STEPS from .param files in examples

### DIFF
--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/grid.param
@@ -59,8 +59,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.

--- a/share/picongpu/examples/Bunch/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/grid.param
@@ -68,8 +68,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
@@ -89,8 +89,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/grid.param
@@ -68,8 +68,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/grid.param
@@ -73,8 +73,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/grid.param
@@ -68,8 +68,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/grid.param
@@ -79,8 +79,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/grid.param
@@ -68,8 +68,6 @@ namespace picongpu
         {1.0e-3, 1.0e-3}  /*z direction [negative,positive]*/
     }; //unit: none
 
-    constexpr uint32_t ABSORBER_FADE_IN_STEPS = 16;
-
     /** When to move the co-moving window.
      *  An initial pseudo particle, flying with the speed of light,
      *  is fired at the begin of the simulation.


### PR DESCRIPTION
This variable is set in most examples, but never used in the code or other input files. I assume it is left from some older times.

While looking for encounters of this name, I've found #390 , which seems already outdated and with this PR is definitely outdated.