### PR TITLE
openPMD: use particle id naming

### DIFF
--- a/include/picongpu/traits/PICToOpenPMD.tpp
+++ b/include/picongpu/traits/PICToOpenPMD.tpp
@@ -46,6 +46,18 @@ namespace traits
         }
     };
 
+    /** Translate the particleId (unitless, global) into the openPMD
+     *  id (unitless, global)
+     */
+    template<>
+    struct OpenPMDName<particleId>
+    {
+        std::string operator()() const
+        {
+            return std::string("id");
+        }
+    };
+
     /** Forward units that are identical in PIConGPU & openPMD
      */
     template<typename T_Identifier>


### PR DESCRIPTION
Add a trait to rename the `particleId` identifier to `id` during ADIOS and HDF5 I/O.
Although particle id is an optional particle record, [its naming is defined in the openPMD 1.X base standard](https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#particle-records) and required for particle tracking tools, e.g. as used in openPMD-viewer.

I have not tried this at runtime (see #3142) and just picked this up since nobody else did, testing welcome.
cc @n01r @PrometheusPi @steindev 

This is a breaking change for checkpoint data, in case particle ids are activated (non-default). Maybe do not backport.
Close #3142