### PR TITLE
refactor: omega read from file

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -121,7 +121,6 @@ TBG_stopWindow="--stopWindow 1337"
 #--<species>_radiation.folderTotalRad     Folder in which total radiation spectra are stored
 #--<species>_radiation.start     Time step to start calculating the radition
 #--<species>_radiation.end     Time step to stop calculating the radiation
-#--<species>_radiation.omegaList     If spectrum frequencies are taken from a file, this gives the path to this list
 #--<species>_radiation.radPerGPU     If flag is set, each GPU stores its own spectra without summing the entire simulation area
 #--<species>_radiation.folderRadPerGPU     Folder where the GPU specific spectras are stored
 #--e_<species>_radiation.compression    If flag is set, the hdf5 output will be compressed.

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -75,7 +75,7 @@ The number of total sample frequencies ``N_omega`` need to be defined as ``const
 In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
 
 For the **file-based frequency** definition,  all definitions need to be in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace.
-The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values un units of :math:`[s^{-1}]` needs to be given as ``constexpr char listLocation[] = "/path/to/frequency_list";``. 
+The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values un units of :math:`[s^{-1}]` needs to be given as ``constexpr const char * listLocation = "/path/to/frequency_list";``.
 
 .. note::
 

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -62,6 +62,24 @@ namespace                     Description
 ============================= ==============================================================================================
 
 
+
+All three options require variable definitions in the according namespaces as described below:
+
+For the **linear frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::linear_frequencies`` namespace. 
+The number of total sample frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``.
+In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
+
+For the **logarithmic frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::log_frequencies`` namespace. 
+Equivalently to the linear case, three variables need to be defined: 
+The number of total sample frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``.
+In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
+
+For the **file-based frequency** definition,  all definitions need to be in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace.
+The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values un units of :math:`[s^{-1}]` needs to be given as ``constexpr char listLocation[] = "/path/to/frequency_list";``. 
+
+
+
+
 Observation directions
 """"""""""""""""""""""
 

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -75,7 +75,8 @@ The number of total sample frequencies ``N_omega`` need to be defined as ``const
 In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
 
 For the **file-based frequency** definition,  all definitions need to be in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace.
-The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values un units of :math:`[s^{-1}]` needs to be given as ``constexpr const char * listLocation = "/path/to/frequency_list";``.
+The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values in units of :math:`[s^{-1}]` needs to be given as ``constexpr const char * listLocation = "/path/to/frequency_list";``.
+The frequency values in the file can be separated by newlines, spaces, tabs, or any other whitespace. The numbers should be given in such a way, that c++ standard ``std::ifstream`` can interpret the number e.g., as ``2.5344e+16``. 
 
 .. note::
 

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -263,8 +263,6 @@ Command line option                       Description
                                           Default is ``2`` in order to get enough history of the particles.
 ``--<species>_radiation.end``             Time step, at which the radiation calculation should end.
                                           Default: ``0``(stops at end of simulation).
-``--<species>_radiation.omegaList``       In case the frequencies for the spectrum are coming from a list stored in a file, this gives the path to this list.
-                                          Default: ``_noPath_`` throws an error. *This does not switch on the frequency calculation via list.*
 ``--<species>_radiation.radPerGPU``       If set, each GPU additionally stores its own spectra without summing over the entire simulation area.
                                           This allows for a localization of specific spectral features.
 ``--<species>_radiation.folderRadPerGPU`` Name of the folder, where the GPU specific spectra are stored.

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -77,7 +77,10 @@ In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum fre
 For the **file-based frequency** definition,  all definitions need to be in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace.
 The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values un units of :math:`[s^{-1}]` needs to be given as ``constexpr char listLocation[] = "/path/to/frequency_list";``. 
 
+.. note::
 
+   Currently, the variable ``listLocation`` is required to be defined in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace, even if ``frequencies_from_list`` is not used.
+   The string does not need to point to an existing file, as long as the file-based frequency definition is not used.
 
 
 Observation directions

--- a/include/picongpu/param/radiation.param
+++ b/include/picongpu/param/radiation.param
@@ -80,7 +80,7 @@ namespace SI
 namespace frequencies_from_list
 {
     /** path to text file with frequencies */
-    constexpr char listLocation[] = "/path/to/frequency_list";
+    constexpr const char * listLocation = "/path/to/frequency_list";
     /** number of frequency values to compute if frequencies are given in a file [unitless] */
     constexpr unsigned int N_omega = 2048;
 } // namespace frequencies_from_list

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -338,7 +338,7 @@ private:
                     detectorFrequencies = new float_64[radiation_frequencies::N_omega];
                     for(uint32_t detectorIndex=0; detectorIndex < radiation_frequencies::N_omega; ++detectorIndex)
                     {
-                        detectorFrequencies[detectorIndex] = freqFkt(detectorIndex);
+                        detectorFrequencies[detectorIndex] = freqFkt.get(detectorIndex);
                     }
 
                 }

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -116,7 +116,6 @@ private:
     bool lastRad;
     std::string folderLastRad;
     std::string folderTotalRad;
-    std::string pathOmegaList;
     bool radPerGPU;
     std::string folderRadPerGPU;
     DataSpace<simDim> lastGPUpos;
@@ -226,7 +225,6 @@ public:
                 ((pluginPrefix + ".folderTotalRad").c_str(), po::value<std::string > (&folderTotalRad)->default_value("totalRad"), "folder in which the integrated radiation from start of simulation is written")
                 ((pluginPrefix + ".start").c_str(), po::value<uint32_t > (&radStart)->default_value(2), "time index when radiation should start with calculation")
                 ((pluginPrefix + ".end").c_str(), po::value<uint32_t > (&radEnd)->default_value(0), "time index when radiation should end with calculation")
-                ((pluginPrefix + ".omegaList").c_str(), po::value<std::string > (&pathOmegaList)->default_value("_noPath_"), "path to file containing all frequencies to calculate")
                 ((pluginPrefix + ".radPerGPU").c_str(), po::bool_switch(&radPerGPU), "enable radiation output from each GPU individually")
                 ((pluginPrefix + ".folderRadPerGPU").c_str(), po::value<std::string > (&folderRadPerGPU)->default_value("radPerGPU"), "folder in which the radiation of each GPU is written")
                 ((pluginPrefix + ".compression").c_str(), po::bool_switch(&compressionOn), "enable compression of hdf5 output");
@@ -316,7 +314,7 @@ private:
 
                 radiation = new GridBuffer<Amplitude, DIM1 > (DataSpace<DIM1 > (elements_amplitude())); //create one int on GPU and host
 
-                freqInit.Init(pathOmegaList);
+                freqInit.Init(frequencies_from_list::listLocation);
                 freqFkt = freqInit.getFunctor();
 
 

--- a/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -43,6 +43,11 @@ namespace linear_frequencies
       {
           return omega_min + float_X(ID) * delta_omega;
       }
+
+      HINLINE float_X get(const int ID)
+      {
+          return operator()(ID);
+      }
     };
 
 

--- a/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -44,17 +44,26 @@ namespace frequencies_from_list
       FreqFunctor(void)
       { }
 
-      FreqFunctor(DBoxType frequencies_handed)
-      : frequencies(frequencies_handed)
-      { }
-
-      HDINLINE float_X operator()(const unsigned int ID)
+      template< typename T >
+      FreqFunctor(T frequencies_handed)
       {
-          return (ID < radiation_frequencies::N_omega) ?  frequencies[ID] : 0.0  ;
+          this->frequencies_dev = frequencies_handed->getDeviceBuffer().getDataBox();
+          this->frequencies_host = frequencies_handed->getHostBuffer().getDataBox();
+      }
+
+      DINLINE float_X operator()(const unsigned int ID)
+      {
+          return (ID < radiation_frequencies::N_omega) ?  frequencies_dev[ID] : 0.0  ;
+      }
+
+      HINLINE float_X get(const unsigned int ID)
+      {
+          return (ID < radiation_frequencies::N_omega) ?  frequencies_host[ID] : 0.0  ;
       }
 
     private:
-      DBoxType frequencies;
+      DBoxType frequencies_dev;
+      DBoxType frequencies_host;
 
     };
 
@@ -111,7 +120,7 @@ namespace frequencies_from_list
 
       FreqFunctor getFunctor(void)
       {
-          return FreqFunctor(frequencyBuffer->getDeviceBuffer().getDataBox());
+          return FreqFunctor(frequencyBuffer);
       }
 
     private:

--- a/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -46,6 +46,11 @@ namespace log_frequencies
           return  math::exp(omega_log_min + (float_X(ID)) * delta_omega_log) ;
       }
 
+      HINLINE float_X get(const int ID)
+      {
+          return operator()(ID);
+      }
+
     private:
       float_X omega_log_min;
       float_X delta_omega_log;

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -65,7 +65,8 @@ constexpr unsigned int N_omega = 2048; // number of frequencies
 
 namespace frequencies_from_list
 {
-//const char listLocation[] = "/scratch/s5960712/list001.freq";
+/** path to text file with frequencies */
+const char listLocation[] = "/path/to/frequency.list";
 constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -66,7 +66,7 @@ constexpr unsigned int N_omega = 2048; // number of frequencies
 namespace frequencies_from_list
 {
 /** path to text file with frequencies */
-const char listLocation[] = "/path/to/frequency.list";
+constexpr const char * listLocation = "/path/to/frequency.list";
 constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -68,7 +68,8 @@ constexpr unsigned int N_omega = 1024; // number of frequencies
 
 namespace frequencies_from_list
 {
-//const char listLocation[] = "/scratch/s5960712/list001.freq";
+/** path to text file with frequencies */
+const char listLocation[] = "/path/to/frequency.list";
 constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -69,7 +69,7 @@ constexpr unsigned int N_omega = 1024; // number of frequencies
 namespace frequencies_from_list
 {
 /** path to text file with frequencies */
-const char listLocation[] = "/path/to/frequency.list";
+constexpr const char * listLocation = "/path/to/frequency.list";
 constexpr unsigned int N_omega = 2048; // number of frequencies
 }
 


### PR DESCRIPTION
In the current implementation the radiation plugin provides a method to set a path tp a list of frequency (omega) values to compute the radiation for. However, the path is set only via command line option and the value set via namespace setting is totally ignored. 

Since various parameters need to be set in `radiation.param` anyway, I removed the command line option (which is not doing anything if the list option has not be selected in `radiation.param` before) end set the path to the path defined in the namespace. 

The documentation was adjusted accordingly.

I would like to do a run-time test just to see whether anything else is not working properly with this frequency option before continuing to work on #800 (for the frequencies). 

- [x] run time test  

----------
**Update:**

With the latest version, all run time tests produced correct results. Both linear and logarithmic frequency scales work as before. The list now works again and has been tested with newlines, tabs and spaces as separators (in agreement with the newly updated documentation). 



