### PR TITLE
Fix a typo in exchange communication tag status output

### DIFF
--- a/include/pmacc/memory/buffers/GridBuffer.hpp
+++ b/include/pmacc/memory/buffers/GridBuffer.hpp
@@ -218,7 +218,7 @@ public:
                 {
                     std::stringstream message;
                     message << "unique exchange communication tag ("
-                        << uniqCommunicationTag << ") witch is created from communicationTag ("
+                        << uniqCommunicationTag << ") which is created from communicationTag ("
                         << communicationTag << ") already used for other GridBuffer exchange";
                     throw std::runtime_error(message.str());
                 }
@@ -311,7 +311,7 @@ public:
                     {
                         std::stringstream message;
                         message << "unique exchange communication tag ("
-                            << uniqCommunicationTag << ") witch is created from communicationTag ("
+                            << uniqCommunicationTag << ") which is created from communicationTag ("
                             << communicationTag << ") already used for other GridBuffer exchange";
                         throw std::runtime_error(message.str());
                     }


### PR DESCRIPTION
Fix a funny typo reported by @jkelling . However, [the wicked which](https://wordwise.typepad.com/blog/2010/01/the-wicked-which.html) is still probably present in multiple places.