### PR TITLE
Fix warning #222-D: floating-point operation result is out of range

### DIFF
--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -93,7 +93,8 @@ HDINLINE float_X LookupTableFunctor::operator()(const float_X Ekin, const float_
 float_64 ScaledSpectrum::dcs(const float_64 Ekin, const float_64 kappa, const float_64 targetZ) const
 {
     constexpr float_64 pi = pmacc::algorithms::math::Pi<float_64>::value;
-    const float_64 bohrRadius = float_64(4.0) * pi * EPS0 * HBAR*HBAR / (ELECTRON_MASS * ELECTRON_CHARGE*ELECTRON_CHARGE);
+    const float_64 bohrRadius = float_64(4.0) * pi * EPS0 * HBAR * HBAR /
+        (float_64(ELECTRON_MASS) * ELECTRON_CHARGE * ELECTRON_CHARGE);
     const float_64 classicalElRadius = ELECTRON_CHARGE*ELECTRON_CHARGE / (float_64(4.0) * pi * EPS0 * ELECTRON_MASS * SPEED_OF_LIGHT*SPEED_OF_LIGHT);
     const float_64 fineStructureConstant = ELECTRON_CHARGE*ELECTRON_CHARGE / (float_64(4.0) * pi * EPS0 * HBAR * SPEED_OF_LIGHT);
 


### PR DESCRIPTION
Was triggered in Bremsstrahlung/ScaledSpectrum by having the denominator as a 32-bit floating-point number, not 64-bit.