### PR TITLE
Radiation Plugin: fix bool conditions for hdf5 output

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -326,6 +326,8 @@ private:
                 if (isMaster)
                 {
                     timeSumArray = new Amplitude[elements_amplitude()];
+                    for (unsigned int i = 0; i < elements_amplitude(); ++i)
+                        timeSumArray[i] = Amplitude::zero();
 
                     /* save detector position / observation direction */
                     detectorPositions = new vector_64[parameters::N_observer];
@@ -343,7 +345,7 @@ private:
 
                 }
 
-                if (isMaster && totalRad)
+                if (isMaster)
                 {
                     fs.createDirectory("radiationHDF5");
                     fs.setDirectoryPermissions("radiationHDF5");
@@ -361,8 +363,6 @@ private:
                     //create folder for total output
                     fs.createDirectory(folderTotalRad);
                     fs.setDirectoryPermissions(folderTotalRad);
-                    for (unsigned int i = 0; i < elements_amplitude(); ++i)
-                        timeSumArray[i] = Amplitude::zero();
                 }
                 if (isMaster && lastRad)
                 {


### PR DESCRIPTION
This pull request fixes issue #3020. It rearranges the dependencies for creating specific (hdf5 related) output directories and arrays. Thus hdf5 output is now always produced, even if `--<species>_radiation.totalRadiation` is not set. 

The following run time test still need to be performed:

- [x] compare `dev` and `pr` total radiation (update: and hdf5)
- [x] compare `dev` and `pr` lastRadiation and hdf5 output when omitting the `--<species>_radiation.totalRadiation` flag (update: of course only in der `pr` branch)
- [x] compare `dev` and `pr` totalRadiation and hdf5 output after a restart

For testing the default Bunch example will be used. 

@Anton-Le this should solve your issue. 
 