### PR TITLE
Fix signed int overflow in particle migration between supercells

### DIFF
--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -618,7 +618,7 @@ struct KernelShiftParticles
         >;
 
         memory::CtxArray<
-            int,
+            int32_t,
             ExchangeDomCfg
         > newParticleInFrame( 0 );
 
@@ -656,7 +656,7 @@ struct KernelShiftParticles
 
                 if ( tmpFrame.isValid() )
                 {
-                    uint32_t particlesInFrame = pb.getSuperCell( relativeCtx[ idx ] ).getSizeLastFrame( );
+                    int32_t const particlesInFrame = pb.getSuperCell( relativeCtx[ idx ] ).getSizeLastFrame( );
                     // do not use the neighbor's last frame if it is full
                     if ( particlesInFrame < frameSize )
                     {


### PR DESCRIPTION
I started looking into this due to a warning in Visual Studio, but turned out this is probably a bug.

This line: `newParticleInFrame[ idx ] = -particlesInFrame;` [just below](https://github.com/sbastrakov/picongpu/blob/fe8a709269c4da5e5de4f03559f74c69ce6f3d98/include/pmacc/particles/ParticlesBase.kernel#L663) used a negation of a `uint32_t` value. Which is not a problem itself (well-defined, works by modulo), although probably a little weird style and caused the warning. But then the result is assigned to an `int` value and in all realistic scenarios, it would overflow, which is UB for signed ints. I guess it worked by bitwise copying which would give the correct result.

- [x] check that this change did not accidentally break something