### PR TITLE
fix GCC constexpr lambda bug

### DIFF
--- a/include/pmacc/attribute/Constexpr.hpp
+++ b/include/pmacc/attribute/Constexpr.hpp
@@ -44,6 +44,9 @@
  */
 #ifdef _MSC_VER
 #   define PMACC_CONSTEXPR_CAPTURE static constexpr
+#elif ( defined __GNUC__ ) && ( __GNUC__ > 7 )
+// workaround for GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91377
+#   define PMACC_CONSTEXPR_CAPTURE static constexpr
 #else
 #   define PMACC_CONSTEXPR_CAPTURE constexpr
 #endif


### PR DESCRIPTION
Apply workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91377

reported by @jkelling 