### PR TITLE
Remove unused includes of pthread

### DIFF
--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -81,7 +81,6 @@
 #include <unistd.h>
 #endif
 
-#include <pthread.h>
 #include <sstream>
 #include <string>
 #include <list>

--- a/include/picongpu/plugins/hdf5/HDF5Writer.hpp
+++ b/include/picongpu/plugins/hdf5/HDF5Writer.hpp
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <pthread.h>
 #include <sstream>
 #include <string>
 #include <list>


### PR DESCRIPTION
This has been spotted during the investigation of #3037 (but is unrelated to that issue).

Now the core code of PIConGPU does not include or use `pthread`, only `cuda_memtest` and `alpaka` do.