### PR TITLE
Unify output text names of vector components

### DIFF
--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 
 #include <pmacc/traits/HasIdentifiers.hpp>
 #include <pmacc/traits/HasFlag.hpp>
@@ -83,9 +84,8 @@ namespace derivedAttributes
         std::string
         getName()
         {
-            const std::string name_lookup[] = {"x", "y", "z"};
-
-            return "midCurrentDensity/" + name_lookup[T_direction];
+            auto const componentNames = plugins::misc::getComponentNames( 3 );
+            return "midCurrentDensity/" + componentNames[T_direction];
         }
 
         /** Calculate a new attribute per particle

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -61,6 +61,7 @@
 #include "picongpu/plugins/adios/restart/LoadSpecies.hpp"
 #include "picongpu/plugins/adios/restart/RestartFieldLoader.hpp"
 #include "picongpu/plugins/adios/NDScalars.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/plugins/misc/SpeciesFilter.hpp"
 
 #include <adios.h>
@@ -527,7 +528,7 @@ private:
         PICToAdios<float_64> adiosDoubleType;
         PICToAdios<float_X> adiosFloatXType;
 
-        const std::string name_lookup_tpl[] = {"x", "y", "z", "w"};
+        auto const componentNames = plugins::misc::getComponentNames( nComponents );
 
         /* parameter checking */
         PMACC_ASSERT( unit.size() == nComponents );
@@ -543,7 +544,7 @@ private:
         {
             std::string datasetName = recordName;
             if (nComponents > 1)
-                datasetName +=  "/" + name_lookup_tpl[c];
+                datasetName +=  "/" + componentNames[c];
 
             /* define adios var for field, e.g. field_FieldE_y */
             const char* path = nullptr;

--- a/include/picongpu/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
+++ b/include/picongpu/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp
@@ -24,6 +24,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/plugins/adios/ADIOSWriter.def"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/PICToOpenPMD.hpp"
 #include <pmacc/traits/GetComponentsType.hpp>
 #include <pmacc/traits/GetNComponents.hpp>
@@ -70,7 +71,7 @@ struct LoadParticleAttributesFromADIOS
 
         log<picLog::INPUT_OUTPUT > ("ADIOS: ( begin ) load species attribute: %1%") % Identifier::getName();
 
-        const std::string name_lookup[] = {"x", "y", "z"};
+        const auto componentNames = plugins::misc::getComponentNames( components );
 
         ComponentType* tmpArray = nullptr;
         if( elements > 0 )
@@ -86,7 +87,7 @@ struct LoadParticleAttributesFromADIOS
             std::stringstream datasetName;
             datasetName << particlePath << openPMDName();
             if (components > 1)
-                datasetName << "/" << name_lookup[n];
+                datasetName << "/" << componentNames[n];
 
             ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer();
 

--- a/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
@@ -23,6 +23,7 @@
 #include <pmacc/types.hpp>
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/plugins/adios/ADIOSWriter.def"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 
 #include <pmacc/particles/frame_types.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
@@ -56,7 +57,7 @@ public:
     {
         log<picLog::INPUT_OUTPUT > ("Begin loading field '%1%'") % objectName;
 
-        const std::string name_lookup_tpl[] = {"x", "y", "z", "w"};
+        const auto componentNames = plugins::misc::getComponentNames( numComponents );
         const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
 
         const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
@@ -79,7 +80,7 @@ public:
             std::stringstream datasetName;
             datasetName << params->adiosBasePath << ADIOS_PATH_FIELDS << objectName;
             if (numComponents > 1)
-                datasetName << "/" << name_lookup_tpl[n];
+                datasetName << "/" << componentNames[n];
 
             log<picLog::INPUT_OUTPUT > ("ADIOS: Read from field '%1%'") %
                 datasetName.str();

--- a/include/picongpu/plugins/adios/writer/ParticleAttributeSize.hpp
+++ b/include/picongpu/plugins/adios/writer/ParticleAttributeSize.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/plugins/adios/ADIOSWriter.def"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/PICToAdios.hpp"
 #include "picongpu/traits/PICToOpenPMD.hpp"
 #include <pmacc/traits/GetComponentsType.hpp>
@@ -70,7 +71,7 @@ struct ParticleAttributeSize
         PICToAdios<float_64> adiosDoubleType;
         PICToAdios<uint32_t> adiosUInt32Type;
 
-        const std::string name_lookup[] = {"x", "y", "z"};
+        const auto componentNames = plugins::misc::getComponentNames( components );
 
         OpenPMDName<T_Identifier> openPMDName;
         const std::string recordPath( params->adiosBasePath +
@@ -93,7 +94,7 @@ struct ParticleAttributeSize
             std::stringstream datasetName;
             datasetName << recordPath;
             if (components > 1)
-                datasetName << "/" << name_lookup[d];
+                datasetName << "/" << componentNames[d];
 
             const char* path = nullptr;
             int64_t adiosParticleAttrId = defineAdiosVar<DIM1>(

--- a/include/picongpu/plugins/hdf5/WriteSpecies.hpp
+++ b/include/picongpu/plugins/hdf5/WriteSpecies.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/traits/SIBaseUnits.hpp"
 #include "picongpu/traits/PICToOpenPMD.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/plugins/output/WriteSpeciesCommon.hpp"
 #include "picongpu/plugins/kernel/CopySpecies.kernel"
 #include "picongpu/particles/traits/GetSpeciesFlagName.hpp"
@@ -435,7 +436,7 @@ public:
          * extent: size of this particle patch, upper bound is excluded
          */
         const pmacc::Selection<simDim>& globalDomain = Environment<simDim>::get().SubGrid().getGlobalDomain();
-        const std::string name_lookup[] = {"x", "y", "z"};
+        const auto componentNames = plugins::misc::getComponentNames( simDim );
         for (uint32_t d = 0; d < simDim; ++d)
         {
             const uint64_t patchOffset =
@@ -452,7 +453,7 @@ public:
                 ctUInt64, 1,
                 myPatchEntries,
                 (particlePatchesPath + std::string("/offset/") +
-                 name_lookup[d]).c_str(),
+                 componentNames[d]).c_str(),
                 &patchOffset);
             params->dataCollector->write(
                 params->currentStep,
@@ -461,7 +462,7 @@ public:
                 ctUInt64, 1,
                 myPatchEntries,
                 (particlePatchesPath + std::string("/extent/") +
-                 name_lookup[d]).c_str(),
+                 componentNames[d]).c_str(),
                 &patchExtent);
 
             /* offsets and extent of the patch are positions (lengths)
@@ -474,14 +475,14 @@ public:
                 params->currentStep,
                 ctDouble,
                 (particlePatchesPath + std::string("/offset/") +
-                 name_lookup[d]).c_str(),
+                 componentNames[d]).c_str(),
                 "unitSI",
                 &(unitCellIdx.at(d)));
             params->dataCollector->writeAttribute(
                 params->currentStep,
                 ctDouble,
                 (particlePatchesPath + std::string("/extent/") +
-                 name_lookup[d]).c_str(),
+                 componentNames[d]).c_str(),
                 "unitSI",
                 &(unitCellIdx.at(d)));
         }

--- a/include/picongpu/plugins/hdf5/openPMD/patchReader.cpp
+++ b/include/picongpu/plugins/hdf5/openPMD/patchReader.cpp
@@ -20,6 +20,7 @@
 #if( ENABLE_HDF5 == 1 )
 
 #  include "picongpu/plugins/hdf5/openPMD/patchReader.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 
 
 namespace picongpu
@@ -93,17 +94,17 @@ namespace openPMD
     {
         // allocate memory for patches
         picongpu::openPMD::ParticlePatches particlePatches( availableRanks );
-        const std::string name_lookup[] = {"x", "y", "z"};
+        const auto componentNames = plugins::misc::getComponentNames( dimensionality );
         for( uint32_t d = 0; d < dimensionality; ++d )
         {
             readPatchAttribute(
                 dc, availableRanks, id,
-                particlePatchPath + std::string("offset/") + name_lookup[d],
+                particlePatchPath + std::string("offset/") + componentNames[d],
                 particlePatches.getOffsetComp( d )
             );
             readPatchAttribute(
                 dc, availableRanks, id,
-                particlePatchPath + std::string("extent/") + name_lookup[d],
+                particlePatchPath + std::string("extent/") + componentNames[d],
                 particlePatches.getExtentComp( d )
             );
         }

--- a/include/picongpu/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
+++ b/include/picongpu/plugins/hdf5/restart/LoadParticleAttributesFromHDF5.hpp
@@ -23,6 +23,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/plugins/hdf5/HDF5Writer.def"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/PICToSplash.hpp"
 #include "picongpu/traits/PICToOpenPMD.hpp"
 #include <pmacc/traits/GetComponentsType.hpp>
@@ -73,7 +74,7 @@ struct LoadParticleAttributesFromHDF5
 
         log<picLog::INPUT_OUTPUT > ("HDF5:  ( begin ) load species attribute: %1%") % Identifier::getName();
 
-        const std::string name_lookup[] = {"x", "y", "z"};
+        const auto componentNames = plugins::misc::getComponentNames( components );
 
         ComponentType* tmpArray = nullptr;
         if( elements > 0 )
@@ -90,7 +91,7 @@ struct LoadParticleAttributesFromHDF5
             std::stringstream datasetName;
             datasetName << subGroup << "/" << openPMDName();
             if (components > 1)
-                datasetName << "/" << name_lookup[d];
+                datasetName << "/" << componentNames[d];
 
             ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer();
             Dimensions sizeRead(0, 0, 0);

--- a/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/hdf5/restart/RestartFieldLoader.hpp
@@ -24,6 +24,7 @@
 #include <pmacc/particles/frame_types.hpp>
 #include "picongpu/fields/FieldE.hpp"
 #include "picongpu/fields/FieldB.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/simulation/control/MovingWindow.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
@@ -60,7 +61,7 @@ public:
         using ValueType = typename Data::ValueType;
         field.getHostBuffer().setValue(ValueType::create(0.0));
 
-        const std::string name_lookup[] = {"x", "y", "z"};
+        const auto componentNames = plugins::misc::getComponentNames( numComponents );
 
         /* globalSlideOffset due to gpu slides between origin at time step 0
          * and origin at current time step
@@ -94,7 +95,7 @@ public:
             DataContainer *field_container =
                 params->dataCollector->readDomain(params->currentStep,
                                            (std::string("fields/") + objectName +
-                                            std::string("/") + name_lookup[i]).c_str(),
+                                            std::string("/") + componentNames[i]).c_str(),
                                            Domain(domain_offset, local_domain_size),
                                            &data_class);
 

--- a/include/picongpu/plugins/hdf5/writer/Field.hpp
+++ b/include/picongpu/plugins/hdf5/writer/Field.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/plugins/hdf5/HDF5Writer.def"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/PICToSplash.hpp"
 #include <pmacc/traits/GetComponentsType.hpp>
 #include <pmacc/traits/GetNComponents.hpp>
@@ -80,12 +81,7 @@ struct Field
         /* component names */
         const std::string recordName = std::string("fields/") + name;
 
-        std::vector<std::string> name_lookup;
-        {
-            const std::string name_lookup_tpl[] = {"x", "y", "z", "w"};
-            for (uint32_t n = 0; n < nComponents; n++)
-                name_lookup.push_back(name_lookup_tpl[n]);
-        }
+        const auto componentNames = plugins::misc::getComponentNames( nComponents );
 
         /*data to describe source buffer*/
         GridLayout<simDim> field_layout = params->gridLayout;
@@ -133,7 +129,7 @@ struct Field
             std::stringstream datasetName;
             datasetName << recordName;
             if (nComponents > 1)
-                datasetName << "/" << name_lookup.at(n);
+                datasetName << "/" << componentNames.at(n);
 
             Dimensions sizeSrcData(1, 1, 1);
 

--- a/include/picongpu/plugins/hdf5/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/hdf5/writer/ParticleAttribute.hpp
@@ -24,6 +24,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/plugins/hdf5/HDF5Writer.def"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/PICToSplash.hpp"
 #include "picongpu/traits/PICToOpenPMD.hpp"
 #include <pmacc/traits/GetComponentsType.hpp>
@@ -87,7 +88,7 @@ struct ParticleAttribute
         OpenPMDName<T_Identifier> openPMDName;
         const std::string recordPath( speciesPath + std::string("/") + openPMDName() );
 
-        const std::string name_lookup[] = {"x", "y", "z"};
+        const auto componentNames = plugins::misc::getComponentNames( components );
 
         // get the SI scaling, dimensionality and weighting of the attribute
         OpenPMDUnit<T_Identifier> openPMDUnit;
@@ -133,7 +134,7 @@ struct ParticleAttribute
             std::stringstream datasetName;
             datasetName << recordPath;
             if (components > 1)
-                datasetName << "/" << name_lookup[d];
+                datasetName << "/" << componentNames[d];
 
             ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer();
             #pragma omp parallel for

--- a/include/picongpu/plugins/misc/ComponentNames.cpp
+++ b/include/picongpu/plugins/misc/ComponentNames.cpp
@@ -1,0 +1,64 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picongpu/plugins/misc/ComponentNames.hpp"
+
+#include <array>
+#include <string>
+#include <vector>
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace misc
+{
+
+    std::vector< std::string > getComponentNames(
+        uint32_t const numComponents
+    )
+    {
+        /* For low number of components, fall back to the previously used
+         * "xyzw" naming scheme for backward compatibility
+         */
+        if( numComponents <= 4 )
+        {
+            std::array< std::string, 4 > names = { "x" , "y", "z", "w" };
+            return std::vector< std::string >{
+                names.begin(),
+                names.begin() + numComponents
+            };
+        }
+        // Special case for 6 PML components
+        else if( numComponents == 6 )
+            return { "xy" , "xz", "yx", "yz", "zx", "zy" };
+        else
+        {
+            // Otherwise use different generic names
+            auto result = std::vector< std::string >( numComponents );
+            for( auto i = 0u; i < result.size(); i++ )
+                result[ i ] = "component" + std::to_string( i );
+            return result;
+        }
+    }
+
+} // namespace misc
+} // namespace plugins
+} // namespace picongpu

--- a/include/picongpu/plugins/misc/ComponentNames.hpp
+++ b/include/picongpu/plugins/misc/ComponentNames.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Rene Widera
+/* Copyright 2020 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -19,10 +19,28 @@
 
 #pragma once
 
-#include "picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp"
-#include "picongpu/plugins/misc/AppendName.hpp"
-#include "picongpu/plugins/misc/ComponentNames.hpp"
-#include "picongpu/plugins/misc/concatenateToString.hpp"
-#include "picongpu/plugins/misc/splitString.hpp"
-#include "picongpu/plugins/misc/containsObject.hpp"
-#include "picongpu/plugins/misc/removeSpaces.hpp"
+#include <string>
+#include <vector>
+
+
+namespace picongpu
+{
+namespace plugins
+{
+namespace misc
+{
+
+    /** Get text names of vector components
+     *
+     * For 1-4 and 6 components use predefined names,
+     * for other amounts use generic different names
+     *
+     * @param numComponents number of components
+     */
+    std::vector< std::string > getComponentNames(
+        uint32_t numComponents
+    );
+
+} // namespace misc
+} // namespace plugins
+} // namespace picongpu


### PR DESCRIPTION
The previous implementation had two issues:

- for > 4 components it led to out-of-bounds access when iterating by component index
- the logic was copied in multiple places

Create a utility function for text names of vector components. Change hardcoded names to use the new function. The new way guarantees unification and avoids potential out-of-bounds access by index.

~~TODO: do more checks with PML output and checkpointing.~~ (done)