### PR TITLE
Make dependency between boundElectrons and atomicNumbers more explicit

### DIFF
--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -129,6 +129,7 @@ namespace picongpu
      * - float_X instead of integer types are reasonable because effective charge
      *   numbers are possible
      * - required for ion species if ionization is enabled
+     * - setting it requires atomicNumbers to also be set
      *
      * @todo connect default to proton number
      */
@@ -191,6 +192,7 @@ namespace picongpu
 
     /** alias for particle flag: atomic numbers, see also ionizer.param
      * - only reasonable for atoms / ions / nuclei
+     * - is required when boundElectrons is set
      */
     alias( atomicNumbers );
 

--- a/include/picongpu/traits/attribute/GetCharge.hpp
+++ b/include/picongpu/traits/attribute/GetCharge.hpp
@@ -20,9 +20,12 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-#include "picongpu/traits/frame/GetCharge.hpp"
-#include <pmacc/traits/HasIdentifier.hpp>
 #include "picongpu/particles/traits/GetAtomicNumbers.hpp"
+#include "picongpu/traits/frame/GetCharge.hpp"
+#include <pmacc/static_assert.hpp>
+#include <pmacc/traits/HasFlag.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
+
 
 namespace picongpu
 {
@@ -53,6 +56,15 @@ struct LoadBoundElectrons
     template<typename T_Particle>
     HDINLINE float_X operator()(const float_X weighting, const T_Particle& particle)
     {
+        using HasAtomicNumbers = typename pmacc::traits::HasFlag<
+            T_Particle,
+            atomicNumbers<>
+        >::type;
+        PMACC_CASSERT_MSG_TYPE(
+            Having_boundElectrons_particle_attribute_requires_atomicNumbers_flag,
+            T_Particle,
+            HasAtomicNumbers::value
+        );
         const float_X protonNumber = GetAtomicNumbers<T_Particle>::type::numberOfProtons;
 
         /* note: ELECTRON_CHARGE is negative and the second term is also negative

--- a/include/picongpu/traits/attribute/GetChargeState.hpp
+++ b/include/picongpu/traits/attribute/GetChargeState.hpp
@@ -20,9 +20,12 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-#include <pmacc/traits/HasIdentifier.hpp>
-#include <pmacc/algorithms/TypeCast.hpp>
 #include "picongpu/particles/traits/GetAtomicNumbers.hpp"
+#include <pmacc/algorithms/TypeCast.hpp>
+#include <pmacc/static_assert.hpp>
+#include <pmacc/traits/HasFlag.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
+
 
 namespace picongpu
 {
@@ -47,6 +50,15 @@ struct LoadChargeState
     template<typename T_Particle>
     HDINLINE float_X operator()(const T_Particle& particle)
     {
+        using HasAtomicNumbers = typename pmacc::traits::HasFlag<
+            T_Particle,
+            atomicNumbers<>
+        >::type;
+        PMACC_CASSERT_MSG_TYPE(
+            Having_boundElectrons_particle_attribute_requires_atomicNumbers_flag,
+            T_Particle,
+            HasAtomicNumbers::value
+        );
         const float_X protonNumber = GetAtomicNumbers<T_Particle>::type::numberOfProtons;
         return protonNumber - particle[boundElectrons_];
     }


### PR DESCRIPTION
Fixes #3075.