### PR TITLE
CUDA 9.0+, GCC 5.1+, Boost 1.65.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ install:
   - travis_wait spack install
       cmake
       $COMPILERSPEC
-  # required dependencies - Boost 1.62.0
+  # required dependencies - Boost 1.65.1
   - travis_wait spack install
-      boost@1.62.0~date_time~graph~iostreams~locale~log~random~thread~timer~wave
+      boost@1.65.1~date_time~graph~iostreams~locale~log~random~thread~timer~wave
       $COMPILERSPEC
   - spack clean -a
   - source /etc/profile &&

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -33,22 +33,21 @@ gcc
 """
 - 4.9 - 7 (if you want to build for Nvidia GPUs, supported compilers depend on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
 
-  - CUDA 8.0: Use gcc 4.9 - 5.3
   - CUDA 9.0 - 9.1: Use gcc 4.9 - 5.5
   - CUDA 9.2 - 10.0: Use gcc 4.9 - 7
-- *note:* be sure to build all libraries/dependencies with the *same* gcc version
+- *note:* be sure to build all libraries/dependencies with the *same* gcc version; GCC 5 or newer is recommended
 - *Debian/Ubuntu:*
   
-  - ``sudo apt-get install gcc-4.9 g++-4.9 build-essential``
-  - ``sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9``
+  - ``sudo apt-get install gcc-5.3 g++-5.3 build-essential``
+  - ``sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5.3 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5.3``
 - *Arch Linux:*
   
   - ``sudo pacman --sync base-devel``
   - if the installed version of **gcc** is too new, `compile an older gcc <https://gist.github.com/slizzered/a9dc4e13cb1c7fffec53>`_
 - *Spack:*
   
-  - ``spack install gcc@4.9.4``
-  - make it the default in your `packages.yaml <http://spack.readthedocs.io/en/latest/getting_started.html#compiler-configuration>`_ or *suffix* `all following <http://spack.readthedocs.io/en/latest/features.html#simple-package-installation>`_ ``spack install`` commands with a *space* and ``%gcc@4.9.4``
+  - ``spack install gcc@5.3.0``
+  - make it the default in your `packages.yaml <http://spack.readthedocs.io/en/latest/getting_started.html#compiler-configuration>`_ or *suffix* `all following <http://spack.readthedocs.io/en/latest/features.html#simple-package-installation>`_ ``spack install`` commands with a *space* and ``%gcc@5.3.0``
 
 CMake
 """""
@@ -89,8 +88,7 @@ zlib
 
 boost
 """""
-- 1.62.0 - 1.68.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
-- *note:* for CUDA 9+ support, use boost 1.65.1 or newer
+- 1.65.1 - 1.68.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
@@ -155,13 +153,13 @@ Optional Libraries
 
 CUDA
 """"
-- `8.0 - 10.0 <https://developer.nvidia.com/cuda-downloads>`_
+- `9.0 - 10.0 <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``
 - *Spack:* ``spack install cuda``
 - at least one **CUDA** capable **GPU**
-- *compute capability*: ``sm_20`` or higher (for CUDA 9+: ``sm_30`` or higher)
+- *compute capability*: ``sm_30`` or higher
 - `full list <https://developer.nvidia.com/cuda-gpus>`_ of CUDA GPUs and their *compute capability*
 - `More <http://www.olcf.ornl.gov/summit/>`_ is always `better <http://www.cscs.ch/computers/piz_daint/index.html>`_. Especially, if we are talking GPUs :-)
 - *environment:*
@@ -231,7 +229,7 @@ libSplash
 
 HDF5
 """"
-- 1.8.6+
+- 1.8.13+
 - standard shared version (no C++, enable parallel)
 - *Debian/Ubuntu:* ``sudo apt-get install libhdf5-openmpi-dev``
 - *Arch Linux:* ``sudo pacman --sync hdf5-openmpi``

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -94,9 +94,9 @@ touch "$thisDir"runGuard
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DALPAKA_CUDA_ARCH=35"
             export PIC_BACKEND="cuda"
             . /etc/profile
-            module load gcc/4.9.4 boost/1.62.0 cmake/3.11.0 cuda/8.0.44 openmpi/1.10.4
+            module load gcc/5.1.0 boost/1.65.1 cmake/3.11.0 cuda/9.0.176 openmpi/3.0.4
             module load libSplash/1.7.0 adios/1.13.1
-            module load pngwriter/0.7.0
+            module load pngwriter/0.7.0 zlib/1.2.11
             module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.4.0
 
             # compile all examples, fetch output and return code

--- a/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
+++ b/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
@@ -23,7 +23,7 @@ then
         # Core Dependencies
         module load gcc/5.3.0
         module load cmake/3.11.0
-        module load boost/1.62.0
+        module load boost/1.65.1
         module load openmpi/1.8.6
         module load numactl
 

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -23,7 +23,7 @@ then
         # Core Dependencies
         module load gcc/5.3.0
         module load cmake/3.13.4
-        module load boost/1.62.0
+        module load boost/1.65.1
         module load openmpi/1.8.6
         module load numactl
 

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -23,8 +23,8 @@ then
         # Core Dependencies
         module load gcc
         module load cuda
-        echo "WARNING: Boost version is too old! (Need: 1.62.0+)" >&2
-        # module load boost/1.62.0-gcc
+        echo "WARNING: Boost version is too old! (Need: 1.65.1+)" >&2
+        # module load boost/1.65.1-gcc
         module load openmpi/1.6.5-gcc
 
         # Core tools

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -49,7 +49,7 @@ module load cray-hdf5-parallel/1.10.0.3
 #
 # needs to be compiled by the user
 export PIC_LIBS="$HOME/lib"
-export BOOST_ROOT=$PIC_LIBS/boost-1.62.0
+export BOOST_ROOT=$PIC_LIBS/boost-1.65.1
 export ZLIB_ROOT=$PIC_LIBS/zlib-1.2.11
 export PNG_ROOT=$PIC_LIBS/libpng-1.6.34
 export BLOSC_ROOT=$PIC_LIBS/blosc-1.12.1

--- a/include/mpiInfo/CMakeLists.txt
+++ b/include/mpiInfo/CMakeLists.txt
@@ -92,7 +92,7 @@ endif(MPI_CXX_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.65.1 REQUIRED COMPONENTS program_options)
 if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -165,7 +165,7 @@ endif()
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options filesystem
+find_package(Boost 1.65.1 REQUIRED COMPONENTS program_options filesystem
                                               system math_tr1 serialization)
 if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -72,7 +72,7 @@ add_definitions(${PMacc_DEFINITIONS})
 # Boost.Test
 ###############################################################################
 
-find_package(Boost 1.62.0 COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost 1.65.1 COMPONENTS unit_test_framework REQUIRED)
 if(TARGET Boost::unit_test_framework)
     set(LIBS ${LIBS} Boost::boost Boost::unit_test_framework)
 else()

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -305,7 +305,7 @@ endif(MPI_CXX_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS filesystem system math_tr1)
+find_package(Boost 1.65.1 REQUIRED COMPONENTS filesystem system math_tr1)
 if(TARGET Boost::filesystem)
     set(PMacc_LIBRARIES ${PMacc_LIBRARIES} Boost::boost Boost::filesystem
                                            Boost::system Boost::math_tr1)
@@ -319,18 +319,6 @@ endif()
 # great for the transition from the "wrong" usage to the "correct" one as
 message(STATUS "Boost: result_of with TR1 style and decltype fallback")
 set(PMacc_DEFINITIONS ${PMacc_DEFINITIONS} -DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
-
-# Boost >= 1.60.0 and CUDA 8.0 fail to compile on mp_defer
-# seen with Boost 1.60.0 - 1.63.0 (latter got config work-around below)
-# CUDA 9.0+ fixed
-if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
-    if( (Boost_VERSION GREATER 105999) AND
-        (CUDA_VERSION VERSION_EQUAL 8.0) )
-        # Boost Bug https://svn.boost.org/trac/boost/ticket/11897
-        message(STATUS "Boost: Disable variadic templates")
-        set(PMacc_DEFINITIONS ${PMacc_DEFINITIONS} -DBOOST_NO_CXX11_VARIADIC_TEMPLATES)
-    endif()
-endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     message(STATUS "Boost: Disable variadic templates")
@@ -346,25 +334,10 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_SMART_PTR")
 endif()
 
-# Boost 1.64.0 is broken with CUDA 8.0 (nvcc) and C++11
-#   https://github.com/ComputationalRadiationPhysics/picongpu/issues/2048
-#   fixed in CUDA 9.0 (ticket 1928813)
-if( ("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc") AND
-    (Boost_VERSION EQUAL 106400) AND
-    (CUDA_VERSION VERSION_EQUAL 8.0) )
-    message(STATUS "Boost: Disable C++11 noexcept")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_NOEXCEPT")
-endif()
-
 # GCC's C++11 tuples are broken in "supported" NVCC versions
 if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        if(CUDA_VERSION VERSION_EQUAL 8.0)
-            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 5.4)
-                message(FATAL_ERROR "NVCC 8.0 does not support the std::tuple "
-                        "implementation in GCC 5.4+. Please use GCC 4.9 - 5.3!")
-            endif()
-        elseif(CUDA_VERSION VERSION_EQUAL 9.0 OR
+        if(CUDA_VERSION VERSION_EQUAL 9.0 OR
                CUDA_VERSION VERSION_EQUAL 9.1)
             if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 6.0)
                 message(FATAL_ERROR "NVCC 9.0 - 9.1 do not support the std::tuple "

--- a/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
@@ -104,7 +104,7 @@ endif(GOL_RELEASE)
 # Find Boost
 ###############################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.65.1 REQUIRED COMPONENTS program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 

--- a/src/tools/png2gas/CMakeLists.txt
+++ b/src/tools/png2gas/CMakeLists.txt
@@ -94,7 +94,7 @@ endif(NOT RELEASE)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.65.1 REQUIRED COMPONENTS program_options)
 if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()

--- a/src/tools/png2gas/README.md
+++ b/src/tools/png2gas/README.md
@@ -16,7 +16,7 @@ Required libraries:
  - **boost** 1.47.0 or higher ("program options")
  - **PNGwriter** 0.7.0 or higher ([GitHub project](https://github.com/pngwriter/pngwriter))
  - **libSplash** (requires *hdf5*)
- - **hdf5** >= 1.8.6, standard shared version (no c++, enable parallel)
+ - **hdf5** >= 1.8.13, standard shared version (no c++, enable parallel)
 
 
 ### Usage

--- a/src/tools/splash2txt/CMakeLists.txt
+++ b/src/tools/splash2txt/CMakeLists.txt
@@ -145,7 +145,7 @@ endif(ADIOS_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.62.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.65.1 REQUIRED COMPONENTS program_options)
 if(TARGET Boost::program_options)
     set(LIBS ${LIBS} Boost::boost Boost::program_options)
 else()


### PR DESCRIPTION
Increase the dependencies to CUDA 9.0+, which in turn requires Boost 1.65.1+ to run.

With that prepare, we also update our CI to run on GCC 5.1+ which will make the transition to C++14 possible soon. While GCC 4.9 is technically still okay as long as we stick with C++11, we deprecate support and continuous CI for it to move forward for the aforementioned reasons.

Slightly increased the transitive HDF5 requirement to same version as in openPMD-api.