### PR TITLE
Summit: Profile & Templates

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -84,6 +84,24 @@ For this profile to work, you need to download the :ref:`PIConGPU source code <i
 .. literalinclude:: profiles/hydra-hzdr/default_picongpu.profile.example
    :language: bash
 
+Summit (ORNL)
+-------------
+
+**System overview:** `link <https://www.olcf.ornl.gov/olcf-resources/compute-systems/summit/>`_
+
+**User guide:** `link <https://www.olcf.ornl.gov/for-users/system-user-guides/summit/>`_
+
+**Production directory:** usually ``$PROJWORK/$proj/`` (`link <https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#file-systems>`_).
+Note that ``$HOME`` is mounted on compute nodes as read-only.
+
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`libSplash and PNGwriter <install-dependencies>` manually.
+
+V100 GPUs (recommended)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/summit-ornl/gpu_picongpu.profile.example
+   :language: bash
+
 Piz Daint (CSCS)
 ----------------
 

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -66,3 +66,12 @@ It is used, e.g. on Hypnos at HZDR.
 
 .. include:: ../install/profiles/hypnos-hzdr/PBS_Tutorial.rst
    :start-line: 3
+
+LSF
+"""
+
+LSF (for *Load Sharing Facility*) is an IBM batch system (``bsub``/BSUB).
+It is used, e.g. on Summit at ORNL.
+
+.. include:: ../install/profiles/summit-ornl/LSF_Tutorial.rst
+   :start-line: 3

--- a/etc/picongpu/summit-ornl/LSF_Tutorial.rst
+++ b/etc/picongpu/summit-ornl/LSF_Tutorial.rst
@@ -1,0 +1,45 @@
+LSF examples
+============
+
+Job Submission
+''''''''''''''
+
+PIConGPU job submission on the *Summit* cluster at *Oak Ridge National Lab*:
+
+* ``tbg -s bsub -c etc/picongpu/0008gpus.cfg -t etc/picongpu/summit-ornl/gpu.tpl $PROJWORK/$proj/test-001``
+
+
+Job Control
+'''''''''''
+
+* interactive job:
+
+  * ``bsub -P $proj -W 2:00 -nnodes 1 -Is /bin/bash``
+
+* `details for my jobs <https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#monitoring-jobs>`_:
+
+  * ``bjobs 12345`` all details for job with <job id> ``12345``
+  * ``bjobs [-l]`` all jobs under my user name
+  * ``jobstat -u $(whoami)`` job eligibility
+  * ``bjdepinfo 12345`` job dependencies on other jobs
+
+* details for queues:
+
+  * ``bqueues`` list queues
+
+* communicate with job:
+
+  * ``bkill <job id>`` abort job
+  * ``bpeek [-f] <job id>`` peek into ``stdout``/``stderr`` of a job
+  * ``bkill -s <signal number> <job id>`` send signal or signal name to job
+  * ``bchkpnt`` and ``brestart`` checkpoint and restart job (untested/unimplemented)
+  * ``bmod -W 1:30 12345`` change the walltime of a job (currently not allowed)
+  * ``bstop <job id>`` prevent the job from starting
+  * ``bresume <job id>`` release the job to be eligible for run (after it was set on hold)
+
+
+References
+''''''''''
+
+* https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#running-jobs
+* https://www.ibm.com/support/knowledgecenter/en/SSETD4/product_welcome_platform_lsf.html

--- a/etc/picongpu/summit-ornl/gpu_batch.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch.tpl
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright 2019 Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for Summit's LSF (bsub) batch system
+#   https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#running-jobs
+
+#BSUB -q !TBG_queue
+#BSUB -W !TBG_wallTimeNoSeconds
+# Sets batch job's name
+#BSUB -J !TBG_jobName
+#BSUB -nnodes !TBG_nodes
+#BSUB -alloc_flags smt4
+# send me mails on job (-B)egin, Fi(-N)ish
+#BSUB !TBG_mailSettings -u !TBG_mailAddress
+#BSUB -cwd !TBG_dstPath
+#BSUB -P !TBG_nameProject
+
+#BSUB -o stdout.%J
+#BSUB -e stderr.%J
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="batch"
+
+# remove seconds from walltime
+.TBG_wallTimeNoSeconds=${TBG_wallTime::-3}
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-""}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${proj:-""}
+.TBG_profile=${PIC_PROFILE:-"${PROJWORK}/!TBG_nameProject/${USER}/picongpu.profile"}
+
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=6
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
+
+# number of cores to block per GPU - we got 2x22 HW CPU cores per node
+#   and we will be accounted those anyway
+.TBG_coresPerGPU=7
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode - 1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+echo !TBG_jobName
+
+cd !TBG_dstPath
+echo -n "present working directory:"
+pwd
+
+
+source !TBG_profile 2>/dev/null
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+#jsrun  -N 1 -n !TBG_nodes !TBG_dstPath/input/bin/cuda_memtest.sh
+
+#if [ $? -eq 0 ] ; then
+export OMP_NUM_THREADS=!TBG_coresPerGPU
+jsrun --nrs !TBG_tasks --tasks_per_rs 1 --cpu_per_rs !TBG_coresPerGPU --gpu_per_rs 1 --latency_priority GPU-CPU --bind rs --smpiargs="-gpu" !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+# note: instead of the PIConGPU binary, one can also debug starting "js_task_info | sort"
+#fi

--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -1,0 +1,66 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on job (-B)egin, Fi(-N)ish
+export MY_MAILNOTIFY=""
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Project Information ######################################## (edit this line)
+#   - project account for computing time
+export proj=<yourProject>
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#module load nano
+#export EDITOR="nano"
+
+# basic environment ###########################################################
+module load gcc/6.4.0
+
+export CC=$(which gcc)
+export CXX=$(which g++)
+
+# required tools and libs
+module load git
+module load cmake/3.14.2
+module load cuda/10.1.168
+module load boost/1.66.0
+
+# plugins (optional) ##########################################################
+module load hdf5/1.10.3
+module load adios/1.13.1-py2 c-blosc zfp sz lz4
+
+# download libSplash and compile it yourself from
+#   https://github.com/ComputationalRadiationPhysics/libSplash/
+export Splash_DIR=$PROJWORK/$proj/huebl/sw/splash-1.7.0
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Splash_DIR/lib
+
+#export T3PIO_ROOT=$PROJWORK/$proj/lib/t3pio
+#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$T3PIO_ROOT/lib
+
+# install pngwriter yourself:
+#   https://github.com/pngwriter/pngwriter#install
+module load zlib/1.2.11
+module load libpng/1.6.34 freetype/2.9.1
+export PNGwriter_DIR=$PROJWORK/$proj/huebl/sw/pngwriter-0.7.0
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGwriter_DIR/lib
+
+# helper variables and tools ##################################################
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:70"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+alias getNode="bsub -P $proj -W 2:00 -nnodes 1 -Is /bin/bash"
+
+# "tbg" default options #######################################################
+export TBG_SUBMIT="bsub"
+export TBG_TPLFILE="etc/picongpu/summit-ornl/gpu_batch.tpl"


### PR DESCRIPTION
Add a software profile, TBG job template and LSF tutorial for Summit at ORNL.

### To Do

- [x] wait for RT test to complete

### Note

Also see: https://jsrunvisualizer.olcf.ornl.gov/index.html?s4f1o17n6c7g1r11d1b1l0=

### Outdated

The information below is outdated and was fixed via #3084 

~~Our self-paced `hostRank` assignment in https://github.com/ComputationalRadiationPhysics/picongpu/blob/0.4.3/include/pmacc/communication/CommunicatorMPI.hpp#L285-L333 prevents that we can just use the automatic placement in `jsrun` [resource sets](https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#job-launcher-(jsrun)) with 7 cores + 1 GPU each.~~

```
.TBG_coresPerGPU=7

jsrun -n !TBG_tasks -g 1 -a 1 -c !TBG_coresPerGPU -b packed:!TBG_coresPerGPU -d packed -l GPU-CPU --smpiargs="-gpu" !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output 
```

```diff
diff --git a/include/pmacc/communication/CommunicatorMPI.hpp b/include/pmacc/communication/CommunicatorMPI.hpp
index d61730e48..cad2f5492 100644
--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -153,7 +153,7 @@ public:
         MPI_CHECK(MPI_Cart_create(computing_comm, DIM, dims, periods, 0, &topology));
 
         // 3. update Host rank
-        updateHostRank();
+        //updateHostRank();
 
         //4. update Coordinates
         updateCoordinates();
```

~~We might want to add a picongpu cmd-line option, e.g. `--isolated` or `--pre-placed`, to control this behavior for already well-placed processes in such splendid batch systems.~~