### PR TITLE
Bashcompletion

### DIFF
--- a/bin/pic-create
+++ b/bin/pic-create
@@ -36,6 +36,8 @@ help()
     echo ""
     echo "usage: pic-create [OPTION] [src_dir] dest_dir"
     echo "If no src_dir is set picongpu a default case is cloned"
+    echo "If src_dir is not in the currrent directory, pic-create will"
+    echo 'look for it in $PIC_EXAMPLES'
     echo ""
     echo "-f | --force         - merge data if destination already exists"
     echo "-h | --help          - show this help message"
@@ -79,6 +81,10 @@ if [ $# -eq 2 ] ; then
     src_path=$1
     dst_path=$2
     selected_default_folder_to_copy=$folder_to_clone
+    # Use example directory if no source directory available at current directory
+    if [[ -d $PIC_EXAMPLES/$src_path && ! -d ./$src_path ]]; then
+        src_path=$PIC_EXAMPLES/$src_path
+    fi
 else
     src_path=$this_dir/..
     dst_path=$1
@@ -121,6 +127,8 @@ else
         mkdir -p "$dst_path"
     fi
 fi
+
+echo "Cloning from $src_path to $dst_path"
 
 #first copy default parameter
 for d in $default_folder_to_copy

--- a/bin/picongpu-completion.bash
+++ b/bin/picongpu-completion.bash
@@ -1,0 +1,253 @@
+#/usr/bin/env bash
+
+show_directory()
+{
+    # Autocompletion from the bash "cd" command
+    # Copied from "bash-completion(1:2.8-1ubuntu1)" in /usr/share/bash-completion/bash_completion
+    local cur prev words cword
+    _init_completion || return
+
+    local IFS=$'\n' i j k
+
+    compopt -o filenames
+
+    # Show example directories with autocompletion for pic-create
+    if [[ $1 == "examples" ]]; then
+        for i in ${PIC_EXAMPLES//:/$'\n'}; do
+            k="${#COMPREPLY[@]}"
+            for j in $( compgen -d -- $i/$cur ); do
+                if [[ ( ! -d ${j#$i/} ) ]]; then
+                  j+="/"
+                fi
+                COMPREPLY[k++]=${j#$i/}
+            done
+        done
+    fi
+
+    # Use standard dir completion if no CDPATH or parameter starts with /,
+    # ./ or ../
+    if [[ -z "${CDPATH:-}" || "$cur" == ?(.)?(.)/* ]]; then
+        _filedir -d
+        return
+    fi
+
+    local -r mark_dirs=$(_rl_enabled mark-directories && echo y)
+    local -r mark_symdirs=$(_rl_enabled mark-symlinked-directories && echo y)
+
+    # we have a CDPATH, so loop on its contents
+    for i in ${CDPATH//:/$'\n'}; do
+        # create an array of matched subdirs
+        k="${#COMPREPLY[@]}"
+        for j in $( compgen -d -- $i/$cur ); do
+            if [[ ( $mark_symdirs && -h $j || $mark_dirs && ! -h $j ) && ! -d ${j#$i/} ]]; then
+                j+="/"
+            fi
+            COMPREPLY[k++]=${j#$i/}
+        done
+    done
+
+    _filedir -d
+
+    # if only one possible result then autocomplete to this result and enter the directory
+    if [[ ${#COMPREPLY[@]} -eq 1 ]]; then
+        i=${COMPREPLY[0]}
+        if [[ "$i" == "$cur" && $i != "*/" ]]; then
+            COMPREPLY[0]="${i}/"
+        fi
+    fi
+
+    return 0
+}
+
+show_parameters()
+{
+    local opts=$1
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}))
+    return 0
+}
+
+_pic-build()
+{
+    # Load current string
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [[ "${prev}" == "-b" || "${prev}" == "--backend" ]]; then
+        # available backends from documentation
+        show_parameters "cuda omp2b serial tbb threads"
+        return 0
+    fi
+
+    if [[ "${prev}" == "-c" || "${prev}" == "--cmake" ]]; then
+        show_parameters "-b --backend -c --cmake -t -f --force -h --help"
+        return 0 # @TODO show available cmake variables
+    fi
+
+    if [[ "${prev}" == "-t" ]]; then
+        show_parameters "-b --backend -c --cmake -t -f --force -h --help"
+        return 0 # @TODO show available preset from cmakeFlags
+    fi
+
+    show_parameters "-b --backend -c --cmake -t -f --force -h --help"
+    return 0
+}
+
+_pic-create()
+{
+    # load current string
+    local cur
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    case "$cur" in
+        # check if it is a parameter
+        -*)
+            show_parameters "-f --force -h --help"
+            return 0
+            ;;
+        # default case list directory content
+        *)
+            show_directory "examples"
+            return 0
+            ;;
+    esac
+}
+
+_pic-compile()
+{
+    # load current string
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [[ "${prev}" == "-c" || "${prev}" == "--cmake" ]]; then
+        return 0 # @TODO show available cmake variables
+    fi
+
+    case "$cur" in
+        # check if it is a parameter
+        -*)
+            show_parameters "-l -q -j -c -ccmake -h --help"
+            return 0
+            ;;
+        *)
+            show_directory
+            return 0
+            ;;
+    esac
+}
+
+_pic-configure()
+{
+    # Load current string
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [[ "${prev}" == "-i" || "${prev}" == "--install" ]]; then
+        show_directory
+    fi
+
+    if [[ "${prev}" == "-b" || "${prev}" == "--backend" ]]; then
+        show_directory
+        return 0 # @TODO show available backends
+    fi
+
+    if [[ "${prev}" == "-c" || "${prev}" == "--cmake" ]]; then
+        show_directory
+        return 0 # @TODO show available cmake variables
+    fi
+
+    if [[ "${prev}" == "-t" ]]; then
+        show_directory
+        return 0 # @TODO show available preset from cmakeFlags
+    fi
+
+    case "$cur" in
+        # check if it is a parameter
+        -*)
+            show_parameters "-b --backend -c --cmake -t -f --force -h --help"
+            return 0
+            ;;
+        *)
+            show_directory
+            return 0
+            ;;
+    esac
+}
+
+_pic-edit()
+{
+    local cur names
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    # Find all param files
+    names=$(for x in $(ls -1 $PICSRC/include/picongpu/param/*.param); do echo ${x} ; done )
+    # Remove .param from param file
+    names=$(for x in $names; do echo ${x%".param"}; done)
+    # Remove filepath from param file
+    names=$(for x in $names; do echo ${x#"$PICSRC/include/picongpu/param/"}; done)
+    COMPREPLY=( $(compgen -W "${names}" -- ${cur}) )
+    return 0
+}
+
+_tbg()
+{
+    # Load current string
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # List available config files in default directory (inspired by https://debian-administration.org/article/317/An_introduction_to_bash_completion_part_2)
+    if [[ "${prev}" == "-c" || "${prev}" == "--config" ]]; then
+        local names=$(for x in $(ls -1 etc/picongpu/*.cfg); do echo ${x/\/etc\/picongpu\//} ; done )
+        COMPREPLY=( $(compgen -W "${names}" -- ${cur}) )
+        return 0
+    fi
+
+    if [[ "${prev}" == "-s" || "${prev}" == "--submit" ]]; then
+        case "$cur" in
+            # check if it is a parameter
+            -*)
+                show_parameters "-c --config -t --tpl -o -f --force"
+                return 0
+                ;;
+            *)
+                # show submit systems which are listed in the docs
+                show_parameters "sbatch qsub bsub"
+                return 0
+                ;;
+        esac
+        return 0
+    fi
+
+    if [[ "${prev}" == "-t" || "${prev}" == "--tpl" ]]; then
+        show_directory
+        return 0 # @TODO show template file
+    fi
+
+    if [[ "${prev}" == "-o" ]]; then
+        show_directory
+        return 0 # @TODO show template variables
+    fi
+
+    case "$cur" in
+        # check if it is a parameter
+        -*)
+            show_parameters "-c --config -s --submit -t --tpl -o -f --force -h --help"
+            return 0
+            ;;
+        *)
+            show_directory
+            return 0
+            ;;
+    esac
+}
+
+# Invoke the responding function calls for completion of pic-commands
+complete -F _pic-build pic-build
+complete -o nospace -F _pic-create pic-create
+complete -o nospace -F _pic-compile pic-compile
+complete -o nospace -F _pic-configure pic-configure
+complete -F _pic-edit pic-edit
+complete -o nospace -F _tbg tbg
+

--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -88,3 +88,6 @@ function getDevice() {
     fi
     srun  --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=$((4 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((63000 * numGPUs)) -A $proj -p dvd_usr_prod --pty bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/cori-nersc/knl_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/knl_picongpu.profile.example
@@ -65,3 +65,6 @@ function getNode() {
     fi
     srun --time=1:00:00 --nodes=$numNodes --ntasks-per-node=1 --cpus-per-task=64 -C "knl,quad,cache" -p regular --pty bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
+++ b/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
@@ -99,3 +99,6 @@ function getDevice() {
     fi
     srun  --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=$((4 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((63000 * numGPUs)) -A $proj -p dvd_usr_prod --pty bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/draco-mpcdf/picongpu.profile.example
+++ b/etc/picongpu/draco-mpcdf/picongpu.profile.example
@@ -63,3 +63,6 @@ export TBG_TPLFILE="etc/picongpu/draco-mpcdf/general.tpl"
 
 # allocate an interactive shell for one hour
 alias getNode='salloc --time=1:00:00 --nodes=1 --exclusive --ntasks-per-node=2 --cpus-per-task=32 --partition general'
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -79,3 +79,6 @@ function getDevice() {
     fi
     srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=$((20 * $numDevices)) --mem=$((180000 * numDevices)) -p defq --pty bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -80,3 +80,6 @@ function getDevice() {
     fi
     srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p gpu --pty bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -80,3 +80,6 @@ function getDevice() {
     fi
     srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=2 --gres=gpu:$numGPUs -A k20 --mem=$((15500 * numGPUs)) -p k20 --pty bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -80,3 +80,6 @@ function getDevice() {
     fi
     srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=2 --gres=gpu:$numGPUs -A k80 --mem=$((29750 * numGPUs)) -p k80 --pty bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
+++ b/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
@@ -61,3 +61,6 @@ export PYTHONPATH=$PICSRC/src/tools/lib/python:$PYTHONPATH
 #   - "default" queue
 export TBG_SUBMIT="qsub"
 export TBG_TPLFILE="etc/picongpu/hydra-hzdr/default.tpl"
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -62,3 +62,6 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 #   - "laser" queue
 export TBG_SUBMIT="qsub"
 export TBG_TPLFILE="etc/picongpu/hypnos-hzdr/laser.tpl"
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -106,3 +106,6 @@ function getDevice() {
     export OMP_NUM_THREADS=24
     salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -105,3 +105,6 @@ function getDevice() {
     export OMP_NUM_THREADS=34
     salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -109,3 +109,6 @@ function getDevice() {
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=126000 -A $proj -p develgpus bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -106,3 +106,6 @@ function getDevice() {
     export OMP_NUM_THREADS=48
     salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p batch bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -116,3 +116,6 @@ function getDevice() {
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $proj -p gpus bash
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -72,3 +72,6 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 #   - fermi queue (also available: 2 K20 via k20.tpl)
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/lawrencium-lbnl/fermi.tpl"
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -105,3 +105,6 @@ getNode() {
     # --ntasks-per-core=2  # activates intel hyper threading
     salloc --time=1:00:00 --nodes="$numNodes" --ntasks-per-node=12 --ntasks-per-core=2 --partition normal --gres=gpu:1 --constraint=gpu
 }
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -64,3 +64,6 @@ alias getNode="bsub -P $proj -W 2:00 -nnodes 1 -Is /bin/bash"
 # "tbg" default options #######################################################
 export TBG_SUBMIT="bsub"
 export TBG_TPLFILE="etc/picongpu/summit-ornl/gpu_batch.tpl"
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -78,3 +78,5 @@ export TBG_TPLFILE="etc/picongpu/taurus-tud/V100.tpl"
 
 alias getNode='srun -p ml --gres=gpu:6 -n 1 --mem=0 --cpus-per-task=44 --pty -t 2:00:00 bash'
 
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -74,3 +74,6 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 #   - "gpu1" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/k20x.tpl"
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -77,3 +77,6 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/k80.tpl"
 
 alias getNode='srun -p gpu2-interactive --gres=gpu:4 -n 1 --pty --mem=0 -t 2:00:00 bash'
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -66,3 +66,6 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/knl.tpl"
 
 alias getNode='srun -p knl -N 1 -c 64 --mem=90000 --constraint="Quadrant&Cache" --pty bash'
+
+# Load autocompletion for PIConGPU commands
+source $PICSRC/bin/picongpu-completion.bash


### PR DESCRIPTION
I finished a basic completion for the important PIConGPU scripts as mentioned in #1972. If you want to test it, you can `source $PICSRC/bin/picongpu-completion.bash` after sourcing a PIConGPU profile (Or just source a new profile which does it automatically). 

This is a list of features:
- [x] Autocomplete options of picongpu commands if you start with a dash, e.g. `pic-create -[TAB]` suggests you `-f`, `--force`, `-h` and `--help` and `pic-create --f[TAB]` completes to `pic-create --force`. I kept all the duplicates like `-f` and `--force`, which do the same thing because some people might want to see the short and long versions
- [x] `tbg -c [TAB]` shows all `*.cfg` files in `etc/picongpu/` in the current parameter set and autocompletes correspondingly
- [x] `pic-edit` autocompletes to all possible `.param`-files in `$PICSRC/include/picongpu/` without the trailing `.param`

The following points have been considered, but decided for future implementation, not  in this PR:

 - Show correct CMAKE variables if the previous option was `--cmake`
- Only show `.tpl` files at `tbg -t [TAB]`
- Show available backends at `--backend`. Here I'm not sure if it is generally possible or too system dependend
- Show available submit systems at `tbg -s [TAB]`. The same with the previous point

It should work so far. Feel free to test it and leave suggestions @ComputationalRadiationPhysics/picongpu-developers :)

I probably want to add the unfinished features in a separate pull request.