### PR TITLE
fix doc transition radiation plugin

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -127,6 +127,10 @@ TBG_stopWindow="--stopWindow 1337"
 TBG_radiation="--<species>_radiation.period 1 --<species>_radiation.dump 2 --<species>_radiation.totalRadiation \
                --<species>_radiation.lastRadiation --<species>_radiation.start 2800 --<species>_radiation.end 3000"
 
+# The following flags are available for the transition radiation plugin.
+# For a full description, see the plugins section in the online documentation.
+#--<species>_transRad.period   Gives the number of time steps between which the radiation should be calculated.
+TBG_transRad="--<species>_transRad.period 1000"
 
 # Create 2D images in PNG format every .period steps.
 # The slice plane is defined using .axis [yx,yz] and .slicePoint (offset from origin

--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -189,8 +189,6 @@ Gamma filter
 In order to consider the radiation only of particles with a gamma higher than a specific threshold.
 In order to do that, the radiating particle species needs the flag ``transitionRadiationMask`` (which is initialized as ``false``) which further needs to be manipulated, to set to true for specific (random) particles.
 
-It can also avoid division by 0 errors in the transition radiation output, which are caused by slowly, but transversely moving electrons.
-
 Using a filter functor as:
 
 .. code:: cpp

--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -58,7 +58,7 @@ There are no external dependencies.
 .param files
 ^^^^^^^^^^^^
 
-In order to setup the transition radiation plugin, the :ref:`transitionRadiation.param <usage-params-plugins>` has to be configured **and** the radiating particles need to have the attributes ``weighting``, ``momentum``, ``location``, ``massRatio``, ``chargeRatio`` and ``transitionRadiationMask`` which can be added in :ref:`speciesDefinition.param <usage-params-core>`.
+In order to setup the transition radiation plugin, the :ref:`transitionRadiation.param <usage-params-plugins>` has to be configured **and** the radiating particles need to have the attributes ``weighting``, ``momentum``, and ``location``, as well as the flags ``massRatio``, ``chargeRatio``, and ``transitionRadiationMask`` which can be added in :ref:`speciesDefinition.param <usage-params-core>`.
 
 In *transitionRadiation.param*, the number of frequencies ``N_omega`` and observation directions ``N_theta`` and ``N_phi`` are defined.
 
@@ -187,7 +187,7 @@ Gamma filter
 """"""""""""
 
 In order to consider the radiation only of particles with a gamma higher than a specific threshold.
-In order to do that, the radiating particle species needs the attribute ``transitionRadiationMask`` (which is initialized as ``false``) which further needs to be manipulated, to set to true for specific (random) particles.
+In order to do that, the radiating particle species needs the flag ``transitionRadiationMask`` (which is initialized as ``false``) which further needs to be manipulated, to set to true for specific (random) particles.
 
 It can also avoid division by 0 errors in the transition radiation output, which are caused by slowly, but transversely moving electrons.
 

--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -216,7 +216,7 @@ For a specific (charged) species ``<species>`` e.g. ``e``, the radiation can be 
 ========================================== ==============================================================================================================================
 Command line option                        Description
 ========================================== ==============================================================================================================================
-``--<species>_transitionRadiation.period`` Gives the number of time steps between which the radiation should be calculated.
+``--<species>_transRad.period``            Gives the number of time steps between which the radiation should be calculated.
 ========================================== ==============================================================================================================================
 
 Memory Complexity


### PR DESCRIPTION
This pull request resolves some errors and incorrect wordings in the transition radiation plugin documentation and adds a command line flag configuration to the `TBG_macro.cfg`.

The plugin was just recently introduced to the `dev` #3003.  

The fixes are:
 - `transitionRaditionMask` is a flag not an attribute
 - the command line names were not correct

@psychocoderHPC strangely I could add the flag `transitionRadiationMask` to the particle attributes without causing a compile time error (of course the plugin wasn't compiled) - shouldn't adding a flag to the attributes cause an error? 