### PR TITLE
MPI direct support

### DIFF
--- a/etc/picongpu/summit-ornl/gpu_batch.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch.tpl
@@ -86,6 +86,6 @@ cd simOutput
 
 #if [ $? -eq 0 ] ; then
 export OMP_NUM_THREADS=!TBG_coresPerGPU
-jsrun --nrs !TBG_tasks --tasks_per_rs 1 --cpu_per_rs !TBG_coresPerGPU --gpu_per_rs 1 --latency_priority GPU-CPU --bind rs --smpiargs="-gpu" !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+jsrun --nrs !TBG_tasks --tasks_per_rs 1 --cpu_per_rs !TBG_coresPerGPU --gpu_per_rs 1 --latency_priority GPU-CPU --bind rs --smpiargs="-gpu" !TBG_dstPath/input/bin/picongpu --mpiDirect !TBG_author !TBG_programParams | tee output
 # note: instead of the PIConGPU binary, one can also debug starting "js_task_info | sort"
 #fi

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -63,7 +63,8 @@ namespace detail
         EnvironmentContext( ) :
             m_isMpiInitialized( false ),
             m_isDeviceSelected( false ),
-            m_isSubGridDefined( false )
+            m_isSubGridDefined( false ),
+            m_isMpiDirectEnabled( false )
         {
         }
 
@@ -75,6 +76,9 @@ namespace detail
 
         /** state if the SubGrid is defined */
         bool m_isSubGridDefined;
+
+        /** state shows if MPI direct is activated */
+        bool m_isMpiDirectEnabled;
 
         /** get the singleton EnvironmentContext
          *
@@ -129,6 +133,18 @@ namespace detail
          * @param deviceNumber number of the device
          */
         HINLINE void setDevice(int deviceNumber);
+
+        //! activate MPI direct usage
+        void enableMpiDirect()
+        {
+            m_isMpiDirectEnabled = true;
+        }
+
+        //! query if MPI direct support is activated
+        bool isMpiDirectEnabled() const
+        {
+            return m_isMpiDirectEnabled;
+        }
 
     };
 
@@ -280,6 +296,15 @@ template< uint32_t T_dim >
 class Environment : public detail::Environment
 {
 public:
+    void enableMpiDirect()
+    {
+        detail::EnvironmentContext::getInstance().enableMpiDirect();
+    }
+
+    bool isMpiDirectEnabled() const
+    {
+        return detail::EnvironmentContext::getInstance().isMpiDirectEnabled();
+    }
 
     /** get the singleton GridController
      *

--- a/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
@@ -46,12 +46,17 @@ public:
 
     virtual void init()
     {
+
+        Buffer<TYPE, DIM>* dst = exchange->getCommunicationBuffer();
+
         this->request = Environment<DIM>::get().EnvironmentController()
-                .getCommunicator().startReceive(
-                                                exchange->getExchangeType(),
-                                                (char*) exchange->getHostBuffer().getBasePointer(),
-                                                exchange->getHostBuffer().getDataSpace().productOfComponents() * sizeof (TYPE),
-                                                exchange->getCommunicationTag());
+            .getCommunicator().startReceive(
+                exchange->getExchangeType(),
+                reinterpret_cast<char*>(dst->getPointer()),
+                dst->getDataSpace().productOfComponents() * sizeof (TYPE),
+                exchange->getCommunicationTag()
+        );
+
     }
 
     bool executeIntern()
@@ -97,7 +102,9 @@ public:
 
     std::string toString()
     {
-        return "TaskReceiveMPI";
+        return std::string("TaskReceiveMPI exchange type=") + std::to_string(
+                exchange->getExchangeType()
+        );
     }
 
 private:

--- a/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
@@ -46,12 +46,15 @@ public:
 
     virtual void init()
     {
+        Buffer< TYPE, DIM >* src = exchange->getCommunicationBuffer();
+
         this->request = Environment<DIM>::get().EnvironmentController()
-                .getCommunicator().startSend(
-                                             exchange->getExchangeType(),
-                                             (char*) exchange->getHostBuffer().getPointer(),
-                                             exchange->getHostBuffer().getCurrentSize() * sizeof (TYPE),
-                                             exchange->getCommunicationTag());
+            .getCommunicator().startSend(
+                exchange->getExchangeType(),
+                reinterpret_cast<char*>(src->getPointer()),
+                src->getCurrentSize() * sizeof (TYPE),
+                exchange->getCommunicationTag()
+            );
     }
 
     bool executeIntern()
@@ -87,7 +90,9 @@ public:
 
     std::string toString()
     {
-        return "TaskSendMPI";
+        return std::string("TaskSendMPI exchange type=") + std::to_string(
+                exchange->getExchangeType()
+        );
     }
 
 private:

--- a/include/pmacc/memory/buffers/Exchange.hpp
+++ b/include/pmacc/memory/buffers/Exchange.hpp
@@ -77,6 +77,13 @@ namespace pmacc
             return communicationTag;
         }
 
+        /**
+         * Return the buffer which can be used for data exchange with MPI
+         *
+         * The buffer can point to device or host memory.
+         */
+        virtual Buffer<TYPE, DIM>* getCommunicationBuffer() = 0;
+
         virtual bool hasDeviceDoubleBuffer()=0;
 
         virtual DeviceBuffer<TYPE, DIM>& getDeviceDoubleBuffer()=0;

--- a/include/pmacc/particles/ParticlesBase.tpp
+++ b/include/pmacc/particles/ParticlesBase.tpp
@@ -115,8 +115,13 @@ namespace pmacc
     {
         if( particlesBuffer->hasReceiveExchange( exchangeType ) )
         {
-            size_t grid( particlesBuffer->getReceiveExchangeStack( exchangeType ).getHostCurrentSize( ) );
-            if( grid != 0u )
+            size_t numParticles = 0u;
+            if( Environment<>::get().isMpiDirectEnabled() )
+                numParticles = particlesBuffer->getReceiveExchangeStack( exchangeType ).getDeviceCurrentSize( );
+            else
+                numParticles = particlesBuffer->getReceiveExchangeStack( exchangeType ).getHostCurrentSize( );
+
+            if( numParticles != 0u )
             {
                 ExchangeMapping<
                     GUARD,
@@ -131,7 +136,7 @@ namespace pmacc
                 >::value;
 
                 PMACC_KERNEL( KernelInsertParticles< numWorkers >{ } )(
-                    grid,
+                    numParticles,
                     numWorkers
                 )(
                     particlesBuffer->getDeviceParticleBox( ),

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -72,7 +72,8 @@ public:
     restartDirectory("checkpoints"),
     restartRequested(false),
     CHECKPOINT_MASTER_FILE("checkpoints.txt"),
-    author("")
+    author(""),
+    useMpiDirect(false)
     {
         tSimulation.toggleStart();
         tInit.toggleStart();
@@ -225,6 +226,9 @@ public:
      */
     void startSimulation()
     {
+        if(useMpiDirect)
+            Environment<>::get().enableMpiDirect();
+
         init();
 
         // translate checkpointPeriod string into checkpoint intervals
@@ -319,7 +323,9 @@ public:
             ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
              "Directory for checkpoints")
             ("author", po::value<std::string>(&author)->default_value(std::string("")),
-             "The author that runs the simulation and is responsible for created output files");
+             "The author that runs the simulation and is responsible for created output files")
+            ("mpiDirect", po::value<bool>(&useMpiDirect)->zero_tokens(),
+             "use device direct for MPI communication e.g. GPU direct");
     }
 
     std::string pluginGetName() const
@@ -383,6 +389,9 @@ protected:
 
     /* author that runs the simulation */
     std::string author;
+
+    //! enable MPI gpu direct
+    bool useMpiDirect;
 
 private:
 


### PR DESCRIPTION
Add support for MPI direct (e.g. CUDA GPU direct)

- disable the host double buffer for exchanges if MPI direct is enabled
- add command line parameter `--mpiDirect`
- active MPI direct for summit

- [x] do not merge before the release branch is for 0.5.0 is created