### PR TITLE
Add implementation of PML

### DIFF
--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -51,6 +51,14 @@ laser.param
 
    laser/profiles.rst
 
+pml.param
+^^^^^^^^^
+
+.. doxygenfile:: pml.param
+   :project: PIConGPU
+   :path: include/picongpu/param/pml.param
+   :no-link:
+
 pusher.param
 ^^^^^^^^^^^^
 

--- a/include/picongpu/_defaultParam.loader
+++ b/include/picongpu/_defaultParam.loader
@@ -43,6 +43,7 @@
 #include "picongpu/param/ionizationEnergies.param"
 #include "picongpu/param/density.param"
 #include "picongpu/param/particle.param"
+#include "picongpu/param/pml.param"
 #include "picongpu/param/unit.param"
 #include "picongpu/param/particleFilters.param"
 #if( PMACC_CUDA_ENABLED == 1 )

--- a/include/picongpu/_defaultUnitless.loader
+++ b/include/picongpu/_defaultUnitless.loader
@@ -31,6 +31,7 @@
 #include "picongpu/unitless/grid.unitless"
 #include "picongpu/unitless/density.unitless"
 #include "picongpu/unitless/particle.unitless"
+#include "picongpu/unitless/pml.unitless"
 #include "picongpu/unitless/pusher.unitless"
 #include "picongpu/unitless/ionizer.unitless"
 #include "picongpu/unitless/speciesAttributes.unitless"

--- a/include/picongpu/fields/MaxwellSolver/Solvers.def
+++ b/include/picongpu/fields/MaxwellSolver/Solvers.def
@@ -23,6 +23,7 @@
 
 #include "picongpu/fields/MaxwellSolver/None/None.def"
 #include "picongpu/fields/MaxwellSolver/Yee/Yee.def"
+#include "picongpu/fields/MaxwellSolver/YeePML/YeePML.def"
 #if (SIMDIM==3)
 #include "picongpu/fields/MaxwellSolver/Lehe/Lehe.def"
 #if( PMACC_CUDA_ENABLED == 1 )

--- a/include/picongpu/fields/MaxwellSolver/Solvers.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Solvers.hpp
@@ -23,6 +23,7 @@
 
 #include "picongpu/fields/MaxwellSolver/None/None.hpp"
 #include "picongpu/fields/MaxwellSolver/Yee/Yee.hpp"
+#include "picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp"
 #if (SIMDIM==3)
 #include "picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp"
 #if( PMACC_CUDA_ENABLED == 1 )

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
@@ -1,0 +1,157 @@
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+/*pic default*/
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/Fields.def"
+#include <pmacc/fields/SimulationFieldHelper.hpp>
+#include <pmacc/dataManagement/ISimulationData.hpp>
+
+/*PMacc*/
+#include <pmacc/memory/buffers/GridBuffer.hpp>
+#include <pmacc/mappings/simulation/GridController.hpp>
+#include <pmacc/memory/boxes/DataBox.hpp>
+#include <pmacc/memory/boxes/PitchedBox.hpp>
+
+#include <pmacc/math/Vector.hpp>
+
+#include <memory>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+namespace yeePML
+{
+
+    //! Additional node values for E or B in PML
+    struct NodeValues
+    {
+        float_X xy, xz, yx, yz, zx, zy;
+    };
+
+    //! Base class for field in PML
+    class Field : public SimulationFieldHelper<MappingDesc>, public ISimulationData
+    {
+    public:
+
+        using ValueType = NodeValues;
+        using UnitValueType = float_X ;
+
+        typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
+
+        typedef MappingDesc::SuperCellSize SuperCellSize;
+
+        Field( MappingDesc cellDescription);
+
+        virtual void reset(uint32_t currentStep);
+
+        HDINLINE static UnitValueType getUnit();
+
+        /** powers of the 7 base measures
+         *
+         * characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         *  thermodynamic temperature theta, amount of substance N,
+         *  luminous intensity J) */
+        HINLINE static std::vector<float_64> getUnitDimension();
+
+        virtual EventTask asyncCommunication(EventTask serialEvent);
+
+        DataBoxType getHostDataBox();
+
+        GridLayout<simDim> getGridLayout();
+
+        DataBoxType getDeviceDataBox();
+
+        GridBuffer<ValueType, simDim> &getGridBuffer();
+
+        void synchronize();
+
+        void syncToDevice();
+
+    private:
+
+        using Buffer = pmacc::GridBuffer<
+            ValueType,
+            simDim
+        >;
+        std::unique_ptr< Buffer > data;
+    };
+
+    //! Additional electric field components in PML
+    class FieldE : public Field
+    {
+    public:
+
+        FieldE( MappingDesc cellDescription):
+            Field( cellDescription )
+        {
+        }
+
+        SimulationDataId getUniqueId( )
+        {
+            return getName();
+        }
+
+        static std::string getName( )
+        {
+            return "PML E components";
+        }
+
+    };
+
+    //! Additional magnetic field components in PML
+    class FieldB : public Field
+    {
+    public:
+
+        FieldB( MappingDesc cellDescription):
+            Field( cellDescription )
+        {
+        }
+
+        SimulationDataId getUniqueId( )
+        {
+            return getName();
+        }
+
+        static std::string getName( )
+        {
+            return "PML B components";
+        }
+
+    };
+
+} // namespace yeePML
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
@@ -18,29 +18,22 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
-#include <string>
-#include <vector>
-
-/*pic default*/
 #include "picongpu/simulation_defines.hpp"
-
 #include "picongpu/fields/Fields.def"
-#include <pmacc/fields/SimulationFieldHelper.hpp>
-#include <pmacc/dataManagement/ISimulationData.hpp>
 
-/*PMacc*/
+#include <pmacc/dataManagement/ISimulationData.hpp>
+#include <pmacc/fields/SimulationFieldHelper.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/memory/boxes/PitchedBox.hpp>
-
 #include <pmacc/math/Vector.hpp>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 
 namespace picongpu
@@ -59,44 +52,44 @@ namespace yeePML
     };
 
     //! Base class for field in PML
-    class Field : public SimulationFieldHelper<MappingDesc>, public ISimulationData
+    class Field : public SimulationFieldHelper< MappingDesc >, public ISimulationData
     {
     public:
 
         using ValueType = NodeValues;
         using UnitValueType = float_X ;
 
-        typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
+        typedef DataBox< PitchedBox< ValueType, simDim > > DataBoxType;
 
         typedef MappingDesc::SuperCellSize SuperCellSize;
 
         Field( MappingDesc cellDescription);
 
-        virtual void reset(uint32_t currentStep);
+        virtual void reset( uint32_t currentStep );
 
-        HDINLINE static UnitValueType getUnit();
+        HDINLINE static UnitValueType getUnit( );
 
         /** powers of the 7 base measures
          *
          * characterizing the record's unit in SI
          * (length L, mass M, time T, electric current I,
-         *  thermodynamic temperature theta, amount of substance N,
-         *  luminous intensity J) */
-        HINLINE static std::vector<float_64> getUnitDimension();
+         * thermodynamic temperature theta, amount of substance N,
+         * luminous intensity J) */
+        HINLINE static std::vector< float_64 > getUnitDimension( );
 
-        virtual EventTask asyncCommunication(EventTask serialEvent);
+        virtual EventTask asyncCommunication( EventTask serialEvent );
 
-        DataBoxType getHostDataBox();
+        DataBoxType getHostDataBox( );
 
-        GridLayout<simDim> getGridLayout();
+        GridLayout< simDim > getGridLayout( );
 
-        DataBoxType getDeviceDataBox();
+        DataBoxType getDeviceDataBox( );
 
-        GridBuffer<ValueType, simDim> &getGridBuffer();
+        GridBuffer< ValueType, simDim > & getGridBuffer( );
 
-        void synchronize();
+        void synchronize( );
 
-        void syncToDevice();
+        void syncToDevice( );
 
     private:
 
@@ -119,7 +112,7 @@ namespace yeePML
 
         SimulationDataId getUniqueId( )
         {
-            return getName();
+            return getName( );
         }
 
         static std::string getName( )
@@ -141,7 +134,7 @@ namespace yeePML
 
         SimulationDataId getUniqueId( )
         {
-            return getName();
+            return getName( );
         }
 
         static std::string getName( )

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
@@ -21,35 +21,28 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-
+#include "picongpu/fields/FieldManipulator.hpp"
 #include "picongpu/fields/MaxwellSolver/YeePML/Field.hpp"
+#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
+#include "picongpu/fields/numericalCellTypes/NumericalCellTypes.hpp"
+#include "picongpu/particles/traits/GetInterpolation.hpp"
+#include "picongpu/particles/traits/GetMarginPusher.hpp"
+#include "picongpu/traits/GetMargin.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
 
+#include <pmacc/dimensions/SuperCellDescription.hpp>
 #include <pmacc/eventSystem/EventSystem.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/mappings/kernel/ExchangeMapping.hpp>
-#include <pmacc/memory/buffers/GridBuffer.hpp>
-
-#include "picongpu/fields/FieldManipulator.hpp"
-
-#include <pmacc/dimensions/SuperCellDescription.hpp>
-
-#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
-#include "picongpu/fields/numericalCellTypes/NumericalCellTypes.hpp"
-
 #include <pmacc/math/Vector.hpp>
-
-#include "picongpu/particles/traits/GetInterpolation.hpp"
+#include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/particles/traits/FilterByFlag.hpp>
-
-#include "picongpu/traits/GetMargin.hpp"
-#include "picongpu/traits/SIBaseUnits.hpp"
-#include "picongpu/particles/traits/GetMarginPusher.hpp"
 
 #include <boost/mpl/accumulate.hpp>
 
-#include <list>
 #include <iostream>
+#include <list>
 #include <memory>
 
 
@@ -63,10 +56,10 @@ namespace yeePML
 {
 
     Field::Field( MappingDesc cellDescription ) :
-    SimulationFieldHelper<MappingDesc>( cellDescription )
+    SimulationFieldHelper< MappingDesc >( cellDescription )
     {
         data.reset(
-            new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) )
+            new GridBuffer< ValueType, simDim > ( cellDescription.getGridLayout( ) )
         );
     }
 
@@ -86,7 +79,7 @@ namespace yeePML
         return eB;
     }
 
-    GridLayout<simDim> Field::getGridLayout( )
+    GridLayout< simDim > Field::getGridLayout( )
     {
         return cellDescription.getGridLayout( );
     }
@@ -101,9 +94,8 @@ namespace yeePML
         return data->getDeviceBuffer( ).getDataBox( );
     }
 
-    GridBuffer<Field::ValueType, simDim> &Field::getGridBuffer( )
+    GridBuffer< Field::ValueType, simDim > & Field::getGridBuffer( )
     {
-
         return *data;
     }
 
@@ -122,10 +114,10 @@ namespace yeePML
     }
 
     HINLINE
-    std::vector<float_64>
+    std::vector< float_64 >
     Field::getUnitDimension( )
     {
-        std::vector<float_64> unitDimension( 7, 0.0 );
+        std::vector< float_64 > unitDimension( 7, 0.0 );
         return unitDimension;
     }
 

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
@@ -1,0 +1,135 @@
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/MaxwellSolver/YeePML/Field.hpp"
+
+#include <pmacc/eventSystem/EventSystem.hpp>
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/mappings/kernel/ExchangeMapping.hpp>
+#include <pmacc/memory/buffers/GridBuffer.hpp>
+
+#include "picongpu/fields/FieldManipulator.hpp"
+
+#include <pmacc/dimensions/SuperCellDescription.hpp>
+
+#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
+#include "picongpu/fields/numericalCellTypes/NumericalCellTypes.hpp"
+
+#include <pmacc/math/Vector.hpp>
+
+#include "picongpu/particles/traits/GetInterpolation.hpp"
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+#include "picongpu/traits/GetMargin.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
+#include "picongpu/particles/traits/GetMarginPusher.hpp"
+
+#include <boost/mpl/accumulate.hpp>
+
+#include <list>
+#include <iostream>
+#include <memory>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+namespace yeePML
+{
+
+    Field::Field( MappingDesc cellDescription ) :
+    SimulationFieldHelper<MappingDesc>( cellDescription )
+    {
+        data.reset(
+            new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) )
+        );
+    }
+
+    void Field::synchronize( )
+    {
+        data->deviceToHost( );
+    }
+
+    void Field::syncToDevice( )
+    {
+        data->hostToDevice( );
+    }
+
+    EventTask Field::asyncCommunication( EventTask serialEvent )
+    {
+        EventTask eB = data->asyncCommunication( serialEvent );
+        return eB;
+    }
+
+    GridLayout<simDim> Field::getGridLayout( )
+    {
+        return cellDescription.getGridLayout( );
+    }
+
+    Field::DataBoxType Field::getHostDataBox( )
+    {
+        return data->getHostBuffer( ).getDataBox( );
+    }
+
+    Field::DataBoxType Field::getDeviceDataBox( )
+    {
+        return data->getDeviceBuffer( ).getDataBox( );
+    }
+
+    GridBuffer<Field::ValueType, simDim> &Field::getGridBuffer( )
+    {
+
+        return *data;
+    }
+
+    void Field::reset( uint32_t )
+    {
+        data->getHostBuffer( ).reset( true );
+        data->getDeviceBuffer( ).reset( false );
+    }
+
+
+    HDINLINE
+    Field::UnitValueType
+    Field::getUnit( )
+    {
+        return UnitValueType( 1.0_X );
+    }
+
+    HINLINE
+    std::vector<float_64>
+    Field::getUnitDimension( )
+    {
+        std::vector<float_64> unitDimension( 7, 0.0 );
+        return unitDimension;
+    }
+
+} // namespace yeePML
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Parameters.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Parameters.hpp
@@ -1,0 +1,122 @@
+/* Copyright 2019 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+namespace yeePML
+{
+
+    /** Parameters of PML, except thickness
+     *
+     * A detailed description and recommended ranges are given in pml.param,
+     * normalizations and unit conversions in pml.unitless.
+     */
+    struct Parameters
+    {
+        /** Max value of artificial electric conductivity
+         *
+         * Components correspond to directions. Normalized, so that
+         * normalizedSigma = sigma / eps0 = sigma* / mue0.
+         * Unit: 1/unit_time in PIC units
+         */
+        floatD_X normalizedSigmaMax;
+
+        /** Order of polynomial growth of sigma and kappa
+         *
+         * The growth is from PML internal boundary to the external boundary.
+         * Sigma grows from 0, kappa from 1, both to their max values.
+         */
+        float_X sigmaKappaGradingOrder;
+
+        /** Max value of coordinate stretching coefficient
+         *
+         * Unitless.
+         */
+        floatD_X kappaMax;
+
+        /** Max value of complex frequency shift
+         *
+         * Components correspond to directions. Normalized by eps0.
+         * Unit: 1/unit_time in PIC units
+         */
+        floatD_X normalizedAlphaMax;
+
+        /** Order of polynomial growth of alpha
+         *
+         * The growth is from PML external boundary to the internal boundary.
+         * Grows from 0 to the max value.
+         */
+        float_X alphaGradingOrder;
+    };
+
+    //! Thickness of PML at each border, in number of cells
+    struct Thickness
+    {
+        //! Negative border is at the local domain sides minimum in coordinates
+        DataSpace< simDim > negativeBorder;
+        //! Positive border is at the local domain sides maximum in coordinates
+        DataSpace< simDim > positiveBorder;
+
+        /** Element access with indexing used in the .param file
+         *
+         * This is only for initialization convenience and so does not have
+         * a device version. Since this is not performance-critical at all,
+         * do range checks on parameters.
+         *
+         * @param axis 0 = x, 1 = y, 2 = z
+         * @param direction 0 = negative, 1 = positive
+         */
+        int & operator()( uint32_t const axis, uint32_t const direction )
+        {
+            if( axis >= simDim )
+                throw std::out_of_range(
+                    "In Thickness::operator() the axis = " +
+                    std::to_string( axis ) + " is invalid"
+                );
+            if( direction == 0 )
+                return negativeBorder[ axis ];
+            else
+                if( direction == 1 )
+                    return positiveBorder[ axis ];
+                else
+                    throw std::out_of_range(
+                        "In Thickness::operator() the direction = " +
+                        std::to_string( direction ) +  " is invalid"
+                    );
+        }
+    };
+
+} // namespace yeePML
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.def
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.def
@@ -1,0 +1,93 @@
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera,
+ *                     Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/MaxwellSolver/Yee/Curl.def"
+#include "picongpu/fields/MaxwellSolver/Yee/Yee.def"
+#include "picongpu/fields/currentInterpolation/CurrentInterpolation.def"
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+
+    template<
+        typename T_CurrentInterpolation = currentInterpolation::None,
+        typename T_CurlE = yee::CurlRight,
+        typename T_CurlB = yee::CurlLeft
+    >
+    class YeePML;
+
+} // namespace maxwellSolver
+} // namespace fields
+
+namespace traits
+{
+
+    template<
+        typename T_CurrentInterpolation,
+        typename T_CurlE,
+        typename T_CurlB
+    >
+    struct GetMargin<
+        picongpu::fields::maxwellSolver::YeePML<
+            T_CurrentInterpolation,
+            T_CurlE,
+            T_CurlB
+        >, FIELD_B
+    > : public GetMargin<
+        picongpu::fields::maxwellSolver::Yee<
+            T_CurrentInterpolation,
+            T_CurlE,
+            T_CurlB
+        >,
+        FIELD_B
+    >
+    {
+    };
+
+    template<
+        typename T_CurrentInterpolation,
+        typename T_CurlE,
+        typename T_CurlB
+    >
+    struct GetMargin<
+        picongpu::fields::maxwellSolver::YeePML<
+            T_CurrentInterpolation,
+            T_CurlE,
+            T_CurlB
+        >, FIELD_E
+    > : public GetMargin<
+        picongpu::fields::maxwellSolver::Yee<
+            T_CurrentInterpolation,
+            T_CurlE,
+            T_CurlB
+        >,
+        FIELD_E
+    >
+    {
+    };
+
+} //namespace traits
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -1,0 +1,431 @@
+/* Copyright 2019 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/MaxwellSolver/YeePML/Field.hpp"
+#include "picongpu/fields/MaxwellSolver/YeePML/Parameters.hpp"
+#include "picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel"
+#include "picongpu/fields/numericalCellTypes/NumericalCellTypes.hpp"
+
+#include <pmacc/memory/MakeUnique.hpp>
+#include <pmacc/traits/GetStringProperties.hpp>
+
+#include <stdexcept>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+
+    /* Note: the yeePML namespace is only used for details and not the YeePML
+     * itself in order to be consistent with other field solvers.
+     */
+    namespace yeePML
+    {
+    namespace detail
+    {
+
+        /** Implementation of Yee + PML solver updates of E and B
+         *
+         * The original paper on this approach is J.A. Roden, S.D. Gedney.
+         * Convolution PML (CPML): An efficient FDTD implementation of the
+         * CFS - PML for arbitrary media. Microwave and optical technology
+         * letters. 27 (5), 334-339 (2000).
+         * https://doi.org/10.1002/1098-2760(20001205)27:5%3C334::AID-MOP14%3E3.0.CO;2-A
+         * Our implementation based on a more detailed description in section
+         * 7.9 of the book A. Taflove, S.C. Hagness. Computational
+         * Electrodynamics. The Finite-Difference Time-Domain Method. Third
+         * Edition. Artech house, Boston (2005), referred to as
+         * [Taflove, Hagness].
+         *
+         * @tparam T_CurlE functor to compute curl of E
+         * @tparam T_CurlB functor to compute curl of B
+         */
+        template<
+            typename T_CurlE,
+            typename T_CurlB
+        >
+        class Solver
+        {
+        public:
+
+            using CurlE = T_CurlE;
+            using CurlB = T_CurlB;
+
+            Solver( MappingDesc const cellDescription ) :
+                cellDescription{ cellDescription }
+            {
+                initParameters( );
+                initFields( );
+            }
+
+            //! Get a reference to field E
+            picongpu::FieldE & getFieldE( )
+            {
+                return *( fieldE.get( ) );
+            }
+
+            //! Get a reference to field B
+            picongpu::FieldB & getFieldB( )
+            {
+                return *( fieldB.get( ) );
+            }
+
+            /** Propagate B values in the given area by half a time step
+             *
+             * @tparam T_Area area to apply updates to, the curl must be
+             * applicable to all points; normally CORE, BORDER, or CORE + BORDER
+             *
+             * @param currentStep index of the current time iteration
+             */
+            template< uint32_t T_Area >
+            void updateBHalf( uint32_t const currentStep )
+            {
+                constexpr auto numWorkers = getNumWorkers( );
+                using Kernel = yeePML::KernelUpdateBHalf<
+                    numWorkers,
+                    BlockDescription< CurlE >
+                >;
+                AreaMapper< T_Area > mapper{ cellDescription };
+                /* Note: here it is possible to first check if PML is enabled
+                 * in the local domain at all, and otherwise optimize by calling
+                 * the normal Yee update kernel. We do not do that, as this
+                 * would be fragile wrt future separation of PML into a plugin.
+                 */
+                PMACC_KERNEL( Kernel{ } )
+                    ( mapper.getGridDim( ), numWorkers )(
+                        mapper,
+                        getLocalParameters( mapper, currentStep ),
+                        CurlE( ),
+                        fieldE->getDeviceDataBox( ),
+                        fieldB->getDeviceDataBox( ),
+                        psiB->getDeviceDataBox( )
+                    );
+            }
+
+            /** Propagate E values in the given area by a time step.
+             *
+             * @tparam T_Area area to apply updates to, the curl must be
+             * applicable to all points; normally CORE, BORDER, or CORE + BORDER
+             *
+             * @param currentStep index of the current time iteration
+             */
+            template< uint32_t T_Area >
+            void updateE( uint32_t currentStep )
+            {
+                constexpr auto numWorkers = getNumWorkers( );
+                using Kernel = yeePML::KernelUpdateE<
+                    numWorkers,
+                    BlockDescription< CurlB >
+                >;
+                AreaMapper< T_Area > mapper{ cellDescription };
+                // Note: optimization considerations same as in updateBHalf( ).
+                PMACC_KERNEL( Kernel{ } )
+                    ( mapper.getGridDim( ), numWorkers )(
+                        mapper,
+                        getLocalParameters( mapper, currentStep ),
+                        CurlB( ),
+                        fieldB->getDeviceDataBox( ),
+                        fieldE->getDeviceDataBox( ),
+                        psiE->getDeviceDataBox( )
+                    );
+            }
+
+        private:
+
+            // Helper types for configuring kernels
+            template< typename T_Curl >
+            using BlockDescription = pmacc::SuperCellDescription<
+                SuperCellSize,
+                typename T_Curl::LowerMargin,
+                typename T_Curl::UpperMargin
+            >;
+            template< uint32_t T_Area >
+            using AreaMapper = pmacc::AreaMapping<
+                T_Area,
+                MappingDesc
+            >;
+
+            // Yee solver data
+            std::shared_ptr< picongpu::FieldE > fieldE;
+            std::shared_ptr< picongpu::FieldB > fieldB;
+            MappingDesc cellDescription;
+
+            /* PML convolutional field data, defined as in [Taflove, Hagness],
+             * eq. (7.105a,b), and similar for other components
+             */
+            std::shared_ptr< yeePML::FieldE > psiE;
+            std::shared_ptr< yeePML::FieldB > psiB;
+
+            /** Thickness in terms of the global domain.
+             *
+             * We store only global thickness, as the local one can change
+             * during the simulation and so has to be recomputed each time step.
+             * There are no limitations on the size, as long as it fits a single
+             * layer of external local domains (near the global simulation area
+             * boundary) on each time step. In particular, PML is not required
+             * to be aligned with the BORDER area.
+             */
+            Thickness globalSize;
+            Parameters parameters;
+
+            void initParameters( )
+            {
+                globalSize = getGlobalThickness( );
+                parameters.sigmaKappaGradingOrder = SIGMA_KAPPA_GRADING_ORDER;
+                parameters.alphaGradingOrder = ALPHA_GRADING_ORDER;
+                for( uint32_t dim = 0u; dim < simDim; dim++ )
+                {
+                    parameters.normalizedSigmaMax[ dim ] = NORMALIZED_SIGMA_MAX[ dim ];
+                    parameters.kappaMax[ dim ] = KAPPA_MAX[ dim ];
+                    parameters.normalizedAlphaMax[ dim ] = NORMALIZED_ALPHA_MAX[ dim ];
+                }
+            }
+
+            Thickness getGlobalThickness( ) const
+            {
+                Thickness globalThickness;
+                for( uint32_t axis = 0u; axis < simDim; axis++ )
+                    for( auto direction = 0; direction < 2; direction++ )
+                        globalThickness( axis, direction ) = NUM_CELLS[ axis ][ direction ];
+                return globalThickness;
+            }
+
+            void initFields( )
+            {
+                /* Split fields are created here (and not with normal E and B)
+                * in order to not waste memory in case PML is not used.
+                */
+                DataConnector & dc = Environment<>::get( ).DataConnector( );
+                fieldE = dc.get< picongpu::FieldE >( picongpu::FieldE::getName( ), true );
+                fieldB = dc.get< picongpu::FieldB >( picongpu::FieldB::getName( ), true );
+                using pmacc::memory::makeUnique;
+                dc.share( makeUnique< yeePML::FieldE >( cellDescription ) );
+                dc.share( makeUnique< yeePML::FieldB >( cellDescription ) );
+                psiE = dc.get< yeePML::FieldE >( yeePML::FieldE::getName( ), true );
+                psiB = dc.get< yeePML::FieldB >( yeePML::FieldB::getName( ), true );
+            }
+
+            template< uint32_t T_Area >
+            yeePML::LocalParameters getLocalParameters(
+                AreaMapper< T_Area > & mapper,
+                uint32_t const currentStep
+            ) const
+            {
+                Thickness localThickness = getLocalThickness( currentStep );
+                checkLocalThickness( localThickness );
+                return yeePML::LocalParameters(
+                    parameters,
+                    localThickness,
+                    mapper.getGridSuperCells( ) * SuperCellSize::toRT( ),
+                    mapper.getGuardingSuperCells( ) * SuperCellSize::toRT( )
+                );
+            }
+
+            /**
+             * Get PML thickness for the local domain at the current time step.
+             * It depends on the current step because of the moving window.
+             */
+            Thickness getLocalThickness( uint32_t const currentStep ) const
+            {
+                /* The logic of the following checks is the same as in
+                 * FieldManipulator::absorbBorder( ), to disable the absorber
+                 * at a border we set the corresponding thickness to 0.
+                 */
+                auto & movingWindow = MovingWindow::getInstance( );
+                auto const numSlides = movingWindow.getSlideCounter( currentStep );
+                auto const numExchanges = NumberOfExchanges< simDim >::value;
+                auto const communicationMask = Environment< simDim >::get( ).GridController( ).getCommunicationMask( );
+                Thickness localThickness = globalSize;
+                for( uint32_t exchange = 1u; exchange < numExchanges; ++exchange )
+                {
+                    // Skip directions except left, right, top, bottom, back, front
+                    if( FRONT % exchange != 0 )
+                        continue;
+
+                    // Transform exchange into a pair of axis and direction
+                    uint32_t axis = 0;
+                    if( exchange >= BOTTOM && exchange <= TOP )
+                        axis = 1;
+                    if( exchange >= BACK )
+                        axis = 2;
+                    uint32_t direction = exchange % 2;
+
+                    // No PML at the borders between two local domains
+                    bool hasNeighbour = communicationMask.isSet( exchange );
+                    if( hasNeighbour )
+                        localThickness( axis, direction ) = 0;
+
+                    // Disable PML during laser initialization
+                    if( fields::laserProfiles::Selected::initPlaneY == 0 )
+                    {
+                        bool isLaserInitializationOver =
+                            (currentStep * DELTA_T) >= fields::laserProfiles::Selected::INIT_TIME;
+                        if( numSlides == 0 && !isLaserInitializationOver && exchange == TOP )
+                            localThickness( axis, direction ) = 0;
+                    }
+
+                    // Disable PML at the far side of the moving window
+                    if( movingWindow.isSlidingWindowActive( currentStep ) && exchange == BOTTOM )
+                        localThickness( axis, direction ) = 0;
+                }
+                return localThickness;
+            }
+
+            //! Verify that PML fits the local domain
+            void checkLocalThickness( Thickness const localThickness ) const
+            {
+                auto const localDomain = Environment< simDim >::get( ).SubGrid( ).getLocalDomain( );
+                auto const localPMLSize = localThickness.negativeBorder + localThickness.positiveBorder;
+                auto pmlFitsDomain = true;
+                for( uint32_t dim = 0u; dim < simDim; dim++ )
+                    if( localPMLSize[ dim ] > localDomain.size[ dim ] )
+                        pmlFitsDomain = false;
+                if( !pmlFitsDomain )
+                    throw std::out_of_range( "Requested PML size exceeds the local domain" );
+            }
+
+            //! Get number of workers for kernels
+            static constexpr uint32_t getNumWorkers( )
+            {
+                return pmacc::traits::GetNumWorkers<
+                    pmacc::math::CT::volume< SuperCellSize >::type::value
+                >::value;
+            }
+
+        };
+
+    } // namespace detail
+    } // namespace yeePML
+
+    /** Yee field solver with perfectly matched layer (PML) absorber
+     *
+     * Absorption is done using convolutional perfectly matched layer (CPML),
+     * implemented according to [Taflove, Hagness].
+     *
+     * This class template is a public interface to be used, e.g. in .param
+     * files and is compatible with other field solvers. Parameters of PML
+     * are taken from pml.param, pml.unitless.
+     *
+     * Enabling this solver results in more memory being used on a device:
+     * 12 additional scalar field values per each grid cell of a local domain.
+     * Another limitation is not full persistency with checkpointing: the
+     * additional values are not saved and so set to 0 after loading a
+     * checkpoint (which in some cases still provides proper absorption, but
+     * it is not guaranteed and results will differ due to checkpointing).
+     *
+     * This class template implements the general flow of CORE and BORDER field
+     * updates and communication. The numerical schemes to perform the updates
+     * are implemented by yeePML::detail::Solver.
+     *
+     * @tparam T_CurrentInterpolation current interpolation functor
+     * @tparam T_CurlE functor to compute curl of E
+     * @tparam T_CurlB functor to compute curl of B
+     */
+    template<
+        typename T_CurrentInterpolation,
+        typename T_CurlE,
+        typename T_CurlB
+    >
+    class YeePML
+    {
+    public:
+
+        // Types required by field solver interface
+        using NummericalCellType = picongpu::numericalCellTypes::YeeCell;
+        using CurrentInterpolation = T_CurrentInterpolation;
+        using CurlE = T_CurlE;
+        using CurlB = T_CurlB;
+
+        YeePML( MappingDesc const cellDescription ) :
+            solver( cellDescription )
+        {
+        }
+
+        /** Perform the first part of E and B propagation by a time step.
+         *
+         * Together with update_afterCurrent( ) forms the full propagation.
+         *
+         * @param currentStep index of the current time iteration
+         */
+        void update_beforeCurrent( uint32_t const currentStep )
+        {
+            /* These steps are the same as in the Yee solver,
+             * PML updates are done as part of solver.updateE( ),
+             * solver.updateBHalf( )
+             */
+            solver.template updateBHalf < CORE + BORDER >( currentStep );
+            auto & fieldB = solver.getFieldB( );
+            EventTask eRfieldB = fieldB.asyncCommunication( __getTransactionEvent( ) );
+
+            solver.template updateE< CORE >( currentStep );
+            __setTransactionEvent( eRfieldB );
+            solver.template updateE< BORDER >( currentStep );
+        }
+
+        /** Perform the last part of E and B propagation by a time step
+         *
+         * Together with update_beforeCurrent( ) forms the full propagation.
+         *
+         * @param currentStep index of the current time iteration
+         */
+        void update_afterCurrent( uint32_t const currentStep )
+        {
+            /* These steps are the same as in the Yee solver,
+             * except the FieldManipulator::absorbBorder( ) is not called,
+             * PML updates are done as part of solver.updateBHalf( ).
+             */
+            if( laserProfiles::Selected::INIT_TIME > 0.0_X )
+                LaserPhysics{ }( currentStep );
+
+            auto & fieldE = solver.getFieldE( );
+            EventTask eRfieldE = fieldE.asyncCommunication( __getTransactionEvent( ) );
+
+            solver.template updateBHalf< CORE >( currentStep );
+            __setTransactionEvent( eRfieldE );
+            solver.template updateBHalf< BORDER >( currentStep );
+
+            auto & fieldB = solver.getFieldB( );
+            EventTask eRfieldB = fieldB.asyncCommunication( __getTransactionEvent( ) );
+            __setTransactionEvent( eRfieldB );
+        }
+
+        static pmacc::traits::StringProperty getStringProperties( )
+        {
+            pmacc::traits::StringProperty propList( "name", "YeePML" );
+            return propList;
+        }
+
+    private:
+
+        yeePML::detail::Solver< CurlE, CurlB > solver;
+
+    };
+
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu
+
+#include "picongpu/fields/MaxwellSolver/YeePML/Field.tpp"

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -54,7 +54,7 @@ namespace maxwellSolver
          * CFS - PML for arbitrary media. Microwave and optical technology
          * letters. 27 (5), 334-339 (2000).
          * https://doi.org/10.1002/1098-2760(20001205)27:5%3C334::AID-MOP14%3E3.0.CO;2-A
-         * Our implementation based on a more detailed description in section
+         * Our implementation is based on a more detailed description in section
          * 7.9 of the book A. Taflove, S.C. Hagness. Computational
          * Electrodynamics. The Finite-Difference Time-Domain Method. Third
          * Edition. Artech house, Boston (2005), referred to as
@@ -112,7 +112,8 @@ namespace maxwellSolver
                 /* Note: here it is possible to first check if PML is enabled
                  * in the local domain at all, and otherwise optimize by calling
                  * the normal Yee update kernel. We do not do that, as this
-                 * would be fragile wrt future separation of PML into a plugin.
+                 * would be fragile with respect to future separation of PML
+                 * into a plugin.
                  */
                 PMACC_KERNEL( Kernel{ } )
                     ( mapper.getGridDim( ), numWorkers )(
@@ -182,11 +183,12 @@ namespace maxwellSolver
             /** Thickness in terms of the global domain.
              *
              * We store only global thickness, as the local one can change
-             * during the simulation and so has to be recomputed each time step.
-             * There are no limitations on the size, as long as it fits a single
-             * layer of external local domains (near the global simulation area
-             * boundary) on each time step. In particular, PML is not required
-             * to be aligned with the BORDER area.
+             * during the simulation and so has to be recomputed for each time
+             * step. PML must be fully contained in a single layer of local
+             * domains near the global simulation area boundary. (Note that
+             * the domains of this layer might be changing, e.g. due to moving
+             * window.) There are no other limitations on PML thickness. In
+             * particular, it is independent of the BORDER area size.
              */
             Thickness globalSize;
             Parameters parameters;
@@ -261,7 +263,11 @@ namespace maxwellSolver
                 Thickness localThickness = globalSize;
                 for( uint32_t exchange = 1u; exchange < numExchanges; ++exchange )
                 {
-                    // Skip directions except left, right, top, bottom, back, front
+                    /* Here we are only interested in the positive and negative
+                     * directions for x, y, z axes and not the "diagonal" ones.
+                     * So skip other directions except left, right, top, bottom,
+                     * back, front
+                     */
                     if( FRONT % exchange != 0 )
                         continue;
 

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
@@ -120,9 +120,9 @@ namespace yeePML
          * @param cellIdx cell index including the guard, can be fractional,
          * e.g. for halves of cells
          * @param parameters parameters of PML in the local domain
-         * @param normalizedSigma value of normalized sigma at the cell, output
-         * @param kappa value of normalized kappa at the cell, output
-         * @param normalizedAlpha value of normalized alpha at the cell, output
+         * @param[out] normalizedSigma value of normalized sigma at the cell
+         * @param[out] kappa value of normalized kappa at the cell
+         * @param[out] normalizedAlpha value of normalized alpha at the cell
          */
         DINLINE void getAbsorptionParameters(
             floatD_X const cellIdx,
@@ -398,11 +398,11 @@ namespace yeePML
                          * components. Coefficients Ca, Cb as given in (7.107a,b)
                          * are general to account for materials, in addition to
                          * artificial PML absorbing medium. We do not have any
-                         * real material, so in (7.107a,b) have to use
+                         * real material, so in (7.107a,b) we have to use
                          * sigma(i + 1/2, j, k) = 0 (it is another sigma,
                          * unrelated to PML), eps(i + 1/2, j, k) = EPS0. Also,
-                         * same as the Yee scheme in PIC, adjust to use B,
-                         * not H, in the right-hand side.
+                         * same as the Yee scheme in PIC, adjusted to use B,
+                         * not H, on the right-hand side.
                          */
                         fieldE( idx ).x( ) += c2 * dt * (dBzDy / coeffs.kappa.y( ) -
                             dByDz / coeffs.kappa.z( ) + psiE.xy - psiE.xz );
@@ -435,8 +435,8 @@ namespace yeePML
          * @tparam T_Acc alpaka accelerator type
          * @tparam T_Mapping mapper functor type
          * @tparam T_Curl curl functor type
-         * @tparam T_EBox pmacc::DataBox, electric field box type
-         * @tparam T_BBox pmacc::DataBox, magnetic field box type
+         * @tparam T_EBox pmacc::DataBox electric field box type
+         * @tparam T_BBox pmacc::DataBox magnetic field box type
          * @tparam T_PsiBBox PML convolutional magnetic field box type
          *
          * @param acc alpaka accelerator
@@ -517,7 +517,7 @@ namespace yeePML
                         DataSpaceOperations< simDim >::template map< SuperCellSize >( linearIdx );
                     // grid index to process with the current thread
                     auto const idx = blockBeginIdx + idxInSuperCell;
-                    // with the current Yee grid, a half cell shift needed here
+                    // with the current Yee grid, a half cell shift is needed here
                     auto const pmlIdx = floatD_X::create( 0.5_X ) +
                         precisionCast< float_X >( idx );
                     auto const coeffs = detail::getCoefficients(
@@ -560,11 +560,11 @@ namespace yeePML
                          * components. Coefficients Da, Db as given in (7.109a,b)
                          * are general to account for materials, in addition to
                          * artificial PML absorbing medium. We do not have any
-                         * real material, so in (7.107a,b) have to use
+                         * real material, so in (7.109a,b) we have to use
                          * sigma*(i + 1/2, j, k) = 0 (it is another sigma*,
                          * unrelated to PML), mue(i + 1/2, j, k) = MUE0. Also,
-                         * same as the Yee scheme in PIC, adjust to use B,
-                         * not H, in the left-hand side.
+                         * same as the Yee scheme in PIC, adjusted to use B,
+                         * not H, on the left-hand side.
                         */
                         fieldB( idx ).x( ) += halfDt * ( dEyDz / coeffs.kappa.z( ) -
                             dEzDy / coeffs.kappa.y( ) + psiB.xz - psiB.xy );

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
@@ -1,0 +1,587 @@
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
+ *                     Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/MaxwellSolver/YeePML/Parameters.hpp"
+#include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
+#include <pmacc/mappings/threads/ForEachIdx.hpp>
+#include <pmacc/mappings/threads/IdxConfig.hpp>
+#include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/memory/boxes/CachedBox.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+namespace yeePML
+{
+
+    //! Parameters of PML for the local domain
+    struct LocalParameters : public Parameters
+    {
+        /** PML size in cells, stored as floats to avoid type casts later,
+         *  negative and positive borders defined the same way as for Thickness
+         */
+        floatD_X const negativeBorderSize;
+        floatD_X const positiveBorderSize;
+
+        //! Local domain characteristics, including guard cells
+        DataSpace< simDim > const numLocalDomainCells;
+        DataSpace< simDim > const numGuardCells;
+
+        LocalParameters(
+            Parameters const parameters,
+            Thickness const localThickness,
+            DataSpace< simDim > const numLocalDomainCells,
+            DataSpace< simDim > const numGuardCells
+        ):
+            Parameters( parameters ),
+            negativeBorderSize( precisionCast< float_X >( localThickness.negativeBorder ) ),
+            positiveBorderSize( precisionCast< float_X >( localThickness.positiveBorder ) ),
+            numLocalDomainCells( numLocalDomainCells ),
+            numGuardCells( numGuardCells )
+        {
+        }
+    };
+
+    namespace detail
+    {
+
+        /** Get relative depth of a given cell for 1D.
+         *
+         * This function operates with a 1D slice of domain and PML.
+         * index == numGuardCells corresponds to the external negative PML
+         * border, and index == numLocalDomainCells - numGuardCells - 1
+         * corresponds to the external positive PML border.
+         * For the internal area result is 0, for points in PML the depth
+         * scales from 0 at the internal border to 1 at the external border.
+         * Index and local domain size include the guard.
+         *
+         * @param cellIdx cell index including the guard, can be fractional,
+         * e.g. for halves of cells
+         * @param numPMLCellsNegative number of PML cells at the negative border
+         * @param numPMLCellsPositive number of PML cells at the positive border
+         * @param numLocalDomainCells number of cells of the local domain
+         * including the guard
+         * @param numGuardCells number of guard cells at each side
+         * @return relative depth, value between 0 and 1
+         */
+        DINLINE float_X getRelativeDepth(
+            float_X const cellIdx,
+            float_X const numPMLCellsNegative,
+            float_X const numPMLCellsPositive,
+            uint32_t const numLocalDomainCells,
+            uint32_t const numGuardCells
+        )
+        {
+            auto zeroBasedIdx = cellIdx - numGuardCells;
+            auto const isInLeftPML = ( zeroBasedIdx < numPMLCellsNegative );
+            if( isInLeftPML )
+                return ( numPMLCellsNegative - zeroBasedIdx ) / numPMLCellsNegative;
+            else
+            {
+                auto zeroBasedRightPMLStart = numLocalDomainCells -
+                    2 * numGuardCells - numPMLCellsPositive;
+                auto const isInRightPML = ( zeroBasedIdx > zeroBasedRightPMLStart );
+                if( isInRightPML )
+                    return ( zeroBasedIdx - zeroBasedRightPMLStart ) / numPMLCellsPositive;
+            }
+            return 0._X;
+        }
+
+        /** Get absorption parameters: sigma, kappa and alpha at a given cell
+         *
+         * Apply polynomial grading, as described in pml.param.
+         *
+         * @param cellIdx cell index including the guard, can be fractional,
+         * e.g. for halves of cells
+         * @param parameters parameters of PML in the local domain
+         * @param normalizedSigma value of normalized sigma at the cell, output
+         * @param kappa value of normalized kappa at the cell, output
+         * @param normalizedAlpha value of normalized alpha at the cell, output
+         */
+        DINLINE void getAbsorptionParameters(
+            floatD_X const cellIdx,
+            LocalParameters const parameters,
+            float3_X & normalizedSigma,
+            float3_X & kappa,
+            float3_X & normalizedAlpha
+        )
+        {
+            // initialize with values for non-PML area
+            normalizedSigma = float3_X::create( 0._X );
+            kappa = float3_X::create( 1._X );
+            normalizedAlpha = float3_X::create( 0._X );
+            for( uint32_t dim = 0u; dim < simDim; dim++ )
+            {
+                auto const relativeDepth = getRelativeDepth(
+                    cellIdx[ dim ],
+                    parameters.negativeBorderSize[ dim ],
+                    parameters.positiveBorderSize[ dim ],
+                    parameters.numLocalDomainCells[ dim ],
+                    parameters.numGuardCells[ dim ]
+                );
+                // Since normally most points are not in PML, avoid costly
+                // computing in this case
+                if( relativeDepth != 0._X )
+                {
+                    /* Grading done according to [Taflove, Hagness], eq. (7.60a, b).
+                     * Note: here we use a general expression, it is possible
+                     * to specialize for sigmaKappaGradingOrder = 2, 3, or 4,
+                     * but currently seems not worth it.
+                     */
+                    auto const sigmaKappaGradingCoeff = math::pow(
+                        relativeDepth,
+                        parameters.sigmaKappaGradingOrder
+                    );
+                    normalizedSigma[ dim ] = parameters.normalizedSigmaMax[ dim ] *
+                        sigmaKappaGradingCoeff;
+                    kappa[ dim ] = 1._X + ( parameters.kappaMax[ dim ] - 1._X ) *
+                        sigmaKappaGradingCoeff;
+                    /* Grading done according to [Taflove, Hagness], eq. (7.79),
+                     * note that this code is only correct when relativeDepth != 0
+                     */
+                    auto const alphaGradingCoeff = math::pow(
+                        1._X - relativeDepth,
+                        parameters.alphaGradingOrder
+                    );
+                    normalizedAlpha[ dim ] = parameters.normalizedAlphaMax[ dim ] *
+                        alphaGradingCoeff;
+                }
+            }
+        }
+
+        //! Coefficients for E or B updates at a particular point
+        struct Coefficients
+        {
+            //! Coordinate stretching coefficient
+            float3_X kappa;
+
+            //! Damping coefficient, [Taflove, Hagness], eq. (7.102)
+            float3_X b;
+
+            //! Spatial difference coefficient, [Taflove, Hagness], eq. (7.99)
+            float3_X c;
+        };
+
+        /** Get coefficients for E or B updates at a given cell
+         *
+         * Apply polynomial grading, as described in pml.param.
+         * Due to normalizations, the same way of computing coefficients applies
+         * to E and B updates.
+         *
+         * @param cellIdx cell index including the guard, can be fractional,
+         * e.g. for halves of cells
+         * @param parameters parameters of PML in the local domain
+         * @param dt value of time step to propagate by
+         * @result an instance of Coefficients with computed values
+         */
+        DINLINE Coefficients getCoefficients(
+            floatD_X const cellIdx,
+            LocalParameters const parameters,
+            float_X const dt
+        )
+        {
+            Coefficients coeffs;
+            float3_X normalizedSigma, normalizedAlpha;
+            getAbsorptionParameters(
+                cellIdx,
+                parameters,
+                normalizedSigma,
+                coeffs.kappa,
+                normalizedAlpha
+            );
+
+            /* [Taflove, Hagness], eq. (7.102), normalizedSigma and
+             * normalizedAlpha are already divided by eps0
+             */
+            coeffs.b = math::exp(
+                -( normalizedSigma / coeffs.kappa + normalizedAlpha ) * dt
+            );
+            /* [Taflove, Hagness], eq. (7.99), in our case both the numerator
+             * and the denominator are equally normalized
+             */
+            coeffs.c = float3_X::create( 0._X );
+            for ( uint32_t dim = 0u; dim < 3; dim++ )
+            {
+                auto const denominator = coeffs.kappa[ dim ] *
+                    ( normalizedSigma[ dim ] + normalizedAlpha[ dim ] *
+                    coeffs.kappa[ dim ] );
+                // Avoid the 0 / 0 uncertainty, in that case keep the value 0
+                if( denominator )
+                    coeffs.c[ dim ] = normalizedSigma[ dim ] *
+                        ( coeffs.b[ dim ] - 1.0_X ) / denominator;
+            }
+            return coeffs;
+        }
+
+        /** Return if a point with given coefficients belongs to PML
+         *
+         * @param coeffs values of coefficients
+         * @result boolean value if a point with given coefficients belongs
+         * to PML
+         */
+        DINLINE bool isInPML( Coefficients const coeffs )
+        {
+            /* Each damping component is < 1 when absorption is enabled
+             * along this direction and == 1 otherwise.
+             * So a product is 1 in the internal area and < 1 in PML
+             */
+            return coeffs.b.x( ) * coeffs.b.y( ) * coeffs.b.z( ) != 1.0_X;
+        }
+
+    } // namespace detail
+
+    /** Functor to update the electric field by a time step
+     *
+     * @tparam T_numWorkers number of workers
+     * @tparam T_BlockDescription field (electric and magnetic) domain description
+     */
+    template<
+        uint32_t T_numWorkers,
+        typename T_BlockDescription
+    >
+    struct KernelUpdateE
+    {
+        /** Update the electric field by a time step
+         *
+         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Mapping mapper functor type
+         * @tparam T_Curl curl functor type
+         * @tparam T_BBox pmacc::DataBox, magnetic field box type
+         * @tparam T_EBox pmacc::DataBox, electric field box type
+         * @tparam T_PsiEBox PML convolutional electric field box type
+         *
+         * @param acc alpaka accelerator
+         * @param mapper functor to map a block to a supercell
+         * @param parameters PML parameters for a local domain
+         * @param curl functor to calculate the electric field, interface must be
+         *             `operator( )( T_EBox )`
+         * @param fieldB magnetic field iterator
+         * @param fieldE electric field iterator
+         * @param fieldPsiE PML convolutional electric field iterator
+         */
+        template<
+            typename T_Acc,
+            typename T_Mapping,
+            typename T_Curl,
+            typename T_BBox,
+            typename T_EBox,
+            typename T_PsiEBox
+        >
+        DINLINE void operator( )(
+            T_Acc const & acc,
+            T_Mapping const mapper,
+            LocalParameters const parameters,
+            T_Curl const curl,
+            T_BBox const fieldB,
+            T_EBox fieldE,
+            T_PsiEBox fieldPsiE
+        ) const
+        {
+            /* Each block processes grid values in a supercell,
+             * the index includes guards, same as all indices in this kernel
+             */
+            auto const blockBeginIdx = mapper.getSuperCellIndex(
+                DataSpace< simDim >( blockIdx )
+            ) * MappingDesc::SuperCellSize::toRT( );
+
+            // Cache B values for the block
+            using namespace mappings::threads;
+            constexpr auto numWorkers = T_numWorkers;
+            auto const workerIdx = threadIdx.x;
+            nvidia::functors::Assign assign;
+            auto fieldBBlock = fieldB.shift( blockBeginIdx );
+            ThreadCollective<
+                T_BlockDescription,
+                numWorkers
+            > collectiveCacheB( workerIdx );
+            auto cachedB = CachedBox::create<
+                0u,
+                typename T_BBox::ValueType
+            >(
+                acc,
+                T_BlockDescription( )
+            );
+            collectiveCacheB(
+                acc,
+                assign,
+                cachedB,
+                fieldBBlock
+            );
+            __syncthreads( );
+
+            // Threads process values of the supercell in parallel
+            constexpr auto numCellsPerSuperCell =
+                pmacc::math::CT::volume< SuperCellSize >::type::value;
+            ForEachIdx<
+                IdxConfig<
+                    numCellsPerSuperCell,
+                    numWorkers
+                >
+            >{ workerIdx }(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const
+                )
+                {
+                    constexpr auto c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+                    constexpr auto dt = DELTA_T;
+
+                    auto const idxInSuperCell =
+                        DataSpaceOperations< simDim >::template map< SuperCellSize >( linearIdx );
+                    // grid index to process with the current thread
+                    auto const idx = blockBeginIdx + idxInSuperCell;
+                    // with the current Yee grid, no shift needed here
+                    auto const pmlIdx = precisionCast< float_X >( idx );
+                    auto const coeffs = detail::getCoefficients(
+                        pmlIdx,
+                        parameters,
+                        dt
+                    );
+
+                    if( detail::isInPML( coeffs ) )
+                    {
+                        /* This precomputation of partial derivatives is done
+                         * more for readability, rather than avoiding computing
+                         * it twice
+                         */
+                        using Difference = typename T_Curl::Difference;
+                        const typename Difference::template GetDifference< 0 > Dx;
+                        const typename Difference::template GetDifference< 1 > Dy;
+                        const typename Difference::template GetDifference< 2 > Dz;
+                        auto const localB = cachedB.shift( idxInSuperCell );
+                        auto const dBxDy = Dy( localB ).x( );
+                        auto const dBxDz = Dz( localB ).x( );
+                        auto const dByDx = Dx( localB ).y( );
+                        auto const dByDz = Dz( localB ).y( );
+                        auto const dBzDx = Dx( localB ).z( );
+                        auto const dBzDy = Dy( localB ).z( );
+
+                        /* Update convolutional fields using [Taflove, Hagness],
+                         * eq. (7.105a,b) and similar for other components.
+                         * For PIC the right-hand side uses B, not H.
+                         */
+                        auto & psiE = fieldPsiE( idx );
+                        psiE.yx = coeffs.b.x( ) * psiE.yx + coeffs.c.x( ) * dBzDx;
+                        psiE.zx = coeffs.b.x( ) * psiE.zx + coeffs.c.x( ) * dByDx;
+                        psiE.xy = coeffs.b.y( ) * psiE.xy + coeffs.c.y( ) * dBzDy;
+                        psiE.zy = coeffs.b.y( ) * psiE.zy + coeffs.c.y( ) * dBxDy;
+                        psiE.xz = coeffs.b.z( ) * psiE.xz + coeffs.c.z( ) * dByDz;
+                        psiE.yz = coeffs.b.z( ) * psiE.yz + coeffs.c.z( ) * dBxDz;
+
+                        /* [Taflove, Hagness], eq. (7.106) and similar for other
+                         * components. Coefficients Ca, Cb as given in (7.107a,b)
+                         * are general to account for materials, in addition to
+                         * artificial PML absorbing medium. We do not have any
+                         * real material, so in (7.107a,b) have to use
+                         * sigma(i + 1/2, j, k) = 0 (it is another sigma,
+                         * unrelated to PML), eps(i + 1/2, j, k) = EPS0. Also,
+                         * same as the Yee scheme in PIC, adjust to use B,
+                         * not H, in the right-hand side.
+                         */
+                        fieldE( idx ).x( ) += c2 * dt * (dBzDy / coeffs.kappa.y( ) -
+                            dByDz / coeffs.kappa.z( ) + psiE.xy - psiE.xz );
+                        fieldE( idx ).y( ) += c2 * dt * (dBxDz / coeffs.kappa.z( ) -
+                            dBzDx / coeffs.kappa.x( ) + psiE.yz - psiE.yx );
+                        fieldE( idx ).z( ) += c2 * dt * (dByDx / coeffs.kappa.x( ) -
+                            dBxDy / coeffs.kappa.y( ) + psiE.zx - psiE.zy );
+                    }
+                    else
+                        // Normal Yee scheme update
+                        fieldE( idx ) += curl( cachedB.shift( idxInSuperCell ) ) * c2 * dt;
+                }
+            );
+        }
+    };
+
+    /** Functor to update the magnetic field by half a time step
+     *
+     * @tparam T_numWorkers number of workers
+     * @tparam T_BlockDescription field (electric and magnetic) domain description
+     */
+    template<
+        uint32_t T_numWorkers,
+        typename T_BlockDescription
+    >
+    struct KernelUpdateBHalf
+    {
+        /** Update the magnetic field by half a time step
+         *
+         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Mapping mapper functor type
+         * @tparam T_Curl curl functor type
+         * @tparam T_EBox pmacc::DataBox, electric field box type
+         * @tparam T_BBox pmacc::DataBox, magnetic field box type
+         * @tparam T_PsiBBox PML convolutional magnetic field box type
+         *
+         * @param acc alpaka accelerator
+         * @param mapper functor to map a block to a supercell
+         * @param parameters PML parameters for a local domain
+         * @param curl functor to calculate the electric field, interface must be
+         *             `operator( )( T_EBox )`
+         * @param fieldE electric field iterator
+         * @param fieldB magnetic field iterator
+         * @param fieldPsiB PML convolutional magnetic field iterator
+         */
+        template<
+            typename T_Acc,
+            typename T_Mapping,
+            typename T_Curl,
+            typename T_EBox,
+            typename T_BBox,
+            typename T_PsiBBox
+        >
+        DINLINE void operator( )(
+            T_Acc const & acc,
+            T_Mapping const mapper,
+            LocalParameters const parameters,
+            T_Curl const curl,
+            T_EBox const fieldE,
+            T_BBox fieldB,
+            T_PsiBBox fieldPsiB
+        ) const
+        {
+            /* Each block processes grid values in a supercell,
+             * the index includes guards, same as all indices in this kernel
+             */
+            auto const blockBeginIdx = mapper.getSuperCellIndex(
+                DataSpace< simDim >( blockIdx )
+            ) * MappingDesc::SuperCellSize::toRT( );
+
+            // Cache B values for the block
+            using namespace mappings::threads;
+            constexpr auto numWorkers = T_numWorkers;
+            auto const workerIdx = threadIdx.x;
+            nvidia::functors::Assign assign;
+            auto fieldEBlock = fieldE.shift( blockBeginIdx );
+            ThreadCollective<
+                T_BlockDescription,
+                numWorkers
+            > collectiveCacheE( workerIdx );
+            auto cachedE = CachedBox::create<
+                0u,
+                typename T_EBox::ValueType
+            >(
+                acc,
+                T_BlockDescription( )
+            );
+            collectiveCacheE(
+                acc,
+                assign,
+                cachedE,
+                fieldEBlock
+            );
+            __syncthreads( );
+
+            // Threads process values of the supercell in parallel
+            constexpr auto numCellsPerSuperCell =
+                pmacc::math::CT::volume< SuperCellSize >::type::value;
+            ForEachIdx<
+                IdxConfig<
+                    numCellsPerSuperCell,
+                    numWorkers
+                >
+            >{ workerIdx }(
+                [&](
+                    uint32_t const linearIdx,
+                    uint32_t const
+                )
+                {
+                    constexpr auto halfDt = 0.5_X * DELTA_T;
+                    auto const idxInSuperCell =
+                        DataSpaceOperations< simDim >::template map< SuperCellSize >( linearIdx );
+                    // grid index to process with the current thread
+                    auto const idx = blockBeginIdx + idxInSuperCell;
+                    // with the current Yee grid, a half cell shift needed here
+                    auto const pmlIdx = floatD_X::create( 0.5_X ) +
+                        precisionCast< float_X >( idx );
+                    auto const coeffs = detail::getCoefficients(
+                        pmlIdx,
+                        parameters,
+                        halfDt
+                    );
+
+                    if( detail::isInPML( coeffs ) )
+                    {
+                        /* This precomputation of partial derivatives is done
+                        * more for readability, rather than avoiding computing
+                        * it twice
+                        */
+                        using Difference = typename T_Curl::Difference;
+                        const typename Difference::template GetDifference< 0 > Dx;
+                        const typename Difference::template GetDifference< 1 > Dy;
+                        const typename Difference::template GetDifference< 2 > Dz;
+                        auto const localE = cachedE.shift( idxInSuperCell );
+                        auto const dExDy = Dy( localE ).x( );
+                        auto const dExDz = Dz( localE ).x( );
+                        auto const dEyDx = Dx( localE ).y( );
+                        auto const dEyDz = Dz( localE ).y( );
+                        auto const dEzDx = Dx( localE ).z( );
+                        auto const dEzDy = Dy( localE ).z( );
+
+                        /* Update convolutional fields using [Taflove, Hagness],
+                         * eq. (7.110a,b) and similar for other components.
+                         * For PIC the left-hand side uses B, not H.
+                         */
+                        auto & psiB = fieldPsiB( idx );
+                        psiB.yx = coeffs.b.x( ) * psiB.yx + coeffs.c.x( ) * dEzDx;
+                        psiB.zx = coeffs.b.x( ) * psiB.zx + coeffs.c.x( ) * dEyDx;
+                        psiB.xy = coeffs.b.y( ) * psiB.xy + coeffs.c.y( ) * dEzDy;
+                        psiB.zy = coeffs.b.y( ) * psiB.zy + coeffs.c.y( ) * dExDy;
+                        psiB.xz = coeffs.b.z( ) * psiB.xz + coeffs.c.z( ) * dEyDz;
+                        psiB.yz = coeffs.b.z( ) * psiB.yz + coeffs.c.z( ) * dExDz;
+
+                        /* [Taflove, Hagness], eq. (7.108) and similar for other
+                         * components. Coefficients Da, Db as given in (7.109a,b)
+                         * are general to account for materials, in addition to
+                         * artificial PML absorbing medium. We do not have any
+                         * real material, so in (7.107a,b) have to use
+                         * sigma*(i + 1/2, j, k) = 0 (it is another sigma*,
+                         * unrelated to PML), mue(i + 1/2, j, k) = MUE0. Also,
+                         * same as the Yee scheme in PIC, adjust to use B,
+                         * not H, in the left-hand side.
+                        */
+                        fieldB( idx ).x( ) += halfDt * ( dEyDz / coeffs.kappa.z( ) -
+                            dEzDy / coeffs.kappa.y( ) + psiB.xz - psiB.xy );
+                        fieldB( idx ).y( ) += halfDt * ( dEzDx / coeffs.kappa.x( ) -
+                            dExDz / coeffs.kappa.z( ) + psiB.yx - psiB.yz );
+                        fieldB( idx ).z( ) += halfDt * ( dExDy / coeffs.kappa.y( ) -
+                            dEyDx / coeffs.kappa.x( ) + psiB.zy - psiB.zx );
+                    }
+                    else
+                        // Normal Yee scheme update
+                        fieldB( idx ) -= curl( cachedE.shift( idxInSuperCell ) ) * halfDt;
+                }
+            );
+        }
+    };
+
+} // namespace yeePML
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/param/physicalConstants.param
+++ b/include/picongpu/param/physicalConstants.param
@@ -37,6 +37,10 @@ namespace picongpu
         constexpr float_64 EPS0_SI = 1.0 / MUE0_SI / SPEED_OF_LIGHT_SI
             / SPEED_OF_LIGHT_SI;
 
+        /** impedance of free space
+         * unit: ohm */
+        constexpr float_64 Z0_SI = MUE0_SI * SPEED_OF_LIGHT_SI;
+
         /** reduced Planck constant
          * unit: J * s
          */

--- a/include/picongpu/param/pml.param
+++ b/include/picongpu/param/pml.param
@@ -1,0 +1,158 @@
+/* Copyright 2019 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure the perfectly matched layer (PML).
+ *
+ * To enable PML use YeePML field solver.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+namespace yeePML
+{
+
+    /* The parameters in this file are only used if field solver is YeePML.
+     * The original paper on this approach is J.A. Roden, S.D. Gedney.
+     * Convolution PML (CPML): An efficient FDTD implementation of the CFS - PML
+     * for arbitrary media. Microwave and optical technology letters. 27 (5),
+     * 334-339 (2000).
+     * https://doi.org/10.1002/1098-2760(20001205)27:5%3C334::AID-MOP14%3E3.0.CO;2-A
+     * Our implementation based on a more detailed description in section 7.9 of
+     * the book A. Taflove, S.C. Hagness. Computational Electrodynamics.
+     * The Finite-Difference Time-Domain Method. Third Edition. Artech house,
+     * Boston (2005), referred to as [Taflove, Hagness].
+     */
+
+    constexpr uint32_t THICKNESS = 8;
+
+    /** Thickness of the absorbing layer, in number of cells
+     *
+     * PML is located inside the global simulation area, near the outer borders.
+     * Setting size to 0 results in disabling absorption at the corresponding
+     * boundary. Normally thickness is between 6 and 16 cells, with larger
+     * values providing less reflections.
+     * 8 cells should be good enough for most simulations. There are no
+     * requirements on thickness being a multiple of the supercell size.
+     * It is only required that PML is small enough to fit near-boundary local
+     * domains at all time steps.
+     * Unit: number of cells.
+     */
+    constexpr uint32_t NUM_CELLS[ 3 ][ 2 ] = {
+        { THICKNESS, THICKNESS },  // x direction [negative, positive]
+        { THICKNESS, THICKNESS },  // y direction [negative, positive]
+        { THICKNESS, THICKNESS }   // z direction [negative, positive]
+    };
+
+    /** Order of polynomial grading for artificial electric conductivity and
+     *  stretching coefficient
+     *
+     * The conductivity (sigma) is polynomially scaling from 0 at the internal
+     * border of PML to the maximum value (defined below) at the external
+     * border. The stretching coefficient (kappa) scales from 1 to the
+     * corresponding maximum value (defined below) with the same polynomial.
+     * The grading is given in [Taflove, Hagness], eq. (7.60a, b), with
+     * the order denoted 'm'.
+     * Must be >= 0. Normally between 3 and 4, not required to be integer.
+     * Unitless.
+     */
+    constexpr float_64 SIGMA_KAPPA_GRADING_ORDER = 4.0;
+
+    // [Taflove, Hagness], eq. (7.66)
+    constexpr float_64 SIGMA_OPT_SI[ 3 ] = {
+        0.8 * ( SIGMA_KAPPA_GRADING_ORDER + 1.0 ) / ( SI::Z0_SI * SI::CELL_WIDTH_SI ),
+        0.8 * ( SIGMA_KAPPA_GRADING_ORDER + 1.0 ) / ( SI::Z0_SI * SI::CELL_HEIGHT_SI ),
+        0.8 * ( SIGMA_KAPPA_GRADING_ORDER + 1.0 ) / ( SI::Z0_SI * SI::CELL_DEPTH_SI )
+    };
+
+    // Muptiplier to express SIGMA_MAX_SI with SIGMA_OPT_SI
+    constexpr float_64 SIGMA_OPT_MULTIPLIER = 1.0;
+
+    /** Max value of artificial electric conductivity in PML
+     *
+     * Components correspond to directions: element 0 corresponds to absorption
+     * along x direction, 1 = y, 2 = z. Grading is described in comments for
+     * SIGMA_KAPPA_GRADING_ORDER.
+     * Too small values lead to significant reflections from the external
+     * border, too large - to reflections due to discretization errors.
+     * Artificial magnetic permeability will be chosen to perfectly match this.
+     * Must be >= 0. Normally between 0.7 * SIGMA_OPT_SI and 1.1 * SIGMA_OPT_SI.
+     * Unit: siemens / m.
+     */
+    constexpr float_64 SIGMA_MAX_SI[ 3 ] = {
+        SIGMA_OPT_SI[ 0 ] * SIGMA_OPT_MULTIPLIER,
+        SIGMA_OPT_SI[ 1 ] * SIGMA_OPT_MULTIPLIER,
+        SIGMA_OPT_SI[ 2 ] * SIGMA_OPT_MULTIPLIER
+    };
+
+    /** Max value of coordinate stretching coefficient in PML
+     *
+     * Components correspond to directions: element 0 corresponds to absorption
+     * along x direction, 1 = y, 2 = z. Grading is described in comments for
+     * SIGMA_KAPPA_GRADING_ORDER.
+     * Must be >= 1. For relatively homogeneous domains 1.0 is a reasonable value.
+     * Highly elongated domains can have better absorption with values between
+     * 7.0 and 20.0, for example, see section 7.11.2 in [Taflove, Hagness].
+     * Unitless.
+     */
+    constexpr float_64 KAPPA_MAX[ 3 ] = {
+        1.0,
+        1.0,
+        1.0
+    };
+
+    /** Order of polynomial grading for complex frequency shift
+     *
+     * The complex frequency shift (alpha) is polynomially downscaling from the
+     * maximum value (defined below) at the internal border of PML to 0 at the
+     * external border. The grading is given in [Taflove, Hagness], eq. (7.79),
+     * with the order denoted 'm_a'.
+     * Must be >= 0. Normally values are around 1.0.
+     * Unitless.
+     */
+    constexpr float_64 ALPHA_GRADING_ORDER = 1.0;
+
+    /** Complex frequency shift in PML
+     *
+     * Components correspond to directions: element 0 corresponds to absorption
+     * along x direction, 1 = y, 2 = z. Setting it to 0 will make PML behave
+     * as uniaxial PML. Setting it to a positive value helps to attenuate
+     * evanescent modes, but can degrade absorption of propagating modes, as
+     * described in section 7.7 and 7.11.3 in [Taflove, Hagness].
+     * Must be >= 0. Normally values are 0 or between 0.15 and 0.3.
+     * Unit: siemens / m.
+     */
+    constexpr float_64 ALPHA_MAX_SI[ 3 ] = {
+        0.2,
+        0.2,
+        0.2
+    };
+
+} // namespace yeePML
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/param/pml.param
+++ b/include/picongpu/param/pml.param
@@ -36,14 +36,15 @@ namespace maxwellSolver
 namespace yeePML
 {
 
-    /* The parameters in this file are only used if field solver is YeePML.
+    /* The parameters in this file are only used if the field solver selected is
+     * YeePML.
      * The original paper on this approach is J.A. Roden, S.D. Gedney.
      * Convolution PML (CPML): An efficient FDTD implementation of the CFS - PML
      * for arbitrary media. Microwave and optical technology letters. 27 (5),
      * 334-339 (2000).
      * https://doi.org/10.1002/1098-2760(20001205)27:5%3C334::AID-MOP14%3E3.0.CO;2-A
-     * Our implementation based on a more detailed description in section 7.9 of
-     * the book A. Taflove, S.C. Hagness. Computational Electrodynamics.
+     * Our implementation is based on a more detailed description in section
+     * 7.9 of the book A. Taflove, S.C. Hagness. Computational Electrodynamics.
      * The Finite-Difference Time-Domain Method. Third Edition. Artech house,
      * Boston (2005), referred to as [Taflove, Hagness].
      */
@@ -58,8 +59,10 @@ namespace yeePML
      * values providing less reflections.
      * 8 cells should be good enough for most simulations. There are no
      * requirements on thickness being a multiple of the supercell size.
-     * It is only required that PML is small enough to fit near-boundary local
-     * domains at all time steps.
+     * It is only required that PML is small enough to be fully contained in
+     * a single layer of local domains near the global simulation area boundary
+     * (Note that the domains of this layer might be changing, e.g. due to
+     * moving window.)
      * Unit: number of cells.
      */
     constexpr uint32_t NUM_CELLS[ 3 ][ 2 ] = {

--- a/include/picongpu/unitless/physicalConstants.unitless
+++ b/include/picongpu/unitless/physicalConstants.unitless
@@ -39,6 +39,9 @@ namespace picongpu
     // = 1/c^2
     constexpr float_X MUE0_EPS0 = float_X(1. / SPEED_OF_LIGHT / SPEED_OF_LIGHT);
 
+    //! Impedance of free space
+    constexpr float_X Z0 = MUE0 * SPEED_OF_LIGHT;
+
     /* Atomic unit of electric field in PIC Efield units */
     constexpr float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / UNIT_EFIELD);
 

--- a/include/picongpu/unitless/pml.unitless
+++ b/include/picongpu/unitless/pml.unitless
@@ -1,0 +1,92 @@
+/* Copyright 2019 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include <pmacc/math/Vector.hpp>
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+namespace yeePML
+{
+
+    // Assert parameters are in the valid ranges
+    PMACC_CASSERT_MSG( You_can_not_set_negative_grading_order_for_pml_kappa_and_sigma___change_pml_param, (SIGMA_KAPPA_GRADING_ORDER >= 0.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_negative_value_pml_sigma_max_x___change_pml_param, (SIGMA_MAX_SI[ 0 ] >= 0.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_negative_value_pml_sigma_max_y___change_pml_param, (SIGMA_MAX_SI[ 1 ] >= 0.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_negative_value_pml_sigma_max_z___change_pml_param, (SIGMA_MAX_SI[ 2 ] >= 0.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_pml_kappa_max_x_value_less_than_one___change_pml_param, (KAPPA_MAX[ 0 ] >= 1.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_pml_kappa_max_y_value_less_than_one___change_pml_param, (KAPPA_MAX[ 1 ] >= 1.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_pml_kappa_max_z_value_less_than_one___change_pml_param, (KAPPA_MAX[ 2 ] >= 1.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_negative_grading_order_for_pml_alpha___change_pml_param, (ALPHA_GRADING_ORDER >= 0.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_negative_pml_alpha_max_x___change_pml_param, (ALPHA_MAX_SI[ 0 ] >= 0.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_negative_pml_alpha_max_y___change_pml_param, (ALPHA_MAX_SI[ 1 ] >= 0.0) );
+    PMACC_CASSERT_MSG( You_can_not_set_negative_pml_alpha_max_z___change_pml_param, (ALPHA_MAX_SI[ 2 ] >= 0.0) );
+
+    /* Normalize artificial conductivity by eps0, so that the result can be used
+     * for matching electric conductivity and magnetic permeability
+     * unit: 1 / s
+     */
+    constexpr float_64 NORMALIZED_SIGMA_MAX_SI[ 3 ] = {
+        SIGMA_MAX_SI[ 0 ] / SI::EPS0_SI,
+        SIGMA_MAX_SI[ 1 ] / SI::EPS0_SI,
+        SIGMA_MAX_SI[ 2 ] / SI::EPS0_SI
+    };
+
+    /** Max value of normalized conductivity in PIC units
+     *
+     * unit: 1 / time
+     * (that is why we multiply by UNIT_TIME and not divide)
+     */
+    constexpr float_64 NORMALIZED_SIGMA_MAX[ 3 ] = {
+        NORMALIZED_SIGMA_MAX_SI[ 0 ] * UNIT_TIME,
+        NORMALIZED_SIGMA_MAX_SI[ 1 ] * UNIT_TIME,
+        NORMALIZED_SIGMA_MAX_SI[ 2 ] * UNIT_TIME
+    };
+
+    /* Normalize complex frequency shift by eps0, so that the result can be used
+     * for matching electric conductivity and magnetic permeability
+     * unit: 1 / s
+     */
+    constexpr float_64 NORMALIZED_ALPHA_MAX_SI[ 3 ] = {
+        ALPHA_MAX_SI[ 0 ] / SI::EPS0_SI,
+        ALPHA_MAX_SI[ 1 ] / SI::EPS0_SI,
+        ALPHA_MAX_SI[ 2 ] / SI::EPS0_SI
+    };
+
+    /** Max value of normalized complex frequency shift in PIC units
+     *
+     * unit: 1 / time
+     * (that is why we multiply by UNIT_TIME and not divide)
+     */
+    constexpr float_64 NORMALIZED_ALPHA_MAX[ 3 ] = {
+        NORMALIZED_ALPHA_MAX_SI[ 0 ] * UNIT_TIME,
+        NORMALIZED_ALPHA_MAX_SI[ 1 ] * UNIT_TIME,
+        NORMALIZED_ALPHA_MAX_SI[ 2 ] * UNIT_TIME
+    };
+
+} // namespace yeePML
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu


### PR DESCRIPTION
I've now put my changes on top of the current dev. There are still some leftovers from the previous efforts, and, importantly, the kernel is still not changed to work in the internal area vs. the guard as originally planned. So still WIP, but hopefully just for 1-2 more days.

I'll now close the older PR #2863 .

To enable the new solver, use `YeePML` as the field solver in `fieldSolver.param`. All the PML-related parameters are in `pml.param` (default values should normally be reasonable), parameters of the old exponential damping absorber should still be specified so that the code compiles, but are not actually used. Otherwise, PML behaves exactly the same as the old absorber, in terms of absorbing area location (inside the simulation area, near the outer border) and interaction with lasers and moving window.
Known limitations:

- When PML is enabled, for each grid node on the whole domain where are 12 additional `float_X` values, so memory requirements for field data on both host and device are increased by about 2 times (particles' data is not affected, ofc). This issue will be addressed in a following PR.
- That additional values are not written to checkpoints. It is technically possible to load from a checkpoint, but field dynamics in the PML area will be changed and reflections introduced, so not worthy for meaningful simulations. This will be addressed shortly when absorbers become plugins in a following PR.
- Now field solver kernels are much more computationally intensive and use way more registers. However, in general PIC scale this should be negligible, as most time is spent on the other stages, and the field solver kernels are also interleaved with asynchronous MPI communications. Even in my tests with no particles, there is no time difference between the `Yee` + old absorber and new `YeePML`.