### PR TITLE
Add a using declaration for Difference type to yee::Curl

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/Yee/Curl.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Curl.hpp
@@ -35,9 +35,10 @@ namespace maxwellSolver
 namespace yee
 {
 
-    template< typename  Difference >
+    template< typename T_Difference >
     struct Curl
     {
+        using Difference = T_Difference;
         using LowerMargin = typename Difference::OffsetOrigin;
         using UpperMargin = typename Difference::OffsetEnd;
 


### PR DESCRIPTION
This type is currently not used anywhere, but will be needed for PML.
The Lehe solver curl is not changed, as it does not have a type ready to use in this role.

As [suggested](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2950#discussion_r281530308), making this a separate PR.