### PR TITLE
CMake: CUDA 9.2-10.1, Boost <= 1.70.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -33,8 +33,8 @@ gcc
 """
 - 4.9 - 7 (if you want to build for Nvidia GPUs, supported compilers depend on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
 
-  - CUDA 9.0 - 9.1: Use gcc 4.9 - 5.5
   - CUDA 9.2 - 10.0: Use gcc 4.9 - 7
+  - CUDA 10.1: Use gcc 4.9 - 8
 - *note:* be sure to build all libraries/dependencies with the *same* gcc version; GCC 5 or newer is recommended
 - *Debian/Ubuntu:*
   
@@ -88,7 +88,7 @@ zlib
 
 boost
 """""
-- 1.65.1 - 1.68.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
+- 1.65.1 - 1.70.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
@@ -153,7 +153,7 @@ Optional Libraries
 
 CUDA
 """"
-- `9.0 - 10.0 <https://developer.nvidia.com/cuda-downloads>`_
+- `9.2 - 10.1 <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/buildsystem/CompileSuite/autoTests/new_commits.sh
+++ b/buildsystem/CompileSuite/autoTests/new_commits.sh
@@ -94,7 +94,7 @@ touch "$thisDir"runGuard
             #export PIC_COMPILE_SUITE_CMAKE="-DPIC_ENABLE_PNG=OFF -DALPAKA_CUDA_ARCH=35"
             export PIC_BACKEND="cuda"
             . /etc/profile
-            module load gcc/5.1.0 boost/1.65.1 cmake/3.11.0 cuda/9.0.176 openmpi/3.0.4
+            module load gcc/5.1.0 boost/1.65.1 cmake/3.11.0 cuda/9.2.148 openmpi/3.0.4
             module load libSplash/1.7.0 adios/1.13.1
             module load pngwriter/0.7.0 zlib/1.2.11
             module load libjpeg-turbo/1.5.1 icet/2.1.1 jansson/2.9 isaac/1.4.0

--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -77,15 +77,7 @@ For more information on *variants* of the ``picongpu`` package in spack run ``sp
 
 .. note::
 
-   If the install fails or you want to compile for CUDA 8.0, try using GCC 5.3.0:
-
-   .. code-block:: bash
-
-      spack compiler list | grep gcc@5.3.0 | spack install gcc@5.3.0 && spack load gcc@5.3.0 && spack compiler add
-      spack install picongpu %gcc@5.3.0
-      spack load picongpu %gcc@5.3.0
-
-   If the install fails or you want to compile for CUDA 9.0/9.1, try using GCC 5.5.0:
+   If the install fails or you want to compile for CUDA 9.2, try using GCC 5.5.0:
 
    .. code-block:: bash
 

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -334,37 +334,20 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_SMART_PTR")
 endif()
 
-# GCC's C++11 tuples are broken in "supported" NVCC versions
-if("${ALPAKA_CUDA_COMPILER}" STREQUAL "nvcc")
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        if(CUDA_VERSION VERSION_EQUAL 9.0 OR
-               CUDA_VERSION VERSION_EQUAL 9.1)
-            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 6.0)
-                message(FATAL_ERROR "NVCC 9.0 - 9.1 do not support the std::tuple "
-                        "implementation in GCC 6+. Please use GCC 4.9 - 5.5!")
-            endif()
-        elseif(CUDA_VERSION VERSION_EQUAL 9.2)
-            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 8.0)
-                message(FATAL_ERROR "NVCC 9.2 does not support GCC 8+. "
-                        "Please use GCC 4.9 - 7.3!")
-            endif()
-        endif()
-    endif()
-endif()
-
 # Newer Boost releases: probably troublesome, warn at least
-if(Boost_VERSION GREATER 106800)
-    message(WARNING "Untested Boost release! Maybe use a newer PIConGPU?")
+if(Boost_VERSION GREATER 107000)
+    message(WARNING "Untested Boost release > 1.70.0 (Found ${Boost_VERSION})! "
+                    "Maybe use a newer PIConGPU?")
 endif()
 
 if(ALPAKA_ACC_GPU_CUDA_ENABLE)
-    if(CUDA_VERSION VERSION_LESS 9.0)
-        message(FATAL_ERROR "CUDA 9.0 or newer required! "
+    if(CUDA_VERSION VERSION_LESS 9.2)
+        message(FATAL_ERROR "CUDA 9.2 or newer required! "
                             "(Found ${CUDA_VERSION})")
     endif()
     # Newer CUDA releases: probably troublesome, warn at least
-    if(CUDA_VERSION VERSION_GREATER 10.0)
-        message(WARNING "Untested CUDA release >10.0 (Found ${CUDA_VERSION})! "
+    if(CUDA_VERSION VERSION_GREATER 10.1)
+        message(WARNING "Untested CUDA release >10.1 (Found ${CUDA_VERSION})! "
                         "Maybe use a newer PIConGPU?")
     endif()
 endif()

--- a/share/picongpu/dockerfiles/README.rst
+++ b/share/picongpu/dockerfiles/README.rst
@@ -76,4 +76,4 @@ Recipes
 
 Currently, the following build recipes exist:
 
-* ``ubuntu-1604/``: Ubuntu 16.04, CUDA 9.0.176 (nvcc), GCC 5.4.0
+* ``ubuntu-1604/``: Ubuntu 16.04, CUDA 9.2.148 (nvcc), GCC 5.4.0

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -1,4 +1,4 @@
-FROM       nvidia/cuda:9.0-base
+FROM       nvidia/cuda:9.2-base
 MAINTAINER Axel Huebl <a.huebl@hzdr.de>
 
 # docker and image environment

--- a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
@@ -1,7 +1,7 @@
 packages:
   cuda:
     paths:
-      cuda@9.0.176%gcc@5.4.0 arch=linux-ubuntu16-x86_64: /usr/local/cuda
+      cuda@9.2.148%gcc@5.4.0 arch=linux-ubuntu16-x86_64: /usr/local/cuda
     buildable: False
   pkg-config:
     paths:


### PR DESCRIPTION
In order to merge the latest Alpaka releases and due to nvcc bugs,
we increase our requirement to CUDA 9.2+. CUDA 10.1 seams to compile as well.
Furthermore, Boost 1.70.0 is working with Alpaka.

Side note: with CUDA 9.2 as the minimum CUDA release, we can also reliably update our code base to C++14 (in upcoming PRs, CUDA 9.0+ supports this).