### PR TITLE
openPMD Plugin

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -325,6 +325,24 @@ ADIOS
   - ``export ADIOS_ROOT=$HOME/lib/adios``
   - ``export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH``
 
+openPMD API
+"""""""""""
+- 0.12.0+ (yet to be released, requires *MPI*)
+- *Spack*: ``spack install openpmd-api``
+- *from source:*
+
+  - ``mkdir -p ~/src ~/lib``
+  - ``cd ~/src``
+  - ``git clone https://github.com/openPMD/openPMD-api.git``
+  - ``cd openPMD-api``
+  - ``mkdir build && cd build``
+  - ``cmake .. -DopenPMD_USE_MPI=ON -DCMAKE_INSTALL_PREFIX=~/lib/openPMD-api``
+  - ``make -j $(nproc) install``
+- environment:* (assumes install from source in ``$HOME/lib/openPMD-api``)
+
+  - ``export CMAKE_PREFIX_PATH="$HOME/lib/openPMD-api:$CMAKE_PREFIX_PATH"``
+  - ``export LD_LIBRARY_PATH="$HOME/lib/openPMD-api/lib:$LD_LIBRARY_PATH"``
+
 ISAAC
 """""
 - 1.4.0+

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -1,4 +1,5 @@
-# Copyright 2014-2020 Felix Schmitt, Axel Huebl, Richard Pausch, Heiko Burau
+# Copyright 2014-2020 Felix Schmitt, Axel Huebl, Richard Pausch, Heiko Burau,
+#                     Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -204,6 +205,22 @@ TBG_adios="--adios.period 100 --adios.file simData --adios.source 'species_all,f
 #   --adios.transport-params "semicolon_separated_list"
 # select data sources for the dump
 #   --adios.source <comma_separated_list_of_data_sources>
+
+# Dump simulation data (fields and particles) via the openPMD API.
+# Data is dumped every .period steps to the fileset .file.
+TBG_openPMD="--openPMD.period 100   \
+             --openPMD.file simOutput \
+             --openPMD.ext bp \
+             --openPMD.json '{ \"adios2\": { \"engine\": { \"type\": \"file\", \"parameters\": { \"BufferGrowthFactor\": \"1.2\", \"InitialBufferSize\": \"2GB\" } } } }'"
+# Further control over the backends used in the openPMD plugins is available
+# through the mechanisms exposed by the openPMD API:
+# * environment variables
+# * JSON-formatted configuration string
+# Further information on both is retrieved from the official documentation
+# https://openpmd-api.readthedocs.io
+# Notice that specifying compression settings via --openPMD.compression
+# is considered legacy and backend-specific settings via the JSON string are
+# preferred if available for a backend.
 
 # Create a checkpoint that is restartable every --checkpoint.period steps
 #   http://git.io/PToFYg

--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -7,6 +7,7 @@ Plugins
 Plugin name                                                                          short description
 ==================================================================================== =================================================================================
 :ref:`ADIOS <usage-plugins-ADIOS>` [#f2]_ [#f7]_                                     stores simulation data as openPMD flavoured ADIOS files [Huebl2017]_
+:ref:`openPMD <usage-plugins-openPMD>` [#f2]_ [#f7]_                                 outputs simulation data via the openPMD API
 :ref:`energy histogram <usage-plugins-energyHistogram>` [#f7]_                       energy histograms for electrons and ions
 :ref:`charge conservation <usage-plugins-chargeConservation>` [#f6]_                 maximum difference between electron charge density and div E
 :ref:`checkpoint <usage-plugins-checkpoint>` [#f2]_                                  stores the primary data of the simulation for restarts.

--- a/docs/source/usage/plugins/checkpoint.rst
+++ b/docs/source/usage/plugins/checkpoint.rst
@@ -21,18 +21,18 @@ What is the format of the created files?
 
 We write our fields and particles in an open markup called :ref:`openPMD <pp-openPMD>`.
 
-For further details, see the according sections in :ref:`HDF5 <usage-plugins-HDF5>` and :ref:`ADIOS <usage-plugins-ADIOS>`.
+For further details, see the according sections in :ref:`the openPMD API <usage-plugins-openPMD>`, :ref:`HDF5 <usage-plugins-HDF5>` and :ref:`ADIOS <usage-plugins-ADIOS>`.
 
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
-The plugin is available as soon as the :ref:`libSplash (HDF5) or ADIOS libraries <install-dependencies>` are compiled in.
+The plugin is available as soon as the :ref:`openPMD API, libSplash (HDF5) or ADIOS libraries <install-dependencies>` are compiled in.
 
 .cfg file
 ^^^^^^^^^
 
 You can use ``--checkpoint.period`` to specify the output period of the created checkpoints.
-Note that this plugin will only be available if libSplash (HDF5) or ADIOS is found during compile configuration.
+Note that this plugin will only be available if the openPMD API, libSplash (HDF5) or ADIOS is found during compile configuration.
 
 ============================================= ======================================================================================
 PIConGPU command line option                  Description
@@ -61,6 +61,7 @@ PIConGPU command line option                  Description
 
 Depending on the available external dependencies (see above), the options for the ``<IO-backend>`` are:
 
+* :ref:`openPMD <usage-plugins-openPMD>`
 * :ref:`hdf5 <usage-plugins-HDF5>`
 * :ref:`adios <usage-plugins-ADIOS>` (keep in mind the :ref:`note on meta-files <usage-plugins-ADIOS-meta>` for restarts)
 

--- a/docs/source/usage/plugins/openPMD.cfg
+++ b/docs/source/usage/plugins/openPMD.cfg
@@ -1,0 +1,21 @@
+TBG_openPMD="--openPMD.period 100   \
+             --openPMD.file simOutput \
+             --openPMD.ext bp \
+             --openPMD.json '{ \
+                 \"adios2\": { \
+                   \"dataset\": { \
+                     \"operators\": [ \
+                       { \
+                         \"type\": \"bzip2\" \
+                       } \
+                     ] \
+                   }, \
+                   \"engine\": { \
+                     \"type\": \"file\", \
+                     \"parameters\": { \
+                       \"BufferGrowthFactor\": \"1.2\", \
+                       \"InitialBufferSize\": \"2GB\" \
+                     } \
+                   } \
+                 } \
+               }'"

--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -1,0 +1,126 @@
+.. _usage-plugins-openPMD:
+
+openPMD
+------
+
+Stores simulation data such as fields and particles according to the `openPMD standard <https://github.com/openPMD/openPMD-standard>`_ using the `openPMD API <https://openpmd-api.readthedocs.io>`_.
+
+External Dependencies
+^^^^^^^^^^^^^^^^^^^^^
+
+The plugin is available as soon as the :ref:`openPMD API <install-dependencies>` is compiled in.
+
+.param file
+^^^^^^^^^^^
+
+The corresponding ``.param`` file is :ref:`fileOutput.param <usage-params-plugins>`.
+
+One can e.g. disable the output of particles by setting:
+
+.. code-block:: cpp
+
+   /* output all species */
+   using FileOutputParticles = VectorAllSpecies;
+   /* disable */
+   using FileOutputParticles = MakeSeq_t< >;
+
+.cfg file
+^^^^^^^^^
+
+You can use ``--openPMD.period`` to specify the output period.
+The base filename is specified via ``--openPMD.file``.
+The openPMD API will parse the file name to decide the chosen backend and iteration layout:
+
+* The filename extension will determine the backend.
+* The openPMD will either create one file encompassing all iterations (group-based iteration layout) or one file per iteration (file-based iteration layout).
+  The filename will be searched for a pattern describing how to derive a concrete iteration's filename.
+  If no such pattern is found, the group-based iteration layout will be chosen.
+  Please refer to the documentation of the openPMD API for further information.
+
+In order to set defaults for these value, two further options control the filename:
+
+* ``--openPMD.ext`` sets the filename extension.
+  Possible extensions include ``.bp`` for the ADIOS backends (default).
+  If the openPMD API has been built with support for the ADIOS1 and ADIOS2 backends, ADIOS2 will take precedence over ADIOS1.
+  This behavior can be overridden by setting the environment variable ``OPENPMD_BP_BACKEND=ADIOS1``.
+  The extension for the HDF5 backend is ``.h5``.
+  (The version of ADIOS will depend on the compile-time configuration of the openPMD API.)
+* ``--openPMD.infix`` sets the filename pattern that controls the iteration layout, default is "_06T" for a six-digit number specifying the iteration.
+  Leave empty to pick group-based iteration layout.
+  Since passing an empty string may be tricky in some workflows, specifying ``--openPMD.infix=NULL`` is also possible.
+
+For example, ``--openPMD.period 128 --openPMD.file simData --openPMD.source 'species_all'`` will write only the particle species data to files of the form ``simData_000000.bp``, ``simData_000128.bp`` in the default simulation output directory every 128 steps.
+Note that this plugin will only be available if the openPMD API is found during compile configuration.
+
+openPMD backend-specific settings may be controlled via two mechanisms:
+* Environment variables.
+  Please refer to the backends' documentations for information on environment variables understood by the backends.
+* Backend-specific runtime parameters may be set via JSON in the openPMD API.
+  PIConGPU exposes this via the command line option ``--openPMD.json``.
+  Please refer to the openPMD API's documentation for further information.
+
+Specifying a JSON-formatted string from within a ``.cfg`` file can be tricky due to colliding escape mechanisms.
+An example for a well-escaped JSON string as part of a ``.cfg`` file is found below.
+
+.. literalinclude:: openPMD.cfg
+
+Two data preparation strategies are available for downloading particle data off compute devices.
+
+* Set ``--openPMD.dataPreparationStrategy doubleBuffer`` for use of the strategy that has been optimized for use with ADIOS-based backends.
+  The alias ``openPMD.dataPreparationStrategy adios`` may be used.
+  This strategy requires at least 2x the GPU main memory on the host side.
+  This is the default.
+* Set ``--openPMD.dataPreparationStrategy mappedMemory`` for use of the strategy that has been optimized for use with HDF5-based backends.
+  This strategy has a small host-side memory footprint (<< GPU main memory).
+  The alias ``openPMD.dataPreparationStrategy hdf5`` may be used.
+
+============================ ==================================================================================================================================================================
+PIConGPU command line option description
+============================ ==================================================================================================================================================================
+``--openPMD.period``                  Period after which simulation data should be stored on disk.
+``--openPMD.source``                  Select data sources to dump. Default is ``species_all,fields_all``, which dumps all fields and particle species.
+``--openPMD.compression``             Legacy parameter to set data transform compression method to be used for ADIOS1 backend until it implements setting compression from JSON config.
+``--openPMD.file``                    Relative or absolute openPMD file prefix for simulation data. If relative, files are stored under ``simOutput``. 
+``--openPMD.ext``                     openPMD filename extension (this controls thebackend picked by the openPMD API).
+``--openPMD.infix``                   openPMD filename infix (use to pick file- or group-based layout in openPMD). Set to NULL to keep empty (e.g. to pick group-based iteration layout).
+``--openPMD.json``                    Set backend-specific parameters for openPMD backends in JSON format.
+``--openPMD.dataPreparationStrategy`` Strategy for preparation of particle data ('doubleBuffer' or 'mappedMemory'). Aliases 'adios' and 'hdf5' may be used respectively.
+============================ ==================================================================================================================================================================
+
+.. note::
+
+   This plugin is a multi plugin. 
+   Command line parameter can be used multiple times to create e.g. dumps with different dumping period.
+   In the case where an optional parameter with a default value is explicitly defined, the parameter will always be passed to the instance of the multi plugin where the parameter is not set.
+   e.g.
+
+   .. code-block:: bash
+
+      --openPMD.period 128 --openPMD.file simData1 --openPMD.source 'species_all' 
+      --openPMD.period 1000 --openPMD.file simData2 --openPMD.source 'fields_all' --openPMD.ext h5
+
+   creates two plugins:
+
+   #. dump all species data each 128th time step, use HDF5 backend.
+   #. dump all field data each 1000th time step, use the default ADIOS backend.
+
+Memory Complexity
+^^^^^^^^^^^^^^^^^
+
+Accelerator
+"""""""""""
+
+no extra allocations.
+
+Host
+""""
+
+As soon as the openPMD plugin is compiled in, one extra ``mallocMC`` heap for the particle buffer is permanently reserved.
+During I/O, particle attributes are allocated one after another.
+Using ``--openPMD.dataPreparationStrategy doubleBuffer`` (default) will require at least 2x the GPU memory on the host side.
+For a smaller host side memory footprint (<< GPU main memory) pick ``--openPMD.dataPreparationStrategy mappedMemory``.
+
+Additional Tools
+^^^^^^^^^^^^^^^^
+
+See our :ref:`openPMD <pp-openPMD>` chapter.

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright 2013-2020 Axel Huebl, Benjamin Schneider, Felix Schmitt, Heiko Burau,
-#                     Rene Widera, Alexander Grund, Alexander Matthes
+#                     Rene Widera, Alexander Grund, Alexander Matthes,
+#                     Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -42,6 +43,7 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CUDA_ROOT}")
 list(APPEND CMAKE_PREFIX_PATH "$ENV{BOOST_ROOT}")
 list(APPEND CMAKE_PREFIX_PATH "$ENV{HDF5_ROOT}")
 list(APPEND CMAKE_PREFIX_PATH "$ENV{ADIOS_ROOT}")
+list(APPEND CMAKE_PREFIX_PATH "$ENV{OPENPMD_ROOT}")
 # Add from environment after specific env vars
 list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 
@@ -234,21 +236,6 @@ add_definitions(-DPIC_VERBOSE_LVL=${PIC_VERBOSE})
 
 
 ################################################################################
-# ADIOS
-################################################################################
-
-# find adios installation
-#   set(ADIOS_USE_STATIC_LIBS ON) # force static linking
-find_package(ADIOS 1.13.1)
-
-if(ADIOS_FOUND)
-    add_definitions(-DENABLE_ADIOS=1)
-    include_directories(SYSTEM ${ADIOS_INCLUDE_DIRS})
-    set(LIBS ${LIBS} ${ADIOS_LIBRARIES})
-endif(ADIOS_FOUND)
-
-
-################################################################################
 # Additional defines for PIConGPU outputs
 ################################################################################
 
@@ -291,6 +278,34 @@ elseif(MSVC)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _ENABLE_EXTENDED_ALIGNED_STORAGE")
     endif()
 endif()
+
+
+################################################################################
+# openPMD
+################################################################################
+
+# find openPMD installation
+find_package(openPMD 0.11.0 CONFIG COMPONENTS MPI)
+
+if(openPMD_FOUND)
+    add_definitions(-DENABLE_OPENPMD=1)
+    set(LIBS ${LIBS} openPMD::openPMD)
+endif(openPMD_FOUND)
+
+
+################################################################################
+# ADIOS
+################################################################################
+
+# find adios installation
+#   set(ADIOS_USE_STATIC_LIBS ON) # force static linking
+find_package(ADIOS 1.13.1)
+
+if(ADIOS_FOUND)
+    add_definitions(-DENABLE_ADIOS=1)
+    include_directories(SYSTEM ${ADIOS_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${ADIOS_LIBRARIES})
+endif(ADIOS_FOUND)
 
 
 ################################################################################

--- a/include/picongpu/plugins/Checkpoint.hpp
+++ b/include/picongpu/plugins/Checkpoint.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Rene Widera
+/* Copyright 2017-2020 Rene Widera, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *
@@ -30,6 +30,9 @@
 #if(ENABLE_HDF5 == 1)
 #   include "picongpu/plugins/hdf5/HDF5Writer.hpp"
 #endif
+#if (ENABLE_OPENPMD == 1)
+#   include "picongpu/plugins/openPMD/openPMDWriter.hpp"
+#endif
 #include <pmacc/pluginSystem/PluginConnector.hpp>
 
 #include <string>
@@ -52,6 +55,9 @@ namespace picongpu
             checkpointFilename( "checkpoint" ),
             restartChunkSize( 0u )
         {
+#if(ENABLE_OPENPMD == 1)
+            ioBackendsHelp[ "openPMD" ] = std::shared_ptr< plugins::multi::IHelp >( openPMD::openPMDWriter::getHelp( ) );
+#endif
 #if(ENABLE_ADIOS == 1)
             ioBackendsHelp[ "adios" ] = std::shared_ptr< plugins::multi::IHelp >( adios::ADIOSWriter::getHelp() );
 #endif
@@ -255,7 +261,7 @@ namespace picongpu
          */
         uint32_t restartChunkSize;
 
-        // can be "adios" and "hdf5"
+        // can be "adios", "hdf5" and "openPMD"
         std::map<
             std::string,
             std::shared_ptr< IIOBackend >

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -1,6 +1,7 @@
 /* Copyright 2013-2020 Axel Huebl, Benjamin Schneider, Felix Schmitt,
  *                     Heiko Burau, Rene Widera, Richard Pausch,
- *                     Benjamin Worpitz, Erik Zenker, Finn-Ole Carstens
+ *                     Benjamin Worpitz, Erik Zenker, Finn-Ole Carstens,
+ *                     Franz Poeschel
  *
  * This file is part of PIConGPU.
  *
@@ -43,6 +44,10 @@
 
 #if (ENABLE_ADIOS == 1)
 #   include "picongpu/plugins/adios/ADIOSWriter.hpp"
+#endif
+
+#if (ENABLE_OPENPMD == 1)
+#   include "picongpu/plugins/openPMD/openPMDWriter.hpp"
 #endif
 
 #if( PMACC_CUDA_ENABLED == 1 )
@@ -166,6 +171,10 @@ private:
         EnergyFields
 #if (ENABLE_ADIOS == 1)
         , plugins::multi::Master< adios::ADIOSWriter >
+#endif
+
+#if (ENABLE_OPENPMD == 1)
+        , plugins::multi::Master< openPMD::openPMDWriter >
 #endif
 
 #if( PMACC_CUDA_ENABLED == 1 )

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -1,0 +1,224 @@
+/* Copyright 2016-2019 Alexander Grund, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/types.hpp>
+
+#include <stdexcept>
+#include <tuple>
+#include <utility>
+
+namespace picongpu
+{
+namespace openPMD
+{
+    /** Functor for writing N-dimensional scalar fields with N=simDim
+     * In the current implementation each process (of the ND grid of processes)
+     * writes 1 scalar value Optionally the processes can also write an
+     * attribute for this dataset by using a non-empty attrName
+     *
+     * @tparam T_Scalar    Type of the scalar value to write
+     * @tparam T_Attribute Type of the attribute (can be omitted if attribute is
+     * not written, defaults to uint64_t)
+     */
+    template< typename T_Scalar, typename T_Attribute = uint64_t >
+    struct WriteNDScalars
+    {
+        WriteNDScalars(
+            const std::string & baseName,
+            const std::string & group,
+            const std::string & dataset,
+            const std::string & attrName = "" ) :
+            baseName( baseName ),
+            group( group ),
+            dataset( dataset ),
+            attrName( attrName )
+        {
+        }
+
+    private:
+        /** Prepare the write operation:
+         *  Define openPMD dataset and write
+         * attribute (if attrName is non-empty)
+         *
+         *  Must be called before executing the functor
+         */
+        std::tuple<
+            ::openPMD::MeshRecordComponent,
+            ::openPMD::Offset,
+            ::openPMD::Extent >
+        prepare( ThreadParams & params, T_Attribute attribute )
+        {
+            auto name = baseName + "/" + group + "/" + dataset;
+            const auto openPMDScalarType =
+                ::openPMD::determineDatatype< T_Scalar >();
+            using Dimensions = pmacc::math::UInt64< simDim >;
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: prepare write %1%D scalars: %2%" ) %
+                simDim % name;
+
+            // Size over all processes
+            Dimensions globalDomainSize = Dimensions::create( 1 );
+            Dimensions localDomainOffset = Dimensions::create( 0 );
+
+            for( uint32_t d = 0; d < simDim; ++d )
+            {
+                globalDomainSize[ d ] = Environment< simDim >::get()
+                    .GridController()
+                    .getGpuNodes()[ d ];
+                localDomainOffset[ d ] = Environment< simDim >::get()
+                    .GridController()
+                    .getPosition()[ d ];
+            }
+
+            ::openPMD::Series & series = *params.openPMDSeries;
+            ::openPMD::MeshRecordComponent mrc =
+                series.iterations[ params.currentStep ]
+                    .meshes[ baseName + "_" + group ][ dataset ];
+
+            if( !attrName.empty() )
+            {
+                log< picLog::INPUT_OUTPUT >(
+                    "openPMD: write attribute %1% of %2%D scalars: %3%" ) %
+                    attrName % simDim % name;
+
+                mrc.setAttribute( attrName, attribute );
+            }
+            params.initDataset< simDim >(
+                mrc,
+                openPMDScalarType,
+                std::move( globalDomainSize ),
+                true,
+                params.compressionMethod );
+
+            return std::make_tuple(
+                std::move( mrc ),
+                static_cast<::openPMD::Offset >(
+                    asStandardVector( std::move( localDomainOffset ) ) ),
+                static_cast<::openPMD::Extent >(
+                    asStandardVector( Dimensions::create( 1 ) ) ) );
+        }
+
+    public:
+        void
+        operator()(
+            ThreadParams & params,
+            T_Scalar value,
+            T_Attribute attribute = T_Attribute() )
+        {
+            auto tuple = prepare( params, std::move( attribute ) );
+            auto name = baseName + "/" + group + "/" + dataset;
+            log< picLog::INPUT_OUTPUT >( "openPMD: write %1%D scalars: %2%" ) %
+                simDim % name;
+
+            std::get< 0 >( tuple ).storeChunk(
+                std::make_shared< T_Scalar >( value ),
+                std::move( std::get< 1 >( tuple ) ),
+                std::move( std::get< 2 >( tuple ) ) );
+            params.openPMDSeries->flush();
+        }
+
+    private:
+        const std::string baseName, group, dataset, attrName;
+        int64_t varId;
+    };
+
+    /** Functor for reading ND scalar fields with N=simDim
+     * In the current implementation each process (of the ND grid of processes)
+     * reads 1 scalar value Optionally the processes can also read an attribute
+     * for this dataset by using a non-empty attrName
+     *
+     * @tparam T_Scalar    Type of the scalar value to read
+     * @tparam T_Attribute Type of the attribute (can be omitted if attribute is
+     * not read, defaults to uint64_t)
+     */
+    template< typename T_Scalar, typename T_Attribute = uint64_t >
+    struct ReadNDScalars
+    {
+        /** Read the skalar field and optionally the attribute into the values
+         * referenced by the pointers */
+        void
+        operator()(
+            ThreadParams & params,
+            const std::string & baseName,
+            const std::string & group,
+            const std::string & dataset,
+            T_Scalar * value,
+            const std::string & attrName = "",
+            T_Attribute * attribute = nullptr )
+        {
+            auto name = baseName + "/" + group + "/" + dataset;
+            log< picLog::INPUT_OUTPUT >( "openPMD: read %1%D scalars: %2%" ) %
+                simDim % name;
+
+
+            auto datasetName = baseName + "/" + group + "/" + dataset;
+            ::openPMD::Series & series = *params.openPMDSeries;
+            ::openPMD::MeshRecordComponent mrc =
+                series.iterations[ params.currentStep ]
+                    .meshes[ baseName + "_" + group ][ dataset ];
+            auto ndim = mrc.getDimensionality();
+            if( ndim != simDim )
+            {
+                throw std::runtime_error(
+                    std::string( "Invalid dimensionality for " ) + name );
+            }
+
+            DataSpace< simDim > gridPos =
+                Environment< simDim >::get().GridController().getPosition();
+            ::openPMD::Offset start;
+            ::openPMD::Extent count;
+            start.reserve( ndim );
+            count.reserve( ndim );
+            for( int d = 0; d < ndim; ++d )
+            {
+                start.push_back( gridPos.revert()[ d ] );
+                count.push_back( 1 );
+            }
+
+            __getTransactionEvent().waitForFinished();
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: Schedule read scalar %1%)" ) %
+                datasetName;
+
+            std::shared_ptr< T_Scalar > readValue =
+                mrc.loadChunk< T_Scalar >( start, count );
+
+            series.flush();
+
+            *value = *readValue;
+
+            if( !attrName.empty() )
+            {
+                log< picLog::INPUT_OUTPUT >(
+                    "openPMD: read attribute %1% for scalars: %2%" ) %
+                    attrName % name;
+                *attribute = mrc.getAttribute( attrName ).get< T_Attribute >();
+            }
+        }
+    };
+
+} // namespace openPMD
+} // namespace picongpu

--- a/include/picongpu/plugins/openPMD/WriteMeta.hpp
+++ b/include/picongpu/plugins/openPMD/WriteMeta.hpp
@@ -1,0 +1,263 @@
+/* Copyright 2013-2019 Axel Huebl, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "picongpu/fields/absorber/ExponentialDamping.hpp"
+#include "picongpu/fields/currentInterpolation/CurrentInterpolation.hpp"
+#include "picongpu/plugins/common/stringHelpers.hpp"
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
+
+#include <pmacc/Environment.hpp>
+
+#include <openPMD/openPMD.hpp>
+
+#include <list>
+#include <sstream>
+#include <string>
+
+
+namespace picongpu
+{
+namespace openPMD
+{
+    using namespace pmacc;
+
+    namespace writeMeta
+    {
+        /** write openPMD species meta data
+         *
+         * @tparam numSpecies count of defined species
+         */
+        template<
+            uint32_t numSpecies = bmpl::size< VectorAllSpecies >::type::value >
+        struct OfAllSpecies
+        {
+            /** write meta data for species
+             *
+             * @param threadParams context of the openPMD plugin
+             * @param fullMeshesPath path to mesh entry
+             */
+            void
+            operator()( ThreadParams * threadParams ) const
+            {
+                /*
+                 * @todo set boundary per species
+                 */
+                GetStringProperties< bmpl::at_c< VectorAllSpecies, 0 >::type >
+                    particleBoundaryProp;
+                std::vector< std::string > listParticleBoundary;
+                std::vector< std::string > listParticleBoundaryParam;
+                auto n = NumberOfExchanges< simDim >::value;
+                listParticleBoundary.reserve( n - 1 );
+                listParticleBoundaryParam.reserve( n - 1 );
+                for( uint32_t i = n - 1; i > 0; --i )
+                {
+                    if( FRONT % i == 0 )
+                    {
+                        listParticleBoundary.push_back(
+                            particleBoundaryProp[ ExchangeTypeNames()[ i ] ]
+                                                [ "name" ]
+                                                    .value );
+                        listParticleBoundaryParam.push_back(
+                            particleBoundaryProp[ ExchangeTypeNames()[ i ] ]
+                                                [ "param" ]
+                                                    .value );
+                    }
+                }
+
+                ::openPMD::Iteration iteration =
+                    threadParams->openPMDSeries
+                        ->iterations[ threadParams->currentStep ];
+                iteration.setAttribute(
+                    "particleBoundary", listParticleBoundary );
+                iteration.setAttribute(
+                    "particleBoundaryParameters", listParticleBoundaryParam );
+            }
+        };
+
+        /** specialization if no species are defined */
+        template<>
+        struct OfAllSpecies< 0 >
+        {
+            /** write meta data for species
+             *
+             * @param threadParams context of the openPMD plugin
+             * @param fullMeshesPath path to mesh entry
+             */
+            void
+            operator()(
+                ThreadParams * /* threadParams */,
+                const std::string & /* fullMeshesPath */
+                ) const
+            {
+            }
+        };
+
+    } // namespace writeMeta
+
+    struct WriteMeta
+    {
+        void
+        operator()( ThreadParams * threadParams )
+        {
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: (begin) write meta attributes." );
+
+            ::openPMD::Series & series = *threadParams->openPMDSeries;
+
+            /*
+             * The openPMD API will kindly write the obligatory metadata by
+             * itself, so we don't need to do this manually. We give the
+             * optional metadata:
+             */
+
+            /*   recommended */
+            const std::string author =
+                Environment<>::get().SimulationDescription().getAuthor();
+            if( author.length() > 0 )
+            {
+                series.setAuthor( author );
+            }
+
+            const std::string software( "PIConGPU" );
+
+            std::stringstream softwareVersion;
+            softwareVersion << PICONGPU_VERSION_MAJOR << "."
+                            << PICONGPU_VERSION_MINOR << "."
+                            << PICONGPU_VERSION_PATCH;
+            if( !std::string( PICONGPU_VERSION_LABEL ).empty() )
+                softwareVersion << "-" << PICONGPU_VERSION_LABEL;
+            series.setSoftware( software, softwareVersion.str() );
+
+            const std::string date = helper::getDateString( "%F %T %z" );
+            series.setDate( date );
+
+            ::openPMD::Iteration iteration =
+                series.iterations[ threadParams->currentStep ];
+            ::openPMD::Container<::openPMD::Mesh > & meshes = iteration.meshes;
+
+            // iteration-level attributes
+            iteration.setDt< float_X >( DELTA_T );
+            iteration.setTime( float_X( threadParams->currentStep ) * DELTA_T );
+            iteration.setTimeUnitSI( UNIT_TIME );
+
+            GetStringProperties< fields::Solver > fieldSolverProps;
+            const std::string fieldSolver( fieldSolverProps[ "name" ].value );
+            meshes.setAttribute( "fieldSolver", fieldSolver );
+
+            /* order as in axisLabels:
+             *    3D: z-lower, z-upper, y-lower, y-upper, x-lower, x-upper
+             *    2D: y-lower, y-upper, x-lower, x-upper
+             */
+            GetStringProperties< fields::absorber::Absorber >
+                fieldBoundaryProp;
+            std::vector< std::string > listFieldBoundary;
+            std::vector< std::string > listFieldBoundaryParam;
+            auto n = NumberOfExchanges< simDim >::value;
+            listFieldBoundary.reserve( n - 1 );
+            listFieldBoundaryParam.reserve( n - 1 );
+            for( uint32_t i = n - 1; i > 0; --i )
+            {
+                if( FRONT % i == 0 )
+                {
+                    listFieldBoundary.push_back(
+                        fieldBoundaryProp[ ExchangeTypeNames()[ i ] ][ "name" ]
+                            .value );
+                    listFieldBoundaryParam.push_back(
+                        fieldBoundaryProp[ ExchangeTypeNames()[ i ] ][ "param" ]
+                            .value );
+                }
+            }
+
+            meshes.setAttribute( "fieldBoundary", listFieldBoundary );
+            meshes.setAttribute(
+                "fieldBoundaryParameters", listFieldBoundaryParam );
+
+            writeMeta::OfAllSpecies<>()( threadParams );
+
+            GetStringProperties< typename fields::Solver::CurrentInterpolation >
+                currentSmoothingProp;
+            const std::string currentSmoothing(
+                currentSmoothingProp[ "name" ].value );
+            meshes.setAttribute( "currentSmoothing", currentSmoothing );
+
+            if( currentSmoothingProp.find( "param" ) !=
+                currentSmoothingProp.end() )
+            {
+                const std::string currentSmoothingParam(
+                    currentSmoothingProp[ "param" ].value );
+                meshes.setAttribute(
+                    "currentSmoothingParameters", currentSmoothingParam );
+            }
+
+            const std::string chargeCorrection( "none" );
+            meshes.setAttribute( "chargeCorrection", chargeCorrection );
+
+            /* write current iteration */
+            log< picLog::INPUT_OUTPUT >( "openPMD: meta: iteration" );
+            iteration.setAttribute(
+                "iteration",
+                threadParams->currentStep ); // openPMD API will not write this
+                                             // automatically
+
+            /* write number of slides */
+            log< picLog::INPUT_OUTPUT >( "openPMD: meta: sim_slides" );
+            uint32_t slides = MovingWindow::getInstance().getSlideCounter(
+                threadParams->currentStep );
+            iteration.setAttribute( "sim_slides", slides );
+
+            /*
+             * Required time attributes are written automatically by openPMD API
+             */
+
+
+            /* write normed grid parameters */
+            log< picLog::INPUT_OUTPUT >( "openPMD: meta: grid" );
+            std::string names[ 3 ] = {
+                "cell_width", "cell_height", "cell_depth" };
+            for( unsigned i = 0; i < 3; ++i )
+            {
+                iteration.setAttribute( names[ i ], cellSize[ i ] );
+            }
+
+
+            /* write base units */
+            log< picLog::INPUT_OUTPUT >( "openPMD: meta: units" );
+            iteration.setAttribute< double >( "unit_energy", UNIT_ENERGY );
+            iteration.setAttribute< double >( "unit_length", UNIT_LENGTH );
+            iteration.setAttribute< double >( "unit_speed", UNIT_SPEED );
+            iteration.setAttribute< double >( "unit_time", UNIT_TIME );
+            iteration.setAttribute< double >( "unit_mass", UNIT_MASS );
+            iteration.setAttribute< double >( "unit_charge", UNIT_CHARGE );
+            iteration.setAttribute< double >( "unit_efield", UNIT_EFIELD );
+            iteration.setAttribute< double >( "unit_bfield", UNIT_BFIELD );
+
+
+            /* write physical constants */
+            iteration.setAttribute( "mue0", MUE0 );
+            iteration.setAttribute( "eps0", EPS0 );
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: ( end ) wite meta attributes." );
+        }
+    };
+} // namespace openPMD
+} // namespace picongpu

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -1,0 +1,586 @@
+/* Copyright 2014-2019 Rene Widera, Felix Schmitt, Axel Huebl,
+ *                     Alexander Grund, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/traits/GetSpeciesFlagName.hpp"
+#include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/kernel/CopySpecies.kernel"
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/plugins/openPMD/writer/ParticleAttribute.hpp"
+#include "picongpu/plugins/output/WriteSpeciesCommon.hpp"
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/assert.hpp>
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/eventSystem/events/kernelEvents.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/meta/conversion/RemoveFromSeq.hpp>
+#include <pmacc/particles/ParticleDescription.hpp>
+#include <pmacc/particles/operations/ConcatListOfFrames.hpp>
+#include <pmacc/particles/particleFilter/FilterFactory.hpp>
+#include <pmacc/particles/particleFilter/PositionFilter.hpp>
+#if( PMACC_CUDA_ENABLED == 1 )
+#    include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
+#endif
+
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/find.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/type_traits.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+
+namespace picongpu
+{
+namespace openPMD
+{
+    using namespace pmacc;
+
+    template<
+        typename SpeciesTmp,
+        typename Filter,
+        typename ParticleFilter,
+        typename ParticleOffset >
+    struct StrategyRunParameters
+    {
+        pmacc::DataConnector & dc;
+        ThreadParams & params;
+        SpeciesTmp & speciesTmp;
+        Filter & filter;
+        ParticleFilter & particleFilter;
+        ParticleOffset & particleOffset;
+        uint64_t myNumParticles, globalNumParticles;
+        StrategyRunParameters(
+            pmacc::DataConnector & c_dc,
+            ThreadParams & c_params,
+            SpeciesTmp & c_speciesTmp,
+            Filter & c_filter,
+            ParticleFilter & c_particleFilter,
+            ParticleOffset & c_particleOffset,
+            uint64_t c_myNumParticles,
+            uint64_t c_globalNumParticles ) :
+            dc( c_dc ),
+            params( c_params ),
+            speciesTmp( c_speciesTmp ),
+            filter( c_filter ),
+            particleFilter( c_particleFilter ),
+            particleOffset( c_particleOffset ),
+            myNumParticles( c_globalNumParticles ),
+            globalNumParticles( c_globalNumParticles )
+        {
+        }
+    };
+
+    template< typename openPMDFrameType, typename RunParameters >
+    struct Strategy
+    {
+        virtual void
+        malloc(
+            std::string name,
+            openPMDFrameType &,
+            uint64_cu const myNumParticles ) = 0;
+
+        virtual void
+        free( openPMDFrameType & hostFrame ) = 0;
+
+        virtual void
+        prepare(
+            std::string name,
+            openPMDFrameType & hostFrame,
+            RunParameters ) = 0;
+    };
+
+    /*
+     * Use double buffer.
+     */
+    template< typename openPMDFrameType, typename RunParameters >
+    struct StrategyADIOS : Strategy< openPMDFrameType, RunParameters >
+    {
+        void
+        malloc(
+            std::string name,
+            openPMDFrameType & hostFrame,
+            uint64_cu const myNumParticles ) override
+        {
+            /* malloc host memory */
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:   (begin) malloc host memory: %1%" ) %
+                name;
+            meta::ForEach<
+                typename openPMDFrameType::ValueTypeSeq,
+                MallocHostMemory< bmpl::_1 > >
+                mallocMem;
+            mallocMem( hostFrame, myNumParticles );
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:   ( end ) malloc host memory: %1%" ) %
+                name;
+        }
+
+        void
+        free( openPMDFrameType & hostFrame ) override
+        {
+            meta::ForEach<
+                typename openPMDFrameType::ValueTypeSeq,
+                FreeHostMemory< bmpl::_1 > >
+                freeMem;
+            freeMem( hostFrame );
+        }
+
+
+        void
+        prepare(
+            std::string name,
+            openPMDFrameType & hostFrame,
+            RunParameters rp ) override
+        {
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:   (begin) copy particle host (with hierarchy) to "
+                "host (without hierarchy): %1%" ) %
+                name;
+#if( PMACC_CUDA_ENABLED == 1 )
+            auto mallocMCBuffer =
+                rp.dc.template get< MallocMCBuffer< DeviceHeap > >(
+                    MallocMCBuffer< DeviceHeap >::getName(), true );
+#endif
+            int globalParticleOffset = 0;
+            AreaMapping< CORE + BORDER, MappingDesc > mapper(
+                *( rp.params.cellDescription ) );
+
+            pmacc::particles::operations::ConcatListOfFrames< simDim >
+                concatListOfFrames( mapper.getGridDim() );
+
+#if( PMACC_CUDA_ENABLED == 1 )
+            auto particlesBox = rp.speciesTmp->getHostParticlesBox(
+                mallocMCBuffer->getOffset() );
+#else
+            /* This separate code path is only a workaround until
+             * MallocMCBuffer is alpaka compatible.
+             *
+             * @todo remove this workaround: we know that we are allowed to
+             * access the device memory directly.
+             */
+            auto particlesBox = rp.speciesTmp->getDeviceParticlesBox();
+            /* Notify to the event system that the particles box is used on
+             * the host.
+             *
+             * @todo remove this workaround
+             */
+            __startOperation( ITask::TASK_HOST );
+
+#endif
+            concatListOfFrames(
+                globalParticleOffset,
+                hostFrame,
+                particlesBox,
+                rp.filter,
+                rp.particleOffset, /*relative to data domain (not to physical
+                                   domain)*/
+                totalCellIdx_,
+                mapper,
+                rp.particleFilter );
+#if( PMACC_CUDA_ENABLED == 1 )
+            rp.dc.releaseData( MallocMCBuffer< DeviceHeap >::getName() );
+#endif
+            /* this costs a little bit of time but writing to external is
+             * slower in general */
+            PMACC_ASSERT(
+                ( uint64_cu )globalParticleOffset == rp.globalNumParticles );
+        }
+    };
+
+    /*
+     * Use mapped memory.
+     */
+    template< typename openPMDFrameType, typename RunParameters >
+    struct StrategyHDF5 : Strategy< openPMDFrameType, RunParameters >
+    {
+        void
+        malloc(
+            std::string name,
+            openPMDFrameType & hostFrame,
+            uint64_cu const myNumParticles ) override
+        {
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  (begin) malloc mapped memory: %1%" ) %
+                name;
+            /*malloc mapped memory*/
+            meta::ForEach<
+                typename openPMDFrameType::ValueTypeSeq,
+                MallocMemory< bmpl::_1 > >
+                mallocMem;
+            mallocMem( hostFrame, myNumParticles );
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  ( end ) malloc mapped memory: %1%" ) %
+                name;
+        }
+
+        void
+        free( openPMDFrameType & hostFrame ) override
+        {
+            meta::ForEach
+                < typename openPMDFrameType::ValueTypeSeq,
+                  FreeMemory< bmpl::_1 > > freeMem;
+            freeMem( hostFrame );
+        }
+
+        void
+        prepare(
+            std::string name,
+            openPMDFrameType & hostFrame,
+            RunParameters rp ) override
+        {
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  (begin) copy particle to host: %1%" ) %
+                name;
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  (begin) get mapped memory device pointer: %1%" ) %
+                name;
+            /*load device pointer of mapped memory*/
+            openPMDFrameType deviceFrame;
+            meta::ForEach
+                < typename openPMDFrameType::ValueTypeSeq,
+                  GetDevicePtr< bmpl::_1 > > getDevicePtr;
+            getDevicePtr( deviceFrame, hostFrame );
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  ( end ) get mapped memory device pointer: %1%" ) %
+                name;
+
+            GridBuffer< int, DIM1 > counterBuffer( DataSpace< DIM1 >( 1 ) );
+            AreaMapping< CORE + BORDER, MappingDesc > mapper(
+                *( rp.params.cellDescription ) );
+
+            constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
+                pmacc::math::CT::volume< SuperCellSize >::type::value >::value;
+
+            /* this sanity check costs a little bit of time but hdf5 writing is
+             * slower */
+            PMACC_KERNEL( CopySpecies< numWorkers >{} )
+            ( mapper.getGridDim(), numWorkers )(
+                counterBuffer.getDeviceBuffer().getPointer(),
+                deviceFrame,
+                rp.speciesTmp->getDeviceParticlesBox(),
+                rp.filter,
+                rp.particleOffset,
+                totalCellIdx_,
+                mapper,
+                rp.particleFilter );
+            counterBuffer.deviceToHost();
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  ( end ) copy particle to host: %1%" ) %
+                name;
+            __getTransactionEvent().waitForFinished();
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  all events are finished: %1%" ) %
+                name;
+
+            PMACC_ASSERT(
+                ( uint64_t )counterBuffer.getHostBuffer().getDataBox()[ 0 ] ==
+                rp.myNumParticles );
+        }
+    }; // namespace openPMD
+
+    /** Write copy particle to host memory and dump to openPMD file
+     *
+     * @tparam T_Species type of species
+     */
+    template< typename T_SpeciesFilter, typename T_Species = T_SpeciesFilter >
+    struct WriteSpecies
+    {
+    public:
+        using ThisSpecies = typename T_SpeciesFilter::Species;
+        using FrameType = typename ThisSpecies::FrameType;
+        using ParticleDescription = typename FrameType::ParticleDescription;
+        using ParticleAttributeList = typename FrameType::ValueTypeSeq;
+
+        /* delete multiMask and localCellIdx in openPMD particle*/
+        using TypesToDelete = bmpl::vector< multiMask, localCellIdx >;
+        using ParticleCleanedAttributeList =
+            typename RemoveFromSeq< ParticleAttributeList, TypesToDelete >::
+                type;
+
+        /* add totalCellIdx for openPMD particle*/
+        using ParticleNewAttributeList =
+            typename MakeSeq< ParticleCleanedAttributeList, totalCellIdx >::
+                type;
+
+        using NewParticleDescription = typename ReplaceValueTypeSeq<
+            ParticleDescription,
+            ParticleNewAttributeList >::type;
+
+        using openPMDFrameType =
+            Frame< OperatorCreateVectorBox, NewParticleDescription >;
+
+        void
+        setParticleAttributes( ::openPMD::Iteration & iteration )
+        {
+            const float_64 particleShape(
+                GetShape< ThisSpecies >::type::support - 1 );
+            iteration.setAttribute( "particleShape", particleShape );
+
+            traits::GetSpeciesFlagName< ThisSpecies, current<> >
+                currentDepositionName;
+            const std::string currentDeposition( currentDepositionName() );
+            iteration.setAttribute(
+                "currentDeposition", currentDeposition.c_str() );
+
+            traits::GetSpeciesFlagName< ThisSpecies, particlePusher<> >
+                particlePushName;
+            const std::string particlePush( particlePushName() );
+            iteration.setAttribute( "particlePush", particlePush.c_str() );
+
+            traits::GetSpeciesFlagName< ThisSpecies, interpolation<> >
+                particleInterpolationName;
+            const std::string particleInterpolation(
+                particleInterpolationName() );
+            iteration.setAttribute(
+                "particleInterpolation", particleInterpolation.c_str() );
+
+            const std::string particleSmoothing( "none" );
+            iteration.setAttribute(
+                "particleSmoothing", particleSmoothing.c_str() );
+        }
+
+        template< typename Space > // has operator[] -> integer type
+        HINLINE void
+        operator()( ThreadParams * params, const Space particleOffset )
+        {
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: (begin) write species: %1%" ) %
+                T_SpeciesFilter::getName();
+            DataConnector & dc = Environment<>::get().DataConnector();
+            GridController< simDim > & gc =
+                Environment< simDim >::get().GridController();
+            uint64_t mpiSize = gc.getGlobalSize();
+            uint64_t mpiRank = gc.getGlobalRank();
+            /* load particle without copy particle data to host */
+            auto speciesTmp = dc.get< ThisSpecies >(
+                ThisSpecies::FrameType::getName(), true );
+            const std::string speciesGroup( T_Species::getName() );
+
+            ::openPMD::Series & series = *params->openPMDSeries;
+            ::openPMD::Iteration iteration =
+                series.iterations[ params->currentStep ];
+
+            // enforce that the filter interface is fulfilled
+            particles::filter::IUnary< typename T_SpeciesFilter::Filter >
+                particleFilter{ params->currentStep };
+            using usedFilters =
+                bmpl::vector< typename GetPositionFilter< simDim >::type >;
+            using MyParticleFilter =
+                typename FilterFactory< usedFilters >::FilterType;
+            MyParticleFilter filter;
+            /* activate filter pipeline if moving window is activated */
+            filter.setStatus( MovingWindow::getInstance().isSlidingWindowActive(
+                params->currentStep ) );
+            filter.setWindowPosition(
+                params->localWindowToDomainOffset,
+                params->window.localDimensions.size );
+
+            using RunParameters_T = StrategyRunParameters<
+                decltype( speciesTmp ),
+                decltype( filter ),
+                decltype( particleFilter ),
+                const Space >;
+
+            using AStrategy =
+                Strategy< openPMDFrameType, RunParameters_T >;
+            std::unique_ptr< AStrategy > strategy;
+
+            switch( params->strategy )
+            {
+                case WriteSpeciesStrategy::ADIOS:
+                {
+                    using type =
+                        StrategyADIOS< openPMDFrameType, RunParameters_T >;
+                    strategy = std::unique_ptr< AStrategy >(
+                        dynamic_cast< AStrategy * >( new type ) );
+                    break;
+                }
+                case WriteSpeciesStrategy::HDF5:
+                {
+                    using type =
+                        StrategyHDF5< openPMDFrameType, RunParameters_T >;
+                    strategy = std::unique_ptr< AStrategy >(
+                        dynamic_cast< AStrategy * >( new type ) );
+                    break;
+                }
+            }
+
+
+            /* count total number of particles on the device */
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:   (begin) count particles: %1%" ) %
+                T_SpeciesFilter::getName();
+            uint64_cu const myNumParticles =
+                pmacc::CountParticles::countOnDevice< CORE + BORDER >(
+                    *speciesTmp,
+                    *( params->cellDescription ),
+                    params->localWindowToDomainOffset,
+                    params->window.localDimensions.size,
+                    particleFilter );
+            uint64_t allNumParticles[ mpiSize ];
+            uint64_t globalNumParticles = 0;
+            uint64_t myParticleOffset = 0;
+
+            // avoid deadlock between not finished pmacc tasks and mpi blocking
+            // collectives
+            __getTransactionEvent().waitForFinished();
+            MPI_CHECK( MPI_Allgather(
+                &myNumParticles,
+                1,
+                MPI_UNSIGNED_LONG_LONG,
+                allNumParticles,
+                1,
+                MPI_UNSIGNED_LONG_LONG,
+                gc.getCommunicator().getMPIComm() ) );
+
+            for( uint64_t i = 0; i < mpiSize; ++i )
+            {
+                globalNumParticles += allNumParticles[ i ];
+                if( i < mpiRank )
+                    myParticleOffset += allNumParticles[ i ];
+            }
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:   ( end ) count particles: %1% = %2%" ) %
+                T_SpeciesFilter::getName() % globalNumParticles;
+
+            ::openPMD::ParticleSpecies & particleSpecies =
+                iteration.particles[ speciesGroup ];
+
+            // copy over particles to host
+            openPMDFrameType hostFrame;
+
+            strategy->malloc(
+                T_SpeciesFilter::getName(), hostFrame, myNumParticles );
+            RunParameters_T runParameters(
+                dc,
+                *params,
+                speciesTmp,
+                filter,
+                particleFilter,
+                particleOffset,
+                myNumParticles,
+                globalNumParticles );
+            if( globalNumParticles > 0 )
+            {
+                strategy->prepare(
+                    T_SpeciesFilter::getName(),
+                    hostFrame,
+                    std::move( runParameters ) );
+            }
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  (begin) write particle records for %1%" ) %
+                T_SpeciesFilter::getName();
+
+            meta::ForEach
+                < typename openPMDFrameType::ValueTypeSeq,
+                  openPMD::ParticleAttribute< bmpl::_1 > > writeToOpenPMD;
+            writeToOpenPMD(
+                params,
+                hostFrame,
+                particleSpecies,
+                myNumParticles,
+                globalNumParticles,
+                myParticleOffset );
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  (begin) free memory: %1%" ) %
+                T_SpeciesFilter::getName();
+            /* free host memory */
+            strategy->free( hostFrame );
+            log< picLog::INPUT_OUTPUT >( "openPMD:  (end) free memory: %1%" ) %
+                T_SpeciesFilter::getName();
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: ( end ) writing species: %1%" ) %
+                T_SpeciesFilter::getName();
+
+            /* write species counter table to openPMD storage */
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: (begin) writing particle index table for %1%" ) %
+                T_SpeciesFilter::getName();
+            {
+                constexpr uint64_t localTableSize = 5;
+
+                GridController< simDim > & gc =
+                    Environment< simDim >::get().GridController();
+
+                const size_t pos_offset = 2;
+
+                /* particlesMetaInfo = (num particles, scalar position, particle
+                 * offset x, y, z) */
+                std::shared_ptr< uint64_t > particlesMetaInfo{
+                    new uint64_t[ localTableSize ]{
+                        myNumParticles, gc.getScalarPosition(), 0, 0, 0 },
+                    []( uint64_t * ptr ) { delete[] ptr; }
+                };
+                auto particlesMetaInfoPtr = particlesMetaInfo.get();
+                for( size_t d = 0; d < simDim; ++d )
+                {
+                    particlesMetaInfoPtr[ pos_offset + d ] =
+                        particleOffset[ d ];
+                }
+
+                /* prevent that top (y) gpus have negative value here */
+                if( gc.getPosition().y() == 0 )
+                    particlesMetaInfoPtr[ pos_offset + 1 ] = 0;
+
+                if( particleOffset[ 1 ] < 0 ) // 1 == y
+                    particlesMetaInfoPtr[ pos_offset + 1 ] = 0;
+
+                ::openPMD::Datatype datatype =
+                    ::openPMD::determineDatatype< uint64_t >();
+                ::openPMD::RecordComponent recordComponent =
+                    particleSpecies[ "particles_info" ]
+                                   [::openPMD::RecordComponent::SCALAR ];
+
+                params
+                    ->initDataset< DIM1 >(
+                        recordComponent,
+                        datatype,
+                        { localTableSize * uint64_t( gc.getGlobalSize() ) },
+                        true,
+                        params->compressionMethod )
+                    .template storeChunk(
+                        particlesMetaInfo,
+                        { localTableSize * uint64_t( gc.getGlobalRank() ) },
+                        { localTableSize } );
+
+                /* openPMD ED-PIC: additional attributes */
+                setParticleAttributes( iteration );
+                params->openPMDSeries->flush();
+            }
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: ( end ) writing particle index table for %1%" ) %
+                T_SpeciesFilter::getName();
+        }
+    };
+
+
+} // namespace openPMD
+
+} // namespace picongpu

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -1,0 +1,146 @@
+/* Copyright 2014-2019 Felix Schmitt, Axel Huebl, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation/control/MovingWindow.hpp"
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/particles/frame_types.hpp>
+#include <pmacc/types.hpp>
+
+#include <openPMD/openPMD.hpp>
+
+#include <iostream> // std::cerr
+#include <limits>
+#include <list>
+#include <sstream>
+#include <stdexcept> // throw std::runtime_error
+#include <string>
+
+#include <type_traits>
+
+namespace picongpu
+{
+namespace openPMD
+{
+    using namespace pmacc;
+
+
+    namespace po = boost::program_options;
+
+
+#define MESHES_PATH "fields"
+
+    template<
+        typename T_Vec,
+        typename T_Ret =
+            std::vector< typename std::remove_reference< T_Vec >::type::type > >
+    T_Ret
+    asStandardVector( T_Vec const & );
+
+    enum class WriteSpeciesStrategy
+    {
+        ADIOS,
+        HDF5
+    };
+
+
+    /**
+     * Writes simulation data to openPMD series.
+     * Implements the ILightweightPlugin interface.
+     */
+
+    class openPMDWriter;
+    class Help;
+
+    struct ThreadParams
+    {
+        uint32_t currentStep; /** current simulation step */
+
+
+        std::unique_ptr<::openPMD::Series >
+            openPMDSeries; /* is null iff there is no series currently open */
+
+        /** current dump is a checkpoint */
+        bool isCheckpoint;
+
+        MPI_Comm communicator; /* MPI communicator for openPMD API */
+        std::string
+            compressionMethod; /* openPMD data transform compression method */
+        std::string
+            fileName; /* Name of the openPMDSeries, excluding the extension */
+        std::string fileExtension; /* Extension of the file name */
+        std::string fileInfix;
+
+        std::string jsonConfig;
+
+        WriteSpeciesStrategy strategy = WriteSpeciesStrategy::ADIOS;
+
+        pmacc::math::UInt64< simDim > fieldsSizeDims;
+        pmacc::math::UInt64< simDim > fieldsGlobalSizeDims;
+        pmacc::math::UInt64< simDim > fieldsOffsetDims;
+
+        GridLayout< simDim > gridLayout;
+        MappingDesc * cellDescription;
+
+        std::vector< float_X > fieldBuffer; /* temp. buffer for fields */
+
+        Window window; /* window describing the volume to be dumped */
+
+        DataSpace< simDim >
+            localWindowToDomainOffset; /** offset from local moving
+                                          window to local domain */
+
+        ::openPMD::Series &
+        openSeries( ::openPMD::AccessType at );
+
+        void
+        closeSeries();
+
+        void
+        initFromConfig(
+            Help &,
+            size_t id,
+            std::string const & file,
+            std::string const & dir );
+
+        /**
+         * Wrapper for ::openPMD::resetDataset, set dataset parameters
+         * @tparam DIM number of variable dimensions
+         * @param recordComponent Location of the dataset within the openPMD
+         * Series
+         * @param datatype Variable type
+         * @param globalDimensions Dataset global dimensions
+         * @param compression Enable compression data transform
+         * @param compressionMethod String denoting the data transform to use
+         * @return The input recordComponent
+         */
+        template< unsigned DIM >
+        ::openPMD::RecordComponent &
+        initDataset(
+            ::openPMD::RecordComponent & recordComponent,
+            ::openPMD::Datatype datatype,
+            pmacc::math::UInt64< DIM > const & globalDimensions,
+            bool compression,
+            std::string const & compressionMethod );
+    };
+} // namespace openPMD
+} // namespace picongpu

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1,0 +1,1421 @@
+/* Copyright 2014-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Benjamin Worpitz, Alexander Grund, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/FieldB.hpp"
+#include "picongpu/fields/FieldE.hpp"
+#include "picongpu/fields/FieldJ.hpp"
+#include "picongpu/fields/FieldTmp.hpp"
+#include "picongpu/particles/filter/filter.hpp"
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
+#include "picongpu/plugins/misc/SpeciesFilter.hpp"
+#include "picongpu/plugins/misc/misc.hpp"
+#include "picongpu/plugins/multi/IHelp.hpp"
+#include "picongpu/plugins/multi/Option.hpp"
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/simulation/control/MovingWindow.hpp"
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/IsFieldDomainBound.hpp"
+
+#include <pmacc/assert.hpp>
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/dimensions/GridLayout.hpp>
+#include <pmacc/mappings/simulation/GridController.hpp>
+#include <pmacc/mappings/simulation/SubGrid.hpp>
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/particles/IdProvider.def>
+#include <pmacc/particles/frame_types.hpp>
+#include <pmacc/particles/operations/CountParticles.hpp>
+#include <pmacc/pluginSystem/PluginConnector.hpp>
+#include <pmacc/static_assert.hpp>
+#if( PMACC_CUDA_ENABLED == 1 )
+#    include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
+#endif
+#include "picongpu/plugins/misc/SpeciesFilter.hpp"
+#include "picongpu/plugins/openPMD/NDScalars.hpp"
+#include "picongpu/plugins/openPMD/WriteMeta.hpp"
+#include "picongpu/plugins/openPMD/WriteSpecies.hpp"
+#include "picongpu/plugins/openPMD/restart/LoadSpecies.hpp"
+#include "picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp"
+#include "picongpu/plugins/output/IIOBackend.hpp"
+
+#include <pmacc/traits/Limits.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/find.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/type_traits.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+#include <openPMD/openPMD.hpp>
+
+#if !defined( _WIN32 )
+#    include <unistd.h>
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib> // getenv
+#include <list>
+#include <pthread.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+
+namespace picongpu
+{
+namespace openPMD
+{
+    using namespace pmacc;
+
+
+    namespace po = boost::program_options;
+
+    template< unsigned DIM >
+    ::openPMD::RecordComponent &
+    ThreadParams::initDataset(
+        ::openPMD::RecordComponent & recordComponent,
+        ::openPMD::Datatype datatype,
+        pmacc::math::UInt64< DIM > const & globalDimensions,
+        bool compression,
+        std::string const & compressionMethod )
+    {
+        std::vector< uint64_t > v = asStandardVector( globalDimensions );
+        ::openPMD::Dataset dataset{ datatype, std::move( v ) };
+        if( compression && compressionMethod != "none" )
+        {
+            dataset.compression = compressionMethod;
+        }
+        recordComponent.resetDataset( std::move( dataset ) );
+        return recordComponent;
+    }
+
+
+    template< typename T_Vec, typename T_Ret >
+    T_Ret
+    asStandardVector( T_Vec const & v )
+    {
+        using __T_Vec = typename std::remove_reference< T_Vec >::type;
+        constexpr auto dim = __T_Vec::dim;
+        T_Ret res( dim );
+        for( unsigned i = 0; i < dim; ++i )
+        {
+            res[ dim - i - 1 ] = v[ i ];
+        }
+        return res;
+    }
+
+    ::openPMD::Series &
+    ThreadParams::openSeries( ::openPMD::AccessType at )
+    {
+        if( !openPMDSeries )
+        {
+            std::string fullName = fileName + fileInfix + "." + fileExtension;
+            log< picLog::INPUT_OUTPUT >( "openPMD: open file: %1%" ) % fullName;
+            openPMDSeries = std::unique_ptr<::openPMD::Series >(
+                new ::openPMD::Series( fullName, at, communicator, jsonConfig ) );
+            if( at == ::openPMD::AccessType::CREATE )
+            {
+                openPMDSeries->setMeshesPath( MESHES_PATH );
+            }
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: successfully opened file: %1%" ) %
+                fullName;
+            return *openPMDSeries;
+        }
+        else
+        {
+            throw std::runtime_error(
+                "openPMD: Tried opening a Series while old Series was still "
+                "active" );
+        }
+    }
+
+    void
+    ThreadParams::closeSeries()
+    {
+        if( openPMDSeries )
+        {
+            log< picLog::INPUT_OUTPUT >( "openPMD: close file: %1%" ) %
+                fileName;
+            openPMDSeries.reset();
+            MPI_Barrier( this->communicator );
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: successfully closed file: %1%" ) %
+                fileName;
+        }
+        else
+        {
+            throw std::runtime_error(
+                "openPMD: Tried closing a Series that was not active" );
+        }
+    }
+
+
+    struct Help : public plugins::multi::IHelp
+    {
+        /** creates a instance of ISlave
+         *
+         * @param help plugin defined help
+         * @param id index of the plugin, range: [0;help->getNumPlugins())
+         */
+        std::shared_ptr< plugins::multi::ISlave >
+        create(
+            std::shared_ptr< IHelp > & help,
+            size_t const id,
+            MappingDesc * cellDescription );
+        // defined later since we need openPMDWriter constructor
+
+        plugins::multi::Option< std::string > notifyPeriod = {
+            "period",
+            "enable openPMD IO [for each n-th step]"
+        };
+
+        plugins::multi::Option< std::string > source = {
+            "source",
+            "data sources: ",
+            "species_all, fields_all"
+        };
+
+        std::vector< std::string > allowedDataSources = { "species_all",
+                                                          "fields_all" };
+
+        plugins::multi::Option< std::string > fileName = {
+            "file",
+            "openPMD file basename"
+        };
+
+        plugins::multi::Option< std::string > fileNameExtension = {
+            "ext",
+            "openPMD filename extension (this controls the"
+            "backend picked by the openPMD API)",
+            "bp"
+        };
+
+        plugins::multi::Option< std::string > fileNameInfix = {
+            "infix",
+            "openPMD filename infix (use to pick file- or group-based "
+            "layout in openPMD)\nset to NULL to keep empty (e.g. to pick"
+            " group-based iteration layout)",
+            "_%06T"
+        };
+
+        plugins::multi::Option< std::string > jsonConfig = {
+            "json",
+            "advanced (backend) configuration for openPMD in JSON format",
+            "{}"
+        };
+
+        plugins::multi::Option< std::string > dataPreparationStrategy = {
+            "dataPreparationStrategy",
+            "Strategy for preparation of particle data ('doubleBuffer' or "
+            "'mappedMemory'). Aliases 'adios' and 'hdf5' may be used "
+            "respectively.",
+            "doubleBuffer"
+        };
+
+        plugins::multi::Option< std::string > compression = {
+            "compression",
+            "Backend-specific openPMD compression method, e.g., zlib (see "
+            "`adios_config -m` for help). Legacy parameter until compression"
+            " can be fully configured via JSON in the openPMD API.",
+            "none"
+        };
+
+        /** defines if the plugin must register itself to the PMacc plugin
+         * system
+         *
+         * true = the plugin is registering it self
+         * false = the plugin is not registering itself (plugin is
+         * controlled by another class)
+         */
+        bool selfRegister = false;
+
+        template< typename T_TupleVector >
+        struct CreateSpeciesFilter
+        {
+            using type = plugins::misc::SpeciesFilter<
+                typename pmacc::math::CT::
+                    At< T_TupleVector, bmpl::int_< 0 > >::type,
+                typename pmacc::math::CT::
+                    At< T_TupleVector, bmpl::int_< 1 > >::type >;
+        };
+
+        using AllParticlesTimesAllFilters =
+            typename AllCombinations< bmpl::vector<
+                FileOutputParticles,
+                particles::filter::AllParticleFilters > >::type;
+
+        using AllSpeciesFilter = typename bmpl::transform<
+            AllParticlesTimesAllFilters,
+            CreateSpeciesFilter< bmpl::_1 > >::type;
+
+        using AllEligibleSpeciesSources = typename bmpl::copy_if<
+            AllSpeciesFilter,
+            plugins::misc::speciesFilter::IsEligible< bmpl::_1 > >::type;
+
+        using AllFieldSources = FileOutputFields;
+
+        ///! method used by plugin controller to get --help description
+        void
+        registerHelp(
+            boost::program_options::options_description & desc,
+            std::string const & masterPrefix = std::string{} )
+        {
+            meta::ForEach<
+                AllEligibleSpeciesSources,
+                plugins::misc::AppendName< bmpl::_1 > >
+                getEligibleDataSourceNames;
+            getEligibleDataSourceNames( allowedDataSources );
+
+            meta::ForEach<
+                AllFieldSources,
+                plugins::misc::AppendName< bmpl::_1 > >
+                appendFieldSourceNames;
+            appendFieldSourceNames( allowedDataSources );
+
+            // string list with all possible particle sources
+            std::string concatenatedSourceNames =
+                plugins::misc::concatenateToString(
+                    allowedDataSources, ", " );
+
+            notifyPeriod.registerHelp( desc, masterPrefix + prefix );
+            source.registerHelp(
+                desc,
+                masterPrefix + prefix,
+                std::string( "[" ) + concatenatedSourceNames + "]" );
+
+            expandHelp( desc, "" );
+            selfRegister = true;
+        }
+
+        void
+        expandHelp(
+            boost::program_options::options_description & desc,
+            std::string const & masterPrefix = std::string{} )
+        {
+            compression.registerHelp( desc, masterPrefix + prefix );
+            fileName.registerHelp( desc, masterPrefix + prefix );
+            fileNameExtension.registerHelp( desc, masterPrefix + prefix );
+            fileNameInfix.registerHelp( desc, masterPrefix + prefix );
+            jsonConfig.registerHelp( desc, masterPrefix + prefix );
+            dataPreparationStrategy.registerHelp(
+                desc, masterPrefix + prefix );
+        }
+
+        void
+        validateOptions()
+        {
+            if( selfRegister )
+            {
+                if( notifyPeriod.empty() || fileName.empty() )
+                    throw std::runtime_error(
+                        name +
+                        ": parameter period and file must be defined" );
+
+                // check if user passed data source names are valid
+                for( auto const & dataSourceNames : source )
+                {
+                    auto vectorOfDataSourceNames =
+                        plugins::misc::splitString(
+                            plugins::misc::removeSpaces(
+                                dataSourceNames ) );
+
+                    for( auto const & f : vectorOfDataSourceNames )
+                    {
+                        if( !plugins::misc::containsObject(
+                                allowedDataSources, f ) )
+                        {
+                            throw std::runtime_error(
+                                name + ": unknown data source '" + f +
+                                "'" );
+                        }
+                    }
+                }
+            }
+        }
+
+        size_t
+        getNumPlugins() const
+        {
+            if( selfRegister )
+                return notifyPeriod.size();
+            else
+                return 1;
+        }
+
+        std::string
+        getDescription() const
+        {
+            return description;
+        }
+
+        std::string
+        getOptionPrefix() const
+        {
+            return prefix;
+        }
+
+        std::string
+        getName() const
+        {
+            return name;
+        }
+
+        std::string const name = "openPMDWriter";
+        //! short description of the plugin
+        std::string const description = "dump simulation data with openPMD";
+        //! prefix used for command line arguments
+        std::string const prefix = "openPMD";
+    };
+
+    void
+    ThreadParams::initFromConfig(
+        Help & help,
+        size_t id,
+        std::string const & file,
+        std::string const & dir )
+    {
+
+        fileExtension = help.fileNameExtension.get( id );
+        fileInfix = help.fileNameInfix.get( id );
+        if ( fileInfix == "NULL" )
+        {
+            fileInfix = "";
+        }
+        /* if file name is relative, prepend with common directory */
+        fileName = boost::filesystem::path( file ).has_root_path() ?
+            file : dir + "/" + file;
+
+        jsonConfig = help.jsonConfig.get( id );
+
+        log< picLog::INPUT_OUTPUT >( "openPMD: setting file pattern: %1%%2%.%3%" ) %
+        fileName % fileInfix % fileExtension;
+
+        log< picLog::INPUT_OUTPUT >(
+            "openPMD: setting JSON configuration to %1%" ) %
+            jsonConfig;
+
+        {
+            std::string strategyString = help.dataPreparationStrategy.get( id );
+            if( strategyString == "adios" || strategyString == "doubleBuffer" )
+            {
+                strategy = WriteSpeciesStrategy::ADIOS;
+            }
+            else if(
+                strategyString == "hdf5" || strategyString == "mappedMemory" )
+            {
+                strategy = WriteSpeciesStrategy::HDF5;
+            }
+            else
+            {
+                std::cerr << "Passed dataPreparationStrategy for openPMD"
+                             " plugin is invalid."
+                          << std::endl;
+            }
+        }
+    }
+
+    /** Writes simulation data to openPMD.
+     *
+     * Implements the IIOBackend interface.
+     */
+    class openPMDWriter : public IIOBackend
+    {
+    public:
+
+        //! must be implemented by the user
+        static std::shared_ptr< plugins::multi::IHelp >
+        getHelp()
+        {
+            return std::shared_ptr< plugins::multi::IHelp >( new Help{} );
+        }
+
+    private:
+        template< typename UnitType >
+        static std::vector< float_64 >
+        createUnit( UnitType unit, uint32_t numComponents )
+        {
+            std::vector< float_64 > tmp( numComponents );
+            for( uint32_t i = 0; i < numComponents; ++i )
+                tmp[ i ] = unit[ i ];
+            return tmp;
+        }
+
+        /**
+         * Write calculated fields to openPMD.
+         */
+        template< typename T_Field >
+        struct GetFields
+        {
+        private:
+            using ValueType = typename T_Field::ValueType;
+            using ComponentType = typename GetComponentsType< ValueType >::type;
+            using UnitType = typename T_Field::UnitValueType;
+
+        public:
+            static std::vector< float_64 >
+            getUnit()
+            {
+                UnitType unit = T_Field::getUnit();
+                return createUnit( unit, T_Field::numComponents );
+            }
+
+            HDINLINE void
+            operator()( ThreadParams * params )
+            {
+#ifndef __CUDA_ARCH__
+                DataConnector & dc =
+                    Environment< simDim >::get().DataConnector();
+
+                auto field = dc.get< T_Field >( T_Field::getName() );
+                params->gridLayout = field->getGridLayout();
+                bool const isDomainBound =
+                    traits::IsFieldDomainBound< T_Field >::value;
+
+                const traits::FieldPosition< fields::CellType, T_Field >
+                    fieldPos;
+
+                std::vector< std::vector< float_X > > inCellPosition;
+                for( uint32_t n = 0; n < T_Field::numComponents; ++n )
+                {
+                    std::vector< float_X > inCellPositonComponent;
+                    for( uint32_t d = 0; d < simDim; ++d )
+                        inCellPositonComponent.push_back(
+                            fieldPos()[ n ][ d ] );
+                    inCellPosition.push_back( inCellPositonComponent );
+                }
+
+                /** \todo check if always correct at this point, depends on
+                 * solver implementation */
+                const float_X timeOffset = 0.0;
+
+                openPMDWriter::writeField< ComponentType >(
+                    params,
+                    sizeof( ComponentType ),
+                    ::openPMD::determineDatatype< ComponentType >(),
+                    GetNComponents< ValueType >::value,
+                    T_Field::getName(),
+                    field->getHostDataBox().getPointer(),
+                    getUnit(),
+                    T_Field::getUnitDimension(),
+                    std::move( inCellPosition ),
+                    timeOffset,
+                    isDomainBound );
+
+                dc.releaseData( T_Field::getName() );
+#endif
+            }
+        };
+
+        /** Calculate FieldTmp with given solver and particle species
+         * and write them to openPMD.
+         *
+         * FieldTmp is calculated on device and then dumped to openPMD.
+         */
+        template< typename Solver, typename Species >
+        struct GetFields< FieldTmpOperation< Solver, Species > >
+        {
+            /*
+             * This is only a wrapper function to allow disable nvcc warnings.
+             * Warning: calling a __host__ function from __host__ __device__
+             * function.
+             * Use of PMACC_NO_NVCC_HDWARNING is not possible if we call a
+             * virtual method inside of the method were we disable the warnings.
+             * Therefore we create this method and call a new method were we can
+             * call virtual functions.
+             */
+            PMACC_NO_NVCC_HDWARNING
+            HDINLINE void
+            operator()( ThreadParams * tparam )
+            {
+                this->operator_impl( tparam );
+            }
+
+        private:
+            using UnitType = typename FieldTmp::UnitValueType;
+            using ValueType = typename FieldTmp::ValueType;
+            using ComponentType = typename GetComponentsType< ValueType >::type;
+
+            /** Get the unit for the result from the solver*/
+            static std::vector< float_64 >
+            getUnit()
+            {
+                UnitType unit = FieldTmp::getUnit< Solver >();
+                const uint32_t components = GetNComponents< ValueType >::value;
+                return createUnit( unit, components );
+            }
+
+            /** Create a name for the openPMD identifier.
+             */
+            static std::string
+            getName()
+            {
+                return FieldTmpOperation< Solver, Species >::getName();
+            }
+
+            HINLINE void
+            operator_impl( ThreadParams * params )
+            {
+                DataConnector & dc = Environment<>::get().DataConnector();
+
+                /*## update field ##*/
+
+                /*load FieldTmp without copy data to host*/
+                PMACC_CASSERT_MSG(
+                    _please_allocate_at_least_one_FieldTmp_in_memory_param,
+                    fieldTmpNumSlots > 0 );
+                auto fieldTmp =
+                    dc.get< FieldTmp >( FieldTmp::getUniqueId( 0 ), true );
+                /*load particle without copy particle data to host*/
+                auto speciesTmp =
+                    dc.get< Species >( Species::FrameType::getName(), true );
+
+                fieldTmp->getGridBuffer().getDeviceBuffer().setValue(
+                    ValueType::create( 0.0 ) );
+                /*run algorithm*/
+                fieldTmp->template computeValue< CORE + BORDER, Solver >(
+                    *speciesTmp, params->currentStep );
+
+                EventTask fieldTmpEvent =
+                    fieldTmp->asyncCommunication( __getTransactionEvent() );
+                __setTransactionEvent( fieldTmpEvent );
+                /* copy data to host that we can write same to disk*/
+                fieldTmp->getGridBuffer().deviceToHost();
+                dc.releaseData( Species::FrameType::getName() );
+                /*## finish update field ##*/
+
+                const uint32_t components = GetNComponents< ValueType >::value;
+
+                /*wrap in a one-component vector for writeField API*/
+                const traits::
+                    FieldPosition< typename fields::CellType, FieldTmp >
+                        fieldPos;
+
+                std::vector< std::vector< float_X > > inCellPosition;
+                std::vector< float_X > inCellPositonComponent;
+                for( uint32_t d = 0; d < simDim; ++d )
+                    inCellPositonComponent.push_back( fieldPos()[ 0 ][ d ] );
+                inCellPosition.push_back( inCellPositonComponent );
+
+                /** \todo check if always correct at this point, depends on
+                 * solver implementation */
+                const float_X timeOffset = 0.0;
+
+                params->gridLayout = fieldTmp->getGridLayout();
+                bool const isDomainBound =
+                    traits::IsFieldDomainBound< FieldTmp >::value;
+                /*write data to openPMD Series*/
+                openPMDWriter::template writeField< ComponentType >(
+                    params,
+                    sizeof( ComponentType ),
+                    ::openPMD::determineDatatype< ComponentType >(),
+                    components,
+                    getName(),
+                    fieldTmp->getHostDataBox().getPointer(),
+                    getUnit(),
+                    FieldTmp::getUnitDimension< Solver >(),
+                    std::move( inCellPosition ),
+                    timeOffset,
+                    isDomainBound );
+
+                dc.releaseData( FieldTmp::getUniqueId( 0 ) );
+            }
+        };
+
+    public:
+        /** constructor
+         *
+         * @param help instance of the class Help
+         * @param id index of this plugin instance within help
+         * @param cellDescription PIConGPu cell description information for
+         * kernel index mapping
+         */
+        openPMDWriter(
+            std::shared_ptr< plugins::multi::IHelp > & help,
+            size_t const id,
+            MappingDesc * cellDescription ) :
+            m_help( std::static_pointer_cast< Help >( help ) ),
+            m_id( id ),
+            m_cellDescription( cellDescription ),
+            outputDirectory( "openPMD" ),
+            lastSpeciesSyncStep( pmacc::traits::limits::Max< uint32_t >::value )
+        {
+            mThreadParams.compressionMethod = m_help->compression.get( id );
+
+            GridController< simDim > & gc =
+                Environment< simDim >::get().GridController();
+            /* It is important that we never change the mpi_pos after this point
+             * because we get problems with the restart.
+             * Otherwise we do not know which gpu must load the ghost parts
+             * around the sliding window.
+             */
+            mpi_pos = gc.getPosition();
+            mpi_size = gc.getGpuNodes();
+
+            if( m_help->selfRegister )
+            {
+                std::string notifyPeriod = m_help->notifyPeriod.get( id );
+                /* only register for notify callback when .period is set on
+                 * command line */
+                if( !notifyPeriod.empty() )
+                {
+                    Environment<>::get()
+                        .PluginConnector()
+                        .setNotificationPeriod( this, notifyPeriod );
+
+                    /** create notify directory */
+                    Environment< simDim >::get()
+                        .Filesystem()
+                        .createDirectoryWithPermissions( outputDirectory );
+                }
+            }
+
+            // avoid deadlock between not finished pmacc tasks and mpi blocking
+            // collectives
+            __getTransactionEvent().waitForFinished();
+            mThreadParams.communicator = MPI_COMM_NULL;
+            MPI_CHECK( MPI_Comm_dup(
+                gc.getCommunicator().getMPIComm(),
+                &( mThreadParams.communicator ) ) );
+        }
+
+        virtual ~openPMDWriter()
+        {
+            if( mThreadParams.communicator != MPI_COMM_NULL )
+            {
+                // avoid deadlock between not finished pmacc tasks and mpi
+                // blocking collectives
+                __getTransactionEvent().waitForFinished();
+                MPI_CHECK_NO_EXCEPT(
+                    MPI_Comm_free( &( mThreadParams.communicator ) ) );
+            }
+        }
+
+        void
+        notify( uint32_t currentStep )
+        {
+            // notify is only allowed if the plugin is not controlled by the
+            // class Checkpoint
+            assert( m_help->selfRegister );
+
+            __getTransactionEvent().waitForFinished();
+
+            mThreadParams.initFromConfig(
+                *m_help, m_id, m_help->fileName.get( m_id ), outputDirectory );
+
+            /* window selection */
+            mThreadParams.window =
+                MovingWindow::getInstance().getWindow( currentStep );
+            mThreadParams.isCheckpoint = false;
+            dumpData( currentStep );
+        }
+
+        virtual void
+        restart( uint32_t restartStep, std::string const & restartDirectory )
+        {
+            /* ISlave restart interface is not needed becase IIOBackend
+             * restart interface is used
+             */
+        }
+
+        virtual void
+        checkpoint(
+            uint32_t currentStep,
+            std::string const & checkpointDirectory )
+        {
+            /* ISlave checkpoint interface is not needed becase IIOBackend
+             * checkpoint interface is used
+             */
+        }
+
+        void
+        dumpCheckpoint(
+            const uint32_t currentStep,
+            const std::string & checkpointDirectory,
+            const std::string & checkpointFilename )
+        {
+            // checkpointing is only allowed if the plugin is controlled by the
+            // class Checkpoint
+            assert( !m_help->selfRegister );
+
+            __getTransactionEvent().waitForFinished();
+            /* if file name is relative, prepend with common directory */
+
+            mThreadParams.isCheckpoint = true;
+            mThreadParams.initFromConfig(
+                *m_help, m_id, checkpointFilename, checkpointDirectory );
+
+            mThreadParams.window =
+                MovingWindow::getInstance().getDomainAsWindow( currentStep );
+
+            dumpData( currentStep );
+        }
+
+        void
+        doRestart(
+            const uint32_t restartStep,
+            const std::string & restartDirectory,
+            const std::string & constRestartFilename,
+            const uint32_t restartChunkSize )
+        {
+            // restart is only allowed if the plugin is controlled by the class
+            // Checkpoint
+            assert( !m_help->selfRegister );
+
+            mThreadParams.initFromConfig(
+                *m_help, m_id, constRestartFilename, restartDirectory );
+
+            // mThreadParams.isCheckpoint = isCheckpoint;
+            mThreadParams.currentStep = restartStep;
+            mThreadParams.cellDescription = m_cellDescription;
+
+            mThreadParams.openSeries( ::openPMD::AccessType::READ_ONLY );
+
+            ::openPMD::Iteration iteration =
+                mThreadParams.openPMDSeries
+                    ->iterations[ mThreadParams.currentStep ];
+
+            /* load number of slides to initialize MovingWindow */
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: (begin) read attr (%1% available)" ) %
+                iteration.numAttributes();
+
+
+            uint32_t slides =
+                iteration.getAttribute( "sim_slides" ).get< uint32_t >();
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: value of sim_slides = %1%" ) %
+                slides;
+
+            uint32_t lastStep =
+                iteration.getAttribute( "iteration" ).get< uint32_t >();
+            log< picLog::INPUT_OUTPUT >( "openPMD: value of iteration = %1%" ) %
+                lastStep;
+
+            PMACC_ASSERT( lastStep == restartStep );
+
+            /* apply slides to set gpus to last/written configuration */
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: Setting slide count for moving window to %1%" ) %
+                slides;
+            MovingWindow::getInstance().setSlideCounter( slides, restartStep );
+
+            /* re-distribute the local offsets in y-direction
+             * this will work for restarts with moving window still enabled
+             * and restarts that disable the moving window
+             * \warning enabling the moving window from a checkpoint that
+             *          had no moving window will not work
+             */
+            GridController< simDim > & gc =
+                Environment< simDim >::get().GridController();
+            gc.setStateAfterSlides( slides );
+
+            /* set window for restart, complete global domain */
+            mThreadParams.window =
+                MovingWindow::getInstance().getDomainAsWindow( restartStep );
+            mThreadParams.localWindowToDomainOffset =
+                DataSpace< simDim >::create( 0 );
+
+            /* load all fields */
+            meta::ForEach< FileCheckpointFields, LoadFields< bmpl::_1 > >
+                ForEachLoadFields;
+            ForEachLoadFields( &mThreadParams );
+
+            /* load all particles */
+            meta::ForEach< FileCheckpointParticles, LoadSpecies< bmpl::_1 > >
+                ForEachLoadSpecies;
+            ForEachLoadSpecies( &mThreadParams, restartChunkSize );
+
+            IdProvider< simDim >::State idProvState;
+            ReadNDScalars< uint64_t, uint64_t >()(
+                mThreadParams,
+                "picongpu",
+                "idProvider",
+                "startId",
+                &idProvState.startId,
+                "maxNumProc",
+                &idProvState.maxNumProc );
+            ReadNDScalars< uint64_t >()(
+                mThreadParams,
+                "picongpu",
+                "idProvider",
+                "nextId",
+                &idProvState.nextId );
+            log< picLog::INPUT_OUTPUT >(
+                "Setting next free id on current rank: %1%" ) %
+                idProvState.nextId;
+            IdProvider< simDim >::setState( idProvState );
+
+            // avoid deadlock between not finished pmacc tasks and mpi calls in
+            // openPMD
+            __getTransactionEvent().waitForFinished();
+
+            // Finalize the openPMD Series by calling its destructor
+            mThreadParams.closeSeries();
+        }
+
+    private:
+        void
+        endWrite()
+        {
+            mThreadParams.fieldBuffer.resize( 0 );
+        }
+
+        void
+        initWrite()
+        {
+            // may be zero
+            auto size =
+                mThreadParams.window.localDimensions.size.productOfComponents();
+            mThreadParams.fieldBuffer.resize( size );
+        }
+
+        /**
+         * Notification for dump or checkpoint received
+         *
+         * @param currentStep current simulation step
+         */
+        void
+        dumpData( uint32_t currentStep )
+        {
+            // local offset + extent
+            const pmacc::Selection< simDim > & localDomain =
+                Environment< simDim >::get().SubGrid().getLocalDomain();
+            mThreadParams.cellDescription = m_cellDescription;
+            mThreadParams.currentStep = currentStep;
+
+            for( uint32_t i = 0; i < simDim; ++i )
+            {
+                mThreadParams.localWindowToDomainOffset[ i ] = 0;
+                if( mThreadParams.window.globalDimensions.offset[ i ] >
+                    localDomain.offset[ i ] )
+                {
+                    mThreadParams.localWindowToDomainOffset[ i ] =
+                        mThreadParams.window.globalDimensions.offset[ i ] -
+                        localDomain.offset[ i ];
+                }
+            }
+
+            /* copy species only one time per timestep to the host */
+            if( mThreadParams.strategy == WriteSpeciesStrategy::ADIOS &&
+                lastSpeciesSyncStep != currentStep )
+            {
+                DataConnector & dc = Environment<>::get().DataConnector();
+
+#if( PMACC_CUDA_ENABLED == 1 )
+                /* synchronizes the MallocMCBuffer to the host side */
+                dc.get< MallocMCBuffer< DeviceHeap > >(
+                    MallocMCBuffer< DeviceHeap >::getName() );
+#endif
+                /* here we are copying all species to the host side since we
+                 * can not say at this point if this time step will need all of
+                 * them for sure (checkpoint) or just some user-defined species
+                 * (dump)
+                 */
+                meta::ForEach<
+                    FileCheckpointParticles,
+                    CopySpeciesToHost< bmpl::_1 > >
+                    copySpeciesToHost;
+                copySpeciesToHost();
+                lastSpeciesSyncStep = currentStep;
+#if( PMACC_CUDA_ENABLED == 1 )
+                dc.releaseData( MallocMCBuffer< DeviceHeap >::getName() );
+#endif
+            }
+
+            initWrite();
+
+            write( &mThreadParams, mpiTransportParams );
+
+            endWrite();
+        }
+
+        static void
+        writeFieldAttributes(
+            ThreadParams * params,
+            std::vector< float_64 > const & unitDimension,
+            float_X timeOffset,
+            ::openPMD::Mesh & mesh )
+        {
+            static constexpr ::openPMD::UnitDimension
+                openPMDUnitDimensions[ 7 ] = {
+                    ::openPMD::UnitDimension::L,
+                    ::openPMD::UnitDimension::M,
+                    ::openPMD::UnitDimension::T,
+                    ::openPMD::UnitDimension::I,
+                    ::openPMD::UnitDimension::theta,
+                    ::openPMD::UnitDimension::N,
+                    ::openPMD::UnitDimension::J };
+            std::map<::openPMD::UnitDimension, double > unitMap;
+            for( unsigned i = 0; i < 7; ++i )
+            {
+                unitMap[ openPMDUnitDimensions[ i ] ] = unitDimension[ i ];
+            }
+
+            mesh.setUnitDimension( unitMap );
+            mesh.setTimeOffset< float_X >( timeOffset );
+            mesh.setGeometry( ::openPMD::Mesh::Geometry::cartesian );
+            mesh.setDataOrder( ::openPMD::Mesh::DataOrder::C );
+
+            if( simDim == DIM2 )
+            {
+                std::vector< std::string > axisLabels = {
+                    "y", "x"
+                }; // 2D: F[y][x]
+                mesh.setAxisLabels( axisLabels );
+            }
+            if( simDim == DIM3 )
+            {
+                std::vector< std::string > axisLabels = {
+                    "z", "y", "x"
+                }; // 3D: F[z][y][x]
+                mesh.setAxisLabels( axisLabels );
+            }
+
+            // cellSize is {x, y, z} but fields are F[z][y][x]
+            std::vector< float_X > gridSpacing( simDim, 0.0 );
+            for( uint32_t d = 0; d < simDim; ++d )
+                gridSpacing.at( simDim - 1 - d ) = cellSize[ d ];
+
+            mesh.setGridSpacing( gridSpacing );
+
+            /* globalSlideOffset due to gpu slides between origin at time step 0
+             * and origin at current time step
+             * ATTENTION: splash offset are globalSlideOffset + picongpu offsets
+             */
+            DataSpace< simDim > globalSlideOffset;
+            const pmacc::Selection< simDim > & localDomain =
+                Environment< simDim >::get().SubGrid().getLocalDomain();
+            const uint32_t numSlides =
+                MovingWindow::getInstance().getSlideCounter(
+                    params->currentStep );
+            globalSlideOffset.y() += numSlides * localDomain.size.y();
+
+            // globalDimensions is {x, y, z} but fields are F[z][y][x]
+            std::vector< float_64 > gridGlobalOffset( simDim, 0.0 );
+            for( uint32_t d = 0; d < simDim; ++d )
+                gridGlobalOffset.at( simDim - 1 - d ) = float_64(
+                                                            cellSize[ d ] ) *
+                    float_64( params->window.globalDimensions.offset[ d ] +
+                              globalSlideOffset[ d ] );
+
+            mesh.setGridGlobalOffset( std::move( gridGlobalOffset ) );
+            mesh.setGridUnitSI( UNIT_LENGTH );
+            mesh.setAttribute( "fieldSmoothing", "none" );
+        }
+
+        template< typename ComponentType >
+        static void
+        writeField(
+            ThreadParams * params,
+            const uint32_t sizePtrType,
+            ::openPMD::Datatype openPMDType,
+            const uint32_t nComponents,
+            const std::string name,
+            void * ptr,
+            std::vector< float_64 > unit,
+            std::vector< float_64 > unitDimension,
+            std::vector< std::vector< float_X > > inCellPosition,
+            float_X timeOffset,
+            bool isDomainBound )
+        {
+            auto const name_lookup_tpl =
+                plugins::misc::getComponentNames( nComponents );
+
+            /* parameter checking */
+            PMACC_ASSERT( unit.size() == nComponents );
+            PMACC_ASSERT( inCellPosition.size() == nComponents );
+            for( uint32_t n = 0; n < nComponents; ++n )
+                PMACC_ASSERT( inCellPosition.at( n ).size() == simDim );
+            PMACC_ASSERT(
+                unitDimension.size() == 7 ); // seven openPMD base units
+
+            log< picLog::INPUT_OUTPUT >( "openPMD: write field: %1% %2% %3%" ) %
+                name % nComponents % ptr;
+
+            const bool fieldTypeCorrect(
+                boost::is_same< ComponentType, float_X >::value );
+            PMACC_CASSERT_MSG(
+                Precision_mismatch_in_Field_Components__ADIOS,
+                fieldTypeCorrect );
+
+            ::openPMD::Iteration iteration =
+                params->openPMDSeries->iterations[ params->currentStep ];
+            ::openPMD::Mesh mesh = iteration.meshes[ name ];
+
+            // set mesh attributes
+            writeFieldAttributes( params, unitDimension, timeOffset, mesh );
+
+            /* data to describe source buffer */
+            GridLayout< simDim > field_layout = params->gridLayout;
+            DataSpace< simDim > field_full = field_layout.getDataSpace();
+
+            DataSpace< simDim > field_no_guard =
+                params->window.localDimensions.size;
+            DataSpace< simDim > field_guard =
+                field_layout.getGuard() + params->localWindowToDomainOffset;
+            std::vector< float_X > & dstBuffer = params->fieldBuffer;
+
+            auto fieldsSizeDims = params->fieldsSizeDims;
+            auto fieldsGlobalSizeDims = params->fieldsGlobalSizeDims;
+            auto fieldsOffsetDims = params->fieldsOffsetDims;
+
+            /* Patch for non-domain-bound fields
+             * Allow for the output of reduced 1d PML buffers,
+             * that are the same size on each domain.
+             */
+            if( !isDomainBound )
+            {
+                field_no_guard = field_layout.getDataSpaceWithoutGuarding();
+                field_guard = field_layout.getGuard();
+                dstBuffer.resize( field_no_guard.productOfComponents() );
+
+                DataConnector & dc = Environment<>::get().DataConnector();
+                fieldsSizeDims = precisionCast< uint64_t >(
+                    params->gridLayout.getDataSpaceWithoutGuarding() );
+                dc.releaseData( name );
+                auto const & gridController =
+                    Environment< simDim >::get().GridController();
+                auto const numRanks = gridController.getGlobalSize();
+                auto const rank = gridController.getGlobalRank();
+                fieldsGlobalSizeDims =
+                    pmacc::math::UInt64< simDim >::create( 1 );
+                fieldsGlobalSizeDims[ 0 ] = numRanks * fieldsSizeDims[ 0 ];
+                fieldsOffsetDims =
+                    pmacc::math::UInt64< simDim >::create( 0 );
+                fieldsOffsetDims[ 0 ] = rank * fieldsSizeDims[ 0 ];
+            }
+
+            /* write the actual field data */
+            for( uint32_t d = 0; d < nComponents; d++ )
+            {
+                const size_t plane_full_size =
+                    field_full[ 1 ] * field_full[ 0 ] * nComponents;
+                const size_t plane_no_guard_size =
+                    field_no_guard[ 1 ] * field_no_guard[ 0 ];
+
+                /* copy strided data from source to temporary buffer
+                 *
+                 * \todo use d1Access as in
+                 * `include/plugins/hdf5/writer/Field.hpp`
+                 */
+                const int maxZ = simDim == DIM3 ? field_no_guard[ 2 ] : 1;
+                const int guardZ = simDim == DIM3 ? field_guard[ 2 ] : 0;
+                for( int z = 0; z < maxZ; ++z )
+                {
+                    for( int y = 0; y < field_no_guard[ 1 ]; ++y )
+                    {
+                        const size_t base_index_src =
+                            ( z + guardZ ) * plane_full_size +
+                            ( y + field_guard[ 1 ] ) * field_full[ 0 ] *
+                                nComponents;
+
+                        const size_t base_index_dst =
+                            z * plane_no_guard_size + y * field_no_guard[ 0 ];
+
+                        for( int x = 0; x < field_no_guard[ 0 ]; ++x )
+                        {
+                            size_t index_src = base_index_src +
+                                ( x + field_guard[ 0 ] ) * nComponents + d;
+                            size_t index_dst = base_index_dst + x;
+
+                            dstBuffer[ index_dst ] =
+                                reinterpret_cast< float_X * >(
+                                    ptr )[ index_src ];
+                        }
+                    }
+                }
+
+                ::openPMD::MeshRecordComponent mrc = mesh
+                    [ nComponents > 1 ? name_lookup_tpl[ d ]
+                                      : ::openPMD::RecordComponent::SCALAR ];
+
+                params->initDataset< simDim >(
+                    mrc,
+                    openPMDType,
+                    fieldsGlobalSizeDims,
+                    true,
+                    params->compressionMethod );
+                if( dstBuffer.size() > 0 )
+                    mrc.storeChunk< std::vector< float_X > >(
+                        dstBuffer,
+                        asStandardVector( fieldsOffsetDims ),
+                        asStandardVector( fieldsSizeDims ) );
+
+                // define record component level attributes
+                mrc.setPosition( inCellPosition.at( d ) );
+                mrc.setUnitSI( unit.at( d ) );
+
+                params->openPMDSeries->flush();
+            }
+        }
+
+
+        template< typename T_ParticleFilter >
+        struct CallWriteSpecies
+        {
+            template< typename Space >
+            void
+            operator()(
+                const std::vector< std::string > & vectorOfDataSourceNames,
+                ThreadParams * params,
+                const Space domainOffset )
+            {
+                bool const containsDataSource = plugins::misc::containsObject(
+                    vectorOfDataSourceNames, T_ParticleFilter::getName() );
+
+                if( containsDataSource )
+                {
+                    WriteSpecies< T_ParticleFilter > writeSpecies;
+                    writeSpecies( params, domainOffset );
+                }
+            }
+        };
+
+        template< typename T_Fields >
+        struct CallGetFields
+        {
+            void
+            operator()(
+                const std::vector< std::string > & vectorOfDataSourceNames,
+                ThreadParams * params )
+            {
+                bool const containsDataSource = plugins::misc::containsObject(
+                    vectorOfDataSourceNames, T_Fields::getName() );
+
+                if( containsDataSource )
+                {
+                    GetFields< T_Fields > getFields;
+                    getFields( params );
+                }
+            }
+        };
+
+        void
+        write( ThreadParams * threadParams, std::string mpiTransportParams )
+        {
+            /* y direction can be negative for first gpu */
+            const pmacc::Selection< simDim > & localDomain =
+                Environment< simDim >::get().SubGrid().getLocalDomain();
+            DataSpace< simDim > particleOffset( localDomain.offset );
+            particleOffset.y() -=
+                threadParams->window.globalDimensions.offset.y();
+
+            threadParams->fieldsOffsetDims =
+                precisionCast< uint64_t >( localDomain.offset );
+
+            /* write created variable values */
+            for( uint32_t d = 0; d < simDim; ++d )
+            {
+                /* dimension 1 is y and is the direction of the moving window
+                 * (if any) */
+                if( 1 == d )
+                {
+                    uint64_t offset = std::max(
+                        0,
+                        localDomain.offset.y() -
+                            threadParams->window.globalDimensions.offset.y() );
+                    threadParams->fieldsOffsetDims[ d ] = offset;
+                }
+
+                threadParams->fieldsSizeDims[ d ] =
+                    threadParams->window.localDimensions.size[ d ];
+                threadParams->fieldsGlobalSizeDims[ d ] =
+                    threadParams->window.globalDimensions.size[ d ];
+            }
+
+            std::vector< std::string > vectorOfDataSourceNames;
+            if( m_help->selfRegister )
+            {
+                std::string dataSourceNames = m_help->source.get( m_id );
+
+                vectorOfDataSourceNames = plugins::misc::splitString(
+                    plugins::misc::removeSpaces( dataSourceNames ) );
+            }
+
+            bool dumpFields = plugins::misc::containsObject(
+                vectorOfDataSourceNames, "fields_all" );
+
+            if( threadParams->openPMDSeries )
+            {
+                log< picLog::INPUT_OUTPUT >( "openPMD: Series still open, reusing" );
+                //TODO check for same configuration
+            }
+            else
+            {
+                log< picLog::INPUT_OUTPUT >( "openPMD: opening Series %1%" ) %
+                    threadParams->fileName;
+                threadParams->openSeries( ::openPMD::AccessType::CREATE );
+            }
+
+            bool dumpAllParticles = plugins::misc::containsObject(
+                vectorOfDataSourceNames, "species_all" );
+
+            /* write fields */
+            log< picLog::INPUT_OUTPUT >( "openPMD: (begin) writing fields." );
+            if( threadParams->isCheckpoint )
+            {
+                meta::ForEach< FileCheckpointFields, GetFields< bmpl::_1 > >
+                    ForEachGetFields;
+                ForEachGetFields( threadParams );
+            }
+            else
+            {
+                if( dumpFields )
+                {
+                    meta::ForEach< FileOutputFields, GetFields< bmpl::_1 > >
+                        ForEachGetFields;
+                    ForEachGetFields( threadParams );
+                }
+
+                // move over all field data sources
+                meta::ForEach<
+                    typename Help::AllFieldSources,
+                    CallGetFields< bmpl::_1 > >{}(
+                    vectorOfDataSourceNames, threadParams );
+            }
+            log< picLog::INPUT_OUTPUT >( "openPMD: ( end ) writing fields." );
+
+
+            /* print all particle species */
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: (begin) writing particle species." );
+            if( threadParams->isCheckpoint )
+            {
+                meta::ForEach<
+                    FileCheckpointParticles,
+                    WriteSpecies<
+                        plugins::misc::SpeciesFilter< bmpl::_1 >,
+                        plugins::misc::UnfilteredSpecies< bmpl::_1 > > >
+                    writeSpecies;
+                writeSpecies( threadParams, particleOffset );
+            }
+            else
+            {
+                // dump data if data source "species_all" is selected
+                if( dumpAllParticles )
+                {
+                    // move over all species defined in FileOutputParticles
+                    meta::ForEach<
+                        FileOutputParticles,
+                        WriteSpecies<
+                            plugins::misc::UnfilteredSpecies< bmpl::_1 > > >
+                        writeSpecies;
+                    writeSpecies( threadParams, particleOffset );
+                }
+
+                // move over all species data sources
+                meta::ForEach<
+                    typename Help::AllEligibleSpeciesSources,
+                    CallWriteSpecies< bmpl::_1 > >{}(
+                    vectorOfDataSourceNames, threadParams, particleOffset );
+            }
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: ( end ) writing particle species." );
+
+
+            auto idProviderState = IdProvider< simDim >::getState();
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: Writing IdProvider state (StartId: %1%, NextId: %2%, "
+                "maxNumProc: %3%)" ) %
+                idProviderState.startId % idProviderState.nextId %
+                idProviderState.maxNumProc;
+
+            WriteNDScalars< uint64_t, uint64_t > writeIdProviderStartId(
+                "picongpu", "idProvider", "startId", "maxNumProc" );
+            WriteNDScalars< uint64_t, uint64_t > writeIdProviderNextId(
+                "picongpu", "idProvider", "nextId" );
+            writeIdProviderStartId(
+                *threadParams,
+                idProviderState.startId,
+                idProviderState.maxNumProc );
+            writeIdProviderNextId( *threadParams, idProviderState.nextId );
+
+            /* attributes written here are pure meta data */
+            WriteMeta writeMetaAttributes;
+            writeMetaAttributes( threadParams );
+
+            // avoid deadlock between not finished pmacc tasks and mpi calls in
+            // openPMD
+            __getTransactionEvent().waitForFinished();
+            if( threadParams->fileInfix.empty() )
+            {
+                // using group-based iteration layout (non-default)
+                // keep series open, just flush
+                log< picLog::INPUT_OUTPUT >(
+                    "openPMD: final flush of series: %1% in iteration %2%" ) %
+                    mThreadParams.fileName % mThreadParams.currentStep;
+                mThreadParams.openPMDSeries->flush();
+            }
+            else
+            {
+                /* using file-based iteration layout (default)
+                 * for now, close series between data dumps
+                 * Currently, this is the only way in the openPMD API
+                 * to guarantee that files are closed
+                 * @todo Change this as soon as this is properly implemented
+                 *       in the openPMD API
+                 */
+                log< picLog::INPUT_OUTPUT >( "openPMD: closing series: %1%" ) %
+                    threadParams->fileName;
+                mThreadParams.closeSeries();
+            }
+
+            return;
+        }
+
+        ThreadParams mThreadParams;
+
+        std::shared_ptr< Help > m_help;
+        size_t m_id;
+
+        MappingDesc * m_cellDescription;
+
+        std::string outputDirectory;
+
+        /* select MPI method, #OSTs and #aggregators */
+        std::string mpiTransportParams;
+
+        uint32_t lastSpeciesSyncStep;
+
+        DataSpace< simDim > mpi_pos;
+        DataSpace< simDim > mpi_size;
+    };
+
+    std::shared_ptr< plugins::multi::ISlave >
+    Help::create(
+        std::shared_ptr< plugins::multi::IHelp > & help,
+        size_t const id,
+        MappingDesc * cellDescription )
+    {
+        return std::shared_ptr< plugins::multi::ISlave >(
+            new openPMDWriter( help, id, cellDescription ) );
+    }
+
+} // namespace openPMD
+} // namespace picongpu

--- a/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
@@ -1,0 +1,145 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Rene Widera, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/PICToOpenPMD.hpp"
+
+#include <pmacc/assert.hpp>
+#include <pmacc/traits/GetComponentsType.hpp>
+#include <pmacc/traits/GetNComponents.hpp>
+#include <pmacc/traits/Resolve.hpp>
+
+#include <openPMD/openPMD.hpp>
+
+#include <memory>
+
+namespace picongpu
+{
+namespace openPMD
+{
+    using namespace pmacc;
+
+    /** Load attribute of a species from openPMD checkpoint storage
+     *
+     * @tparam T_Identifier identifier of species attribute
+     */
+    template< typename T_Identifier >
+    struct LoadParticleAttributesFromOpenPMD
+    {
+        /** read attributes from openPMD file
+         *
+         * @param params thread params
+         * @param frame frame with all particles
+         * @param particleSpecies the openpmd representation of the species
+         * @param particlesOffset read offset in the attribute array
+         * @param elements number of elements which should be read the attribute
+         * array
+         */
+        template< typename FrameType >
+        HINLINE void
+        operator()(
+            ThreadParams * params,
+            FrameType & frame,
+            ::openPMD::ParticleSpecies particleSpecies,
+            const uint64_t particlesOffset,
+            const uint64_t elements )
+        {
+            using Identifier = T_Identifier;
+            using ValueType =
+                typename pmacc::traits::Resolve< Identifier >::type::type;
+            const uint32_t components = GetNComponents< ValueType >::value;
+            using ComponentType = typename GetComponentsType< ValueType >::type;
+            OpenPMDName< Identifier > openPMDName;
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: ( begin ) load species attribute: %1%" ) %
+                openPMDName();
+
+            const std::string name_lookup[] = { "x", "y", "z" };
+
+            std::shared_ptr< ComponentType > loadBfr;
+            if( elements > 0 )
+            {
+                loadBfr = std::shared_ptr< ComponentType >{
+                    new ComponentType[ elements ],
+                    []( ComponentType * ptr ) { delete[] ptr; }
+                };
+            }
+
+            for( uint32_t n = 0; n < components; ++n )
+            {
+                ::openPMD::Record record = particleSpecies[ openPMDName() ];
+                ::openPMD::RecordComponent rc = components > 1
+                    ? record[ name_lookup[ n ] ]
+                    : record[::openPMD::RecordComponent::SCALAR ];
+
+                ValueType * dataPtr =
+                    frame.getIdentifier( Identifier() ).getPointer();
+
+                if( elements > 0 )
+                {
+                    // avoid deadlock between not finished pmacc tasks and mpi
+                    // calls in openPMD
+                    __getTransactionEvent().waitForFinished();
+                    rc.loadChunk< ComponentType >(
+                        loadBfr,
+                        ::openPMD::Offset{ particlesOffset },
+                        ::openPMD::Extent{ elements } );
+                }
+
+                /** start a blocking read of all scheduled variables
+                 *  (this is collective call in many methods of openPMD
+                 * backends)
+                 */
+                params->openPMDSeries->flush();
+
+                uint64_t globalNumElements = 1;
+                for( auto ext : rc.getExtent() )
+                {
+                    globalNumElements *= ext;
+                }
+
+                log< picLog::INPUT_OUTPUT >(
+                    "openPMD:  Did read %1% local of %2% global elements for "
+                    "%3%" ) %
+                    elements % globalNumElements % openPMDName();
+
+/* copy component from temporary array to array of structs */
+#pragma omp parallel for simd
+                for( size_t i = 0; i < elements; ++i )
+                {
+                    ComponentType * ref = &reinterpret_cast< ComponentType * >(
+                        dataPtr )[ i * components + n ];
+                    *ref = loadBfr.get()[ i ];
+                }
+            }
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  ( end ) load species attribute: %1%" ) %
+                openPMDName();
+        }
+    };
+
+} /* namespace openPMD */
+} /* namespace picongpu */

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -1,0 +1,236 @@
+/* Copyright 2013-2019 Rene Widera, Felix Schmitt, Axel Huebl, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp"
+#include "picongpu/plugins/output/WriteSpeciesCommon.hpp"
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/meta/conversion/RemoveFromSeq.hpp>
+#include <pmacc/particles/ParticleDescription.hpp>
+#include <pmacc/particles/operations/splitIntoListOfFrames.kernel>
+
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/find.hpp>
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/type_traits.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+#include <openPMD/openPMD.hpp>
+
+
+namespace picongpu
+{
+namespace openPMD
+{
+    using namespace pmacc;
+
+    /** Load species from openPMD checkpoint storage
+     *
+     * @tparam T_Species type of species
+     */
+    template< typename T_Species >
+    struct LoadSpecies
+    {
+    public:
+        using ThisSpecies = T_Species;
+        using FrameType = typename ThisSpecies::FrameType;
+        using ParticleDescription = typename FrameType::ParticleDescription;
+        using ParticleAttributeList = typename FrameType::ValueTypeSeq;
+
+
+        /* delete multiMask and localCellIdx in openPMD particle*/
+        using TypesToDelete = bmpl::vector2< multiMask, localCellIdx >;
+        using ParticleCleanedAttributeList =
+            typename RemoveFromSeq< ParticleAttributeList, TypesToDelete >::
+                type;
+
+        /* add totalCellIdx for openPMD particle*/
+        using ParticleNewAttributeList =
+            typename MakeSeq< ParticleCleanedAttributeList, totalCellIdx >::
+                type;
+
+        using NewParticleDescription = typename ReplaceValueTypeSeq<
+            ParticleDescription,
+            ParticleNewAttributeList >::type;
+
+        using openPMDFrameType =
+            Frame< OperatorCreateVectorBox, NewParticleDescription >;
+
+        /** Load species from openPMD checkpoint storage
+         *
+         * @param params thread params
+         * @param restartChunkSize number of particles processed in one kernel
+         * call
+         */
+        HINLINE void
+        operator()( ThreadParams * params, const uint32_t restartChunkSize )
+        {
+            std::string const speciesName = FrameType::getName();
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: (begin) load species: %1%" ) %
+                speciesName;
+            DataConnector & dc = Environment<>::get().DataConnector();
+            GridController< simDim > & gc =
+                Environment< simDim >::get().GridController();
+
+            ::openPMD::Series & series = *params->openPMDSeries;
+            ::openPMD::Container<::openPMD::ParticleSpecies > & particles =
+                series.iterations[ params->currentStep ].particles;
+            ::openPMD::ParticleSpecies particleSpecies =
+                particles[ speciesName ];
+
+            const pmacc::Selection< simDim > & localDomain =
+                Environment< simDim >::get().SubGrid().getLocalDomain();
+
+            /* load particle without copying particle data to host */
+            auto speciesTmp =
+                dc.get< ThisSpecies >( FrameType::getName(), true );
+
+            /* count total number of particles on the device */
+            uint64_t totalNumParticles = 0;
+
+            /* load particles info table entry for ONE process
+               (note: this is NOT necessarily THIS process!) :uniaku:
+               particlesInfo is (part-count, scalar pos, x, y, z) */
+
+            uint64_t start = 5 * gc.getGlobalRank();
+            uint64_t count = 5; // openPMDCountParticles: uint64_t
+
+            // avoid deadlock between not finished pmacc tasks and mpi calls in
+            // openPMD
+            __getTransactionEvent().waitForFinished();
+            std::shared_ptr< uint64_t > particlesInfo =
+                particleSpecies[ "particles_info" ]
+                               [::openPMD::RecordComponent::SCALAR ]
+                                   .loadChunk< uint64_t >(
+                                       ::openPMD::Offset{ start },
+                                       ::openPMD::Extent{ count } );
+            series.flush();
+
+            /* Run a prefix sum over the numParticles[0] element in
+             * particlesInfo to retreive the offset of particles before
+             * gc.getGlobalRank() */
+            uint64_t particleOffset = 0;
+
+            uint64_t fullParticlesInfo[ gc.getGlobalSize() ];
+
+            auto particlesInfoPtr = particlesInfo.get();
+
+            // avoid deadlock between not finished pmacc tasks and mpi blocking
+            // collectives
+            __getTransactionEvent().waitForFinished();
+            MPI_CHECK( MPI_Allgather(
+                particlesInfoPtr,
+                1,
+                MPI_UINT64_T,
+                fullParticlesInfo,
+                1,
+                MPI_UINT64_T,
+                gc.getCommunicator().getMPIComm() ) );
+
+            for( size_t i = 0; i < gc.getGlobalSize(); ++i )
+            {
+                /* this comparison is potentially harmful, since the order of
+                   ranks is not necessarily the same in subsequent MPI jobs. But
+                   due to the wrong sorting by rank in
+                   `openPMDCountParticles.hpp` while calculating the
+                   `myParticleOffset` we have to immitate that. */
+                if( i < gc.getGlobalRank() )
+                    particleOffset += fullParticlesInfo[ i ];
+                if( i == gc.getGlobalRank() )
+                    totalNumParticles = fullParticlesInfo[ i ];
+            }
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: Loading %1% particles from offset %2%" ) %
+                ( long long unsigned )totalNumParticles %
+                ( long long unsigned )particleOffset;
+
+            openPMDFrameType hostFrame;
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: malloc mapped memory: %1%" ) %
+                speciesName;
+            /*malloc mapped memory*/
+            meta::ForEach<
+                typename openPMDFrameType::ValueTypeSeq,
+                MallocMemory< bmpl::_1 > >
+                mallocMem;
+            mallocMem( hostFrame, totalNumParticles );
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: get mapped memory device pointer: %1%" ) %
+                speciesName;
+            /*load device pointer of mapped memory*/
+            openPMDFrameType deviceFrame;
+            meta::ForEach<
+                typename openPMDFrameType::ValueTypeSeq,
+                GetDevicePtr< bmpl::_1 > >
+                getDevicePtr;
+            getDevicePtr( deviceFrame, hostFrame );
+
+            meta::ForEach<
+                typename openPMDFrameType::ValueTypeSeq,
+                LoadParticleAttributesFromOpenPMD< bmpl::_1 > >
+                loadAttributes;
+            loadAttributes(
+                params,
+                hostFrame,
+                particleSpecies,
+                particleOffset,
+                totalNumParticles );
+
+            if( totalNumParticles != 0 )
+            {
+                pmacc::particles::operations::splitIntoListOfFrames(
+                    *speciesTmp,
+                    deviceFrame,
+                    totalNumParticles,
+                    restartChunkSize,
+                    localDomain.offset,
+                    totalCellIdx_,
+                    *( params->cellDescription ),
+                    picLog::INPUT_OUTPUT() );
+
+                /*free host memory*/
+                meta::ForEach<
+                    typename openPMDFrameType::ValueTypeSeq,
+                    FreeMemory< bmpl::_1 > >
+                    freeMem;
+                freeMem( hostFrame );
+            }
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: ( end ) load species: %1%" ) %
+                speciesName;
+        }
+    };
+
+
+} /* namespace openPMD */
+
+} /* namespace picongpu */

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -1,0 +1,227 @@
+/* Copyright 2014-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+ *                     Benjamin Worpitz, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
+#include "picongpu/simulation/control/MovingWindow.hpp"
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/IsFieldDomainBound.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/dimensions/GridLayout.hpp>
+#include <pmacc/particles/frame_types.hpp>
+#include <pmacc/types.hpp>
+
+#include <openPMD/openPMD.hpp>
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+
+namespace picongpu
+{
+namespace openPMD
+{
+    /**
+     * Helper class for openPMD plugin to load fields from parallel openPMD
+     * storages.
+     */
+    class RestartFieldLoader
+    {
+    public:
+        template< class Data >
+        static void
+        loadField(
+            Data & field,
+            const uint32_t numComponents,
+            std::string objectName,
+            ThreadParams * params,
+            bool const isDomainBound )
+        {
+            log< picLog::INPUT_OUTPUT >( "Begin loading field '%1%'" ) %
+                objectName;
+
+            auto const name_lookup_tpl =
+                plugins::misc::getComponentNames( numComponents );
+            const DataSpace< simDim > field_guard =
+                field.getGridLayout().getGuard();
+
+            const pmacc::Selection< simDim > & localDomain =
+                Environment< simDim >::get().SubGrid().getLocalDomain();
+
+            using ValueType = typename Data::ValueType;
+            field.getHostBuffer().setValue( ValueType::create( 0.0 ) );
+
+            DataSpace< simDim > domain_offset = localDomain.offset;
+            DataSpace< simDim > local_domain_size =
+                params->window.localDimensions.size;
+            bool useLinearIdxAsDestination = false;
+
+            /* Patch for non-domain-bound fields
+             * This is an ugly fix to allow output of reduced 1d PML buffers,
+             * that are the same size on each domain.
+             */
+            if( !isDomainBound )
+            {
+                auto const field_layout = params->gridLayout;
+                auto const field_no_guard =
+                    field_layout.getDataSpaceWithoutGuarding();
+                auto const elementCount = field_no_guard.productOfComponents();
+                auto const & gridController =
+                    Environment< simDim >::get().GridController();
+                auto const rank = gridController.getGlobalRank();
+                domain_offset = DataSpace< simDim >::create( 0 );
+                domain_offset[ 0 ] = rank * elementCount;
+                local_domain_size = DataSpace< simDim >::create( 1 );
+                local_domain_size[ 0 ] = elementCount;
+                useLinearIdxAsDestination = true;
+            }
+
+            ::openPMD::Series & series = *params->openPMDSeries;
+            ::openPMD::Container<::openPMD::Mesh > & meshes =
+                series.iterations[ params->currentStep ].meshes;
+
+            auto destBox = field.getHostBuffer().getDataBox();
+            for( uint32_t n = 0; n < numComponents; ++n )
+            {
+                // Read the subdomain which belongs to our mpi position.
+                // The total grid size must match the grid size of the stored
+                // data.
+                log< picLog::INPUT_OUTPUT >(
+                    "openPMD: Read from domain: offset=%1% size=%2%" ) %
+                    domain_offset % local_domain_size;
+                ::openPMD::RecordComponent rc = numComponents > 1
+                    ? meshes[ objectName ][ name_lookup_tpl[ n ] ]
+                    : meshes[ objectName ][::openPMD::RecordComponent::SCALAR ];
+
+                log< picLog::INPUT_OUTPUT >(
+                    "openPMD: Read from field '%1%'" ) %
+                    objectName;
+
+                auto ndim = rc.getDimensionality();
+                ::openPMD::Offset start = asStandardVector<
+                    DataSpace< simDim > &,
+                    ::openPMD::Offset >( domain_offset );
+                ::openPMD::Extent count = asStandardVector<
+                    DataSpace< simDim > &,
+                    ::openPMD::Extent >( local_domain_size );
+
+                log< picLog::INPUT_OUTPUT >(
+                    "openPMD: Allocate %1% elements" ) %
+                    local_domain_size.productOfComponents();
+
+                // avoid deadlock between not finished pmacc tasks and mpi calls
+                // in openPMD backends
+                __getTransactionEvent().waitForFinished();
+
+                /*
+                 * @todo float_X should be some kind of gridBuffer's
+                 *       GetComponentsType<ValueType>::type
+                 */
+                std::shared_ptr< float_X > field_container =
+                    rc.loadChunk< float_X >( start, count );
+
+                /* start a blocking read of all scheduled variables */
+                series.flush();
+
+
+                int const elementCount =
+                    local_domain_size.productOfComponents();
+
+#pragma omp parallel for simd
+                for( int linearId = 0; linearId < elementCount; ++linearId )
+                {
+                    DataSpace< simDim > destIdx;
+                    if( useLinearIdxAsDestination )
+                    {
+                        destIdx[ 0 ] = linearId;
+                    }
+                    else
+                    {
+                        /* calculate index inside the moving window domain which
+                         * is located on the local grid*/
+                        destIdx = DataSpaceOperations< simDim >::map(
+                            params->window.localDimensions.size, linearId );
+                        /* jump over guard and local sliding window offset*/
+                        destIdx +=
+                            field_guard + params->localWindowToDomainOffset;
+                    }
+
+                    destBox( destIdx )[ n ] = field_container.get()[ linearId ];
+                }
+            }
+
+            field.hostToDevice();
+
+            __getTransactionEvent().waitForFinished();
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: Read from domain: offset=%1% size=%2%" ) %
+                domain_offset % local_domain_size;
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD: Finished loading field '%1%'" ) %
+                objectName;
+        }
+    };
+
+    /**
+     * Helper class for openPMDWriter (forEach operator) to load a field from
+     * openPMD
+     *
+     * @tparam T_Field field class to load
+     */
+    template< typename T_Field >
+    struct LoadFields
+    {
+    public:
+        HDINLINE void
+        operator()( ThreadParams * params )
+        {
+#ifndef __CUDA_ARCH__
+            DataConnector & dc = Environment<>::get().DataConnector();
+            ThreadParams * tp = params;
+
+            /* load field without copying data to host */
+            auto field = dc.get< T_Field >( T_Field::getName(), true );
+            tp->gridLayout = field->getGridLayout();
+
+            /* load from openPMD */
+            bool const isDomainBound =
+                traits::IsFieldDomainBound< T_Field >::value;
+            RestartFieldLoader::loadField(
+                field->getGridBuffer(),
+                ( uint32_t )T_Field::numComponents,
+                T_Field::getName(),
+                tp,
+                isDomainBound );
+
+            dc.releaseData( T_Field::getName() );
+#endif
+        }
+    };
+
+    using namespace pmacc;
+
+} /* namespace openPMD */
+} /* namespace picongpu */

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -1,0 +1,169 @@
+/* Copyright 2014-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/PICToOpenPMD.tpp"
+
+#include <pmacc/traits/GetComponentsType.hpp>
+#include <pmacc/traits/GetNComponents.hpp>
+#include <pmacc/traits/Resolve.hpp>
+
+namespace picongpu
+{
+namespace openPMD
+{
+    using namespace pmacc;
+
+    static const std::string name_lookup[] = { "x", "y", "z" };
+
+
+    /** write attribute of a particle to openPMD series
+     *
+     * @tparam T_Identifier identifier of a particle attribute
+     */
+    template< typename T_Identifier >
+    struct ParticleAttribute
+    {
+        /** write attribute to openPMD series
+         *
+         * @param params wrapped params
+         * @param elements elements of this attribute
+         */
+        template< typename FrameType >
+        HINLINE void
+        operator()(
+            ThreadParams * params,
+            FrameType & frame,
+            ::openPMD::Container<::openPMD::Record > & particleSpecies,
+            const size_t elements,
+            const size_t globalElements,
+            const size_t globalOffset )
+        {
+            using Identifier = T_Identifier;
+            using ValueType =
+                typename pmacc::traits::Resolve< Identifier >::type::type;
+            const uint32_t components = GetNComponents< ValueType >::value;
+            using ComponentType = typename GetComponentsType< ValueType >::type;
+
+            OpenPMDName< T_Identifier > openPMDName;
+            ::openPMD::Record record = particleSpecies[ openPMDName() ];
+            ::openPMD::Datatype openPMDType =
+                ::openPMD::determineDatatype< ComponentType >();
+
+            // get the SI scaling, dimensionality and weighting of the attribute
+            OpenPMDUnit< T_Identifier > openPMDUnit;
+            std::vector< float_64 > unit = openPMDUnit();
+            OpenPMDUnitDimension< T_Identifier > openPMDUnitDimension;
+            std::vector< float_64 > unitDimension = openPMDUnitDimension();
+            const bool macroWeightedBool = MacroWeighted< T_Identifier >::get();
+            const uint32_t macroWeighted = ( macroWeightedBool ? 1 : 0 );
+            const float_64 weightingPower =
+                WeightingPower< T_Identifier >::get();
+
+            PMACC_ASSERT(
+                unit.size() == components ); // unitSI for each component
+            PMACC_ASSERT(
+                unitDimension.size() == 7 ); // seven openPMD base units
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  (begin) write species attribute: %1%" ) %
+                Identifier::getName();
+
+            std::shared_ptr< ComponentType > storeBfr;
+            if ( elements > 0 )
+                storeBfr = std::shared_ptr< ComponentType >{
+                    new ComponentType[ elements ],
+                    []( ComponentType * ptr ) { delete[] ptr; }
+                };
+
+            for( uint32_t d = 0; d < components; d++ )
+            {
+                ::openPMD::RecordComponent recordComponent = components > 1
+                    ? record[ name_lookup[ d ] ]
+                    : record[::openPMD::MeshRecordComponent::SCALAR ];
+                ::openPMD::Datatype openPMDType =
+                    ::openPMD::determineDatatype< ComponentType >();
+
+                ValueType * dataPtr = frame.getIdentifier( Identifier() )
+                                          .getPointer(); // can be moved up?
+                auto storePtr = storeBfr.get();
+
+/* copy strided data from source to temporary buffer */
+#pragma omp parallel for simd
+                for( size_t i = 0; i < elements; ++i )
+                {
+                    storePtr[ i ] = reinterpret_cast< ComponentType * >(
+                        dataPtr )[ d + i * components ];
+                }
+
+                params
+                    ->initDataset< DIM1 >(
+                        recordComponent,
+                        openPMDType,
+                        { globalElements },
+                        true,
+                        params->compressionMethod );
+                if( storeBfr )
+                    recordComponent.storeChunk(
+                        storeBfr, { globalOffset }, { elements } );
+
+                if( unit.size() >= ( d + 1 ) )
+                {
+                    recordComponent.setUnitSI( unit[ d ] );
+                }
+                params->openPMDSeries->flush();
+            }
+
+            static constexpr ::openPMD::UnitDimension
+                openPMDUnitDimensions[ 7 ] = {
+                    ::openPMD::UnitDimension::L,
+                    ::openPMD::UnitDimension::M,
+                    ::openPMD::UnitDimension::T,
+                    ::openPMD::UnitDimension::I,
+                    ::openPMD::UnitDimension::theta,
+                    ::openPMD::UnitDimension::N,
+                    ::openPMD::UnitDimension::J };
+            std::map<::openPMD::UnitDimension, double > unitMap;
+            for( unsigned i = 0; i < 7; ++i )
+            {
+                unitMap[ openPMDUnitDimensions[ i ] ] = unitDimension[ i ];
+            }
+
+            record.setUnitDimension( unitMap );
+            record.setAttribute( "macroWeighted", macroWeighted );
+            record.setAttribute( "weightingPower", weightingPower );
+
+            /* @todo check if always correct at this point,
+             * depends on attribute and MW-solver/pusher implementation
+             */
+            float_X const timeOffset = 0.0;
+            record.setAttribute( "timeOffset", timeOffset );
+
+            log< picLog::INPUT_OUTPUT >(
+                "openPMD:  ( end ) write species attribute: %1%" ) %
+                Identifier::getName();
+        }
+    };
+
+} // namespace openPMD
+} // namespace picongpu

--- a/include/picongpu/versionFormat.cpp
+++ b/include/picongpu/versionFormat.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2020 Axel Huebl
+/* Copyright 2015-2020 Axel Huebl, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *
@@ -37,6 +37,9 @@
 #endif
 #if( PIC_ENABLE_PNG == 1 )
 #   include <pngwriter.h>
+#endif
+#if( ENABLE_OPENPMD == 1 )
+#   include <openPMD/openPMD.hpp>
 #endif
 
 #include <sstream>
@@ -138,6 +141,13 @@ namespace picongpu
         adios << versionNotFound;
 #endif
 
+        std::stringstream openPMD;
+#if( ENABLE_OPENPMD == 1 )
+        openPMD << openPMD::getVersion( );
+#else
+        openPMD << versionNotFound;
+#endif
+
         // CLI Formatting
         cliText << "PIConGPU: " << picongpu.str() << std::endl;
         cliText << "  Build-Type: " << buildType.str() << std::endl
@@ -181,6 +191,8 @@ namespace picongpu
             software.push_back( std::string( "libSplash/" ) + splash.str() );
         if( adios.str().compare( versionNotFound ) != 0 )
             software.push_back( std::string( "ADIOS/" ) + adios.str() );
+        if( openPMD.str().compare( versionNotFound ) != 0 )
+            software.push_back( std::string( "openPMD/" ) + openPMD.str() );
 
         return software;
     }

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Axel Huebl
+# Copyright 2017-2020 Axel Huebl, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -71,12 +71,12 @@ TBG_sumEnergy="--fields_energy.period 100 \
 TBG_chargeConservation="--chargeConservation.period 100"
 
 # regular output
-TBG_hdf5="--hdf5.period 250 --hdf5.file simData"
+TBG_openPMD="--openPMD.period 250 --openPMD.file simData --openPMD.ext bp"
 
 TBG_plugins="!TBG_e_histogram !TBG_H_histogram !TBG_C_histogram !TBG_N_histogram \
              !TBG_e_PSypy !TBG_H_PSypy !TBG_C_PSypy !TBG_N_PSypy                 \
              !TBG_sumEnergy !TBG_chargeConservation                              \
-             !TBG_hdf5"
+             !TBG_openPMD"
 
 
 #################################

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Axel Huebl
+# Copyright 2017-2020 Axel Huebl, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -71,12 +71,12 @@ TBG_sumEnergy="--fields_energy.period 100 \
 TBG_chargeConservation="--chargeConservation.period 100"
 
 # regular output
-TBG_hdf5="--hdf5.period 250 --hdf5.file simData"
+TBG_openPMD="--openPMD.period 250 --openPMD.file simData --openPMD.ext bp"
 
 TBG_plugins="!TBG_e_histogram !TBG_H_histogram !TBG_C_histogram !TBG_N_histogram \
              !TBG_e_PSypy !TBG_H_PSypy !TBG_C_PSypy !TBG_N_PSypy                 \
              !TBG_sumEnergy !TBG_chargeConservation                              \
-             !TBG_hdf5"
+             !TBG_openPMD"
 
 
 #################################

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -63,10 +63,12 @@ TBG_e_PSypy="--e_phaseSpace.period 100                         \
              --e_phaseSpace.min -1.0 --e_phaseSpace.max 1.0    \
              --e_phaseSpace.filter all"
 
-# HDF5 raw data output (DISABLED, add to TBG_plugins below to ENABLE!)
-TBG_hdf5="--hdf5.period 100   \
-          --hdf5.file simData \
-          --hdf5.source 'species_all,fields_all'"
+TBG_openPMD="--openPMD.period 100   \
+             --openPMD.file simData \
+             --openPMD.ext bp \
+             --checkpoint.backend openPMD \
+             --checkpoint.period 100
+             --checkpoint.restart.backend openPMD"
 
 # macro particle counter (electrons, debug information for memory)
 TBG_e_macroCount="--e_macroParticlesCount.period 100"
@@ -74,7 +76,8 @@ TBG_e_macroCount="--e_macroParticlesCount.period 100"
 TBG_plugins="!TBG_pngYX                    \
              !TBG_e_histogram              \
              !TBG_e_PSypy                  \
-             !TBG_e_macroCount"
+             !TBG_e_macroCount             \
+             !TBG_e_openPMD"
 
 #################################
 ## Section: Program Parameters ##

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -64,10 +64,12 @@ TBG_e_PSypy="--e_phaseSpace.period 100                         \
              --e_phaseSpace.min -1.0 --e_phaseSpace.max 1.0    \
              --e_phaseSpace.filter all"
 
-# HDF5 raw data output (DISABLED, add to TBG_plugins below to ENABLE!)
-TBG_hdf5="--hdf5.period 100   \
-          --hdf5.file simData \
-          --hdf5.source 'species_all,fields_all'"
+TBG_openPMD="--openPMD.period 100   \
+            --openPMD.file simData \
+            --openPMD.ext bp \
+            --checkpoint.backend openPMD \
+            --checkpoint.period 100
+            --checkpoint.restart.backend openPMD"
 
 # macro particle counter (electrons, debug information for memory)
 TBG_e_macroCount="--e_macroParticlesCount.period 100"
@@ -75,7 +77,8 @@ TBG_e_macroCount="--e_macroParticlesCount.period 100"
 TBG_plugins="!TBG_pngYX                    \
              !TBG_e_histogram              \
              !TBG_e_PSypy                  \
-             !TBG_e_macroCount"
+             !TBG_e_macroCount             \
+             !TBG_e_openPMD"
 
 
 #################################

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -64,10 +64,12 @@ TBG_e_PSypy="--e_phaseSpace.period 100                         \
              --e_phaseSpace.min -1.0 --e_phaseSpace.max 1.0    \
              --e_phaseSpace.filter all"
 
-# HDF5 raw data output (DISABLED, add to TBG_plugins below to ENABLE!)
-TBG_hdf5="--hdf5.period 100   \
-          --hdf5.file simData \
-          --hdf5.source 'species_all,fields_all'"
+TBG_openPMD="--openPMD.period 100   \
+            --openPMD.file simData \
+            --openPMD.ext bp \
+            --checkpoint.backend openPMD \
+            --checkpoint.period 100
+            --checkpoint.restart.backend openPMD"
 
 # macro particle counter (electrons, debug information for memory)
 TBG_e_macroCount="--e_macroParticlesCount.period 100"
@@ -75,7 +77,8 @@ TBG_e_macroCount="--e_macroParticlesCount.period 100"
 TBG_plugins="!TBG_pngYX                    \
              !TBG_e_histogram              \
              !TBG_e_PSypy                  \
-             !TBG_e_macroCount"
+             !TBG_e_macroCount             \
+             !TBG_openPMD"
 
 #################################
 ## Section: Program Parameters ##

--- a/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
@@ -1,4 +1,5 @@
-# Copyright 2013-2020 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2020 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl,
+#                     Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -49,7 +50,8 @@ TBG_periodic="--periodic 1 1 1"
 # write position to stdout (messy):
 # --e_position.period 1
 
-TBG_plugins="--hdf5.period 1 --hdf5.file simData \
+TBG_openPMD="openPMD.period 1 --openPMD.file simData --openPMD.ext bp"
+TBG_plugins="!TBG_openPMD \
              --e_macroParticlesCount.period 100"
 
 
@@ -59,7 +61,7 @@ TBG_plugins="--hdf5.period 1 --hdf5.file simData \
 
 TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="-d !TBG_deviceDist \
+TBG_programParams="!TBG_deviceDist \
                    -g !TBG_gridSize   \
                    -s !TBG_steps      \
                    !TBG_periodic      \

--- a/share/picongpu/examples/WarmCopper/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/WarmCopper/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Axel Huebl
+# Copyright 2013-2020 Axel Huebl, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #
@@ -52,10 +52,15 @@ TBG_ehot_histogram="--ehot_energyHistogram.period 100 --ehot_energyHistogram.fil
                     --ehot_energyHistogram.minEnergy 0 --ehot_energyHistogram.maxEnergy 250"
 
 # file I/O
-TBG_hdf5="--hdf5.period 100 --hdf5.file simData"
+TBG_openPMD="--openPMD.period 100 \
+             --openPMD.file simData \
+             --openPMD.ext bp \
+             --checkpoint.period 100 \
+             --checkpoint.backend openPMD"
 
-TBG_plugins="!TBG_eth_histogram !TBG_ehot_histogram \
-             !TBG_hdf5"
+TBG_plugins="!TBG_eth_histogram  \
+             !TBG_ehot_histogram \
+             !TBG_openPMD"
 
 
 #################################


### PR DESCRIPTION
Implement writing to and reading from openPMD.
**Todo**
- [x] The plugin is based very closely on the existing [ADIOS plugin](https://github.com/ComputationalRadiationPhysics/picongpu/tree/master/include/picongpu/plugins/adios) and carries some baggage. Especially the strict separation of (1) declaration of datasets (ADIOS variables) and (2) writing data to them is unnecessary from openPMD's point of view and ought to be removed.
- [x] openPMD does not allow to create datasets that have zero extent in any dimension. This is what happens for example in the WarmCopper example. Fix that.
- [x] The existing HDF5 and ADIOS plugins use different strategies for data preparation. This plugin currently uses the strategy applied in the ADIOS plugin, but both should be supported in the end.
- [x] Further testing, especially (1) reading (e.g. restarting) and (2) using openPMD backends other than ADIOS(1|2), i.e. HDF5.
- [x] Either wait for [this PR](https://github.com/openPMD/openPMD-api/pull/529) in the openPMD API or revert commit [51d55c9](https://github.com/ComputationalRadiationPhysics/picongpu/commit/51d55c9e5db45c38f9c56602208e3c5000defbc8).
- [x] The plugin needs [this commit](https://github.com/openPMD/openPMD-api/commit/d7b6dbd3acdc2e81097b39041f2351005a2b785f) ([PR #511](https://github.com/openPMD/openPMD-api/pull/511)) to compile without error. This should be considered before pulling.

For testing purposes, please use [this branch of the openPMD API](https://github.com/franzpoeschel/openPMD-api/tree/topic-advanced-backend-configuration).
- [x] Wait for [JSON configuration](https://github.com/openPMD/openPMD-api/pull/569) to land in openPMD API.
- [x] Documentation



As [noted below](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2966#issuecomment-501717152), the HDF5 backend in the openPMD API is currently broken and may not be used in this plugin at the moment.
- [x] Investigate a workaround for that. EDIT: HDF5 backend has been patched and can now be used from within openPMD plugin.


The resulting storage files are *incompatible* with the files written by the existing plugins: The existing plugin writes datasets `/data/<iteration>/picongpu/idProvider/startID`, but the openPMD API only supports writing datasets `/data/<iteration>/(fields|particles)/*/*(/*)` at the moment, so those datasets have been temporarily relocated to `/data/0/fields/picongpu_idProvider/startId` until the openPMD allows to write "heavy" metadata more flexibly.

I've written up [a simple guide](https://gist.github.com/franzpoeschel/004d2665e8dd513d4c7d88c65683dc3c) for building and installing.

- [x] wait for results from @steindev's runtime tests 