### PR TITLE
Jupyter widgets output capture

### DIFF
--- a/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
@@ -118,9 +118,6 @@ class BaseWidget(widgets.VBox):
             top = widgets.HBox(children=[
                 vis_widgets, self.fig.canvas])
         else:
-            # it is not our responsibility to display
-            # the figure but we have to display the
-            # output widget somewhere
             top = vis_widgets
 
         if add_out_to_children:

--- a/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
@@ -24,12 +24,14 @@ class EnergyHistogramWidget(BaseWidget):
 
         display(EnergyHistogramWidget(run_dir_options="path/to/outputs"))
     """
-    def __init__(self, run_dir_options, fig=None, **kwargs):
+    def __init__(self, run_dir_options, fig=None,
+                 output_widget=None, **kwargs):
 
         BaseWidget.__init__(self,
                             EnergyHistogramMPL,
                             run_dir_options,
                             fig,
+                            output_widget,
                             **kwargs)
 
     def _create_widgets_for_vis_args(self):

--- a/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
@@ -24,12 +24,14 @@ class PhaseSpaceWidget(BaseWidget):
 
         display(PhaseSpaceWidget(run_dir_options="path/to/outputs"))
     """
-    def __init__(self, run_dir_options, fig=None, **kwargs):
+    def __init__(self, run_dir_options, fig=None,
+                 output_widget=None, **kwargs):
 
         BaseWidget.__init__(self,
                             PhaseSpaceMPL,
                             run_dir_options,
                             fig,
+                            output_widget,
                             **kwargs)
 
     def _create_widgets_for_vis_args(self):

--- a/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
@@ -24,12 +24,14 @@ class PNGWidget(BaseWidget):
 
         display(PNGWidget(run_dir_options="path/to/outputs"))
     """
-    def __init__(self, run_dir_options, fig=None, **kwargs):
+    def __init__(self, run_dir_options, fig=None,
+                 output_widget, **kwargs):
 
         BaseWidget.__init__(self,
                             PNGMPL,
                             run_dir_options,
                             fig,
+                            output_widget,
                             **kwargs)
 
     def _create_sim_dropdown(self, options):

--- a/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
@@ -25,7 +25,7 @@ class PNGWidget(BaseWidget):
         display(PNGWidget(run_dir_options="path/to/outputs"))
     """
     def __init__(self, run_dir_options, fig=None,
-                 output_widget, **kwargs):
+                 output_widget=None, **kwargs):
 
         BaseWidget.__init__(self,
                             PNGMPL,


### PR DESCRIPTION
This PR adds the optional keyword argument `output_widget` to the jupyter widgets to provide an instance of `widgets.Output` for capturing relevant output of the member functions.
This has the advantage, that we now get control over where the output is written within the notebook and can clear messages without getting an ever increasing stack of lines below the cell of the widget.

The default valufe for the argument is `None` in which case a new `widgets.Output` instance is created and made part of the widgets list of children.

If a reference to an existing output widget is provided, it is the callers responsibility to display the output widget somewhere in the notebook and it is not made part of our widgets children.