### PR TITLE
Enable checkpoints for the PML fields

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
@@ -35,7 +35,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -87,7 +86,9 @@ namespace yeePML
         /** Element access for compatibility with pmacc vectors
          *
          * This is a utility for checkpointing and does not need a device
-         * version.Throws for indices out of range.
+         * version. For performance considerations does not check that the index
+         * is valid and relies on the components being stored in order, without
+         * padding.
          *
          * @param idx index less than 6
          */
@@ -101,25 +102,15 @@ namespace yeePML
         /** Const element access for compatibility with pmacc vectors
          *
          * This is a utility for checkpointing and does not need a device
-         * version.Throws for indices out of range.
+         * version. For performance considerations does not check that the index
+         * is valid and relies on the components being stored in order, without
+         * padding.
          *
          * @param idx index less than 6
          */
         float_X const & operator[ ]( uint32_t const idx ) const
         {
-            switch( idx )
-            {
-                case 0: return xy;
-                case 1: return xz;
-                case 2: return yx;
-                case 3: return yz;
-                case 4: return zx;
-                case 5: return zy;
-            }
-            throw std::out_of_range(
-                "In NodeValues::operator() the index = " +
-                std::to_string( idx ) + " is invalid"
-            );
+            return *( &xy + idx );
         }
 
     };

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
@@ -22,6 +22,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/Fields.def"
+#include "picongpu/fields/numericalCellTypes/NumericalCellTypes.hpp"
+#include "picongpu/traits/FieldPosition.hpp"
 
 #include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/fields/SimulationFieldHelper.hpp>
@@ -31,7 +33,9 @@
 #include <pmacc/memory/boxes/PitchedBox.hpp>
 #include <pmacc/math/Vector.hpp>
 
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -48,7 +52,76 @@ namespace yeePML
     //! Additional node values for E or B in PML
     struct NodeValues
     {
+
+        /* The first letter corresponds to x, y, z field components,
+         * the second to transverse directions for the component
+         */
         float_X xy, xz, yx, yz, zx, zy;
+
+        //! Number of components per node value
+        static constexpr int numComponents = 6;
+
+        /** Construct node values
+         *
+         * @param initialValue initial value for all components
+         */
+        HDINLINE NodeValues( float_X const initialValue = 0._X ):
+            xy( initialValue ),
+            xz( initialValue ),
+            yx( initialValue ),
+            yz( initialValue ),
+            zx( initialValue ),
+            zy( initialValue )
+        {
+        }
+
+        /** Construction for compatibility with pmacc vectors
+         *
+         * @param initialValue initial value for all components
+         */
+        HDINLINE static const NodeValues create( float_X const initialValue )
+        {
+            return NodeValues{ initialValue };
+        }
+
+        /** Element access for compatibility with pmacc vectors
+         *
+         * This is a utility for checkpointing and does not need a device
+         * version.Throws for indices out of range.
+         *
+         * @param idx index less than 6
+         */
+        float_X & operator[ ]( uint32_t const idx )
+        {
+            // Here it is safe to call the const version
+            auto constThis = const_cast< NodeValues const * >( this );
+            return const_cast< float_X & >( ( *constThis )[ idx ] );
+        }
+
+        /** Const element access for compatibility with pmacc vectors
+         *
+         * This is a utility for checkpointing and does not need a device
+         * version.Throws for indices out of range.
+         *
+         * @param idx index less than 6
+         */
+        float_X const & operator[ ]( uint32_t const idx ) const
+        {
+            switch( idx )
+            {
+                case 0: return xy;
+                case 1: return xz;
+                case 2: return yx;
+                case 3: return yz;
+                case 4: return zx;
+                case 5: return zy;
+            }
+            throw std::out_of_range(
+                "In NodeValues::operator() the index = " +
+                std::to_string( idx ) + " is invalid"
+            );
+        }
+
     };
 
     //! Base class for field in PML
@@ -57,7 +130,8 @@ namespace yeePML
     public:
 
         using ValueType = NodeValues;
-        using UnitValueType = float_X ;
+        static constexpr int numComponents = NodeValues::numComponents;
+        using UnitValueType = pmacc::math::Vector< float_64, numComponents >;
 
         typedef DataBox< PitchedBox< ValueType, simDim > > DataBoxType;
 
@@ -66,16 +140,6 @@ namespace yeePML
         Field( MappingDesc cellDescription);
 
         virtual void reset( uint32_t currentStep );
-
-        HDINLINE static UnitValueType getUnit( );
-
-        /** powers of the 7 base measures
-         *
-         * characterizing the record's unit in SI
-         * (length L, mass M, time T, electric current I,
-         * thermodynamic temperature theta, amount of substance N,
-         * luminous intensity J) */
-        HINLINE static std::vector< float_64 > getUnitDimension( );
 
         virtual EventTask asyncCommunication( EventTask serialEvent );
 
@@ -115,6 +179,22 @@ namespace yeePML
             return getName( );
         }
 
+        HDINLINE static UnitValueType getUnit( )
+        {
+            return UnitValueType::create( UNIT_EFIELD );
+        }
+
+        /** powers of the 7 base measures
+         *
+         * characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         * thermodynamic temperature theta, amount of substance N,
+         * luminous intensity J) */
+        HINLINE static std::vector< float_64 > getUnitDimension( )
+        {
+            return picongpu::FieldE::getUnitDimension( );
+        }
+
         static std::string getName( )
         {
             return "PML E components";
@@ -137,6 +217,22 @@ namespace yeePML
             return getName( );
         }
 
+        HDINLINE static UnitValueType getUnit( )
+        {
+            return UnitValueType::create( UNIT_BFIELD );
+        }
+
+        /** powers of the 7 base measures
+         *
+         * characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         * thermodynamic temperature theta, amount of substance N,
+         * luminous intensity J) */
+        HINLINE static std::vector< float_64 > getUnitDimension( )
+        {
+            return picongpu::FieldB::getUnitDimension( );
+        }
+
         static std::string getName( )
         {
             return "PML B components";
@@ -147,4 +243,74 @@ namespace yeePML
 } // namespace yeePML
 } // namespace maxwellSolver
 } // namespace fields
+
+namespace traits
+{
+
+    /** Field position traits for checkpointing
+     *
+     * PML fields do not fit well, for now just copy the normal fields.
+     * Specialize only for Yee cell type, as this is the only one supported.
+     */
+    template< uint32_t T_dim >
+    struct FieldPosition<
+        numericalCellTypes::YeeCell,
+        fields::maxwellSolver::yeePML::FieldE,
+        T_dim
+    > : FieldPosition<
+        numericalCellTypes::YeeCell,
+        FieldE,
+        T_dim
+    >
+    {
+    };
+
+    /** Field position traits for checkpointing
+     *
+     * PML fields do not fit well, for now just copy the normal fields.
+     * Specialize only for Yee cell type, as this is the only one supported.
+     */
+    template< uint32_t T_dim >
+    struct FieldPosition<
+        numericalCellTypes::YeeCell,
+        fields::maxwellSolver::yeePML::FieldB,
+        T_dim
+    > : FieldPosition<
+        numericalCellTypes::YeeCell,
+        FieldB,
+        T_dim
+    >
+    {
+    };
+
+} // namespace traits
 } // namespace picongpu
+
+namespace pmacc
+{
+namespace traits
+{
+
+    //! Node value traits for checkpointing
+    template< >
+    struct GetComponentsType<
+        picongpu::fields::maxwellSolver::yeePML::NodeValues,
+        false
+    >
+    {
+        typedef picongpu::float_X type;
+    };
+
+    //! Node value traits for checkpointing
+    template< >
+    struct GetNComponents<
+        picongpu::fields::maxwellSolver::yeePML::NodeValues,
+        false
+    >
+    {
+        static constexpr uint32_t value =
+            picongpu::fields::maxwellSolver::yeePML::NodeValues::numComponents;
+    };
+
+} // namespace traits
+} // namespace pmacc

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
@@ -105,22 +105,6 @@ namespace yeePML
         data->getDeviceBuffer( ).reset( false );
     }
 
-
-    HDINLINE
-    Field::UnitValueType
-    Field::getUnit( )
-    {
-        return UnitValueType( 1.0_X );
-    }
-
-    HINLINE
-    std::vector< float_64 >
-    Field::getUnitDimension( )
-    {
-        std::vector< float_64 > unitDimension( 7, 0.0 );
-        return unitDimension;
-    }
-
 } // namespace yeePML
 } // namespace maxwellSolver
 } // namespace fields

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -37,6 +37,7 @@
 #include "picongpu/fields/FieldE.hpp"
 #include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/fields/FieldTmp.hpp"
+#include "picongpu/fields/MaxwellSolver/YeePML/Field.hpp"
 #include <pmacc/particles/operations/CountParticles.hpp>
 
 #include <pmacc/dataManagement/DataConnector.hpp>

--- a/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
@@ -61,7 +61,8 @@ public:
 
         const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
-        field.getHostBuffer().setValue(float3_X::create(0.0));
+        using ValueType = typename Data::ValueType;
+        field.getHostBuffer().setValue(ValueType::create(0.0));
 
         DataSpace<simDim> domain_offset = localDomain.offset;
 

--- a/include/picongpu/plugins/hdf5/HDF5Writer.hpp
+++ b/include/picongpu/plugins/hdf5/HDF5Writer.hpp
@@ -45,6 +45,7 @@
 #include "picongpu/fields/FieldE.hpp"
 #include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/fields/FieldTmp.hpp"
+#include "picongpu/fields/MaxwellSolver/YeePML/Field.hpp"
 #include <pmacc/particles/particleFilter/FilterFactory.hpp>
 #include <pmacc/particles/particleFilter/PositionFilter.hpp>
 #include <pmacc/particles/operations/CountParticles.hpp>

--- a/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -57,7 +57,8 @@ public:
         const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
         const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
-        field.getHostBuffer().setValue(float3_X::create(0.0));
+        using ValueType = typename Data::ValueType;
+        field.getHostBuffer().setValue(ValueType::create(0.0));
 
         const std::string name_lookup[] = {"x", "y", "z"};
 

--- a/include/picongpu/unitless/checkpoints.unitless
+++ b/include/picongpu/unitless/checkpoints.unitless
@@ -1,4 +1,5 @@
-/* Copyright 2013-2019 Axel Huebl, Rene Widera, Felix Schmitt, Benjamin Worpitz
+/* Copyright 2013-2019 Axel Huebl, Rene Widera, Felix Schmitt, Benjamin Worpitz,
+ *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -27,6 +28,33 @@
 
 namespace picongpu
 {
+namespace detail
+{
+
+        /** Additional fields for checkpointing
+         *
+         * @tparam T_FieldSolver field solver type
+         */
+        template< typename T_FieldSolver >
+        struct AdditionalCheckpointFields
+        {
+            using type = MakeSeq_t< >;
+        };
+
+        //! Only the YeePML solver needs additional fields for checkpointing
+        template< typename ... T_Args >
+        struct AdditionalCheckpointFields<
+            fields::maxwellSolver::YeePML< T_Args ... >
+        >
+        {
+            using type = MakeSeq_t<
+                fields::maxwellSolver::yeePML::FieldE,
+                fields::maxwellSolver::yeePML::FieldB
+            >;
+        };
+
+} // namespace detail
+
     /** Note: we need at least FieldE and FieldB for restart
      *        capabilities!
      */
@@ -35,11 +63,15 @@ namespace picongpu
         FieldB
     >;
 
+    using AdditionalFileCheckpointFields =
+        typename picongpu::detail::AdditionalCheckpointFields< fields::Solver >::type;
+
     /* List of particle species for checkpoint/restart */
     using FileCheckpointParticles = VectorAllSpecies;
 
     /**  List of fields for checkpoint/restart */
     using FileCheckpointFields = MakeSeq_t<
-        NativeFileCheckpointFields
+        NativeFileCheckpointFields,
+        AdditionalFileCheckpointFields
     >;
 }

--- a/include/pmacc/memory/buffers/HostDeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostDeviceBuffer.hpp
@@ -38,6 +38,7 @@ namespace pmacc{
         typedef HostBufferIntern<T_Type, T_dim> HostBufferType;
         typedef DeviceBufferIntern<T_Type, T_dim> DeviceBufferType;
     public:
+        using ValueType = T_Type;
         typedef HostBuffer<T_Type, T_dim> HBuffer;
         typedef DeviceBuffer<T_Type, T_dim> DBuffer;
         typedef typename HostBufferType::DataBoxType DataBoxType;


### PR DESCRIPTION
The original implementation of PML #2950 does not save the additional PML fields in checkpoints. This PR enables full support for checkpointing with PML. The checkpointing of fields has been a tiny bit too narrow, so I have extended it a little bit to fit the PML fields.