### PR TITLE
Remove template parameter for initialization method of Pointer and FramePointer

### DIFF
--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -129,8 +129,7 @@ public:
      *
      * @param frame frame to remove
      */
-    template<typename T_InitMethod>
-    DINLINE void removeFrame( FramePointer<FrameType, T_InitMethod>& frame )
+    DINLINE void removeFrame( FramePtr& frame )
     {
 #if( PMACC_CUDA_ENABLED == 1 )
         m_deviceHeapHandle.free( (void*) frame.ptr );
@@ -205,15 +204,11 @@ public:
      * @param idx position of supercell
      */
     template<
-        typename T_InitMethod,
         typename T_Acc
     >
     DINLINE void setAsFirstFrame(
         T_Acc const & acc,
-        FramePointer<
-            FrameType,
-            T_InitMethod
-        >& frame,
+        FramePtr & frame,
         DataSpace< DIM > const &idx
     )
     {
@@ -255,14 +250,12 @@ public:
      * @param idx position of supercell
      */
     template<
-        typename T_InitMethod,
         typename T_Acc
     >
     DINLINE void setAsLastFrame(
         T_Acc const & acc,
         FramePointer<
-            FrameType,
-            T_InitMethod
+            FrameType
         >& frame,
         DataSpace< DIM > const &idx
     )

--- a/include/pmacc/particles/memory/dataTypes/FramePointer.hpp
+++ b/include/pmacc/particles/memory/dataTypes/FramePointer.hpp
@@ -22,26 +22,23 @@
 
 #include "pmacc/types.hpp"
 #include "pmacc/particles/memory/dataTypes/Pointer.hpp"
-#include "pmacc/expressions/DoNothing.hpp"
-#include "pmacc/expressions/SetToNull.hpp"
 
 
 namespace pmacc
 {
 
-/** wrapper for native C pointer to a PMacc frame
+/** Wrapper for a raw pointer a PMacc frame
  *
  * @tparam T_Type type of the pointed object
- * @tparam T_InitMethod empty constructor method for object initilization
  */
-template <typename T_Type, typename T_InitMethod = expressions::SetToNull>
-class FramePointer : public Pointer<T_Type, T_InitMethod>
+template< typename T_Type >
+class FramePointer : public Pointer< T_Type >
 {
 private:
-    typedef Pointer<T_Type, T_InitMethod> Base;
+    using Base = Pointer< T_Type >;
 public:
-    typedef typename Base::type type;
-    typedef typename Base::PtrType PtrType;
+    using type = typename Base::type;
+    using PtrType = typename Base::PtrType;
 
     /** default constructor
      *
@@ -59,17 +56,11 @@ public:
     {
     }
 
-    HDINLINE FramePointer( const FramePointer<type>& other ) : Base( other )
+    HDINLINE FramePointer( const FramePointer& other ) : Base( other )
     {
     }
 
-    template<typename T_OtherInitMethod>
-    HDINLINE FramePointer( const FramePointer<type, T_OtherInitMethod>& other ) : Base( other )
-    {
-    }
-
-    template<typename T_OtherInitMethod>
-    HDINLINE FramePointer& operator=(const FramePointer<type, T_OtherInitMethod>& other)
+    HDINLINE FramePointer& operator=(const FramePointer& other)
     {
         Base::operator=(other);
         return *this;

--- a/include/pmacc/particles/memory/dataTypes/Pointer.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Pointer.hpp
@@ -21,50 +21,38 @@
 #pragma once
 
 #include "pmacc/types.hpp"
-#include "pmacc/expressions/DoNothing.hpp"
-#include "pmacc/expressions/SetToNull.hpp"
 
 
 namespace pmacc
 {
 
-/** wrapper for native C pointer
+/** Wrapper for a raw pointer
  *
  * @tparam T_Type type of the pointed object
  */
-template <typename T_Type, typename T_InitMethod = expressions::SetToNull>
+template< typename T_Type >
 class Pointer
 {
 public:
 
-    typedef T_Type type;
-    typedef type* PtrType;
-    typedef const type* ConstPtrType;
+    using type = T_Type;
+    using PtrType = type*;
+    using ConstPtrType = const type*;
 
-    /** default constructor
-     *
-     * the default pointer points to invalid memory
-     */
-    HDINLINE Pointer( )
+    HDINLINE Pointer( ):
+        ptr{ nullptr }
     {
-        T_InitMethod()( ptr );
     }
 
     HDINLINE Pointer( PtrType const ptrIn ) : ptr( ptrIn )
     {
     }
 
-    HDINLINE Pointer( const Pointer<type>& other ) : ptr( other.ptr )
+    HDINLINE Pointer( const Pointer& other ) : ptr( other.ptr )
     {
     }
 
-    template<typename T_OtherInitMethod>
-    HDINLINE Pointer( const Pointer<type, T_OtherInitMethod>& other ) : ptr( other.ptr )
-    {
-    }
-
-    template<typename T_OtherInitMethod>
-    HDINLINE Pointer& operator=(const Pointer<type, T_OtherInitMethod>& other)
+    HDINLINE Pointer& operator=(const Pointer& other)
     {
         ptr = other.ptr;
         return *this;


### PR DESCRIPTION
Taking into account #2976, there will be no use for alternatives here. So this PR removes this template parameter and now the pointers are always default-initialized with `nullptr`. This does not change the behavior of the existing code, as it has always been the set to zero policy anyways.

Edit: the first commit is the same as in #2976 (merged already at the time of the edit), please review only the second.

- [x] do not merge before #2976 is merged.