### PR TITLE
hemera-hzdr: remove project definition

### DIFF
--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -24,7 +24,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!proj
+#SBATCH --account=!TBG_queue
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -9,10 +9,6 @@ export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
-# Project Information ######################################## (edit this line)
-#   - project account for computing time
-export proj="k20"
-
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
@@ -66,7 +62,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=2 --gres=gpu:4 -A $proj --mem=62000 -p k20 --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=2 --gres=gpu:4 -A k20 --mem=62000 -p k20 --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -82,5 +78,5 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=2 --gres=gpu:$numGPUs -A $proj --mem=$((15500 * numGPUs)) -p k20 --pty bash
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=2 --gres=gpu:$numGPUs -A k20 --mem=$((15500 * numGPUs)) -p k20 --pty bash
 }

--- a/etc/picongpu/hemera-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k20_restart.tpl
@@ -55,7 +55,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!proj
+#SBATCH --account=!TBG_queue
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName

--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -24,7 +24,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!proj
+#SBATCH --account=!TBG_queue
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -9,10 +9,6 @@ export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
-# Project Information ######################################## (edit this line)
-#   - project account for computing time
-export proj="k80"
-
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
@@ -66,7 +62,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=8 --cpus-per-task=2 --gres=gpu:8 -A $proj --mem=238000 -p k80 --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=8 --cpus-per-task=2 --gres=gpu:8 -A k80 --mem=238000 -p k80 --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -82,5 +78,5 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=2 --gres=gpu:$numGPUs -A $proj --mem=$((29750 * numGPUs)) -p k80 --pty bash
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=2 --gres=gpu:$numGPUs -A k80 --mem=$((29750 * numGPUs)) -p k80 --pty bash
 }

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -55,7 +55,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!proj
+#SBATCH --account=!TBG_queue
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName


### PR DESCRIPTION
On hemera we have no projects like on other system, we have access groups for a few queues.
Since the slurm option `-A` is queue specific and not user-specific (will be never changed by the user) it makes no sense to have it changeable.
The current implementation also breaks the option `tbg -t anytemplate.tpl` because it is not possible to switch the queue via the explicit selection of the used template.