### PR TITLE
Separate the code processing currents from MySimulation

### DIFF
--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -144,23 +144,4 @@ private:
     FieldB *fieldB;
 };
 
-template<typename T_SpeciesType, typename T_Area>
-struct ComputeCurrent
-{
-    using SpeciesType = T_SpeciesType;
-    using FrameType = typename SpeciesType::FrameType;
-
-    HINLINE void operator()( const uint32_t currentStep ) const
-    {
-        DataConnector &dc = Environment<>::get().DataConnector();
-        auto species = dc.get< SpeciesType >( FrameType::getName(), true );
-        auto fieldJ = dc.get< FieldJ >( FieldJ::getName(), true );
-
-        fieldJ->computeCurrent< T_Area::value, SpeciesType >( *species, currentStep );
-
-        dc.releaseData( FrameType::getName() );
-        dc.releaseData( FieldJ::getName() );
-    }
-};
-
 } // namespace picongpu

--- a/include/picongpu/simulation/stage/CurrentBackground.hpp
+++ b/include/picongpu/simulation/stage/CurrentBackground.hpp
@@ -1,0 +1,90 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/background/cellwiseOperation.hpp"
+#include "picongpu/fields/FieldJ.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/Environment.hpp>
+#include <pmacc/nvidia/functors/Add.hpp>
+#include <pmacc/type/Area.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    //! Functor for the stage of the PIC loop applying current background
+    class CurrentBackground
+    {
+    public:
+
+        /** Create a current background functor
+         *
+         * Having this in constructor is a temporary solution.
+         *
+         * @param cellDescription mapping for kernels
+         */
+        CurrentBackground( MappingDesc const cellDescription ):
+            cellDescription( cellDescription )
+        {
+        }
+
+        /** Add the current background to the current density
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using namespace pmacc;
+            DataConnector & dc = Environment< >::get( ).DataConnector( );
+            auto & fieldJ = *dc.get< FieldJ >( FieldJ::getName( ), true );
+            using CurrentBackground = cellwiseOperation::CellwiseOperation<
+                type::CORE + type::BORDER
+            >;
+            CurrentBackground currentBackground( cellDescription );
+            currentBackground(
+                &fieldJ,
+                nvidia::functors::Add( ),
+                FieldBackgroundJ( fieldJ.getUnit() ),
+                step,
+                FieldBackgroundJ::activated
+            );
+            dc.releaseData( FieldJ::getName( ) );
+        }
+
+    private:
+
+        //! Mapping for kernels
+        MappingDesc cellDescription;
+
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/CurrentDeposition.hpp
+++ b/include/picongpu/simulation/stage/CurrentDeposition.hpp
@@ -1,0 +1,99 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/FieldJ.hpp"
+
+#include <pmacc/algorithms/ForEach.hpp>
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/Environment.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/type/Area.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+namespace detail
+{
+
+    template<
+        typename T_SpeciesType,
+        typename T_Area
+    >
+    struct CurrentDeposition
+    {
+        using SpeciesType = T_SpeciesType;
+        using FrameType = typename SpeciesType::FrameType;
+
+        HINLINE void operator( )(
+            const uint32_t currentStep,
+            FieldJ & fieldJ,
+            pmacc::DataConnector & dc
+        ) const
+        {
+            auto species = dc.get< SpeciesType >( FrameType::getName(), true );
+            fieldJ.computeCurrent< T_Area::value, SpeciesType >( *species, currentStep );
+            dc.releaseData( FrameType::getName() );
+        }
+    };
+
+} // namespace detail
+
+    //! Functor for the stage of the PIC loop performing current deposition
+    struct CurrentDeposition
+    {
+        /** Compute the current created by particles and add it to the current
+         *  density
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using namespace pmacc;
+            DataConnector & dc = Environment< >::get( ).DataConnector( );
+            auto & fieldJ = *dc.get< FieldJ >( FieldJ::getName( ), true );
+            using SpeciesWithCurrentSolver = typename pmacc::particles::traits::FilterByFlag<
+                VectorAllSpecies,
+                current< >
+            >::type;
+            algorithms::forEach::ForEach<
+                SpeciesWithCurrentSolver,
+                detail::CurrentDeposition<
+                    bmpl::_1,
+                    bmpl::int_< type::CORE + type::BORDER >
+                >
+            > depositCurrent;
+            depositCurrent( step, fieldJ, dc );
+            dc.releaseData( FieldJ::getName( ) );
+        }
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -1,0 +1,109 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/currentInterpolation/CurrentInterpolation.hpp"
+#include "picongpu/fields/FieldJ.hpp"
+#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
+#include "picongpu/traits/GetMargin.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/Environment.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/type/Area.hpp>
+
+#include <boost/mpl/count.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    /** Functor for the stage of the PIC loop performing current interpolation
+     *  and addition to grid values of the electromagnetic field
+     */
+    struct CurrentInterpolationAndAdditionToEMF
+    {
+        /** Compute the current created by particles and add it to the current
+         *  density
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using namespace pmacc;
+            using SpeciesWithCurrentSolver = typename pmacc::particles::traits::FilterByFlag<
+                VectorAllSpecies,
+                current< >
+            >::type;
+            auto const numSpeciesWithCurrentSolver =
+                bmpl::size< SpeciesWithCurrentSolver >::type::value;
+            auto const existsCurrent = numSpeciesWithCurrentSolver > 0;
+            if( !existsCurrent )
+                return;
+
+            DataConnector & dc = Environment< >::get( ).DataConnector( );
+            auto & fieldJ = *dc.get< FieldJ >( FieldJ::getName( ), true );
+            auto eRecvCurrent = fieldJ.asyncCommunication( __getTransactionEvent() );
+            using CurrentInterpolation = fields::Solver::CurrentInterpolation;
+            CurrentInterpolation currentInterpolation;
+            using Margin = traits::GetMargin< CurrentInterpolation >;
+            DataSpace< simDim > const currentRecvLower( Margin::LowerMargin().toRT() );
+            DataSpace< simDim > const currentRecvUpper( Margin::UpperMargin().toRT() );
+
+            /* without interpolation, we do not need to access the FieldJ GUARD
+            * and can therefore overlap communication of GUARD->(ADD)BORDER & computation of CORE */
+            if( currentRecvLower == DataSpace< simDim >::create( 0 ) &&
+                currentRecvUpper == DataSpace< simDim >::create( 0 )
+            )
+            {
+                fieldJ.addCurrentToEMF< type::CORE >( currentInterpolation );
+                __setTransactionEvent( eRecvCurrent );
+                fieldJ.addCurrentToEMF< type::BORDER >( currentInterpolation );
+            }
+            else
+            {
+                /* in case we perform a current interpolation/filter, we need
+                * to access the BORDER area from the CORE (and the GUARD area
+                * from the BORDER)
+                * `fieldJ->asyncCommunication` first adds the neighbors' values
+                * to BORDER (send) and then updates the GUARD (receive)
+                * \todo split the last `receive` part in a separate method to
+                *       allow already a computation of CORE */
+                __setTransactionEvent( eRecvCurrent );
+                fieldJ.addCurrentToEMF<
+                    type::CORE + type::BORDER
+                >( currentInterpolation );
+            }
+            dc.releaseData( FieldJ::getName( ) );
+        }
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/CurrentReset.hpp
+++ b/include/picongpu/simulation/stage/CurrentReset.hpp
@@ -1,0 +1,59 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/FieldJ.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/Environment.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    //! Functor for the stage of the PIC loop setting the current values to zero
+    struct CurrentReset
+    {
+        /** Set all current density values to zero
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const ) const
+        {
+            using namespace pmacc;
+            DataConnector & dc = Environment< >::get( ).DataConnector( );
+            auto & fieldJ = *dc.get< FieldJ >( FieldJ::getName( ), true );
+            FieldJ::ValueType zeroJ( FieldJ::ValueType::create( 0._X ) );
+            fieldJ.assign( zeroJ );
+            dc.releaseData( FieldJ::getName( ) );
+        }
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu


### PR DESCRIPTION
Create a new functor for each stage (part) of the current processing. Put the new functors to a new directory `picongpu/simulation/stages`.

A similar separation of other stages will follow, as discussed offline earlier today. I believe once we have a proper separation into many translation units, this change should also be helpful, as we could put implementations in .cpp files and instantiate (some) templates only there.