### PR TITLE
Docs: create conda env for building docs

### DIFF
--- a/docs/picongpu-docs-env.yml
+++ b/docs/picongpu-docs-env.yml
@@ -1,12 +1,13 @@
 # Create a separate conda environment which fulfills the package requirements
 # for building the documentation
-# E.g. run `conda create --file picongpu-docs-env.yml`
+# E.g. run `conda env create --file picongpu-docs-env.yml`
 #
 
 name: picongpu-docs-env
 channels:
     - conda-forge
 dependencies:
+    - doxygen
     - sphinx_rtd_theme>=0.3.1
     - recommonmark
     - sphinx==2.0.1

--- a/docs/picongpu-docs-env.yml
+++ b/docs/picongpu-docs-env.yml
@@ -5,17 +5,11 @@
 
 name: picongpu-docs-env
 channels:
-    - conda-forge
+  - conda-forge
 dependencies:
-    - doxygen
-    - sphinx_rtd_theme>=0.3.1
-    - recommonmark
-    - sphinx==2.0.1
-    - breathe>=4.12.0
-    - sphinxcontrib-programoutput
-    - sphinxcontrib-napoleon>=0.7
-    - pygments
-    - matplotlib
-    - scipy
-    - numpy
+  - python>=3.7
+  - doxygen
+  - pip
+  - pip:
+    - "-r requirements.txt"
 

--- a/docs/picongpu-docs-env.yml
+++ b/docs/picongpu-docs-env.yml
@@ -1,0 +1,20 @@
+# Create a separate conda environment which fulfills the package requirements
+# for building the documentation
+# E.g. run `conda create --file picongpu-docs-env.yml`
+#
+
+name: picongpu-docs-env
+channels:
+    - conda-forge
+dependencies:
+    - sphinx_rtd_theme>=0.3.1
+    - recommonmark
+    - sphinx==2.0.1
+    - breathe>=4.12.0
+    - sphinxcontrib-programoutput
+    - sphinxcontrib-napoleon>=0.7
+    - pygments
+    - matplotlib
+    - scipy
+    - numpy
+

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -39,6 +39,18 @@ The following requirements need to be installed (once) to build our documentatio
     # python tools & style theme
     pip install -r requirements.txt # --user
 
+However, in order to not break any of your existing Python configurations you can also create a new environment that you only use for building the documentation.
+
+.. code-block:: bash
+
+    cd docs/
+
+    # create a bare conda environment containing just all the requirements
+    # for building the picongpu documentation
+    conda env create picongpu-docs-env.yml
+
+    # start up the environment
+    conda activate picongpu-docs-env
 
 With all documentation-related software successfully installed, just run the following commands to build your docs locally.
 Please check your documentation build is successful and renders as you expected before opening a pull request!

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -39,7 +39,8 @@ The following requirements need to be installed (once) to build our documentatio
     # python tools & style theme
     pip install -r requirements.txt # --user
 
-However, in order to not break any of your existing Python configurations you can also create a new environment that you only use for building the documentation.
+In order to not break any of your existing Python configurations, you can also create a new environment that you only use for building the documentation.
+Since it is possible to install doxygen with conda, the following method employs this way.
 
 .. code-block:: bash
 
@@ -47,6 +48,7 @@ However, in order to not break any of your existing Python configurations you ca
 
     # create a bare conda environment containing just all the requirements
     # for building the picongpu documentation
+    # note: also installs doxygen inside this environment
     conda env create picongpu-docs-env.yml
 
     # start up the environment

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -49,7 +49,7 @@ Since it is possible to install doxygen with conda, the following demonstrates t
     # create a bare conda environment containing just all the requirements
     # for building the picongpu documentation
     # note: also installs doxygen inside this environment
-    conda env create picongpu-docs-env.yml
+    conda env create --file picongpu-docs-env.yml
 
     # start up the environment
     conda activate picongpu-docs-env

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -51,8 +51,10 @@ Since it is possible to install doxygen with conda, the following demonstrates t
     # note: also installs doxygen inside this environment
     conda env create --file picongpu-docs-env.yml
 
-    # start up the environment
+    # start up the environment as suggested during its creation e.g.
     conda activate picongpu-docs-env
+    # or
+    source activate picongpu-docs-env
 
 With all documentation-related software successfully installed, just run the following commands to build your docs locally.
 Please check your documentation build is successful and renders as you expected before opening a pull request!

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -3,7 +3,7 @@
 Sphinx
 ======
 
-.. sectionauthor:: Axel Huebl
+.. sectionauthor:: Axel Huebl, Marco Garten
 
 In the following section we explain how to contribute to this documentation.
 
@@ -40,7 +40,7 @@ The following requirements need to be installed (once) to build our documentatio
     pip install -r requirements.txt # --user
 
 In order to not break any of your existing Python configurations, you can also create a new environment that you only use for building the documentation.
-Since it is possible to install doxygen with conda, the following method employs this way.
+Since it is possible to install doxygen with conda, the following demonstrates this.
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PR adds a way to create a clean conda environment just for building our docs.
This seems useful since installing the required packages might otherwise break users' previous Python configurations.

- [x] try out creating the environment
- [x] build `dev` docs from it