### PR TITLE
fix gamma filter transition radiation

### DIFF
--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -58,7 +58,7 @@ There are no external dependencies.
 .param files
 ^^^^^^^^^^^^
 
-In order to setup the transition radiation plugin, the :ref:`transitionRadiation.param <usage-params-plugins>` has to be configured **and** the radiating particles need to have the attributes ``weighting``, ``momentum``, and ``location``, as well as the flags ``massRatio``, ``chargeRatio``, and ``transitionRadiationMask`` which can be added in :ref:`speciesDefinition.param <usage-params-core>`.
+In order to setup the transition radiation plugin, the :ref:`transitionRadiation.param <usage-params-plugins>` has to be configured **and** the radiating particles need to have the attributes ``weighting``, ``momentum``, ``location``, and ``transitionRadiationMask`` (which can be added in :ref:`speciesDefinition.param <usage-params-core>`) as well as the flags ``massRatio`` and ``chargeRatio``.
 
 In *transitionRadiation.param*, the number of frequencies ``N_omega`` and observation directions ``N_theta`` and ``N_phi`` are defined.
 

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -639,7 +639,7 @@ namespace traits
         >::type;
 
         // this plugin needs the transitionRadiationMask flag
-        using SpeciesHasMask = typename pmacc::traits::HasFlag<
+        using SpeciesHasMask = typename pmacc::traits::HasIdentifier<
             FrameType,
             transitionRadiationMask
         >::type;

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,5 @@
-/* Copyright 2013-2019 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2019 Rene Widera, Benjamin Worpitz, Heiko Burau,
+ *                     Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -38,7 +39,8 @@ namespace picongpu
     using DefaultParticleAttributes = MakeSeq_t<
         position< position_pic >,
         momentum,
-        weighting
+        weighting,
+        transitionRadiationMask
     >;
 
     /*########################### end particle attributes ########################*/
@@ -56,8 +58,7 @@ namespace picongpu
         shape< UsedParticleShape >,
         interpolation< UsedField2Particle >,
         massRatio< MassRatioElectrons >,
-        chargeRatio< ChargeRatioElectrons >,
-        transitionRadiationMask
+        chargeRatio< ChargeRatioElectrons >
     >;
 
     /* define species electrons */


### PR DESCRIPTION
This pull request fixes a bug in the transition radiation plugin that prevented the gamma filter from working.
The `transitionRadiationMask` was set as flag not as attribute, thus the filter was never applied and assumed to be always true. 

The documentation was updated alongside. 