### PR TITLE
Fix code causing cudaErrorInvalidDeviceFunction

### DIFF
--- a/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
@@ -57,10 +57,6 @@ namespace detail
         using SpeciesType = T_SpeciesType;
         using FrameType = typename SpeciesType::FrameType;
         using ShapeType = typename GetShape< SpeciesType >::type;
-        using Density = particleToGrid::ComputeGridValuePerFrame<
-            ShapeType,
-            particleToGrid::derivedAttributes::Density
-        >;
 
         /** Functor
          *
@@ -77,6 +73,10 @@ namespace detail
             // load particle without copy particle data to host
             auto speciesTmp = dc.get< SpeciesType >( FrameType::getName(), true );
 
+            using Density = particleToGrid::ComputeGridValuePerFrame<
+                ShapeType,
+                particleToGrid::derivedAttributes::Density
+            >;
             fieldTmp->template computeValue< CORE + BORDER, Density >( *speciesTmp, currentStep );
 
             dc.releaseData( FrameType::getName() );


### PR DESCRIPTION
@psychocoderHPC and I spent quite a long time figuring out the cause of #3010. Our current understanding is that somehow nvcc gets confused with templates and incorrectly decides some code paths to be host-only, and so does not properly generate kernels called inside. This leads to strange `cudaErrorInvalidDeviceFunction` errors with CUDA. To work around such behavior, this PR moves some of the templates inside the functions with kernel calls. Thomas-Fermi is what we believe caused #3010, also noticed a similar pattern in FLYLite. There could be more, but if we understand the issue correctly, that could be fixed once encountered.

Fixes #3010. @psychocoderHPC checked on the test machine that it now works.