### PR TITLE
ADIOS Writer: Fix timeOffset

### DIFF
--- a/include/picongpu/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/include/picongpu/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -136,7 +136,7 @@ struct ParticleAttributeSize
         const float_X timeOffset = 0.0;
         ADIOS_CMD(adios_define_attribute_byvalue(params->adiosGroupHandle,
             "timeOffset", recordPath.c_str(),
-            adiosFloatXType.type, 7, (void*)&timeOffset ));
+            adiosFloatXType.type, 1, (void*)&timeOffset ));
 
     }
 


### PR DESCRIPTION
`timeOffset` should be a scalar, not an array.

Opening this since I needs this when I get to work in the morning.

Fix #3119 
