### PR TITLE
fix examples particle filters

### DIFF
--- a/include/picongpu/particles/filter/generic/Free.def
+++ b/include/picongpu/particles/filter/generic/Free.def
@@ -48,6 +48,7 @@ namespace generic
      *               result = true;
      *           return result;
      *       }
+     *       static constexpr char const * name = "eachParticleAboveMiddleOfTheCell";
      *   };
      *
      *   using EachParticleAboveMiddleOfTheCell = generic::Free<

--- a/include/picongpu/particles/filter/generic/Free.def
+++ b/include/picongpu/particles/filter/generic/Free.def
@@ -44,7 +44,7 @@ namespace generic
      *       HDINLINE bool operator()( T_Particle const & particle )
      *       {
      *           bool result = false;
-     *           if( particle[ position_ ] >= float_X( 0.5 ) )
+     *           if( particle[ position_ ].y() >= float_X( 0.5 ) )
      *               result = true;
      *           return result;
      *       }

--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -57,6 +57,7 @@ namespace generic
      *               result = true;
      *           return result;
      *       }
+     *       static constexpr char const * name = "eachSecondParticle";
      *   };
      *
      *   using EachSecondParticle = generic::FreeRng<

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
@@ -58,6 +58,7 @@ namespace generic
      *               result = true;
      *           return result;
      *       }
+     *       static constexpr char const * name = "eachParticleInXCell5";
      *   };
      *
      *   using EachParticleInXCell5 = generic::FreeTotalCellOffset<


### PR DESCRIPTION
This pull request fixes a missing name definition in the particle filter examples. (first commit) 
As you can see in the doxygen generated documentation [here](https://picongpu.readthedocs.io/en/latest/usage/param/particles/init.html#manipulation-filters), the names have been missing before. (this also effects previous documentations. @ax3l Do we need to backport this?) 

The second commit fixes a comparison ion the free filter that compares a 3D vector with a scalar. This should probably not work. Do you agree @psychocoderHPC, @sbastrakov ? 