### PR TITLE
add namespace "radiation" around code related to radiation plugin

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -49,16 +49,16 @@ The frequency range is set up by choosing a specific namespace that defines the 
 .. code:: cpp
 
    /* choose linear frequency range */
-   namespace radiation_frequencies = rad_linear_frequencies;
+   namespace radiation_frequencies = linear_frequencies;
 
 Currently you can choose from the following setups for the frequency range:
 
 ============================= ==============================================================================================
 namespace                     Description
 ============================= ==============================================================================================
-``rad_linear_frequencies``    linear frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
-``rad_log_frequencies``       logarithmic frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
-``rad_frequencies_from_list`` ``N_omega`` frequencies taken from a text file with location ``listLocation[]``
+``linear_frequencies``    linear frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
+``log_frequencies``       logarithmic frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
+``frequencies_from_list`` ``N_omega`` frequencies taken from a text file with location ``listLocation[]``
 ============================= ==============================================================================================
 
 

--- a/include/picongpu/param/radiation.param
+++ b/include/picongpu/param/radiation.param
@@ -44,6 +44,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace linear_frequencies
@@ -200,4 +202,5 @@ namespace parameters
 
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/param/radiation.param
+++ b/include/picongpu/param/radiation.param
@@ -46,7 +46,7 @@ namespace picongpu
 {
 namespace radiation
 {
-namespace rad_linear_frequencies
+namespace linear_frequencies
 {
 namespace SI
 {
@@ -58,9 +58,9 @@ namespace SI
 
     /** number of frequency values to compute in the linear frequency [unitless] */
     constexpr unsigned int N_omega = 2048;
-} // namespace rad_linear_frequencies
+} // namespace linear_frequencies
 
-namespace rad_log_frequencies
+namespace log_frequencies
 {
 namespace SI
 {
@@ -72,25 +72,25 @@ namespace SI
 
     /** number of frequency values to compute in the logarithmic frequency [unitless] */
     constexpr unsigned int N_omega = 2048;
-} // namespace rad_log_frequencies
+} // namespace log_frequencies
 
 
-namespace rad_frequencies_from_list
+namespace frequencies_from_list
 {
     /** path to text file with frequencies */
     constexpr char listLocation[] = "/path/to/frequency_list";
     /** number of frequency values to compute if frequencies are given in a file [unitless] */
     constexpr unsigned int N_omega = 2048;
-} // namespace rad_frequencies_from_list
+} // namespace frequencies_from_list
 
     /** selected mode of frequency scaling:
      *
      * options:
-     * - rad_linear_frequencies
-     * - rad_log_frequencies
-     * - rad_frequencies_from_list
+     * - linear_frequencies
+     * - log_frequencies
+     * - frequencies_from_list
      */
-    namespace radiation_frequencies = rad_linear_frequencies;
+    namespace radiation_frequencies = linear_frequencies;
 
 namespace radiationNyquist
 {
@@ -146,7 +146,7 @@ namespace parameters
     {
         /** Gamma value above which the radiation is calculated */
         static constexpr float_X radiationGamma = 5.0;
-      
+
         template< typename T_Particle >
         HDINLINE void operator()( T_Particle& particle )
         {

--- a/include/picongpu/param/radiation.param
+++ b/include/picongpu/param/radiation.param
@@ -44,42 +44,44 @@
 
 namespace picongpu
 {
-    namespace rad_linear_frequencies
-    {
-        namespace SI
-        {
-            /** mimimum frequency of the linear frequency scale in units of [1/s] */
-            constexpr float_64 omega_min = 0.0;
-            /** maximum frequency of the linear frequency scale in units of [1/s] */
-            constexpr float_64 omega_max = 1.06e16;
-        }
+namespace radiation
+{
+namespace rad_linear_frequencies
+{
+namespace SI
+{
+    /** mimimum frequency of the linear frequency scale in units of [1/s] */
+    constexpr float_64 omega_min = 0.0;
+    /** maximum frequency of the linear frequency scale in units of [1/s] */
+    constexpr float_64 omega_max = 1.06e16;
+} // namespace SI
 
-        /** number of frequency values to compute in the linear frequency [unitless] */
-        constexpr unsigned int N_omega = 2048;
-    }
+    /** number of frequency values to compute in the linear frequency [unitless] */
+    constexpr unsigned int N_omega = 2048;
+} // namespace rad_linear_frequencies
 
-    namespace rad_log_frequencies
-    {
-        namespace SI
-        {
-            /** mimimum frequency of the logarithmic frequency scale in units of [1/s] */
-            constexpr float_64 omega_min = 1.0e14;
-            /** maximum frequency of the logarithmic frequency scale in units of [1/s] */
-            constexpr float_64 omega_max = 1.0e17;
-        }
+namespace rad_log_frequencies
+{
+namespace SI
+{
+    /** mimimum frequency of the logarithmic frequency scale in units of [1/s] */
+    constexpr float_64 omega_min = 1.0e14;
+    /** maximum frequency of the logarithmic frequency scale in units of [1/s] */
+    constexpr float_64 omega_max = 1.0e17;
+} // namespace SI
 
-        /** number of frequency values to compute in the logarithmic frequency [unitless] */
-        constexpr unsigned int N_omega = 2048;
-    }
+    /** number of frequency values to compute in the logarithmic frequency [unitless] */
+    constexpr unsigned int N_omega = 2048;
+} // namespace rad_log_frequencies
 
 
-    namespace rad_frequencies_from_list
-    {
-        /** path to text file with frequencies */
-        constexpr char listLocation[] = "/path/to/frequency_list";
-        /** number of frequency values to compute if frequencies are given in a file [unitless] */
-        constexpr unsigned int N_omega = 2048;
-    }
+namespace rad_frequencies_from_list
+{
+    /** path to text file with frequencies */
+    constexpr char listLocation[] = "/path/to/frequency_list";
+    /** number of frequency values to compute if frequencies are given in a file [unitless] */
+    constexpr unsigned int N_omega = 2048;
+} // namespace rad_frequencies_from_list
 
     /** selected mode of frequency scaling:
      *
@@ -90,14 +92,13 @@ namespace picongpu
      */
     namespace radiation_frequencies = rad_linear_frequencies;
 
-
-    namespace radiationNyquist
-    {
-        /** Nyquist factor: fraction of the local Nyquist frequency above which the spectra is set to zero
-         * should be in (0, 1).
-         */
-        constexpr float_32 NyquistFactor = 0.5;
-    }
+namespace radiationNyquist
+{
+    /** Nyquist factor: fraction of the local Nyquist frequency above which the spectra is set to zero
+     * should be in (0, 1).
+     */
+    constexpr float_32 NyquistFactor = 0.5;
+} // namespace radiationNyquist
 
 
     ///////////////////////////////////////////////////
@@ -130,54 +131,50 @@ namespace picongpu
     ///////////////////////////////////////////////////////////
 
 
-    namespace parameters
+namespace parameters
+{
+
+    /** number of observation directions */
+    constexpr unsigned int N_observer = 256;
+
+} // namespace parameters
+
+    /** select particles for radiation
+     * example of a filter for the relativistic Lorentz factor gamma
+     */
+    struct GammaFilterFunctor
     {
-
-        /** number of observation directions */
-        constexpr unsigned int N_observer = 256;
-
-
-
-    } /* end namespace parameters */
-
-    namespace radiation
-    {
-        /** select particles for radiation
-         * example of a filter for the relativistic Lorentz factor gamma
-         */
-        struct GammaFilterFunctor
+        /** Gamma value above which the radiation is calculated */
+        static constexpr float_X radiationGamma = 5.0;
+      
+        template< typename T_Particle >
+        HDINLINE void operator()( T_Particle& particle )
         {
-            /** Gamma value above which the radiation is calculated */
-            static constexpr float_X radiationGamma = 5.0;
-
-            template< typename T_Particle >
-            HDINLINE void operator()( T_Particle& particle )
-            {
-                if(
-                    picongpu::gamma<float_X>(
-                        particle[ picongpu::momentum_ ],
-                        picongpu::traits::attribute::getMass(
-                            particle[ picongpu::weighting_ ],
-                            particle
-                        )
-                    ) >= radiationGamma
-                )
-                    particle[ picongpu::radiationMask_ ] = true;
-            }
-        };
+            if(
+               picongpu::gamma<float_X>(
+                                        particle[ picongpu::momentum_ ],
+                                        picongpu::traits::attribute::getMass(
+                                                                             particle[ picongpu::weighting_ ],
+                                                                             particle
+                                                                             )
+                                        ) >= radiationGamma
+               )
+              particle[ picongpu::radiationMask_ ] = true;
+        }
+    };
 
 
-        /** filter to (de)select particles for the radiation calculation
-         *
-         * to activate the filter:
-         *   - goto file `speciesDefinition.param`
-         *   - add the attribute `radiationMask` to the particle species
-         */
-        using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<
-            GammaFilterFunctor
-        >;
+    /** filter to (de)select particles for the radiation calculation
+     *
+     * to activate the filter:
+     *   - goto file `speciesDefinition.param`
+     *   - add the attribute `radiationMask` to the particle species
+     */
+    using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<
+        GammaFilterFunctor
+      >;
 
-    } // namespace radiation
+
 
     //////////////////////////////////////////////////
 
@@ -202,4 +199,5 @@ namespace picongpu
     namespace radWindowFunction = radWindowFunctionNone;
 
 
-}//namespace picongpu
+} // namespace radiation
+} // namespace picongpu

--- a/include/picongpu/param/radiationObserver.param
+++ b/include/picongpu/param/radiationObserver.param
@@ -29,6 +29,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace radiation_observer
@@ -128,4 +130,5 @@ namespace radiation_observer
 
 } // namespace radiation_observer
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/param/radiationObserver.param
+++ b/include/picongpu/param/radiationObserver.param
@@ -108,7 +108,7 @@ namespace radiation_observer
         /** step width angle phi */
         const picongpu::float_64 delta_angle_phi   =  (angle_phi_end -
                                                        angle_phi_start)   / (N_angle_split-1.0);
-        
+
         /** compute observation angles theta */
         const picongpu::float_64 theta( my_index_theta * delta_angle_theta + angle_theta_start );
         /** compute observation angles theta */

--- a/include/picongpu/param/radiationObserver.param
+++ b/include/picongpu/param/radiationObserver.param
@@ -29,8 +29,10 @@
 
 namespace picongpu
 {
-  namespace radiation_observer
-  {
+namespace radiation
+{
+namespace radiation_observer
+{
     /** Compute observation angles
      *
      * This function is used in the Radiation plug-in kernel to compute
@@ -71,58 +73,59 @@ namespace picongpu
      */
     HDINLINE vector_64 observation_direction(const int observation_id_extern)
     {
-      /* generate two indices from single block index */
-      /** split distance of given index
-       * pseudo-code:
-       * index_a = index / split_distance
-       * index_b = index % split_distance
-       */
-      constexpr int N_angle_split = 16;
-      /** get index for computing angle theta: */
-      const int my_index_theta = observation_id_extern / N_angle_split;
-      /** get index for computing angle phi: */
-      const int my_index_phi = observation_id_extern % N_angle_split;
+        /* generate two indices from single block index */
+        /** split distance of given index
+         * pseudo-code:
+         * index_a = index / split_distance
+         * index_b = index % split_distance
+         */
+        constexpr int N_angle_split = 16;
+        /** get index for computing angle theta: */
+        const int my_index_theta = observation_id_extern / N_angle_split;
+        /** get index for computing angle phi: */
+        const int my_index_phi = observation_id_extern % N_angle_split;
 
 
-      /* set up observation angle range */
-      /* angles range for theta */
-      /** minimum theta angle [rad] */
-      const picongpu::float_64 angle_theta_start = - picongpu::PI/8.0;
-      /** maximum theta angle [rad] */
-      const picongpu::float_64 angle_theta_end   = + picongpu::PI/8.0;
-      /* angles range for phi */
-      /** minimum phi angle [rad] */
-      constexpr picongpu::float_64 angle_phi_start = - picongpu::PI/8.0;
-      /** maximum phi angle [rad] */
-      constexpr picongpu::float_64 angle_phi_end   = + picongpu::PI/8.0;
+        /* set up observation angle range */
+        /* angles range for theta */
+        /** minimum theta angle [rad] */
+        const picongpu::float_64 angle_theta_start = - picongpu::PI/8.0;
+        /** maximum theta angle [rad] */
+        const picongpu::float_64 angle_theta_end   = + picongpu::PI/8.0;
+        /* angles range for phi */
+        /** minimum phi angle [rad] */
+        constexpr picongpu::float_64 angle_phi_start = - picongpu::PI/8.0;
+        /** maximum phi angle [rad] */
+        constexpr picongpu::float_64 angle_phi_end   = + picongpu::PI/8.0;
 
 
-      /* compute step with between two angles for range [angle_??_start : angle_??_end] */
-      /** number of theta angles */
-      constexpr int N_theta = parameters::N_observer / N_angle_split;
-      /** step width angle theta */
-      const picongpu::float_64 delta_angle_theta =  (angle_theta_end -
-                       angle_theta_start) / (N_theta-1.0);
-      /** step width angle phi */
-      const picongpu::float_64 delta_angle_phi   =  (angle_phi_end -
-                       angle_phi_start)   / (N_angle_split-1.0);
+        /* compute step with between two angles for range [angle_??_start : angle_??_end] */
+        /** number of theta angles */
+        constexpr int N_theta = parameters::N_observer / N_angle_split;
+        /** step width angle theta */
+        const picongpu::float_64 delta_angle_theta =  (angle_theta_end -
+                                                       angle_theta_start) / (N_theta-1.0);
+        /** step width angle phi */
+        const picongpu::float_64 delta_angle_phi   =  (angle_phi_end -
+                                                       angle_phi_start)   / (N_angle_split-1.0);
+        
+        /** compute observation angles theta */
+        const picongpu::float_64 theta( my_index_theta * delta_angle_theta + angle_theta_start );
+        /** compute observation angles theta */
+        const picongpu::float_64 phi( my_index_phi * delta_angle_phi - angle_phi_start );
 
-      /** compute observation angles theta */
-      const picongpu::float_64 theta( my_index_theta * delta_angle_theta + angle_theta_start );
-      /** compute observation angles theta */
-      const picongpu::float_64 phi( my_index_phi * delta_angle_phi - angle_phi_start );
-
-      /* helper functions for efficient trigonometric calculations */
-      picongpu::float_32 sinPhi;
-      picongpu::float_32 cosPhi;
-      picongpu::float_32 sinTheta;
-      picongpu::float_32 cosTheta;
-      math::sincos(precisionCast<picongpu::float_32>(phi), sinPhi, cosPhi);
-      math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
-      /** compute observation unit vector */
-      return vector_64( sinTheta*cosPhi , cosTheta, sinTheta*sinPhi ) ;
+        /* helper functions for efficient trigonometric calculations */
+        picongpu::float_32 sinPhi;
+        picongpu::float_32 cosPhi;
+        picongpu::float_32 sinTheta;
+        picongpu::float_32 cosTheta;
+        math::sincos(precisionCast<picongpu::float_32>(phi), sinPhi, cosPhi);
+        math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+        /** compute observation unit vector */
+        return vector_64( sinTheta*cosPhi , cosTheta, sinTheta*sinPhi ) ;
 
     }
 
-  } // end namespace radiation_observer
-} // end namespace picongpu
+} // namespace radiation_observer
+} // namespace radiation
+} // namespace picongpu

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -216,7 +216,7 @@ private:
         CountParticles<bmpl::_1>,
         PngPlugin< Visualisation<bmpl::_1, PngCreator> >
 #if(ENABLE_HDF5 == 1)
-        , Radiation<bmpl::_1>
+        , radiation::Radiation<bmpl::_1>
         , plugins::multi::Master< ParticleCalorimeter<bmpl::_1> >
         , plugins::multi::Master< PhaseSpace<particles::shapes::Counter::ChargeAssignment, bmpl::_1> >
 #endif

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -216,7 +216,7 @@ private:
         CountParticles<bmpl::_1>,
         PngPlugin< Visualisation<bmpl::_1, PngCreator> >
 #if(ENABLE_HDF5 == 1)
-        , radiation::Radiation<bmpl::_1>
+        , plugins::radiation::Radiation<bmpl::_1>
         , plugins::multi::Master< ParticleCalorimeter<bmpl::_1> >
         , plugins::multi::Master< PhaseSpace<particles::shapes::Counter::ChargeAssignment, bmpl::_1> >
 #endif

--- a/include/picongpu/plugins/radiation/ExecuteParticleFilter.hpp
+++ b/include/picongpu/plugins/radiation/ExecuteParticleFilter.hpp
@@ -29,6 +29,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -46,7 +48,7 @@ namespace radiation
         void operator()( std::shared_ptr<T_Species> const &, const uint32_t currentStep )
         {
             particles::Manipulate<
-                picongpu::radiation::RadiationParticleFilter,
+            picongpu::plugins::radiation::RadiationParticleFilter,
                 T_Species
             >{}( currentStep );
         }
@@ -92,4 +94,5 @@ namespace radiation
     }
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/GetRadiationMask.hpp
+++ b/include/picongpu/plugins/radiation/GetRadiationMask.hpp
@@ -26,6 +26,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
     /** read the `radiationMask` of a species */
     template< bool hasRadiationMask >
     struct GetRadiationMask
@@ -80,4 +82,5 @@ namespace picongpu
         >::type::value;
         return GetRadiationMask< hasRadiationMask >{}( particle );
     }
+} // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/GetRadiationMask.hpp
+++ b/include/picongpu/plugins/radiation/GetRadiationMask.hpp
@@ -26,6 +26,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
     /** read the `radiationMask` of a species */
@@ -40,7 +42,7 @@ namespace radiation
         template< typename T_Particle >
         HDINLINE bool operator()( const T_Particle& particle ) const
         {
-            return particle[ radiationMask_ ];
+          return particle[ picongpu::radiationMask_ ];
         }
     };
 
@@ -83,4 +85,5 @@ namespace radiation
         return GetRadiationMask< hasRadiationMask >{}( particle );
     }
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -55,6 +55,9 @@
 
 namespace picongpu
 {
+namespace radiation
+{
+
 using namespace pmacc;
 
 namespace po = boost::program_options;
@@ -1245,7 +1248,9 @@ private:
 
 };
 
-}
+} // namespace radiation
+
+} // namespace picongpu
 
 
 

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -55,6 +55,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -1249,7 +1251,7 @@ private:
 };
 
 } // namespace radiation
-
+} // namespace plugins
 } // namespace picongpu
 
 

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -58,6 +58,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
     /** calculate the radiation of a species
      *
@@ -536,4 +538,6 @@ namespace picongpu
         }
     };
 
-}
+} // namespace radiation
+
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -58,6 +58,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -539,5 +541,7 @@ namespace radiation
     };
 
 } // namespace radiation
+
+} // namespace plugins
 
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -27,6 +27,9 @@
 
 namespace picongpu
 {
+namespace radiation
+{
+
 /** class to store 3 complex numbers for the radiated amplitude
  */
 class Amplitude
@@ -135,6 +138,7 @@ private:
   complex_64 amp_z; // complex amplitude z-component
 
 };
+} // namespace radiation
 } // namespace picongpu
 
 namespace pmacc
@@ -144,10 +148,10 @@ namespace mpi
 
   /** implementation of MPI transaction on Amplitude class */
   template<>
-  MPI_StructAsArray getMPI_StructAsArray< picongpu::Amplitude >()
+  MPI_StructAsArray getMPI_StructAsArray< picongpu::radiation::Amplitude >()
   {
-      MPI_StructAsArray result = getMPI_StructAsArray< picongpu::Amplitude::complex_64::type > ();
-      result.sizeMultiplier *= picongpu::Amplitude::numComponents;
+      MPI_StructAsArray result = getMPI_StructAsArray< picongpu::radiation::Amplitude::complex_64::type > ();
+      result.sizeMultiplier *= picongpu::radiation::Amplitude::numComponents;
       return result;
   };
 

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -27,6 +27,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -139,6 +141,7 @@ private:
 
 };
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu
 
 namespace pmacc
@@ -148,10 +151,10 @@ namespace mpi
 
   /** implementation of MPI transaction on Amplitude class */
   template<>
-  MPI_StructAsArray getMPI_StructAsArray< picongpu::radiation::Amplitude >()
+  MPI_StructAsArray getMPI_StructAsArray< picongpu::plugins::radiation::Amplitude >()
   {
-      MPI_StructAsArray result = getMPI_StructAsArray< picongpu::radiation::Amplitude::complex_64::type > ();
-      result.sizeMultiplier *= picongpu::radiation::Amplitude::numComponents;
+      MPI_StructAsArray result = getMPI_StructAsArray< picongpu::plugins::radiation::Amplitude::complex_64::type > ();
+      result.sizeMultiplier *= picongpu::plugins::radiation::Amplitude::numComponents;
       return result;
   };
 

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -26,6 +26,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -174,4 +176,5 @@ private:
 };
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -26,6 +26,9 @@
 
 namespace picongpu
 {
+namespace radiation
+{
+
 //protected:
 // error class for wrong time access
 
@@ -170,4 +173,5 @@ private:
 
 };
 
+} // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/check_consistency.hpp
+++ b/include/picongpu/plugins/radiation/check_consistency.hpp
@@ -25,6 +25,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
 void check_consistency(void)
 {
@@ -37,4 +39,5 @@ void check_consistency(void)
   // is there a way to do this with  compile time asserts???
 }
 
-} //namespace picongpu
+} // namespace radiation
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/check_consistency.hpp
+++ b/include/picongpu/plugins/radiation/check_consistency.hpp
@@ -25,6 +25,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -40,4 +42,5 @@ void check_consistency(void)
 }
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
+++ b/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
@@ -26,6 +26,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -44,7 +46,6 @@ DEFINE_VERBOSE_CLASS(PIConGPUVerboseRadiation)
 (NOTHING::lvl|PIC_VERBOSE_RADIATION);
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu
-
-
 

--- a/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
+++ b/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
@@ -26,6 +26,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
 /*create verbose class*/
 DEFINE_VERBOSE_CLASS(PIConGPUVerboseRadiation)
@@ -41,7 +43,8 @@ DEFINE_VERBOSE_CLASS(PIConGPUVerboseRadiation)
 /*set default verbose levels (integer number)*/
 (NOTHING::lvl|PIC_VERBOSE_RADIATION);
 
-}// namespace picongpu
+} // namespace radiation
+} // namespace picongpu
 
 
 

--- a/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -27,7 +27,7 @@ namespace picongpu
 namespace radiation
 {
 
-namespace rad_linear_frequencies
+namespace linear_frequencies
 {
 
 
@@ -60,6 +60,6 @@ namespace rad_linear_frequencies
       }
     };
 
-} // namespace rad_linear_frequencies
+} // namespace linear_frequencies
 } // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -24,8 +24,11 @@
 
 namespace picongpu
 {
-  namespace rad_linear_frequencies
-  {
+namespace radiation
+{
+
+namespace rad_linear_frequencies
+{
 
 
     class FreqFunctor
@@ -57,5 +60,6 @@ namespace picongpu
       }
     };
 
-  }
-}
+} // namespace rad_linear_frequencies
+} // namespace radiation
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -24,6 +24,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -62,4 +64,5 @@ namespace linear_frequencies
 
 } // namespace linear_frequencies
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -29,7 +29,7 @@ namespace picongpu
 {
 namespace radiation
 {
-namespace rad_frequencies_from_list
+namespace frequencies_from_list
 {
 
 
@@ -117,6 +117,6 @@ namespace rad_frequencies_from_list
     };
 
 
-} // namespace rad_frequencies_from_list
+} // namespace frequencies_from_list
 } // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -27,6 +27,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace frequencies_from_list
@@ -119,4 +121,5 @@ namespace frequencies_from_list
 
 } // namespace frequencies_from_list
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -27,8 +27,10 @@
 
 namespace picongpu
 {
-  namespace rad_frequencies_from_list
-  {
+namespace radiation
+{
+namespace rad_frequencies_from_list
+{
 
 
     class FreqFunctor
@@ -115,5 +117,6 @@ namespace picongpu
     };
 
 
-  }
-}
+} // namespace rad_frequencies_from_list
+} // namespace radiation
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -24,8 +24,10 @@
 
 namespace picongpu
 {
-  namespace rad_log_frequencies
-  {
+namespace radiation
+{
+namespace rad_log_frequencies
+{
 
 
     class FreqFunctor
@@ -65,6 +67,6 @@ namespace picongpu
     };
 
 
-  }
-
-}
+} // namespace rad_log_frequencies
+} // namespace radiation
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -26,7 +26,7 @@ namespace picongpu
 {
 namespace radiation
 {
-namespace rad_log_frequencies
+namespace log_frequencies
 {
 
 
@@ -67,6 +67,6 @@ namespace rad_log_frequencies
     };
 
 
-} // namespace rad_log_frequencies
+} // namespace log_frequencies
 } // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -24,6 +24,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace log_frequencies
@@ -69,4 +71,5 @@ namespace log_frequencies
 
 } // namespace log_frequencies
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
+++ b/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
@@ -26,6 +26,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -64,4 +66,5 @@ private:
 };
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
+++ b/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
@@ -26,6 +26,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
 class NyquistLowPass : public One_minus_beta_times_n
 {
@@ -61,4 +63,5 @@ private:
     float_32 omegaNyquist; // Nyquist frequency for a particle (at a certain time step) for one direction
 };
 
+} // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/parameters.hpp
+++ b/include/picongpu/plugins/radiation/parameters.hpp
@@ -26,10 +26,13 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
     using vector_X = cuda_vec< picongpu::float3_X, picongpu::float_X >;
     using vector_32 = /*__align__(16)*/ cuda_vec< picongpu::float3_32, picongpu::float_32 >;
     using vector_64 = /*__align__(32)*/ cuda_vec< picongpu::float3_64, picongpu::float_64 >;
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/parameters.hpp
+++ b/include/picongpu/plugins/radiation/parameters.hpp
@@ -26,7 +26,10 @@
 
 namespace picongpu
 {
+namespace radiation
+{
     using vector_X = cuda_vec< picongpu::float3_X, picongpu::float_X >;
     using vector_32 = /*__align__(16)*/ cuda_vec< picongpu::float3_32, picongpu::float_32 >;
     using vector_64 = /*__align__(32)*/ cuda_vec< picongpu::float3_64, picongpu::float_64 >;
+} // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -28,6 +28,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -172,4 +174,5 @@ HDINLINE vector_64 Particle::get_momentum<When::old>(void) const
 } // get momentum at time when
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -28,6 +28,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
 class When
 {
@@ -169,4 +171,5 @@ HDINLINE vector_64 Particle::get_momentum<When::old>(void) const
     return momentum_old;
 } // get momentum at time when
 
+} // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -22,6 +22,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -208,5 +210,5 @@ namespace radFormFactor_coherent
 } // namespace radFormFactor_coherent
 
 } // namespace radiation
-
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -22,9 +22,11 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
-  namespace radFormFactor_baseShape_3D
-  {
+namespace radFormFactor_baseShape_3D
+{
     /** general form factor class of discrete charge distribution of PIC particle shape of order T_shapeOrder
      *
      * @tparam T_shapeOrder order of charge distribution shape in PIC code used for radiation form factor
@@ -57,31 +59,30 @@ namespace picongpu
           return math::sqrt( N + ( N * N - N ) * util::pow( sincValue , 2 * T_shapeOrder ) );
       }
     };
-  } // radFormFactor_baseShape_3D
+} // namespace radFormFactor_baseShape_3D
 
 
-  namespace radFormFactor_CIC_3D
-  {
+namespace radFormFactor_CIC_3D
+{
     struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor< 1 >
     { };
-  } // radFormFactor_CIC_3D
+} // namespace radFormFactor_CIC_3D
 
-  namespace radFormFactor_TSC_3D
-  {
+namespace radFormFactor_TSC_3D
+{
     struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor< 2 >
     { };
-  } // radFormFactor_TSC_3D
+} // namespace radFormFactor_TSC_3D
 
-  namespace radFormFactor_PCS_3D
-  {
+namespace radFormFactor_PCS_3D
+{
     struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor< 3 >
     { };
+} // namespace radFormFactor_PCS_3D
 
-  } // radFormFactor_PCS_3D
 
-
-  namespace radFormFactor_CIC_1Dy
-  {
+namespace radFormFactor_CIC_1Dy
+{
     struct radFormFactor
     {
       /** Form Factor for 1-d CIC charge distribution iy y of N discrete electrons:
@@ -107,11 +108,11 @@ namespace picongpu
           );
       }
     };
-  } // radFormFactor_CIC_1Dy
+} // namespace radFormFactor_CIC_1Dy
 
 
-  namespace radFormFactor_Gauss_spherical
-  {
+namespace radFormFactor_Gauss_spherical
+{
     struct radFormFactor
     {
       /** Form Factor for point-symmetric Gauss-shaped charge distribution of N discrete electrons:
@@ -133,11 +134,11 @@ namespace picongpu
           );
       }
     };
-  } // radFormFactor_Gauss_spherical
+} // namespace radFormFactor_Gauss_spherical
 
 
-  namespace radFormFactor_Gauss_cell
-  {
+namespace radFormFactor_Gauss_cell
+{
     struct radFormFactor
     {
       /** Form Factor for per-dimension Gauss-shaped charge distribution of N discrete electrons:
@@ -164,12 +165,12 @@ namespace picongpu
         );
       }
     };
-  } // radFormFactor_Gauss_cell
+} // namespace radFormFactor_Gauss_cell
 
 
 
-  namespace radFormFactor_incoherent
-  {
+namespace radFormFactor_incoherent
+{
     struct radFormFactor
     {
       /** Form Factor for an incoherent charge distribution:
@@ -185,11 +186,11 @@ namespace picongpu
 
       }
     };
-  } // radFormFactor_incoherent
+} // namespace radFormFactor_incoherent
 
 
-  namespace radFormFactor_coherent
-  {
+namespace radFormFactor_coherent
+{
     struct radFormFactor
     {
       /** Form Factor for a coherent charge distribution:
@@ -204,6 +205,8 @@ namespace picongpu
         return N;
       }
     };
-  } // radFormFactor_coherent
+} // namespace radFormFactor_coherent
 
-}
+} // namespace radiation
+
+} // namespace picongpu

--- a/include/picongpu/plugins/radiation/taylor.hpp
+++ b/include/picongpu/plugins/radiation/taylor.hpp
@@ -23,6 +23,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 struct Taylor
@@ -40,4 +42,5 @@ struct Taylor
 };
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/taylor.hpp
+++ b/include/picongpu/plugins/radiation/taylor.hpp
@@ -23,6 +23,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 struct Taylor
 {
     // a Taylor development for 1-sqrt(1-x)
@@ -37,4 +39,5 @@ struct Taylor
 
 };
 
+} // namespace radiation
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/utilities.hpp
+++ b/include/picongpu/plugins/radiation/utilities.hpp
@@ -21,6 +21,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
 namespace util
 {
@@ -108,5 +110,7 @@ namespace details
   }
 
 } // namespace util
+
+} // namespace radiation
 
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/utilities.hpp
+++ b/include/picongpu/plugins/radiation/utilities.hpp
@@ -21,6 +21,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -112,5 +114,7 @@ namespace details
 } // namespace util
 
 } // namespace radiation
+
+} // namespace plugins
 
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -25,6 +25,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -170,12 +172,13 @@ struct cuda_vec : public V
 };
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu
 
 // print
 
 template<typename V, typename T>
-HINLINE std::ostream & operator <<(std::ostream & os, const picongpu::radiation::cuda_vec<V, T> & v)
+HINLINE std::ostream & operator <<(std::ostream & os, const picongpu::plugins::radiation::cuda_vec<V, T> & v)
 {
     os << " ( " << v.x() << " , " << v.y() << " , " << v.z() << " ) ";
     return os;

--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -25,6 +25,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
 template<typename V, typename T>
 struct cuda_vec : public V
@@ -167,12 +169,13 @@ struct cuda_vec : public V
 
 };
 
+} // namespace radiation
 } // namespace picongpu
 
 // print
 
 template<typename V, typename T>
-HINLINE std::ostream & operator <<(std::ostream & os, const picongpu::cuda_vec<V, T> & v)
+HINLINE std::ostream & operator <<(std::ostream & os, const picongpu::radiation::cuda_vec<V, T> & v)
 {
     os << " ( " << v.x() << " , " << v.y() << " , " << v.z() << " ) ";
     return os;

--- a/include/picongpu/plugins/radiation/windowFunctions.hpp
+++ b/include/picongpu/plugins/radiation/windowFunctions.hpp
@@ -25,12 +25,14 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 
   /* several window functions behind namespaces: */
 
 
-  namespace radWindowFunctionTriangle
-  {
+namespace radWindowFunctionTriangle
+{
     struct radWindowFunction
     {
       /** 1D Window function according to the triangle window:
@@ -54,12 +56,12 @@ namespace picongpu
           * (float_X(1.0) - float_X(2.0)/L_x * math::abs(x) );
       }
     };
-  } /* namespace radWindowFunctionTriangle */
+} // namespace radWindowFunctionTriangle
 
 
 
-  namespace radWindowFunctionHamming
-  {
+namespace radWindowFunctionHamming
+{
     struct radWindowFunction
     {
       /** 1D Window function according to the Hamming window:
@@ -85,12 +87,12 @@ namespace picongpu
           * (a + (float_X(1.0)-a)*cosinusValue*cosinusValue);
       }
     };
-  } /* namespace radWindowFunctionHamming */
+} // namespace radWindowFunctionHamming
 
 
 
-  namespace radWindowFunctionTriplett
-  {
+namespace radWindowFunctionTriplett
+{
     struct radWindowFunction
     {
       /** 1D Window function according to the Triplett window:
@@ -116,12 +118,12 @@ namespace picongpu
           * (math::exp(float_X(-1.0)*lambda*math::abs(x))*cosinusValue*cosinusValue);
       }
     };
-  } /* namespace radWindowFunctionTriplett */
+} // namespace radWindowFunctionTriplett
 
 
 
-  namespace radWindowFunctionGauss
-  {
+namespace radWindowFunctionGauss
+{
     struct radWindowFunction
     {
       /** 1D Window function according to the Gauss window:
@@ -147,11 +149,11 @@ namespace picongpu
           * (math::exp(float_X(-0.5)*relativePosition*relativePosition));
       }
     };
-  } /* namespace radWindowFunctionGauss */
+} // namespace radWindowFunctionGauss
 
 
-  namespace radWindowFunctionNone
-  {
+namespace radWindowFunctionNone
+{
     struct radWindowFunction
     {
       /** 1D Window function according to the no window:
@@ -169,8 +171,9 @@ namespace picongpu
         return float_X(1.0);
       }
     };
-  } /* namespace radWindowFunctionRectangle */
+} // namespace radWindowFunctionNone
 
 
-}  /* namespace picongpu */
+} // namespace radiation
+} // namespace picongpu
 

--- a/include/picongpu/plugins/radiation/windowFunctions.hpp
+++ b/include/picongpu/plugins/radiation/windowFunctions.hpp
@@ -25,6 +25,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 
@@ -175,5 +177,6 @@ namespace radWindowFunctionNone
 
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu
 

--- a/include/picongpu/unitless/radiation.unitless
+++ b/include/picongpu/unitless/radiation.unitless
@@ -22,43 +22,44 @@
 #include <pmacc/static_assert.hpp>
 
 
-PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_below_one, ( picongpu::radiationNyquist::NyquistFactor < 1.0 ) );
-PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_larger_than_zero, ( picongpu::radiationNyquist::NyquistFactor > 0.0 ) );
+PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_below_one, ( picongpu::radiation::radiationNyquist::NyquistFactor < 1.0 ) );
+PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_larger_than_zero, ( picongpu::radiation::radiationNyquist::NyquistFactor > 0.0 ) );
 namespace picongpu
 {
-  namespace rad_linear_frequencies
-  {
+namespace radiation
+{
+namespace rad_linear_frequencies
+{
     constexpr float_X omega_min = SI::omega_min*UNIT_TIME;
     constexpr float_X omega_max = SI::omega_max*UNIT_TIME;
     constexpr float_X delta_omega = (float_X) ((omega_max - omega_min) / (float_X) (N_omega - 1)); // difference beween two omega
 
     constexpr unsigned int blocksize_omega = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
-  }
+} // namespace rad_linear_frequencies
 
-  namespace rad_log_frequencies
-  {
+namespace rad_log_frequencies
+{
     constexpr float_X omega_min = (SI::omega_min*UNIT_TIME);
     constexpr float_X omega_max = (SI::omega_max*UNIT_TIME);
 
     constexpr unsigned int blocksize_omega = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
-  }
+} // namespace rad_log_frequencies
 
-  namespace rad_frequencies_from_list
-  {
+namespace rad_frequencies_from_list
+{
     constexpr unsigned int blocksize_omega = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
-  }
+} // namespace rad_frequencies_from_list
 
 namespace parameters
 {
-
     constexpr unsigned int gridsize_theta = N_observer; // size of grid /dim: y); radiation
+} // namespace parameters
 
-}
-
-} //namespace picongpu
+} // namespace radiation
+} // namespace picongpu
 
 #include "picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp"
 #include "picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp"

--- a/include/picongpu/unitless/radiation.unitless
+++ b/include/picongpu/unitless/radiation.unitless
@@ -22,9 +22,11 @@
 #include <pmacc/static_assert.hpp>
 
 
-PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_below_one, ( picongpu::radiation::radiationNyquist::NyquistFactor < 1.0 ) );
-PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_larger_than_zero, ( picongpu::radiation::radiationNyquist::NyquistFactor > 0.0 ) );
+PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_below_one, ( picongpu::plugins::radiation::radiationNyquist::NyquistFactor < 1.0 ) );
+PMACC_CASSERT_MSG( The_Nyquist_limit_needs_to_be_larger_than_zero, ( picongpu::plugins::radiation::radiationNyquist::NyquistFactor > 0.0 ) );
 namespace picongpu
+{
+namespace plugins
 {
 namespace radiation
 {
@@ -59,6 +61,7 @@ namespace parameters
 } // namespace parameters
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu
 
 #include "picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp"

--- a/include/picongpu/unitless/radiation.unitless
+++ b/include/picongpu/unitless/radiation.unitless
@@ -28,7 +28,7 @@ namespace picongpu
 {
 namespace radiation
 {
-namespace rad_linear_frequencies
+namespace linear_frequencies
 {
     constexpr float_X omega_min = SI::omega_min*UNIT_TIME;
     constexpr float_X omega_max = SI::omega_max*UNIT_TIME;
@@ -36,22 +36,22 @@ namespace rad_linear_frequencies
 
     constexpr unsigned int blocksize_omega = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
-} // namespace rad_linear_frequencies
+} // namespace linear_frequencies
 
-namespace rad_log_frequencies
+namespace log_frequencies
 {
     constexpr float_X omega_min = (SI::omega_min*UNIT_TIME);
     constexpr float_X omega_max = (SI::omega_max*UNIT_TIME);
 
     constexpr unsigned int blocksize_omega = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
-} // namespace rad_log_frequencies
+} // namespace log_frequencies
 
-namespace rad_frequencies_from_list
+namespace frequencies_from_list
 {
     constexpr unsigned int blocksize_omega = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
     constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
-} // namespace rad_frequencies_from_list
+} // namespace frequencies_from_list
 
 namespace parameters
 {

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -36,6 +36,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 namespace rad_linear_frequencies
 {
 namespace SI
@@ -114,41 +116,39 @@ constexpr unsigned int N_observer = 128; // number of looking directions
 
 } /* end namespace parameters */
 
-namespace radiation
-{
-    /** activate particles for radiation */
-    struct GammaFilterFunctor
-    {
-        static constexpr float_X radiationGamma = 3.0;
+  /** activate particles for radiation */
+  struct GammaFilterFunctor
+  {
+      static constexpr float_X radiationGamma = 3.0;
 
-        template< typename T_Particle >
-        HDINLINE void operator()( T_Particle& particle )
-        {
-            if(
-                picongpu::gamma<float_X>(
-                    particle[ picongpu::momentum_ ],
-                    picongpu::traits::attribute::getMass(
-                        particle[ picongpu::weighting_ ],
-                        particle
-                    )
-                ) >= radiationGamma
-            )
-                particle[ picongpu::radiationMask_ ] = true;
-        }
-    };
+      template< typename T_Particle >
+      HDINLINE void operator()( T_Particle& particle )
+      {
+          if(
+             picongpu::gamma<float_X>(
+                                      particle[ picongpu::momentum_ ],
+                                      picongpu::traits::attribute::getMass(
+                                                                           particle[ picongpu::weighting_ ],
+                                                                           particle
+                                                                           )
+                                      ) >= radiationGamma
+             )
+            particle[ picongpu::radiationMask_ ] = true;
+      }
+  };
 
 
-    /* filter to enable radiation for electrons
-     *
-     * to enable the filter:
-     *   - goto file `speciesDefinition.param`
-     *   - add the attribute `radiationMask` to the electron species
-     */
-    using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<
-        GammaFilterFunctor
+  /* filter to enable radiation for electrons
+   *
+   * to enable the filter:
+   *   - goto file `speciesDefinition.param`
+   *   - add the attribute `radiationMask` to the electron species
+   */
+  using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<
+    GammaFilterFunctor
     >;
 
-} // namespace radiation
+
 
 // add a window function weighting to the radiation in order
 // to avoid ringing effects from sharpe boundaries
@@ -173,5 +173,5 @@ namespace radiation
 
   namespace radWindowFunction = PARAM_RADWINDOW;
 
-
-}//namespace picongpu
+} // namespace radiation
+} // namespace picongpu

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -38,7 +38,7 @@ namespace picongpu
 {
 namespace radiation
 {
-namespace rad_linear_frequencies
+namespace linear_frequencies
 {
 namespace SI
 {
@@ -49,7 +49,7 @@ constexpr float_64 omega_max = 5.8869e17;
 constexpr unsigned int N_omega = 1024; // number of frequencies
 }
 
-namespace rad_log_frequencies
+namespace log_frequencies
 {
 namespace SI
 {
@@ -61,14 +61,14 @@ constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
-namespace rad_frequencies_from_list
+namespace frequencies_from_list
 {
 //const char listLocation[] = "/scratch/s5960712/list001.freq";
 constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
-namespace radiation_frequencies = rad_linear_frequencies;
+namespace radiation_frequencies = linear_frequencies;
 
 
 namespace radiationNyquist

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -36,6 +36,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace linear_frequencies
@@ -174,4 +176,5 @@ constexpr unsigned int N_observer = 128; // number of looking directions
   namespace radWindowFunction = PARAM_RADWINDOW;
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
@@ -22,8 +22,10 @@
 
 namespace picongpu
 {
-  namespace radiation_observer
-  {
+namespace radiation
+{
+namespace radiation_observer
+{
     /** Compute observation angles
      *
      * This function is used in the Radiation plug-in kernel to compute
@@ -71,5 +73,6 @@ namespace picongpu
 
     }
 
-  } // end namespace radiation_observer
-} // end namespace picongpu
+} // namespace radiation_observer
+} // namespace radiation
+} // namespace picongpu

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
@@ -22,6 +22,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace radiation_observer
@@ -75,4 +77,5 @@ namespace radiation_observer
 
 } // namespace radiation_observer
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -36,6 +36,8 @@
 
 namespace picongpu
 {
+namespace radiation
+{
 namespace rad_linear_frequencies
 {
 namespace SI
@@ -114,41 +116,39 @@ constexpr unsigned int N_observer = 256; // number of looking directions
 
 } /* end namespace parameters */
 
-namespace radiation
-{
-    /** activate particles for radiation */
-    struct GammaFilterFunctor
-    {
-        static constexpr float_X radiationGamma = 5.0;
+  /** activate particles for radiation */
+  struct GammaFilterFunctor
+  {
+      static constexpr float_X radiationGamma = 5.0;
 
-        template< typename T_Particle >
-        HDINLINE void operator()( T_Particle& particle )
-        {
-            if(
-                picongpu::gamma<float_X>(
-                    particle[ picongpu::momentum_ ],
-                    picongpu::traits::attribute::getMass(
-                        particle[ picongpu::weighting_ ],
-                        particle
-                    )
-                ) >= radiationGamma
-            )
-                particle[ picongpu::radiationMask_ ] = true;
-        }
-    };
+      template< typename T_Particle >
+      HDINLINE void operator()( T_Particle& particle )
+      {
+          if(
+             picongpu::gamma<float_X>(
+                                      particle[ picongpu::momentum_ ],
+                                      picongpu::traits::attribute::getMass(
+                                                                           particle[ picongpu::weighting_ ],
+                                                                           particle
+                                                                           )
+                                      ) >= radiationGamma
+             )
+            particle[ picongpu::radiationMask_ ] = true;
+      }
+  };
 
 
-    /* filter to enable radiation for electrons
-     *
-     * to enable the filter:
-     *   - goto file `speciesDefinition.param`
-     *   - add the attribute `radiationMask` to the electron species
-     */
-    using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<
-        GammaFilterFunctor
-    >;
+  /* filter to enable radiation for electrons
+   *
+   * to enable the filter:
+   *   - goto file `speciesDefinition.param`
+   *   - add the attribute `radiationMask` to the electron species
+   */
+  using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<
+      GammaFilterFunctor
+      >;
 
-} // namespace radiation
+
 
 //////////////////////////////////////////////////
 
@@ -172,5 +172,5 @@ namespace radWindowFunctionNone { }
 
 namespace radWindowFunction = radWindowFunctionTriangle;
 
-
-}//namespace picongpu
+} // namespace radiation
+} // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -38,7 +38,7 @@ namespace picongpu
 {
 namespace radiation
 {
-namespace rad_linear_frequencies
+namespace linear_frequencies
 {
 namespace SI
 {
@@ -49,7 +49,7 @@ constexpr float_64 omega_max = 1.06e16;
 constexpr unsigned int N_omega = 1024; // number of frequencies
 }
 
-namespace rad_log_frequencies
+namespace log_frequencies
 {
 namespace SI
 {
@@ -64,14 +64,14 @@ constexpr unsigned int N_omega = 1024; // number of frequencies
 }
 
 
-namespace rad_frequencies_from_list
+namespace frequencies_from_list
 {
 //const char listLocation[] = "/scratch/s5960712/list001.freq";
 constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 
 
-namespace radiation_frequencies = rad_log_frequencies;
+namespace radiation_frequencies = log_frequencies;
 
 
 namespace radiationNyquist

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -36,6 +36,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace linear_frequencies
@@ -173,4 +175,5 @@ namespace radWindowFunctionNone { }
 namespace radWindowFunction = radWindowFunctionTriangle;
 
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
@@ -22,6 +22,8 @@
 
 namespace picongpu
 {
+namespace plugins
+{
 namespace radiation
 {
 namespace radiation_observer
@@ -79,4 +81,5 @@ namespace radiation_observer
 
 } // namespace radiation_observer
 } // namespace radiation
+} // namespace plugins
 } // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
@@ -22,8 +22,10 @@
 
 namespace picongpu
 {
-  namespace radiation_observer
-  {
+namespace radiation
+{
+namespace radiation_observer
+{
     /** Compute observation angles
      *
      * This function is used in the Radiation plug-in kernel to compute
@@ -75,5 +77,6 @@ namespace picongpu
 
     }
 
-  } // end namespace radiation_observer
-} // end namespace picongpu
+} // namespace radiation_observer
+} // namespace radiation
+} // namespace picongpu


### PR DESCRIPTION
This pull request closes #1643. 

It surrounds the code related to the radiation plugin with the namespace `radiation`. 
