### PR TITLE
Add forgotten CFL check for YeePML

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -137,6 +137,10 @@ namespace maxwellSolver
             template< uint32_t T_Area >
             void updateE( uint32_t currentStep )
             {
+                /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
+                PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
+                    (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
+
                 constexpr auto numWorkers = getNumWorkers( );
                 using Kernel = yeePML::KernelUpdateE<
                     numWorkers,


### PR DESCRIPTION
The reason that was forgotten is that originally the `YeePML` implementation inherited the `Yee` solver which had the CFL check in place, and so PML did not. The inheritance was later changed, and I forgot to add the check back. Thanks to @cbontoiu  for [reporting](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3207#issuecomment-596948103).