### PR TITLE
Fix a crash in reporting deprecated parameters

### DIFF
--- a/include/picongpu/ArgsParser.cpp
+++ b/include/picongpu/ArgsParser.cpp
@@ -54,7 +54,7 @@ namespace
         /* Moving window: a new run-time parameter 'windowMovePoint' to replace
          * compile-time 'movePoint' variable
          */
-        bool isMovingWindowEnabled = vm[ "moving" ].as< bool >( );
+        bool isMovingWindowEnabled = !vm[ "moving" ].empty();
         if( isMovingWindowEnabled )
         {
             bool isWindowMovePointSet = !vm[ "windowMovePoint" ].defaulted( );


### PR DESCRIPTION
Fixes  #3034.
The bug was introduced in #3022.

- [x] do a test run on Hemera (in the queue atm)