### PR TITLE
fix wrong underline in TrasRad plugin doc

### DIFF
--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -251,7 +251,7 @@ Known Issues
 The output is currently only physically correct for electron passing through a metal foil.
 
 References
-----------
+^^^^^^^^^^
 
 - *Theory of coherent transition radiation generated at a plasma-vacuum interface*
    Schroeder, C. B. and Esarey, E. and van Tilborg, J. and Leemans, W. P.,


### PR DESCRIPTION
There was a wrong underlines in the mark down files of the Transition Radiation radiation plugin documentation. Its reference section escaped the structure and appeared as a separate "plugin". 

Now only
 - `Period Syntax` has the same level as a plugin
 - `Python Postprocessing` has the same level as a plugin

@ComputationalRadiationPhysics/picongpu-maintainers is this Okay with you or should these sections disappear from the list. 

See: https://picongpu.readthedocs.io/en/latest/usage/plugins.html#