### PR TITLE
added silicon element to ioniser

### DIFF
--- a/include/picongpu/param/ionizationEnergies.param
+++ b/include/picongpu/param/ionizationEnergies.param
@@ -137,6 +137,24 @@ namespace AU
         2304.14 * UNITCONV_eV_to_AU
     );
 
+    /* ionization energy for aluminium in atomic units */
+    PMACC_CONST_VECTOR(float_X, 14, Silicon,
+        8.151683 * UNITCONV_eV_to_AU,
+        16.345845 * UNITCONV_eV_to_AU,
+        33.493 * UNITCONV_eV_to_AU,
+        45.14179 * UNITCONV_eV_to_AU,
+        166.767 * UNITCONV_eV_to_AU,
+        205.267 * UNITCONV_eV_to_AU,
+        246.32 * UNITCONV_eV_to_AU,
+        303.66 * UNITCONV_eV_to_AU,
+        351.1 * UNITCONV_eV_to_AU,
+        401.38 * UNITCONV_eV_to_AU,
+        476.18 * UNITCONV_eV_to_AU,
+        523.415 * UNITCONV_eV_to_AU,
+        2437.65804 * UNITCONV_eV_to_AU,
+        2673.1774 * UNITCONV_eV_to_AU
+    );
+
     /* ionization energy for copper in atomic units */
     PMACC_CONST_VECTOR(float_X, 29, Copper,
         7.72638 * UNITCONV_eV_to_AU,

--- a/include/picongpu/param/ionizationEnergies.param
+++ b/include/picongpu/param/ionizationEnergies.param
@@ -137,7 +137,7 @@ namespace AU
         2304.14 * UNITCONV_eV_to_AU
     );
 
-    /* ionization energy for aluminium in atomic units */
+    /* ionization energy for silicon in atomic units */
     PMACC_CONST_VECTOR(float_X, 14, Silicon,
         8.151683 * UNITCONV_eV_to_AU,
         16.345845 * UNITCONV_eV_to_AU,

--- a/include/picongpu/param/ionizer.param
+++ b/include/picongpu/param/ionizer.param
@@ -132,6 +132,13 @@ namespace atomicNumbers
         static constexpr float_X numberOfNeutrons = 14.0;
     };
 
+    /** Si-28 ~92.23% NA */
+    struct Silicon_t
+    {
+        static constexpr float_X numberOfProtons  = 14.0;
+        static constexpr float_X numberOfNeutrons = 14.0;
+    };
+
     /** Cu-63 69.15% NA */
     struct Copper_t
     {
@@ -253,6 +260,30 @@ namespace effectiveNuclearCharge
         12.591,
         12.591
     );
+
+    /* Example: silicon */
+    PMACC_CONST_VECTOR(float_X, 14, Silicon,
+        /* 3p^2 */
+        4.285,
+        4.285,
+        /* 3s^2 */
+        4.903,
+        4.903,
+        /* 2p^6 */
+        9.945,
+        9.945,
+        9.945,
+        9.945,
+        9.945,
+        9.945,
+        /* 2s^2 */
+        9.020,
+        9.020,
+        /* 1s^2 */
+        13.575,
+        13.575
+    );
+
 
     /* Example: copper
      * Note: Copper is one of the few exceptions to the Madelung energy ordering


### PR DESCRIPTION
For some experiments, for example harmonics from solids, people use silicon-based targets (e.g. fused silica), so it would be good to have `Si` included to the _commonly used elements_ list. This PR fixes it -- i took ionisation potentials from `mendeleev`  and effective nuclear charge from [wiki](http://en.wikipedia.org/wiki/Effective_nuclear_charge) (as recommended).