### PR TITLE
Change imread import from scipy.misc to imageio

### DIFF
--- a/lib/python/picongpu/plugins/data/png.py
+++ b/lib/python/picongpu/plugins/data/png.py
@@ -9,8 +9,10 @@ from .base_reader import DataReader
 
 import numpy as np
 import os
-from scipy import misc
 import collections
+
+from imageio import imread
+
 
 SPECIES_LONG_NAMES = {
     'e': 'Electrons'
@@ -196,7 +198,7 @@ class PNGData(DataReader):
             # iteration is None, so we use all available data
             iteration = available_iterations
 
-        imgs = [misc.imread(
+        imgs = [imread(
             self.get_data_path(species, species_filter, axis,
                                slice_point, it)) for it in iteration]
 

--- a/lib/python/picongpu/plugins/data/png.py
+++ b/lib/python/picongpu/plugins/data/png.py
@@ -10,7 +10,6 @@ from .base_reader import DataReader
 import numpy as np
 import os
 import collections
-
 from imageio import imread
 
 

--- a/lib/python/picongpu/plugins/data/requirements.txt
+++ b/lib/python/picongpu/plugins/data/requirements.txt
@@ -2,4 +2,4 @@ numpy
 pandas>=0.21.0
 h5py
 pillow
-scipy
+imageio


### PR DESCRIPTION
The python reader for the PNG plugin relies on the `scipy.misc.imread` function which was deprecated and removed for `scipy>=1.2.0` according to the docs (https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imread.html).
This PR exchanges the import of the `imread` function as suggested in the scipy docs.