### PR TITLE
allow constructor for density free formular functor

### DIFF
--- a/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
@@ -28,10 +28,10 @@ namespace picongpu
 {
 namespace densityProfiles
 {
-    template< typename T_UserFuntor >
-    struct FreeFormulaImpl : public particles::functor::User< T_UserFuntor >
+    template< typename T_UserFunctor >
+    struct FreeFormulaImpl : public particles::functor::User< T_UserFunctor >
     {
-        using UserFunctor = particles::functor::User< T_UserFuntor >;
+        using UserFunctor = particles::functor::User< T_UserFunctor >;
 
         template< typename T_SpeciesType >
         struct apply


### PR DESCRIPTION
`FreeFormulaImpl` allows the user functor to define a constructor to move additional information into the profile.
This allow e.g. filtering by cell position relative to the global volume

# example
```C++
//! example implementation is not supporting moving window
struct RelativeRangeProfile
{
    static constexpr float_X start_ratio = 0.1_X;
    static constexpr float_X end_ratio = 0.3_X;
    static constexpr uint32_t usedDim = 1u;

    float_64 first_cell = 0.0_X;
    float_64 last_cell = 0.0_X;
    RelativeRangeProfile()
    {
        const SubGrid< simDim >& subGrid = Environment< simDim >::get().SubGrid();

        auto globalSize = subGrid.getGlobalDomain().size;
        auto deviceOffset = subGrid.getLocalDomain().offset;
        first_cell = ( static_cast< float_64 >( globalSize[usedDim] ) * start_ratio ) -
            static_cast< float_64 >( deviceOffset[ usedDim ] );
        last_cell = ( static_cast< float_64 >( globalSize[ usedDim ] ) * end_ratio ) -
            static_cast< float_64 >( deviceOffset[ usedDim ] );
    }

    //! homogenous density between [start_ratio;end_ratio) of the global domain
    HDINLINE float_X
    operator()(
        floatD_64 const & position_SI,
        float3_64 const & cellSize_SI
    )
    {
        return position_SI[usedDim] >= first_cell && position_SI[usedDim] < last_cell ? 1.0_X : 0.0_X;
    }
};

// definition of free formula profile
using HomogenousRange = FreeFormulaImpl< RelativeRangeProfile >;
```