### PR TITLE
Add picongpu::particles::manipulate() as a high-level interface to particle manipulation

### DIFF
--- a/include/picongpu/simulation/stage/MomentumBackup.hpp
+++ b/include/picongpu/simulation/stage/MomentumBackup.hpp
@@ -21,7 +21,8 @@
 
 #pragma once
 
-#include <pmacc/meta/ForEach.hpp>
+#include "picongpu/particles/Manipulate.hpp"
+
 #include <pmacc/particles/traits/FilterByIdentifier.hpp>
 
 #include <cstdint>
@@ -52,17 +53,14 @@ namespace stage
                 VectorAllSpecies,
                 momentumPrev1
             >::type;
-            pmacc::meta::ForEach<
-                SpeciesWithMomentumPrev1,
-                particles::Manipulate<
-                    particles::manipulators::unary::CopyAttribute<
-                        momentumPrev1,
-                        momentum
-                    >,
-                    bmpl::_1
-                >
-            > copyMomentumPrev1;
-            copyMomentumPrev1( step );
+            using CopyMomentum = particles::manipulators::unary::CopyAttribute<
+                momentumPrev1,
+                momentum
+            >;
+            particles::manipulate<
+                CopyMomentum,
+                SpeciesWithMomentumPrev1
+            >( step );
         }
     };
 


### PR DESCRIPTION
This is a function-style wrapper around creating a `Manipulate` object and calling its `operator()`. Unlike `picongpu::particles::Manipulate`, it supports both single species and sequences of species.

For a bit of a context: @psychocoderHPC and I had lots of discussions recently on interfaces for the `forEach`-style processing, so that it is easier to express the simple patterns. Like this one - applying a manipulator for a sequence of particle species. #2991 is another step in that direction, this PR is orthogonal to it and (should) work with both the old and new `Manipulate`. More PRs in this direction will be coming, including more actively employing manipulate in the existing code.