### PR TITLE
Add pmacc::memory::makeUnique similar to std::make_unique

### DIFF
--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -28,6 +28,7 @@
 #include "picongpu/particles/traits/GetInterpolation.hpp"
 
 #include <pmacc/memory/buffers/GridBuffer.hpp>
+#include <pmacc/memory/MakeUnique.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
@@ -63,13 +64,13 @@ namespace picongpu
         m_commTagGather = ++pmacc::traits::detail::GetUniqueTypeId< uint8_t >::counter +
             SPECIES_FIRSTTAG;
 
-        fieldTmp.reset(
-            new GridBuffer <ValueType, simDim >( cellDescription.getGridLayout( ) )
-        );
+        using Buffer = GridBuffer< ValueType, simDim >;
+        fieldTmp = memory::makeUnique< Buffer >( cellDescription.getGridLayout( ) );
 
         if( fieldTmpSupportGatherCommunication )
-            fieldTmpRecv.reset(
-                new GridBuffer< ValueType, simDim >( fieldTmp->getDeviceBuffer(), cellDescription.getGridLayout( ) )
+            fieldTmpRecv = memory::makeUnique< Buffer >(
+                fieldTmp->getDeviceBuffer(),
+                cellDescription.getGridLayout( )
             );
 
         /** \todo The exchange has to be resetted and set again regarding the

--- a/include/pmacc/memory/MakeUnique.hpp
+++ b/include/pmacc/memory/MakeUnique.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2019 Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+
+namespace pmacc
+{
+namespace memory
+{
+
+    /*
+     * Analogue of std::make_unique for C++11, except not disabled for arrays.
+     * Implementation is taken from
+     * https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
+     */
+    template<
+        typename T,
+        typename ... T_Args
+    >
+    inline std::unique_ptr< T > makeUnique( T_Args && ... args )
+    {
+        return std::unique_ptr< T >( new T( std::forward< T_Args >( args ) ... ) );
+    }
+
+} // namespace memory
+} // namespace pmacc

--- a/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -26,6 +26,7 @@
 #include <pmacc/nvidia/functors/Assign.hpp>
 #include <pmacc/memory/boxes/CachedBox.hpp>
 #include <pmacc/memory/dataTypes/Mask.hpp>
+#include <pmacc/memory/MakeUnique.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
 #include <pmacc/nvidia/rng/RNG.hpp>
 #include <pmacc/nvidia/rng/methods/Xor.hpp>
@@ -241,11 +242,9 @@ namespace kernel
             Space const & guardSize
         )
         {
-            mapping = std::unique_ptr< T_MappingDesc >(
-                new T_MappingDesc(
-                    layout,
-                    guardSize
-                )
+            mapping = memory::makeUnique< T_MappingDesc >(
+                layout,
+                guardSize
             );
         }
 


### PR DESCRIPTION
`std::make_unique` is C++14, so we need own C++11 implementation. It has been [discussed and agreed on long time ago](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2669#discussion_r208204183). Now due to recent offline talks to @psychocoderHPC we will use `std::unique_ptr` more actively and so having a creation routine is useful.

New implementation is taken from cppreference (link in comments). It does not handle arrays in the standard way, but I think this is fine for us.

I've also replaced all current creation of unique pointers with the new function, it was really not a lot.