### PR TITLE
 Dockerfile: No SSH Deamon & Keys, Fix Flex Build

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -34,7 +34,7 @@ RUN        apt-get update && \
               gfortran \
               git \
               nano \
-              openssh-server \
+              openssh-client \
               pkg-config \
               python \
               rsync \

--- a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
@@ -16,6 +16,10 @@ packages:
     variants: +cuda fabrics=verbs,ucx,libfabric
   hwloc:
     variants: +cuda
+  # install issue with gettext
+  # https://github.com/spack/spack/issues/11551
+  flex:
+    version: [2.6.3]
   all:
     providers:
       mpi: [openmpi]


### PR DESCRIPTION
For local startup, an SSH daemon is not necessary.

This is a security fix, removing pre-set keys installed alongside the openssh-server package in /etc/ssh which would be known and published in the docker image. The published dockerhub images ax3l/picongpu:0.4.3 and ax3l/picongpu:latest have been replaced with a fixed version.

Affected are users that would run the docker container on a non-private network or shared system which could lead to the security implication of unauthorized login into the running docker instance, if the docker SSH server port is published (note that this is not the default and has to be exposed manually).

Thank you to @AdamSimpson (Nvidia) for reporting the issue!

Also: Avoid Latest Flex by configuring the latest flex with spack applies a patch that reconfigures flex which fails on gettext version mismatches https://github.com/spack/spack/issues/11551