### PR TITLE
Add information about submit.cfg and submit.tpl files to docs.

### DIFF
--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -22,6 +22,7 @@ After combining the *machine independent* (portable) ``.cfg`` file from user inp
 
 Last but not least, one usually wants to store the input of a simulation with its output.
 ``tbg`` conveniently automates this task before submission.
+The ``.tpl`` and the ``.cfg`` files that were used to start the simulation can be found in ``<tbg destination dir>/tbg/`` and can be used together with the ``.param`` files from ``<tbg destination dir>/input/.../param/`` to recreate the simulation setup.
 
 In summary, PIConGPU runtime options in ``.cfg`` files are portable to any machine.
 When accessing a machine for the first time, one needs to write template ``.tpl`` files, abstractly describing how to run PIConGPU on the specific queue(s) of the batch system.


### PR DESCRIPTION
I was missing the feature of automated copying of the configuration file into the output directory by ``tbg``.
Well, I found out that ``tbg`` already does it, while trying to add it, so I added these lines to the ``tbg`` documentation instead. It's pretty useful so let people know that it's there. What do you think? @ComputationalRadiationPhysics/picongpu-maintainers 
 