### PR TITLE
CMake: Warning in 3.14+ Cache List

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -374,7 +374,7 @@ find_path(PIC_EXTENSION_PATH
     )
 
 set(PIC_COPY_ON_INSTALL "include/picongpu;etc/picongpu;lib"
-    CACHE LIST
+    CACHE STRING
     "Folders that are copied to installation path during install" )
 
 # enforce that all picongpu includes must be prefixed with `picongpu/`


### PR DESCRIPTION
Fix a warning with CMake 3.14+:

```
CMake Warning (dev) at CMakeLists.txt:376 (set):
  implicitly converting 'LIST' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

There is no (cached) `LIST` type in CMake, those are just interpreted
strings.