### PR TITLE
Pass mapping description by value instead of pointer from simulation stages

### DIFF
--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -361,12 +361,12 @@ struct CallIonizationScheme
      *
      * \tparam T_CellDescription contains the number of blocks and blocksize
      *                           that is later passed to the kernel
-     * \param cellDesc points to logical block information like dimension and cell sizes
+     * \param cellDesc logical block information like dimension and cell sizes
      * \param currentStep The current time step
      */
     template<typename T_CellDescription>
     HINLINE void operator()(
-        T_CellDescription* cellDesc,
+        T_CellDescription cellDesc,
         const uint32_t currentStep
     ) const
     {
@@ -415,12 +415,12 @@ struct CallIonization
      *
      * \tparam T_CellDescription contains the number of blocks and blocksize
      *                           that is later passed to the kernel
-     * \param cellDesc points to logical block information like dimension and cell sizes
+     * \param cellDesc logical block information like dimension and cell sizes
      * \param currentStep The current time step
      */
     template<typename T_CellDescription>
     HINLINE void operator()(
-        T_CellDescription* cellDesc,
+        T_CellDescription cellDesc,
         const uint32_t currentStep
     ) const
     {
@@ -477,12 +477,12 @@ struct CallBremsstrahlung
      *
      * \tparam T_CellDescription contains the number of blocks and blocksize
      *                           that is later passed to the kernel
-     * \param cellDesc points to logical block information like dimension and cell sizes
+     * \param cellDesc logical block information like dimension and cell sizes
      * \param currentStep the current time step
      */
     template<typename T_CellDescription, typename ScaledSpectrumMap>
     HINLINE void operator()(
-        T_CellDescription* cellDesc,
+        T_CellDescription cellDesc,
         const uint32_t currentStep,
         const ScaledSpectrumMap& scaledSpectrumMap,
         const bremsstrahlung::GetPhotonAngle& photonAngle
@@ -535,13 +535,13 @@ struct CallSynchrotronPhotons
      *
      * \tparam T_CellDescription contains the number of blocks and blocksize
      *                           that is later passed to the kernel
-     * \param cellDesc points to logical block information like dimension and cell sizes
+     * \param cellDesc logical block information like dimension and cell sizes
      * \param currentStep The current time step
      * \param synchrotronFunctions synchrotron functions wrapper object
      */
     template<typename T_CellDescription>
     HINLINE void operator()(
-        T_CellDescription* cellDesc,
+        T_CellDescription cellDesc,
         const uint32_t currentStep,
         const synchrotronPhotons::SynchrotronFunctions& synchrotronFunctions
     ) const

--- a/include/picongpu/particles/creation/creation.hpp
+++ b/include/picongpu/particles/creation/creation.hpp
@@ -49,11 +49,11 @@ template<typename T_SourceSpecies, typename T_TargetSpecies, typename T_Particle
 void createParticlesFromSpecies(T_SourceSpecies& sourceSpecies,
                                 T_TargetSpecies& targetSpecies,
                                 T_ParticleCreator particleCreator,
-                                T_CellDescription* cellDesc)
+                                T_CellDescription cellDesc)
 {
     using SuperCellSize = typename MappingDesc::SuperCellSize;
-    const pmacc::math::Int<simDim> coreBorderGuardSuperCells = cellDesc->getGridSuperCells();
-    const pmacc::math::Int<simDim> guardSuperCells = cellDesc->getGuardingSuperCells();
+    const pmacc::math::Int<simDim> coreBorderGuardSuperCells = cellDesc.getGridSuperCells();
+    const pmacc::math::Int<simDim> guardSuperCells = cellDesc.getGuardingSuperCells();
     const pmacc::math::Int<simDim> coreBorderSuperCells = coreBorderGuardSuperCells - 2 * guardSuperCells;
 
     constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<

--- a/include/picongpu/simulation/stage/Bremsstrahlung.hpp
+++ b/include/picongpu/simulation/stage/Bremsstrahlung.hpp
@@ -91,7 +91,7 @@ namespace stage
                 particles::CallBremsstrahlung< bmpl::_1 >
             > particleBremsstrahlung;
             particleBremsstrahlung(
-                &cellDescription,
+                cellDescription,
                 step,
                 scaledSpectrumMap,
                 photonAngle

--- a/include/picongpu/simulation/stage/ParticleIonization.hpp
+++ b/include/picongpu/simulation/stage/ParticleIonization.hpp
@@ -68,7 +68,7 @@ namespace stage
                 SpeciesWithIonizers,
                 particles::CallIonization< bmpl::_1 >
             > particleIonization;
-            particleIonization( &cellDescription, step );
+            particleIonization( cellDescription, step );
         }
 
     private:

--- a/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
+++ b/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
@@ -76,7 +76,7 @@ namespace stage
                 particles::CallSynchrotronPhotons< bmpl::_1 >
             > synchrotronRadiation;
             synchrotronRadiation(
-                &cellDescription,
+                cellDescription,
                 step,
                 functions
             );


### PR DESCRIPTION
It is potentially unsafe to pass by pointer in these cases, as we pass a pointer to a local member and inside it could start a kernel asynchronously, then return and destroy the stage class instance. This does not lead to problems now but just unnecessary unsafe and passing by value is more natural anyways.