### PR TITLE
Singularity: Avoid Dotfiles in Home

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -44,7 +44,7 @@ RUN        apt-get update && \
            rm -rf /var/lib/apt/lists/*
 
 # spack settings
-COPY       packages.yaml modules.yaml $SPACK_ROOT/etc/spack/
+COPY       compilers.yaml packages.yaml modules.yaml $SPACK_ROOT/etc/spack/
 
 # install spack && PIConGPU dependencies
 # TODO: fix to a specific spack SHA or tag
@@ -53,7 +53,7 @@ RUN        curl -s -L https://github.com/spack/spack/archive/develop.tar.gz \
            mkdir -p $SPACK_EXTRA_REPO && \
            curl -s -L https://api.github.com/repos/ComputationalRadiationPhysics/spack-repo/tarball \
                 | tar xzC $SPACK_EXTRA_REPO --strip 1 && \
-           spack repo add $SPACK_EXTRA_REPO
+           spack repo add --scope=system $SPACK_EXTRA_REPO
 RUN        spack install $PIC_PACKAGE && \
            spack clean -a
 

--- a/share/picongpu/dockerfiles/ubuntu-1604/compilers.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc: /usr/bin/gcc-5
+      cxx: /usr/bin/g++-5
+      f77: /usr/bin/gfortran-5
+      fc: /usr/bin/gfortran-5
+    spec: gcc@5.4.0
+    target: x86_64


### PR DESCRIPTION
Avoid creating a ~/.spack/linux/repos.yaml with spack add and instead modify the "system-wide" (in the container) config files.

Also explicitly move compilers.yaml to the same, system-wide location.

Thanks to @AdamSimpson and Nvidia QA for the report!

- [x] are there more `~/.spack/` files causing trouble? e.g. `compilers.yaml`?
- [x] dockerhub images for `0.4.3` and `latest` tags updated
- [x] re-build and check QA

Local diff for the 0.4.3 release to build (CUDA 9.0 based):
```diff
diff --git a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
index 2872b24..a1c9b85 100644
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -1,4 +1,4 @@
-FROM       nvidia/cuda:9.2-base
+FROM       nvidia/cuda:9.0-base
 MAINTAINER Axel Huebl <a.huebl@hzdr.de>
 
 # docker and image environment
@@ -6,7 +6,7 @@ ENV        DEBIAN_FRONTEND=noninteractive \
            FORCE_UNSAFE_CONFIGURE=1 \
            SPACK_ROOT=/usr/local \
            SPACK_EXTRA_REPO=/usr/local/share/spack-repo \
-           PIC_PACKAGE='picongpu@0.5.0+isaac backend=cuda'
+           PIC_PACKAGE='picongpu@0.4.3+isaac backend=cuda'
 
 # install minimal spack dependencies
 #   - adds gfortran for spack's openmpi package
diff --git a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
index 06b5351..c0b7e93 100644
--- a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
@@ -1,7 +1,7 @@
 packages:
   cuda:
     paths:
-      cuda@9.2.148%gcc@5.4.0 arch=linux-ubuntu16-x86_64: /usr/local/cuda
+      cuda@9.0.176%gcc@5.4.0 arch=linux-ubuntu16-x86_64: /usr/local/cuda
     buildable: False
   pkg-config:
     paths:
```