### PR TITLE
Add an implementation of exp for pmacc vectors

### DIFF
--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -1,4 +1,5 @@
-/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+ *                     Sergei Bastrakov
  *
  * This file is part of PMacc.
  *
@@ -164,6 +165,30 @@ struct Dot< ::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim> >
         result tmp = a.x( ) * b.x( );
         for ( int i = 1; i < dim; i++ )
             tmp += a[i] * b[i];
+        return tmp;
+    }
+};
+
+/*#### exp ###################################################################*/
+
+/*! Specialization of exp where power is a vector
+ *
+ * Compute exp separately for every component of the vector.
+ *
+ * @param power vector with power values
+ */
+template<typename T1, int dim>
+struct Exp< ::pmacc::math::Vector<T1, dim> >
+{
+    typedef ::pmacc::math::Vector<T1, dim> Vector1;
+    typedef Vector1 result;
+
+    HDINLINE result operator( )(const Vector1& power )
+    {
+        BOOST_STATIC_ASSERT( dim > 0 );
+        result tmp;
+        for ( int i = 0; i < dim; ++i )
+            tmp[i] = pmacc::algorithms::math::exp( power[i] );
         return tmp;
     }
 };


### PR DESCRIPTION
This allows a little nicer and more expressive code, as suggested [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2950#discussion_r281540518).