### PR TITLE
Fix mapping of cell indexes in the particle merger plugin

### DIFF
--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -129,7 +129,7 @@ namespace particleMerging
             constexpr uint32_t numWorkers = pmacc::math::CT::volume< SuperCellSize >::type::value;
             const uint32_t workerIdx = DataSpaceOperations< simDim >::template map<
                 SuperCellSize
-            >( cellIdx );
+            >( cellIdx % SuperCellSize::toRT() );
             particleAccess::Cell2Particle< SuperCellSize, numWorkers > forEachFrame;
             forEachFrame(
                 acc,
@@ -192,7 +192,7 @@ namespace particleMerging
             constexpr uint32_t numWorkers = pmacc::math::CT::volume< SuperCellSize >::type::value;
             const uint32_t workerIdx = DataSpaceOperations< simDim >::template map<
                 SuperCellSize
-            >( cellIdx );
+            >( cellIdx % SuperCellSize::toRT() );
             particleAccess::Cell2Particle< SuperCellSize, numWorkers > forEachFrame;
             forEachFrame(
                 acc,


### PR DESCRIPTION
This caused wrong worker indexes which led to deadlocks. The issue was caused by `DataSpaceOperations::map` no longer handling out-of-domain indices, which the plugin relied on. So now perform the modulo operations inside the plugin.