### PR TITLE
DO NOT MERGE: add whitespace at end of line

### DIFF
--- a/include/picongpu/initialization/SimStartInitialiser.hpp
+++ b/include/picongpu/initialization/SimStartInitialiser.hpp
@@ -38,7 +38,7 @@ class SimStartInitialiser : public AbstractInitialiser
 {
 public:
 
-    void init(ISimulationData& data, uint32_t currentStep)
+    void init(ISimulationData& data, uint32_t currentStep) 
     {
 
     }


### PR DESCRIPTION
This pull request is a test for the updated TravisCI output for OS X #3073 
```diff
- DO NOT MERGE THIS PULL REQUEST
```

The TravisCI will remark an extra white space at an end of a line. I will test the suggested fix on both OS X and Linux.

- [x] fix worked on OS X
- [x] fix worked on Ubuntu Linux
