### PR TITLE
Proper Constructor in unitDimension std::vector

### DIFF
--- a/include/picongpu/fields/FieldB.tpp
+++ b/include/picongpu/fields/FieldB.tpp
@@ -52,7 +52,7 @@ namespace picongpu
         /* B is in Tesla : kg / (A * s^2)
          *   -> M * T^-2 * I^-1
          */
-        std::vector< float_64 > unitDimension{ 7, 0.0 };
+        std::vector< float_64 > unitDimension( 7, 0.0 );
         unitDimension.at( SIBaseUnits::mass ) =  1.0;
         unitDimension.at( SIBaseUnits::time ) = -2.0;
         unitDimension.at( SIBaseUnits::electricCurrent ) = -1.0;

--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -52,7 +52,7 @@ namespace picongpu
         /* E is in volts per meters: V / m = kg * m / (A * s^3)
          *   -> L * M * T^-3 * I^-1
          */
-        std::vector< float_64 > unitDimension{ 7, 0.0 };
+        std::vector< float_64 > unitDimension( 7, 0.0 );
         unitDimension.at( SIBaseUnits::length ) =  1.0;
         unitDimension.at( SIBaseUnits::mass )   =  1.0;
         unitDimension.at( SIBaseUnits::time )   = -3.0;


### PR DESCRIPTION
The bug has been introduced in #3005 by confusing constructors of `std::vector`.
It causes crashes in all code calling `getUnitDimension()` of `FieldE` and `FieldB`, notably output and checkpoints, such as #3037.