### PR TITLE
Singularity: Workaround Chmod Issue, No UCX

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -73,32 +73,37 @@ RUN        /bin/echo -e "source $SPACK_ROOT/share/spack/setup-env.sh\n" \
 # force the use of a login shell
 RUN        /bin/echo -e '#!/bin/bash -l\n' \
                         'exec "$@"\n' \
-               > /etc/entrypoint.sh
-RUN        chmod a+x /etc/entrypoint.sh
+               > /etc/entrypoint.sh && \
+           chmod a+x /etc/entrypoint.sh
 
 # build example for out-of-the-box usage: LWFA
 RUN        /bin/bash -l -c ' \
                pic-create $PICSRC/share/picongpu/examples/LaserWakefield /opt/picInputs/lwfa && \
                cd /opt/picInputs/lwfa && \
                pic-build -b "cuda:30;35;37;50;60;70" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
-               rm -rf .build'
+               rm -rf .build && \
+               chmod a+x /opt/picInputs/*/bin/* && \
+               chmod a+r -R /opt/picInputs/* && \
+               find /opt/picInputs -type d -exec chmod a+rx {} \;'
 # KHI (Benchmark)
 RUN        /bin/bash -l -c ' \
                pic-create $PICSRC/share/picongpu/examples/KelvinHelmholtz /opt/picInputs/khi && \
                cd /opt/picInputs/khi && \
                pic-build -b "cuda:30;35;37;50;60;70" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
-               rm -rf .build'
+               rm -rf .build && \
+               chmod a+x /opt/picInputs/*/bin/* && \
+               chmod a+r -R /opt/picInputs/* && \
+               find /opt/picInputs -type d -exec chmod a+rx {} \;'
 # Laser-Ion Acceleration
 RUN        /bin/bash -l -c ' \
                pic-create $PICSRC/share/picongpu/examples/FoilLCT /opt/picInputs/foil && \
                cd /opt/picInputs/foil && \
                pic-build -b "cuda:30;35;37;50;60;70" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
-               rm -rf .build'
-
-# make input directories readable and files executable for all users
-RUN        chmod a+x /opt/picInputs/*/bin/* && \
-           chmod a+r -R /opt/picInputs/* && \
-           find /opt/picInputs -type d -exec chmod a+rx {} \;
+               rm -rf .build && \
+               chmod a+x /opt/picInputs/*/bin/* && \
+               chmod a+r -R /opt/picInputs/* && \
+               find /opt/picInputs -type d -exec chmod a+rx {} \;'
+# ... also made input directories readable and files executable for all users
 
 COPY       start_lwfa.sh /usr/bin/lwfa
 COPY       start_lwfa_4.sh /usr/bin/lwfa4

--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -80,7 +80,7 @@ RUN        /bin/echo -e '#!/bin/bash -l\n' \
 RUN        /bin/bash -l -c ' \
                pic-create $PICSRC/share/picongpu/examples/LaserWakefield /opt/picInputs/lwfa && \
                cd /opt/picInputs/lwfa && \
-               pic-build -b "cuda:30;35;37;50;60;70" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
+               pic-build -b "cuda:30;35;37;50;60;70" -c"-DCUDAMEMTEST_ENABLE=OFF" && \
                rm -rf .build && \
                chmod a+x /opt/picInputs/*/bin/* && \
                chmod a+r -R /opt/picInputs/* && \
@@ -89,7 +89,7 @@ RUN        /bin/bash -l -c ' \
 RUN        /bin/bash -l -c ' \
                pic-create $PICSRC/share/picongpu/examples/KelvinHelmholtz /opt/picInputs/khi && \
                cd /opt/picInputs/khi && \
-               pic-build -b "cuda:30;35;37;50;60;70" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
+               pic-build -b "cuda:30;35;37;50;60;70" -c"-DCUDAMEMTEST_ENABLE=OFF" && \
                rm -rf .build && \
                chmod a+x /opt/picInputs/*/bin/* && \
                chmod a+r -R /opt/picInputs/* && \
@@ -98,7 +98,7 @@ RUN        /bin/bash -l -c ' \
 RUN        /bin/bash -l -c ' \
                pic-create $PICSRC/share/picongpu/examples/FoilLCT /opt/picInputs/foil && \
                cd /opt/picInputs/foil && \
-               pic-build -b "cuda:30;35;37;50;60;70" -c'-DCUDAMEMTEST_ENABLE=OFF' && \
+               pic-build -b "cuda:30;35;37;50;60;70" -c"-DCUDAMEMTEST_ENABLE=OFF" && \
                rm -rf .build && \
                chmod a+x /opt/picInputs/*/bin/* && \
                chmod a+r -R /opt/picInputs/* && \

--- a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
@@ -13,7 +13,7 @@ packages:
     buildable: False
   openmpi:
     version: [3.1.3]
-    variants: +cuda fabrics=verbs,libfabric
+    variants: +cuda fabrics=libfabric
   hwloc:
     variants: +cuda
   # install issue with gettext

--- a/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-1604/packages.yaml
@@ -13,7 +13,7 @@ packages:
     buildable: False
   openmpi:
     version: [3.1.3]
-    variants: +cuda fabrics=verbs,ucx,libfabric
+    variants: +cuda fabrics=verbs,libfabric
   hwloc:
     variants: +cuda
   # install issue with gettext


### PR DESCRIPTION
Found by @AdamSimpson (Nvidia) et al., singularity incorrectly sets the permissions of some dirs and files when not `chmod`-ed in the same `RUN` statement.

https://github.com/sylabs/singularity/issues/3880

We just fuse them for now.

Also, disable the UCX backend in OpenMPI due to known issues:
- https://github.com/open-mpi/ompi/issues/4948#issuecomment-512987494
- https://github.com/openucx/ucx/issues/3545