### PR TITLE
adjust cores per gpu on taurus after multicore update

### DIFF
--- a/etc/picongpu/taurus-tud/V100.tpl
+++ b/etc/picongpu/taurus-tud/V100.tpl
@@ -55,9 +55,12 @@
 # That is, replace in the following line the two appearances of 6 with 3.
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 6 ] ; then echo 6; else echo $TBG_tasks; fi`
 
-# number of cores to block per GPU - we got 28 cpus per gpu
-#   and we will be accounted 28 CPUs per GPU anyway
-.TBG_coresPerGPU=28
+# number of CPU cores to block per GPU
+# we got 7 CPU cores per GPU (44cores/6gpus ~ 7cores)
+.TBG_coresPerGPU=7
+# this does not yet include hyperthreading
+#SBATCH --hint=nomultithread
+# (this is currently also the default setting on taurus)
 
 # We only start 1 MPI task per GPU
 .TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -76,5 +76,5 @@ export CXXFLAGS="-Dlinux"
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/V100.tpl"
 
-alias getNode='srun -p ml --gres=gpu:6 -n 1 --mem=0 --cpus-per-task=28 --pty -t 2:00:00 bash'
+alias getNode='srun -p ml --gres=gpu:6 -n 1 --mem=0 --cpus-per-task=44 --pty -t 2:00:00 bash'
 

--- a/etc/picongpu/taurus-tud/V100_restart.tpl
+++ b/etc/picongpu/taurus-tud/V100_restart.tpl
@@ -61,9 +61,12 @@
 # 6 gpus per node
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt 6 ] ; then echo 6; else echo $TBG_tasks; fi`
 
-# number of cores to block per GPU - we got 6 cpus per gpu
-#   and we will be accounted 6 CPUs per GPU anyway
-.TBG_coresPerGPU=28
+# number of CPU cores to block per GPU
+# we got 7 CPU cores per GPU (44cores/6gpus ~ 7cores)
+.TBG_coresPerGPU=7
+# this does not yet include hyperthreading
+#SBATCH --hint=nomultithread
+# (this is currently also the default setting on taurus)
 
 # We only start 1 MPI task per GPU
 .TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"


### PR DESCRIPTION
This pull request changes the cores per task setting for the `ml` (V100 GPUs) partition on taurus at ZIH. This became necessary after they changed the default to use the SLURM hint `--hint=nomultithread`. Currently, the tpl files do not allow to start any simulations because they allocate too many physical cores. This pull request reduces the allocation to the maximum possible number, that still allows allocating all GPUs.

**node setup of `ml` partition:**
The `ml` partition has a node that has 44 physical CPU cores and 6 V100 GPUs. The 44 cores have the ability to have 4 hyper-threads each resulting in a total number of virtual cores of `44*4=176`. Neither 44 nor 176 are dividable by the number of GPUs (=6). 
Together with @psychocoderHPC and @sbastrakov, we decided to allocate only the maximum number of physical cores and not to use hyper-threading for now. Thus, **7 cores per Task=GPU** are now used.

**situation before the change on taurus:**
Before changing the default setup, hyper-threading was enabled. Therefore, despite setting the number of cores to 28, we only used 7 physical cores. 

**current situation:**
All tasks (=6, one per GPU) try to allocate 28 physical cores each which fails since there are only 44 cores. Furthermore the maximum number of cores per GPU is 8.

**situation with the pull request:**
Now we allocate only 7 cores per task/GPU.

 