### PR TITLE
Unify absorber size for PML and exponential damping

### DIFF
--- a/include/picongpu/fields/LaserPhysics.hpp
+++ b/include/picongpu/fields/LaserPhysics.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/absorber/NumCells.hpp"
 #include "picongpu/fields/LaserPhysics.def"
 #include "picongpu/fields/laserProfiles/profiles.hpp"
 
@@ -148,7 +149,8 @@ namespace fields
                 constexpr bool isLaserDisabled = laserProfiles::Selected::Unitless::INIT_TIME == 0.0_X;
                 constexpr bool isLaserInitInFirstCell = laserProfiles::Selected::Unitless::initPlaneY == 0;
                 // X + 1 is a workaround to avoid warning: pointless comparison of unsigned integer with zero
-                constexpr bool isInitPlaneYOutsideOfAbsorber = laserProfiles::Selected::Unitless::initPlaneY + 1 > ABSORBER_CELLS[1][0] + 1;
+                constexpr bool isInitPlaneYOutsideOfAbsorber =
+                    laserProfiles::Selected::Unitless::initPlaneY + 1 > absorber::numCells[1][0] + 1;
                 PMACC_CASSERT_MSG(
                     __initPlaneY_needs_to_be_greater_than_the_top_absorber_cells_or_zero,
                     isLaserDisabled || isLaserInitInFirstCell || isInitPlaneYOutsideOfAbsorber

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/absorber/NumCells.hpp"
 #include "picongpu/fields/MaxwellSolver/YeePML/Field.hpp"
 #include "picongpu/fields/MaxwellSolver/YeePML/Parameters.hpp"
 #include "picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel"
@@ -211,7 +212,7 @@ namespace maxwellSolver
                 Thickness globalThickness;
                 for( uint32_t axis = 0u; axis < simDim; axis++ )
                     for( auto direction = 0; direction < 2; direction++ )
-                        globalThickness( axis, direction ) = NUM_CELLS[ axis ][ direction ];
+                        globalThickness( axis, direction ) = absorber::numCells[ axis ][ direction ];
                 return globalThickness;
             }
 

--- a/include/picongpu/fields/absorber/ExponentialDamping.hpp
+++ b/include/picongpu/fields/absorber/ExponentialDamping.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/absorber/ExponentialDamping.kernel"
+#include "picongpu/fields/absorber/NumCells.hpp"
 #include "picongpu/simulation/control/MovingWindow.hpp"
 #include "picongpu/fields/laserProfiles/profiles.hpp"
 
@@ -63,8 +64,8 @@ public:
                  */
                 uint32_t pos_or_neg = i % 2;
 
-                uint32_t thickness = ABSORBER_CELLS[direction][pos_or_neg];
-                float_X absorber_strength = ABSORBER_STRENGTH[direction][pos_or_neg];
+                uint32_t thickness = absorber::numCells[direction][pos_or_neg];
+                float_X absorber_strength = absorber::numCells[direction][pos_or_neg];
 
                 if (thickness == 0) continue; /*if the absorber has no thickness we check the next side*/
 
@@ -140,7 +141,7 @@ public:
                 {
                     std::ostringstream boundaryParam;
                     boundaryParam << "exponential damping over "
-                                  << ABSORBER_CELLS[axis][axisDir] << " cells";
+                                  << absorber::numCells[axis][axisDir] << " cells";
                     propList[directionName]["param"] = boundaryParam.str();
                 }
                 else

--- a/include/picongpu/fields/absorber/NumCells.hpp
+++ b/include/picongpu/fields/absorber/NumCells.hpp
@@ -1,0 +1,122 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+
+    /** Forward declaration to avoid mutual including with YeePML.hpp
+     *
+     * @tparam T_CurrentInterpolation current interpolation functor
+     * @tparam T_CurlE functor to compute curl of E
+     * @tparam T_CurlB functor to compute curl of B
+     */
+    template<
+        typename T_CurrentInterpolation,
+        typename T_CurlE,
+        typename T_CurlB
+    >
+    class YeePML;
+
+} // namespace maxwellSolver
+
+namespace absorber
+{
+namespace detail
+{
+
+    /** Number of cells helper
+     *
+     * The general version uses exponential absorber settings
+     *
+     * @tparam T_FieldSolver field solver
+     */
+    template< typename T_FieldSolver >
+    struct NumCellsHelper
+    {
+        static constexpr uint32_t xNegative = ABSORBER_CELLS[ 0 ][ 0 ];
+        static constexpr uint32_t xPositive = ABSORBER_CELLS[ 0 ][ 1 ];
+        static constexpr uint32_t yNegative = ABSORBER_CELLS[ 1 ][ 0 ];
+        static constexpr uint32_t yPositive = ABSORBER_CELLS[ 1 ][ 1 ];
+        static constexpr uint32_t zNegative = ABSORBER_CELLS[ 2 ][ 0 ];
+        static constexpr uint32_t zPositive = ABSORBER_CELLS[ 2 ][ 1 ];
+    };
+
+    namespace pml = maxwellSolver::yeePML;
+
+    /** Number of cells helper
+     *
+     * Specialization for PML
+     *
+     * @tparam T_CurrentInterpolation current interpolation for YeePML
+     * @tparam T_CurlE curl E for YeePML
+     * @tparam T_CurlB curl B for YeePML
+     */
+    template<
+        typename T_CurrentInterpolation,
+        typename T_CurlE,
+        typename T_CurlB
+    >
+    struct NumCellsHelper<
+        maxwellSolver::YeePML<
+            T_CurrentInterpolation,
+            T_CurlE,
+            T_CurlB
+        >
+    >
+    {
+        static constexpr uint32_t xNegative = pml::NUM_CELLS[ 0 ][ 0 ];
+        static constexpr uint32_t xPositive = pml::NUM_CELLS[ 0 ][ 1 ];
+        static constexpr uint32_t yNegative = pml::NUM_CELLS[ 1 ][ 0 ];
+        static constexpr uint32_t yPositive = pml::NUM_CELLS[ 1 ][ 1 ];
+        static constexpr uint32_t zNegative = pml::NUM_CELLS[ 2 ][ 0 ];
+        static constexpr uint32_t zPositive = pml::NUM_CELLS[ 2 ][ 1 ];
+    };
+
+    //! Number of cells helper for the selected field solver + absorber
+    using NumCells = NumCellsHelper< Solver >;
+
+} // namespace detail
+
+    /** Number of absorber cells along each boundary
+     *
+     * Is uniform for both PML and exponential damping absorbers.
+     * First index: 0 = x, 1 = y, 2 = z.
+     * Second index: 0 = negative (min coordinate), 1 = positive (max coordinate).
+     * Not for ODR-use.
+     */
+    constexpr uint32_t numCells[ 3 ][ 2 ] = {
+        { detail::NumCells::xNegative, detail::NumCells::xPositive },
+        { detail::NumCells::yNegative, detail::NumCells::yPositive },
+        { detail::NumCells::zNegative, detail::NumCells::zPositive }
+    };
+
+} // namespace absorber
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/simulation/control/DomainAdjuster.hpp
+++ b/include/picongpu/simulation/control/DomainAdjuster.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "picongpu/fields/absorber/NumCells.hpp"
+
 #include <pmacc/dimensions/DataSpace.hpp>
 
 #include <pmacc/Environment.hpp>
@@ -239,7 +241,7 @@ namespace picongpu
             if( isAbsorberEnabled && isBoundaryDevice )
             {
                 size_t boundary = m_mpiPosition[ dim ] == 0u ? 0u : 1u;
-                int maxAbsorberCells = ABSORBER_CELLS[ dim ][ boundary ];
+                int maxAbsorberCells = fields::absorber::numCells[ dim ][ boundary ];
 
                 if( m_movingWindowEnabled && dim == 1u )
                 {
@@ -248,8 +250,8 @@ namespace picongpu
                      */
                     maxAbsorberCells = static_cast< int >(
                         std::max(
-                            ABSORBER_CELLS[ dim ][ 0 ],
-                            ABSORBER_CELLS[ dim ][ 1 ]
+                            fields::absorber::numCells[ dim ][ 0 ],
+                            fields::absorber::numCells[ dim ][ 1 ]
                         )
                     );
                 }


### PR DESCRIPTION
Add a new variable for the absorber size. Change all usage outside of `.param` files to the new variable. This unifies the size of the exponential damping and PML absorbers. It avoids potential issues with compile-time checks pointed out
in the [comments of #3148](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3148#issuecomment-582865342).