### PR TITLE
Add a runtime parameter for window move point

### DIFF
--- a/include/picongpu/simulation/control/MovingWindow.hpp
+++ b/include/picongpu/simulation/control/MovingWindow.hpp
@@ -199,6 +199,32 @@ private:
      */
     bool slidingWindowEnabled = false;
 
+    /** Defines when to start sliding the window
+     *
+     * A virtual photon starts at t=0 at the lower end (min y) of the global
+     * simulation box in the positive y direction. The window sliding starts at
+     * the moment of time when the particle covers the movePoint ratio of the
+     * global moving window size in the y direction.
+     *
+     * Note that with the moving window enabled, there is an additional "hidden"
+     * row of local domains (and devices simulating them) at the y-front.
+     * Therefore, the global moving window size in the y direction is the global
+     * domain size minus a local domain size (which is required to be the same
+     * for all domains).
+     *
+     * So, in short, the window starts sliding in time required to pass the
+     * distance of movePoint * (global window size in y) when moving with
+     * the speed of light.
+     *
+     * Setting movePoint to 0.0 makes the window start sliding at the start
+     * of a simulation, and setting it to 1.0 makes it start sliding when the
+     * virtual photon reaches the start of the "hidden" row of local domains.
+     * It is permitted to use values outside of the [0.0, 1.0] interval to
+     * achieve the effects of "pre-movement" and "delayed movement", however
+     * this might complicate the setup and so not recommended unless essential.
+     */
+    float_64 movePoint;
+
     /** current number of slides since start of simulation */
     uint32_t slideCounter = 0u;
 
@@ -212,6 +238,17 @@ private:
     uint32_t endSlidingOnStep = 0u;
 
 public:
+
+    /** Set window move point which defines when to start sliding the window
+     *
+     * See declaration of movePoint for a detailed explanation.
+     *
+     * @param point ratio of the global window size
+     */
+    void setMovePoint(float_64 const point)
+    {
+        movePoint = point;
+    }
 
     /**
      * Set step where the simulation stops the moving window


### PR DESCRIPTION
Solves #2943.

I spent some time considering how to do such changes without breaking the user sets of input files. The issue is that just adding a new runtime parameter and removing the dependency on the compile-time one would make old files silently produce different results, which is far from desired. So this PR goes for a compromise. Now the old compile-time variable is still required, its value is used as a default for the new runtime parameter. In case the moving window is enabled but the new value is not set (so the setup relies on the old behavior) it would still work as usual for now, but there is an explanatory warning in the log. Then we can remove support for the old way e.g. one release after this change is added.

Also noted a description of how the moving window works seems to be missing in the readthedocs.  However, not subject of this PR to fix it.

Edit: with these changes, some of our standard examples will also trigger the warning. This will be fixed after this PR is merged.