### PR TITLE
Separate the code processing particles from MySimulation

### DIFF
--- a/include/picongpu/simulation/stage/Bremsstrahlung.hpp
+++ b/include/picongpu/simulation/stage/Bremsstrahlung.hpp
@@ -1,0 +1,119 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Bremsstrahlung is available only with CUDA
+#if( PMACC_CUDA_ENABLED == 1 )
+
+#include "picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp"
+#include "picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp"
+#include "picongpu/particles/ParticlesFunctors.hpp"
+
+#include <pmacc/algorithms/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+#include <cstdint>
+#include <map>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    /** Functor for the stage of the PIC loop computing Bremsstrahlung
+     *
+     * Only affects particle species with the bremsstrahlungIons attribute.
+     */
+    class Bremsstrahlung
+    {
+    public:
+
+        using ScaledSpectrumMap = std::map<
+            float_X,
+            particles::bremsstrahlung::ScaledSpectrum
+        >;
+
+        /** Create a Bremsstrahlung functor
+         *
+         * Having this in constructor is a temporary solution.
+         *
+         * @param cellDescription mapping for kernels
+         * @param scaledSpectrumMap initialized spectrum lookup table
+         * @param photonAngle initialized photon angle lookup table
+         */
+        Bremsstrahlung(
+            MappingDesc const cellDescription,
+            ScaledSpectrumMap & scaledSpectrumMap,
+            particles::bremsstrahlung::GetPhotonAngle & photonAngle
+        ):
+            cellDescription( cellDescription ),
+            scaledSpectrumMap( scaledSpectrumMap ),
+            photonAngle( photonAngle )
+        {
+        }
+
+        /** Ionize particles
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using pmacc::particles::traits::FilterByFlag;
+            using pmacc::algorithms::forEach::ForEach;
+            using SpeciesWithBremsstrahlung = typename FilterByFlag
+            <
+                VectorAllSpecies,
+                bremsstrahlungIons< >
+            >::type;
+            ForEach<
+                SpeciesWithBremsstrahlung,
+                particles::CallBremsstrahlung< bmpl::_1 >
+            > particleBremsstrahlung;
+            particleBremsstrahlung(
+                &cellDescription,
+                step,
+                scaledSpectrumMap,
+                photonAngle
+            );
+        }
+
+    private:
+
+        //! Mapping for kernels
+        MappingDesc cellDescription;
+
+        //! Loopup table: atomic number -> scaled bremsstrahlung spectrum
+        ScaledSpectrumMap & scaledSpectrumMap;
+
+        //! Loopup table for photon angle
+        particles::bremsstrahlung::GetPhotonAngle & photonAngle;
+
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu
+
+#endif // ( PMACC_CUDA_ENABLED == 1 )

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -1,0 +1,103 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/background/cellwiseOperation.hpp"
+#include "picongpu/fields/FieldB.hpp"
+#include "picongpu/fields/FieldE.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/Environment.hpp>
+#include <pmacc/type/Area.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    //! Functor for the stage of the PIC loop applying field background
+    class FieldBackground
+    {
+    public:
+
+        /** Create a field background functor
+         *
+         * Having this in constructor is a temporary solution.
+         *
+         * @param cellDescription mapping for kernels
+         */
+        FieldBackground( MappingDesc const cellDescription ):
+            cellDescription( cellDescription )
+        {
+        }
+
+        /** Add the field background to the current density
+         *
+         * @tparam T_Functor functor type compatible to nvidia::functors
+         *
+         * @param step index of time iteration
+         * @param functor functor to apply to the background
+         */
+        template< typename T_Functor >
+        void operator( )( uint32_t const step, T_Functor functor ) const
+        {
+            using namespace pmacc;
+            DataConnector & dc = Environment< >::get( ).DataConnector( );
+            auto fieldE = dc.get< FieldE >( FieldE::getName( ), true );
+            auto fieldB = dc.get< FieldB >( FieldB::getName( ), true );
+            using Background = cellwiseOperation::CellwiseOperation<
+                CORE + BORDER + GUARD
+            >;
+            Background background( cellDescription );
+            background(
+                fieldE,
+                functor,
+                FieldBackgroundE( fieldE->getUnit( ) ),
+                step,
+                FieldBackgroundE::InfluenceParticlePusher
+            );
+            background(
+                fieldB,
+                functor,
+                FieldBackgroundB( fieldB->getUnit( ) ),
+                step,
+                FieldBackgroundB::InfluenceParticlePusher
+            );
+            dc.releaseData( FieldE::getName( ) );
+            dc.releaseData( FieldB::getName( ) );
+        }
+
+    private:
+
+        //! Mapping for kernels
+        MappingDesc cellDescription;
+
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/MomentumBackup.hpp
+++ b/include/picongpu/simulation/stage/MomentumBackup.hpp
@@ -1,0 +1,72 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/algorithms/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByIdentifier.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    /** Functor for the stage of the PIC loop copying particles' momentums
+     *  to momentumPrev1
+     *
+     * Only affects particle species with the momentumPrev1 attribute.
+     */
+    struct MomentumBackup
+    {
+        /** Copy the momentums
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using pmacc::particles::traits::FilterByIdentifier;
+            using pmacc::algorithms::forEach::ForEach;
+            using SpeciesWithMomentumPrev1 = typename FilterByIdentifier<
+                VectorAllSpecies,
+                momentumPrev1
+            >::type;
+            ForEach<
+                SpeciesWithMomentumPrev1,
+                particles::Manipulate<
+                    particles::manipulators::unary::CopyAttribute<
+                        momentumPrev1,
+                        momentum
+                    >,
+                    bmpl::_1
+                >
+            > copyMomentumPrev1;
+            copyMomentumPrev1( step );
+        }
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/ParticleIonization.hpp
+++ b/include/picongpu/simulation/stage/ParticleIonization.hpp
@@ -1,0 +1,84 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/algorithms/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    /** Functor for the stage of the PIC loop performing particle ionization
+     *
+     * Only affects particle species with the ionizers attribute.
+     */
+    class ParticleIonization
+    {
+    public:
+
+        /** Create a particle ionization functor
+         *
+         * Having this in constructor is a temporary solution.
+         *
+         * @param cellDescription mapping for kernels
+         */
+        ParticleIonization( MappingDesc const cellDescription ):
+            cellDescription( cellDescription )
+        {
+        }
+
+        /** Ionize particles
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using pmacc::particles::traits::FilterByFlag;
+            using pmacc::algorithms::forEach::ForEach;
+            using SpeciesWithIonizers = typename FilterByFlag<
+                VectorAllSpecies,
+                ionizers< >
+            >::type;
+            ForEach<
+                SpeciesWithIonizers,
+                particles::CallIonization< bmpl::_1 >
+            > particleIonization;
+            particleIonization( &cellDescription, step );
+        }
+
+    private:
+
+        //! Mapping for kernels
+        MappingDesc cellDescription;
+
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/ParticlePush.hpp
+++ b/include/picongpu/simulation/stage/ParticlePush.hpp
@@ -1,0 +1,62 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/ParticlesFunctors.hpp"
+
+#include <pmacc/eventSystem/Manager.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    //! Functor for the stage of the PIC loop performing particle push
+    struct ParticlePush
+    {
+        /** Push all particle species
+         *
+         * @param step index of time iteration
+         * @param[out] commEvent particle communication event
+         */
+        void operator( )( uint32_t const step, pmacc::EventTask & commEvent ) const
+        {
+            pmacc::EventTask initEvent = __getTransactionEvent( );
+            pmacc::EventTask updateEvent;
+            particles::PushAllSpecies pushAllSpecies;
+            pushAllSpecies(
+                step, initEvent,
+                updateEvent,
+                commEvent
+            );
+            __setTransactionEvent( updateEvent );
+        }
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/PopulationKinetics.hpp
+++ b/include/picongpu/simulation/stage/PopulationKinetics.hpp
@@ -1,0 +1,67 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/algorithms/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByIdentifier.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    /** Functor for the stage of the PIC loop performing FLYlite population
+     *  kinetics for atomic physics
+     *
+     *  Only affects particle species with the populationKinetics attribute.
+     */
+    struct PopulationKinetics
+    {
+        /** Perform FLYlite population kinetics for atomic physics
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using pmacc::particles::traits::FilterByFlag;
+            using pmacc::algorithms::forEach::ForEach;
+            using FlyLiteIons = typename FilterByFlag<
+                VectorAllSpecies,
+                populationKinetics< >
+            >::type;
+            ForEach<
+                FlyLiteIons,
+                particles::CallPopulationKinetics< bmpl::_1 >,
+                bmpl::_1
+            > populationKinetics;
+            populationKinetics( step );
+        }
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
+++ b/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
@@ -1,0 +1,98 @@
+/* Copyright 2013-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp"
+
+#include <pmacc/algorithms/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace simulation
+{
+namespace stage
+{
+
+    /** Functor for the stage of the PIC loop computing synchrotron radiation
+     *
+     * Only affects particle species with the synchrotronPhotons attribute.
+     */
+    class SynchrotronRadiation
+    {
+    public:
+
+        /** Create a synchrotron radiation functor
+         *
+         * Having this in constructor is a temporary solution.
+         *
+         * @param cellDescription mapping for kernels
+         * @param functions initialized synchrotron functions
+         */
+        SynchrotronRadiation(
+            MappingDesc const cellDescription,
+            particles::synchrotronPhotons::SynchrotronFunctions & functions
+        ):
+            cellDescription( cellDescription ),
+            functions( functions )
+        {
+        }
+
+        /** Ionize particles
+         *
+         * @param step index of time iteration
+         */
+        void operator( )( uint32_t const step ) const
+        {
+            using pmacc::particles::traits::FilterByFlag;
+            using pmacc::algorithms::forEach::ForEach;
+            using SynchrotronPhotonsSpecies = typename FilterByFlag<
+                VectorAllSpecies,
+                synchrotronPhotons< >
+            >::type;
+            ForEach<
+                SynchrotronPhotonsSpecies,
+                particles::CallSynchrotronPhotons< bmpl::_1 >
+            > synchrotronRadiation;
+            synchrotronRadiation(
+                &cellDescription,
+                step,
+                functions
+            );
+        }
+
+    private:
+
+        //! Mapping for kernels
+        MappingDesc cellDescription;
+
+        //! Initialized synchrotron functions
+        particles::synchrotronPhotons::SynchrotronFunctions & functions;
+
+    };
+
+} // namespace stage
+} // namespace simulation
+} // namespace picongpu


### PR DESCRIPTION
This is the second and final part of the refactoring started in #2964. Imo, now from the code of `MySimulation::runOneStep()` it is easier to figure out what is going on, or draw a flowchart of simulation stages.

There are a couple of stages that have additional arguments in constructor or `operator()()`, but this is rather manageable, so I suggest to leave it as is for now.