### PR TITLE
Add missing inline specifiers for functions defined in header files

### DIFF
--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -71,7 +71,7 @@ namespace picongpu
          * @param cellDescription mapping for kernels
          * @param slotId index of the temporary field
          */
-        FieldTmp(
+        HINLINE FieldTmp(
             MappingDesc const & cellDescription,
             uint32_t slotId
         );

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -107,7 +107,7 @@ private:
 
 public:
     /* host constructor initializing member */
-    Bremsstrahlung(
+    HINLINE Bremsstrahlung(
         const ScaledSpectrum::LookupTableFunctor& scaledSpectrumFunctor,
         const ScaledSpectrum::LookupTableFunctor& stoppingPowerFunctor,
         const GetPhotonAngle::GetPhotonAngleFunctor& getPhotonAngleFunctor,

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -116,7 +116,7 @@ private:
      * @param kappa energy loss normalized to Ekin
      * @param targetZ atomic number of the target material
      */
-    float_64 dcs(const float_64 Ekin, const float_64 kappa, const float_64 targetZ) const;
+    HINLINE float_64 dcs(const float_64 Ekin, const float_64 kappa, const float_64 targetZ) const;
 
     /** differential cross section times energy loss
      */
@@ -142,19 +142,19 @@ public:
      *
      * @param targetZ atomic number of the target material
      */
-    void init(const float_64 targetZ);
+    HINLINE void init(const float_64 targetZ);
 
     /** Return a functor representing the scaled differential cross section
      *
      * scaled differential cross section = electron energy loss times cross section per unit energy
      */
-    LookupTableFunctor getScaledSpectrumFunctor() const;
+    HINLINE LookupTableFunctor getScaledSpectrumFunctor() const;
 
     /** Return a functor representing the stopping power
      *
      * stopping power = energy loss per unit length
      */
-    LookupTableFunctor getStoppingPowerFunctor() const;
+    HINLINE LookupTableFunctor getStoppingPowerFunctor() const;
 };
 
 

--- a/include/picongpu/plugins/ChargeConservation.hpp
+++ b/include/picongpu/plugins/ChargeConservation.hpp
@@ -57,18 +57,18 @@ private:
     using AllGPU_reduce = boost::shared_ptr<pmacc::algorithm::mpi::Reduce<simDim> >;
     AllGPU_reduce allGPU_reduce;
 
-    void restart(uint32_t restartStep, const std::string restartDirectory);
-    void checkpoint(uint32_t currentStep, const std::string checkpointDirectory);
+    HINLINE void restart(uint32_t restartStep, const std::string restartDirectory);
+    HINLINE void checkpoint(uint32_t currentStep, const std::string checkpointDirectory);
 
-    void pluginLoad();
+    HINLINE void pluginLoad();
 public:
-    ChargeConservation();
+    HINLINE ChargeConservation();
     virtual ~ChargeConservation() {}
 
-    void notify(uint32_t currentStep);
-    void setMappingDescription(MappingDesc*);
-    void pluginRegisterHelp(po::options_description& desc);
-    std::string pluginGetName() const;
+    HINLINE void notify(uint32_t currentStep);
+    HINLINE void setMappingDescription(MappingDesc*);
+    HINLINE void pluginRegisterHelp(po::options_description& desc);
+    HINLINE std::string pluginGetName() const;
 };
 
 namespace particles

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -151,7 +151,7 @@ namespace mpi
 
   /** implementation of MPI transaction on Amplitude class */
   template<>
-  MPI_StructAsArray getMPI_StructAsArray< picongpu::plugins::radiation::Amplitude >()
+  HINLINE MPI_StructAsArray getMPI_StructAsArray< picongpu::plugins::radiation::Amplitude >()
   {
       MPI_StructAsArray result = getMPI_StructAsArray< picongpu::plugins::radiation::Amplitude::complex_64::type > ();
       result.sizeMultiplier *= picongpu::plugins::radiation::Amplitude::numComponents;

--- a/include/picongpu/plugins/radiation/check_consistency.hpp
+++ b/include/picongpu/plugins/radiation/check_consistency.hpp
@@ -30,15 +30,15 @@ namespace plugins
 namespace radiation
 {
 
-void check_consistency(void)
+HINLINE void check_consistency(void)
 {
-  using namespace parameters;
-  std::cout << " checking efficiency of radiation code: " ;
-  if(radiation_frequencies::N_omega%radiation_frequencies::blocksize_omega == 0)
-    std::cout << "OK" << std::endl;
-  else
-    std::cout << "better use power of two for N_omega" << std::endl;
-  // is there a way to do this with  compile time asserts???
+    using namespace parameters;
+    std::cout << " checking efficiency of radiation code: " ;
+    if(radiation_frequencies::N_omega%radiation_frequencies::blocksize_omega == 0)
+        std::cout << "OK" << std::endl;
+    else
+        std::cout << "better use power of two for N_omega" << std::endl;
+    // \@todo is there a way to do this with  compile time asserts???
 }
 
 } // namespace radiation


### PR DESCRIPTION
Most of this `inline` stuff was covered by #3006, but a couple of things were missed.

For the context: with all these PRs aimed at avoiding double definitions, it is now almost possible to have multiple object files in picongpu that include pmacc and all the real stuff. With a couple more changes, not submitted yet, LWFA is building on both my MSVS and on Hemera in that "multiple object files" mode.