### PR TITLE
Fix missing override flags

### DIFF
--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -114,10 +114,10 @@ namespace picongpu
         }
 
         //! Synchronize host data with device data
-        HINLINE void synchronize();
+        HINLINE void synchronize() override;
 
         //! Get id
-        HINLINE SimulationDataId getUniqueId();
+        HINLINE SimulationDataId getUniqueId() override;
 
         //! Get units of field components
         HDINLINE static UnitValueType getUnit();

--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -111,7 +111,7 @@ namespace picongpu
         HINLINE void syncToDevice( ) override;
 
         //! Synchronize host data with device data
-        HINLINE void synchronize( );
+        HINLINE void synchronize( ) override;
 
         /** Get id
          *
@@ -120,7 +120,7 @@ namespace picongpu
         HINLINE static SimulationDataId getUniqueId( uint32_t slotId );
 
         //! Get id
-        HINLINE SimulationDataId getUniqueId();
+        HINLINE SimulationDataId getUniqueId() override;
 
         //! Get unit of field components
         template< class FrameSolver >

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -170,7 +170,7 @@ public:
         T_SrcFilterFunctor& srcFilterFunctor
     );
 
-    SimulationDataId getUniqueId();
+    SimulationDataId getUniqueId() override;
 
     /* sync device data to host
      *
@@ -178,9 +178,9 @@ public:
      *            - the shared (between all species) mallocMC buffer must be copied once
      *              by the user
      */
-    void synchronize();
+    void synchronize() override;
 
-    void syncToDevice();
+    void syncToDevice() override;
 
     static pmacc::traits::StringProperty getStringProperties()
     {

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.hpp
@@ -92,13 +92,13 @@ namespace helperFields
 
         /* implement ISimulationData members */
         void
-        synchronize()
+        synchronize() override
         {
             m_density->deviceToHost( );
         }
 
         SimulationDataId
-        getUniqueId()
+        getUniqueId() override
         {
             return getName();
         }

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.hpp
@@ -104,13 +104,13 @@ namespace helperFields
 
         /* implement ISimulationData members */
         void
-        synchronize()
+        synchronize() override
         {
             m_energyHistogram->deviceToHost( );
         }
 
         SimulationDataId
-        getUniqueId()
+        getUniqueId() override
         {
             return getName();
         }

--- a/include/picongpu/particles/flylite/helperFields/LocalRateMatrix.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalRateMatrix.hpp
@@ -99,13 +99,13 @@ namespace helperFields
 
         /* implement ISimulationData members */
         void
-        synchronize()
+        synchronize() override
         {
             m_rateMatrix->deviceToHost( );
         }
 
         SimulationDataId
-        getUniqueId()
+        getUniqueId() override
         {
             return getName();
         }

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
@@ -42,7 +42,7 @@ namespace pmacc
 
         virtual ~MallocMCBuffer();
 
-        SimulationDataId getUniqueId()
+        SimulationDataId getUniqueId() override
         {
             return getName();
         }
@@ -57,7 +57,7 @@ namespace pmacc
             return hostBufferOffset;
         }
 
-        void synchronize();
+        void synchronize() override;
 
     private:
 

--- a/include/pmacc/random/RNGProvider.hpp
+++ b/include/pmacc/random/RNGProvider.hpp
@@ -104,8 +104,8 @@ namespace random
          * Returns the default id for this type
          */
         static std::string getName();
-        SimulationDataId getUniqueId();
-        void synchronize();
+        SimulationDataId getUniqueId() override;
+        void synchronize() override;
 
         /**
          * Return a reference to the buffer containing the states


### PR DESCRIPTION
Clang is throwing warnings that the qualifier `override` is missing for when
a virtual method is overridden from the child class.

CC-ing: @jkelling 