### PR TITLE
add pillow as dependency

### DIFF
--- a/lib/python/picongpu/plugins/data/requirements.txt
+++ b/lib/python/picongpu/plugins/data/requirements.txt
@@ -1,4 +1,5 @@
 numpy
 pandas>=0.21.0
 h5py
+pillow
 scipy


### PR DESCRIPTION
This pull request adds [pillow](https://python-pillow.org/) as dependency before scipy because it conflicts otherwise with matplotlib - suggested by @codingS3b.

