### PR TITLE
PMacc Vector: C++11 Using

### DIFF
--- a/include/pmacc/math/vector/Float.hpp
+++ b/include/pmacc/math/vector/Float.hpp
@@ -31,7 +31,7 @@ namespace math
 template<int dim>
 struct Float : public Vector<float, dim>
 {
-    typedef Vector<float, dim> BaseType;
+    using BaseType = Vector<float, dim>;
 
     HDINLINE Float()
     {

--- a/include/pmacc/math/vector/Int.hpp
+++ b/include/pmacc/math/vector/Int.hpp
@@ -31,7 +31,7 @@ namespace math
 template<int dim>
 struct Int : public Vector<int, dim>
 {
-    typedef Vector<int, dim> BaseType;
+    using BaseType = Vector<int, dim>;
 
     HDINLINE Int()
     {

--- a/include/pmacc/math/vector/Size_t.hpp
+++ b/include/pmacc/math/vector/Size_t.hpp
@@ -31,7 +31,7 @@ namespace math
 template<int dim>
 struct Size_t : public Vector<size_t, dim>
 {
-    typedef Vector<size_t, dim> BaseType;
+    using BaseType = Vector<size_t, dim>;
 
     HDINLINE Size_t()
     {

--- a/include/pmacc/math/vector/TwistComponents.hpp
+++ b/include/pmacc/math/vector/TwistComponents.hpp
@@ -36,7 +36,10 @@ template<typename T_Axes,
 typename T_Vector>
 struct TwistComponents
 {
-    typedef typename TwistComponents<T_Axes,typename T_Vector::This>::type type;
+    using type = typename TwistComponents<
+        T_Axes,
+        typename T_Vector::This
+    >::type;
 };
 
 template<typename T_Axes,
@@ -46,8 +49,16 @@ typename T_Navigator,
 template <typename, int> class T_Storage>
 struct TwistComponents<T_Axes,math::Vector<T_Type,T_Dim,T_Accessor,T_Navigator,T_Storage> >
 {
-    typedef math::Vector<T_Type, T_Dim, T_Accessor,
-            math::StackedNavigator<T_Navigator, math::PermutedNavigator<T_Axes> >,T_Storage >& type;
+    using type = math::Vector<
+        T_Type,
+        T_Dim,
+        T_Accessor,
+        math::StackedNavigator<
+            T_Navigator,
+            math::PermutedNavigator<T_Axes>
+        >,
+        T_Storage
+    >&;
 };
 
 } // result_of

--- a/include/pmacc/math/vector/UInt32.hpp
+++ b/include/pmacc/math/vector/UInt32.hpp
@@ -31,7 +31,7 @@ namespace math
 template<int dim>
 struct UInt32 : public Vector<uint32_t, dim>
 {
-    typedef Vector<uint32_t, dim> BaseType;
+    using BaseType = Vector<uint32_t, dim>;
 
     HDINLINE UInt32()
     {

--- a/include/pmacc/math/vector/UInt64.hpp
+++ b/include/pmacc/math/vector/UInt64.hpp
@@ -31,7 +31,7 @@ namespace math
 template<int dim>
 struct UInt64 : public Vector<uint64_t, dim>
 {
-    typedef Vector<uint64_t, dim> BaseType;
+    using BaseType = Vector<uint64_t, dim>;
 
     HDINLINE UInt64()
     {

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -46,7 +46,7 @@ struct Vector_components
 {
     static constexpr bool isConst = false;
     static constexpr int dim = T_Dim;
-    typedef T_Type type;
+    using type = T_Type;
 
     /*align full vector*/
     PMACC_ALIGN(v[dim], type);
@@ -113,14 +113,14 @@ typename T_Navigator = StandardNavigator,
 template <typename, int> class T_Storage = detail::Vector_components>
 struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protected T_Navigator
 {
-    typedef T_Storage<T_Type, T_dim> Storage;
-    typedef typename Storage::type type;
+    using Storage = T_Storage<T_Type, T_dim>;
+    using type = typename Storage::type;
     static constexpr int dim = Storage::dim;
-    typedef tag::Vector tag;
-    typedef T_Accessor Accessor;
-    typedef T_Navigator Navigator;
-    typedef Vector<type, dim, Accessor, Navigator, T_Storage> This;
-    typedef typename boost::call_traits<type>::param_type ParamType;
+    using tag = tag::Vector;
+    using Accessor = T_Accessor;
+    using Navigator = T_Navigator;
+    using This = Vector<type, dim, Accessor, Navigator, T_Storage>;
+    using ParamType = typename boost::call_traits<type>::param_type;
 
     /*Vectors without elements are not allowed*/
     PMACC_CASSERT_MSG(math_Vector__with_DIM_0_is_not_allowed,dim > 0);
@@ -130,13 +130,13 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
     template<class F, typename T>
     struct result < F(T)>
     {
-        typedef typename F::type& type;
+        using type = typename F::type&;
     };
 
     template<class F, typename T>
     struct result < const F(T)>
     {
-        typedef const typename F::type& type;
+        using type = const typename F::type&;
     };
 
     HDINLINE Vector()
@@ -538,7 +538,7 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
 template<typename Type>
 struct Vector<Type, 0 >
 {
-    typedef Type type;
+    using type = Type;
     static constexpr int dim = 0;
 
     template<typename OtherType >
@@ -852,13 +852,13 @@ namespace result_of
 template<typename TVector>
 struct Functor<math::Abs2, TVector>
 {
-    typedef typename TVector::type type;
+    using type = typename TVector::type;
 };
 
 template<typename TVector>
 struct Functor<math::Abs, TVector>
 {
-    typedef typename TVector::type type;
+    using type = typename TVector::type;
 };
 
 } //namespace result_of

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -41,7 +41,7 @@ namespace traits
 template<typename T_DataType, int T_Dim>
 struct GetComponentsType<pmacc::math::Vector<T_DataType, T_Dim>, false >
 {
-    typedef typename pmacc::math::Vector<T_DataType, T_Dim>::type type;
+    using type = typename pmacc::math::Vector<T_DataType, T_Dim>::type;
 };
 
 template<typename T_DataType, int T_Dim>
@@ -53,8 +53,8 @@ struct GetNComponents<pmacc::math::Vector<T_DataType, T_Dim>,false >
 template<typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, template<typename, int> class T_Storage>
 struct GetInitializedInstance<math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage> >
 {
-    typedef math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage> Type;
-    typedef typename Type::type ValueType;
+    using Type = math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>;
+    using ValueType = typename Type::type;
 
     HDINLINE Type operator()(const ValueType value) const
     {
@@ -62,8 +62,8 @@ struct GetInitializedInstance<math::Vector<T_Type, T_dim, T_Accessor, T_Navigato
     }
 };
 
-} //namespace traits
-} //namespace pmacc
+} // namespace traits
+} // namespace pmacc
 
 
 namespace pmacc
@@ -79,7 +79,7 @@ namespace math
 template<typename Type, int dim>
 struct Max< ::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim> >
 {
-    typedef ::pmacc::math::Vector<Type, dim> result;
+    using result = ::pmacc::math::Vector<Type, dim>;
 
     HDINLINE result operator( )(const ::pmacc::math::Vector<Type, dim> &vector1, const ::pmacc::math::Vector<Type, dim> &vector2 )
     {
@@ -94,7 +94,7 @@ struct Max< ::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim> >
 template<typename Type, int dim>
 struct Min< ::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim> >
 {
-    typedef ::pmacc::math::Vector<Type, dim> result;
+    using result = ::pmacc::math::Vector<Type, dim>;
 
     HDINLINE result operator( )(const ::pmacc::math::Vector<Type, dim> &vector1, const ::pmacc::math::Vector<Type, dim> &vector2 )
     {
@@ -111,7 +111,7 @@ struct Min< ::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim> >
 template<typename Type, int dim>
 struct Abs2< ::pmacc::math::Vector<Type, dim> >
 {
-    typedef typename ::pmacc::math::Vector<Type, dim>::type result;
+    using result = typename ::pmacc::math::Vector<Type, dim>::type;
 
     HDINLINE result operator( )(const ::pmacc::math::Vector<Type, dim> &vector )
     {
@@ -126,7 +126,7 @@ struct Abs2< ::pmacc::math::Vector<Type, dim> >
 template<typename Type, int dim>
 struct Abs< ::pmacc::math::Vector<Type, dim> >
 {
-    typedef typename ::pmacc::math::Vector<Type, dim>::type result;
+    using result = typename ::pmacc::math::Vector<Type, dim>::type;
 
     HDINLINE result operator( )( ::pmacc::math::Vector<Type, dim> vector )
     {
@@ -140,8 +140,8 @@ struct Abs< ::pmacc::math::Vector<Type, dim> >
 template<typename Type>
 struct Cross< ::pmacc::math::Vector<Type, DIM3>, ::pmacc::math::Vector<Type, DIM3> >
 {
-    typedef ::pmacc::math::Vector<Type, DIM3> myType;
-    typedef myType result;
+    using myType = ::pmacc::math::Vector<Type, DIM3>;
+    using result = myType;
 
     HDINLINE myType operator( )(const myType& lhs, const myType & rhs )
     {
@@ -156,8 +156,8 @@ struct Cross< ::pmacc::math::Vector<Type, DIM3>, ::pmacc::math::Vector<Type, DIM
 template<typename Type, int dim>
 struct Dot< ::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim> >
 {
-    typedef ::pmacc::math::Vector<Type, dim> myType;
-    typedef Type result;
+    using myType = ::pmacc::math::Vector<Type, dim>;
+    using result = Type;
 
     HDINLINE result operator( )(const myType& a, const myType & b )
     {
@@ -180,8 +180,8 @@ struct Dot< ::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim> >
 template<typename T1, int dim>
 struct Exp< ::pmacc::math::Vector<T1, dim> >
 {
-    typedef ::pmacc::math::Vector<T1, dim> Vector1;
-    typedef Vector1 result;
+    using Vector1 = ::pmacc::math::Vector<T1, dim>;
+    using result = Vector1;
 
     HDINLINE result operator( )(const Vector1& power )
     {
@@ -205,8 +205,8 @@ struct Exp< ::pmacc::math::Vector<T1, dim> >
 template<typename T1, typename T2, int dim>
 struct Pow< ::pmacc::math::Vector<T1, dim>, T2 >
 {
-    typedef ::pmacc::math::Vector<T1, dim> Vector1;
-    typedef Vector1 result;
+    using Vector1 = ::pmacc::math::Vector<T1, dim>;
+    using result = Vector1;
 
     HDINLINE result operator( )(const Vector1& base, const T2 & exponent )
     {
@@ -224,7 +224,7 @@ struct Pow< ::pmacc::math::Vector<T1, dim>, T2 >
 template<typename Type, int dim>
 struct Floor< ::pmacc::math::Vector<Type, dim> >
 {
-    typedef ::pmacc::math::Vector<Type, dim> result;
+    using result = ::pmacc::math::Vector<Type, dim>;
 
     HDINLINE result operator( )( ::pmacc::math::Vector<Type, dim> &vector )
     {
@@ -236,8 +236,8 @@ struct Floor< ::pmacc::math::Vector<Type, dim> >
 };
 
 
-} //namespace math
-} //namespace algorithms
+} // namespace math
+} // namespace algorithms
 } // namespace pmacc
 
 namespace pmacc
@@ -257,12 +257,12 @@ struct TypeCast<
     ::pmacc::math::Vector<CastToType, dim, T_Accessor, T_Navigator, T_Storage>
 >
 {
-    typedef const ::pmacc::math::Vector<
+    using result = const ::pmacc::math::Vector<
         CastToType,
         dim,
         T_Accessor,
         T_Navigator,
-        T_Storage>& result;
+        T_Storage>&;
 
     HDINLINE result operator( )( result vector ) const
     {
@@ -281,8 +281,8 @@ struct TypeCast<
     ::pmacc::math::Vector<OldType, dim, T_Accessor, T_Navigator, T_Storage>
 >
 {
-    typedef ::pmacc::math::Vector<CastToType, dim> result;
-    typedef ::pmacc::math::Vector<OldType, dim, T_Accessor, T_Navigator, T_Storage> ParamType;
+    using result = ::pmacc::math::Vector<CastToType, dim>;
+    using ParamType = ::pmacc::math::Vector<OldType, dim, T_Accessor, T_Navigator, T_Storage>;
 
     HDINLINE result operator( )(const ParamType& vector ) const
     {
@@ -290,9 +290,9 @@ struct TypeCast<
     }
 };
 
-} //namespace typecast
-} //namespace algorithms
-} //PMacc
+} // namespace typecast
+} // namespace algorithms
+} // namespace pmacc
 
 namespace pmacc
 {
@@ -304,13 +304,13 @@ namespace promoteType
 template<typename PromoteToType, typename OldType, int dim>
 struct promoteType<PromoteToType, ::pmacc::math::Vector<OldType, dim> >
 {
-    typedef typename promoteType<OldType, PromoteToType>::type PartType;
-    typedef ::pmacc::math::Vector<PartType, dim> type;
+    using PartType = typename promoteType<OldType, PromoteToType>::type;
+    using type = ::pmacc::math::Vector<PartType, dim>;
 };
 
-} //namespace promoteType
-} //namespace algorithms
-} //namespace pmacc
+} // namespace promoteType
+} // namespace algorithms
+} // namespace pmacc
 
 namespace pmacc
 {
@@ -359,8 +359,6 @@ struct GetMPI_StructAsArray< ::pmacc::math::Vector<double, T_dim>[T_N] >
     }
 };
 
-} //namespace def
-
-} //namespace mpi
-
-}//namespace pmacc
+} // namespace def
+} // namespace mpi
+} // namespace pmacc

--- a/include/pmacc/math/vector/compile-time/Float.hpp
+++ b/include/pmacc/math/vector/compile-time/Float.hpp
@@ -38,9 +38,9 @@ template<typename X = mpl::void_,
          typename Z = mpl::void_>
 struct Float
 {
-    typedef X x;
-    typedef Y y;
-    typedef Z z;
+    using x = X;
+    using y = Y;
+    using z = Z;
 
     static constexpr int dim = 3;
 };
@@ -51,7 +51,7 @@ struct Float<> {};
 template<typename X>
 struct Float<X>
 {
-    typedef X x;
+    using x = X;
 
     static constexpr int dim = 1;
 };
@@ -59,8 +59,8 @@ struct Float<X>
 template<typename X, typename Y>
 struct Float<X, Y>
 {
-    typedef X x;
-    typedef Y y;
+    using x = X;
+    using y = Y;
 
     static constexpr int dim = 2u;
 };

--- a/include/pmacc/math/vector/compile-time/Int.hpp
+++ b/include/pmacc/math/vector/compile-time/Int.hpp
@@ -72,19 +72,19 @@ struct make_Int;
 template<int val>
 struct make_Int<1, val>
 {
-    typedef Int<val> type;
+    using type = Int<val>;
 };
 
 template<int val>
 struct make_Int<2, val>
 {
-    typedef Int<val, val> type;
+    using type = Int<val, val>;
 };
 
 template<int val>
 struct make_Int<3, val>
 {
-    typedef Int<val, val, val> type;
+    using type = Int<val, val, val>;
 };
 
 } // CT

--- a/include/pmacc/math/vector/compile-time/TwistComponents.hpp
+++ b/include/pmacc/math/vector/compile-time/TwistComponents.hpp
@@ -38,8 +38,8 @@ namespace CT
  *
  * Example:
  *
- * typedef pmacc::math::CT::Int<1,2,0> Orientation_Y;
- * typedef typename pmacc::math::CT::TwistComponents<BlockDim, Orientation_Y>::type TwistedBlockDim;
+ * using Orientation_Y = pmacc::math::CT::Int<1,2,0>;
+ * using TwistedBlockDim = typename pmacc::math::CT::TwistComponents<BlockDim, Orientation_Y>::type;
  */
 template<typename Vec, typename Axes, int dim=Vec::dim>
 struct TwistComponents;
@@ -47,18 +47,18 @@ struct TwistComponents;
 template<typename Vec, typename Axes>
 struct TwistComponents<Vec, Axes, DIM2>
 {
-    typedef math::CT::Vector<
+    using type = math::CT::Vector<
         typename Vec::template at<Axes::x::value>::type,
-        typename Vec::template at<Axes::y::value>::type> type;
+        typename Vec::template at<Axes::y::value>::type>;
 };
 
 template<typename Vec, typename Axes>
 struct TwistComponents<Vec, Axes, DIM3>
 {
-    typedef math::CT::Vector<
+    using type = math::CT::Vector<
         typename Vec::template at<Axes::x::value>::type,
         typename Vec::template at<Axes::y::value>::type,
-        typename Vec::template at<Axes::z::value>::type> type;
+        typename Vec::template at<Axes::z::value>::type>;
 };
 
 } // namespace CT

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -97,20 +97,20 @@ struct VectorFromCT<3>
 template<typename Arg0>
 struct TypeSelector
 {
-    typedef Arg0 type;
+    using type = Arg0;
 };
 
 /** get integral type*/
 template<typename T, T value>
 struct TypeSelector<mpl::integral_c<T, value > >
 {
-    typedef T type;
+    using type = T;
 };
 
 template<>
 struct TypeSelector<mpl::na>
 {
-    typedef mpl::int_<0> type;
+    using type = mpl::int_<0>;
 };
 
 }
@@ -122,24 +122,24 @@ typename Arg1 = mpl::na,
 typename Arg2 = mpl::na>
 struct Vector
 {
-    typedef Arg0 x;
-    typedef Arg1 y;
-    typedef Arg2 z;
+    using x = Arg0;
+    using y = Arg1;
+    using z = Arg2;
 
-    typedef mpl::vector<x, y, z> mplVector;
+    using mplVector = mpl::vector<x, y, z>;
 
     template<int element>
     struct at
     {
-        typedef typename mpl::at_c<mplVector, element>::type type;
+        using type = typename mpl::at_c<mplVector, element>::type;
     };
 
     static constexpr int dim = mpl::size<mplVector >::type::value;
 
-    typedef typename detail::TypeSelector<x>::type type;
-    typedef Vector<x, y, z> This;
-    typedef math::Vector<type, dim> RT_type;
-    typedef This vector_type;
+    using type = typename detail::TypeSelector<x>::type;
+    using This = Vector<x, y, z>;
+    using RT_type = math::Vector<type, dim>;
+    using vector_type = This;
 
     template<typename OtherType>
     HDINLINE
@@ -171,8 +171,11 @@ struct Vector
 template<typename Lhs, typename Rhs, typename T_BinaryOperator>
 struct applyOperator
 {
-    typedef typename applyOperator<typename Lhs::vector_type,
-    typename Rhs::vector_type, T_BinaryOperator>::type type;
+    using type = typename applyOperator<
+        typename Lhs::vector_type,
+        typename Rhs::vector_type,
+        T_BinaryOperator
+    >::type;
 };
 
 template<typename T_TypeA,
@@ -180,8 +183,8 @@ typename T_TypeB,
 typename T_BinaryOperator>
 struct applyOperator<CT::Vector<T_TypeA>, CT::Vector<T_TypeB>, T_BinaryOperator>
 {
-    typedef typename mpl::apply<T_BinaryOperator, T_TypeA, T_TypeB>::type OpResult;
-    typedef CT::Vector<OpResult> type;
+    using OpResult = typename mpl::apply<T_BinaryOperator, T_TypeA, T_TypeB>::type;
+    using type = CT::Vector<OpResult>;
 };
 
 template<typename T_TypeA0, typename T_TypeA1,
@@ -191,9 +194,9 @@ struct applyOperator<CT::Vector<T_TypeA0, T_TypeA1>,
 CT::Vector<T_TypeB0, T_TypeB1>,
 T_BinaryOperator>
 {
-    typedef typename mpl::apply<T_BinaryOperator, T_TypeA0, T_TypeB0>::type OpResult0;
-    typedef typename mpl::apply<T_BinaryOperator, T_TypeA1, T_TypeB1>::type OpResult1;
-    typedef CT::Vector<OpResult0, OpResult1> type;
+    using OpResult0 = typename mpl::apply<T_BinaryOperator, T_TypeA0, T_TypeB0>::type;
+    using OpResult1 = typename mpl::apply<T_BinaryOperator, T_TypeA1, T_TypeB1>::type;
+    using type = CT::Vector<OpResult0, OpResult1>;
 };
 
 template<typename T_TypeA0, typename T_TypeA1, typename T_TypeA2,
@@ -203,10 +206,10 @@ struct applyOperator<CT::Vector<T_TypeA0, T_TypeA1, T_TypeA2>,
 CT::Vector<T_TypeB0, T_TypeB1, T_TypeB2>,
 T_BinaryOperator>
 {
-    typedef typename mpl::apply<T_BinaryOperator, T_TypeA0, T_TypeB0>::type OpResult0;
-    typedef typename mpl::apply<T_BinaryOperator, T_TypeA1, T_TypeB1>::type OpResult1;
-    typedef typename mpl::apply<T_BinaryOperator, T_TypeA2, T_TypeB2>::type OpResult2;
-    typedef CT::Vector<OpResult0, OpResult1, OpResult2> type;
+    using OpResult0 = typename mpl::apply<T_BinaryOperator, T_TypeA0, T_TypeB0>::type;
+    using OpResult1 = typename mpl::apply<T_BinaryOperator, T_TypeA1, T_TypeB1>::type;
+    using OpResult2 = typename mpl::apply<T_BinaryOperator, T_TypeA2, T_TypeB2>::type;
+    using type = CT::Vector<OpResult0, OpResult1, OpResult2>;
 };
 
 //________________________A D D____________________________
@@ -214,10 +217,11 @@ T_BinaryOperator>
 template<typename Lhs, typename Rhs>
 struct add
 {
-    typedef typename applyOperator<
-    typename Lhs::vector_type,
-    typename Rhs::vector_type,
-    mpl::plus<mpl::_1, mpl::_2> >::type type;
+    using type = typename applyOperator<
+        typename Lhs::vector_type,
+        typename Rhs::vector_type,
+        mpl::plus<mpl::_1, mpl::_2>
+    >::type;
 };
 
 //________________________M U L____________________________
@@ -225,10 +229,11 @@ struct add
 template<typename Lhs, typename Rhs>
 struct mul
 {
-    typedef typename applyOperator<
-    typename Lhs::vector_type,
-    typename Rhs::vector_type,
-    mpl::times<mpl::_1, mpl::_2> >::type type;
+    using type = typename applyOperator<
+        typename Lhs::vector_type,
+        typename Rhs::vector_type,
+        mpl::times<mpl::_1, mpl::_2>
+    >::type;
 };
 
 //________________________M A X____________________________
@@ -243,10 +248,11 @@ struct mul
 template<typename Lhs, typename Rhs = void>
 struct max
 {
-    typedef typename applyOperator<
-    typename Lhs::vector_type,
-    typename Rhs::vector_type,
-    mpl::max<mpl::_1, mpl::_2> >::type type;
+    using type = typename applyOperator<
+        typename Lhs::vector_type,
+        typename Rhs::vector_type,
+        mpl::max<mpl::_1, mpl::_2>
+    >::type;
 };
 
 
@@ -261,14 +267,14 @@ struct max<
     void
 >
 {
-    typedef typename mpl::accumulate<
+    using type = typename mpl::accumulate<
         typename T_Vec::mplVector,
         typename T_Vec::x,
         mpl::max<
             mpl::_1,
             mpl::_2
         >
-    >::type type;
+    >::type;
 };
 
 //________________________M I N____________________________
@@ -284,10 +290,11 @@ struct max<
 template<typename Lhs, typename Rhs = void>
 struct min
 {
-    typedef typename applyOperator<
-    typename Lhs::vector_type,
-    typename Rhs::vector_type,
-    mpl::min<mpl::_1, mpl::_2> >::type type;
+    using type = typename applyOperator<
+        typename Lhs::vector_type,
+        typename Rhs::vector_type,
+        mpl::min<mpl::_1, mpl::_2>
+    >::type;
 };
 
 /** get element with minimum value
@@ -301,14 +308,14 @@ struct min<
     void
 >
 {
-    typedef typename mpl::accumulate<
+    using type = typename mpl::accumulate<
         typename T_Vec::mplVector,
         typename T_Vec::x,
         mpl::min<
             mpl::_1,
             mpl::_2
         >
-    >::type type;
+    >::type;
 };
 
 //________________________D O T____________________________
@@ -316,12 +323,12 @@ struct min<
 template<typename Lhs, typename Rhs>
 struct dot
 {
-    typedef typename mul<Lhs, Rhs>::type MulResult;
-    typedef typename mpl::accumulate<
-    typename MulResult::mplVector,
-    mpl::int_<0>,
-    mpl::plus<mpl::_1, mpl::_2>
-    >::type type;
+    using MulResult = typename mul<Lhs, Rhs>::type;
+    using type = typename mpl::accumulate<
+        typename MulResult::mplVector,
+        mpl::int_<0>,
+        mpl::plus<mpl::_1, mpl::_2>
+    >::type;
 };
 
 //________________________V O L U M E____________________________
@@ -329,11 +336,11 @@ struct dot
 template<typename T_Vec>
 struct volume
 {
-    typedef typename mpl::accumulate<
-    typename T_Vec::mplVector,
-    mpl::int_<1>,
-    mpl::times<mpl::_1, mpl::_2>
-    >::type type;
+    using type = typename mpl::accumulate<
+        typename T_Vec::mplVector,
+        mpl::int_<1>,
+        mpl::times<mpl::_1, mpl::_2>
+    >::type;
 };
 
 //________________________S H R I N K T O________________________
@@ -352,22 +359,22 @@ struct shrinkTo;
 template<typename T_Vec>
 struct shrinkTo<T_Vec, DIM3>
 {
-    typedef T_Vec Vec;
-    typedef CT::Vector<typename Vec::x, typename Vec::y, typename Vec::z> type;
+    using Vec = T_Vec;
+    using type = CT::Vector<typename Vec::x, typename Vec::y, typename Vec::z>;
 };
 
 template<typename T_Vec>
 struct shrinkTo<T_Vec, DIM2>
 {
-    typedef T_Vec Vec;
-    typedef CT::Vector<typename Vec::x, typename Vec::y, mpl::na> type;
+    using Vec = T_Vec;
+    using type = CT::Vector<typename Vec::x, typename Vec::y, mpl::na>;
 };
 
 template<typename T_Vec>
 struct shrinkTo<T_Vec, DIM1>
 {
-    typedef T_Vec Vec;
-    typedef CT::Vector<typename Vec::x, mpl::na, mpl::na> type;
+    using Vec = T_Vec;
+    using type = CT::Vector<typename Vec::x, mpl::na, mpl::na>;
 };
 
 //________________________A S S I G N________________________
@@ -386,19 +393,19 @@ struct Assign;
 template<typename T_Value, typename T_0, typename T_1, typename T_2, typename T_IntegralType>
 struct Assign<pmacc::math::CT::Vector<T_0, T_1, T_2>, bmpl::integral_c<T_IntegralType,0> , T_Value>
 {
-    typedef pmacc::math::CT::Vector<T_Value, T_1, T_2> type;
+    using type = pmacc::math::CT::Vector<T_Value, T_1, T_2>;
 };
 
 template<typename T_Value, typename T_0, typename T_1, typename T_2, typename T_IntegralType>
 struct Assign<pmacc::math::CT::Vector<T_0, T_1, T_2>, bmpl::integral_c<T_IntegralType,1>, T_Value>
 {
-    typedef pmacc::math::CT::Vector<T_0, T_Value, T_2> type;
+    using type = pmacc::math::CT::Vector<T_0, T_Value, T_2>;
 };
 
 template<typename T_Value, typename T_0, typename T_1, typename T_2, typename T_IntegralType>
 struct Assign<pmacc::math::CT::Vector<T_0, T_1, T_2>, bmpl::integral_c<T_IntegralType,2>, T_Value>
 {
-    typedef pmacc::math::CT::Vector<T_0, T_1, T_Value> type;
+    using type = pmacc::math::CT::Vector<T_0, T_1, T_Value>;
 };
 
 /** Assign a type to a given component in the CT::Vector if position is not out of range
@@ -414,12 +421,12 @@ struct Assign<pmacc::math::CT::Vector<T_0, T_1, T_2>, bmpl::integral_c<T_Integra
 template<typename T_Vec, typename T_ComponentPos, typename T_Value>
 struct AssignIfInRange
 {
-    typedef bmpl::integral_c<size_t,T_Vec::dim> VectorDim;
-    typedef typename bmpl::if_<
-    bmpl::less<T_ComponentPos, VectorDim>,
+    using VectorDim = bmpl::integral_c<size_t,T_Vec::dim>;
+    using type = typename bmpl::if_<
+        bmpl::less<T_ComponentPos, VectorDim>,
         typename pmacc::math::CT::Assign<T_Vec,T_ComponentPos,T_Value>::type,
         T_Vec
-        >::type type;
+    >::type;
 };
 
 //________________________At_c____________________________
@@ -434,7 +441,7 @@ struct AssignIfInRange
 template<typename T_Vec,size_t T_idx>
 struct At_c
 {
-    typedef typename mpl::at_c<typename T_Vec::mplVector,T_idx>::type type;
+    using type = typename mpl::at_c<typename T_Vec::mplVector,T_idx>::type;
 };
 
 //________________________At____________________________
@@ -449,7 +456,7 @@ struct At_c
 template<typename T_Vec, typename T_Idx>
 struct At
 {
-    typedef typename mpl::at<typename T_Vec::mplVector,T_Idx>::type type;
+    using type = typename mpl::at<typename T_Vec::mplVector,T_Idx>::type;
 };
 
 //________________________make_Vector___________________
@@ -467,19 +474,19 @@ struct make_Vector;
 template<typename T_Type>
 struct make_Vector<1, T_Type>
 {
-    typedef pmacc::math::CT::Vector<T_Type> type;
+    using type = pmacc::math::CT::Vector<T_Type>;
 };
 
 template<typename T_Type>
 struct make_Vector<2, T_Type>
 {
-    typedef pmacc::math::CT::Vector<T_Type, T_Type> type;
+    using type = pmacc::math::CT::Vector<T_Type, T_Type>;
 };
 
 template<typename T_Type>
 struct make_Vector<3, T_Type>
 {
-    typedef pmacc::math::CT::Vector<T_Type, T_Type, T_Type> type;
+    using type = pmacc::math::CT::Vector<T_Type, T_Type, T_Type>;
 };
 
 } // CT

--- a/include/pmacc/math/vector/math_functor/abs.hpp
+++ b/include/pmacc/math/vector/math_functor/abs.hpp
@@ -50,9 +50,8 @@ namespace result_of
 template<typename Type>
 struct Functor<pmacc::math::math_functor::Abs, Type>
 {
-    typedef Type type;
+    using type = Type;
 };
 
 } // result_of
-
 } // pmacc

--- a/include/pmacc/math/vector/math_functor/cosf.hpp
+++ b/include/pmacc/math/vector/math_functor/cosf.hpp
@@ -33,7 +33,7 @@ namespace math_functor
 
 struct Cosf
 {
-    typedef float result_type;
+    using result_type = float;
 
     DINLINE result_type operator()(const result_type& value) const
     {

--- a/include/pmacc/math/vector/math_functor/max.hpp
+++ b/include/pmacc/math/vector/math_functor/max.hpp
@@ -50,9 +50,8 @@ namespace result_of
 template<typename Type>
 struct Functor<math::math_functor::Max, Type, Type>
 {
-    typedef Type type;
+    using type = Type;
 };
 
 } // result_of
-
 } // pmacc

--- a/include/pmacc/math/vector/math_functor/min.hpp
+++ b/include/pmacc/math/vector/math_functor/min.hpp
@@ -51,7 +51,7 @@ namespace result_of
 template<typename Type>
 struct Functor<math::math_functor::Min, Type, Type>
 {
-    typedef Type type;
+    using type = Type;
 };
 
 }

--- a/include/pmacc/math/vector/math_functor/sin.hpp
+++ b/include/pmacc/math/vector/math_functor/sin.hpp
@@ -34,7 +34,7 @@ namespace math_functor
 template<typename T_Type>
 struct Sin
 {
-    typedef T_Type result_type;
+    using result_type = T_Type;
 
     DINLINE result_type operator()(const result_type& value) const
     {

--- a/include/pmacc/math/vector/math_functor/sqrtf.hpp
+++ b/include/pmacc/math/vector/math_functor/sqrtf.hpp
@@ -33,7 +33,7 @@ namespace math_functor
 
 struct Sqrtf
 {
-    typedef float result_type;
+    using result_type = float;
 
     HDINLINE result_type operator()(const result_type& value) const
     {


### PR DESCRIPTION
Continue transitioning PMacc to C++11 syntax with "using" instead of "typedef".
Avoid adding more outdated syntax (follow-up to #2956).

Committed as generic "tools" user:
```
GIT_AUTHOR_NAME="Tools" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git ...
```