### PR TITLE
Spack: w/o Modules by Default

### DIFF
--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -24,9 +24,6 @@ First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html
    # get spack
    git clone https://github.com/spack/spack.git $HOME/src/spack
 
-   # build spack's dependencies via spack :)
-   $HOME/src/spack/bin/spack bootstrap
-
    # activate the spack environment
    source $HOME/src/spack/share/spack/setup-env.sh
 


### PR DESCRIPTION
Recent versions of Spack perform `spack load` without requiring modulefiles. The `spack bootstrap` command is deprecated in [0.14.0+](https://github.com/spack/spack/releases/tag/v0.14.0).

Follow-up: someone should check if the workflow for container builds in [`share/picongpu/dockerfiles`](https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/dockerfiles) needs an update.