### PR TITLE
Docs: Cori's KNL Nodes (NERSC)

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -154,8 +154,8 @@ Queue: gpu2 (Nvidia K80 GPUs)
 .. literalinclude:: profiles/taurus-tud/k80_picongpu.profile.example
    :language: bash
 
-Queue: knl (Intel  Intel Xeon Phi - Knights Landing)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Queue: knl (Intel Xeon Phi - Knights Landing)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For this profile, you additionally need to install your own :ref:`boost <install-dependencies>`.
 
@@ -205,8 +205,8 @@ Cori (NERSC)
 
 For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter and libSplash <install-dependencies>` manually.
 
-Queue: regular (Intel  Intel Xeon Phi - Knights Landing)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Queue: regular (Intel Xeon Phi - Knights Landing)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: profiles/cori-nersc/knl_picongpu.profile.example
    :language: bash

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -194,6 +194,23 @@ Additionally, you need to make the ``rsync`` command available as written below.
 .. literalinclude:: profiles/lawrencium-lbnl/picongpu.profile.example
    :language: bash
 
+Cori (NERSC)
+------------
+
+**System overview:** `link <https://www.nersc.gov/users/computational-systems/cori/configuration/>`_
+
+**User guide:** `link <https://docs.nersc.gov/>`_
+
+**Production directory:** ``$SCRATCH`` (`link <https://www.nersc.gov/users/storage-and-file-systems/>`_).
+
+For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter and libSplash <install-dependencies>` manually.
+
+Queue: regular (Intel  Intel Xeon Phi - Knights Landing)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/cori-nersc/knl_picongpu.profile.example
+   :language: bash
+
 Draco (MPCDF)
 -------------
 

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -52,7 +52,7 @@ Batch System Examples
 Slurm
 """""
 
-Slurm is a modern batch system, e.g. installed on the Taurus cluster at TU Dresden.
+Slurm is a modern batch system, e.g. installed on the Taurus cluster at TU Dresden, Hemera at HZDR, Cori at NERSC, among others.
 
 .. include:: ../install/profiles/taurus-tud/Slurm_Tutorial.rst
    :start-line: 3

--- a/etc/picongpu/cori-nersc/knl.tpl
+++ b/etc/picongpu/cori-nersc/knl.tpl
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Copyright 2013-2019 Axel Huebl, Richard Pausch, Alexander Matthes
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for Cori's SLURM batch system
+
+#SBATCH -p !TBG_queue
+#SBATCH --constraint="knl,quad,cache"
+#SBATCH --time=!TBG_wallTime
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --core-spec=!TBG_coresForSystem
+#SBATCH --chdir=!TBG_dstPath
+
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --account=!TBG_nameProject
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="regular"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${proj:-""}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of hardware threads used per core (hyperthreading: 1-4)
+.TBG_hardwareThreadsPerCore=1
+
+# 1 accelerator per node
+.TBG_accPerNode=1
+
+# number of cores to block per KNL - we got 64(+4) cores per node
+.TBG_coresPerAcc=64
+.TBG_coresForSystem=4
+
+# use ceil to calculate nodes
+.TBG_nodes=!TBG_tasks
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+# note: no need to source profile as environment is cloned from submit environment
+# source !TBG_profile
+echo "profile cloned at submit time: !TBG_profile"
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+export OMP_NUM_THREADS=$(( !TBG_coresPerAcc * !TBG_hardwareThreadsPerCore ))
+export OMP_PLACES=threads
+export OMP_PROC_BIND=spread  # variants: spread and close
+
+# Run PIConGPU
+srun --cpu_bind=cores                 \
+     --ntasks=!TBG_tasks              \
+     --cpus-per-task=!TBG_coresPerAcc \
+     !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams

--- a/etc/picongpu/cori-nersc/knl_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/knl_picongpu.profile.example
@@ -56,7 +56,7 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/cori-nersc/knl.tpl"
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
         numNodes=1

--- a/etc/picongpu/cori-nersc/knl_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/knl_picongpu.profile.example
@@ -1,0 +1,67 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Project Information ######################################## (edit this line)
+#   - project account for computing time
+export proj="<yourProject>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# General modules #############################################################
+#
+module swap craype-haswell craype-mic-knl
+module swap PrgEnv-intel PrgEnv-gnu  # GCC 8.2.0
+module load cmake/3.14.4
+module load boost/1.70.0
+
+# Other Software ##############################################################
+#
+module load adios/1.13.1
+module load cray-hdf5-parallel/1.10.2.0
+module load png/1.6.34
+
+export Splash_ROOT=${HOME}/sw/libSplash-1.7.0-8-gb9421ba
+export PNGwriter_ROOT=${HOME}/sw/pngwriter-0.7.0-21-g9dc58ed
+
+# Environment #################################################################
+#
+export CC="$(which cc)"
+export CXX="$(which CC)"
+export CRAYPE_LINK_TYPE=dynamic
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="omp2b"  # usually ":MIC-AVX512" but we use PrgEnv wrappers
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "defq" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/cori-nersc/knl.tpl"
+
+# allocate an interactive shell for one hour
+#   getNode 2  # allocates to interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    srun --time=1:00:00 --nodes=$numNodes --ntasks-per-node=1 --cpus-per-task=64 -C "knl,quad,cache" -p regular --pty bash
+}


### PR DESCRIPTION
Add profiles for Cori's KNL nodes.

As on Taurus' KNL nodes at ZIH, I kept the "one MPI rank per KNL" and "one hyperthread per code" strategy.

I am not sure if we ever tuned this for ideal performance, because e.g. [WarpX](https://warpx.readthedocs.io/en/latest/running_cpp/platforms.html)/PICSAR reported better performance with 8 MPI ranks per device to sub-partition the KNL. If I remember correctly, we just checked some hyperthread performance [here](https://arxiv.org/abs/1706.10086) on KNL and sub-partition all other, multi-socket CPU hardware these days.

Either way, as the Taurus KNL profile, this profile works.

I guess @sbastrakov would have some experience tuning the checked-in KNL profiles further (e.g. on Taurus). Maybe we want to revisit partitioning a KNL into multiple "devices" like we do for multi-socket systems. And maybe we want to use hyperthreading in those profiles with "close" process binding.