### PR TITLE
Bremsstrahlung: use more constexpr

### DIFF
--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -93,20 +93,20 @@ HDINLINE float_X LookupTableFunctor::operator()(const float_X Ekin, const float_
 float_64 ScaledSpectrum::dcs(const float_64 Ekin, const float_64 kappa, const float_64 targetZ) const
 {
     constexpr float_64 pi = pmacc::algorithms::math::Pi<float_64>::value;
-    const float_64 bohrRadius = float_64(4.0) * pi * EPS0 * HBAR * HBAR /
+    constexpr float_64 bohrRadius = pi * 4.0 * EPS0 * HBAR * HBAR /
         (float_64(ELECTRON_MASS) * ELECTRON_CHARGE * ELECTRON_CHARGE);
-    const float_64 classicalElRadius = ELECTRON_CHARGE*ELECTRON_CHARGE / (float_64(4.0) * pi * EPS0 * ELECTRON_MASS * SPEED_OF_LIGHT*SPEED_OF_LIGHT);
-    const float_64 fineStructureConstant = ELECTRON_CHARGE*ELECTRON_CHARGE / (float_64(4.0) * pi * EPS0 * HBAR * SPEED_OF_LIGHT);
+    constexpr float_64 classicalElRadius = float_64(ELECTRON_CHARGE*ELECTRON_CHARGE) / (pi * 4.0 * EPS0 * ELECTRON_MASS * SPEED_OF_LIGHT*SPEED_OF_LIGHT);
+    constexpr float_64 fineStructureConstant = float_64(ELECTRON_CHARGE*ELECTRON_CHARGE) / (pi * 4.0 * EPS0 * HBAR * SPEED_OF_LIGHT);
 
-    const float_64 c = SPEED_OF_LIGHT;
-    const float_64 c2 = c*c;
-    const float_64 m_e = ELECTRON_MASS;
-    const float_64 r_e = classicalElRadius;
-    const float_64 alpha = fineStructureConstant;
+    constexpr float_64 c = SPEED_OF_LIGHT;
+    constexpr float_64 c2 = c*c;
+    constexpr float_64 m_e = ELECTRON_MASS;
+    constexpr float_64 r_e = classicalElRadius;
+    constexpr float_64 alpha = fineStructureConstant;
 
     const float_64 W = kappa * Ekin;
     const float_64 eps = W / (Ekin + m_e * c2);
-    const float_64 R = math::pow(targetZ, float_64(-1.0) / float_64(3.0)) * bohrRadius;
+    const float_64 R = math::pow(targetZ, float_64(-1.0/3.0)) * bohrRadius;
     const float_64 gamma = Ekin / (m_e * c2) + float_64(1.0);
     const float_64 b = R * m_e * c / HBAR / (float_64(2.0) * gamma) * eps / (float_64(1.0) - eps);
 


### PR DESCRIPTION
Add more `constexpr` evaluated maths in Bremsstrahlung physics.

Follow-up to #3170