### PR TITLE
fix loading picongpu profile

### DIFF
--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -90,4 +90,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/cori-nersc/knl_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/knl_picongpu.profile.example
@@ -67,4 +67,9 @@ function getNode() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
+++ b/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
@@ -101,4 +101,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/draco-mpcdf/picongpu.profile.example
+++ b/etc/picongpu/draco-mpcdf/picongpu.profile.example
@@ -65,4 +65,9 @@ export TBG_TPLFILE="etc/picongpu/draco-mpcdf/general.tpl"
 alias getNode='salloc --time=1:00:00 --nodes=1 --exclusive --ntasks-per-node=2 --cpus-per-task=32 --partition general'
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -81,4 +81,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -82,4 +82,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -82,4 +82,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -82,4 +82,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
+++ b/etc/picongpu/hydra-hzdr/default_picongpu.profile.example
@@ -63,4 +63,9 @@ export TBG_SUBMIT="qsub"
 export TBG_TPLFILE="etc/picongpu/hydra-hzdr/default.tpl"
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
+++ b/etc/picongpu/hypnos-hzdr/laser_picongpu.profile.example
@@ -64,4 +64,9 @@ export TBG_SUBMIT="qsub"
 export TBG_TPLFILE="etc/picongpu/hypnos-hzdr/laser.tpl"
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -108,4 +108,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -107,4 +107,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -111,4 +111,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -108,4 +108,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -118,4 +118,9 @@ function getDevice() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
+++ b/etc/picongpu/lawrencium-lbnl/picongpu.profile.example
@@ -74,4 +74,9 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/lawrencium-lbnl/fermi.tpl"
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -107,4 +107,9 @@ getNode() {
 }
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -66,4 +66,9 @@ export TBG_SUBMIT="bsub"
 export TBG_TPLFILE="etc/picongpu/summit-ornl/gpu_batch.tpl"
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -79,4 +79,9 @@ export TBG_TPLFILE="etc/picongpu/taurus-tud/V100.tpl"
 alias getNode='srun -p ml --gres=gpu:6 -n 1 --mem=0 --cpus-per-task=44 --pty -t 2:00:00 bash'
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -76,4 +76,9 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/k20x.tpl"
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -79,4 +79,9 @@ export TBG_TPLFILE="etc/picongpu/taurus-tud/k80.tpl"
 alias getNode='srun -p gpu2-interactive --gres=gpu:4 -n 1 --pty --mem=0 -t 2:00:00 bash'
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -68,4 +68,9 @@ export TBG_TPLFILE="etc/picongpu/taurus-tud/knl.tpl"
 alias getNode='srun -p knl -N 1 -c 64 --mem=90000 --constraint="Quadrant&Cache" --pty bash'
 
 # Load autocompletion for PIConGPU commands
-source $PICSRC/bin/picongpu-completion.bash
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $PICSRC/bin/picongpu-completion.bash
+else
+    echo "bash completion file '$PICSRC/bin/picongpu-completion.bash' not found." >&2
+fi


### PR DESCRIPTION
It is not possible to source the profiles for the PIConGPU environment
if the file `$PICSRC/bin/picongpu-completion.bash` is not available.
All tpl files are loding the profile inside the jobscript. If the
completion file is not available the simulation will not start.

bug was introduced with #3069