### PR TITLE
update profile hemera-hzdr: CMake version

### DIFF
--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -17,7 +17,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module purge
 module load gcc/7.3.0
-module load cmake/3.11.3
+module load cmake/3.15.2
 module load openmpi/2.1.2
 module load boost/1.68.0
 

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -17,7 +17,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module purge
 module load gcc/7.3.0
-module load cmake/3.11.3
+module load cmake/3.15.2
 module load cuda/10.0
 module load openmpi/2.1.2-cuda100
 module load boost/1.68.0

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -17,7 +17,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module purge
 module load gcc/7.3.0
-module load cmake/3.11.3
+module load cmake/3.15.2
 module load cuda/10.0
 module load openmpi/2.1.2-cuda100
 module load boost/1.68.0

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -17,7 +17,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module purge
 module load gcc/7.3.0
-module load cmake/3.11.3
+module load cmake/3.15.2
 module load cuda/10.0
 module load openmpi/2.1.2-cuda100
 module load boost/1.68.0


### PR DESCRIPTION
switch from for hemera from cmake/3.11.3 to cmake/3.15.2

Edit: the new version is required by the future (upcoming) alpaka release.