### PR TITLE
fix wrong used method prefix

### DIFF
--- a/include/picongpu/fields/FieldB.tpp
+++ b/include/picongpu/fields/FieldB.tpp
@@ -42,7 +42,7 @@ namespace picongpu
     {
     }
 
-    FieldB::UnitValueType FieldB::getUnit( )
+    HDINLINE FieldB::UnitValueType FieldB::getUnit( )
     {
         return UnitValueType{ UNIT_BFIELD, UNIT_BFIELD, UNIT_BFIELD };
     }

--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -42,7 +42,7 @@ namespace picongpu
     {
     }
 
-    FieldE::UnitValueType FieldE::getUnit( )
+    HDINLINE FieldE::UnitValueType FieldE::getUnit( )
     {
         return UnitValueType{ UNIT_EFIELD, UNIT_EFIELD, UNIT_EFIELD };
     }

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -48,7 +48,7 @@ namespace detail
 
  * @param x position of the synchrotron function to be evaluated
  */
-float_X MapToLookupTable::operator()(const float_X x) const
+HDINLINE float_X MapToLookupTable::operator()(const float_X x) const
 {
     /* This mapping increases the sample point density for small values of x
      * where the synchrotron functions have a divergent slope. Without this mapping


### PR DESCRIPTION
Fix places where the method prefix of the declaration and implementation
is not matching. Bugs found with hip-clang.

The latest release 0.4.3 is also effected but I never got an error before using hip-clang.