### PR TITLE
Fix python requirements: remove sys and getopt

### DIFF
--- a/lib/python/picongpu/plugins/plot_mpl/requirements.txt
+++ b/lib/python/picongpu/plugins/plot_mpl/requirements.txt
@@ -1,6 +1,4 @@
 matplotlib
 numpy
 scipy
-sys
-getopt
 -r ../data/requirements.txt


### PR DESCRIPTION
Removes requirements `sys` and `getopt` that are already part of all python installations anyway.
At the moment, executing `pip install -r <pic_path>/lib/python/picongpu/requirements.txt` crashes due to not finding requirement files for the above mentioned packages.