### PR TITLE
Add missing const to some GridController getters

### DIFF
--- a/include/pmacc/mappings/simulation/GridController.hpp
+++ b/include/pmacc/mappings/simulation/GridController.hpp
@@ -130,7 +130,7 @@ namespace pmacc
              *
              * return local rank on host
              */
-            uint32_t getHostRank()
+            uint32_t getHostRank() const
             {
                 return comm.getHostRank();
             }
@@ -140,7 +140,7 @@ namespace pmacc
              *
              * @return global MPI rank
              */
-            uint32_t getGlobalRank()
+            uint32_t getGlobalRank() const
             {
                 return comm.getRank();
             }
@@ -150,7 +150,7 @@ namespace pmacc
              *
              * @return global number of MPI ranks
              */
-            uint32_t getGlobalSize()
+            uint32_t getGlobalSize() const
             {
                 return comm.getSize();
             }


### PR DESCRIPTION
Just a small thing that popped up when trying to do a natural `auto const & gridController = Environment<simDim>::get().GridController();` and then `gridController.getGlobalRank()` not compiling due to lack of `const` in this getter.