### PR TITLE
fix wrong constructor call

### DIFF
--- a/include/picongpu/particles/pusher/particlePusherProbe.hpp
+++ b/include/picongpu/particles/pusher/particlePusherProbe.hpp
@@ -77,7 +77,7 @@ namespace particlePusherProbe
                 functorEField( pos )
             );
 
-            ActualPush actualPush();
+            ActualPush actualPush;
             actualPush(
                 functorBField,
                 functorEField,


### PR DESCRIPTION
It is normally only a warning but the compiler is interpreting it as function call I marked it as bug.

```
picongpu/particles/pusher/particlePusherProbe.hpp:80:34: warning: empty parentheses interpreted as a function declaration [-Wvexing-parse]
            ActualPush actualPush();
                                 ^~
picongpu/particles/pusher/particlePusherProbe.hpp:80:34: note: replace parentheses with an initializer to declare a variable
            ActualPush actualPush();
```