### PR TITLE
Refactor and modernize implementation of fields

### DIFF
--- a/include/picongpu/fields/EMFieldBase.hpp
+++ b/include/picongpu/fields/EMFieldBase.hpp
@@ -1,0 +1,136 @@
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/simulation_types.hpp"
+#include "picongpu/fields/Fields.def"
+
+#include <pmacc/fields/SimulationFieldHelper.hpp>
+#include <pmacc/dataManagement/ISimulationData.hpp>
+#include <pmacc/memory/buffers/GridBuffer.hpp>
+#include <pmacc/mappings/simulation/GridController.hpp>
+#include <pmacc/memory/boxes/DataBox.hpp>
+#include <pmacc/memory/boxes/PitchedBox.hpp>
+#include <pmacc/math/Vector.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include <type_traits>
+
+
+namespace picongpu
+{
+namespace fields
+{
+
+    /** Base class for implementation inheritance in classes for the
+     *  electromagnetic fields
+     *
+     * Stores field values on host and device and provides data synchronization
+     * between them.
+     *
+     * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
+     * ISimulationData.
+     */
+    class EMFieldBase :
+        public SimulationFieldHelper< MappingDesc >,
+        public ISimulationData
+    {
+    public:
+
+        //! Type of each field value
+        using ValueType = float3_X;
+
+        //! Number of components of ValueType, for serialization
+        static constexpr int numComponents = ValueType::dim;
+
+        //! Type of host-device buffer for field values
+        using Buffer = pmacc::GridBuffer< ValueType, simDim >;
+
+        //! Type of data box for field values on host and device
+        using DataBoxType = pmacc::DataBox< PitchedBox< ValueType, simDim > >;
+
+        //! Size of supercell
+        using SuperCellSize = MappingDesc::SuperCellSize;
+
+        /** Create a field
+         *
+         * @tparam T_tag communication tag value
+         *
+         * @param cellDescription mapping for kernels
+         * @param id unique id
+         * @param tag helper parameter for T_tag deduction
+         */
+        template< CommunicationTag T_tag >
+        HINLINE EMFieldBase(
+            MappingDesc const & cellDescription,
+            pmacc::SimulationDataId const & id,
+            std::integral_constant< CommunicationTag, T_tag > tag
+        );
+
+        //! Get a reference to the host-device buffer for the field values
+        HINLINE Buffer & getGridBuffer( );
+
+        //! Get the grid layout
+        HINLINE GridLayout< simDim > getGridLayout( );
+
+        //! Get the host data box for the field values
+        HINLINE DataBoxType getHostDataBox( );
+
+        //! Get the device data box for the field values
+        HINLINE DataBoxType getDeviceDataBox( );
+
+        /** Start asynchronous communication of field values
+         *
+         * @param serialEvent event to depend on
+         */
+        HINLINE EventTask asyncCommunication( EventTask serialEvent );
+
+        /** Reset the host-device buffer for field values
+         *
+         * @param currentStep index of time iteration
+         */
+        HINLINE void reset( uint32_t currentStep ) override;
+
+        //! Synchronize device data with host data
+        HINLINE void syncToDevice( ) override;
+
+        //! Synchronize host data with device data
+        HINLINE void synchronize( ) override;
+
+        //! Get id
+        HINLINE SimulationDataId getUniqueId( ) override;
+
+    private:
+
+        //! Host-device buffer for field values
+        std::unique_ptr< Buffer > buffer;
+
+        //! Unique id
+        pmacc::SimulationDataId id;
+
+    };
+
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/EMFieldBase.tpp
+++ b/include/picongpu/fields/EMFieldBase.tpp
@@ -1,0 +1,180 @@
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/EMFieldBase.hpp"
+#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
+#include "picongpu/particles/traits/GetInterpolation.hpp"
+#include "picongpu/traits/GetMargin.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
+#include "picongpu/particles/traits/GetMarginPusher.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/dimensions/SuperCellDescription.hpp>
+#include <pmacc/eventSystem/EventSystem.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/mappings/kernel/ExchangeMapping.hpp>
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/memory/buffers/GridBuffer.hpp>
+#include <pmacc/memory/MakeUnique.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+#include <boost/mpl/accumulate.hpp>
+
+#include <memory>
+#include <type_traits>
+
+
+namespace picongpu
+{
+namespace fields
+{
+
+    template< CommunicationTag T_tag >
+    EMFieldBase::EMFieldBase(
+        MappingDesc const & cellDescription,
+        pmacc::SimulationDataId const & id,
+        std::integral_constant< CommunicationTag, T_tag >
+    ) :
+        SimulationFieldHelper< MappingDesc >( cellDescription ),
+        id( id )
+    {
+        buffer = pmacc::memory::makeUnique< Buffer >(
+            cellDescription.getGridLayout( )
+        );
+
+        using VectorSpeciesWithInterpolation = typename pmacc::particles::traits::FilterByFlag
+        <
+            VectorAllSpecies,
+            interpolation<>
+        >::type;
+        using LowerMarginInterpolation = bmpl::accumulate<
+            VectorSpeciesWithInterpolation,
+            typename pmacc::math::CT::make_Int<simDim, 0>::type,
+            pmacc::math::CT::max<bmpl::_1, GetLowerMargin< GetInterpolation<bmpl::_2> > >
+        >::type;
+        using UpperMarginInterpolation = bmpl::accumulate<
+            VectorSpeciesWithInterpolation,
+            typename pmacc::math::CT::make_Int<simDim, 0>::type,
+            pmacc::math::CT::max<bmpl::_1, GetUpperMargin< GetInterpolation<bmpl::_2> > >
+        >::type;
+
+        /* Calculate the maximum Neighbors we need from MAX(ParticleShape, FieldSolver) */
+        using LowerMarginSolver = typename GetMargin<fields::Solver, T_tag >::LowerMargin;
+        using LowerMarginInterpolationAndSolver = typename pmacc::math::CT::max<
+            LowerMarginInterpolation,
+            LowerMarginSolver
+        >::type;
+        using UpperMarginSolver = typename GetMargin<fields::Solver, T_tag >::UpperMargin;
+        using UpperMarginInterpolationAndSolver = typename pmacc::math::CT::max<
+            UpperMarginInterpolation,
+            UpperMarginSolver
+        >::type;
+
+        /* Calculate upper and lower margin for pusher
+           (currently all pusher use the interpolation of the species)
+           and find maximum margin
+        */
+        using VectorSpeciesWithPusherAndInterpolation = typename pmacc::particles::traits::FilterByFlag
+        <
+            VectorSpeciesWithInterpolation,
+            particlePusher<>
+        >::type;
+        using LowerMargin = typename bmpl::accumulate<
+            VectorSpeciesWithPusherAndInterpolation,
+            LowerMarginInterpolationAndSolver,
+            pmacc::math::CT::max<bmpl::_1, GetLowerMarginPusher<bmpl::_2> >
+        >::type;
+
+        using UpperMargin = typename bmpl::accumulate<
+            VectorSpeciesWithPusherAndInterpolation,
+            UpperMarginInterpolationAndSolver,
+            pmacc::math::CT::max<bmpl::_1, GetUpperMarginPusher<bmpl::_2> >
+        >::type;
+
+        const DataSpace< simDim > originGuard( LowerMargin( ).toRT( ) );
+        const DataSpace< simDim > endGuard( UpperMargin( ).toRT( ) );
+
+        /*go over all directions*/
+        for ( uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i )
+        {
+            DataSpace<simDim> relativeMask = Mask::getRelativeDirections<simDim > ( i );
+            /* guarding cells depend on direction
+             * for negative direction use originGuard else endGuard (relative direction ZERO is ignored)
+             * don't switch end and origin because this is a read buffer and no send buffer
+             */
+            DataSpace<simDim> guardingCells;
+            for ( uint32_t d = 0; d < simDim; ++d )
+                guardingCells[d] = ( relativeMask[d] == -1 ? originGuard[d] : endGuard[d] );
+            buffer->addExchange( GUARD, i, guardingCells, T_tag );
+        }
+    }
+
+    EMFieldBase::Buffer & EMFieldBase::getGridBuffer( )
+    {
+        return *buffer;
+    }
+
+    GridLayout< simDim > EMFieldBase::getGridLayout( )
+    {
+        return cellDescription.getGridLayout( );
+    }
+
+    EMFieldBase::DataBoxType EMFieldBase::getHostDataBox( )
+    {
+        return buffer->getHostBuffer( ).getDataBox( );
+    }
+
+    EMFieldBase::DataBoxType EMFieldBase::getDeviceDataBox( )
+    {
+        return buffer->getDeviceBuffer( ).getDataBox( );
+    }
+
+    EventTask EMFieldBase::asyncCommunication( EventTask serialEvent )
+    {
+        EventTask eB = buffer->asyncCommunication( serialEvent );
+        return eB;
+    }
+
+    void EMFieldBase::reset( uint32_t )
+    {
+        buffer->getHostBuffer( ).reset( true );
+        buffer->getDeviceBuffer( ).reset( false );
+    }
+
+    void EMFieldBase::syncToDevice( )
+    {
+        buffer->hostToDevice( );
+    }
+
+    void EMFieldBase::synchronize( )
+    {
+        buffer->deviceToHost( );
+    }
+
+    pmacc::SimulationDataId EMFieldBase::getUniqueId( )
+    {
+        return id;
+    }
+
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/FieldB.hpp
+++ b/include/picongpu/fields/FieldB.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -18,84 +18,57 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/Fields.def"
+#include "picongpu/fields/EMFieldBase.hpp"
+
+#include <pmacc/algorithms/PromoteType.hpp>
 
 #include <string>
 #include <vector>
 
-/*pic default*/
-#include "picongpu/simulation_defines.hpp"
-
-#include "picongpu/fields/Fields.def"
-#include <pmacc/fields/SimulationFieldHelper.hpp>
-#include <pmacc/dataManagement/ISimulationData.hpp>
-
-/*PMacc*/
-#include <pmacc/memory/buffers/GridBuffer.hpp>
-#include <pmacc/mappings/simulation/GridController.hpp>
-#include <pmacc/memory/boxes/DataBox.hpp>
-#include <pmacc/memory/boxes/PitchedBox.hpp>
-
-#include <pmacc/math/Vector.hpp>
-
 
 namespace picongpu
 {
-    using namespace pmacc;
 
-    class FieldB : public SimulationFieldHelper<MappingDesc>, public ISimulationData
+    /** Representation of the magnetic field
+     *
+     * Stores field values on host and device and provides data synchronization
+     * between them.
+     *
+     * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
+     * ISimulationData.
+     */
+    class FieldB : public fields::EMFieldBase
     {
     public:
-        typedef float3_X ValueType;
-        typedef promoteType<float_64, ValueType>::type UnitValueType;
-        static constexpr int numComponents = ValueType::dim;
 
-        typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
-
-        typedef MappingDesc::SuperCellSize SuperCellSize;
-
-        FieldB( MappingDesc cellDescription);
-
-        virtual ~FieldB();
-
-        virtual void reset(uint32_t currentStep);
-
-        HDINLINE static UnitValueType getUnit();
-
-        /** powers of the 7 base measures
+        /** Create a field
          *
-         * characterizing the record's unit in SI
+         * @param cellDescription mapping for kernels
+         */
+        HINLINE FieldB( MappingDesc const & cellDescription );
+
+        //! Unit type of field components
+        using UnitValueType = promoteType< float_64, ValueType >::type;
+
+        //! Get units of field components
+        HDINLINE static UnitValueType getUnit( );
+
+        /** Get unit representation as powers of the 7 base measures
+         *
+         * Characterizing the record's unit in SI
          * (length L, mass M, time T, electric current I,
          *  thermodynamic temperature theta, amount of substance N,
-         *  luminous intensity J) */
-        HINLINE static std::vector<float_64> getUnitDimension();
+         *  luminous intensity J)
+         */
+        HINLINE static std::vector< float_64 > getUnitDimension( );
 
-        static std::string getName();
+        //! Get text name
+        HINLINE static std::string getName( );
 
-        virtual EventTask asyncCommunication(EventTask serialEvent);
-
-        DataBoxType getHostDataBox();
-
-        GridLayout<simDim> getGridLayout();
-
-        DataBoxType getDeviceDataBox();
-
-        GridBuffer<ValueType, simDim> &getGridBuffer();
-
-        SimulationDataId getUniqueId();
-
-        void synchronize();
-
-        void syncToDevice();
-
-    private:
-
-        void absorbeBorder();
-
-        GridBuffer<ValueType, simDim> *fieldB;
     };
 
-
-}
+} // namespace picongpu

--- a/include/picongpu/fields/FieldB.tpp
+++ b/include/picongpu/fields/FieldB.tpp
@@ -1,5 +1,5 @@
 /* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Richard Pausch, Benjamin Worpitz
+ *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -20,199 +20,48 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
-
 #include "picongpu/fields/FieldB.hpp"
-
-#include <pmacc/eventSystem/EventSystem.hpp>
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
-#include <pmacc/mappings/kernel/ExchangeMapping.hpp>
-#include <pmacc/memory/buffers/GridBuffer.hpp>
-#include <pmacc/dimensions/SuperCellDescription.hpp>
-
-#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
-
-#include <pmacc/math/Vector.hpp>
-
-#include "picongpu/particles/traits/GetInterpolation.hpp"
-#include <pmacc/particles/traits/FilterByFlag.hpp>
-
-#include "picongpu/traits/GetMargin.hpp"
+#include "picongpu/fields/EMFieldBase.hpp"
+#include "picongpu/simulation_types.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
-#include "picongpu/particles/traits/GetMarginPusher.hpp"
 
-#include <boost/mpl/accumulate.hpp>
-
-#include <list>
-#include <iostream>
-#include <memory>
+#include <string>
+#include <vector>
+#include <type_traits>
 
 
 namespace picongpu
 {
 
-using namespace pmacc;
-
-FieldB::FieldB( MappingDesc cellDescription ) :
-SimulationFieldHelper<MappingDesc>( cellDescription )
-{
-    /*#####create FieldB###############*/
-    fieldB = new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) );
-
-    typedef typename pmacc::particles::traits::FilterByFlag
-    <
-        VectorAllSpecies,
-        interpolation<>
-    >::type VectorSpeciesWithInterpolation;
-    typedef bmpl::accumulate<
-        VectorSpeciesWithInterpolation,
-        typename pmacc::math::CT::make_Int<simDim, 0>::type,
-        pmacc::math::CT::max<bmpl::_1, GetLowerMargin< GetInterpolation<bmpl::_2> > >
-        >::type LowerMarginInterpolation;
-
-    typedef bmpl::accumulate<
-        VectorSpeciesWithInterpolation,
-        typename pmacc::math::CT::make_Int<simDim, 0>::type,
-        pmacc::math::CT::max<bmpl::_1, GetUpperMargin< GetInterpolation<bmpl::_2> > >
-        >::type UpperMarginInterpolation;
-
-    /* Calculate the maximum Neighbors we need from MAX(ParticleShape, FieldSolver) */
-    typedef pmacc::math::CT::max<
-        LowerMarginInterpolation,
-        GetMargin<fields::Solver, FIELD_B>::LowerMargin
-        >::type LowerMarginInterpolationAndSolver;
-    typedef pmacc::math::CT::max<
-        UpperMarginInterpolation,
-        GetMargin<fields::Solver, FIELD_B>::UpperMargin
-        >::type UpperMarginInterpolationAndSolver;
-
-    /* Calculate upper and lower margin for pusher
-       (currently all pusher use the interpolation of the species)
-       and find maximum margin
-    */
-    typedef typename pmacc::particles::traits::FilterByFlag
-    <
-        VectorSpeciesWithInterpolation,
-        particlePusher<>
-    >::type VectorSpeciesWithPusherAndInterpolation;
-    typedef bmpl::accumulate<
-        VectorSpeciesWithPusherAndInterpolation,
-        LowerMarginInterpolationAndSolver,
-        pmacc::math::CT::max<bmpl::_1, GetLowerMarginPusher<bmpl::_2> >
-        >::type LowerMargin;
-
-    typedef bmpl::accumulate<
-        VectorSpeciesWithPusherAndInterpolation,
-        UpperMarginInterpolationAndSolver,
-        pmacc::math::CT::max<bmpl::_1, GetUpperMarginPusher<bmpl::_2> >
-        >::type UpperMargin;
-
-    const DataSpace<simDim> originGuard( LowerMargin( ).toRT( ) );
-    const DataSpace<simDim> endGuard( UpperMargin( ).toRT( ) );
-
-    /*go over all directions*/
-    for ( uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i )
+    FieldB::FieldB( MappingDesc const & cellDescription ) :
+        fields::EMFieldBase(
+            cellDescription,
+            getName( ),
+            std::integral_constant< CommunicationTag, FIELD_B >{ }
+        )
     {
-        DataSpace<simDim> relativMask = Mask::getRelativeDirections<simDim > ( i );
-        /* guarding cells depend on direction
-         * for negative direction use originGuard else endGuard (relative direction ZERO is ignored)
-         * don't switch end and origin because this is a read buffer and no send buffer
-         */
-        DataSpace<simDim> guardingCells;
-        for ( uint32_t d = 0; d < simDim; ++d )
-            guardingCells[d] = ( relativMask[d] == -1 ? originGuard[d] : endGuard[d] );
-        fieldB->addExchange( GUARD, i, guardingCells, FIELD_B );
     }
 
-}
+    FieldB::UnitValueType FieldB::getUnit( )
+    {
+        return UnitValueType{ UNIT_BFIELD, UNIT_BFIELD, UNIT_BFIELD };
+    }
 
-FieldB::~FieldB( )
-{
-    __delete(fieldB);
-}
+    std::vector< float_64 > FieldB::getUnitDimension( )
+    {
+        /* B is in Tesla : kg / (A * s^2)
+         *   -> M * T^-2 * I^-1
+         */
+        std::vector< float_64 > unitDimension{ 7, 0.0 };
+        unitDimension.at( SIBaseUnits::mass ) =  1.0;
+        unitDimension.at( SIBaseUnits::time ) = -2.0;
+        unitDimension.at( SIBaseUnits::electricCurrent ) = -1.0;
+        return unitDimension;
+    }
 
-SimulationDataId FieldB::getUniqueId()
-{
-    return getName();
-}
-
-void FieldB::synchronize( )
-{
-    fieldB->deviceToHost( );
-}
-
-void FieldB::syncToDevice( )
-{
-
-    fieldB->hostToDevice( );
-}
-
-EventTask FieldB::asyncCommunication( EventTask serialEvent )
-{
-
-    EventTask eB = fieldB->asyncCommunication( serialEvent );
-    return eB;
-}
-
-GridLayout<simDim> FieldB::getGridLayout( )
-{
-
-    return cellDescription.getGridLayout( );
-}
-
-FieldB::DataBoxType FieldB::getHostDataBox( )
-{
-
-    return fieldB->getHostBuffer( ).getDataBox( );
-}
-
-FieldB::DataBoxType FieldB::getDeviceDataBox( )
-{
-
-    return fieldB->getDeviceBuffer( ).getDataBox( );
-}
-
-GridBuffer<FieldB::ValueType, simDim> &FieldB::getGridBuffer( )
-{
-
-    return *fieldB;
-}
-
-void FieldB::reset( uint32_t )
-{
-    fieldB->getHostBuffer( ).reset( true );
-    fieldB->getDeviceBuffer( ).reset( false );
-}
-
-HDINLINE
-FieldB::UnitValueType
-FieldB::getUnit( )
-{
-    return UnitValueType( UNIT_BFIELD, UNIT_BFIELD, UNIT_BFIELD );
-}
-
-HINLINE
-std::vector<float_64>
-FieldB::getUnitDimension( )
-{
-    /* L, M, T, I, theta, N, J
-     *
-     * B is in Tesla : kg / (A * s^2)
-     *   -> M * T^-2 * I^-1
-     */
-    std::vector<float_64> unitDimension( 7, 0.0 );
-    unitDimension.at(SIBaseUnits::mass) =  1.0;
-    unitDimension.at(SIBaseUnits::time) = -2.0;
-    unitDimension.at(SIBaseUnits::electricCurrent) = -1.0;
-
-    return unitDimension;
-}
-
-std::string
-FieldB::getName( )
-{
-    return "B";
-}
+    std::string FieldB::getName( )
+    {
+        return "B";
+    }
 
 } //namespace picongpu

--- a/include/picongpu/fields/FieldE.hpp
+++ b/include/picongpu/fields/FieldE.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -18,86 +18,57 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/Fields.def"
+#include "picongpu/fields/EMFieldBase.hpp"
+
+#include <pmacc/algorithms/PromoteType.hpp>
 
 #include <string>
 #include <vector>
 
-/*pic default*/
-#include <pmacc/types.hpp>
-#include "picongpu/simulation_defines.hpp"
-
-#include "picongpu/fields/Fields.def"
-#include <pmacc/fields/SimulationFieldHelper.hpp>
-#include <pmacc/dataManagement/ISimulationData.hpp>
-
-/*PMacc*/
-#include <pmacc/memory/buffers/GridBuffer.hpp>
-#include <pmacc/mappings/simulation/GridController.hpp>
-#include <pmacc/memory/boxes/DataBox.hpp>
-#include <pmacc/memory/boxes/PitchedBox.hpp>
-
-#include <pmacc/math/Vector.hpp>
-
 
 namespace picongpu
 {
-    using namespace pmacc;
 
-    class FieldE: public SimulationFieldHelper<MappingDesc>, public ISimulationData
+    /** Representation of the electric field
+     *
+     * Stores field values on host and device and provides data synchronization
+     * between them.
+     *
+     * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
+     * ISimulationData.
+     */
+    class FieldE : public fields::EMFieldBase
     {
     public:
-        typedef float3_X ValueType;
-        typedef promoteType<float_64, ValueType>::type UnitValueType;
-        static constexpr int numComponents = ValueType::dim;
 
-        typedef MappingDesc::SuperCellSize SuperCellSize;
-
-        typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
-
-
-        FieldE(MappingDesc cellDescription);
-
-        virtual ~FieldE();
-
-        virtual void reset(uint32_t currentStep);
-
-        HDINLINE static UnitValueType getUnit();
-
-        /** powers of the 7 base measures
+        /** Create a field
          *
-         * characterizing the record's unit in SI
+         * @param cellDescription mapping for kernels
+         */
+        HINLINE FieldE( MappingDesc const & cellDescription );
+
+        //! Unit type of field components
+        using UnitValueType = promoteType< float_64, ValueType >::type;
+
+        //! Get units of field components
+        HDINLINE static UnitValueType getUnit( );
+
+        /** Get unit representation as powers of the 7 base measures
+         *
+         * Characterizing the record's unit in SI
          * (length L, mass M, time T, electric current I,
          *  thermodynamic temperature theta, amount of substance N,
-         *  luminous intensity J) */
-        HINLINE static std::vector<float_64> getUnitDimension();
+         *  luminous intensity J)
+         */
+        HINLINE static std::vector< float_64 > getUnitDimension( );
 
-        static std::string getName();
+        //! Get text name
+        HINLINE static std::string getName( );
 
-        virtual EventTask asyncCommunication(EventTask serialEvent);
-
-        DataBoxType getDeviceDataBox();
-
-        DataBoxType getHostDataBox();
-
-        GridBuffer<ValueType,simDim>& getGridBuffer();
-
-        GridLayout<simDim> getGridLayout();
-
-        SimulationDataId getUniqueId();
-
-        void synchronize();
-
-        void syncToDevice();
-
-    private:
-
-        void absorbeBorder();
-
-
-        GridBuffer<ValueType,simDim> *fieldE;
     };
-
 
 } // namespace picongpu

--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -1,5 +1,5 @@
 /* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Richard Pausch, Benjamin Worpitz
+ *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -20,188 +20,49 @@
 
 #pragma once
 
-#include <pmacc/memory/buffers/GridBuffer.hpp>
-#include <pmacc/mappings/simulation/GridController.hpp>
-
-#include <pmacc/dataManagement/DataConnector.hpp>
-
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
-#include <pmacc/eventSystem/EventSystem.hpp>
-#include <pmacc/mappings/kernel/ExchangeMapping.hpp>
-#include <pmacc/dimensions/SuperCellDescription.hpp>
-
-#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
-
-#include <pmacc/math/Vector.hpp>
-
-#include "picongpu/particles/traits/GetInterpolation.hpp"
-#include <pmacc/particles/traits/FilterByFlag.hpp>
-#include "picongpu/traits/GetMargin.hpp"
+#include "picongpu/fields/FieldE.hpp"
+#include "picongpu/fields/EMFieldBase.hpp"
+#include "picongpu/simulation_types.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
-#include "picongpu/particles/traits/GetMarginPusher.hpp"
 
-#include <boost/mpl/accumulate.hpp>
-
-#include <list>
-#include <memory>
+#include <string>
+#include <vector>
+#include <type_traits>
 
 
 namespace picongpu
 {
-using namespace pmacc;
 
-FieldE::FieldE( MappingDesc cellDescription ) :
-SimulationFieldHelper<MappingDesc>( cellDescription )
-{
-    fieldE = new GridBuffer<ValueType, simDim > ( cellDescription.getGridLayout( ) );
-    typedef typename pmacc::particles::traits::FilterByFlag
-    <
-        VectorAllSpecies,
-        interpolation<>
-    >::type VectorSpeciesWithInterpolation;
-
-    typedef bmpl::accumulate<
-        VectorSpeciesWithInterpolation,
-        typename pmacc::math::CT::make_Int<simDim, 0>::type,
-        pmacc::math::CT::max<bmpl::_1, GetLowerMargin< GetInterpolation<bmpl::_2> > >
-        >::type LowerMarginInterpolation;
-
-    typedef bmpl::accumulate<
-        VectorSpeciesWithInterpolation,
-        typename pmacc::math::CT::make_Int<simDim, 0>::type,
-        pmacc::math::CT::max<bmpl::_1, GetUpperMargin< GetInterpolation<bmpl::_2> > >
-        >::type UpperMarginInterpolation;
-
-    /* Calculate the maximum Neighbors we need from MAX(ParticleShape, FieldSolver) */
-    typedef pmacc::math::CT::max<
-        LowerMarginInterpolation,
-        GetMargin<fields::Solver, FIELD_E>::LowerMargin
-        >::type LowerMarginInterpolationAndSolver;
-    typedef pmacc::math::CT::max<
-        UpperMarginInterpolation,
-        GetMargin<fields::Solver, FIELD_E>::UpperMargin
-        >::type UpperMarginInterpolationAndSolver;
-
-    /* Calculate upper and lower margin for pusher
-       (currently all pusher use the interpolation of the species)
-       and find maximum margin
-    */
-    typedef typename pmacc::particles::traits::FilterByFlag
-    <
-        VectorSpeciesWithInterpolation,
-        particlePusher<>
-    >::type VectorSpeciesWithPusherAndInterpolation;
-    typedef bmpl::accumulate<
-        VectorSpeciesWithPusherAndInterpolation,
-        LowerMarginInterpolationAndSolver,
-        pmacc::math::CT::max<bmpl::_1, GetLowerMarginPusher<bmpl::_2> >
-        >::type LowerMargin;
-
-    typedef bmpl::accumulate<
-        VectorSpeciesWithPusherAndInterpolation,
-        UpperMarginInterpolationAndSolver,
-        pmacc::math::CT::max<bmpl::_1, GetUpperMarginPusher<bmpl::_2> >
-        >::type UpperMargin;
-
-    const DataSpace<simDim> originGuard( LowerMargin( ).toRT( ) );
-    const DataSpace<simDim> endGuard( UpperMargin( ).toRT( ) );
-
-    /*receive from all directions*/
-    for ( uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i )
+    FieldE::FieldE( MappingDesc const & cellDescription ) :
+        fields::EMFieldBase(
+            cellDescription,
+            getName( ),
+            std::integral_constant< CommunicationTag, FIELD_E >{ }
+        )
     {
-        DataSpace<simDim> relativMask = Mask::getRelativeDirections<simDim > ( i );
-        /*guarding cells depend on direction
-         * for negativ direction use originGuard else endGuard (relativ direction ZERO is ignored)
-         * don't switch end and origin because this is a readbuffer and no sendbuffer
-         */
-        DataSpace<simDim> guardingCells;
-        for ( uint32_t d = 0; d < simDim; ++d )
-            guardingCells[d] = ( relativMask[d] == -1 ? originGuard[d] : endGuard[d] );
-        fieldE->addExchange( GUARD, i, guardingCells, FIELD_E );
     }
-}
 
-FieldE::~FieldE( )
-{
-    __delete(fieldE);
-}
+    FieldE::UnitValueType FieldE::getUnit( )
+    {
+        return UnitValueType{ UNIT_EFIELD, UNIT_EFIELD, UNIT_EFIELD };
+    }
 
-SimulationDataId FieldE::getUniqueId()
-{
-    return getName();
-}
+    std::vector< float_64 > FieldE::getUnitDimension( )
+    {
+        /* E is in volts per meters: V / m = kg * m / (A * s^3)
+         *   -> L * M * T^-3 * I^-1
+         */
+        std::vector< float_64 > unitDimension{ 7, 0.0 };
+        unitDimension.at( SIBaseUnits::length ) =  1.0;
+        unitDimension.at( SIBaseUnits::mass )   =  1.0;
+        unitDimension.at( SIBaseUnits::time )   = -3.0;
+        unitDimension.at( SIBaseUnits::electricCurrent ) = -1.0;
+        return unitDimension;
+    }
 
-void FieldE::synchronize( )
-{
-    fieldE->deviceToHost( );
-}
+    std::string FieldE::getName( )
+    {
+        return "E";
+    }
 
-void FieldE::syncToDevice( )
-{
-    fieldE->hostToDevice( );
-}
-
-EventTask FieldE::asyncCommunication( EventTask serialEvent )
-{
-    return fieldE->asyncCommunication( serialEvent );
-}
-
-FieldE::DataBoxType FieldE::getDeviceDataBox( )
-{
-    return fieldE->getDeviceBuffer( ).getDataBox( );
-}
-
-FieldE::DataBoxType FieldE::getHostDataBox( )
-{
-    return fieldE->getHostBuffer( ).getDataBox( );
-}
-
-GridBuffer<FieldE::ValueType, simDim> &FieldE::getGridBuffer( )
-{
-    return *fieldE;
-}
-
-GridLayout< simDim> FieldE::getGridLayout( )
-{
-    return cellDescription.getGridLayout( );
-}
-
-void FieldE::reset( uint32_t )
-{
-    fieldE->getHostBuffer( ).reset( true );
-    fieldE->getDeviceBuffer( ).reset( false );
-}
-
-
-HDINLINE
-FieldE::UnitValueType
-FieldE::getUnit( )
-{
-    return UnitValueType( UNIT_EFIELD, UNIT_EFIELD, UNIT_EFIELD );
-}
-
-HINLINE
-std::vector<float_64>
-FieldE::getUnitDimension( )
-{
-    /* L, M, T, I, theta, N, J
-     *
-     * E is in volts per meters: V / m = kg * m / (A * s^3)
-     *   -> L * M * T^-3 * I^-1
-     */
-    std::vector<float_64> unitDimension( 7, 0.0 );
-    unitDimension.at(SIBaseUnits::length) =  1.0;
-    unitDimension.at(SIBaseUnits::mass)   =  1.0;
-    unitDimension.at(SIBaseUnits::time)   = -3.0;
-    unitDimension.at(SIBaseUnits::electricCurrent) = -1.0;
-
-    return unitDimension;
-}
-
-std::string
-FieldE::getName( )
-{
-    return "E";
-}
-
-}
+} // namespace picongpu

--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -164,10 +164,15 @@ namespace picongpu
         /** Bash field in a direction.
          *
          * Copy all particles from the guard of a direction to the device exchange buffer
+         *
+         * @param exchangeType exchange type
          */
         HINLINE void bashField(uint32_t exchangeType);
 
-        //! Insert all fields which are in device exchange buffer
+        /** Insert all fields which are in device exchange buffer
+         *
+         * @param exchangeType exchange type
+         */
         HINLINE void insertField(uint32_t exchangeType);
 
     private:

--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -21,127 +21,163 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-
-/*pic default*/
-#include <pmacc/types.hpp>
-#include "picongpu/simulation_defines.hpp"
-
 #include "picongpu/fields/Fields.def"
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/types.hpp>
 #include <pmacc/fields/SimulationFieldHelper.hpp>
 #include <pmacc/dataManagement/ISimulationData.hpp>
-
-/*PMacc*/
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/memory/boxes/PitchedBox.hpp>
-
 #include <pmacc/math/Vector.hpp>
-#include "picongpu/particles/Particles.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 
 namespace picongpu
 {
-using namespace pmacc;
 
-// The fieldJ saves the current density j
-//
-// j = current / area
-// To obtain the current which goes out of a cell in the 3 directions,
-// calculate J = float3_X( j.x() * cellSize.y() * cellSize.z(),
-//                            j.y() * cellSize.x() * cellSize.z(),
-//                            j.z() * cellSize.x() * cellSize.y())
-//
-
-class FieldJ : public SimulationFieldHelper<MappingDesc>, public ISimulationData
-{
-public:
-
-    typedef float3_X ValueType;
-    typedef promoteType<float_64, ValueType>::type UnitValueType;
-    static constexpr int numComponents = ValueType::dim;
-
-    typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
-
-    FieldJ(MappingDesc cellDescription);
-
-    virtual ~FieldJ();
-
-    virtual EventTask asyncCommunication(EventTask serialEvent);
-
-    GridLayout<simDim> getGridLayout();
-
-    void reset(uint32_t currentStep);
-
-    /** Assign a value to all cells
+    /** Representation of the current density field
      *
-     * Example usage:
-     * ```C++
-     *   FieldJ::ValueType zeroJ( FieldJ::ValueType::create(0.) );
-     *   fieldJ->assign( zeroJ );
-     * ```
+     * Stores field values on host and device and provides data synchronization
+     * between them.
      *
-     * \param value date to fill all cells with
+     * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
+     * ISimulationData.
      */
-    void assign(ValueType value);
-
-    HDINLINE static UnitValueType getUnit();
-
-    /** powers of the 7 base measures
-     *
-     * characterizing the record's unit in SI
-     * (length L, mass M, time T, electric current I,
-     *  thermodynamic temperature theta, amount of substance N,
-     *  luminous intensity J) */
-    HINLINE static std::vector<float_64> getUnitDimension();
-
-    static std::string getName();
-
-    template<uint32_t AREA, class ParticlesClass>
-    void computeCurrent(ParticlesClass &parClass, uint32_t currentStep);
-
-    template<uint32_t AREA, class T_CurrentInterpolation>
-    void addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation );
-
-    SimulationDataId getUniqueId();
-
-    void synchronize();
-
-    void syncToDevice()
+    class FieldJ : public SimulationFieldHelper<MappingDesc>, public ISimulationData
     {
-        ValueType tmp = float3_X(0., 0., 0.);
-        fieldJ.getDeviceBuffer().setValue(tmp);
-    }
+    public:
 
-    DataBoxType getDeviceDataBox()
-    {
-        return fieldJ.getDeviceBuffer().getDataBox();
-    }
+        //! Type of each field value
+        using ValueType = float3_X;
 
-    DataBoxType getHostDataBox()
-    {
-        return fieldJ.getHostBuffer().getDataBox();
-    }
+        //! Number of components of ValueType, for serialization
+        static constexpr int numComponents = ValueType::dim;
 
-    GridBuffer<ValueType, simDim> &getGridBuffer();
+        //! Unit type of field components
+        using UnitValueType = promoteType<float_64, ValueType>::type;
 
-    /* Bash particles in a direction.
-     * Copy all particles from the guard of a direction to the device exchange buffer
-     */
-    void bashField(uint32_t exchangeType);
+        //! Type of data box for field values on host and device
+        using DataBoxType = DataBox<PitchedBox<ValueType, simDim> >;
 
-    /* Insert all particles which are in device exchange buffer
-     */
-    void insertField(uint32_t exchangeType);
+        /** Create a field
+         *
+         * @param cellDescription mapping for kernels
+         */
+        HINLINE FieldJ(MappingDesc const & cellDescription);
 
-private:
+        //! Destroy a field
+        HINLINE virtual ~FieldJ() = default;
 
-    GridBuffer<ValueType, simDim> fieldJ;
-    GridBuffer<ValueType, simDim>* fieldJrecv;
+        //! Get a reference to the host-device buffer for the field values
+        HINLINE GridBuffer<ValueType, simDim> &getGridBuffer();
 
-    FieldE *fieldE;
-    FieldB *fieldB;
-};
+        //! Get the grid layout
+        HINLINE GridLayout<simDim> getGridLayout();
+
+        //! Get the host data box for the field values
+        DataBoxType getHostDataBox()
+        {
+            return buffer.getHostBuffer().getDataBox();
+        }
+
+        //! Get the device data box for the field values
+        DataBoxType getDeviceDataBox()
+        {
+            return buffer.getDeviceBuffer().getDataBox();
+        }
+
+        /** Start asynchronous communication of field values
+         *
+         * @param serialEvent event to depend on
+         */
+        HINLINE virtual EventTask asyncCommunication(EventTask serialEvent);
+
+        /** Reset the host-device buffer for field values
+         *
+         * @param currentStep index of time iteration
+         */
+        HINLINE void reset(uint32_t currentStep) override;
+
+        //! Synchronize device data with host data
+        void syncToDevice() override
+        {
+            ValueType tmp = float3_X(0., 0., 0.);
+            buffer.getDeviceBuffer().setValue(tmp);
+        }
+
+        //! Synchronize host data with device data
+        HINLINE void synchronize();
+
+        //! Get id
+        HINLINE SimulationDataId getUniqueId();
+
+        //! Get units of field components
+        HDINLINE static UnitValueType getUnit();
+
+        /** Get unit representation as powers of the 7 base measures
+         *
+         * Characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         *  thermodynamic temperature theta, amount of substance N,
+         *  luminous intensity J)
+         */
+        HINLINE static std::vector<float_64> getUnitDimension();
+
+        //! Get text name
+        HINLINE static std::string getName();
+
+        /** Assign the given value to elements
+         *
+         * @param value value to assign all elements to
+         */
+        HINLINE void assign(ValueType value);
+
+        /** Compute current density created by a species in an area
+         *
+         * @tparam T_area area to compute currents in
+         * @tparam T_Species particle species type
+         *
+         * @param species particle species
+         * @param currentStep index of time iteration
+         */
+        template<uint32_t T_area, class T_Species>
+        HINLINE void computeCurrent(T_Species & species, uint32_t currentStep);
+
+        /** Smooth current density and add it to the electric field
+         *
+         * @tparam T_area area to operate on
+         * @tparam T_CurrentInterpolation current interpolation type
+         *
+         * @param myCurrentInterpolation current interpolation
+         */
+        template<uint32_t T_area, class T_CurrentInterpolation>
+        HINLINE void addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation );
+
+        /** Bash field in a direction.
+         *
+         * Copy all particles from the guard of a direction to the device exchange buffer
+         */
+        HINLINE void bashField(uint32_t exchangeType);
+
+        //! Insert all fields which are in device exchange buffer
+        HINLINE void insertField(uint32_t exchangeType);
+
+    private:
+
+        //! Host-device buffer for current density values
+        GridBuffer<ValueType, simDim> buffer;
+
+        //! Buffer for receiving near-boundary values
+        std::unique_ptr< GridBuffer<ValueType, simDim> > fieldJrecv;
+
+    };
 
 } // namespace picongpu

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -32,6 +32,7 @@
 #include <pmacc/mappings/kernel/StrideMapping.hpp>
 #include <pmacc/fields/tasks/FieldFactory.hpp>
 #include <pmacc/math/Vector.hpp>
+#include <pmacc/memory/MakeUnique.hpp>
 #include <pmacc/fields/operations/CopyGuardToExchange.hpp>
 #include <pmacc/fields/operations/AddExchangeToBorder.hpp>
 #include "picongpu/particles/traits/GetCurrentSolver.hpp"
@@ -51,43 +52,44 @@ namespace picongpu
 
 using namespace pmacc;
 
-FieldJ::FieldJ( MappingDesc cellDescription ) :
-SimulationFieldHelper<MappingDesc>( cellDescription ),
-fieldJ( cellDescription.getGridLayout( ) ), fieldJrecv( nullptr )
+FieldJ::FieldJ( MappingDesc const & cellDescription ) :
+    SimulationFieldHelper<MappingDesc>( cellDescription ),
+    buffer( cellDescription.getGridLayout( ) ),
+    fieldJrecv( nullptr )
 {
     const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout( ).getDataSpaceWithoutGuarding( );
 
     /* cell margins the current might spread to due to particle shapes */
-    typedef typename pmacc::particles::traits::FilterByFlag<
+    using AllSpeciesWithCurrent = typename pmacc::particles::traits::FilterByFlag<
         VectorAllSpecies,
         current<>
-    >::type AllSpeciesWithCurrent;
+    >::type;
 
-    typedef bmpl::accumulate<
+    using LowerMarginShapes = bmpl::accumulate<
         AllSpeciesWithCurrent,
         typename pmacc::math::CT::make_Int<simDim, 0>::type,
         pmacc::math::CT::max<bmpl::_1, GetLowerMargin< GetCurrentSolver<bmpl::_2> > >
-        >::type LowerMarginShapes;
+        >::type;
 
-    typedef bmpl::accumulate<
+    using UpperMarginShapes = bmpl::accumulate<
         AllSpeciesWithCurrent,
         typename pmacc::math::CT::make_Int<simDim, 0>::type,
         pmacc::math::CT::max<bmpl::_1, GetUpperMargin< GetCurrentSolver<bmpl::_2> > >
-        >::type UpperMarginShapes;
+        >::type;
 
     /* margins are always positive, also for lower margins
      * additional current interpolations and current filters on FieldJ might
      * spread the dependencies on neighboring cells
      *   -> use max(shape,filter) */
-    typedef pmacc::math::CT::max<
+    using LowerMargin = pmacc::math::CT::max<
         LowerMarginShapes,
         GetMargin<typename fields::Solver::CurrentInterpolation>::LowerMargin
-        >::type LowerMargin;
+        >::type;
 
-    typedef pmacc::math::CT::max<
+    using UpperMargin = pmacc::math::CT::max<
         UpperMarginShapes,
         GetMargin<typename fields::Solver::CurrentInterpolation>::UpperMargin
-        >::type UpperMargin;
+        >::type;
 
     const DataSpace<simDim> originGuard( LowerMargin( ).toRT( ) );
     const DataSpace<simDim> endGuard( UpperMargin( ).toRT( ) );
@@ -118,7 +120,7 @@ fieldJ( cellDescription.getGridLayout( ) ), fieldJrecv( nullptr )
 
         }
         // std::cout << "ex " << i << " x=" << guardingCells[0] << " y=" << guardingCells[1] << " z=" << guardingCells[2] << std::endl;
-        fieldJ.addExchangeBuffer( i, guardingCells, FIELD_J );
+        buffer.addExchangeBuffer( i, guardingCells, FIELD_J );
     }
 
     /* Receive border values in own guard for "receive" communication pattern - necessary for current interpolation/filter */
@@ -127,7 +129,10 @@ fieldJ( cellDescription.getGridLayout( ) ), fieldJrecv( nullptr )
     if( originRecvGuard != DataSpace<simDim>::create(0) ||
         endRecvGuard != DataSpace<simDim>::create(0) )
     {
-        fieldJrecv = new GridBuffer<ValueType, simDim > ( fieldJ.getDeviceBuffer(), cellDescription.getGridLayout( ) );
+        fieldJrecv = pmacc::memory::makeUnique< GridBuffer<ValueType, simDim > >(
+            buffer.getDeviceBuffer(),
+            cellDescription.getGridLayout( )
+        );
 
         /*go over all directions*/
         for ( uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i )
@@ -145,24 +150,14 @@ fieldJ( cellDescription.getGridLayout( ) ), fieldJrecv( nullptr )
     }
 }
 
-FieldJ::~FieldJ( )
-{
-    __delete(fieldJrecv);
-}
-
-SimulationDataId FieldJ::getUniqueId( )
-{
-    return getName( );
-}
-
-void FieldJ::synchronize( )
-{
-    fieldJ.deviceToHost( );
-}
-
 GridBuffer<FieldJ::ValueType, simDim> &FieldJ::getGridBuffer( )
 {
-    return fieldJ;
+    return buffer;
+}
+
+GridLayout<simDim> FieldJ::getGridLayout( )
+{
+    return cellDescription.getGridLayout( );
 }
 
 EventTask FieldJ::asyncCommunication( EventTask serialEvent )
@@ -185,37 +180,18 @@ EventTask FieldJ::asyncCommunication( EventTask serialEvent )
         return ret;
 }
 
-void FieldJ::bashField( uint32_t exchangeType )
-{
-    pmacc::fields::operations::CopyGuardToExchange{ }(
-        fieldJ,
-        SuperCellSize{ },
-        exchangeType
-    );
-}
-
-void FieldJ::insertField( uint32_t exchangeType )
-{
-    pmacc::fields::operations::AddExchangeToBorder{ }(
-        fieldJ,
-        SuperCellSize{ },
-        exchangeType
-    );
-}
-
-GridLayout<simDim> FieldJ::getGridLayout( )
-{
-    return cellDescription.getGridLayout( );
-}
-
 void FieldJ::reset( uint32_t )
 {
 }
 
-void FieldJ::assign( ValueType value )
+void FieldJ::synchronize( )
 {
-    fieldJ.getDeviceBuffer( ).setValue( value );
-    //fieldJ.reset(false);
+    buffer.deviceToHost( );
+}
+
+SimulationDataId FieldJ::getUniqueId( )
+{
+    return getName( );
 }
 
 HDINLINE
@@ -231,10 +207,10 @@ std::vector<float_64>
 FieldJ::getUnitDimension( )
 {
     /* L, M, T, I, theta, N, J
-     *
-     * J is in A/m^2
-     *   -> L^-2 * I
-     */
+    *
+    * J is in A/m^2
+    *   -> L^-2 * I
+    */
     std::vector<float_64> unitDimension( 7, 0.0 );
     unitDimension.at(SIBaseUnits::length) = -2.0;
     unitDimension.at(SIBaseUnits::electricCurrent) =  1.0;
@@ -248,15 +224,21 @@ FieldJ::getName( )
     return "J";
 }
 
-template<uint32_t AREA, class ParticlesClass>
-void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
+void FieldJ::assign( ValueType value )
+{
+    buffer.getDeviceBuffer( ).setValue( value );
+    //fieldJ.reset(false);
+}
+
+template<uint32_t T_area, class T_Species>
+void FieldJ::computeCurrent( T_Species & species, uint32_t )
 {
     /* tuning parameter to use more workers than cells in a supercell
-     * valid domain: 1 <= workerMultiplier
-     */
+    * valid domain: 1 <= workerMultiplier
+    */
     const int workerMultiplier = 2;
 
-    using FrameType = typename ParticlesClass::FrameType;
+    using FrameType = typename T_Species::FrameType;
     typedef typename pmacc::traits::Resolve<
         typename GetFlagType<FrameType, current<> >::type
     >::type ParticleCurrentSolver;
@@ -270,10 +252,10 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
     > BlockArea;
 
     /* The needed stride for the stride mapper depends on the stencil width.
-     * If the upper and lower margin of the stencil fits into one supercell
-     * a double checker board (stride 2) is needed.
-     * The round up sum of margins is the number of supercells to skip.
-     */
+    * If the upper and lower margin of the stencil fits into one supercell
+    * a double checker board (stride 2) is needed.
+    * The round up sum of margins is the number of supercells to skip.
+    */
     using MarginPerDim = typename pmacc::math::CT::add<
         typename GetMargin<ParticleCurrentSolver>::LowerMargin,
         typename GetMargin<ParticleCurrentSolver>::UpperMargin
@@ -282,17 +264,17 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
     using SuperCellMinSize = typename pmacc::math::CT::min< SuperCellSize >::type;
 
     /* number of supercells which must be skipped to avoid overlapping areas
-     * between different blocks in the kernel
-     */
+    * between different blocks in the kernel
+    */
     constexpr uint32_t skipSuperCells = ( MaxMargin::value + SuperCellMinSize::value - 1u ) / SuperCellMinSize::value;
     StrideMapping<
-        AREA,
+        T_area,
         skipSuperCells + 1u, // stride 1u means each supercell is used
         MappingDesc
     > mapper( cellDescription );
 
-    typename ParticlesClass::ParticlesBoxType pBox = parClass.getDeviceParticlesBox( );
-    FieldJ::DataBoxType jBox = this->fieldJ.getDeviceBuffer( ).getDataBox( );
+    typename T_Species::ParticlesBoxType pBox = species.getDeviceParticlesBox( );
+    FieldJ::DataBoxType jBox = buffer.getDeviceBuffer( ).getDataBox( );
     FrameSolver solver( DELTA_T );
 
     constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
@@ -304,13 +286,13 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
         PMACC_KERNEL( KernelComputeCurrent< numWorkers, BlockArea >{} )
             ( mapper.getGridDim( ), numWorkers )
             ( jBox,
-              pBox, solver, mapper );
+                pBox, solver, mapper );
     }
     while ( mapper.next( ) );
 
 }
 
-template<uint32_t AREA, class T_CurrentInterpolation>
+template<uint32_t T_area, class T_CurrentInterpolation>
 void FieldJ::addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation )
 {
     DataConnector &dc = Environment<>::get().DataConnector();
@@ -318,7 +300,7 @@ void FieldJ::addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation )
     auto fieldB = dc.get< FieldB >( FieldB::getName(), true );
 
     AreaMapping<
-        AREA,
+        T_area,
         MappingDesc
     > mapper(cellDescription);
 
@@ -329,15 +311,33 @@ void FieldJ::addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation )
     PMACC_KERNEL( KernelAddCurrentToEMF< numWorkers >{} )(
         mapper.getGridDim(),
         numWorkers
-    )(
-        fieldE->getDeviceDataBox( ),
-        fieldB->getDeviceDataBox( ),
-        this->fieldJ.getDeviceBuffer( ).getDataBox( ),
-        myCurrentInterpolation,
-        mapper
-    );
+        )(
+            fieldE->getDeviceDataBox( ),
+            fieldB->getDeviceDataBox( ),
+            buffer.getDeviceBuffer( ).getDataBox( ),
+            myCurrentInterpolation,
+            mapper
+            );
     dc.releaseData( FieldE::getName() );
     dc.releaseData( FieldB::getName() );
 }
 
+void FieldJ::bashField( uint32_t exchangeType )
+{
+    pmacc::fields::operations::CopyGuardToExchange{ }(
+        buffer,
+        SuperCellSize{ },
+        exchangeType
+    );
 }
+
+void FieldJ::insertField( uint32_t exchangeType )
+{
+    pmacc::fields::operations::AddExchangeToBorder{ }(
+        buffer,
+        SuperCellSize{ },
+        exchangeType
+    );
+}
+
+} // namespace picongpu

--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -18,132 +18,184 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
-#include <string>
-#include <vector>
-
-/*pic default*/
 #include "picongpu/simulation_defines.hpp"
-
 #include "picongpu/fields/Fields.def"
+
 #include <pmacc/fields/SimulationFieldHelper.hpp>
 #include <pmacc/dataManagement/ISimulationData.hpp>
-
-/*PMacc*/
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/memory/boxes/PitchedBox.hpp>
 
+#include <cstdint>
 #include <memory>
+#include <string>
+#include <vector>
 
 
 namespace picongpu
 {
-    using namespace pmacc;
 
-
-    /** Tmp (at the moment: scalar) field for plugins and tmp data like
-     *  "gridded" particle data (charge density, energy density, ...)
+    /** Representation of the temporary scalar field for plugins and temporary
+     *  particle data mapped to grid (charge density, energy density, etc.)
+     *
+     * Stores field values on host and device and provides data synchronization
+     * between them.
+     *
+     * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
+     * ISimulationData.
      */
     class FieldTmp :
         public SimulationFieldHelper<MappingDesc>,
         public ISimulationData
     {
     public:
-        typedef float1_X ValueType;
-        typedef promoteType<float_64, ValueType>::type UnitValueType;
 
-        typedef MappingDesc::SuperCellSize SuperCellSize;
-        typedef DataBox<PitchedBox<ValueType, simDim> > DataBoxType;
+        //! Type of each field value
+        using ValueType = float1_X;
 
+        //! Unit type of field components
+        using UnitValueType = promoteType<float_64, ValueType>::type;
+
+        //! Size of supercell
+        using SuperCellSize = MappingDesc::SuperCellSize;
+
+        //! Type of data box for field values on host and device
+        using DataBoxType = DataBox<PitchedBox<ValueType, simDim> >;
+
+        /** Create a field
+         *
+         * @param cellDescription mapping for kernels
+         * @param slotId index of the temporary field
+         */
+        FieldTmp(
+            MappingDesc const & cellDescription,
+            uint32_t slotId
+        );
+
+        //! Destroy a field
+        virtual ~FieldTmp( ) = default;
+
+        //! Get a reference to the host-device buffer for the field values
+        HINLINE GridBuffer<ValueType, simDim>& getGridBuffer( );
+
+        //! Get the grid layout
+        HINLINE GridLayout<simDim> getGridLayout( );
+
+        //! Get the host data box for the field values
+        HINLINE DataBoxType getHostDataBox( );
+
+        //! Get the device data box for the field values
+        HINLINE DataBoxType getDeviceDataBox( );
+
+        /** Start asynchronous send of field values
+         *
+         * Add data from the local guard of the GPU to the border of the neighboring GPUs.
+         * This method can be called before or after asyncCommunicationGather without
+         * explicit handling to avoid race conditions between both methods.
+         *
+         * @param serialEvent event to depend on
+         */
+        HINLINE virtual EventTask asyncCommunication( EventTask serialEvent );
+
+        /** Reset the host-device buffer for field values
+         *
+         * @param currentStep index of time iteration
+         */
+        HINLINE void reset( uint32_t currentStep ) override;
+
+        //! Synchronize device data with host data
+        HINLINE void syncToDevice( ) override;
+
+        //! Synchronize host data with device data
+        HINLINE void synchronize( );
+
+        /** Get id
+         *
+         * @param slotId index of the temporary field
+         */
+        HINLINE static SimulationDataId getUniqueId( uint32_t slotId );
+
+        //! Get id
+        HINLINE SimulationDataId getUniqueId();
+
+        //! Get unit of field components
+        template< class FrameSolver >
+        HDINLINE static UnitValueType getUnit();
+
+        /** Get unit representation as powers of the 7 base measures
+         *
+         * Characterizing the record's unit in SI
+         * (length L, mass M, time T, electric current I,
+         *  thermodynamic temperature theta, amount of substance N,
+         *  luminous intensity J)
+         */
+        template< class FrameSolver >
+        HINLINE static std::vector<float_64> getUnitDimension();
+
+        //! Get mapping for kernels
         MappingDesc getCellDescription()
         {
             return this->cellDescription;
         }
 
-        FieldTmp(
-            MappingDesc cellDescription,
-            uint32_t slotId
-        );
+        //! Get text name
+        HINLINE static std::string getName();
 
-        virtual ~FieldTmp( );
-
-        virtual void reset( uint32_t currentStep );
-
-        template< class FrameSolver >
-        HDINLINE static UnitValueType getUnit();
-
-        /** powers of the 7 base measures
-         *
-         * characterizing the record's unit in SI
-         * (length L, mass M, time T, electric current I,
-         *  thermodynamic temperature theta, amount of substance N,
-         *  luminous intensity J) */
-        template<class FrameSolver >
-        HINLINE static std::vector<float_64> getUnitDimension();
-
-        static std::string getName();
-
-        /** scatter data to neighboring GPUs
-         *
-         * Add data from the local guard of the GPU to the border of the neighboring GPUs.
-         * This method can be called before or after asyncCommunicationGather without
-         * explicit handling to avoid race conditions between both methods.
-         */
-        virtual EventTask asyncCommunication( EventTask serialEvent );
-
-        /** gather data from neighboring GPUs
+        /** Gather data from neighboring GPUs
          *
          * Copy data from the border of neighboring GPUs into the local guard.
          * This method can be called before or after asyncCommunication without
          * explicit handling to avoid race conditions between both methods.
          */
-        EventTask asyncCommunicationGather( EventTask serialEvent );
+        HINLINE EventTask asyncCommunicationGather( EventTask serialEvent );
 
-        DataBoxType getDeviceDataBox( );
-
-        DataBoxType getHostDataBox( );
-
-        GridBuffer<ValueType, simDim>& getGridBuffer( );
-
-        GridLayout<simDim> getGridLayout( );
-
+        /** Compute current density created by a species in an area
+         *
+         * @tparam T_area area to compute currents in
+         * @tparam T_Species particle species type
+         *
+         * @param species particle species
+         * @param currentStep index of time iteration
+         */
         template<uint32_t AREA, class FrameSolver, class ParticlesClass>
-        void computeValue(ParticlesClass& parClass, uint32_t currentStep);
+        HINLINE void computeValue(ParticlesClass& parClass, uint32_t currentStep);
 
-        static SimulationDataId getUniqueId( uint32_t slotId );
-
-        SimulationDataId getUniqueId();
-
-        void synchronize( );
-
-        void syncToDevice( );
-
-        /* Bash particles in a direction.
+        /** Bash particles in a direction.
          * Copy all particles from the guard of a direction to the device exchange buffer
+         *
+         * @param exchangeType exchange type
          */
-        void bashField( uint32_t exchangeType );
+        HINLINE void bashField( uint32_t exchangeType );
 
-        /* Insert all particles which are in device exchange buffer
+        /** Insert all particles which are in device exchange buffer
+         *
+         * @param exchangeType exchange type
          */
-        void insertField( uint32_t exchangeType );
+        HINLINE void insertField( uint32_t exchangeType );
 
     private:
 
+        //! Host-device buffer for current density values
         std::unique_ptr< GridBuffer<ValueType, simDim> > fieldTmp;
+
+        //! Buffer for receiving near-boundary values
         std::unique_ptr< GridBuffer<ValueType, simDim> > fieldTmpRecv;
 
+        //! Index of the temporary field
         uint32_t m_slotId;
 
+        //! Events for communication
         EventTask m_scatterEv;
-        uint32_t m_commTagScatter;
         EventTask m_gatherEv;
+
+        //! Tags for communication
+        uint32_t m_commTagScatter;
         uint32_t m_commTagGather;
+
     };
 
-
-}
+} // namespace picongpu

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -51,7 +51,7 @@ namespace picongpu
     using namespace pmacc;
 
     FieldTmp::FieldTmp(
-        MappingDesc cellDescription,
+        MappingDesc const & cellDescription,
         uint32_t slotId
     ) :
         SimulationFieldHelper<MappingDesc>( cellDescription ),
@@ -183,10 +183,6 @@ namespace picongpu
             }
         }
 
-    }
-
-    FieldTmp::~FieldTmp( )
-    {
     }
 
     template<uint32_t AREA, class FrameSolver, class ParticlesClass>

--- a/include/picongpu/fields/Fields.tpp
+++ b/include/picongpu/fields/Fields.tpp
@@ -21,6 +21,7 @@
 #pragma once
 
 
+#include "picongpu/fields/EMFieldBase.tpp"
 #include "picongpu/fields/FieldB.tpp"
 #include "picongpu/fields/FieldE.tpp"
 #include "picongpu/fields/FieldJ.tpp"


### PR DESCRIPTION
This PR provides several small improvements to the implementations of the fields:

- a new base class for `FieldB` and `FieldE` implementations, since they had a substantially identical part
- add missing `inline` qualifiers
- fix shadowing of the virtual method `SimulationFieldHelper::syncToDevice()`, however, I believe it has never been used polymorphically (via a pointer to the base class); so it was a bug but we did not use this behavior 
- occasionally modernize the code style and other minor things

TODO:
- [x] check that I did not break anything
- [x] add documentation, at least to the new code