### PR TITLE
Add missing inline qualifiers potentially causing multiple definitions

### DIFF
--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -102,10 +102,10 @@ private:
 
     /** First synchrotron function
      */
-    float_64 F_1(const float_64 x) const;
+    HINLINE float_64 F_1(const float_64 x) const;
     /** Second synchrotron function
      */
-    float_64 F_2(const float_64 x) const;
+    HINLINE float_64 F_2(const float_64 x) const;
 
 public:
     enum Select
@@ -113,13 +113,13 @@ public:
         first=0, second=1
     };
 
-    void init();
+    HINLINE void init();
     /** Return a cursor representing a synchrotron function
      *
      * @param syncFunction first or second synchrotron function
      * @see: SynchrotronFunctions::Select
      */
-    SyncFuncCursor getCursor(Select syncFunction) const;
+    HINLINE SyncFuncCursor getCursor(Select syncFunction) const;
 
 }; // class SynchrotronFunctions
 

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -48,7 +48,7 @@ namespace detail
 
  * @param x position of the synchrotron function to be evaluated
  */
-HDINLINE float_X MapToLookupTable::operator()(const float_X x) const
+float_X MapToLookupTable::operator()(const float_X x) const
 {
     /* This mapping increases the sample point density for small values of x
      * where the synchrotron functions have a divergent slope. Without this mapping

--- a/include/picongpu/plugins/ResourceLog.hpp
+++ b/include/picongpu/plugins/ResourceLog.hpp
@@ -60,7 +60,7 @@
 namespace boost_swap_impl
 {
     BOOST_GPU_ENABLED
-    void swap(std::string& s1, std::string& s2)
+    inline void swap(std::string& s1, std::string& s2)
     {
 #ifndef __CUDA_ARCH__
         std::swap(s1, s2);

--- a/include/picongpu/plugins/common/txtFileHandling.hpp
+++ b/include/picongpu/plugins/common/txtFileHandling.hpp
@@ -43,7 +43,7 @@ using namespace boost::filesystem;
      *
      * \return operation was successful or not
      */
-    bool restoreTxtFile( std::ofstream& outFile, std::string filename,
+    HINLINE bool restoreTxtFile( std::ofstream& outFile, std::string filename,
                          uint32_t restartStep, const std::string restartDirectory )
     {
         /* get restart time step as string */
@@ -93,7 +93,7 @@ using namespace boost::filesystem;
      * \param currentStep the current time step
      * \param checkpointDirectory path to the checkpoint directory
      */
-    void checkpointTxtFile( std::ofstream& outFile, std::string filename,
+    HINLINE void checkpointTxtFile( std::ofstream& outFile, std::string filename,
                             uint32_t currentStep, const std::string checkpointDirectory )
     {
         outFile.flush();

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -117,10 +117,10 @@ namespace detail
          *
          * After this call it is allowed to use MPI.
          */
-        void init();
+        HINLINE void init();
 
         /** cleanup the environment */
-        void finalize();
+        HINLINE void finalize();
 
         /** select a computing device
          *
@@ -128,7 +128,7 @@ namespace detail
          *
          * @param deviceNumber number of the device
          */
-        void setDevice(int deviceNumber);
+        HINLINE void setDevice(int deviceNumber);
 
     };
 

--- a/include/pmacc/eventSystem/events/CudaEvent.def
+++ b/include/pmacc/eventSystem/events/CudaEvent.def
@@ -62,16 +62,16 @@ public:
      *
      * if called before the cuda device is initialized the behavior is undefined
      */
-    CudaEvent( );
+    HINLINE CudaEvent( );
 
     /** Destructor */
-    ~CudaEvent( );
+    HINLINE ~CudaEvent( );
 
     /** register a existing handle to a event instance */
-    void registerHandle( );
+    HINLINE void registerHandle( );
 
     /** free a registered handle */
-    void releaseHandle( );
+    HINLINE void releaseHandle( );
 
     /** get native cudaEvent_t object
      *
@@ -96,13 +96,13 @@ public:
      *
      * @return true if event is finished else false
      */
-    bool isFinished( );
+    HINLINE bool isFinished( );
 
     /** record event in a device stream
      *
      * @param stream native cuda stream
      */
-    void recordEvent( cudaStream_t stream );
+    HINLINE void recordEvent( cudaStream_t stream );
 
 };
 }

--- a/include/pmacc/eventSystem/tasks/TaskKernel.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskKernel.hpp
@@ -58,7 +58,7 @@ namespace pmacc
         {
         }
 
-        void activateChecks();
+        HINLINE void activateChecks();
 
         virtual std::string toString()
         {

--- a/include/pmacc/eventSystem/transactions/Transaction.hpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.hpp
@@ -41,7 +41,7 @@ public:
      *
      * @param event initial EventTask for base event
      */
-    Transaction(EventTask event);
+    HINLINE Transaction(EventTask event);
 
     /**
      * Adds event to the base event of this transaction.
@@ -49,27 +49,27 @@ public:
      * @param event EventTask to add to base event
      * @return new base event
      */
-    EventTask setTransactionEvent(const EventTask& event);
+    HINLINE EventTask setTransactionEvent(const EventTask& event);
 
     /**
      * Returns the current base event.
      *
      * @return current base event
      */
-    EventTask getTransactionEvent();
+    HINLINE EventTask getTransactionEvent();
 
     /**
      * Performs an operation on the transaction which leads to synchronization.
      *
      * @param operation type of operation to perform, defines resulting synchronization.
      */
-    void operation(ITask::TaskType operation);
+    HINLINE void operation(ITask::TaskType operation);
 
     /* Get a EventStream which include all dependencies
      * @param operation type of operation to perform
      * @return EventStream with solved dependencies
      */
-    EventStream* getEventStream(ITask::TaskType operation);
+    HINLINE EventStream* getEventStream(ITask::TaskType operation);
 
 private:
     EventTask baseEvent;

--- a/include/pmacc/eventSystem/transactions/Transaction.tpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.tpp
@@ -35,13 +35,13 @@ Transaction::Transaction( EventTask event ) : baseEvent( event )
 
 }
 
-inline EventTask Transaction::setTransactionEvent( const EventTask& event )
+EventTask Transaction::setTransactionEvent( const EventTask& event )
 {
     baseEvent += event;
     return baseEvent;
 }
 
-inline EventTask Transaction::getTransactionEvent( )
+EventTask Transaction::getTransactionEvent( )
 {
     return baseEvent;
 }

--- a/include/pmacc/misc/splitString.hpp
+++ b/include/pmacc/misc/splitString.hpp
@@ -40,7 +40,7 @@ namespace misc
      * @param input string to split
      * @param regex separator between two elements
      */
-    std::vector< std::string > splitString(
+    HINLINE std::vector< std::string > splitString(
         std::string const & input,
         std::string const & delimiter = ","
     )

--- a/include/pmacc/nvidia/functors/Add.hpp
+++ b/include/pmacc/nvidia/functors/Add.hpp
@@ -53,7 +53,7 @@ namespace pmacc
 namespace mpi
 {
     template<>
-    MPI_Op getMPI_Op<pmacc::nvidia::functors::Add>()
+    HINLINE MPI_Op getMPI_Op<pmacc::nvidia::functors::Add>()
     {
         return MPI_SUM;
     }

--- a/include/pmacc/nvidia/functors/Max.hpp
+++ b/include/pmacc/nvidia/functors/Max.hpp
@@ -55,7 +55,7 @@ namespace pmacc
 namespace mpi
 {
     template<>
-    MPI_Op getMPI_Op<pmacc::nvidia::functors::Max>()
+    HINLINE MPI_Op getMPI_Op<pmacc::nvidia::functors::Max>()
     {
         return MPI_MAX;
     }

--- a/include/pmacc/nvidia/functors/Min.hpp
+++ b/include/pmacc/nvidia/functors/Min.hpp
@@ -56,7 +56,7 @@ namespace pmacc
 namespace mpi
 {
     template<>
-    MPI_Op getMPI_Op<pmacc::nvidia::functors::Min>()
+    HINLINE MPI_Op getMPI_Op<pmacc::nvidia::functors::Min>()
     {
         return MPI_MIN;
     }

--- a/include/pmacc/nvidia/functors/Mul.hpp
+++ b/include/pmacc/nvidia/functors/Mul.hpp
@@ -55,7 +55,7 @@ namespace pmacc
 namespace mpi
 {
     template<>
-    MPI_Op getMPI_Op<pmacc::nvidia::functors::Mul>()
+    HINLINE MPI_Op getMPI_Op<pmacc::nvidia::functors::Mul>()
     {
         return MPI_PROD;
     }

--- a/include/pmacc/pluginSystem/containsStep.hpp
+++ b/include/pmacc/pluginSystem/containsStep.hpp
@@ -36,7 +36,7 @@ namespace pluginSystem
      * @param timeStep simulation time step to check
      * @return true if step is included in the interval list else false
      */
-    bool containsStep(
+    HINLINE bool containsStep(
         std::vector< pluginSystem::TimeSlice > const & seqTimeSlices,
         uint32_t const timeStep
     )

--- a/include/pmacc/pluginSystem/toTimeSlice.hpp
+++ b/include/pmacc/pluginSystem/toTimeSlice.hpp
@@ -45,7 +45,7 @@ namespace detail
      * @param str string to check
      * @return true if str contains only digits else false
      */
-    bool is_number( std::string const & str )
+    HINLINE bool is_number( std::string const & str )
     {
         return std::all_of(
             str.begin(),
@@ -62,7 +62,7 @@ namespace detail
      *   - `start:stop:period`
      *   - a number ``N is equal to `::N`
      */
-    std::vector< TimeSlice > toTimeSlice( std::string const & str )
+    HINLINE std::vector< TimeSlice > toTimeSlice( std::string const & str )
     {
         std::vector< TimeSlice > result;
         auto const seqOfSlices = misc::splitString(

--- a/include/pmacc/traits/GetStringProperties.hpp
+++ b/include/pmacc/traits/GetStringProperties.hpp
@@ -77,7 +77,7 @@ namespace traits
 
     /** stream operator for a StringProperty
      */
-    std::ostream& operator<<( std::ostream& out, const StringProperty& property )
+    HINLINE std::ostream& operator<<( std::ostream& out, const StringProperty& property )
     {
         out << property.value;
         return out;
@@ -124,7 +124,7 @@ namespace traits
      * \return StringProperty of the given instance
      */
     template< typename T_Type >
-    StringProperty
+    HINLINE StringProperty
     getStringProperties( const T_Type& )
     {
         return GetStringProperties<T_Type>()();


### PR DESCRIPTION
These missing `inline` qualifiers cause multiple definitions of the functions in question, in case it is present in multiple object files. This is one (but not only) of the issues preventing us from using more object files.

For functions defined in header files (so almost all our functions) the rules are as follows:

- `inline` should be part of declaration (not definition)
- for class/struct methods defined at declaration `inline` is applied automatically

This PR catches the cases that my Visual Studio reports on. I assume there might be some more, but probably not too many.

Files related to fields are not fixed in this PR, but as part of #3005.