### PR TITLE
fix 8.cfg for Bremsstrahlung example

### DIFF
--- a/share/picongpu/examples/Bremsstrahlung/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/Bremsstrahlung/etc/picongpu/8.cfg
@@ -47,7 +47,8 @@ TBG_periodic="--periodic 0 0 0"
 #################################
 
 TBG_ph_calorimeter="--ph_calorimeter.period 1000 --ph_calorimeter.openingYaw 360 --ph_calorimeter.openingPitch 180 \
-                    --ph_calorimeter.numBinsEnergy 1024 --ph_calorimeter.minEnergy 10 --ph_calorimeter.maxEnergy 10000"
+                    --ph_calorimeter.numBinsEnergy 1024 --ph_calorimeter.minEnergy 10 --ph_calorimeter.maxEnergy 10000 \
+                    --ph_calorimeter.file calorimeter --ph_calorimeter.filter all"
 
 TBG_ph_energyHistogram="--ph_energyHistogram.period 1000 --ph_energyHistogram.filter all --ph_energyHistogram.minEnergy 10 --ph_energyHistogram.maxEnergy 10000"
 


### PR DESCRIPTION
This pull request adds the missing calorimeter sub-arguments `file` and `filter` in the `8.cfg` of the Bremsstrahlung example. 

@sbastrakov and @psychocoderHPC I am not yet sure when this bug was introduced since due to the restructuring of the code, its history is not easily accessible. But it definitely affects the latest release. 

This pull request closes #3096. 