### PR TITLE
Add DataConnector::consume(), which shares and consumes the input

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -224,8 +224,8 @@ namespace maxwellSolver
                 fieldE = dc.get< picongpu::FieldE >( picongpu::FieldE::getName( ), true );
                 fieldB = dc.get< picongpu::FieldB >( picongpu::FieldB::getName( ), true );
                 using pmacc::memory::makeUnique;
-                dc.share( makeUnique< yeePML::FieldE >( cellDescription ) );
-                dc.share( makeUnique< yeePML::FieldB >( cellDescription ) );
+                dc.consume( makeUnique< yeePML::FieldE >( cellDescription ) );
+                dc.consume( makeUnique< yeePML::FieldB >( cellDescription ) );
                 psiE = dc.get< yeePML::FieldE >( yeePML::FieldE::getName( ), true );
                 psiB = dc.get< yeePML::FieldB >( yeePML::FieldB::getName( ), true );
             }

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -28,6 +28,7 @@
 #include <pmacc/Environment.hpp>
 #include <pmacc/communication/AsyncCommunication.hpp>
 #include <pmacc/particles/compileTime/FindByNameOrType.hpp>
+#include <pmacc/memory/MakeUnique.hpp>
 
 #include "picongpu/particles/traits/GetIonizerList.hpp"
 #if( PMACC_CUDA_ENABLED == 1 )
@@ -97,13 +98,11 @@ struct CreateSpecies
     ) const
     {
         DataConnector &dc = Environment<>::get().DataConnector();
-        dc.share(
-            std::shared_ptr< ISimulationData >(
-                new SpeciesType(
-                    deviceHeap,
-                    *cellDesc,
-                    FrameType::getName()
-                )
+        dc.consume(
+            pmacc::memory::makeUnique<SpeciesType>(
+                deviceHeap,
+                *cellDesc,
+                FrameType::getName()
             )
         );
     }

--- a/include/picongpu/particles/flylite/NonLTE.tpp
+++ b/include/picongpu/particles/flylite/NonLTE.tpp
@@ -31,6 +31,7 @@
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/traits/GetNumWorkers.hpp>
+#include <pmacc/memory/MakeUnique.hpp>
 
 #include <memory>
 
@@ -63,55 +64,46 @@ namespace flylite
 
         DataConnector &dc = Environment<>::get().DataConnector();
 
+        using pmacc::memory::makeUnique;
         // once allocated for all ion species to share
         if( ! dc.hasId( helperFields::LocalEnergyHistogram::getName( "electrons" ) ) )
-            dc.share(
-                std::shared_ptr< ISimulationData >(
-                    new helperFields::LocalEnergyHistogram(
-                        "electrons",
-                        m_avgGridSizeLocal
-                    )
+            dc.consume(
+                makeUnique< helperFields::LocalEnergyHistogram >(
+                    "electrons",
+                    m_avgGridSizeLocal
                 )
             );
 
         if( ! dc.hasId( helperFields::LocalEnergyHistogram::getName( "photons" ) ) )
-            dc.share(
-                std::shared_ptr< ISimulationData >(
-                    new helperFields::LocalEnergyHistogram(
-                        "photons",
-                        m_avgGridSizeLocal
-                    )
+            dc.consume(
+                makeUnique< helperFields::LocalEnergyHistogram >(
+                    "photons",
+                    m_avgGridSizeLocal
                 )
             );
 
         if( ! dc.hasId( helperFields::LocalDensity::getName( "electrons" ) ) )
-            dc.share(
-                std::shared_ptr< ISimulationData >(
-                    new helperFields::LocalDensity(
-                        "electrons",
-                        m_avgGridSizeLocal
-                    )
+            dc.consume(
+                makeUnique< helperFields::LocalDensity >(
+                    "electrons",
+                    m_avgGridSizeLocal
                 )
             );
 
         // for each ion species
         if( ! dc.hasId( helperFields::LocalRateMatrix::getName( ionSpeciesName ) ) )
-            dc.share(
-                std::shared_ptr< ISimulationData >(
-                    new helperFields::LocalRateMatrix(
-                        ionSpeciesName,
-                        m_avgGridSizeLocal
-                    )
+            dc.consume(
+                makeUnique< helperFields::LocalRateMatrix >(
+                    ionSpeciesName,
+                    m_avgGridSizeLocal
                 )
             );
 
         if( ! dc.hasId( helperFields::LocalDensity::getName( ionSpeciesName ) ) )
-            dc.share(
-                std::shared_ptr< ISimulationData >(
-                    new helperFields::LocalDensity(
-                        ionSpeciesName,
-                        m_avgGridSizeLocal
-                    )
+            dc.consume(
+                makeUnique< helperFields::LocalDensity >(
+                    ionSpeciesName,
+                    m_avgGridSizeLocal
                 )
             );
     }

--- a/include/pmacc/dataManagement/DataConnector.hpp
+++ b/include/pmacc/dataManagement/DataConnector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2019 Rene Widera, Felix Schmitt, Axel Huebl
+/* Copyright 2013-2019 Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <memory>
+#include <utility>
 
 
 namespace pmacc
@@ -94,9 +95,9 @@ namespace pmacc
             initialiser.teardown();
         }
 
-        /** Registers a new Dataset with data and identifier id.
+        /** Register a new Dataset and share its ownership.
          *
-         * If a Dataset with identifier id already exists, a runtime_error is thrown.
+         * If a Dataset with the same id already exists, a runtime_error is thrown.
          * (Check with DataConnector::hasId when necessary.)
          *
          * @param data simulation data to share ownership
@@ -121,12 +122,27 @@ namespace pmacc
             datasets.push_back( data );
         }
 
+        /** Register a new Dataset and transfer its ownership.
+         *
+         * If a Dataset with the same id already exists, a runtime_error is thrown.
+         * (Check with DataConnector::hasId when necessary.)
+         * The only difference from share() is transfer of ownership.
+         *
+         * @param data simulation data to transfer ownership
+         */
+        void
+        consume( std::unique_ptr< ISimulationData > data )
+        {
+            std::shared_ptr< ISimulationData > newOwner( std::move( data ) );
+            share( newOwner );
+        }
+
         /** End sharing a dataset with identifier id
          *
          * @param id id of the dataset to remove
          */
         void
-        unshare( SimulationDataId id )
+        deregister( SimulationDataId id )
         {
             const auto it = findId( id );
 


### PR DESCRIPTION
So now there are two scenarios for registering data at `DataConnector`:

- the old `share()` to register and share;
- the new `consume()` to register and consume (the caller gives away ownership to data connector).

The only difference is in ownership. Now it follows [the usual design style](https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/): taking a shared pointer means "I'll share ownership with caller", taking a unique pointer - "I'll take away ownership from caller".

Previously, all calls to `share()` actually wanted just to `consume()` and had to artificially wrap stuff in shared pointers. Which is no longer needed and I've changed it, which also simplifies code a little bit. It turns out, now there are no external calls to `share()` left at all. However, I still kept it as this is a perfectly viable and useful scenario.