### PR TITLE
fix errors in transition radiation documentation

### DIFF
--- a/docs/source/usage/plugins.rst
+++ b/docs/source/usage/plugins.rst
@@ -27,7 +27,7 @@ Plugin name                                                                     
 :ref:`slice emittance <usage-plugins-sliceEmittance>`                                compute emittance and slice emittance of particles
 :ref:`slice field printer <usage-plugins-sliceFieldPrinter>` [#f5]_                  print out a slice of the electric and/or magnetic and/or current field
 :ref:`sum currents <usage-plugins-sumCurrents>`                                      compute the total current summed over all cells
-:ref:`transitionRadiation <usage-plugins-radiation>`                                 compute emitted electromagnetic spectra
+:ref:`transitionRadiation <usage-plugins-transitionRadiation>`                       compute emitted electromagnetic spectra
 ==================================================================================== =================================================================================
 
 .. rubric:: Footnotes

--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -77,9 +77,9 @@ Currently you can choose from the following setups for the frequency range:
 ============================= ==============================================================================================
 namespace                     Description
 ============================= ==============================================================================================
-``linear_frequencies``    linear frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
-``log_frequencies``       logarithmic frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
-``frequencies_from_list`` ``N_omega`` frequencies taken from a text file with location ``listLocation[]``
+``linear_frequencies``        linear frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
+``log_frequencies``           logarithmic frequency range from ``SI::omega_min`` to ``SI::omega_max`` with ``N_omega`` steps
+``frequencies_from_list``     ``N_omega`` frequencies taken from a text file with location ``listLocation[]``
 ============================= ==============================================================================================
 
 

--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -101,7 +101,7 @@ The frequency values in the file can be separated by newlines, spaces, tabs, or 
 
 .. note::
 
-   Currently, the variable ``listLocation`` is required to be defined in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace, even if ``frequencies_from_list`` is not used.
+   Currently, the variable ``listLocation`` is required to be defined in the ``picongpu::plugins::transitionRadiation::frequencies_from_list`` namespace, even if ``frequencies_from_list`` is not used.
    The string does not need to point to an existing file, as long as the file-based frequency definition is not used.
 
 


### PR DESCRIPTION
This pull request fixes various errors elated to the CTR plugin documentation:
 - the link in the table in the plugin  overview lead to the radiation - not to the transition radiation plugin documentation 
 - the table with the three frequency options did not show up online due to the malformatted table 
 - a warning regarding the list frequency setup referenced the wrong namespace

