### PR TITLE
[WIP] add check negative mass ratio

### DIFF
--- a/include/picongpu/param/speciesDefinition.param
+++ b/include/picongpu/param/speciesDefinition.param
@@ -59,8 +59,8 @@ using DefaultParticleAttributes = MakeSeq_t<
 
 /*--------------------------- photons -------------------------------------------*/
 
-value_identifier( float_X, MassRatioPhotons, 0.0 );
-value_identifier( float_X, ChargeRatioPhotons, 0.0 );
+const_value_identifier( float_X, MassRatioPhotons, 0.0 );
+const_value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
 using ParticleFlagsPhotons = MakeSeq_t<
     particlePusher< particles::pusher::Photon >,
@@ -80,8 +80,8 @@ using PIC_Photons = Particles<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
 using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
@@ -105,8 +105,8 @@ using PIC_Electrons = Particles<
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioIons, 1836.152672 );
-value_identifier( float_X, ChargeRatioIons, -1.0 );
+const_value_identifier( float_X, MassRatioIons, 1836.152672 );
+const_value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioIons, 1.0 );

--- a/include/picongpu/unitless/speciesDefinition.unitless
+++ b/include/picongpu/unitless/speciesDefinition.unitless
@@ -52,6 +52,9 @@ HDINLINE float_X getMass()
         >::type
     >::type;
 
+    /* check if massRatio is not negative */
+    PMACC_CASSERT_MSG( set_massRatio_greater_or_equal_0, MassRatioValue::getValue( ) >= float_X( 0.0 ) );
+
     return BASE_MASS * MassRatioValue::getValue();
 };
 

--- a/include/pmacc/identifier/value_identifier.hpp
+++ b/include/pmacc/identifier/value_identifier.hpp
@@ -57,3 +57,17 @@
                 return std::string(#name);                                     \
         }                                                                      \
     )
+
+/* same method as above but explicitly for constexpr values/flags */
+#define const_value_identifier(in_type,name,in_default)                        \
+        identifier(name,                                                       \
+        typedef in_type type;                                                  \
+        static HDINLINE constexpr type getValue()                              \
+        {                                                                      \
+                return in_default;                                             \
+        }                                                                      \
+        static std::string getName()                                           \
+        {                                                                      \
+                return std::string(#name);                                     \
+        }                                                                      \
+    )

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
@@ -52,8 +52,8 @@ using DefaultParticleAttributes = MakeSeq_t<
 
 /*--------------------------- photons -------------------------------------------*/
 
-value_identifier( float_X, MassRatioPhotons, 0.0 );
-value_identifier( float_X, ChargeRatioPhotons, 0.0 );
+const_value_identifier( float_X, MassRatioPhotons, 0.0 );
+const_value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
 using ParticleFlagsPhotons = MakeSeq_t<
     particlePusher< particles::pusher::Photon >,
@@ -74,9 +74,9 @@ using PIC_Photons = Particles<
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioIons, 359100);
-value_identifier(float_X, ChargeRatioIons, -79.0);
-value_identifier(float_X, DensityRatioIons, 1.0);
+const_value_identifier(float_X, MassRatioIons, 359100);
+const_value_identifier(float_X, ChargeRatioIons, -79.0);
+const_value_identifier(float_X, DensityRatioIons, 1.0);
 
 using ParticleFlagsIons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
@@ -100,9 +100,9 @@ using PIC_Ions = Particles<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
-value_identifier( float_X, DensityRatioElectrons, 79.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, DensityRatioElectrons, 79.0 );
 
 using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,

--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
@@ -58,8 +58,8 @@ using DefaultParticleAttributes = MakeSeq_t<
 
 /*--------------------------- photons -------------------------------------------*/
 
-value_identifier( float_X, MassRatioPhotons, 0.0 );
-value_identifier( float_X, ChargeRatioPhotons, 0.0 );
+const_value_identifier( float_X, MassRatioPhotons, 0.0 );
+const_value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
 using ParticleFlagsPhotons = MakeSeq_t<
     particlePusher< particles::pusher::Photon >,
@@ -79,8 +79,8 @@ using PIC_Photons = Particles<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
 using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
@@ -67,8 +67,8 @@ using IonParticleAttributes = MakeSeq_t<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
 using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
@@ -89,8 +89,8 @@ using Electrons = Particles<
 /*--------------------------- H+ --------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioHydrogen, 1836.152672 );
-value_identifier( float_X, ChargeRatioHydrogen, -1.0 );
+const_value_identifier( float_X, MassRatioHydrogen, 1836.152672 );
+const_value_identifier( float_X, ChargeRatioHydrogen, -1.0 );
 
 /* ratio relative to BASE_DENSITY (n_e) */
 value_identifier( float_X, DensityRatioHydrogen, 25. / 158. );
@@ -125,8 +125,8 @@ using Hydrogen = Particles<
 /*--------------------------- C ---------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioCarbon, 22032.0 );
-value_identifier( float_X, ChargeRatioCarbon, -6.0 );
+const_value_identifier( float_X, MassRatioCarbon, 22032.0 );
+const_value_identifier( float_X, ChargeRatioCarbon, -6.0 );
 
 /* ratio relative to BASE_DENSITY (n_e) */
 value_identifier( float_X, DensityRatioCarbon, 21. / 158. );
@@ -161,8 +161,8 @@ using Carbon = Particles<
 /*--------------------------- N ---------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioNitrogen, 25716.852 );
-value_identifier( float_X, ChargeRatioNitrogen, -7.0 );
+const_value_identifier( float_X, MassRatioNitrogen, 25716.852 );
+const_value_identifier( float_X, ChargeRatioNitrogen, -7.0 );
 
 /* ratio relative to BASE_DENSITY (n_e) */
 value_identifier( float_X, DensityRatioNitrogen, 1. / 158. );

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
@@ -57,8 +57,8 @@ using DefaultParticleAttributes = MakeSeq_t<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
 using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
@@ -79,8 +79,8 @@ using PIC_Electrons = Particles<
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioIons, 1836.152672 );
-value_identifier( float_X, ChargeRatioIons, -1.0 );
+const_value_identifier( float_X, MassRatioIons, 1836.152672 );
+const_value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioIons, -1.0 );

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
@@ -58,8 +58,8 @@ using AttributeSeqIons = MakeSeq_t<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
 using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
@@ -80,8 +80,8 @@ using PIC_Electrons = Particles<
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioIons, 1836.152672 );
-value_identifier( float_X, ChargeRatioIons, -1.0 );
+const_value_identifier( float_X, MassRatioIons, 1836.152672 );
+const_value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 using ParticleFlagsIons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
@@ -55,8 +55,8 @@ using DefaultParticleAttributes = MakeSeq_t<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier(float_X, MassRatioElectrons, 1.0);
-value_identifier(float_X, ChargeRatioElectrons, 1.0);
+const_value_identifier(float_X, MassRatioElectrons, 1.0);
+const_value_identifier(float_X, ChargeRatioElectrons, 1.0);
 
 using ParticleFlagsElectrons = MakeSeq_t<
 /* enable the pusher only if PARAM_ENABLEPUSHER is defined as one `1` */

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesDefinition.param
@@ -48,8 +48,8 @@ namespace picongpu
     /*--------------------------- electrons --------------------------------------*/
 
     /* ratio relative to BASE_CHARGE and BASE_MASS */
-    value_identifier( float_X, MassRatioElectrons, 1.0 );
-    value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+    const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+    const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
     using ParticleFlagsElectrons = MakeSeq_t<
         particlePusher< UsedParticlePusher >,

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
@@ -57,8 +57,8 @@ using DefaultParticleAttributes = MakeSeq_t<
 
 /*--------------------------- photons -------------------------------------------*/
 
-value_identifier( float_X, MassRatioPhotons, 0.0 );
-value_identifier( float_X, ChargeRatioPhotons, 0.0 );
+const_value_identifier( float_X, MassRatioPhotons, 0.0 );
+const_value_identifier( float_X, ChargeRatioPhotons, 0.0 );
 
 using ParticleFlagsPhotons = MakeSeq_t<
 #if( PARAM_ENABLE_PUSHER == 1 )
@@ -84,8 +84,8 @@ using Photons = Particles<
  */
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
 /* ratio relative to BASE_DENSITY
  * thermal "bulk": 1x ionized n_Cu
@@ -130,8 +130,8 @@ using PromptElectrons = Particles<
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioCopper, 115840. );
-value_identifier( float_X, ChargeRatioCopper, -29.0 );
+const_value_identifier( float_X, MassRatioCopper, 115840. );
+const_value_identifier( float_X, ChargeRatioCopper, -29.0 );
 
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioCopper, 1.0 );

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
@@ -49,8 +49,8 @@ using DefaultParticleAttributes = MakeSeq_t<
 /*--------------------------- electrons --------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioElectrons, 1.0 );
-value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+const_value_identifier( float_X, MassRatioElectrons, 1.0 );
+const_value_identifier( float_X, ChargeRatioElectrons, 1.0 );
 
 using ParticleFlagsElectrons = MakeSeq_t<
     particlePusher<UsedParticlePusher>,
@@ -71,8 +71,8 @@ using PIC_Electrons = Particles<
 /*--------------------------- ions -------------------------------------------*/
 
 /* ratio relative to BASE_CHARGE and BASE_MASS */
-value_identifier( float_X, MassRatioIons, 1.0 );
-value_identifier( float_X, ChargeRatioIons, -1.0 );
+const_value_identifier( float_X, MassRatioIons, 1.0 );
+const_value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /* ratio relative to BASE_DENSITY */
 value_identifier( float_X, DensityRatioIons, 1.0 );


### PR DESCRIPTION
This pull request adds the compile-time check if `massRatio` is negative. 
This was suggested by @Anton-Le in #3033. 

Thanks @sbastrakov for the help with the `constexpr` implementation. 

We both think this is a hack and there might be a better solution that this hack. (Thus, the pull equest as a WIP flag.)
 @ComputationalRadiationPhysics/picongpu-developers I am open for any suggestions to make this more general and perhaps avoids breaking old setups (which do not use `const_value_identifier` for `massRatio`s). 
