### PR TITLE
Modernize ArgsParser::ArgsErrorCode

### DIFF
--- a/include/picongpu/ArgsParser.cpp
+++ b/include/picongpu/ArgsParser.cpp
@@ -61,7 +61,7 @@ namespace picongpu
         return instance;
     }
 
-    ArgsParser::ArgsErrorCode ArgsParser::parse( int argc, char** argv )
+    ArgsParser::Status ArgsParser::parse( int argc, char** argv )
     {
         namespace po = boost::program_options;
 
@@ -112,13 +112,13 @@ namespace picongpu
             if ( vm.count( "help" ) )
             {
                 std::cout << desc << "\n";
-                return SUCCESS_EXIT;
+                return Status::successExit;
             }
             // print versions of dependent software
             if ( vm.count( "version" ) )
             {
                 void( getSoftwareVersions( std::cout ) );
-                return SUCCESS_EXIT;
+                return Status::successExit;
             }
             // no parameters set: required parameters (e.g., -g) will be missing
             // -> obvious wrong usage
@@ -126,7 +126,7 @@ namespace picongpu
             if ( argc == 1 ) // argc[0] is always the program name
             {
                 std::cerr << desc << "\n";
-                return ERROR;
+                return Status::error;
             }
 
             if ( vm.count( "validate" ) )
@@ -134,16 +134,16 @@ namespace picongpu
                 /* if we reach this part of code the parameters are valid
                  * and the option `validate` is set.
                  */
-                return SUCCESS_EXIT;
+                return Status::successExit;
             }
         }
         catch ( const po::error& e )
         {
             std::cerr << e.what() << std::endl;
-            return ERROR;
+            return Status::error;
         }
 
-        return SUCCESS;
+        return Status::success;
     }
 
 }

--- a/include/picongpu/ArgsParser.hpp
+++ b/include/picongpu/ArgsParser.hpp
@@ -42,7 +42,14 @@ namespace picongpu
     {
     public:
 
-        enum ArgsErrorCode {SUCCESS=0,SUCCESS_EXIT=1,ERROR=42};
+        //! Parsing status
+        enum Status
+        {
+            success,
+            successExit,
+            error
+        };
+
         /**
          * Returns an instance of ArgsParser
          *
@@ -60,11 +67,9 @@ namespace picongpu
          *
          * @param argc number of command line arguments
          * @param argv command line arguments
-         * @return true if the simulation should proceed, false otherwise
+         * @return parsing status
          */
-        ArgsErrorCode parse(int argc, char **argv);
-
-
+        Status parse(int argc, char **argv);
 
     private:
         /**

--- a/include/picongpu/main.cpp
+++ b/include/picongpu/main.cpp
@@ -29,13 +29,6 @@
 #include <stdexcept>
 #include <string>
 
-/* Workaround for Visual Studio to avoid a collision between ERROR macro
- * defined in wingdi.h file (included from some standard library headers) and
- * enumerator ArgsParser::ArgsErrorCode::ERROR.
- */
-#ifdef _MSC_VER
-#   undef ERROR
-#endif
 
 namespace
 {
@@ -50,20 +43,20 @@ namespace
         using namespace picongpu;
 
         simulation_starter::SimStarter sim;
-        ArgsParser::ArgsErrorCode parserCode = sim.parseConfigs( argc, argv );
+        auto const parserStatus = sim.parseConfigs( argc, argv );
         int errorCode = EXIT_FAILURE;
 
-        switch( parserCode )
+        switch( parserStatus )
         {
-            case ArgsParser::ERROR:
+            case ArgsParser::Status::error:
                 errorCode = EXIT_FAILURE;
                 break;
-            case ArgsParser::SUCCESS:
+            case ArgsParser::Status::success:
                 sim.load( );
                 sim.start( );
                 sim.unload( );
                 PMACC_FALLTHROUGH;
-            case ArgsParser::SUCCESS_EXIT:
+            case ArgsParser::Status::successExit:
                 errorCode = 0;
                 break;
         };

--- a/include/picongpu/simulation/control/ISimulationStarter.hpp
+++ b/include/picongpu/simulation/control/ISimulationStarter.hpp
@@ -43,7 +43,7 @@ namespace picongpu
          *
          * @return true if no error else false
          */
-        virtual ArgsParser::ArgsErrorCode parseConfigs(int argc, char **argv) = 0;
+        virtual ArgsParser::Status parseConfigs(int argc, char **argv) = 0;
 
         /*start simulation
          * is called after parsConfig and pluginLoad

--- a/include/picongpu/simulation/control/SimulationStarter.hpp
+++ b/include/picongpu/simulation/control/SimulationStarter.hpp
@@ -88,7 +88,7 @@ namespace picongpu
         {
         }
 
-        ArgsParser::ArgsErrorCode parseConfigs(int argc, char **argv)
+        ArgsParser::Status parseConfigs(int argc, char **argv)
         {
             ArgsParser& ap = ArgsParser::getInstance();
             PluginConnector& pluginConnector = Environment<>::get().PluginConnector();


### PR DESCRIPTION
And rename it to Status. Due to this change, the Visual Studio-specific workaround with the `ERROR` macro is no longer needed, so got rid of it.