### PR TITLE
Fix a typo in density ratio value of the KHI example

### DIFF
--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
@@ -83,7 +83,7 @@ value_identifier( float_X, MassRatioIons, 1836.152672 );
 value_identifier( float_X, ChargeRatioIons, -1.0 );
 
 /* ratio relative to BASE_DENSITY */
-value_identifier( float_X, DensityRatioIons, -1.0 );
+value_identifier( float_X, DensityRatioIons, 1.0 );
 
 using ParticleFlagsIons = MakeSeq_t<
     particlePusher< UsedParticlePusher >,


### PR DESCRIPTION
While looking into [another potential bug](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3160#issuecomment-584186175), accidentally found out this typo (or a copy-paste error perhaps). Ideally, we would perhaps want to check non-negativity of the resulting densities automatically, however this is probably problematic, same as #3109.