### PR TITLE
Remove unused getCommTag() in FieldE, FieldB, FieldJ

### DIFF
--- a/include/picongpu/fields/FieldB.hpp
+++ b/include/picongpu/fields/FieldB.hpp
@@ -74,8 +74,6 @@ namespace picongpu
 
         static std::string getName();
 
-        static uint32_t getCommTag();
-
         virtual EventTask asyncCommunication(EventTask serialEvent);
 
         DataBoxType getHostDataBox();

--- a/include/picongpu/fields/FieldB.tpp
+++ b/include/picongpu/fields/FieldB.tpp
@@ -219,10 +219,4 @@ FieldB::getName( )
     return "B";
 }
 
-uint32_t
-FieldB::getCommTag( )
-{
-    return FIELD_B;
-}
-
 } //namespace picongpu

--- a/include/picongpu/fields/FieldE.hpp
+++ b/include/picongpu/fields/FieldE.hpp
@@ -75,8 +75,6 @@ namespace picongpu
 
         static std::string getName();
 
-        static uint32_t getCommTag();
-
         virtual EventTask asyncCommunication(EventTask serialEvent);
 
         DataBoxType getDeviceDataBox();

--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -207,10 +207,4 @@ FieldE::getName( )
     return "E";
 }
 
-uint32_t
-FieldE::getCommTag( )
-{
-    return FIELD_E;
-}
-
 }

--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -98,8 +98,6 @@ public:
 
     static std::string getName();
 
-    static uint32_t getCommTag();
-
     template<uint32_t AREA, class ParticlesClass>
     void computeCurrent(ParticlesClass &parClass, uint32_t currentStep);
 

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -251,12 +251,6 @@ FieldJ::getName( )
     return "J";
 }
 
-uint32_t
-FieldJ::getCommTag( )
-{
-    return FIELD_J;
-}
-
 template<uint32_t AREA, class ParticlesClass>
 void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
 {


### PR DESCRIPTION
This is probably some legacy, that is no longer used.