### PR TITLE
CMake: mark cuda 10.2 as tested

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -34,7 +34,7 @@ gcc
 - 4.9 - 7 (if you want to build for Nvidia GPUs, supported compilers depend on your current `CUDA version <https://gist.github.com/ax3l/9489132>`_)
 
   - CUDA 9.2 - 10.0: Use gcc 4.9 - 7
-  - CUDA 10.1: Use gcc 4.9 - 8
+  - CUDA 10.1/10.2: Use gcc 4.9 - 8
 - *note:* be sure to build all libraries/dependencies with the *same* gcc version; GCC 5 or newer is recommended
 - *Debian/Ubuntu:*
   
@@ -153,7 +153,7 @@ Optional Libraries
 
 CUDA
 """"
-- `9.2 - 10.1 <https://developer.nvidia.com/cuda-downloads>`_
+- `9.2 - 10.2 <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -349,8 +349,8 @@ if(ALPAKA_ACC_GPU_CUDA_ENABLE)
                             "(Found ${CUDA_VERSION})")
     endif()
     # Newer CUDA releases: probably troublesome, warn at least
-    if(CUDA_VERSION VERSION_GREATER 10.1)
-        message(WARNING "Untested CUDA release >10.1 (Found ${CUDA_VERSION})! "
+    if(CUDA_VERSION VERSION_GREATER 10.2)
+        message(WARNING "Untested CUDA release >10.2 (Found ${CUDA_VERSION})! "
                         "Maybe use a newer PIConGPU?")
     endif()
 endif()


### PR DESCRIPTION
remove warning that CUDA 10.2 is untested

I tested CUDA 10.2 (runtime/compile) on our test system with a V100. :fireworks: NVIDIA not introduced breaking changes.

Modules used for the test:

```
boost@1.68.0
cmake@3.15.4
cuda@10.2.89
openmpi@3.1.2
```