### PR TITLE
Reduce PML memory consumption

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.hpp
@@ -25,6 +25,7 @@
 #include "picongpu/fields/MaxwellSolver/YeePML/Parameters.hpp"
 #include "picongpu/fields/cellType/Yee.hpp"
 #include "picongpu/traits/FieldPosition.hpp"
+#include "picongpu/traits/IsFieldDomainBound.hpp"
 
 #include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/fields/SimulationFieldHelper.hpp>
@@ -495,6 +496,24 @@ namespace traits
         FieldB,
         T_dim
     >
+    {
+    };
+
+    /** Field domain boundness trait for output and checkpointing:
+     *  PML fields are not domain-bound
+     */
+    template< >
+    struct IsFieldDomainBound< fields::maxwellSolver::yeePML::FieldE > :
+        std::false_type
+    {
+    };
+
+    /** Field domain boundness trait for output and checkpointing:
+     *  PML fields are not domain-bound
+     */
+    template< >
+    struct IsFieldDomainBound< fields::maxwellSolver::yeePML::FieldB > :
+        std::false_type
     {
     };
 

--- a/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/Field.tpp
@@ -23,6 +23,7 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/MaxwellSolver/YeePML/Field.hpp"
 
+#include <pmacc/memory/boxes/DataBoxDim1Access.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 
 #include <cstdint>
@@ -37,22 +38,258 @@ namespace maxwellSolver
 namespace yeePML
 {
 
-    Field::Field( MappingDesc const & cellDescription ) :
-        SimulationFieldHelper< MappingDesc >( cellDescription )
+    namespace detail
     {
-        data.reset(
-            new GridBuffer< ValueType, simDim > ( cellDescription.getGridLayout( ) )
+
+        /** Construct an simDim-dimensional index out of 3 components.
+        *
+        * For 2d z is ignored
+        *
+        * @param x x component
+        * @param y y component
+        * @param z z component
+        */
+        HDINLINE pmacc::DataSpace< simDim > makeIdx(
+            int const x,
+            int const y,
+            int const z
+        )
+        {
+            auto const idx = pmacc::DataSpace< 3 >{ x, y, z };
+            pmacc::DataSpace< simDim > result;
+            for( uint32_t dim = 0u; dim < simDim; dim++ )
+                result[ dim ] = idx[ dim ];
+            return result;
+        }
+
+        /** Get linear size of the outer layer box
+        *
+        * @param gridLayout grid layout, as for normal fields
+        * @param globalThickness global PML thickness
+        */
+        HDINLINE int getOuterLayerBoxLinearSize(
+            GridLayout< simDim > const & gridLayout,
+            Thickness const & globalThickness
+        )
+        {
+            // All sizes are without guard, since Pml is only on the internal area
+            auto const gridDataSpace = gridLayout.getDataSpaceWithoutGuarding( );
+            auto const nonPmlDataSpace = gridDataSpace -
+                ( globalThickness.positiveBorder + globalThickness.negativeBorder );
+            auto const numGridCells = gridDataSpace.productOfComponents( );
+            auto const numNonPmlCells = nonPmlDataSpace.productOfComponents( );
+            return numGridCells - numNonPmlCells;
+        }
+
+    } // namespace detail
+
+    HDINLINE NodeValues::NodeValues( float_X const initialValue /* = 0._X */ ):
+        xy( initialValue ),
+        xz( initialValue ),
+        yx( initialValue ),
+        yz( initialValue ),
+        zx( initialValue ),
+        zy( initialValue )
+    {
+    }
+
+    HDINLINE const NodeValues NodeValues::create(
+        float_X const initialValue
+    )
+    {
+        return NodeValues{ initialValue };
+    }
+
+    float_X & NodeValues::operator[ ]( uint32_t const idx )
+    {
+        // Here it is safe to call the const version
+        auto constThis = const_cast< NodeValues const * >( this );
+        return const_cast< float_X & >( ( *constThis )[ idx ] );
+    }
+
+    float_X const & NodeValues::operator[ ]( uint32_t const idx ) const
+    {
+        return *( &xy + idx );
+    }
+
+    template< typename T_Value >
+    OuterLayerBox< T_Value >::OuterLayerBox(
+        GridLayout< simDim > const & gridLayout,
+        Thickness const & globalThickness,
+        DataBox box
+    ):
+        guardSize( gridLayout.getGuard( ) ),
+        box( box )
+    {
+        auto const negativeSize = globalThickness.negativeBorder;
+        auto const positiveSize = globalThickness.positiveBorder;
+        /* The region of interest is grid without guard,
+         * which consists of PML and internal area
+         */
+        auto const gridSize = gridLayout.getDataSpaceWithoutGuarding( );
+        auto const positiveBegin = gridSize - positiveSize;
+
+        // Note: since this should compile for 2d, .z( ) can't be used
+        using detail::makeIdx;
+        int layerIdx = 0;
+        if( simDim == 3 )
+        {
+            auto const negativeZLayer = Layer{
+                makeIdx( 0, 0, 0 ),
+                makeIdx( gridSize[ 0 ], gridSize[ 1 ], negativeSize[ 2 ] )
+            };
+            layers[ layerIdx++ ] = negativeZLayer;
+            auto const positiveZLayer = Layer{
+                makeIdx( 0, 0, positiveBegin[ 2 ] ),
+                makeIdx( gridSize[ 0 ], gridSize[ 1 ], gridSize[ 2 ] )
+            };
+            layers[ layerIdx++ ] = positiveZLayer;
+        }
+
+        auto const negativeYLayer = Layer{
+            makeIdx( 0, 0, negativeSize[ 2 ] ),
+            makeIdx( gridSize[ 0 ], negativeSize[ 1 ], positiveBegin[ 2 ] )
+        };
+        layers[ layerIdx++ ] = negativeYLayer;
+        auto const positiveYLayer = Layer{
+            makeIdx( 0, positiveBegin[ 1 ], negativeSize[ 2 ] ),
+            makeIdx( gridSize[ 0 ], gridSize[ 1 ], positiveBegin[ 2 ] )
+        };
+        layers[ layerIdx++ ] = positiveYLayer;
+
+        auto const negativeXLayer = Layer{
+            makeIdx( 0, negativeSize[ 1 ], negativeSize[ 2 ] ),
+            makeIdx( negativeSize[ 0 ], positiveBegin[ 1 ], positiveBegin[ 2 ] )
+        };
+        layers[ layerIdx++ ] = negativeXLayer;
+        auto const positiveXLayer = Layer{
+            makeIdx( positiveBegin[ 0 ], negativeSize[ 1 ], negativeSize[ 2 ] ),
+            makeIdx( gridSize[ 0 ], positiveBegin[ 1 ], positiveBegin[ 2 ] )
+        };
+        layers[ layerIdx++ ] = positiveXLayer;
+    }
+
+    template< typename T_Value >
+    HDINLINE typename OuterLayerBox< T_Value >::ValueType const &
+        OuterLayerBox< T_Value >::operator( )( Idx const & idx ) const
+    {
+        return box(
+            getLinearIdx( idx )
         );
     }
 
-    GridBuffer< Field::ValueType, simDim > & Field::getGridBuffer( )
+    template< typename T_Value >
+    HDINLINE typename OuterLayerBox< T_Value >::ValueType &
+        OuterLayerBox< T_Value >::operator( )( Idx const & idx )
+    {
+        return box(
+            getLinearIdx( idx )
+        );
+    }
+
+    template< typename T_Value >
+    HDINLINE int OuterLayerBox< T_Value >::getLinearIdx(
+        Idx const & idxWithGuard
+    ) const
+    {
+        /* Each PML layer provide a contiguous 1d index range.
+         * The resulting index is a sum of the baseIdx representing the total
+         * size of all previous layers and an index inside the current layer.
+         */
+        auto const idx = idxWithGuard - guardSize;
+        int currentLayerBeginIdx = 0;
+        int result = -1;
+        for( Layer const & layer : layers )
+            if( layer.contains( idx ) )
+            {
+                /* Note: here we could have returned the result directly,
+                 * but chose to have a single return for potential
+                 * performance gains on GPU. The break is not required,
+                 * since each valid index belonds to exactly one layer.
+                 */
+                result = currentLayerBeginIdx + layer.getLinearIdx( idx );
+                break;
+            }
+            else
+                currentLayerBeginIdx += layer.getVolume( );
+        return result;
+    }
+
+    template< typename T_Value >
+    HDINLINE OuterLayerBox< T_Value >::Layer::Layer(
+        Idx const & beginIdx,
+        Idx const & endIdx
+    ):
+        beginIdx{ beginIdx },
+        size{ endIdx - beginIdx },
+        volume{ size.productOfComponents( ) }
+    {
+    }
+
+    template< typename T_Value >
+    HDINLINE bool OuterLayerBox< T_Value >::Layer::contains(
+        Idx const & idx
+    ) const
+    {
+        for( uint32_t dim = 0u; dim < simDim; dim++ )
+            if( ( idx[ dim ] < beginIdx[ dim ] ) ||
+                ( idx[ dim ] >= beginIdx[ dim ] + size[ dim ] ) )
+                return false;
+        return true;
+    }
+
+    template< typename T_Value >
+    HDINLINE int OuterLayerBox< T_Value >::Layer::getVolume( ) const
+    {
+        return volume;
+    }
+
+    template< typename T_Value >
+    HDINLINE int OuterLayerBox< T_Value >::Layer::getLinearIdx(
+        Idx const & idx
+    ) const
+    {
+        // Convert to 3d zero-based index, for 2d keep .z( ) == 0
+        pmacc::DataSpace< 3 > zeroBasedIdx{ 0, 0, 0 };
+        for( uint32_t dim = 0u; dim < simDim; dim++ )
+            zeroBasedIdx[ dim ] = idx[ dim ] - beginIdx[ dim ];
+        return zeroBasedIdx.x( ) + zeroBasedIdx.y( ) * size.x( ) +
+            zeroBasedIdx.z( ) * size.y( ) * size.x( );
+    }
+
+    Field::Field(
+        MappingDesc const & cellDescription,
+        Thickness const & globalThickness ) :
+        SimulationFieldHelper< MappingDesc >( cellDescription ),
+        gridLayout( cellDescription.getGridLayout( ) ),
+        globalThickness( globalThickness )
+    {
+        /* Create a simDim-dimentional buffer
+         * with size = linearSize x 1 [x 1 for 3d]
+         */
+        auto size = pmacc::DataSpace< simDim >::create( 1 );
+        size[ 0 ] = detail::getOuterLayerBoxLinearSize(
+            gridLayout,
+            globalThickness
+        );
+        auto const guardSize = pmacc::DataSpace< simDim >::create( 0 );
+        auto const layout = pmacc::GridLayout< simDim >(
+            size,
+            guardSize
+        );
+        data.reset(
+            new Buffer( layout )
+        );
+    }
+
+    Field::Buffer & Field::getGridBuffer( )
     {
         return *data;
     }
 
-    GridLayout< simDim > Field::getGridLayout( )
+    pmacc::GridLayout< simDim > Field::getGridLayout( )
     {
-        return cellDescription.getGridLayout( );
+        return data->getGridLayout( );
     }
 
     Field::DataBoxType Field::getHostDataBox( )
@@ -63,6 +300,22 @@ namespace yeePML
     Field::DataBoxType Field::getDeviceDataBox( )
     {
         return data->getDeviceBuffer( ).getDataBox( );
+    }
+
+    Field::OuterLayerBoxType Field::getDeviceOuterLayerBox( )
+    {
+        auto const boxWrapper1d = pmacc::DataBoxDim1Access< DataBoxType >{
+            getDeviceDataBox( ),
+            data->getGridLayout( ).getDataSpace( )
+        };
+        /* Note: the outer layer box type just provides access to data,
+         * it does not own or make copy of the data (nor is that required)
+         */
+        return OuterLayerBoxType{
+            gridLayout,
+            globalThickness,
+            boxWrapper1d
+        };
     }
 
     EventTask Field::asyncCommunication( EventTask serialEvent )

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -26,9 +26,9 @@
 #include "picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel"
 #include "picongpu/fields/cellType/Yee.hpp"
 
-#include <pmacc/memory/MakeUnique.hpp>
 #include <pmacc/traits/GetStringProperties.hpp>
 
+#include <memory>
 #include <stdexcept>
 
 
@@ -122,7 +122,7 @@ namespace maxwellSolver
                         CurlE( ),
                         fieldE->getDeviceDataBox( ),
                         fieldB->getDeviceDataBox( ),
-                        psiB->getDeviceDataBox( )
+                        psiB->getDeviceOuterLayerBox( )
                     );
             }
 
@@ -150,7 +150,7 @@ namespace maxwellSolver
                         CurlB( ),
                         fieldB->getDeviceDataBox( ),
                         fieldE->getDeviceDataBox( ),
-                        psiE->getDeviceDataBox( )
+                        psiE->getDeviceOuterLayerBox( )
                     );
             }
 
@@ -218,16 +218,27 @@ namespace maxwellSolver
             void initFields( )
             {
                 /* Split fields are created here (and not with normal E and B)
-                * in order to not waste memory in case PML is not used.
-                */
+                 * in order to not waste memory in case PML is not used.
+                 */
                 DataConnector & dc = Environment<>::get( ).DataConnector( );
-                fieldE = dc.get< picongpu::FieldE >( picongpu::FieldE::getName( ), true );
-                fieldB = dc.get< picongpu::FieldB >( picongpu::FieldB::getName( ), true );
-                using pmacc::memory::makeUnique;
-                dc.consume( makeUnique< yeePML::FieldE >( cellDescription ) );
-                dc.consume( makeUnique< yeePML::FieldB >( cellDescription ) );
-                psiE = dc.get< yeePML::FieldE >( yeePML::FieldE::getName( ), true );
-                psiB = dc.get< yeePML::FieldB >( yeePML::FieldB::getName( ), true );
+                fieldE = dc.get< picongpu::FieldE >(
+                    picongpu::FieldE::getName( ),
+                    true
+                );
+                fieldB = dc.get< picongpu::FieldB >(
+                    picongpu::FieldB::getName( ),
+                    true
+                );
+                psiE = std::make_shared< yeePML::FieldE >(
+                    cellDescription,
+                    globalSize
+                );
+                psiB = std::make_shared< yeePML::FieldB >(
+                    cellDescription,
+                    globalSize
+                );
+                dc.share( psiE );
+                dc.share( psiB );
             }
 
             template< uint32_t T_Area >

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
@@ -251,7 +251,7 @@ namespace yeePML
              * along this direction and == 1 otherwise.
              * So a product is 1 in the internal area and < 1 in PML
              */
-            return coeffs.b.x( ) * coeffs.b.y( ) * coeffs.b.z( ) != 1.0_X;
+            return coeffs.b.productOfComponents( ) != 1.0_X;
         }
 
     } // namespace detail
@@ -274,7 +274,6 @@ namespace yeePML
          * @tparam T_Curl curl functor type
          * @tparam T_BBox pmacc::DataBox, magnetic field box type
          * @tparam T_EBox pmacc::DataBox, electric field box type
-         * @tparam T_PsiEBox PML convolutional electric field box type
          *
          * @param acc alpaka accelerator
          * @param mapper functor to map a block to a supercell
@@ -290,8 +289,7 @@ namespace yeePML
             typename T_Mapping,
             typename T_Curl,
             typename T_BBox,
-            typename T_EBox,
-            typename T_PsiEBox
+            typename T_EBox
         >
         DINLINE void operator( )(
             T_Acc const & acc,
@@ -300,7 +298,7 @@ namespace yeePML
             T_Curl const curl,
             T_BBox const fieldB,
             T_EBox fieldE,
-            T_PsiEBox fieldPsiE
+            FieldBox fieldPsiE
         ) const
         {
             /* Each block processes grid values in a supercell,
@@ -437,7 +435,6 @@ namespace yeePML
          * @tparam T_Curl curl functor type
          * @tparam T_EBox pmacc::DataBox electric field box type
          * @tparam T_BBox pmacc::DataBox magnetic field box type
-         * @tparam T_PsiBBox PML convolutional magnetic field box type
          *
          * @param acc alpaka accelerator
          * @param mapper functor to map a block to a supercell
@@ -453,8 +450,7 @@ namespace yeePML
             typename T_Mapping,
             typename T_Curl,
             typename T_EBox,
-            typename T_BBox,
-            typename T_PsiBBox
+            typename T_BBox
         >
         DINLINE void operator( )(
             T_Acc const & acc,
@@ -463,7 +459,7 @@ namespace yeePML
             T_Curl const curl,
             T_EBox const fieldE,
             T_BBox fieldB,
-            T_PsiBBox fieldPsiB
+            FieldBox fieldPsiB
         ) const
         {
             /* Each block processes grid values in a supercell,
@@ -473,7 +469,7 @@ namespace yeePML
                 DataSpace< simDim >( blockIdx )
             ) * MappingDesc::SuperCellSize::toRT( );
 
-            // Cache B values for the block
+            // Cache E values for the block
             using namespace mappings::threads;
             constexpr auto numWorkers = T_numWorkers;
             auto const workerIdx = threadIdx.x;

--- a/include/picongpu/param/fieldSolver.param
+++ b/include/picongpu/param/fieldSolver.param
@@ -62,8 +62,6 @@ namespace fields
      * Field Solver Selection:
      *  - Yee< CurrentInterpolation > : standard Yee solver
      *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
-     *      warning: requires a substantial amount of additional memory,
-     *      equal to 12 scalar fields
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B

--- a/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/fields/FieldB.hpp"
 #include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/simulation/control/MovingWindow.hpp"
+#include "picongpu/traits/IsFieldDomainBound.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpace.hpp>
@@ -50,7 +51,13 @@ class RestartFieldLoader
 {
 public:
     template<class Data>
-    static void loadField(Data& field, const uint32_t numComponents, std::string objectName, ThreadParams *params)
+    static void loadField(
+        Data& field,
+        const uint32_t numComponents,
+        std::string objectName,
+        ThreadParams *params,
+        const bool isDomainBound
+    )
     {
         log<picLog::INPUT_OUTPUT > ("Begin loading field '%1%'") % objectName;
         const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
@@ -80,6 +87,34 @@ public:
         Dimensions local_domain_size;
         for (uint32_t d = 0; d < simDim; ++d)
             local_domain_size[d] = params->window.localDimensions.size[d];
+        int elementCount = params->window.localDimensions.size.productOfComponents();
+        bool useLinearIdxAsDestination = false;
+
+        /* Patch for non-domain-bound fields
+         * This is an ugly fix to allow output of reduced 1d PML buffers,
+         * that are the same size on each domain.
+         * This code is to be replaced with the openPMD output plugin soon.
+         */
+        if( !isDomainBound )
+        {
+            auto const field_layout = params->gridLayout;
+            auto const field_no_guard = field_layout.getDataSpaceWithoutGuarding();
+            elementCount = field_no_guard.productOfComponents();
+            // Number of elements on each local domain
+            local_domain_size = Dimensions(
+                elementCount,
+                1,
+                1
+            );
+            auto const & gridController = Environment<simDim>::get().GridController();
+            auto const rank = gridController.getGlobalRank();
+            domain_offset = Dimensions(
+                rank * elementCount,
+                0,
+                0
+            );
+            useLinearIdxAsDestination = true;
+        }
 
         // avoid deadlock between not finished pmacc tasks and mpi calls in splash/HDF5
         __getTransactionEvent().waitForFinished();
@@ -99,15 +134,20 @@ public:
                                            Domain(domain_offset, local_domain_size),
                                            &data_class);
 
-            int elementCount = params->window.localDimensions.size.productOfComponents();
-
             for (int linearId = 0; linearId < elementCount; ++linearId)
             {
-                /* calculate index inside the moving window domain which is located on the local grid*/
-                DataSpace<simDim> destIdx = DataSpaceOperations<simDim>::map(params->window.localDimensions.size, linearId);
-                /* jump over guard and local sliding window offset*/
-                destIdx += field_guard + params->localWindowToDomainOffset;
-
+                DataSpace<simDim> destIdx;
+                if( useLinearIdxAsDestination )
+                {
+                    destIdx[ 0 ] = linearId;
+                }
+                else
+                {
+                    /* calculate index inside the moving window domain which is located on the local grid*/
+                    destIdx = DataSpaceOperations<simDim>::map(params->window.localDimensions.size, linearId);
+                    /* jump over guard and local sliding window offset*/
+                    destIdx += field_guard + params->localWindowToDomainOffset;
+                }
                 destBox(destIdx)[i] = ((float_X*) (field_container->getIndex(0)->getData()))[linearId];
             }
 
@@ -149,9 +189,9 @@ public:
 /**
  * Hepler class for HDF5Writer (forEach operator) to load a field from HDF5
  *
- * @tparam FieldType field class to load
+ * @tparam T_Field field class to load
  */
-template< typename FieldType >
+template< typename T_Field >
 struct LoadFields
 {
 public:
@@ -163,16 +203,20 @@ public:
         ThreadParams *tp = params;
 
         /* load field without copying data to host */
-        std::shared_ptr< FieldType > field = dc.get< FieldType >( FieldType::getName(), true );
+        std::shared_ptr< T_Field > field = dc.get< T_Field >( T_Field::getName(), true );
+        tp->gridLayout = field->getGridLayout();
 
         /* load from HDF5 */
+        bool const isDomainBound = traits::IsFieldDomainBound< T_Field >::value;
         RestartFieldLoader::loadField(
-                field->getGridBuffer(),
-                (uint32_t)FieldType::numComponents,
-                FieldType::getName(),
-                tp);
+            field->getGridBuffer(),
+            static_cast< uint32_t >( T_Field::numComponents ),
+            T_Field::getName(),
+            tp,
+            isDomainBound
+        );
 
-        dc.releaseData( FieldType::getName() );
+        dc.releaseData( T_Field::getName() );
 #endif
     }
 

--- a/include/picongpu/plugins/hdf5/writer/Field.hpp
+++ b/include/picongpu/plugins/hdf5/writer/Field.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2014-2020 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2014-2020 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -45,16 +46,21 @@ struct Field
      *                       vector for each component and the inner vector for
      *                       the simDim position offset within the cell [0.0; 1.0)
      */
-    template<typename T_ValueType, typename T_DataBoxType>
-    static void writeField(ThreadParams *params,
-                           const std::string name,
-                           std::vector<float_64> unit,
-                           std::vector<float_64> unitDimension,
-                           std::vector<std::vector<float_X> > inCellPosition,
-                           float_X timeOffset,
-                           T_DataBoxType dataBox,
-                           const T_ValueType&
-                           )
+    template<
+        typename T_ValueType,
+        typename T_DataBoxType
+    >
+    static void writeField(
+        ThreadParams *params,
+        const std::string name,
+        std::vector<float_64> unit,
+        std::vector<float_64> unitDimension,
+        std::vector<std::vector<float_X> > inCellPosition,
+        float_X timeOffset,
+        T_DataBoxType dataBox,
+        const T_ValueType&,
+        const bool isDomainBound
+    )
     {
         typedef T_DataBoxType NativeDataBoxType;
         typedef T_ValueType ValueType;
@@ -109,6 +115,38 @@ struct Field
 
         splashGlobalOffsetFile[1] = std::max(0, localDomain.offset[1] -
                                              params->window.globalDimensions.offset[1]);
+
+        /* Patch for non-domain-bound fields
+         * This is an ugly fix to allow output of reduced 1d PML buffers,
+         * that are the same size on each domain.
+         * This code is to be replaced with the openPMD output plugin soon.
+         */
+        if( !isDomainBound )
+        {
+            field_no_guard = field_layout.getDataSpaceWithoutGuarding();
+            auto const localSize = field_no_guard.productOfComponents();
+            auto const & gridController = Environment<simDim>::get().GridController();
+            auto const numRanks = gridController.getGlobalSize();
+            auto const rank = gridController.getGlobalRank();
+            // Number of elements on all domains combined
+            splashGlobalDomainSize = Dimensions(
+                localSize * numRanks,
+                1,
+                1
+            );
+            // Offset for this rank
+            splashGlobalOffsetFile = Dimensions(
+                localSize * rank,
+                0,
+                0
+            );
+            // We are not affected by moving window, so all have offset to 0
+            splashGlobalDomainOffset = Dimensions(
+                0,
+                0,
+                0
+            );
+        }
 
         size_t tmpArraySize = field_no_guard.productOfComponents();
         ComponentType* tmpArray = new ComponentType[tmpArraySize];

--- a/include/picongpu/traits/IsFieldDomainBound.hpp
+++ b/include/picongpu/traits/IsFieldDomainBound.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <type_traits>
+
+
+namespace picongpu
+{
+namespace traits
+{
+
+    /** Whether a field is geometrically bound to the domain decomposition
+     *  with respect to size, guard size, and offset
+     *
+     * Inherits std::true_type, std::false_type or a compatible type.
+     *
+     * @tparam T_Field field type
+     */
+    template< typename T_Field >
+    struct IsFieldDomainBound : std::true_type
+    {
+    };
+
+} // namespace traits
+} // namespace picongpu

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldSolver.param
@@ -62,8 +62,6 @@ namespace fields
      * Field Solver Selection:
      *  - Yee< CurrentInterpolation >: standard Yee solver
      *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
-     *      warning: requires a substantial amount of additional memory,
-     *      equal to 12 scalar fields
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fieldSolver.param
@@ -66,8 +66,6 @@ namespace fields
      *  - Yee< CurrentInterpolation >: standard Yee solver
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
      *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
-     *      warning: requires a substantial amount of additional memory,
-     *      equal to 12 scalar fields
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B
      */

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/fieldSolver.param
@@ -65,8 +65,6 @@ namespace fields
      * Field Solver Selection:
      *  - Yee< CurrentInterpolation >: standard Yee solver
      *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
-     *      warning: requires a substantial amount of additional memory,
-     *      equal to 12 scalar fields
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B


### PR DESCRIPTION
By internally storing only the required near-boundary values instead of the whole local domain as for normal E and B. Along the way did small style improvements.

TODO:

- [x] fix 2D case
- [x] test checkpointing
- [x] refactor and document
- [x] update the memory calculator