### PR TITLE
fix typo in getNode and getDevice

### DIFF
--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -63,7 +63,7 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/aris-grnet/gpu.tpl"
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
         numNodes=1
@@ -74,7 +74,7 @@ function getNode() {
 }
 
 # allocate an interactive shell for one hour
-#   getDevice 2  # allocates to interactive devices (default: 1)
+#   getDevice 2  # allocates two interactive devices (default: 1)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
+++ b/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
@@ -74,7 +74,7 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/davide-cineca/gpu.tpl"
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
         numNodes=1
@@ -85,7 +85,7 @@ function getNode() {
 }
 
 # allocate an interactive shell for one hour
-#   getDevice 2  # allocates to interactive devices (default: 1)
+#   getDevice 2  # allocates two interactive devices (default: 1)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -54,7 +54,7 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/defq.tpl"
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
         numNodes=1
@@ -65,7 +65,7 @@ function getNode() {
 }
 
 # allocate an interactive shell for one hour
-#   getDevice 2  # allocates to interactive devices (default: 1)
+#   getDevice 2  # allocates two interactive devices (default: 1)
 function getDevice() {
     if [ -z "$1" ] ; then
         numDevices=1

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -55,7 +55,7 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/gpu.tpl"
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
         numNodes=1
@@ -66,7 +66,7 @@ function getNode() {
 }
 
 # allocate an interactive shell for one hour
-#   getDevice 2  # allocates to interactive devices (default: 1)
+#   getDevice 2  # allocates two interactive devices (default: 1)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -55,7 +55,7 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/k20.tpl"
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
         numNodes=1
@@ -66,7 +66,7 @@ function getNode() {
 }
 
 # allocate an interactive shell for one hour
-#   getDevice 2  # allocates to interactive devices (default: 1)
+#   getDevice 2  # allocates two interactive devices (default: 1)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -55,7 +55,7 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/k80.tpl"
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
         numNodes=1
@@ -66,7 +66,7 @@ function getNode() {
 }
 
 # allocate an interactive shell for one hour
-#   getDevice 2  # allocates to interactive devices (default: 1)
+#   getDevice 2  # allocates two interactive devices (default: 1)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -95,7 +95,7 @@ export TBG_TPLFILE="etc/picongpu/pizdaint-cscs/normal.tpl"
 # helper tools ################################################################
 
 # allocate an interactive shell for one hour
-#   getNode 2  # allocates to interactive nodes (default: 1)
+#   getNode 2  # allocates two interactive nodes (default: 1)
 getNode() {
     if [ -z "$1" ] ; then
         numNodes=1


### PR DESCRIPTION
This pull request fixes a typo in the documentation of `getNode` and `getDevice` in the example profiles for **all** supported clusters. 

