### PR TITLE
Fix cmake flags for MSVS

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -282,6 +282,14 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
 # PGI
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
+# MSVS
+elseif(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+    # Required for MSVS 15.8+ due to alignment change
+    # https://devblogs.microsoft.com/cppblog/stl-features-and-fixes-in-vs-2017-15-8/
+    if(MSVC_VERSION GREATER_EQUAL 1916)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _ENABLE_EXTENDED_ALIGNED_STORAGE")
+    endif()
 endif()
 
 


### PR DESCRIPTION
The `/bigobj` flag is required for almost all PIConGPU setups, so reasonable to set by default. The other flag is needed for Visual Studio versions after 15.8, I put an explanatory link. Just discovered it recently after updating my VS.

I also now have one more weird error in the cmake-generated VS project (easy to fix manually). It seems to link to the correct Boost program_options but somehow also adds a dependency to the same library but without the path to it. But not yet sure where it comes from, maybe some issues on my system. Adding the directory to the search path helps.