### PR TITLE
EnergyHistogram: allow non-keyword arguments

### DIFF
--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -107,12 +107,10 @@ You can quickly load and interact with the data in Python with:
    counts, bins_keV, _, _ = eh_data.get(species='e', species_filter='all', iteration=2000)
 
    # get data for multiple iterations
-   d, bins, iteration, dt = eh_data.get(species='e', iteration=[200, 400, 8000])
+   counts, bins_keV, iteration, dt = eh_data.get(species='e', iteration=[200, 400, 8000])
 
    # load data for a given time
    counts, bins_keV, iteration, dt = eh_data.get(species='e', species_filter='all', time=1.3900e-14)
-
-
 
 
 Matplotlib Visualizer

--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -104,13 +104,15 @@ You can quickly load and interact with the data in Python with:
    eh_data.get_times(species='e')
 
    # load data for a given iteration
-   counts, bins_keV = eh_data.get('e', species_filter='all', iteration=2000)
-
-   # load data for a given time
-   counts, bins_keV = eh_data.get('e', species_filter='all', time=1.3900e-14)
+   counts, bins_keV, _, _ = eh_data.get(species='e', species_filter='all', iteration=2000)
 
    # get data for multiple iterations
    d, bins, iteration, dt = eh_data.get(species='e', iteration=[200, 400, 8000])
+
+   # load data for a given time
+   counts, bins_keV, iteration, dt = eh_data.get(species='e', species_filter='all', time=1.3900e-14)
+
+
 
 
 Matplotlib Visualizer

--- a/lib/python/picongpu/plugins/data/base_reader.py
+++ b/lib/python/picongpu/plugins/data/base_reader.py
@@ -74,6 +74,10 @@ class DataReader(object):
         If both are given, the 'time' argument is converted to
         an iteration and data for the iteration matching the time
         is returned.
+        For other valid args and kwargs, please look at the
+        documentation of the '_get_for_iteration' methods
+        of the derived classes since the parameters are passed
+        on to that function.
 
         time: float or np.array of float or None.
             If None, data for all available times is returned.

--- a/lib/python/picongpu/plugins/data/base_reader.py
+++ b/lib/python/picongpu/plugins/data/base_reader.py
@@ -38,7 +38,7 @@ class DataReader(object):
         """
         return self.find_time.get_dt()
 
-    def get_times(self, **kwargs):
+    def get_times(self, *args, **kwargs):
         """
         Returns
         -------
@@ -46,10 +46,10 @@ class DataReader(object):
         data is available
         """
 
-        iterations = np.array(self.get_iterations(**kwargs))
+        iterations = np.array(self.get_iterations(*args, **kwargs))
         return self.find_time.get_time(iterations)
 
-    def get_data_path(self, **kwargs):
+    def get_data_path(self, *args, **kwargs):
         """
         Returns
         -------
@@ -57,7 +57,7 @@ class DataReader(object):
         """
         raise NotImplementedError
 
-    def get_iterations(self, **kwargs):
+    def get_iterations(self, *args, **kwargs):
         """
         Returns
         -------
@@ -66,7 +66,7 @@ class DataReader(object):
         """
         raise NotImplementedError
 
-    def get(self, **kwargs):
+    def get(self, *args, **kwargs):
         """
         Parameters
         ----------
@@ -103,15 +103,15 @@ class DataReader(object):
             time = kwargs.pop('time')
             if time is None:
                 # use all times that are available, i.e. all iterations
-                iteration = self.get_iterations(**kwargs)
+                iteration = self.get_iterations(*args, **kwargs)
             else:
                 iteration = self.find_time.get_iteration(
                     time, method='closest')
             # print("got 'time'=", time, ", converted to iter", iteration)
 
-        return self._get_for_iteration(iteration, **kwargs)
+        return self._get_for_iteration(iteration, *args, **kwargs)
 
-    def _get_for_iteration(self, iteration, **kwargs):
+    def _get_for_iteration(self, iteration, *args, **kwargs):
         """
         Get the data for a given iteration.
 


### PR DESCRIPTION
Fixes #3140 by updating the example for the `EnergyHistogramData` in the documentation.
Now the correct number of return values for the `.get` method are provided and all arguments are provided as keyword arguments.
However, providing arguments should now also work since the base class function signature got updated as well.