### PR TITLE
Fix multiple definitions of PMacc identifiers and aliases

### DIFF
--- a/include/pmacc/identifier/alias.hpp
+++ b/include/pmacc/identifier/alias.hpp
@@ -38,8 +38,13 @@ identifier(pmacc_isAlias);
 
 #ifdef __CUDACC__
 #   define PMACC_alias_CUDA(name,id)                                          \
-        namespace PMACC_JOIN(device_placeholder,id){                           \
-            __constant__ PMACC_JOIN(placeholder_definition,id)::name<> PMACC_JOIN(name,_); \
+        namespace PMACC_JOIN(device_placeholder,id){                          \
+            /* This variable exists only for template parameter deduction, its
+             * value is never used. So in this case it is fine to have a
+             * separate version in each translation unit due to static.
+             */                                                               \
+            static __constant__ PMACC_JOIN(placeholder_definition,id)::name<> \
+                PMACC_JOIN(name,_);                                           \
         }
 #else
 #   define PMACC_alias_CUDA(name,id)
@@ -59,7 +64,12 @@ identifier(pmacc_isAlias);
     }                                                                          \
     using namespace PMACC_JOIN(placeholder_definition,id);                     \
     namespace PMACC_JOIN(host_placeholder,id){                                 \
-        PMACC_JOIN(placeholder_definition,id)::name<> PMACC_JOIN(name,_);      \
+        /* This variable exists only for template parameter deduction, its value
+         * is never used. So in this case it is fine to have a separate version
+         * in each translation unit due to static.
+         */                                                                    \
+        static PMACC_JOIN(placeholder_definition,id)::name<>                   \
+            PMACC_JOIN(name,_);                                                \
     }                                                                          \
     PMACC_alias_CUDA(name,id);                                                 \
     PMACC_PLACEHOLDER(id);

--- a/include/pmacc/identifier/identifier.hpp
+++ b/include/pmacc/identifier/identifier.hpp
@@ -35,7 +35,11 @@
 #ifdef __CUDACC__
 #   define PMACC_identifier_CUDA(name,id)                                         \
         namespace PMACC_JOIN(device_placeholder,id){                               \
-            __constant__ PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
+            /* This variable exists only for template parameter deduction, its value
+             * is never used. So in this case it is fine to have a separate version
+             * in each translation unit due to static.
+             */                                                                    \
+            static __constant__ PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
         }
 #else
 #   define PMACC_identifier_CUDA(name,id)
@@ -50,7 +54,11 @@
     }                                                                          \
     using namespace PMACC_JOIN(placeholder_definition,id);                     \
     namespace PMACC_JOIN(host_placeholder,id){                                 \
-        PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_);        \
+        /* This variable exists only for template parameter deduction, its value
+         * is never used. So in this case it is fine to have a separate version
+         * in each translation unit due to static.
+         */                                                                    \
+        static PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
     }                                                                          \
     PMACC_identifier_CUDA(name,id);                                            \
     PMACC_PLACEHOLDER(id);


### PR DESCRIPTION
Now these variables are `static` and so will exist in each translation unit including the headers in question.
This is however fine, since the variables are only used for template parameter deduction.

This PR is working towards removing limitations on including PMacc stuff to several object files, started with #3006. (but a few more PRs required to reach that goal).