### PR TITLE
Fix field solver initialization order

### DIFF
--- a/include/picongpu/simulation/control/MySimulation.hpp
+++ b/include/picongpu/simulation/control/MySimulation.hpp
@@ -305,6 +305,9 @@ public:
         DataConnector &dc = Environment<>::get().DataConnector();
         initFields(dc);
 
+        // create field solver
+        this->myFieldSolver = new fields::Solver(*cellDescription);
+
         // Initialize random number generator and synchrotron functions, if there are synchrotron or bremsstrahlung Photons
         using AllSynchrotronPhotonsSpecies = typename pmacc::particles::traits::FilterByFlag<
             VectorAllSpecies,
@@ -417,9 +420,6 @@ public:
         log<picLog::MEMORY > ("free mem after all mem is allocated %1% MiB") % (freeGpuMem / 1024 / 1024);
 
         IdProvider<simDim>::init();
-
-        // create field solver
-        this->myFieldSolver = new fields::Solver(*cellDescription);
 
 #if( PMACC_CUDA_ENABLED == 1 )
         /* add CUDA streams to the StreamController for concurrent execution */


### PR DESCRIPTION
When developing PML I did not think of the memory allocation order and continued using the old one with field solver being constructed after the particle memory allocation (and my tests were small enough that it worked fine). But since the `YeePML` solver involves allocation of additional field components that lead to out-of-memory error #3027.

Imo there is also room for improvement in terms of design, as such limitations are not obvious at all. I could try to refactor it in a follow-up PR.