### PR TITLE
SimulationFieldHelper: getter method to access cell description

### DIFF
--- a/include/pmacc/fields/SimulationFieldHelper.hpp
+++ b/include/pmacc/fields/SimulationFieldHelper.hpp
@@ -52,6 +52,11 @@ public:
      */
     virtual void syncToDevice() = 0;
 
+    CellDescription getCellDescription() const
+    {
+        return cellDescription;
+    }
+
 protected:
     CellDescription cellDescription;
 };


### PR DESCRIPTION
add a getter methode access the celldescription of a field