### PR TITLE
add 1.cfg to Bremsstrahlung example

### DIFF
--- a/share/picongpu/examples/Bremsstrahlung/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/Bremsstrahlung/etc/picongpu/1.cfg
@@ -1,0 +1,78 @@
+# Copyright 2013-2019 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      doc/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="8:00:00"
+
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
+
+TBG_gridSize="2048 2048 1"
+TBG_steps="5000"
+
+TBG_periodic="--periodic 0 0 0"
+
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+TBG_ph_calorimeter="--ph_calorimeter.period 1000 --ph_calorimeter.openingYaw 360 --ph_calorimeter.openingPitch 180 \
+                    --ph_calorimeter.numBinsEnergy 1024 --ph_calorimeter.minEnergy 10 --ph_calorimeter.maxEnergy 10000 \
+                    --ph_calorimeter.file calorimeter --ph_calorimeter.filter all"
+
+TBG_ph_energyHistogram="--ph_energyHistogram.period 1000 --ph_energyHistogram.filter all --ph_energyHistogram.minEnergy 10 --ph_energyHistogram.maxEnergy 10000"
+
+TBG_plugins="--hdf5.period 1000 --hdf5.file simData \
+             --e_macroParticlesCount.period 1000 \
+             --i_macroParticlesCount.period 1000 \
+             --ph_macroParticlesCount.period 1000 \
+             !TBG_ph_calorimeter \
+             !TBG_ph_energyHistogram"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_plugins       \
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+"$TBG_cfgPath"/submitAction.sh


### PR DESCRIPTION
This pull request adds a single GPU setup `1.cfg` to the Bremsstrahlung example as suggested by @ax3l in issue #3092. 