### PR TITLE
fix various sphinx issues not related to doxygen

### DIFF
--- a/docs/source/install/path.rst
+++ b/docs/source/install/path.rst
@@ -53,7 +53,7 @@ Useful for small desktop or single-node runs.
 Nvidia-Docker
 ^^^^^^^^^^^^^
 
-Not yet officially supported, but we already provide a ``Dockerfile`` to get started.
+Not yet officially supported [nvidia-docker]_, but we already provide a ``Dockerfile`` to get started.
 Performance might be not ideal if the image is not built for the specific local hardware again.
 Useful for small desktop or single-node runs.
 We are also working on `Singularity <http://singularity.lbl.gov/>`_ images.

--- a/docs/source/models/photons.rst
+++ b/docs/source/models/photons.rst
@@ -5,12 +5,12 @@ Photons
 .. moduleauthor:: Heiko Burau
 
 Radiation reaction and (hard) photons: why and when are they needed.
-Models we implemented and verified:
+Models we implemented ([Gonoskov]_ and [Furry]_) and verified:
 
 * :ref:`Landau-Lifschitz Model (semi-classical) <model-LL-RR>`
 * QED Models (Synchrotron & Bremsstrahlung)
 
-Would be great to add your Diploma Thesis talk with pictures and comments here.
+Would be great to add your Diploma Thesis [Burau2016]_ talk with pictures and comments here.
 
 Please add notes and warnings on the models' assumptions for an easy guiding on their usage :)
 

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -165,6 +165,7 @@ sure that ``ipywidgets`` and ``ìpympl`` are installed.
 After starting the notebook server write the following
 
 .. code:: python
+
    # this is required!
    %matplotlib widget
    import matplotlib.pyplot as plt

--- a/docs/source/usage/plugins/positionsParticles.rst
+++ b/docs/source/usage/plugins/positionsParticles.rst
@@ -80,7 +80,7 @@ Known Issues
 
    This plugin only works correctly if a single particle is simulated.
    If more than one particle is simulated, the output becomes random, because only the information of one particle is printed.
-   This plugin might be upgraded to work with multiple particles, but better use our HDF5 or ADIOS plugin instead and assign `particleId`s to individual particles.
+   This plugin might be upgraded to work with multiple particles, but better use our HDF5 or ADIOS plugin instead and assign ``particleId``\ s to individual particles.
 
 .. attention::
 


### PR DESCRIPTION
This issues solves a few of the errors/warnings documented in #2564 but does not fix redefinitions caused by doxygen (#2383) nor does it solve the linking issue (#3055). It also avoids issues with the documentation of the radiation plugin, since hose are solved with #3052.

The following issues were solved (see separate commits): 
 - fixes syntax error in phase space documentation that prevented showing the python widget code
 - fixes warnings of not cited references 
 - fixes wrong syntax inline code in particles position plugin
