### PR TITLE
[WIP] Add templates for zero field backgrounds

### DIFF
--- a/include/picongpu/fields/background/templates/zero/FieldB.hpp
+++ b/include/picongpu/fields/background/templates/zero/FieldB.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2014-2019 Axel Huebl, Alexander Debus, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace background
+{
+namespace templates
+{
+namespace zero
+{
+
+    //! Zero B field background
+    class FieldB
+    {
+    public:
+
+        //! Does not contribute to particle pushing
+        static constexpr bool InfluenceParticlePusher = false;
+
+        /** Construct the background field
+         *
+         * @param unitField PIC unit for the field
+         */
+        HDINLINE FieldB( float3_64 const unitField );
+
+        /** Background values are always zero
+         *
+         * \param cellIdx total cell index counted from the start at t = 0
+         * \param currentStep current time iteration
+         */
+        HDINLINE float3_X
+        operator( )(
+            pmacc::DataSpace< simDim > const & cellIdx,
+            uint32_t const currentStep
+        ) const;
+
+    };
+
+} // namespace zero
+} // namespace templates
+} // namespace background
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/background/templates/zero/FieldB.tpp
+++ b/include/picongpu/fields/background/templates/zero/FieldB.tpp
@@ -1,0 +1,57 @@
+/* Copyright 2019 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/background/templates/zero/FieldB.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace background
+{
+namespace templates
+{
+namespace zero
+{
+
+    HDINLINE FieldB::FieldB( float3_64 const /* unitField */ )
+    {
+    }
+
+    HDINLINE float3_X FieldB::operator( )(
+        pmacc::DataSpace< simDim > const & /*cellIdx*/,
+        uint32_t const /*currentStep*/
+    ) const
+    {
+        return float3_X::create( 0._X );
+    }
+
+} // namespace zero
+} // namespace templates
+} // namespace background
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/background/templates/zero/FieldE.hpp
+++ b/include/picongpu/fields/background/templates/zero/FieldE.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2014-2019 Axel Huebl, Alexander Debus, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace background
+{
+namespace templates
+{
+namespace zero
+{
+
+    //! Zero E field background
+    class FieldE
+    {
+    public:
+
+        //! Does not contribute to particle pushing
+        static constexpr bool InfluenceParticlePusher = false;
+
+        /** Construct the background field
+         *
+         * @param unitField PIC unit for the field
+         */
+        HDINLINE FieldE( float3_64 const unitField );
+
+        /** Background values are always zero
+         *
+         * \param cellIdx total cell index counted from the start at t = 0
+         * \param currentStep current time iteration
+         */
+        HDINLINE float3_X
+        operator( )(
+            pmacc::DataSpace< simDim > const & cellIdx,
+            uint32_t const currentStep
+        ) const;
+
+    };
+
+} // namespace zero
+} // namespace templates
+} // namespace background
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/background/templates/zero/FieldE.tpp
+++ b/include/picongpu/fields/background/templates/zero/FieldE.tpp
@@ -1,0 +1,57 @@
+/* Copyright 2019 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/background/templates/zero/FieldE.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace background
+{
+namespace templates
+{
+namespace zero
+{
+
+    HDINLINE FieldE::FieldE( float3_64 const /* unitField */ )
+    {
+    }
+
+    HDINLINE float3_X FieldE::operator( )(
+        pmacc::DataSpace< simDim > const & /*cellIdx*/,
+        uint32_t const /*currentStep*/
+    ) const
+    {
+        return float3_X::create( 0._X );
+    }
+
+} // namespace zero
+} // namespace templates
+} // namespace background
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/background/templates/zero/FieldJ.hpp
+++ b/include/picongpu/fields/background/templates/zero/FieldJ.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2014-2019 Axel Huebl, Alexander Debus, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace background
+{
+namespace templates
+{
+namespace zero
+{
+
+    //! Zero J field background
+    class FieldJ
+    {
+    public:
+
+        //! Is not activated
+        static constexpr bool activated = false;
+
+        /** Construct the background field
+         *
+         * @param unitField PIC unit for the field
+         */
+        HDINLINE FieldJ( float3_64 const unitField );
+
+        /** Background values are always zero
+         *
+         * \param cellIdx total cell index counted from the start at t = 0
+         * \param currentStep current time iteration
+         */
+        HDINLINE float3_X
+        operator( )(
+            const DataSpace< simDim > & cellIdx,
+            const uint32_t currentStep
+        ) const;
+
+    };
+
+} // namespace zero
+} // namespace templates
+} // namespace background
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/background/templates/zero/FieldJ.tpp
+++ b/include/picongpu/fields/background/templates/zero/FieldJ.tpp
@@ -1,0 +1,57 @@
+/* Copyright 2019 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/background/templates/zero/FieldJ.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace background
+{
+namespace templates
+{
+namespace zero
+{
+
+    HDINLINE FieldJ::FieldJ( float3_64 const /* unitField */ )
+    {
+    }
+
+    HDINLINE float3_X FieldJ::operator( )(
+        pmacc::DataSpace< simDim > const & /*cellIdx*/,
+        uint32_t const /*currentStep*/
+    ) const
+    {
+        return float3_X::create( 0._X );
+    }
+
+} // namespace zero
+} // namespace templates
+} // namespace background
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/background/templates/zero/Zero.hpp
+++ b/include/picongpu/fields/background/templates/zero/Zero.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2019 Axel Huebl
+/* Copyright 2019 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -17,9 +17,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-/** Load pre-defined templates (implementation) */
-#include "picongpu/fields/background/templates/TWTS/TWTS.tpp"
-#include "picongpu/fields/background/templates/zero/Zero.tpp"
+
+#include "picongpu/fields/background/templates/zero/FieldB.hpp"
+#include "picongpu/fields/background/templates/zero/FieldE.hpp"
+#include "picongpu/fields/background/templates/zero/FieldJ.hpp"

--- a/include/picongpu/fields/background/templates/zero/Zero.tpp
+++ b/include/picongpu/fields/background/templates/zero/Zero.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2019 Axel Huebl
+/* Copyright 2019 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -17,9 +17,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-/** Load pre-defined templates (implementation) */
-#include "picongpu/fields/background/templates/TWTS/TWTS.tpp"
-#include "picongpu/fields/background/templates/zero/Zero.tpp"
+
+#include "picongpu/fields/background/templates/zero/FieldB.tpp"
+#include "picongpu/fields/background/templates/zero/FieldE.tpp"
+#include "picongpu/fields/background/templates/zero/FieldJ.tpp"

--- a/include/picongpu/param/fieldBackground.param
+++ b/include/picongpu/param/fieldBackground.param
@@ -19,7 +19,9 @@
 
 /** @file fieldBackground.param
  *
- * Load external background fields
+ * Load external background fields.
+ * There are pre-made templates for zero background and traveling-wave Thomson
+ * scattering laser one in picongpu::fields::background::templates.
  */
 
 #pragma once

--- a/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
@@ -21,6 +21,8 @@
 
 /** Load pre-defined templates */
 #include "picongpu/fields/background/templates/TWTS/TWTS.hpp"
+#include "picongpu/fields/background/templates/zero/Zero.hpp"
+
 
 #ifndef PARAM_INCLUDE_FIELDBACKGROUND
 #define PARAM_INCLUDE_FIELDBACKGROUND false
@@ -195,28 +197,7 @@ namespace picongpu
         }
     };
 
-    class FieldBackgroundJ
-    {
-    public:
-        /* Add this additional field? */
-        static constexpr bool activated = false;
+    // No background for J
+    using FieldBackgroundJ = fields::background::templates::zero::FieldJ;
 
-        /* We use this to calculate your SI input back to our unit system */
-        PMACC_ALIGN(m_unitField, const float3_64);
-
-        HDINLINE FieldBackgroundJ( const float3_64 unitField ) : m_unitField(unitField)
-        {}
-
-        /** Specify your background field J(r,t) here
-         *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
-        HDINLINE float3_X
-        operator()( const DataSpace<simDim>& cellIdx,
-                    const uint32_t currentStep ) const
-        {
-            return float3_X(0.0, 0.0, 0.0);
-        }
-    };
-
-} /* namespace picongpu */
+} // namespace picongpu

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2019 Axel Huebl, Alexander Debus
+/* Copyright 2014-2019 Axel Huebl, Alexander Debus, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -19,80 +19,18 @@
 
 #pragma once
 
+
+#include "picongpu/fields/background/templates/zero/Zero.hpp"
+
 /** Load external background fields
  *
  */
 namespace picongpu
 {
-    class FieldBackgroundE
-    {
-    public:
-        /* Add this additional field for pushing particles */
-        static constexpr bool InfluenceParticlePusher = true;
 
-        /* We use this to calculate your SI input back to our unit system */
-        PMACC_ALIGN(
-            m_unitField,
-            const float3_64
-        );
-
-        HDINLINE FieldBackgroundE( const float3_64 unitField ) :
-            m_unitField( unitField )
-        {}
-
-        /** Specify your background field E(r,t) here
-         *
-         * \param cellIdx The total cell id counted from the start at t = 0
-         * \param currentStep The current time step */
-        HDINLINE float3_X
-        operator()(
-            const DataSpace<simDim>& /*cellIdx*/,
-            const uint32_t /*currentStep*/
-        ) const
-        {
-            /* specify your E-Field in V/m and convert to PIConGPU units */
-            return float3_X(
-                0.0,
-                0.0,
-                0.0
-            );
-        }
-    };
-
-    class FieldBackgroundB
-    {
-    public:
-        /* Add this additional field for pushing particles */
-        static constexpr bool InfluenceParticlePusher = true;
-
-        /* We use this to calculate your SI input back to our unit system */
-        PMACC_ALIGN(
-            m_unitField,
-            const float3_64
-        );
-
-        HDINLINE FieldBackgroundB( const float3_64 unitField ) :
-            m_unitField( unitField )
-        {}
-
-        /** Specify your background field B(r,t) here
-         *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
-        HDINLINE float3_X
-        operator()(
-            const DataSpace<simDim>& /*cellIdx*/,
-            const uint32_t /*currentStep*/
-        ) const
-        {
-            /* specify your B-Field in T and convert to PIConGPU units */
-            return float3_X(
-                0.0,
-                0.0,
-                0.0
-            );
-        }
-    };
+    // No background for E and B fields
+    using FieldBackgroundE = fields::background::templates::zero::FieldE;
+    using FieldBackgroundB = fields::background::templates::zero::FieldB;
 
     class FieldBackgroundJ
     {

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
@@ -19,6 +19,9 @@
 
 #pragma once
 
+
+#include "picongpu/fields/background/templates/zero/Zero.hpp"
+
 /** Load external background fields
  *
  */
@@ -94,39 +97,7 @@ namespace picongpu
         }
     };
 
-    class FieldBackgroundJ
-    {
-    public:
-        /* Add this additional field? */
-        static constexpr bool activated = false;
-
-        /* We use this to calculate your SI input back to our unit system */
-        PMACC_ALIGN(
-            m_unitField,
-            const float3_64
-        );
-
-        HDINLINE FieldBackgroundJ( const float3_64 unitField ) :
-            m_unitField(unitField)
-        {}
-
-        /** Specify your background field J(r,t) here
-         *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
-        HDINLINE float3_X
-        operator()(
-            const DataSpace<simDim>& /*cellIdx*/,
-            const uint32_t /*currentStep*/
-        ) const
-        {
-            /* specify your J-Field in A/m^2 and convert to PIConGPU units */
-            return float3_X(
-                0.0,
-                0.0,
-                0.0
-            );
-        }
-    };
+    // No background for J
+    using FieldBackgroundJ = fields::background::templates::zero::FieldJ;
 
 } // namespace picongpu


### PR DESCRIPTION
Motivation: #2944, often only a subset of E, B, J backgrounds is needed and the rest are zeroes. Add new background templates to simplify this use case. Modify the examples accordingly. In my opinion, this makes `fieldBackground.param` files have less boilerplate code and so more focused on the actual setup.

cc @hightower8083 , I assume this changes the interface of `fieldBackground.param` (however, manually setting zero backgrounds still works ofc). Also, my change is done somewhat consistently with the other background template.