### PR TITLE
use cupla instead of cuda prefix for function calls

### DIFF
--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -113,10 +113,10 @@ struct KernelComputeCurrent
 
         const DataSpace< simDim > block(
             mapper.getSuperCellIndex(
-                DataSpace< simDim >( blockIdx )
+                DataSpace< simDim >( cupla::blockIdx(acc) )
             )
         );
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         using VirtualWorkerDomCfg = IdxConfig<
             numParticlesPerFrame * numVirtualBlocks,
@@ -207,7 +207,7 @@ struct KernelComputeCurrent
         /* initialize shared memory with zeros */
         collectiveSet( acc, set, cachedJ );
 
-        __syncthreads();
+        cupla::__syncthreads( acc );
 
         while( true )
         {
@@ -268,7 +268,7 @@ struct KernelComputeCurrent
         }
 
         /* we wait that all workers finish the loop */
-        __syncthreads();
+        cupla::__syncthreads( acc );
 
         nvidia::functors::Add add;
         DataSpace< simDim > const blockCell = block * SuperCellSize::toRT();
@@ -372,7 +372,7 @@ struct KernelAddCurrentToEMF
         constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume< SuperCellSize >::type::value;
         constexpr uint32_t numWorkers = T_numWorkers;
 
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         auto cachedJ = CachedBox::create<
             0,
@@ -384,7 +384,7 @@ struct KernelAddCurrentToEMF
 
         nvidia::functors::Assign assign;
         DataSpace< simDim > const block(
-            mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
+            mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) )
         );
         DataSpace< simDim > const blockCell = block * MappingDesc::SuperCellSize::toRT();
 

--- a/include/picongpu/fields/FieldTmp.kernel
+++ b/include/picongpu/fields/FieldTmp.kernel
@@ -89,9 +89,9 @@ namespace picongpu
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim > ( blockIdx ) ) );
+            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim > ( cupla::blockIdx(acc) ) ) );
 
             FramePtr frame;
             lcellId_t particlesInSuperCell;

--- a/include/picongpu/fields/LaserPhysics.hpp
+++ b/include/picongpu/fields/LaserPhysics.hpp
@@ -69,11 +69,11 @@ namespace fields
             constexpr uint32_t planeSize = pmacc::math::CT::volume< LaserPlaneSizeInSuperCell >::type::value;
             PMACC_CONSTEXPR_CAPTURE uint32_t numWorkers = T_numWorkers;
 
-            const uint32_t workerIdx = threadIdx.x;
+            const uint32_t workerIdx = cupla::threadIdx(acc).x;
 
             // offset of the superCell (in cells, without any guards) to the origin of the local domain
 
-            DataSpace< simDim > localSuperCellOffset = DataSpace< simDim >( blockIdx );
+            DataSpace< simDim > localSuperCellOffset = DataSpace< simDim >( cupla::blockIdx(acc) );
 
             // add not handled supercells from LaserFunctor::Unitless::initPlaneY
             localSuperCellOffset.y() += LaserFunctor::Unitless::initPlaneY / SuperCellSize::y::value;

--- a/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -23,7 +23,7 @@
 #include <pmacc/math/vector/Float.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/cuSTL/container/compile-time/SharedBuffer.hpp>
-#include <pmacc/cuSTL/algorithm/cudaBlock/Foreach.hpp>
+#include <pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp>
 #include <pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp>
 #include <pmacc/nvidia/functors/Assign.hpp>
 
@@ -90,7 +90,7 @@ struct DirSplittingKernel
         int linearThreadIdx = threadIdx.z * BlockDim::x::value * BlockDim::y::value +
             threadIdx.y * BlockDim::x::value +
             threadIdx.x;
-        algorithm::cudaBlock::Foreach<BlockDim> foreach(linearThreadIdx);
+        algorithm::cuplaBlock::Foreach<BlockDim> foreach(linearThreadIdx);
 
         for (int x_offset = 0; x_offset < this->m_totalLength; x_offset += BlockDim::x::value)
         {

--- a/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
+++ b/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.kernel
@@ -43,22 +43,22 @@ struct DirSplittingKernel
     PMACC_ALIGN(m_totalLength,int);
     DirSplittingKernel(int totalLength) : m_totalLength(totalLength) {}
 
-    template<typename CursorE, typename CursorB >
-    DINLINE void propagate(CursorE cursorE, CursorB cursorB) const
+    template<typename T_Acc, typename CursorE, typename CursorB>
+    DINLINE void propagate(T_Acc const & acc, CursorE cursorE, CursorB cursorB) const
     {
         float_X a_plus = (*cursorB(-1, 0, 0)).z() + (*cursorE(-1, 0, 0)).y();
         float_X a_minus = (*cursorB(1, 0, 0)).z() - (*cursorE(1, 0, 0)).y();
         float_X a_prime_plus = (*cursorB(-1, 0, 0)).y() - (*cursorE(-1, 0, 0)).z();
         float_X a_prime_minus = (*cursorB(1, 0, 0)).y() + (*cursorE(1, 0, 0)).z();
 
-        __syncthreads();
+        cupla::__syncthreads( acc );
 
         (*cursorB).z() = float_X(0.5) * (a_plus + a_minus);
         (*cursorE).y() = float_X(0.5) * (a_plus - a_minus);
         (*cursorB).y() = float_X(0.5) * (a_prime_plus + a_prime_minus);
         (*cursorE).z() = float_X(0.5) * (a_prime_minus - a_prime_plus);
 
-        __syncthreads();
+        cupla::__syncthreads( acc );
     }
 
     template<
@@ -84,22 +84,22 @@ struct DirSplittingKernel
 
         float3_X fieldE_old;
         float3_X fieldB_old;
-        int threadPos_x = threadIdx.x;
+        int threadPos_x = cupla::threadIdx(acc).x;
 
         //!@todo remove this explicit index calculation, this is a workaround during the lockstep refactoring
-        int linearThreadIdx = threadIdx.z * BlockDim::x::value * BlockDim::y::value +
-            threadIdx.y * BlockDim::x::value +
-            threadIdx.x;
+        int linearThreadIdx = cupla::threadIdx(acc).z * BlockDim::x::value * BlockDim::y::value +
+            cupla::threadIdx(acc).y * BlockDim::x::value +
+            cupla::threadIdx(acc).x;
         algorithm::cuplaBlock::Foreach<BlockDim> foreach(linearThreadIdx);
 
         for (int x_offset = 0; x_offset < this->m_totalLength; x_offset += BlockDim::x::value)
         {
             foreach(acc, typename CacheE::Zone(), cacheE.origin(), globalE(-1 + x_offset, 0, 0), pmacc::nvidia::functors::Assign{});
             foreach(acc, typename CacheB::Zone(), cacheB.origin(), globalB(-1 + x_offset, 0, 0), pmacc::nvidia::functors::Assign{});
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
-            auto cursorE = cacheE.origin()(1, 0, 0)(threadPos_x, threadIdx.y, threadIdx.z);
-            auto cursorB = cacheB.origin()(1, 0, 0)(threadPos_x, threadIdx.y, threadIdx.z);
+            auto cursorE = cacheE.origin()(1, 0, 0)(threadPos_x, cupla::threadIdx(acc).y, cupla::threadIdx(acc).z);
+            auto cursorB = cacheB.origin()(1, 0, 0)(threadPos_x, cupla::threadIdx(acc).y, cupla::threadIdx(acc).z);
 
             if(threadPos_x == BlockDim::x::value - 1)
             {
@@ -112,13 +112,13 @@ struct DirSplittingKernel
                 *cursorB(-1,0,0) = fieldB_old;
             }
 
-            propagate(cursorE, cursorB);
+            propagate(acc, cursorE, cursorB);
 
             typedef zone::CT::SphericZone<BlockDim> BlockZone;
             foreach(acc, BlockZone(), globalE(x_offset, 0, 0), cacheE.origin()(1, 0, 0), pmacc::nvidia::functors::Assign{});
             foreach(acc, BlockZone(), globalB(x_offset, 0, 0), cacheB.origin()(1, 0, 0), pmacc::nvidia::functors::Assign{});
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             threadPos_x = BlockDim::x::value - 1 - threadPos_x;
         }

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.kernel
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.kernel
@@ -82,7 +82,7 @@ namespace yee
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_workers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             auto cachedB = CachedBox::create<
                 0u,
@@ -93,7 +93,7 @@ namespace yee
             );
 
             nvidia::functors::Assign assign;
-            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) ) );
+            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) ) );
             DataSpace< simDim > const blockCell = block * MappingDesc::SuperCellSize::toRT( );
 
             auto fieldBBlock = fieldB.shift( blockCell );
@@ -110,7 +110,7 @@ namespace yee
                 fieldBBlock
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             constexpr float_X c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
             constexpr float_X dt = DELTA_T;
@@ -181,7 +181,7 @@ namespace yee
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_workers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             auto cachedE = CachedBox::create<
                 0u,
@@ -192,7 +192,7 @@ namespace yee
             );
 
             nvidia::functors::Assign assign;
-            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) ) );
+            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) ) );
             DataSpace< simDim > const blockCell = block * MappingDesc::SuperCellSize::toRT( );
 
             auto fieldEBlock = fieldE.shift( blockCell );
@@ -209,7 +209,7 @@ namespace yee
                 fieldEBlock
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             constexpr float_X dt = DELTA_T;
 

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
@@ -305,13 +305,13 @@ namespace yeePML
              * the index includes guards, same as all indices in this kernel
              */
             auto const blockBeginIdx = mapper.getSuperCellIndex(
-                DataSpace< simDim >( blockIdx )
+                DataSpace< simDim >( cupla::blockIdx(acc) )
             ) * MappingDesc::SuperCellSize::toRT( );
 
             // Cache B values for the block
             using namespace mappings::threads;
             constexpr auto numWorkers = T_numWorkers;
-            auto const workerIdx = threadIdx.x;
+            auto const workerIdx = cupla::threadIdx(acc).x;
             nvidia::functors::Assign assign;
             auto fieldBBlock = fieldB.shift( blockBeginIdx );
             ThreadCollective<
@@ -466,13 +466,13 @@ namespace yeePML
              * the index includes guards, same as all indices in this kernel
              */
             auto const blockBeginIdx = mapper.getSuperCellIndex(
-                DataSpace< simDim >( blockIdx )
+                DataSpace< simDim >( cupla::blockIdx(acc) )
             ) * MappingDesc::SuperCellSize::toRT( );
 
             // Cache E values for the block
             using namespace mappings::threads;
             constexpr auto numWorkers = T_numWorkers;
-            auto const workerIdx = threadIdx.x;
+            auto const workerIdx = cupla::threadIdx(acc).x;
             nvidia::functors::Assign assign;
             auto fieldEBlock = fieldE.shift( blockBeginIdx );
             ThreadCollective<

--- a/include/picongpu/fields/absorber/ExponentialDamping.kernel
+++ b/include/picongpu/fields/absorber/ExponentialDamping.kernel
@@ -90,13 +90,13 @@ namespace detail
 
             using SuperCellSize = typename T_Mapping::SuperCellSize;
             DataSpace< simDim > const superCellIdx(
-                mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
+                mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) )
             );
 
             constexpr uint32_t numWorkers = T_NumWorkers::value;
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume< SuperCellSize >::type::value;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             auto const numGuardSuperCells = mapper.getGuardingSuperCells();
             DataSpace< simDim > guardCells( numGuardSuperCells * SuperCellSize::toRT() );

--- a/include/picongpu/fields/background/cellwiseOperation.hpp
+++ b/include/picongpu/fields/background/cellwiseOperation.hpp
@@ -86,9 +86,9 @@ namespace cellwiseOperation
             constexpr uint32_t cellsPerSupercell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorker = T_numWorkers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace<simDim>( blockIdx ) ) );
+            DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace<simDim>( cupla::blockIdx(acc) ) ) );
             DataSpace< simDim > const blockCell = block * SuperCellSize::toRT( );
             DataSpace< simDim > const guardCells = mapper.getGuardingSuperCells( ) * SuperCellSize::toRT( );
 

--- a/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -190,7 +190,8 @@ namespace emz
                          */
                         const float_X W = this->DS( line, k, 2 ) * tmp;
                         accumulated_J += W;
-                        atomicAdd(
+                        cupla::atomicAdd(
+                            acc,
                             &( (*cursorJ( i, j, k ) ).z( ) ),
                             accumulated_J,
                             ::alpaka::hierarchy::Threads{}
@@ -289,7 +290,8 @@ namespace emz
                      */
                     const float_X W = this->DS( line, i, 0 ) * tmp;
                     accumulated_J += W;
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( ( *cursorJ( i, j ) ).x( ) ),
                         accumulated_J,
                         ::alpaka::hierarchy::Threads{}
@@ -333,7 +335,8 @@ namespace emz
                         ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsi * dsj;
 
                     const float_X j_z = W * currentSurfaceDensityZ;
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( ( *cursorJ( i, j ) ).z( ) ),
                         j_z,
                         ::alpaka::hierarchy::Threads{}

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -230,7 +230,7 @@ struct Esirkepov<T_ParticleShape, DIM3>
                                  */
                                 const float_X W = DS( line, k, 2 ) * tmp;
                                 accumulated_J += W;
-                                atomicAdd( &( ( *cursorJ( i, j, k ) ).z() ), accumulated_J, ::alpaka::hierarchy::Threads{} );
+                                cupla::atomicAdd(acc, &( ( *cursorJ( i, j, k ) ).z() ), accumulated_J, ::alpaka::hierarchy::Threads{} );
                             }
                     }
             }

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -221,7 +221,7 @@ struct Esirkepov<T_ParticleShape, DIM2>
                          */
                         const float_X W = DS( line, i, 0 ) * tmp;
                         accumulated_J += W;
-                        atomicAdd( &( ( *cursorJ( i, j ) ).x() ), accumulated_J, ::alpaka::hierarchy::Threads{} );
+                        cupla::atomicAdd(acc, &( ( *cursorJ( i, j ) ).x() ), accumulated_J, ::alpaka::hierarchy::Threads{} );
                     }
             }
 
@@ -260,7 +260,7 @@ struct Esirkepov<T_ParticleShape, DIM2>
                             ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsi * dsj;
 
                         const float_X j_z = W * currentSurfaceDensityZ;
-                        atomicAdd( &( ( *cursorJ( i, j ) ).z() ), j_z, ::alpaka::hierarchy::Threads{} );
+                        cupla::atomicAdd(acc, &( ( *cursorJ( i, j ) ).z() ), j_z, ::alpaka::hierarchy::Threads{} );
                     }
             }
     }

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -155,7 +155,7 @@ struct EsirkepovNative
                     /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
                      * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1) */
                     accumulated_J += -this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * W * cellEdgeLength;
-                    atomicAdd(&((*cursorJ(i, j, k)).z()), accumulated_J, ::alpaka::hierarchy::Threads{});
+                    cupla::atomicAdd(acc,&((*cursorJ(i, j, k)).z()), accumulated_J, ::alpaka::hierarchy::Threads{});
                 }
             }
         }

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -155,20 +155,20 @@ private:
         const float_X rho_dtY = charge * (float_X(1.0) / (CELL_WIDTH * CELL_DEPTH * deltaTime));
         const float_X rho_dtZ = charge * (float_X(1.0) / (CELL_WIDTH * CELL_HEIGHT * deltaTime));
 
-        atomicAdd(&(mem[1][1][0].x()), rho_dtX * (deltaPos.x() * meanPos.y() * meanPos.z() + tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[1][0][0].x()), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * meanPos.z() - tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[0][1][0].x()), rho_dtX * (deltaPos.x() * meanPos.y() * (float_X(1.0) - meanPos.z()) - tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[0][0][0].x()), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * (float_X(1.0) - meanPos.z()) + tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[1][1][0].x()), rho_dtX * (deltaPos.x() * meanPos.y() * meanPos.z() + tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[1][0][0].x()), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * meanPos.z() - tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][1][0].x()), rho_dtX * (deltaPos.x() * meanPos.y() * (float_X(1.0) - meanPos.z()) - tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][0][0].x()), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * (float_X(1.0) - meanPos.z()) + tmp), ::alpaka::hierarchy::Threads{});
 
-        atomicAdd(&(mem[1][0][1].y()), rho_dtY * (deltaPos.y() * meanPos.z() * meanPos.x() + tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[0][0][1].y()), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * meanPos.x() - tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[1][0][0].y()), rho_dtY * (deltaPos.y() * meanPos.z() * (float_X(1.0) - meanPos.x()) - tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[0][0][0].y()), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * (float_X(1.0) - meanPos.x()) + tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[1][0][1].y()), rho_dtY * (deltaPos.y() * meanPos.z() * meanPos.x() + tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][0][1].y()), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * meanPos.x() - tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[1][0][0].y()), rho_dtY * (deltaPos.y() * meanPos.z() * (float_X(1.0) - meanPos.x()) - tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][0][0].y()), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * (float_X(1.0) - meanPos.x()) + tmp), ::alpaka::hierarchy::Threads{});
 
-        atomicAdd(&(mem[0][1][1].z()), rho_dtZ * (deltaPos.z() * meanPos.x() * meanPos.y() + tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[0][1][0].z()), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * meanPos.y() - tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[0][0][1].z()), rho_dtZ * (deltaPos.z() * meanPos.x() * (float_X(1.0) - meanPos.y()) - tmp), ::alpaka::hierarchy::Threads{});
-        atomicAdd(&(mem[0][0][0].z()), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * (float_X(1.0) - meanPos.y()) + tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][1][1].z()), rho_dtZ * (deltaPos.z() * meanPos.x() * meanPos.y() + tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][1][0].z()), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * meanPos.y() - tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][0][1].z()), rho_dtZ * (deltaPos.z() * meanPos.x() * (float_X(1.0) - meanPos.y()) - tmp), ::alpaka::hierarchy::Threads{});
+        cupla::atomicAdd(acc, &(mem[0][0][0].z()), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * (float_X(1.0) - meanPos.y()) + tmp), ::alpaka::hierarchy::Threads{});
 
     }
 

--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -85,8 +85,8 @@ public:
         Environment<>::get().PluginConnector().restartPlugins(restartStep, restartDirectory);
         __getTransactionEvent().waitForFinished();
 
-        CUDA_CHECK(cudaDeviceSynchronize());
-        CUDA_CHECK(cudaGetLastError());
+        CUDA_CHECK(cuplaDeviceSynchronize());
+        CUDA_CHECK(cuplaGetLastError());
 
         GridController<simDim> &gc = Environment<simDim>::get().GridController();
 

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -105,7 +105,7 @@ struct KernelDeriveParticles
         constexpr uint32_t frameSize = pmacc::math::CT::volume< SuperCellSize >::type::value;
         constexpr uint32_t numWorker = T_numWorkers;
 
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         PMACC_SMEM(
             acc,
@@ -118,7 +118,7 @@ struct KernelDeriveParticles
             DestFramePtr
         );
 
-        DataSpace< simDim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) );
+        DataSpace< simDim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) );
 
         // offset of the superCell (in cells, without any guards) to the origin of the local domain
         DataSpace< simDim > const localSuperCellOffset =
@@ -278,12 +278,12 @@ struct KernelMoveAndMarkParticles
         constexpr uint32_t frameSize = pmacc::math::CT::volume< SuperCellSize >::type::value;
         constexpr uint32_t numWorkers = T_numWorkers;
 
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         using FramePtr = typename T_ParBox::FramePtr;
 
         DataSpace< simDim > const block(
-            mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
+            mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) )
         );
 
         // relative offset (in cells) to the supercell (including the guard)
@@ -339,7 +339,7 @@ struct KernelMoveAndMarkParticles
             T_DataDomain( )
         );
 
-        __syncthreads();
+        cupla::__syncthreads( acc );
 
         // end kernel if we have no frames
         if( !frame.isValid( ) )
@@ -367,7 +367,7 @@ struct KernelMoveAndMarkParticles
             fieldEBlock
         );
 
-        __syncthreads();
+        cupla::__syncthreads( acc );
 
         // move over frames and call frame solver
         while( frame.isValid( ) )
@@ -399,7 +399,7 @@ struct KernelMoveAndMarkParticles
             particlesInSuperCell = frameSize;
         }
 
-        __syncthreads();
+        cupla::__syncthreads( acc );
 
         onlyMaster(
             [&](
@@ -413,7 +413,7 @@ struct KernelMoveAndMarkParticles
                 if( mustShift == 1 )
                 {
                     pb.getSuperCell(
-                        mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
+                        mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) )
                     ).setMustShift( true );
                 }
             }

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -121,7 +121,7 @@ namespace picongpu
             PMACC_CONSTEXPR_CAPTURE uint32_t cellsPerSupercell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             using FramePtr = typename T_ParBox::FramePtr;
             using FrameType = typename T_ParBox::FrameType;
@@ -140,7 +140,7 @@ namespace picongpu
             );
 
             DataSpace< simDim > const superCellIdx(
-                mapper.getSuperCellIndex( DataSpace<simDim >( blockIdx ) )
+                mapper.getSuperCellIndex( DataSpace<simDim >( cupla::blockIdx(acc) ) )
             );
 
             /* offset of the superCell relative to the local domain [in supercells] (without guarding supercells) */
@@ -202,7 +202,7 @@ namespace picongpu
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             // initialize the position functor for each cell in the supercell
             ForEachIdx<
@@ -257,7 +257,7 @@ namespace picongpu
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             if( finished == 1 )
                 return; // if there is no particle which has to be created
@@ -281,7 +281,7 @@ namespace picongpu
             do
             {
                 // wait that master updates the current used frame
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 onlyMaster(
                     [&](
@@ -293,7 +293,7 @@ namespace picongpu
                     }
                 );
 
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 forEachParticle(
                     [&](
@@ -346,7 +346,7 @@ namespace picongpu
                     }
                 );
 
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 onlyMaster(
                     [&](

--- a/include/picongpu/particles/access/Cell2Particle.tpp
+++ b/include/picongpu/particles/access/Cell2Particle.tpp
@@ -72,7 +72,7 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
             particlesInSuperCell = pb.getSuperCell(superCellIdx).getSizeLastFrame(); \
         } \
     ); \
-    __syncthreads(); \
+    cupla::__syncthreads( acc ); \
     \
     if (!frame.isValid()) return; /* leave kernel if we have no frames*/ \
     \
@@ -111,7 +111,7 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
                 } \
             } \
         ); \
-        __syncthreads(); \
+        cupla::__syncthreads( acc ); \
         onlyMaster( \
             [&]( \
                 uint32_t const, \
@@ -122,7 +122,7 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
                 particlesInSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value; \
             } \
         ); \
-        __syncthreads(); \
+        cupla::__syncthreads( acc ); \
     } \
 }
 

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -119,7 +119,7 @@ public:
      *         and initialize possible prerequisites, like e.g. random number generator.
      *
      * This function will be called inline on the device which must happen BEFORE threads diverge
-     * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+     * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is necessary after
      * initializing the ion density field in shared memory.
      */
     template< typename T_Acc >

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -119,7 +119,7 @@ DINLINE void Bremsstrahlung<T_IonSpecies, T_ElectronSpecies, T_PhotonSpecies>::c
               );
 
     /* wait for shared memory to be initialized */
-    __syncthreads();
+    cupla::__syncthreads( acc );
 }
 
 template<

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -102,7 +102,7 @@ namespace creation
 
             constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
             pmacc::math::Int< simDim > const block = blockCell / SuperCellSize::toRT( );

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
@@ -82,11 +82,11 @@ namespace helperFields
             constexpr uint32_t numWorkers = T_numWorkers;
 
             // cell index in the average box in reduced resolution
-            DataSpace< simDim > const avgBoxCell( blockIdx );
+            DataSpace< simDim > const avgBoxCell( cupla::blockIdx(acc) );
             // first cell index inside FieldTmp (originating from BORDER) for block
             DataSpace< simDim > const fieldTmpBlockOriginCell = avgBoxCell * spatialAverageBox::toRT();
             // our workers per block are started 1D
-            uint32_t const linearThreadIdx( threadIdx.x );
+            uint32_t const linearThreadIdx( cupla::threadIdx(acc).x );
 
             // shift the fieldTmp to the start of average box
             auto fieldTmpBlock = fieldTmp.shift( fieldTmpBlockOriginCell );
@@ -108,7 +108,7 @@ namespace helperFields
                 spatialAverageBox::toRT()
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             uint32_t const numAvgCells = pmacc::math::CT::volume< spatialAverageBox >::type::value;
 

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
@@ -109,11 +109,11 @@ namespace helperFields
             );
 
             // our workers per block are started 1D
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             // supercell index of current (frame-wise) supercell including GUARD
             DataSpace< simDim > const superCellIdx(
-                mapper.getSuperCellIndex( DataSpace< simDim >( blockIdx ) )
+                mapper.getSuperCellIndex( DataSpace< simDim >( cupla::blockIdx(acc) ) )
             );
             /* index inside local energy histogram in averaged space (has no GUARD)
              * integer division: we average over multiples of supercells;
@@ -174,7 +174,7 @@ namespace helperFields
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             // return if the supercell has no particles
             if( !frame.isValid( ) )
@@ -232,7 +232,8 @@ namespace helperFields
                                 float_X const normedWeighting = weighting /
                                     float_X( particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE );
 
-                                atomicAdd(
+                                cupla::atomicAdd(
+                                    acc,
                                     &( shLocalEnergyHistogram[ binNumber ] ),
                                     normedWeighting,
                                     ::alpaka::hierarchy::Threads{}
@@ -242,7 +243,7 @@ namespace helperFields
                     }
                 );
 
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 // go to next frame
                 ForEachIdx< MasterOnly >{ workerIdx }(
@@ -255,7 +256,7 @@ namespace helperFields
                         particlesInSuperCell = maxParticlesPerFrame;
                     }
                 );
-                __syncthreads();
+                cupla::__syncthreads( acc );
             }
 
             // write histogram back to global memory (add)
@@ -271,7 +272,8 @@ namespace helperFields
                 )
                 {
                     for( int i = linearIdx; i < numBins; i += numWorkers )
-                        atomicAdd(
+                        cupla::atomicAdd(
+                            acc,
                             &( localEnergyHistogram[ i ] ),
                             shLocalEnergyHistogram[ i ],
                             ::alpaka::hierarchy::Blocks{}

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -268,7 +268,7 @@ namespace ionization
                           );
 
                 /* wait for shared memory to be initialized */
-                __syncthreads();
+                cupla::__syncthreads( acc );
             }
 
             /** Initialization function on device
@@ -278,7 +278,7 @@ namespace ionization
              * generator.
              *
              * This function will be called inline on the device which must happen BEFORE threads diverge
-             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+             * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is necessary after
              * initializing the field shared boxes in shared memory.
              *
              * @param blockCell Offset of the cell from the origin of the local domain

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -200,7 +200,7 @@ namespace ionization
                           );
 
                 /* wait for shared memory to be initialized */
-                __syncthreads();
+                cupla::__syncthreads( acc );
             }
 
             /** Initialization function on device
@@ -209,7 +209,7 @@ namespace ionization
              *         and initialize possible prerequisites for ionization, like e.g. random number generator.
              *
              * This function will be called inline on the device which must happen BEFORE threads diverge
-             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+             * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is necessary after
              * initializing the E-/B-field shared boxes in shared memory.
              */
             template< typename T_Acc >

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -161,7 +161,7 @@ namespace ionization
                           );
 
                 /* wait for shared memory to be initialized */
-                __syncthreads();
+                cupla::__syncthreads( acc );
             }
 
             /** Initialization function on device
@@ -170,7 +170,7 @@ namespace ionization
              *         and initialize possible prerequisites for ionization, like e.g. random number generator.
              *
              * This function will be called inline on the device which must happen BEFORE threads diverge
-             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+             * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is necessary after
              * initializing the E-/B-field shared boxes in shared memory.
              *
              * @param blockCell Offset of the cell from the origin of the local domain

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -201,7 +201,7 @@ namespace ionization
                           );
 
                 /* wait for shared memory to be initialized */
-                __syncthreads();
+                cupla::__syncthreads( acc );
             }
 
             /** Initialization function on device
@@ -210,7 +210,7 @@ namespace ionization
              *         and initialize possible prerequisites for ionization, like e.g. random number generator.
              *
              * This function will be called inline on the device which must happen BEFORE threads diverge
-             * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+             * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is necessary after
              * initializing the E-/B-field shared boxes in shared memory.
              */
             template< typename T_Acc >

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -122,7 +122,8 @@ ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::operator()
          * note: the .x() is used because FieldTmp is a scalar field with only
          * one "x" component
          */
-        atomicAdd(
+        cupla::atomicAdd(
+            acc,
             &(fieldTmpShiftToParticle(offsetParticleCellToCurrentCell).x()),
             assign * particleAttr,
             ::alpaka::hierarchy::Threads{}

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -200,7 +200,7 @@ public:
                   );
 
         /* wait for shared memory to be initialized */
-        __syncthreads();
+        cupla::__syncthreads( acc );
     }
 
     /** Initialization function on device
@@ -209,7 +209,7 @@ public:
      *         and initialize possible prerequisites for ionization, like e.g. random number generator.
      *
      * This function will be called inline on the device which must happen BEFORE threads diverge
-     * during loop execution. The reason for this is the `__syncthreads()` call which is necessary after
+     * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is necessary after
      * initializing the E-/B-field shared boxes in shared memory.
      */
     template< typename T_Acc >

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -77,7 +77,7 @@ struct KernelBinEnergyParticles
      *
      * @tparam T_ParBox pmacc::ParticlesBox, particle box type
      * @tparam T_BinBox pmacc::DataBox, box type for the histogram in global memory
-     * @tparam T_Mapping type of the mapper to map a cuda block to a supercell index
+     * @tparam T_Mapping type of the mapper to map a cupla block to a supercell index
      * @tparam T_Acc alpaka accelerator type
      *
      * @param acc alpaka accelerator
@@ -86,7 +86,7 @@ struct KernelBinEnergyParticles
      * @param numBins number of bins in the histogram (must be fit into the shared memory)
      * @param minEnergy particle energy for the first bin
      * @param maxEnergy particle energy for the last bin
-     * @param mapper functor to map a cuda block to a supercells index
+     * @param mapper functor to map a cupla block to a supercells index
      */
     template<
         typename T_ParBox,

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -110,7 +110,7 @@ namespace picongpu
                 typename T_ParBox::FrameType::SuperCellSize
             >::type::value;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             using FramePtr = typename T_ParBox::FramePtr;
 
@@ -175,7 +175,7 @@ namespace picongpu
             __syncthreads( );
 
             DataSpace< simDim > const superCellIdx( mapper.getSuperCellIndex(
-                DataSpace< simDim >( blockIdx )
+                DataSpace< simDim >( cupla::blockIdx(acc) )
             ) );
 
             // each virtual thread is working on an own frame
@@ -246,23 +246,27 @@ namespace picongpu
                                                         + frameCellOffset;
                             float_X const posX = ( float_X( globalCellOffset.x( ) ) + pos.x( ) ) * cellSize.x( );
 
-                            atomicAdd(
+                            cupla::atomicAdd(
+                                acc,
                                 &( shCount_e[ index_y ] ),
                                 normedWeighting,
                                 ::alpaka::hierarchy::Threads{ }
                             );
                             //weighted sum of single Electron values (Momentum = particle_momentum/weighting)
-                            atomicAdd(
+                            cupla::atomicAdd(
+                                acc,
                                 &( shSumMom2[ index_y ] ),
                                 mom.x( ) * mom.x( ) * normedWeighting,
                                 ::alpaka::hierarchy::Threads{ }
                             );
-                            atomicAdd(
+                            cupla::atomicAdd(
+                                acc,
                                 &( shSumPos2[ index_y ] ),
                                 posX * posX * normedWeighting,
                                 ::alpaka::hierarchy::Threads{ }
                             );
-                            atomicAdd(
+                            cupla::atomicAdd(
+                                acc,
                                 &( shSumMomPos[ index_y ] ),
                                 mom.x( ) * posX * normedWeighting,
                                 ::alpaka::hierarchy::Threads{ }
@@ -306,22 +310,26 @@ namespace picongpu
                     uint32_t const
                 )
                 {
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( gSumMom2[ gOffset + linearIdx ] ),
                         static_cast< float_64 >( shSumMom2[ linearIdx ] ),
                         ::alpaka::hierarchy::Blocks{ }
                     );
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( gSumPos2[ gOffset + linearIdx ] ),
                         static_cast< float_64 >( shSumPos2[ linearIdx ] ),
                         ::alpaka::hierarchy::Blocks{ }
                     );
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( gSumMomPos[ gOffset + linearIdx ] ),
                         static_cast< float_64 >( shSumMomPos[ linearIdx ] ),
                         ::alpaka::hierarchy::Blocks{ }
                     );
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( gCount_e[ gOffset + linearIdx ] ),
                         static_cast< float_64 >( shCount_e[ linearIdx ] ),
                         ::alpaka::hierarchy::Blocks{ }

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -98,7 +98,7 @@ namespace picongpu
                 typename T_ParBox::FrameType::SuperCellSize
             >::type::value;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             using FramePtr = typename T_ParBox::FramePtr;
 
@@ -146,7 +146,7 @@ namespace picongpu
             __syncthreads( );
 
             DataSpace< simDim > const superCellIdx( mapper.getSuperCellIndex(
-                DataSpace< simDim >( blockIdx )
+                DataSpace< simDim >( cupla::blockIdx(acc) )
             ));
 
             // each virtual thread is working on an own frame
@@ -251,12 +251,14 @@ namespace picongpu
             }
 
             // each virtual thread adds the energies to the shared memory
-            atomicAdd(
+            cupla::atomicAdd(
+                acc,
                 &shEnergyKin,
                 localEnergyKin,
                 ::alpaka::hierarchy::Threads{}
             );
-            atomicAdd(
+            cupla::atomicAdd(
+                acc,
                 &shEnergy,
                 localEnergy,
                 ::alpaka::hierarchy::Threads{}
@@ -273,13 +275,15 @@ namespace picongpu
                 )
                 {
                     // add kinetic energy
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( gEnergy[ 0 ] ),
                         static_cast< float_64 >( shEnergyKin ),
                         ::alpaka::hierarchy::Blocks{}
                     );
                     // add total energy
-                    atomicAdd(
+                    cupla::atomicAdd(
+                        acc,
                         &( gEnergy[ 1 ] ),
                         static_cast< float_64 >( shEnergy ),
                         ::alpaka::hierarchy::Blocks{}

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -315,7 +315,7 @@ class ParticleSource
                     if (gc.getPosition()[1] == 0) //first gpu
                     {
                         Window window(MovingWindow::getInstance().getWindow( *currentStep ));
-                        for(uint i = 0; i < simDim; i++)
+                        for(uint32_t i = 0; i < simDim; i++)
                             guarding[i] += int(math::ceil((subGrid.getLocalDomain().size[i] - window.localDimensions.size[i]) / (float)MappingDesc::SuperCellSize::toRT()[i]));
                     }
                 }

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 
 #include <pmacc/cuSTL/cursor/MultiIndexCursor.hpp>
-#include <pmacc/cuSTL/algorithm/cudaBlock/Foreach.hpp>
+#include <pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp>
 #include <pmacc/cuSTL/container/compile-time/SharedBuffer.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/math/VectorOperations.hpp>
@@ -197,7 +197,7 @@ namespace picongpu
             container::CT::SharedBuffer<float_PS, dBufferSizeInBlock > dBufferInBlock( acc );
 
             /* init shared mem */
-            pmacc::algorithm::cudaBlock::Foreach<
+            pmacc::algorithm::cuplaBlock::Foreach<
                 pmacc::math::CT::Int< numWorkers >
             > forEachThreadInBlock(workerIdx);
             forEachThreadInBlock( acc,

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -49,7 +49,7 @@ namespace picongpu
         DINLINE void
         operator()( const T_Acc& acc, Type& dest, const Type src ) const
         {
-            atomicAdd( &dest, src, ::alpaka::hierarchy::Blocks{} );
+            cupla::atomicAdd( acc, &dest, src, ::alpaka::hierarchy::Blocks{} );
         }
     };
 
@@ -112,7 +112,8 @@ namespace picongpu
                 p_bin = num_pbins - 1;
 
             /** \todo take particle shape into account */
-            atomicAdd(
+            cupla::atomicAdd(
+                acc,
                 &(*curDBufferOriginInBlock( p_bin, r_bin )),
                 particleChargeDensity,
                 ::alpaka::hierarchy::Threads{}
@@ -186,7 +187,7 @@ namespace picongpu
         operator()( const T_Acc& acc,  const pmacc::math::Int<simDim>& indexBlockOffset )
         {
             constexpr uint32_t numWorkers = T_numWorkers;
-            const uint32_t workerIdx = threadIdx.x;
+            const uint32_t workerIdx = cupla::threadIdx(acc).x;
 
             /** \todo write math::Vector constructor that supports dim3 */
             const pmacc::math::Int<simDim> indexGlobal = indexBlockOffset;
@@ -204,7 +205,7 @@ namespace picongpu
                                   dBufferInBlock.zone(),
                                   dBufferInBlock.origin(),
                                   pmacc::algorithm::functor::AssignValue<float_PS>(0.0) );
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             FunctorParticle<r_dir, num_pbins, SuperCellSize> functorParticle;
 
@@ -226,7 +227,7 @@ namespace picongpu
                 axis_p_range
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
             /* add to global dBuffer */
             forEachThreadInBlock( acc,
                                   /* area to work on */

--- a/include/picongpu/plugins/PositionsParticles.hpp
+++ b/include/picongpu/plugins/PositionsParticles.hpp
@@ -121,16 +121,16 @@ struct KernelPositionsParticles
 
         using SuperCellSize = typename Mapping::SuperCellSize;
 
-        const DataSpace<simDim > threadIndex(threadIdx);
+        const DataSpace<simDim > threadIndex(cupla::threadIdx(acc));
         const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
-        const DataSpace<simDim> superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim > (blockIdx)));
+        const DataSpace<simDim> superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim > (cupla::blockIdx(acc))));
 
         if (linearThreadIdx == 0)
         {
             frame = pb.getLastFrame(superCellIdx);
         }
 
-        __syncthreads();
+        cupla::__syncthreads( acc );
         if (!frame.isValid())
             return; //end kernel if we have no frames
 
@@ -161,13 +161,13 @@ struct KernelPositionsParticles
                     * MappingDesc::SuperCellSize::toRT()
                     + frameCellOffset;
             }
-            __syncthreads();
+            cupla::__syncthreads( acc );
             if (linearThreadIdx == 0)
             {
                 frame = pb.getPreviousFrame(frame);
             }
             isParticle = true;
-            __syncthreads();
+            cupla::__syncthreads( acc );
         }
 
     }

--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -99,7 +99,7 @@ namespace picongpu
             constexpr uint32_t numParticlesPerFrame = pmacc::math::CT::volume< typename SrcFrameType::SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             PMACC_SMEM( acc, srcFramePtr, SrcFramePtr );
             PMACC_SMEM( acc, localCounter, int );
@@ -120,7 +120,7 @@ namespace picongpu
             storageOffsetCtx{};
 
 
-            DataSpace< simDim > const supcerCellIdx = mapper.getSuperCellIndex( DataSpace< simDim > ( blockIdx ) );
+            DataSpace< simDim > const supcerCellIdx = mapper.getSuperCellIndex( DataSpace< simDim > ( cupla::blockIdx(acc) ) );
             /* offset (in cells) of the supercell relative to the origin of the
              * local domain (without any guards)
              */
@@ -155,7 +155,7 @@ namespace picongpu
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             // move over all Frames in the supercell
             while( srcFramePtr.isValid() )
@@ -188,7 +188,7 @@ namespace picongpu
                                 );
                     }
                 );
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 onlyMaster(
                     [&](
@@ -197,7 +197,8 @@ namespace picongpu
                     )
                     {
                         // reserve host memory for particle
-                        globalOffset = atomicAdd(
+                        globalOffset = cupla::atomicAdd(
+                            acc,
                             counter,
                             localCounter,
                             ::alpaka::hierarchy::Blocks{}
@@ -205,7 +206,7 @@ namespace picongpu
                     }
                 );
 
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 forEachParticle(
                     [&](
@@ -234,7 +235,7 @@ namespace picongpu
                     }
                 );
 
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 onlyMaster(
                     [&](
@@ -247,7 +248,7 @@ namespace picongpu
                         localCounter = 0;
                     }
                 );
-                __syncthreads();
+                cupla::__syncthreads( acc );
             }
         }
     };

--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -50,7 +50,7 @@ namespace picongpu
          * @tparam T_Filter type of filer with particle selection rules
          * @tparam T_Space type of coordinate description
          * @tparam T_Identifier type of identifier for the particle cellIdx
-         * @tparam T_Mapping type of the mapper to map cuda idx to supercells
+         * @tparam T_Mapping type of the mapper to map cupla idx to supercells
          * @tparam T_Acc alpaka accelerator type
          *
          * @param acc alpaka accelerator type
@@ -64,7 +64,7 @@ namespace picongpu
          * @param domainCellIdxIdentifier the identifier for the particle cellIdx
          *                                that is calculated with respect to
          *                                domainOffset
-         * @param mapper map cuda idx to supercells
+         * @param mapper map cupla idx to supercells
          */
         template<
             typename T_DestFrame,

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -64,10 +64,10 @@ struct KernelParticleCalorimeter
         constexpr uint32_t numWorkers = T_numWorkers;
         constexpr lcellId_t maxParticlesInFrame = pmacc::math::CT::volume< SuperCellSize >::type::value;
 
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
-        DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim > ( blockIdx ) )) ;
+        DataSpace< simDim > const block( mapper.getSuperCellIndex( DataSpace< simDim > ( cupla::blockIdx(acc) ) )) ;
 
         using ParticlesFramePtr = typename T_ParticlesBox::FramePtr;
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -139,7 +139,7 @@ struct CalorimeterFunctor
                 energyBin = energyBin > 0 ? energyBin : 0;
             }
 
-            atomicAdd( &(*this->calorimeterCur(yawBin, pitchBin, energyBin)),
+            cupla::atomicAdd(acc, &(*this->calorimeterCur(yawBin, pitchBin, energyBin)),
                              energy * normedWeighting, ::alpaka::hierarchy::Threads{});
         }
     }

--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -427,7 +427,7 @@ namespace particleMerging
                 voronoiIndexPool = VoronoiIndexPool( numInitialVoronoiCells );
             }
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             /* set initial Voronoi cells into `collecting` state */
             if( linearThreadIdx < numInitialVoronoiCells )
@@ -445,7 +445,7 @@ namespace particleMerging
                     listVoronoiCells
                 );
 
-                __syncthreads();
+                cupla::__syncthreads( acc );
 
                 /* TODO: parallelize */
                 if( linearThreadIdx == 0 )
@@ -456,7 +456,7 @@ namespace particleMerging
                     );
                 }
 
-                __syncthreads();
+                cupla::__syncthreads( acc );
             }
         }
     };

--- a/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
+++ b/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
@@ -120,7 +120,7 @@ namespace particleMerging
         DINLINE
         bool isFirstParticle(T_Acc const & acc)
         {
-            return atomicExch( &this->firstParticleFlag, 1 ) == 0;
+            return cupla::atomicExch( acc, &this->firstParticleFlag, 1 ) == 0;
         }
 
 
@@ -135,7 +135,7 @@ namespace particleMerging
         )
         {
             nvidia::atomicAllInc( acc, &this->numMacroParticles, ::alpaka::hierarchy::Threads{} );
-            atomicAdd( &this->numRealParticles, weighting, ::alpaka::hierarchy::Threads{} );
+            cupla::atomicAdd(acc,  &this->numRealParticles, weighting, ::alpaka::hierarchy::Threads{} );
 
             if( this->splittingStage == VoronoiSplittingStage::position )
             {
@@ -143,8 +143,8 @@ namespace particleMerging
 
                 for( int i = 0; i < simDim; i++ )
                 {
-                    atomicAdd( &this->meanValue[i], weighting * position[i], ::alpaka::hierarchy::Threads{} );
-                    atomicAdd( &this->meanSquaredValue[i], weighting * position2[i], ::alpaka::hierarchy::Threads{} );
+                    cupla::atomicAdd(acc,  &this->meanValue[i], weighting * position[i], ::alpaka::hierarchy::Threads{} );
+                    cupla::atomicAdd(acc,  &this->meanSquaredValue[i], weighting * position2[i], ::alpaka::hierarchy::Threads{} );
                 }
             }
             else
@@ -153,8 +153,8 @@ namespace particleMerging
 
                 for( int i = 0; i < DIM3; i++ )
                 {
-                    atomicAdd( &this->meanValue[i], weighting * momentum[i], ::alpaka::hierarchy::Threads{} );
-                    atomicAdd( &this->meanSquaredValue[i], weighting * momentum2[i], ::alpaka::hierarchy::Threads{} );
+                    cupla::atomicAdd(acc,  &this->meanValue[i], weighting * momentum[i], ::alpaka::hierarchy::Threads{} );
+                    cupla::atomicAdd(acc,  &this->meanSquaredValue[i], weighting * momentum2[i], ::alpaka::hierarchy::Threads{} );
                 }
             }
         }

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -375,7 +375,7 @@ private:
             }
 
             __delete(radiation);
-            CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cuplaGetLastError());
 
             __deleteArray(tmp_result);
         }

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -131,7 +131,7 @@ namespace radiation
 
             using namespace parameters; // parameters of radiation
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             /// calculate radiated Amplitude
             /* parallelized in 1 dimensions:
@@ -162,7 +162,7 @@ namespace radiation
             PMACC_SMEM( acc, lowpass_s, memory::Array< NyquistLowPass, blockSize > );
 
 
-            int const theta_idx = blockIdx.x; //blockIdx.x is used to determine theta
+            int const theta_idx = cupla::blockIdx(acc).x; //cupla::blockIdx(acc).x is used to determine theta
 
             // simulation time (needed for retarded time)
             picongpu::float_64 const t(
@@ -223,7 +223,7 @@ namespace radiation
                      *  all threads must wait for the selection of a new frame
                      *  until all threads have evaluated "isValid"
                      */
-                    __syncthreads();
+                    cupla::__syncthreads( acc );
 
                     ForEachIdx<
                         IdxConfig<
@@ -247,7 +247,7 @@ namespace radiation
                         }
                     );
 
-                    __syncthreads();
+                    cupla::__syncthreads( acc );
 
                     using ParticleDomCfg = IdxConfig<
                         frameSize,
@@ -417,7 +417,7 @@ namespace radiation
                         }
                     );
 
-                    __syncthreads(); // wait till every thread has loaded its particle data
+                    cupla::__syncthreads( acc ); // wait till every thread has loaded its particle data
 
 
 
@@ -487,7 +487,7 @@ namespace radiation
 
 
                     // wait till all radiation contributions for this super cell are done
-                    __syncthreads();
+                    cupla::__syncthreads( acc );
 
                     /* First threads starts loading next frame of the super-cell:
                      *

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -312,7 +312,7 @@ namespace transitionRadiation
                 {
                     __deleteArray( theTransRad );
                 }
-                CUDA_CHECK( cudaGetLastError( ) );
+                CUDA_CHECK( cuplaGetLastError( ) );
                 __delete( incTransRad );
                 __delete( cohTransRadPara );
                 __delete( cohTransRadPerp );

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -97,7 +97,7 @@ namespace transitionRadiation
             using FrameType = typename T_ParBox::FrameType;
             using FramePtr = typename T_ParBox::FramePtr;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             /* parallelized in 2 dimensions:
             * looking direction (theta, phi)
@@ -128,7 +128,7 @@ namespace transitionRadiation
             PMACC_SMEM( acc, counter_s, int );
 
 
-            int const theta_idx = blockIdx.x; //blockIdx.x is used to determine theta
+            int const theta_idx = cupla::blockIdx(acc).x; //cupla::blockIdx(acc).x is used to determine theta
 
             // looking direction (needed for observer) used in the thread
             float3_X const look = transitionRadiation::observationDirection( theta_idx );

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -559,7 +559,7 @@ namespace detail
  * depended on the opType this method is blocking
  *
  * @param opType place were the operation is running
- *               possible places are: `ITask::TASK_CUDA`, `ITask::TASK_MPI`, `ITask::TASK_HOST`
+ *               possible places are: `ITask::TASK_DEVICE`, `ITask::TASK_MPI`, `ITask::TASK_HOST`
  */
 #define __startOperation(opType) (pmacc::Environment<>::get().TransactionManager().startOperation(opType))
 
@@ -568,7 +568,7 @@ namespace detail
  * depended on the opType this method is blocking
  *
  * @param opType place were the operation is running
- *               possible places are: `ITask::TASK_CUDA`, `ITask::TASK_MPI`, `ITask::TASK_HOST`
+ *               possible places are: `ITask::TASK_DEVICE`, `ITask::TASK_MPI`, `ITask::TASK_HOST`
  */
 #define __getEventStream(opType) (pmacc::Environment<>::get().TransactionManager().getEventStream(opType))
 

--- a/include/pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp
@@ -31,7 +31,7 @@ namespace pmacc
 {
 namespace algorithm
 {
-namespace cudaBlock
+namespace cuplaBlock
 {
 
 #ifndef FOREACH_KERNEL_MAX_PARAMS
@@ -61,11 +61,11 @@ namespace cudaBlock
         }                                                                          \
     }
 
-/** Foreach algorithm that is executed by one cuda thread block
+/** Foreach algorithm that is executed by one cupla thread block
  *
- * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cuda blockDim.
+ * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
  *
- * BlockDim could also be obtained from cuda itself at runtime but
+ * BlockDim could also be obtained from cupla itself at runtime but
  * it is faster to know it at compile-time.
  */
 template<typename BlockDim>
@@ -93,6 +93,6 @@ public:
 #undef SHIFTACCESS_CURSOR
 #undef FOREACH_OPERATOR
 
-} // cudaBlock
+} // cuplaBlock
 } // algorithm
 } // pmacc

--- a/include/pmacc/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/Foreach.hpp
@@ -64,14 +64,14 @@ namespace kernel
         auto blockSize = BlockDim::toRT();                                                                   \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace pmacc;                                                                              \
-        PMACC_KERNEL(detail::KernelForeach{})(mapper.cudaGridDim(p_zone.size), blockSize)                    \
+        PMACC_KERNEL(detail::KernelForeach{})(mapper.cuplaGridDim(p_zone.size), blockSize)                    \
                   /* c0_shifted, c1_shifted, ... */                                                         \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), functor);                   \
     }
 
-/** Foreach algorithm that calls a cuda kernel
+/** Foreach algorithm that calls a cupla kernel
  *
- * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cuda blockDim.
+ * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
  *
  * blockDim has to fit into the computing volume.
  * E.g. (8,8,4) fits into (256, 256, 256)
@@ -133,7 +133,7 @@ struct ForeachLockstep
         > mapper;
 
          PMACC_KERNEL( detail::KernelForeachLockstep{ } )(
-            mapper.cudaGridDim( p_zone.size ),
+            mapper.cuplaGridDim( p_zone.size ),
             T_numWorkers
         )(
             mapper,

--- a/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -58,7 +58,7 @@ template<typename Mapper, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor,
                                                 /* C0 c0, C1 c1, ... */                                     \
 DINLINE void operator()(T_Acc const & acc, Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) const         \
 {                                                                                                           \
-    math::Int<Mapper::dim> cellIndex(mapper(acc, dim3(blockIdx)));                                               \
+    math::Int<Mapper::dim> cellIndex(mapper(acc, cupla::dim3(blockIdx)));                                               \
          /* c0[cellIndex], c1[cellIndex], ... */                                                            \
     functor(acc, BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _));                                                       \
 }
@@ -91,18 +91,18 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(FOREACH_KERNEL_MAX_PARAMS), KERNEL_FOREA
         auto blockDim = ThreadBlock::toRT();                                                                \
         detail::SphericMapper<Zone::dim, BlockDim> mapper;                                                  \
         using namespace pmacc;                                                                              \
-        PMACC_KERNEL(detail::KernelForeachBlock{})(mapper.cudaGridDim(p_zone.size), blockDim)               \
+        PMACC_KERNEL(detail::KernelForeachBlock{})(mapper.cuplaGridDim(p_zone.size), blockDim)               \
                     /* c0_shifted, c1_shifted, ... */                                                       \
             (mapper, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _), functor);                   \
     }
 
-/** Special foreach algorithm that calls a cuda kernel
+/** Special foreach algorithm that calls a cupla kernel
  *
  * Behaves like kernel::Foreach, except that is doesn't shift the cursors cell by cell, but
- * shifts them to the top left (front) corner cell of their corresponding cuda block.
+ * shifts them to the top left (front) corner cell of their corresponding cupla block.
  * So if BlockDim is 4x4x4 it shifts 64 cursors to (0,0,0), 64 to (4,0,0), 64 to (8,0,0), ...
  *
- * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cuda blockDim.
+ * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
  * \tparam ThreadBlock ignored
  */
 template<typename BlockDim, typename ThreadBlock = BlockDim>

--- a/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -58,7 +58,7 @@ template<typename Mapper, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor,
                                                 /* C0 c0, C1 c1, ... */                                     \
 DINLINE void operator()(T_Acc const & acc, Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) const         \
 {                                                                                                           \
-    math::Int<Mapper::dim> cellIndex(mapper(acc, cupla::dim3(blockIdx)));                                               \
+    math::Int<Mapper::dim> cellIndex(mapper(acc, cupla::dim3(cupla::blockIdx(acc))));                                               \
          /* c0[cellIndex], c1[cellIndex], ... */                                                            \
     functor(acc, BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _));                                                       \
 }

--- a/include/pmacc/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/Reduce.hpp
@@ -33,7 +33,7 @@ namespace algorithm
 namespace kernel
 {
 
-/** Reduce algorithm that calls a cuda kernel
+/** Reduce algorithm that calls a cupla kernel
  *
  */
 struct Reduce

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -49,7 +49,7 @@ template<typename Mapper, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor,
 /*                                          C0 c0, ..., CN cN   */ \
 DINLINE void operator()(T_Acc const & acc, Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) const \
 { \
-    math::Int<Mapper::dim> cellIndex(mapper(acc, cupla::dim3(blockIdx), cupla::dim3(threadIdx))); \
+    math::Int<Mapper::dim> cellIndex(mapper(acc, cupla::dim3(cupla::blockIdx(acc)), cupla::dim3(cupla::threadIdx(acc)))); \
 /*          c0[cellIndex]), ..., cN[cellIndex]     */ \
     functor(acc, BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _)); \
 }
@@ -86,7 +86,7 @@ struct KernelForeachLockstep
         > cellIndex(
             mapper(
                 acc,
-                cupla::dim3( blockIdx ),
+                cupla::dim3( cupla::blockIdx(acc) ),
                 cupla::dim3(
                     0,
                     0,
@@ -144,7 +144,7 @@ namespace RT
                 mapper(
                     acc,
                     domainSize.toDim3(),
-                    cupla::dim3( blockIdx ),
+                    cupla::dim3( cupla::blockIdx(acc) ),
                     cupla::dim3(
                         0,
                         0,
@@ -155,7 +155,7 @@ namespace RT
 
 
 
-            for( uint32_t i = threadIdx.x; i < domainElementCount; i += blockDim.x )
+            for( uint32_t i = cupla::threadIdx(acc).x; i < domainElementCount; i += cupla::blockDim(acc).x )
             {
                 auto const inBlockOffset = DataSpaceOperations< T_Mapper::dim >::map(
                     domainSize,

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -49,7 +49,7 @@ template<typename Mapper, BOOST_PP_ENUM_PARAMS(N, typename C), typename Functor,
 /*                                          C0 c0, ..., CN cN   */ \
 DINLINE void operator()(T_Acc const & acc, Mapper mapper, BOOST_PP_ENUM_BINARY_PARAMS(N, C, c), Functor functor) const \
 { \
-    math::Int<Mapper::dim> cellIndex(mapper(acc, dim3(blockIdx), dim3(threadIdx))); \
+    math::Int<Mapper::dim> cellIndex(mapper(acc, cupla::dim3(blockIdx), cupla::dim3(threadIdx))); \
 /*          c0[cellIndex]), ..., cN[cellIndex]     */ \
     functor(acc, BOOST_PP_ENUM(N, SHIFTACCESS_CURSOR, _)); \
 }
@@ -86,8 +86,8 @@ struct KernelForeachLockstep
         > cellIndex(
             mapper(
                 acc,
-                dim3( blockIdx ),
-                dim3(
+                cupla::dim3( blockIdx ),
+                cupla::dim3(
                     0,
                     0,
                     0
@@ -144,8 +144,8 @@ namespace RT
                 mapper(
                     acc,
                     domainSize.toDim3(),
-                    dim3( blockIdx ),
-                    dim3(
+                    cupla::dim3( blockIdx ),
+                    cupla::dim3(
                         0,
                         0,
                         0

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -37,12 +37,12 @@ namespace detail
 
 namespace mpl = boost::mpl;
 
-/** The SphericMapper maps from cuda blockIdx and/or threadIdx to the cell index
+/** The SphericMapper maps from cupla blockIdx and/or threadIdx to the cell index
  * \tparam dim dimension
- * \tparam BlockSize compile-time vector of the cuda block size (optional)
+ * \tparam BlockSize compile-time vector of the cupla block size (optional)
  * \tparam dummy neccesary to implement the optional BlockSize parameter
  *
- * If BlockSize is given the cuda variable blockDim is not used which is faster.
+ * If BlockSize is given the cupla variable blockDim is not used which is faster.
  */
 template<int dim, typename BlockSize = mpl::void_, typename dummy = mpl::void_>
 struct SphericMapper;
@@ -55,7 +55,7 @@ struct SphericMapper<1, BlockSize>
     static constexpr int dim = 1;
 
     typename math::Size_t<3>::BaseType
-    cudaGridDim(const math::Size_t<1>& size) const
+    cuplaGridDim(const math::Size_t<1>& size) const
     {
         return math::Size_t<3>(
             size.x() / BlockSize::x::value,
@@ -79,8 +79,8 @@ struct SphericMapper<1, BlockSize>
     HDINLINE
     math::Int<1> operator()(
         T_Acc const & acc,
-        const dim3& _blockIdx,
-        const dim3& _threadIdx = dim3(0,0,0)
+        const cupla::dim3& _blockIdx,
+        const cupla::dim3& _threadIdx = cupla::dim3(0,0,0)
     ) const
     {
         return operator()(
@@ -97,7 +97,7 @@ struct SphericMapper<2, BlockSize>
     static constexpr int dim = 2;
 
     typename math::Size_t<3>::BaseType
-    cudaGridDim(const math::Size_t<2>& size) const
+    cuplaGridDim(const math::Size_t<2>& size) const
     {
         return math::Size_t<3>(
             size.x() / BlockSize::x::value,
@@ -122,8 +122,8 @@ struct SphericMapper<2, BlockSize>
     HDINLINE
     math::Int<2> operator()(
         T_Acc const & acc,
-        const dim3& _blockIdx,
-        const dim3& _threadIdx = dim3(0,0,0)
+        const cupla::dim3& _blockIdx,
+        const cupla::dim3& _threadIdx = cupla::dim3(0,0,0)
     ) const
     {
         return operator()(
@@ -140,7 +140,7 @@ struct SphericMapper<3, BlockSize>
     static constexpr int dim = 3;
 
     typename math::Size_t<3>::BaseType
-    cudaGridDim(const math::Size_t<3>& size) const
+    cuplaGridDim(const math::Size_t<3>& size) const
     {
         return math::Size_t<3>(
             size.x() / BlockSize::x::value,
@@ -164,8 +164,8 @@ struct SphericMapper<3, BlockSize>
     HDINLINE
     math::Int<3> operator()(
         T_Acc const & acc,
-        const dim3& _blockIdx,
-        const dim3& _threadIdx = dim3(0,0,0)
+        const cupla::dim3& _blockIdx,
+        const cupla::dim3& _threadIdx = cupla::dim3(0,0,0)
     ) const
     {
         return operator()(
@@ -184,7 +184,7 @@ struct SphericMapper<1, mpl::void_>
     static constexpr int dim = 1;
 
     typename math::Size_t<3>::BaseType
-    cudaGridDim(const math::Size_t<1>& size, const math::Size_t<3>& blockSize) const
+    cuplaGridDim(const math::Size_t<1>& size, const math::Size_t<3>& blockSize) const
     {
         return math::Size_t<3>(
             size.x() / blockSize.x(),
@@ -209,9 +209,9 @@ struct SphericMapper<1, mpl::void_>
     DINLINE
     math::Int<1> operator()(
         T_Acc const & acc,
-        const dim3& _blockDim,
-        const dim3& _blockIdx,
-        const dim3& _threadIdx
+        const cupla::dim3& _blockDim,
+        const cupla::dim3& _blockIdx,
+        const cupla::dim3& _threadIdx
     ) const
     {
         return operator()(
@@ -229,7 +229,7 @@ struct SphericMapper<2, mpl::void_>
     static constexpr int dim = 2;
 
     typename math::Size_t<3>::BaseType
-    cudaGridDim(const math::Size_t<2>& size, const math::Size_t<3>& blockSize) const
+    cuplaGridDim(const math::Size_t<2>& size, const math::Size_t<3>& blockSize) const
     {
         return math::Size_t<3>(
             size.x() / blockSize.x(),
@@ -255,9 +255,9 @@ struct SphericMapper<2, mpl::void_>
     DINLINE
     math::Int<2> operator()(
         T_Acc const & acc,
-        const dim3& _blockDim,
-        const dim3& _blockIdx,
-        const dim3& _threadIdx
+        const cupla::dim3& _blockDim,
+        const cupla::dim3& _blockIdx,
+        const cupla::dim3& _threadIdx
     ) const
     {
         return operator()(
@@ -275,7 +275,7 @@ struct SphericMapper<3, mpl::void_>
     static constexpr int dim = 3;
 
     typename math::Size_t<3>::BaseType
-    cudaGridDim(const math::Size_t<3>& size, const math::Size_t<3>& blockSize) const
+    cuplaGridDim(const math::Size_t<3>& size, const math::Size_t<3>& blockSize) const
     {
         return math::Size_t<3>(
             size.x() / blockSize.x(),
@@ -302,9 +302,9 @@ struct SphericMapper<3, mpl::void_>
     DINLINE
     math::Int<3> operator()(
         T_Acc const & acc,
-        const dim3& _blockDim,
-        const dim3& _blockIdx,
-        const dim3& _threadIdx
+        const cupla::dim3& _blockDim,
+        const cupla::dim3& _blockIdx,
+        const cupla::dim3& _threadIdx
     ) const
     {
         return operator()(

--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -55,7 +55,7 @@ namespace RT
 /** Heuristic maximum threads per block and per axis
  * in agreement to sm_2.x - sm_5.3
  *
- * These values don't fully exploit the limits from the cuda specification
+ * These values don't fully exploit the limits from the cupla specification
  * but they give reasonable speed.
  */
 template<int dim>
@@ -79,22 +79,22 @@ struct MaxCudaBlockDim<DIM3>
     typedef math::CT::Size_t<8, 8, 8> type;
 };
 
-/** Check if MaxCudaBlockDim holds the cuda specification limits
+/** Check if MaxCudaBlockDim holds the cupla specification limits
  *
  * @cond
  */
-PMACC_CASSERT_MSG(_cuda_blockDim_exceeds_maximum_number_of_threads_per_block,
+PMACC_CASSERT_MSG(_cupla_blockDim_exceeds_maximum_number_of_threads_per_block,
     math::CT::volume<typename MaxCudaBlockDim<DIM1>::type >::type::value <= cudaSpecs::maxNumThreadsPerBlock);
-PMACC_CASSERT_MSG(_cuda_blockDim_exceeds_maximum_number_of_threads_per_block,
+PMACC_CASSERT_MSG(_cupla_blockDim_exceeds_maximum_number_of_threads_per_block,
     math::CT::volume<typename MaxCudaBlockDim<DIM2>::type >::type::value <= cudaSpecs::maxNumThreadsPerBlock);
-PMACC_CASSERT_MSG(_cuda_blockDim_exceeds_maximum_number_of_threads_per_block,
+PMACC_CASSERT_MSG(_cupla_blockDim_exceeds_maximum_number_of_threads_per_block,
     math::CT::volume<typename MaxCudaBlockDim<DIM3>::type >::type::value <= cudaSpecs::maxNumThreadsPerBlock);
 /** @endcond */
 
-/** Return a suitable cuda blockDim for a given gridDimension.
+/** Return a suitable cupla blockDim for a given gridDimension.
  *
  * @param gridDimension 1D, 2D or 3D grid size
- * @return cuda blockDim
+ * @return cupla blockDim
  */
 template<int dim>
 math::Size_t<DIM3> getBestCudaBlockDim(const math::Size_t<dim> gridDimension)
@@ -147,15 +147,15 @@ math::Size_t<DIM3> getBestCudaBlockDim(const math::Size_t<dim> gridDimension)
             numWorkers = blockSize.productOfComponents();                                                           \
         kernel::detail::SphericMapper<Zone::dim> mapper;                                                            \
         using namespace pmacc;                                                                                      \
-        PMACC_KERNEL(kernel::detail::RT::KernelForeachLockstep{})(mapper.cudaGridDim(p_zone.size, this->_blockDim), numWorkers) \
+        PMACC_KERNEL(kernel::detail::RT::KernelForeachLockstep{})(mapper.cuplaGridDim(p_zone.size, this->_blockDim), numWorkers) \
                 /*   c0_shifted, ..., cN_shifted    */                                                              \
             (mapper, blockSize, functor, BOOST_PP_ENUM(N, SHIFTED_CURSOR, _));                           \
     }
 
-/** Foreach algorithm that calls a cuda kernel
+/** Foreach algorithm that calls a cupla kernel
  *
  * This is the run-time version of kernel::Foreach where the
- * cuda blockDim is specified in the constructor
+ * cupla blockDim is specified in the constructor
  *
  * @warning collective functors (containing synchronization) are not supported
  */
@@ -163,7 +163,7 @@ struct Foreach
 {
     math::Size_t<DIM3> _blockDim;
 
-    /* \param _blockDim size of the cuda blockDim.
+    /* \param _blockDim size of the cupla blockDim.
      *
      * blockDim has to fit into the computing volume.
      * E.g. (8,8,4) fits into (256, 256, 256)

--- a/include/pmacc/cuSTL/algorithm/mpi/Gather.tpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Gather.tpp
@@ -198,13 +198,13 @@ void Gather<dim>::CopyToDest::operator()(
         // calculate srcPitch (contiguous memory)
         Size_t<memDim-1> srcPitch = GatherHelper::ContiguousPitch<memDim, Type>()(srcSizes[i]);
 
-        cudaWrapper::Memcopy<memDim>()(
+        cuplaWrapper::Memcopy<memDim>()(
             &(*dest.origin()(ndim_offset)),
             dest.getPitch(),
             tmpDest.data() + srcOffsets1D[i],
             srcPitch,
             srcSizes[i],
-            cudaWrapper::flags::Memcopy::hostToHost);
+            cuplaWrapper::flags::Memcopy::hostToHost);
     }
 }
 

--- a/include/pmacc/cuSTL/container/CartBuffer.tpp
+++ b/include/pmacc/cuSTL/container/CartBuffer.tpp
@@ -88,7 +88,7 @@ namespace detail
     {
 #ifndef __CUDA_ARCH__
         using namespace pmacc;
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
 #endif
     }
 

--- a/include/pmacc/cuSTL/container/DeviceBuffer.hpp
+++ b/include/pmacc/cuSTL/container/DeviceBuffer.hpp
@@ -123,8 +123,8 @@ public:
                 std::stringstream() << "Assignment: Sizes of buffers do not match: "
                     << this->size() << " <-> " << rhs.size() << std::endl).str());
 
-        cudaWrapper::Memcopy<T_dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
-                                this->_size, cudaWrapper::flags::Memcopy::hostToDevice);
+        cuplaWrapper::Memcopy<T_dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
+                                this->_size, cuplaWrapper::flags::Memcopy::hostToDevice);
 
         return *this;
     }

--- a/include/pmacc/cuSTL/container/HostBuffer.hpp
+++ b/include/pmacc/cuSTL/container/HostBuffer.hpp
@@ -132,8 +132,8 @@ public:
                 std::stringstream() << "Assignment: Sizes of buffers do not match: "
                     << this->size() << " <-> " << rhs.size() << std::endl).str());
 
-        cudaWrapper::Memcopy<T_dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
-                                this->_size, cudaWrapper::flags::Memcopy::deviceToHost);
+        cuplaWrapper::Memcopy<T_dim>()(this->dataPointer, this->pitch, rhs.getDataPointer(), rhs.getPitch(),
+                                this->_size, cuplaWrapper::flags::Memcopy::deviceToHost);
 
         return *this;
     }

--- a/include/pmacc/cuSTL/container/PseudoBuffer.tpp
+++ b/include/pmacc/cuSTL/container/PseudoBuffer.tpp
@@ -30,14 +30,14 @@ template<typename Type, int dim>
 template<typename _Type>
 PseudoBuffer<Type, dim>::PseudoBuffer(pmacc::DeviceBuffer<_Type, dim>& devBuffer)
 {
-    cudaPitchedPtr cudaData = devBuffer.getCudaPitched();
-    this->dataPointer = (Type*)cudaData.ptr;
+    cuplaPitchedPtr cuplaData = devBuffer.getCudaPitched();
+    this->dataPointer = (Type*)cuplaData.ptr;
     this->_size = (math::Size_t<dim>)devBuffer.getDataSpace();
-    if(dim == 2) this->pitch[0] = cudaData.pitch;
+    if(dim == 2) this->pitch[0] = cuplaData.pitch;
     if(dim == 3)
     {
-        this->pitch[0] = cudaData.pitch;
-        this->pitch[1] = cudaData.pitch * this->_size.y();
+        this->pitch[0] = cuplaData.pitch;
+        this->pitch[1] = cuplaData.pitch * this->_size.y();
     }
 }
 

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.tpp
@@ -34,33 +34,33 @@ DeviceMemAllocator<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
 #ifndef __CUDA_ARCH__
     Type* dataPointer;
     math::Size_t<T_dim-1> pitch;
-    cudaPitchedPtr cudaData;
+    cuplaPitchedPtr cuplaData;
 
-    cudaData.ptr = nullptr;
-    cudaData.pitch = 1;
-    cudaData.xsize = size[0] * sizeof (Type);
-    cudaData.ysize = 1;
+    cuplaData.ptr = nullptr;
+    cuplaData.pitch = 1;
+    cuplaData.xsize = size[0] * sizeof (Type);
+    cuplaData.ysize = 1;
 
     if (dim == 2u)
     {
-        cudaData.xsize = size[0] * sizeof (Type);
-        cudaData.ysize = size[1];
+        cuplaData.xsize = size[0] * sizeof (Type);
+        cuplaData.ysize = size[1];
         if(size.productOfComponents())
-            CUDA_CHECK(cudaMallocPitch(&cudaData.ptr, &cudaData.pitch, cudaData.xsize, cudaData.ysize));
-        pitch[0] = cudaData.pitch;
+            CUDA_CHECK(cuplaMallocPitch(&cuplaData.ptr, &cuplaData.pitch, cuplaData.xsize, cuplaData.ysize));
+        pitch[0] = cuplaData.pitch;
     }
     else if (dim == 3u)
     {
-        cudaExtent extent;
+        cuplaExtent extent;
         extent.width = size[0] * sizeof (Type);
         extent.height = size[1];
         extent.depth = size[2];
         if(size.productOfComponents())
-            CUDA_CHECK(cudaMalloc3D(&cudaData, extent));
-        pitch[0] = cudaData.pitch;
-        pitch[1] = cudaData.pitch * size[1];
+            CUDA_CHECK(cuplaMalloc3D(&cuplaData, extent));
+        pitch[0] = cuplaData.pitch;
+        pitch[1] = cuplaData.pitch * size[1];
     }
-    dataPointer = (Type*)cudaData.ptr;
+    dataPointer = (Type*)cuplaData.ptr;
 
     return cursor::BufferCursor<Type, T_dim>(dataPointer, pitch);
 #endif
@@ -81,7 +81,7 @@ DeviceMemAllocator<Type, 1>::allocate(const math::Size_t<1>& size)
     Type* dataPointer = nullptr;
 
     if(size[0])
-        CUDA_CHECK(cudaMalloc((void**)&dataPointer, size[0] * sizeof(Type)));
+        CUDA_CHECK(cuplaMalloc((void**)&dataPointer, size[0] * sizeof(Type)));
 
     return cursor::BufferCursor<Type, 1>(dataPointer, math::Size_t<0>());
 #endif
@@ -98,7 +98,7 @@ HDINLINE
 void DeviceMemAllocator<Type, T_dim>::deallocate(const TCursor& cursor)
 {
 #ifndef __CUDA_ARCH__
-    CUDA_CHECK(cudaFree(cursor.getMarker()));
+    CUDA_CHECK(cuplaFree(cursor.getMarker()));
 #endif
 }
 
@@ -108,7 +108,7 @@ HDINLINE
 void DeviceMemAllocator<Type, 1>::deallocate(const TCursor& cursor)
 {
 #ifndef __CUDA_ARCH__
-    CUDA_CHECK(cudaFree(cursor.getMarker()));
+    CUDA_CHECK(cuplaFree(cursor.getMarker()));
 #endif
 }
 

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -34,7 +34,7 @@ DeviceMemEvenPitch<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
     math::Size_t<T_dim-1> pitch;
 
     if(size.productOfComponents())
-        CUDA_CHECK(cudaMalloc((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
+        CUDA_CHECK(cuplaMalloc((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
 
     if (dim == 2u)
     {
@@ -56,7 +56,7 @@ DeviceMemEvenPitch<Type, 1>::allocate(const math::Size_t<1>& size)
     Type* dataPointer = nullptr;
 
     if(size.productOfComponents())
-        CUDA_CHECK(cudaMalloc((void**)&dataPointer, size[0] * sizeof(Type)));
+        CUDA_CHECK(cuplaMalloc((void**)&dataPointer, size[0] * sizeof(Type)));
 
     return cursor::BufferCursor<Type, 1>(dataPointer, math::Size_t<0>());
 }
@@ -65,14 +65,14 @@ template<typename Type, int T_dim>
 template<typename TCursor>
 void DeviceMemEvenPitch<Type, T_dim>::deallocate(const TCursor& cursor)
 {
-    CUDA_CHECK(cudaFree(cursor.getMarker()));
+    CUDA_CHECK(cuplaFree(cursor.getMarker()));
 }
 
 template<typename Type>
 template<typename TCursor>
 void DeviceMemEvenPitch<Type, 1>::deallocate(const TCursor& cursor)
 {
-    CUDA_CHECK(cudaFree(cursor.getMarker()));
+    CUDA_CHECK(cuplaFree(cursor.getMarker()));
 }
 
 } // allocator

--- a/include/pmacc/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -36,7 +36,7 @@ HostMemAllocator<Type, T_dim>::allocate(const math::Size_t<T_dim>& size)
     math::Size_t<T_dim-1> pitch;
 
     if(size.productOfComponents())
-        CUDA_CHECK(cudaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
+        CUDA_CHECK(cuplaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
     if(dim == 2u)
     {
         pitch[0] = size[0] * sizeof(Type);
@@ -67,7 +67,7 @@ HostMemAllocator<Type, 1>::allocate(const math::Size_t<1>& size)
     math::Size_t<0> pitch;
 
     if(size.productOfComponents())
-        CUDA_CHECK(cudaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
+        CUDA_CHECK(cuplaMallocHost((void**)&dataPointer, sizeof(Type) * size.productOfComponents()));
 
     return cursor::BufferCursor<Type, 1>(dataPointer, pitch);
 #endif
@@ -85,7 +85,7 @@ HDINLINE
 void HostMemAllocator<Type, T_dim>::deallocate(const TCursor& cursor)
 {
 #ifndef __CUDA_ARCH__
-    CUDA_CHECK(cudaFreeHost(cursor.getMarker()));
+    CUDA_CHECK(cuplaFreeHost(cursor.getMarker()));
 #endif
 }
 
@@ -95,7 +95,7 @@ HDINLINE
 void HostMemAllocator<Type, 1>::deallocate(const TCursor& cursor)
 {
 #ifndef __CUDA_ARCH__
-    CUDA_CHECK(cudaFreeHost(cursor.getMarker()));
+    CUDA_CHECK(cuplaFreeHost(cursor.getMarker()));
 #endif
 }
 

--- a/include/pmacc/cuSTL/container/compile-time/SharedBuffer.hpp
+++ b/include/pmacc/cuSTL/container/compile-time/SharedBuffer.hpp
@@ -31,7 +31,7 @@ namespace container
 namespace CT
 {
 
-/* typedef version of container::CT::CartBuffer for shared mem on a GPU inside a cuda kernel.
+/* typedef version of container::CT::CartBuffer for shared mem on a GPU inside a cupla kernel.
  * \param uid If two containers in one kernel have the same Type and Size,
  * uid has to be different. This is due to a nvcc bug.
  */

--- a/include/pmacc/cuSTL/container/copier/D2DCopier.hpp
+++ b/include/pmacc/cuSTL/container/copier/D2DCopier.hpp
@@ -62,8 +62,8 @@ struct D2DCopier
             destCursor[i] = srcCursor[i];
         }
 #else
-        cudaWrapper::Memcopy<dim>()(dest, pitchDest, source, pitchSource,
-                                    size, cudaWrapper::flags::Memcopy::deviceToDevice);
+        cuplaWrapper::Memcopy<dim>()(dest, pitchDest, source, pitchSource,
+                                    size, cuplaWrapper::flags::Memcopy::deviceToDevice);
 #endif
     }
 };

--- a/include/pmacc/cuSTL/container/copier/H2HCopier.hpp
+++ b/include/pmacc/cuSTL/container/copier/H2HCopier.hpp
@@ -41,8 +41,8 @@ struct H2HCopier
          Type* source, const math::Size_t<dim-1>& pitchSource,
          const math::Size_t<dim>& size)
     {
-        cudaWrapper::Memcopy<dim>()(dest, pitchDest, source, pitchSource,
-                                    size, cudaWrapper::flags::Memcopy::hostToHost);
+        cuplaWrapper::Memcopy<dim>()(dest, pitchDest, source, pitchSource,
+                                    size, cuplaWrapper::flags::Memcopy::hostToHost);
     }
 };
 

--- a/include/pmacc/cuSTL/container/copier/Memcopy.hpp
+++ b/include/pmacc/cuSTL/container/copier/Memcopy.hpp
@@ -26,7 +26,7 @@
 
 namespace pmacc
 {
-namespace cudaWrapper
+namespace cuplaWrapper
 {
 
 namespace flags
@@ -48,9 +48,9 @@ struct Memcopy<1>
                     const Type* source, const math::Size_t<0>, const math::Size_t<1>& size,
                     flags::Memcopy::Direction direction)
     {
-            const cudaMemcpyKind kind[] = {cudaMemcpyHostToDevice, cudaMemcpyDeviceToHost,
-                                     cudaMemcpyHostToHost, cudaMemcpyDeviceToDevice};
-            CUDA_CHECK(cudaMemcpy(dest, source, sizeof(Type) * size.x(), kind[direction]));
+            const cuplaMemcpyKind kind[] = {cuplaMemcpyHostToDevice, cuplaMemcpyDeviceToHost,
+                                     cuplaMemcpyHostToHost, cuplaMemcpyDeviceToDevice};
+            CUDA_CHECK(cuplaMemcpy(dest, source, sizeof(Type) * size.x(), kind[direction]));
     }
 };
 
@@ -62,10 +62,10 @@ struct Memcopy<2u>
                     const Type* source, const math::Size_t<1> pitchSource, const math::Size_t<2u>& size,
                     flags::Memcopy::Direction direction)
     {
-            const cudaMemcpyKind kind[] = {cudaMemcpyHostToDevice, cudaMemcpyDeviceToHost,
-                                     cudaMemcpyHostToHost, cudaMemcpyDeviceToDevice};
+            const cuplaMemcpyKind kind[] = {cuplaMemcpyHostToDevice, cuplaMemcpyDeviceToHost,
+                                     cuplaMemcpyHostToHost, cuplaMemcpyDeviceToDevice};
 
-            CUDA_CHECK(cudaMemcpy2D(dest, pitchDest.x(), source, pitchSource.x(), sizeof(Type) * size.x(), size.y(),
+            CUDA_CHECK(cuplaMemcpy2D(dest, pitchDest.x(), source, pitchSource.x(), sizeof(Type) * size.x(), size.y(),
                          kind[direction]));
     }
 };
@@ -78,30 +78,30 @@ struct Memcopy<3>
                     Type* source, const math::Size_t<2u> pitchSource, const math::Size_t<3>& size,
                     flags::Memcopy::Direction direction)
     {
-            const cudaMemcpyKind kind[] = {cudaMemcpyHostToDevice, cudaMemcpyDeviceToHost,
-                                     cudaMemcpyHostToHost, cudaMemcpyDeviceToDevice};
+            const cuplaMemcpyKind kind[] = {cuplaMemcpyHostToDevice, cuplaMemcpyDeviceToHost,
+                                     cuplaMemcpyHostToHost, cuplaMemcpyDeviceToDevice};
 
-            cudaPitchedPtr pitchedPtrDest;
+            cuplaPitchedPtr pitchedPtrDest;
             pitchedPtrDest.pitch = pitchDest.x(); pitchedPtrDest.ptr = dest;
             pitchedPtrDest.xsize = size.x() * sizeof (Type);
             pitchedPtrDest.ysize = size.y();
-            cudaPitchedPtr pitchedPtrSource;
+            cuplaPitchedPtr pitchedPtrSource;
             pitchedPtrSource.pitch = pitchSource.x(); pitchedPtrSource.ptr = source;
             pitchedPtrSource.xsize = size.x() * sizeof (Type);
             pitchedPtrSource.ysize = size.y();
 
-            cudaMemcpy3DParms params;
+            cuplaMemcpy3DParms params;
             params.srcArray = nullptr;
-            params.srcPos = make_cudaPos(0,0,0);
+            params.srcPos = make_cuplaPos(0,0,0);
             params.srcPtr = pitchedPtrSource;
             params.dstArray = nullptr;
-            params.dstPos = make_cudaPos(0,0,0);
+            params.dstPos = make_cuplaPos(0,0,0);
             params.dstPtr = pitchedPtrDest;
-            params.extent = make_cudaExtent(size.x() * sizeof(Type), size.y(), size.z());
+            params.extent = make_cuplaExtent(size.x() * sizeof(Type), size.y(), size.z());
             params.kind = kind[direction];
-            CUDA_CHECK(cudaMemcpy3D(&params));
+            CUDA_CHECK(cuplaMemcpy3D(&params));
     }
 };
 
-} // cudaWrapper
+} // cuplaWrapper
 } // pmacc

--- a/include/pmacc/cuplaHelper/ValidateCall.hpp
+++ b/include/pmacc/cuplaHelper/ValidateCall.hpp
@@ -31,27 +31,27 @@ namespace pmacc
 {
 
 /**
- * Print a cuda error message including file/line info to stderr
+ * Print a cupla error message including file/line info to stderr
  */
-#define PMACC_PRINT_CUDA_ERROR(msg) \
-    std::cerr << "[CUDA] Error: <" << __FILE__ << ">:" << __LINE__ << " " << msg << std::endl
+#define PMACC_PRINT_CUPLA_ERROR(msg) \
+    std::cerr << "[cupla] Error: <" << __FILE__ << ">:" << __LINE__ << " " << msg << std::endl
 
 /**
- * Print a cuda error message including file/line info to stderr and raises an exception
+ * Print a cupla error message including file/line info to stderr and raises an exception
  */
-#define PMACC_PRINT_CUDA_ERROR_AND_THROW(cudaError, msg) \
-    PMACC_PRINT_CUDA_ERROR(msg);                         \
-    throw std::runtime_error(std::string("[CUDA] Error: ") + std::string(cudaGetErrorString(cudaError)))
+#define PMACC_PRINT_CUPLA_ERROR_AND_THROW(cuplaError, msg) \
+    PMACC_PRINT_CUPLA_ERROR(msg);                         \
+    throw std::runtime_error(std::string("[cupla] Error: ") + std::string(cuplaGetErrorString(cuplaError)))
 
 /**
  * Captures CUDA errors and prints messages to stdout, including line number and file.
  *
- * @param cmd command with cudaError_t return value to check
+ * @param cmd command with cuplaError_t return value to check
  */
-#define CUDA_CHECK(cmd) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR_AND_THROW(error, ""); }}
+#define CUDA_CHECK(cmd) {cuplaError_t error = cmd; if(error!=cuplaSuccess){ PMACC_PRINT_CUPLA_ERROR_AND_THROW(error, ""); }}
 
-#define CUDA_CHECK_MSG(cmd,msg) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR_AND_THROW(error, msg); }}
+#define CUDA_CHECK_MSG(cmd,msg) {cuplaError_t error = cmd; if(error!=cuplaSuccess){ PMACC_PRINT_CUPLA_ERROR_AND_THROW(error, msg); }}
 
-#define CUDA_CHECK_NO_EXCEPT(cmd) {cudaError_t error = cmd; if(error!=cudaSuccess){ PMACC_PRINT_CUDA_ERROR(""); }}
+#define CUDA_CHECK_NO_EXCEPT(cmd) {cuplaError_t error = cmd; if(error!=cuplaSuccess){ PMACC_PRINT_CUPLA_ERROR(""); }}
 
 } // namespace pmacc

--- a/include/pmacc/cuplaHelper/ValidateCall.hpp
+++ b/include/pmacc/cuplaHelper/ValidateCall.hpp
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <cuda_to_cupla.hpp>
+#include <cupla.hpp>
 #include <iostream>
 #include <stdexcept>
 

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -60,7 +60,7 @@ namespace pmacc
          * constructor.
          * Sets size of all dimensions from cuda dim3.
          */
-        HDINLINE explicit DataSpace(dim3 value)
+        HDINLINE explicit DataSpace(cupla::dim3 value)
         {
             for (uint32_t i = 0; i < T_Dim; ++i)
             {
@@ -70,9 +70,9 @@ namespace pmacc
 
         /**
          * constructor.
-         * Sets size of all dimensions from cuda uint3 (e.g. threadIdx/blockIdx)
+         * Sets size of all dimensions from cupla uint3 (e.g. threadIdx/blockIdx)
          */
-        HDINLINE explicit DataSpace(uint3 value)
+        HDINLINE DataSpace(cupla::uint3 value)
         {
             for (uint32_t i = 0; i < T_Dim; ++i)
             {
@@ -176,7 +176,7 @@ namespace pmacc
             return result;
         }
 
-        HDINLINE explicit operator dim3() const
+        HDINLINE operator cupla::dim3() const
         {
             return this->toDim3();
         }

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -70,7 +70,7 @@ namespace pmacc
 
         /**
          * constructor.
-         * Sets size of all dimensions from cupla uint3 (e.g. threadIdx/blockIdx)
+         * Sets size of all dimensions from cupla uint3 (e.g. cupla::threadIdx(acc)/cupla::blockIdx(acc))
          */
         HDINLINE DataSpace(cupla::uint3 value)
         {

--- a/include/pmacc/eventSystem/Manager.tpp
+++ b/include/pmacc/eventSystem/Manager.tpp
@@ -38,9 +38,9 @@ namespace pmacc
 
 inline Manager::~Manager( )
 {
-    CUDA_CHECK_NO_EXCEPT(cudaGetLastError( ));
+    CUDA_CHECK_NO_EXCEPT(cuplaGetLastError( ));
     waitForAllTasks( );
-    CUDA_CHECK_NO_EXCEPT(cudaGetLastError( ));
+    CUDA_CHECK_NO_EXCEPT(cuplaGetLastError( ));
 }
 
 inline bool Manager::execute( id_t taskToWait )

--- a/include/pmacc/eventSystem/events/CudaEvent.def
+++ b/include/pmacc/eventSystem/events/CudaEvent.def
@@ -29,7 +29,7 @@
 namespace pmacc
 {
 
-/** Wrapper for cudaEvent_t
+/** Wrapper for cuplaEvent_t
  *
  * This class follows the RAII rules
  */
@@ -37,18 +37,18 @@ class CudaEvent
 {
 private:
 
-    /** native cuda event */
-    cudaEvent_t event;
-    /** native cuda stream where the event is recorded
+    /** native cupla event */
+    cuplaEvent_t event;
+    /** native cupla stream where the event is recorded
      *
      *  only valid if isRecorded is true
      */
-    cudaStream_t stream;
+    cuplaStream_t stream;
     /** state if event is recorded */
     bool isRecorded;
     /** state if a recorded event is finished
      *
-     * avoid cuda driver calls after `isFinished()` returns the first time true
+     * avoid cupla driver calls after `isFinished()` returns the first time true
      */
     bool finished;
 
@@ -60,7 +60,7 @@ public:
 
     /** Constructor
      *
-     * if called before the cuda device is initialized the behavior is undefined
+     * if called before the cupla device is initialized the behavior is undefined
      */
     HINLINE CudaEvent( );
 
@@ -73,20 +73,20 @@ public:
     /** free a registered handle */
     HINLINE void releaseHandle( );
 
-    /** get native cudaEvent_t object
+    /** get native cuplaEvent_t object
      *
-     * @return native cuda event
+     * @return native cupla event
      */
-    cudaEvent_t operator*( ) const
+    cuplaEvent_t operator*( ) const
     {
         return event;
     }
 
     /** get stream in which this event is recorded
      *
-     * @return native cuda stream
+     * @return native cupla stream
      */
-    cudaStream_t getStream( ) const
+    cuplaStream_t getStream( ) const
     {
         assert( isRecorded );
         return stream;
@@ -100,9 +100,9 @@ public:
 
     /** record event in a device stream
      *
-     * @param stream native cuda stream
+     * @param stream native cupla stream
      */
-    HINLINE void recordEvent( cudaStream_t stream );
+    HINLINE void recordEvent( cuplaStream_t stream );
 
 };
 }

--- a/include/pmacc/eventSystem/events/CudaEvent.hpp
+++ b/include/pmacc/eventSystem/events/CudaEvent.hpp
@@ -33,7 +33,7 @@ namespace pmacc
     CudaEvent::CudaEvent( ) : isRecorded( false ), finished( true ), refCounter( 0u )
     {
         log( ggLog::CUDA_RT()+ggLog::EVENT(), "create event" );
-        CUDA_CHECK( cudaEventCreateWithFlags( &event, cudaEventDisableTiming ) );
+        CUDA_CHECK( cuplaEventCreateWithFlags( &event, cuplaEventDisableTiming ) );
     }
 
 
@@ -41,9 +41,9 @@ namespace pmacc
     {
         PMACC_ASSERT( refCounter == 0u );
         log( ggLog::CUDA_RT()+ggLog::EVENT(), "sync and delete event" );
-        // free cuda event
-        CUDA_CHECK_NO_EXCEPT(cudaEventSynchronize( event ));
-        CUDA_CHECK_NO_EXCEPT(cudaEventDestroy( event ));
+        // free cupla event
+        CUDA_CHECK_NO_EXCEPT(cuplaEventSynchronize( event ));
+        CUDA_CHECK_NO_EXCEPT(cuplaEventDestroy( event ));
 
     }
 
@@ -70,33 +70,33 @@ namespace pmacc
 
     bool CudaEvent::isFinished()
     {
-        // avoid cuda driver calls if event is already finished
+        // avoid cupla driver calls if event is already finished
         if( finished )
             return true;
         assert( isRecorded );
 
-        cudaError_t rc = cudaEventQuery(event);
+        cuplaError_t rc = cuplaEventQuery(event);
 
-        if(rc == cudaSuccess)
+        if(rc == cuplaSuccess)
         {
             finished = true;
             return true;
         }
-        else if(rc == cudaErrorNotReady)
+        else if(rc == cuplaErrorNotReady)
             return false;
         else
-            PMACC_PRINT_CUDA_ERROR_AND_THROW(rc, "Event query failed");
+            PMACC_PRINT_CUPLA_ERROR_AND_THROW(rc, "Event query failed");
     }
 
 
-    void CudaEvent::recordEvent(cudaStream_t stream)
+    void CudaEvent::recordEvent(cuplaStream_t stream)
     {
         /* disallow double recording */
         assert(isRecorded == false);
         isRecorded = true;
         finished = false;
         this->stream = stream;
-        CUDA_CHECK(cudaEventRecord(event, stream));
+        CUDA_CHECK(cuplaEventRecord(event, stream));
     }
 
 } // namepsace pmacc

--- a/include/pmacc/eventSystem/events/CudaEventHandle.hpp
+++ b/include/pmacc/eventSystem/events/CudaEventHandle.hpp
@@ -90,11 +90,11 @@ public:
     }
 
     /**
-     * get native cuda event
+     * get native cupla event
      *
-     * @return native cuda event
+     * @return native cupla event
      */
-    cudaEvent_t operator*( ) const
+    cuplaEvent_t operator*( ) const
     {
         assert( event );
         return **event;
@@ -113,9 +113,9 @@ public:
 
     /** get stream in which this event is recorded
      *
-     * @return native cuda stream
+     * @return native cupla stream
      */
-    cudaStream_t getStream( ) const
+    cuplaStream_t getStream( ) const
     {
         PMACC_ASSERT( event );
         return event->getStream( );
@@ -123,9 +123,9 @@ public:
 
     /** record event in a device stream
      *
-     * @param stream native cuda stream
+     * @param stream native cupla stream
      */
-    void recordEvent( cudaStream_t stream )
+    void recordEvent( cuplaStream_t stream )
     {
         PMACC_ASSERT( event );
         event->recordEvent( stream );

--- a/include/pmacc/eventSystem/events/EventPool.hpp
+++ b/include/pmacc/eventSystem/events/EventPool.hpp
@@ -34,14 +34,14 @@
 namespace pmacc
 {
 
-    /** Manages a pool of cudaEvent_t objects and gives access to them. */
+    /** Manages a pool of cuplaEvent_t objects and gives access to them. */
     class EventPool
     {
     public:
 
-        /** Returns a free cuda event
+        /** Returns a free cupla event
          *
-         * @return free cuda event
+         * @return free cupla event
          */
         CudaEventHandle pop( )
         {
@@ -71,9 +71,9 @@ namespace pmacc
                 freeEvents.push_back( CudaEventHandle(ev) );
         }
 
-        /** create and add cuda events to the pool
+        /** create and add cupla events to the pool
          *
-         * @param count number of cuda events to add
+         * @param count number of cupla events to add
          */
         void createEvents( size_t count = 1u )
         {
@@ -85,9 +85,9 @@ namespace pmacc
             }
         }
 
-        /** Returns the number of cuda events in the pool.
+        /** Returns the number of cupla events in the pool.
          *
-         * @return number of cuda events
+         * @return number of cupla events
          */
         size_t getEventsCount( )
         {
@@ -111,7 +111,7 @@ namespace pmacc
 
         /** Destructor
          *
-         * destroys all cuda events in the pool
+         * destroys all cupla events in the pool
          */
         ~EventPool()
         {

--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -55,8 +55,8 @@ namespace exec
      * this objects contains the functor and the starting parameter
      *
      * @tparam T_Kernel pmacc Kernel object
-     * @tparam T_VectorGrid type which defines the grid extents (type must be castable to CUDA dim3)
-     * @tparam T_VectorBlock type which defines the block extents (type must be castable to CUDA dim3)
+     * @tparam T_VectorGrid type which defines the grid extents (type must be castable to cupla dim3)
+     * @tparam T_VectorBlock type which defines the block extents (type must be castable to cupla dim3)
      */
     template<
         typename T_Kernel,
@@ -103,8 +103,8 @@ namespace exec
          *
          * this objects contains the functor and the starting parameter
          *
-         * @tparam T_VectorGrid type which defines the grid extents (type must be castable to CUDA dim3)
-         * @tparam T_VectorBlock type which defines the block extents (type must be castable to CUDA dim3)
+         * @tparam T_VectorGrid type which defines the grid extents (type must be castable to cupla dim3)
+         * @tparam T_VectorBlock type which defines the block extents (type must be castable to cupla dim3)
          *
          * @param gridExtent grid extent configuration for the kernel
          * @param blockExtent block extent configuration for the kernel
@@ -186,7 +186,7 @@ namespace exec
                 std::to_string( m_kernel.m_line ) + std::string( " ]" );
 
             CUDA_CHECK_KERNEL_MSG(
-                cudaDeviceSynchronize( ),
+                cuplaDeviceSynchronize( ),
                 std::string( "Crash before kernel call " ) + kernelInfo
             );
 
@@ -215,16 +215,16 @@ namespace exec
                 args ...
             );
             CUDA_CHECK_KERNEL_MSG(
-                cudaGetLastError( ),
+                cuplaGetLastError( ),
                 std::string( "Last error after kernel launch " ) + kernelInfo
             );
             CUDA_CHECK_KERNEL_MSG(
-                cudaDeviceSynchronize( ),
+                cuplaDeviceSynchronize( ),
                 std::string( "Crash after kernel launch " ) + kernelInfo
             );
             taskKernel->activateChecks( );
             CUDA_CHECK_KERNEL_MSG(
-                cudaDeviceSynchronize( ),
+                cuplaDeviceSynchronize( ),
                 std::string(  "Crash after kernel activation" ) + kernelInfo
             );
         }

--- a/include/pmacc/eventSystem/streams/EventStream.hpp
+++ b/include/pmacc/eventSystem/streams/EventStream.hpp
@@ -30,8 +30,8 @@ namespace pmacc
 {
 
 /**
- * Wrapper for a single cuda stream.
- * Allows recording cuda events on the stream.
+ * Wrapper for a single cupla stream.
+ * Allows recording cupla events on the stream.
  */
 class EventStream
 {
@@ -39,11 +39,11 @@ public:
 
     /**
      * Constructor.
-     * Creates the cudaStream_t object.
+     * Creates the cuplaStream_t object.
      */
     EventStream() : stream(nullptr)
     {
-        CUDA_CHECK(cudaStreamCreate(&stream));
+        CUDA_CHECK(cuplaStreamCreate(&stream));
     }
 
     /**
@@ -53,15 +53,15 @@ public:
     virtual ~EventStream()
     {
         // wait for all kernels in stream to finish
-        CUDA_CHECK_NO_EXCEPT(cudaStreamSynchronize(stream));
-        CUDA_CHECK_NO_EXCEPT(cudaStreamDestroy(stream));
+        CUDA_CHECK_NO_EXCEPT(cuplaStreamSynchronize(stream));
+        CUDA_CHECK_NO_EXCEPT(cuplaStreamDestroy(stream));
     }
 
     /**
-     * Returns the cudaStream_t object associated with this EventStream.
-     * @return the internal cuda stream object
+     * Returns the cuplaStream_t object associated with this EventStream.
+     * @return the internal cupla stream object
      */
-    cudaStream_t getCudaStream() const
+    cuplaStream_t getCudaStream() const
     {
         return stream;
     }
@@ -70,12 +70,12 @@ public:
     {
         if (this->stream != ev.getStream())
         {
-            CUDA_CHECK(cudaStreamWaitEvent(this->getCudaStream(), *ev, 0));
+            CUDA_CHECK(cuplaStreamWaitEvent(this->getCudaStream(), *ev, 0));
         }
     }
 
 private:
-    cudaStream_t stream;
+    cuplaStream_t stream;
 };
 
 }

--- a/include/pmacc/eventSystem/streams/StreamController.hpp
+++ b/include/pmacc/eventSystem/streams/StreamController.hpp
@@ -74,8 +74,8 @@ namespace pmacc
 
             /* This is the single point in PIC where ALL CUDA work must be finished. */
             /* Accessing CUDA objects after this point may fail! */
-            CUDA_CHECK_NO_EXCEPT(cudaDeviceSynchronize());
-            CUDA_CHECK_NO_EXCEPT(cudaDeviceReset());
+            CUDA_CHECK_NO_EXCEPT(cuplaDeviceSynchronize());
+            CUDA_CHECK_NO_EXCEPT(cuplaDeviceReset());
         }
 
         /**

--- a/include/pmacc/eventSystem/tasks/ITask.hpp
+++ b/include/pmacc/eventSystem/tasks/ITask.hpp
@@ -42,7 +42,7 @@ namespace pmacc
 
         enum TaskType
         {
-            TASK_UNKNOWN, TASK_CUDA, TASK_MPI, TASK_HOST
+            TASK_UNKNOWN, TASK_DEVICE, TASK_MPI, TASK_HOST
         };
 
         /**

--- a/include/pmacc/eventSystem/tasks/StreamTask.hpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.hpp
@@ -29,7 +29,7 @@ namespace pmacc
     class EventStream;
 
     /**
-     * Abstract base class for all tasks which depend on cuda streams.
+     * Abstract base class for all tasks which depend on cupla streams.
      */
     class StreamTask : public ITask
     {
@@ -50,19 +50,19 @@ namespace pmacc
         }
 
         /**
-         * Returns the cuda event associated with this task.
+         * Returns the cupla event associated with this task.
          * An event has to be recorded or set before calling this.
          *
-         * @return the task's cuda event
+         * @return the task's cupla event
          */
         CudaEventHandle getCudaEventHandle() const;
 
         /**
          * Sets the
          *
-         * @param cudaEvent
+         * @param cuplaEvent
          */
-        void setCudaEventHandle(const CudaEventHandle& cudaEvent);
+        void setCudaEventHandle(const CudaEventHandle& cuplaEvent);
 
         /**
          * Returns if this task is finished.
@@ -86,11 +86,11 @@ namespace pmacc
         void setEventStream(EventStream* newStream);
 
         /**
-         * Returns the cuda stream of the underlying EventStream.
+         * Returns the cupla stream of the underlying EventStream.
          *
-         * @return the associated cuda stream
+         * @return the associated cupla stream
          */
-        cudaStream_t getCudaStream();
+        cuplaStream_t getCudaStream();
 
 
     protected:
@@ -102,7 +102,7 @@ namespace pmacc
 
 
         EventStream *stream;
-        CudaEventHandle cudaEvent;
+        CudaEventHandle cuplaEvent;
         bool hasCudaEventHandle;
         bool alwaysFinished;
     };

--- a/include/pmacc/eventSystem/tasks/StreamTask.tpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.tpp
@@ -36,7 +36,7 @@ stream( nullptr ),
 hasCudaEventHandle( false ),
 alwaysFinished( false )
 {
-    this->setTaskType( ITask::TASK_CUDA );
+    this->setTaskType( ITask::TASK_DEVICE );
 }
 
 inline CudaEventHandle StreamTask::getCudaEventHandle( ) const
@@ -69,7 +69,7 @@ inline bool StreamTask::isFinished( )
 inline EventStream* StreamTask::getEventStream( )
 {
     if ( stream == nullptr )
-        stream = __getEventStream( TASK_CUDA );
+        stream = __getEventStream( TASK_DEVICE );
     return stream;
 }
 
@@ -83,7 +83,7 @@ inline void StreamTask::setEventStream( EventStream* newStream )
 inline cuplaStream_t StreamTask::getCudaStream( )
 {
     if ( stream == nullptr )
-        stream = Environment<>::get( ).TransactionManager( ).getEventStream( TASK_CUDA );
+        stream = Environment<>::get( ).TransactionManager( ).getEventStream( TASK_DEVICE );
     return stream->getCudaStream( );
 }
 

--- a/include/pmacc/eventSystem/tasks/StreamTask.tpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.tpp
@@ -42,13 +42,13 @@ alwaysFinished( false )
 inline CudaEventHandle StreamTask::getCudaEventHandle( ) const
 {
     PMACC_ASSERT( hasCudaEventHandle );
-    return cudaEvent;
+    return cuplaEvent;
 }
 
-inline void StreamTask::setCudaEventHandle(const CudaEventHandle& cudaEvent )
+inline void StreamTask::setCudaEventHandle(const CudaEventHandle& cuplaEvent )
 {
     this->hasCudaEventHandle = true;
-    this->cudaEvent = cudaEvent;
+    this->cuplaEvent = cuplaEvent;
 }
 
 inline bool StreamTask::isFinished( )
@@ -57,7 +57,7 @@ inline bool StreamTask::isFinished( )
         return true;
     if ( hasCudaEventHandle )
     {
-        if ( cudaEvent.isFinished( ) )
+        if ( cuplaEvent.isFinished( ) )
         {
             alwaysFinished = true;
             return true;
@@ -80,7 +80,7 @@ inline void StreamTask::setEventStream( EventStream* newStream )
     this->stream = newStream;
 }
 
-inline cudaStream_t StreamTask::getCudaStream( )
+inline cuplaStream_t StreamTask::getCudaStream( )
 {
     if ( stream == nullptr )
         stream = Environment<>::get( ).TransactionManager( ).getEventStream( TASK_CUDA );
@@ -89,8 +89,8 @@ inline cudaStream_t StreamTask::getCudaStream( )
 
 inline void StreamTask::activate( )
 {
-    cudaEvent = Environment<>::get().EventPool( ).pop( );
-    cudaEvent.recordEvent( getCudaStream( ) );
+    cuplaEvent = Environment<>::get().EventPool( ).pop( );
+    cuplaEvent.recordEvent( getCudaStream( ) );
     hasCudaEventHandle = true;
 }
 

--- a/include/pmacc/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
@@ -86,9 +86,9 @@ namespace pmacc
 
         void fastCopy(TYPE* src, TYPE* dst, size_t size)
         {
-            CUDA_CHECK(cudaMemcpyAsync(dst,
+            CUDA_CHECK(cuplaMemcpyAsync(dst,
                                        src,
-                                       size * sizeof (TYPE), cudaMemcpyDeviceToDevice,
+                                       size * sizeof (TYPE), cuplaMemcpyDeviceToDevice,
                                        this->getCudaStream()));
         }
 
@@ -115,9 +115,9 @@ namespace pmacc
         virtual void copy(DataSpace<DIM1> &devCurrentSize)
         {
 
-            CUDA_CHECK(cudaMemcpyAsync(this->destination->getPointer(),
+            CUDA_CHECK(cuplaMemcpyAsync(this->destination->getPointer(),
                                        this->source->getPointer(),
-                                       devCurrentSize[0] * sizeof (TYPE), cudaMemcpyDeviceToDevice,
+                                       devCurrentSize[0] * sizeof (TYPE), cuplaMemcpyDeviceToDevice,
                                        this->getCudaStream()));
         }
 
@@ -137,13 +137,13 @@ namespace pmacc
 
         virtual void copy(DataSpace<DIM2> &devCurrentSize)
         {
-            CUDA_CHECK(cudaMemcpy2DAsync(this->destination->getPointer(),
+            CUDA_CHECK(cuplaMemcpy2DAsync(this->destination->getPointer(),
                                          this->destination->getPitch(),
                                          this->source->getPointer(),
                                          this->source->getPitch(),
                                          devCurrentSize[0] * sizeof (TYPE),
                                          devCurrentSize[1],
-                                         cudaMemcpyDeviceToDevice,
+                                         cuplaMemcpyDeviceToDevice,
                                          this->getCudaStream()));
 
         }
@@ -165,28 +165,28 @@ namespace pmacc
         virtual void copy(DataSpace<DIM3> &devCurrentSize)
         {
 
-            cudaMemcpy3DParms params;
+            cuplaMemcpy3DParms params;
             params.srcArray = nullptr;
-            params.srcPos = make_cudaPos(
+            params.srcPos = make_cuplaPos(
                                          this->source->getOffset()[0] * sizeof (TYPE),
                                          this->source->getOffset()[1],
                                          this->source->getOffset()[2]);
             params.srcPtr = this->source->getCudaPitched();
 
             params.dstArray = nullptr;
-            params.dstPos = make_cudaPos(
+            params.dstPos = make_cuplaPos(
                                          this->destination->getOffset()[0] * sizeof (TYPE),
                                          this->destination->getOffset()[1],
                                          this->destination->getOffset()[2]);
             ;
             params.dstPtr = this->destination->getCudaPitched();
 
-            params.extent = make_cudaExtent(
+            params.extent = make_cuplaExtent(
                                             devCurrentSize[0] * sizeof (TYPE),
                                             devCurrentSize[1],
                                             devCurrentSize[2]);
-            params.kind = cudaMemcpyDeviceToDevice;
-            CUDA_CHECK(cudaMemcpy3DAsync(&params, this->getCudaStream()));
+            params.kind = cuplaMemcpyDeviceToDevice;
+            CUDA_CHECK(cuplaMemcpy3DAsync(&params, this->getCudaStream()));
         }
 
     };

--- a/include/pmacc/eventSystem/tasks/TaskCopyDeviceToHost.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyDeviceToHost.hpp
@@ -88,10 +88,10 @@ namespace pmacc
 
         void fastCopy(TYPE* src,TYPE* dst,  size_t size)
         {
-            CUDA_CHECK(cudaMemcpyAsync(dst,
+            CUDA_CHECK(cuplaMemcpyAsync(dst,
                                        src,
                                        size * sizeof (TYPE),
-                                       cudaMemcpyDeviceToHost,
+                                       cuplaMemcpyDeviceToHost,
                                        this->getCudaStream()));
         }
 
@@ -117,10 +117,10 @@ namespace pmacc
         virtual void copy(DataSpace<DIM1> &devCurrentSize)
         {
 
-            CUDA_CHECK(cudaMemcpyAsync(this->host->getBasePointer(),
+            CUDA_CHECK(cuplaMemcpyAsync(this->host->getBasePointer(),
                                        this->device->getPointer(),
                                        devCurrentSize[0] * sizeof (TYPE),
-                                       cudaMemcpyDeviceToHost,
+                                       cuplaMemcpyDeviceToHost,
                                        this->getCudaStream()));
 
         }
@@ -141,13 +141,13 @@ namespace pmacc
 
         virtual void copy(DataSpace<DIM2> &devCurrentSize)
         {
-            CUDA_CHECK(cudaMemcpy2DAsync(this->host->getBasePointer(),
+            CUDA_CHECK(cuplaMemcpy2DAsync(this->host->getBasePointer(),
                                          this->host->getDataSpace()[0] * sizeof (TYPE), /*this is pitch*/
                                          this->device->getPointer(),
                                          this->device->getPitch(), /*this is pitch*/
                                          devCurrentSize[0] * sizeof (TYPE),
                                          devCurrentSize[1],
-                                         cudaMemcpyDeviceToHost,
+                                         cuplaMemcpyDeviceToHost,
                                          this->getCudaStream()));
 
         }
@@ -168,30 +168,30 @@ namespace pmacc
 
         virtual void copy(DataSpace<DIM3> &devCurrentSize)
         {
-            cudaPitchedPtr hostPtr;
+            cuplaPitchedPtr hostPtr;
             hostPtr.pitch = this->host->getDataSpace()[0] * sizeof (TYPE);
             hostPtr.ptr = this->host->getBasePointer();
             hostPtr.xsize = this->host->getDataSpace()[0] * sizeof (TYPE);
             hostPtr.ysize = this->host->getDataSpace()[1];
 
-            cudaMemcpy3DParms params;
+            cuplaMemcpy3DParms params;
             params.srcArray = nullptr;
-            params.srcPos = make_cudaPos(this->device->getOffset()[0] * sizeof (TYPE),
+            params.srcPos = make_cuplaPos(this->device->getOffset()[0] * sizeof (TYPE),
                                          this->device->getOffset()[1],
                                          this->device->getOffset()[2]);
             params.srcPtr = this->device->getCudaPitched();
 
             params.dstArray = nullptr;
-            params.dstPos = make_cudaPos(0, 0, 0);
+            params.dstPos = make_cuplaPos(0, 0, 0);
             params.dstPtr = hostPtr;
 
-            params.extent = make_cudaExtent(
+            params.extent = make_cuplaExtent(
                                             devCurrentSize[0] * sizeof (TYPE),
                                             devCurrentSize[1],
                                             devCurrentSize[2]);
-            params.kind = cudaMemcpyDeviceToHost;
+            params.kind = cuplaMemcpyDeviceToHost;
 
-            CUDA_CHECK(cudaMemcpy3DAsync(&params, this->getCudaStream()));
+            CUDA_CHECK(cuplaMemcpy3DAsync(&params, this->getCudaStream()));
 
         }
 

--- a/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -65,10 +65,10 @@ public:
 
     virtual void init()
     {
-        CUDA_CHECK(cudaMemcpyAsync((void*) buffer->getCurrentSizeHostSidePointer(),
+        CUDA_CHECK(cuplaMemcpyAsync((void*) buffer->getCurrentSizeHostSidePointer(),
                                    buffer->getCurrentSizeOnDevicePointer(),
                                    sizeof (size_t),
-                                   cudaMemcpyDeviceToHost,
+                                   cuplaMemcpyDeviceToHost,
                                    this->getCudaStream()));
         this->activate();
     }

--- a/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -81,10 +81,10 @@ namespace pmacc
                 if(task != nullptr)
                 {
                     ITask::TaskType type = task->getTaskType();
-                    if (type == ITask::TASK_CUDA )
+                    if (type == ITask::TASK_DEVICE )
                     {
                         this->stream = static_cast<StreamTask*>(task)->getEventStream();
-                        this->setTaskType(ITask::TASK_CUDA);
+                        this->setTaskType(ITask::TASK_DEVICE);
                         this->cuplaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
                         this->hasCudaEventHandle = true;
                     }
@@ -98,10 +98,10 @@ namespace pmacc
                 if(task != nullptr)
                 {
                     ITask::TaskType type = task->getTaskType();
-                    if (type == ITask::TASK_CUDA )
+                    if (type == ITask::TASK_DEVICE )
                     {
                         this->stream = static_cast<StreamTask*>(task)->getEventStream();
-                        this->setTaskType(ITask::TASK_CUDA);
+                        this->setTaskType(ITask::TASK_DEVICE);
                         this->cuplaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
                         this->hasCudaEventHandle = true;
                     }
@@ -131,19 +131,19 @@ namespace pmacc
         {
             s1->addObserver(this);
             s2->addObserver(this);
-            if(s1->getTaskType() == ITask::TASK_CUDA && s2->getTaskType() == ITask::TASK_CUDA)
+            if(s1->getTaskType() == ITask::TASK_DEVICE && s2->getTaskType() == ITask::TASK_DEVICE)
             {
-                this->setTaskType(ITask::TASK_CUDA);
+                this->setTaskType(ITask::TASK_DEVICE);
                 this->setEventStream(static_cast<StreamTask*> (s2)->getEventStream());
                 if(static_cast<StreamTask*> (s1)->getEventStream() != static_cast<StreamTask*> (s2)->getEventStream())
                     this->getEventStream()->waitOn(static_cast<StreamTask*> (s1)->getCudaEventHandle());
                 this->activate();
             }
-            else if(s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_CUDA)
+            else if(s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_DEVICE)
             {
                 this->setTaskType(ITask::TASK_MPI);
             }
-            else if(s2->getTaskType() == ITask::TASK_MPI && s1->getTaskType() == ITask::TASK_CUDA)
+            else if(s2->getTaskType() == ITask::TASK_MPI && s1->getTaskType() == ITask::TASK_DEVICE)
             {
                 this->setTaskType(ITask::TASK_MPI);
             }

--- a/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -85,7 +85,7 @@ namespace pmacc
                     {
                         this->stream = static_cast<StreamTask*>(task)->getEventStream();
                         this->setTaskType(ITask::TASK_CUDA);
-                        this->cudaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
+                        this->cuplaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
                         this->hasCudaEventHandle = true;
                     }
                 }
@@ -102,7 +102,7 @@ namespace pmacc
                     {
                         this->stream = static_cast<StreamTask*>(task)->getEventStream();
                         this->setTaskType(ITask::TASK_CUDA);
-                        this->cudaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
+                        this->cuplaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
                         this->hasCudaEventHandle = true;
                     }
                 }

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -124,12 +124,12 @@ struct KernelSetValue
         using namespace mappings::threads;
         using SizeVecType = T_SizeVecType;
 
-        SizeVecType const blockIndex( blockIdx );
+        SizeVecType const blockIndex( cupla::blockIdx(acc) );
         SizeVecType blockSize( SizeVecType::create( 1 ) );
         blockSize.x( ) = T_xChunkSize;
 
         constexpr uint32_t numWorkers = T_numWorkers;
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         ForEachIdx<
             IdxConfig<

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -88,7 +88,7 @@ getValue(T_Type& value)
 /** set a value to all elements of a box
  *
  * @tparam T_numWorkers number of workers
- * @tparam T_xChunkSize number of elements in x direction to prepare with one cuda block
+ * @tparam T_xChunkSize number of elements in x direction to prepare with one cupla block
  */
 template<
     uint32_t T_numWorkers,
@@ -160,7 +160,7 @@ class DeviceBuffer;
  *
  * T_ValueType  = data type (e.g. float, float2)
  * T_dim   = dimension of the GridBuffer
- * T_isSmallValue = true if T_ValueType can be send via kernel parameter (on cuda T_ValueType must be smaller than 256 byte)
+ * T_isSmallValue = true if T_ValueType can be send via kernel parameter (on cupla T_ValueType must be smaller than 256 byte)
  */
 template <class T_ValueType, unsigned T_dim, bool T_isSmallValue>
 class TaskSetValue;
@@ -293,7 +293,7 @@ public:
     {
         if (valuePointer_host != nullptr)
         {
-            CUDA_CHECK_NO_EXCEPT(cudaFreeHost(valuePointer_host));
+            CUDA_CHECK_NO_EXCEPT(cuplaFreeHost(valuePointer_host));
             valuePointer_host = nullptr;
         }
     }
@@ -322,17 +322,17 @@ public:
 
             ValueType* devicePtr = this->destination->getPointer();
 
-            CUDA_CHECK( cudaMallocHost(
+            CUDA_CHECK( cuplaMallocHost(
                 (void**)&valuePointer_host,
                 sizeof( ValueType )
             ));
             *valuePointer_host = this->value; //copy value to new place
 
-            CUDA_CHECK( cudaMemcpyAsync(
+            CUDA_CHECK( cuplaMemcpyAsync(
                 devicePtr,
                 valuePointer_host,
                 sizeof( ValueType ),
-                cudaMemcpyHostToDevice,
+                cuplaMemcpyHostToDevice,
                 this->getCudaStream( )
             ));
 

--- a/include/pmacc/eventSystem/transactions/Transaction.tpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.tpp
@@ -48,14 +48,14 @@ EventTask Transaction::getTransactionEvent( )
 
 void Transaction::operation( ITask::TaskType operation )
 {
-    if ( operation == ITask::TASK_CUDA )
+    if ( operation == ITask::TASK_DEVICE )
     {
         Manager &manager = Environment<>::get( ).Manager( );
 
         ITask* baseTask = manager.getITaskIfNotFinished( this->baseEvent.getTaskId( ) );
         if ( baseTask != nullptr )
         {
-            if ( baseTask->getTaskType( ) == ITask::TASK_CUDA )
+            if ( baseTask->getTaskType( ) == ITask::TASK_DEVICE )
             {
                 /* no blocking is needed */
                 return;
@@ -72,7 +72,7 @@ EventStream* Transaction::getEventStream( ITask::TaskType )
 
     if ( baseTask != nullptr )
     {
-        if ( baseTask->getTaskType( ) == ITask::TASK_CUDA )
+        if ( baseTask->getTaskType( ) == ITask::TASK_DEVICE )
         {
             /* `StreamTask` from previous task must be reused to guarantee
              * that the dependency chain not brake

--- a/include/pmacc/fields/operations/AddExchangeToBorder.hpp
+++ b/include/pmacc/fields/operations/AddExchangeToBorder.hpp
@@ -87,10 +87,10 @@ namespace operations
             constexpr uint32_t numWorkers = T_numWorkers;
             PMACC_CONSTEXPR_CAPTURE int dim = T_Mapping::Dim;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             DataSpace< dim > const blockCell(
-                mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) )
+                mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) )
                     * SuperCellSize::toRT()
             );
 

--- a/include/pmacc/fields/operations/CopyGuardToExchange.hpp
+++ b/include/pmacc/fields/operations/CopyGuardToExchange.hpp
@@ -84,10 +84,10 @@ namespace operations
             constexpr uint32_t numWorkers = T_numWorkers;
             PMACC_CONSTEXPR_CAPTURE int dim = T_Mapping::Dim;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             DataSpace< dim > const blockCell(
-                mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) ) *
+                mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) ) *
                 SuperCellSize::toRT()
             );
 

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -525,9 +525,9 @@ struct Vector : private T_Storage<T_Type, T_dim>, protected T_Accessor, protecte
         return stream.str();
     }
 
-    HDINLINE dim3 toDim3() const
+    HDINLINE cupla::dim3 toDim3() const
     {
-        dim3 result;
+        cupla::dim3 result;
         unsigned int* ptr = &result.x;
         for (int d = 0; d < dim; ++d)
             ptr[d] = (*this)[d];

--- a/include/pmacc/math/vector/compile-time/UInt32.hpp
+++ b/include/pmacc/math/vector/compile-time/UInt32.hpp
@@ -33,7 +33,7 @@ namespace math
 namespace CT
 {
 
-/** Compile time uint vector
+/** Compile time uint32_t vector
  *
  *
  * @tparam x value for x allowed range [0;max uint32_t value -1]

--- a/include/pmacc/math/vector/compile-time/UInt64.hpp
+++ b/include/pmacc/math/vector/compile-time/UInt64.hpp
@@ -33,7 +33,7 @@ namespace math
 namespace CT
 {
 
-/** Compile time uint vector
+/** Compile time uint64_t vector
  *
  *
  * @tparam x value for x allowed range [0;max uint64_t value -1]

--- a/include/pmacc/memory/buffers/Buffer.hpp
+++ b/include/pmacc/memory/buffers/Buffer.hpp
@@ -56,7 +56,7 @@ namespace pmacc
         Buffer(DataSpace<DIM> size, DataSpace<DIM> physicalMemorySize) :
         data_space(size), data1D(true), current_size(nullptr), m_physicalMemorySize(physicalMemorySize)
         {
-            CUDA_CHECK(cudaMallocHost((void**)&current_size, sizeof (size_t)));
+            CUDA_CHECK(cuplaMallocHost((void**)&current_size, sizeof (size_t)));
             *current_size = size.productOfComponents();
         }
 
@@ -65,7 +65,7 @@ namespace pmacc
          */
         virtual ~Buffer()
         {
-            CUDA_CHECK_NO_EXCEPT(cudaFreeHost(current_size));
+            CUDA_CHECK_NO_EXCEPT(cuplaFreeHost(current_size));
         }
 
         /*! Get base pointer to memory

--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -86,13 +86,13 @@ namespace pmacc
                                 assigner::DeviceMemAssigner<> >
         cartBuffer() const
         {
-            cudaPitchedPtr cudaData = this->getCudaPitched();
+            cuplaPitchedPtr cuplaData = this->getCudaPitched();
             math::Size_t<DIM - 1> pitch;
             if(DIM >= 2)
-                pitch[0] = cudaData.pitch;
+                pitch[0] = cuplaData.pitch;
             if(DIM == 3)
                 pitch[1] = pitch[0] * this->getPhysicalMemorySize()[1];
-            container::DeviceBuffer<TYPE, DIM> result((TYPE*)cudaData.ptr, this->getDataSpace(), false, pitch);
+            container::DeviceBuffer<TYPE, DIM> result((TYPE*)cuplaData.ptr, this->getDataSpace(), false, pitch);
             return result;
         }
 
@@ -135,11 +135,11 @@ namespace pmacc
         virtual void setCurrentSize(const size_t size) = 0;
 
         /**
-         * Returns the internal pitched cuda pointer.
+         * Returns the internal pitched cupla pointer.
          *
-         * @return internal pitched cuda pointer
+         * @return internal pitched cupla pointer
          */
-        virtual const cudaPitchedPtr getCudaPitched() const = 0;
+        virtual const cuplaPitchedPtr getCudaPitched() const = 0;
 
         /** get line pitch of memory in byte
          *

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -83,7 +83,7 @@ public:
 
     virtual ~DeviceBufferIntern()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
 
         if (sizeOnDevice)
         {
@@ -100,7 +100,7 @@ public:
     {
         this->setCurrentSize(Buffer<TYPE, DIM>::getDataSpace().productOfComponents());
 
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         if (!preserveData)
         {
             TYPE value;
@@ -117,14 +117,14 @@ public:
 
     DataBoxType getDataBox()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         return DataBoxType(PitchedBox<TYPE, DIM > ((TYPE*) data.ptr, offset,
                                                    this->getPhysicalMemorySize(), data.pitch));
     }
 
     TYPE* getPointer()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
 
         if (DIM == DIM1)
         {
@@ -154,7 +154,7 @@ public:
 
     size_t* getCurrentSizeOnDevicePointer()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         if (!sizeOnDevice)
         {
             throw std::runtime_error("Buffer has no size on device!, currentSize is only stored on host side.");
@@ -170,7 +170,7 @@ public:
 
     TYPE* getBasePointer()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         return (TYPE*) data.ptr;
     }
 
@@ -218,7 +218,7 @@ public:
 
     const cuplaPitchedPtr getCudaPitched() const
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         return data;
     }
 
@@ -238,7 +238,7 @@ private:
      */
     void createData()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         data.ptr = nullptr;
         data.pitch = 1;
         data.xsize = this->getDataSpace()[0] * sizeof (TYPE);
@@ -274,7 +274,7 @@ private:
      */
     void createFakeData()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         data.ptr = nullptr;
         data.pitch = 1;
         data.xsize = this->getDataSpace()[0] * sizeof (TYPE);

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -87,11 +87,11 @@ public:
 
         if (sizeOnDevice)
         {
-            CUDA_CHECK_NO_EXCEPT(cudaFree(sizeOnDevicePtr));
+            CUDA_CHECK_NO_EXCEPT(cuplaFree(sizeOnDevicePtr));
         }
         if (!useOtherMemory)
         {
-            CUDA_CHECK_NO_EXCEPT(cudaFree(data.ptr));
+            CUDA_CHECK_NO_EXCEPT(cuplaFree(data.ptr));
 
         }
     }
@@ -216,7 +216,7 @@ public:
 
     }
 
-    const cudaPitchedPtr getCudaPitched() const
+    const cuplaPitchedPtr getCudaPitched() const
     {
         __startOperation(ITask::TASK_CUDA);
         return data;
@@ -247,24 +247,24 @@ private:
         if (DIM == DIM1)
         {
             log<ggLog::MEMORY >("Create device 1D data: %1% MiB") % (data.xsize / 1024 / 1024);
-            CUDA_CHECK(cudaMallocPitch(&data.ptr, &data.pitch, data.xsize, 1));
+            CUDA_CHECK(cuplaMallocPitch(&data.ptr, &data.pitch, data.xsize, 1));
         }
         if (DIM == DIM2)
         {
             data.ysize = this->getDataSpace()[1];
             log<ggLog::MEMORY >("Create device 2D data: %1% MiB") % (data.xsize * data.ysize / 1024 / 1024);
-            CUDA_CHECK(cudaMallocPitch(&data.ptr, &data.pitch, data.xsize, data.ysize));
+            CUDA_CHECK(cuplaMallocPitch(&data.ptr, &data.pitch, data.xsize, data.ysize));
 
         }
         if (DIM == DIM3)
         {
-            cudaExtent extent;
+            cuplaExtent extent;
             extent.width = this->getDataSpace()[0] * sizeof (TYPE);
             extent.height = this->getDataSpace()[1];
             extent.depth = this->getDataSpace()[2];
 
             log<ggLog::MEMORY >("Create device 3D data: %1% MiB") % (this->getDataSpace().productOfComponents() * sizeof (TYPE) / 1024 / 1024);
-            CUDA_CHECK(cudaMalloc3D(&data, extent));
+            CUDA_CHECK(cuplaMalloc3D(&data, extent));
         }
 
         reset(false);
@@ -281,7 +281,7 @@ private:
         data.ysize = 1;
 
         log<ggLog::MEMORY >("Create device fake data: %1% MiB") % (this->getDataSpace().productOfComponents() * sizeof (TYPE) / 1024 / 1024);
-        CUDA_CHECK(cudaMallocPitch(&data.ptr, &data.pitch, this->getDataSpace().productOfComponents() * sizeof (TYPE), 1));
+        CUDA_CHECK(cuplaMallocPitch(&data.ptr, &data.pitch, this->getDataSpace().productOfComponents() * sizeof (TYPE), 1));
 
         //fake the pitch, thus we can use this 1D Buffer as 2D or 3D
         data.pitch = this->getDataSpace()[0] * sizeof (TYPE);
@@ -301,7 +301,7 @@ private:
 
         if (sizeOnDevice)
         {
-            CUDA_CHECK(cudaMalloc((void**)&sizeOnDevicePtr, sizeof (size_t)));
+            CUDA_CHECK(cuplaMalloc((void**)&sizeOnDevicePtr, sizeof (size_t)));
         }
         setCurrentSize(this->getDataSpace().productOfComponents());
     }
@@ -311,7 +311,7 @@ private:
 
     bool sizeOnDevice;
     size_t* sizeOnDevicePtr;
-    cudaPitchedPtr data;
+    cuplaPitchedPtr data;
     bool useOtherMemory;
 };
 

--- a/include/pmacc/memory/buffers/HostBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/HostBufferIntern.hpp
@@ -49,7 +49,7 @@ public:
     HostBuffer<TYPE, DIM>(size, size),
     pointer(nullptr),ownPointer(true)
     {
-        CUDA_CHECK(cudaMallocHost((void**)&pointer, size.productOfComponents() * sizeof (TYPE)));
+        CUDA_CHECK(cuplaMallocHost((void**)&pointer, size.productOfComponents() * sizeof (TYPE)));
         reset(false);
     }
 
@@ -70,7 +70,7 @@ public:
 
         if (pointer && ownPointer)
         {
-            CUDA_CHECK_NO_EXCEPT(cudaFreeHost(pointer));
+            CUDA_CHECK_NO_EXCEPT(cuplaFreeHost(pointer));
         }
     }
 

--- a/include/pmacc/memory/buffers/MappedBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/MappedBufferIntern.hpp
@@ -68,7 +68,7 @@ public:
      */
     virtual ~MappedBufferIntern()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         __startOperation(ITask::TASK_HOST);
 
         if (pointer && ownPointer)
@@ -174,7 +174,7 @@ public:
 
     const cuplaPitchedPtr getCudaPitched() const
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         TYPE* dPointer;
         cuplaHostGetDevicePointer(&dPointer, pointer, 0);
 
@@ -206,7 +206,7 @@ public:
 
     DataBoxType getDataBox()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         TYPE* dPointer;
         cuplaHostGetDevicePointer(&dPointer, pointer, 0);
         return DataBoxType(PitchedBox<TYPE, DIM > (dPointer, DataSpace<DIM > (),

--- a/include/pmacc/memory/buffers/MappedBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/MappedBufferIntern.hpp
@@ -172,20 +172,20 @@ public:
         Buffer<TYPE, DIM>::setCurrentSize(size);
     }
 
-    const cudaPitchedPtr getCudaPitched() const
+    const cuplaPitchedPtr getCudaPitched() const
     {
         __startOperation(ITask::TASK_CUDA);
         TYPE* dPointer;
-        cudaHostGetDevicePointer(&dPointer, pointer, 0);
+        cuplaHostGetDevicePointer(&dPointer, pointer, 0);
 
         /* on 1D memory we have no size for y, therefore we set y to 1 to
-         * get a valid cudaPitchedPtr
+         * get a valid cuplaPitchedPtr
          */
         int size_y=1;
         if(DIM>DIM1)
             size_y= this->data_space[1];
 
-        return make_cudaPitchedPtr(dPointer,
+        return make_cuplaPitchedPtr(dPointer,
                                    this->data_space.x() * sizeof (TYPE),
                                    this->data_space.x(),
                                    size_y
@@ -208,7 +208,7 @@ public:
     {
         __startOperation(ITask::TASK_CUDA);
         TYPE* dPointer;
-        cudaHostGetDevicePointer(&dPointer, pointer, 0);
+        cuplaHostGetDevicePointer(&dPointer, pointer, 0);
         return DataBoxType(PitchedBox<TYPE, DIM > (dPointer, DataSpace<DIM > (),
                                                    this->data_space, this->data_space[0] * sizeof (TYPE)));
     }

--- a/include/pmacc/memory/buffers/MultiGridBuffer.hpp
+++ b/include/pmacc/memory/buffers/MultiGridBuffer.hpp
@@ -235,7 +235,7 @@ public:
 
     DataBoxType getDeviceDataBox()
     {
-        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_DEVICE);
         return DataBoxType(MultiBox<Type, DIM > (getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getBasePointer(),
                                                  getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getOffset(),
                                                  getGridBuffer(static_cast<NameType> (0)).getDeviceBuffer().getPhysicalMemorySize(),

--- a/include/pmacc/nvidia/memory/MemoryInfo.hpp
+++ b/include/pmacc/nvidia/memory/MemoryInfo.hpp
@@ -52,7 +52,7 @@ public:
         size_t freeInternal = 0;
         size_t totalInternal = 0;
 
-        CUDA_CHECK(cudaMemGetInfo(&freeInternal, &totalInternal));
+        CUDA_CHECK(cuplaMemGetInfo(&freeInternal, &totalInternal));
 
         if (free != nullptr)
         {

--- a/include/pmacc/nvidia/reduce/Reduce.hpp
+++ b/include/pmacc/nvidia/reduce/Reduce.hpp
@@ -104,9 +104,9 @@ namespace kernel
             using namespace mappings::threads;
 
             constexpr uint32_t numWorkers = T_numWorkers;
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-            uint32_t const numGlobalVirtualThreadCount = gridDim.x * T_blockSize;
+            uint32_t const numGlobalVirtualThreadCount = cupla::gridDim(acc).x * T_blockSize;
             WorkerCfg< numWorkers > workerCfg( workerIdx );
 
             sharedMemExtern(s_mem,Type);
@@ -119,7 +119,7 @@ namespace kernel
                 bufferSize,
                 func,
                 s_mem,
-                blockIdx.x
+                cupla::blockIdx(acc).x
             );
 
             using MasterOnly = IdxConfig<
@@ -135,7 +135,7 @@ namespace kernel
                 {
                     destFunc(
                         acc,
-                        destBuffer[ blockIdx.x ],
+                        destBuffer[ cupla::blockIdx(acc).x ],
                         s_mem[ 0 ]
                     );
                 }
@@ -165,7 +165,7 @@ namespace kernel
          * @param sharedMem shared memory buffer with storage for `linearThreadIdxInBlock` elements,
          *        buffer must implement `operator[](size_t)` (one dimensional access)
          * @param blockIndex index of the cupla block,
-         *                   for a global reduce: `blockIdx.x`,
+         *                   for a global reduce: `cupla::blockIdx(acc).x`,
          *                   for a reduce within a block: `0`
          *
          * @result void the result is stored in the first slot of @p sharedMem
@@ -287,7 +287,7 @@ namespace kernel
                                 sharedMem[ linearIdx + chunk_count ]
                             );
 
-                        __syncthreads();
+                        cupla::__syncthreads( acc );
                     }
                 );
             }

--- a/include/pmacc/nvidia/reduce/Reduce.hpp
+++ b/include/pmacc/nvidia/reduce/Reduce.hpp
@@ -146,7 +146,7 @@ namespace kernel
          *
          * This method can be used to reduce a chunk of an array.
          * This method is a **collective** method and needs to be called by all
-         * threads within a cuda block.
+         * threads within a cupla block.
          *
          * @tparam T_SrcBuffer type of the buffer
          * @tparam T_Functor type of the binary functor to reduce two elements
@@ -164,7 +164,7 @@ namespace kernel
          *        first argument is the source and get the new reduced value.
          * @param sharedMem shared memory buffer with storage for `linearThreadIdxInBlock` elements,
          *        buffer must implement `operator[](size_t)` (one dimensional access)
-         * @param blockIndex index of the cuda block,
+         * @param blockIndex index of the cupla block,
          *                   for a global reduce: `blockIdx.x`,
          *                   for a reduce within a block: `0`
          *
@@ -300,7 +300,7 @@ namespace kernel
     public:
 
         /* Constructor
-         * Don't create a instance before you have set you cuda device!
+         * Don't create a instance before you have set you cupla device!
          * @param byte how many bytes in global gpu memory can reserved for the reduce algorithm
          * @param sharedMemByte limit the usage of shared memory per block on gpu
          */

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -91,7 +91,7 @@ struct KernelFillGapsLastFrame
 
         using FramePtr = typename T_ParBox::FramePtr;
 
-        DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim > ( blockIdx ) );
+        DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim > ( cupla::blockIdx(acc) ) );
 
         PMACC_SMEM(
             acc,
@@ -122,7 +122,7 @@ struct KernelFillGapsLastFrame
             int
         );
 
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         using MasterOnly = IdxConfig<
             1,
@@ -288,9 +288,9 @@ struct KernelFillGaps
         constexpr uint32_t dim = T_Mapping::Dim;
         constexpr uint32_t numWorkers = T_numWorkers;
 
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-        DataSpace< dim > const superCellIdx( mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) ) );
+        DataSpace< dim > const superCellIdx( mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) ) );
 
         // data copied from right (last) to left (first)
         PMACC_SMEM(
@@ -584,8 +584,8 @@ struct KernelShiftParticles
             bool
         );
 
-        DataSpace< dim > superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
-        uint32_t const workerIdx = threadIdx.x;
+        DataSpace< dim > superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) );
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         using namespace mappings::threads;
 
@@ -704,7 +704,7 @@ struct KernelShiftParticles
                     directionCtx[ idx ] = frame[ linearIdx ][ multiMask_ ] - 2;
                     if ( directionCtx[ idx ] >= 0 )
                     {
-                        destParticleIdxCtx[ idx ] = atomicAdd( &(destFramesCounter[ directionCtx[ idx ] ]), 1, ::alpaka::hierarchy::Threads{} );
+                        destParticleIdxCtx[ idx ] = cupla::atomicAdd( acc, &(destFramesCounter[ directionCtx[ idx ] ]), 1, ::alpaka::hierarchy::Threads{} );
                     }
                 }
             );
@@ -885,8 +885,8 @@ struct KernelDeleteParticles
         constexpr uint32_t frameSize = math::CT::volume< typename FrameType::SuperCellSize >::type::value;
         constexpr uint32_t numWorkers = T_numWorkers;
 
-        DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
-        uint32_t const workerIdx = threadIdx.x;
+        DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) );
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         PMACC_SMEM(
             acc,
@@ -1014,8 +1014,8 @@ struct KernelCopyGuardToExchange
 
         using FramePtr = typename T_ParBox::FramePtr;
 
-        DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) );
-        uint32_t const workerIdx = threadIdx.x;
+        DataSpace< dim > const superCellIdx = mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) );
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         // number of particles in the current handled frame
         PMACC_SMEM(
@@ -1233,7 +1233,7 @@ struct KernelInsertParticles
         constexpr uint32_t frameSize = math::CT::volume< typename T_ParBox::FrameType::SuperCellSize >::type::value;
         constexpr uint32_t numWorkers = T_numWorkers;
 
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         using FramePtr = typename T_ParBox::FramePtr;
 
@@ -1277,7 +1277,7 @@ struct KernelInsertParticles
             )
             {
                 exchangeChunk = exchangeBox.get(
-                    blockIdx.x,
+                    cupla::blockIdx(acc).x,
                     compressedSuperCellIdxCtx[ idx ]
                 );
                 elementCount = exchangeChunk.getSize( );

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -82,10 +82,10 @@ namespace detail
             constexpr uint32_t frameSize = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             DataSpace< dim > const superCellIdx(
-                mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) )
+                mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) )
             );
 
             auto const & superCell = pb.getSuperCell( superCellIdx );

--- a/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -77,11 +77,11 @@ public:
         T_Hierarchy const & hierarchy
     )
     {
-        TYPE oldSize = atomicAdd(currentSizePointer, count, hierarchy); //get count VALUEs
+        TYPE oldSize = cupla::atomicAdd(acc, currentSizePointer, count, hierarchy); //get count VALUEs
 
         if (oldSize + count > maxSize)
         {
-            atomicExch(currentSizePointer, maxSize, hierarchy); //reset size to maxsize
+            cupla::atomicExch(acc, currentSizePointer, maxSize, hierarchy); //reset size to maxsize
             if (oldSize >= maxSize)
             {
                 return TileDataBox<VALUE > (nullptr,

--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -224,7 +224,8 @@ public:
         __threadfence( );
 #endif
         FramePtr oldFirstFramePtr(
-            (FrameType*) atomicExch(
+            (FrameType*) cupla::atomicExch(
+                acc,
                 (unsigned long long int*) firstFrameNativPtr,
                 (unsigned long long int) frame.ptr,
                 ::alpaka::hierarchy::Grids{}
@@ -272,7 +273,8 @@ public:
         __threadfence( );
 #endif
         FramePtr oldLastFramePtr(
-            (FrameType*) atomicExch(
+            (FrameType*) cupla::atomicExch(
+                acc,
                 (unsigned long long int*) lastFrameNativPtr,
                 (unsigned long long int) frame.ptr,
                 ::alpaka::hierarchy::Grids{}

--- a/include/pmacc/particles/memory/boxes/PushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/PushDataBox.hpp
@@ -76,7 +76,7 @@ namespace pmacc
         template< typename T_Acc, typename T_Hierarchy >
         HDINLINE TileDataBox<VALUE> pushN(T_Acc const & acc, TYPE count, T_Hierarchy const & hierarchy)
         {
-            TYPE old_addr = atomicAdd(currentSize, count, hierarchy);
+            TYPE old_addr = cupla::atomicAdd(acc, currentSize, count, hierarchy);
             return TileDataBox<VALUE > (this->fixedPointer, DataSpace<DIM1>(old_addr));
         }
 
@@ -97,7 +97,7 @@ namespace pmacc
         template< typename T_Acc, typename T_Hierarchy >
         HDINLINE void push(T_Acc const & acc, VALUE val, T_Hierarchy const & hierarchy)
         {
-            TYPE old_addr = atomicAdd(currentSize, 1, hierarchy);
+            TYPE old_addr = cupla::atomicAdd(acc, currentSize, 1, hierarchy);
             (*this)[old_addr] = val;
         }
 

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
@@ -71,7 +71,7 @@ void MallocMCBuffer< T_DeviceHeap >::synchronize( )
     /* add event system hints */
     __startOperation(ITask::TASK_CUDA);
     __startOperation(ITask::TASK_HOST);
-    CUDA_CHECK(cudaMemcpy(hostPtr, deviceHeapInfo.p, deviceHeapInfo.size, cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cuplaMemcpy(hostPtr, deviceHeapInfo.p, deviceHeapInfo.size, cuplaMemcpyDeviceToHost));
 
 }
 

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
@@ -69,7 +69,7 @@ void MallocMCBuffer< T_DeviceHeap >::synchronize( )
         this->hostBufferOffset = static_cast<int64_t>(reinterpret_cast<char*>(deviceHeapInfo.p) - hostPtr);
     }
     /* add event system hints */
-    __startOperation(ITask::TASK_CUDA);
+    __startOperation(ITask::TASK_DEVICE);
     __startOperation(ITask::TASK_HOST);
     CUDA_CHECK(cuplaMemcpy(hostPtr, deviceHeapInfo.p, deviceHeapInfo.size, cuplaMemcpyDeviceToHost));
 

--- a/include/pmacc/particles/operations/CountParticles.hpp
+++ b/include/pmacc/particles/operations/CountParticles.hpp
@@ -103,12 +103,12 @@ struct KernelCountParticles
 
         using SuperCellSize = typename T_Mapping::SuperCellSize;
 
-        DataSpace< dim > const threadIndex( threadIdx );
+        DataSpace< dim > const threadIndex( cupla::threadIdx(acc) );
         uint32_t const workerIdx = static_cast< uint32_t >(
             DataSpaceOperations< dim >::template map< SuperCellSize >( threadIndex )
         );
 
-        DataSpace< dim > const superCellIdx( mapper.getSuperCellIndex( DataSpace< dim >( blockIdx ) ) );
+        DataSpace< dim > const superCellIdx( mapper.getSuperCellIndex( DataSpace< dim >( cupla::blockIdx(acc) ) ) );
 
         ForEachIdx<
             IdxConfig<
@@ -203,7 +203,8 @@ struct KernelCountParticles
             )
             {
 
-                atomicAdd(
+                cupla::atomicAdd(
+                    acc,
                     gCounter,
                     static_cast< uint64_cu >( counter ),
                     ::alpaka::hierarchy::Blocks{}

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -129,7 +129,7 @@ namespace kernel
                 int
             );
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             DataSpace< numDims > const numSuperCells(
                 cellDesc.getGridSuperCells( ) - cellDesc.getGuardingSuperCells( ) * 2
@@ -151,7 +151,8 @@ namespace kernel
                     /* apply for work for the full block, counter[0] contains the
                      * offset in srcFrame to load N particles
                      */
-                    sharedSrcParticleOffset = atomicAdd(
+                    sharedSrcParticleOffset = cupla::atomicAdd(
+                        acc,
                         &( counter[ 0 ] ),
                         particlesPerFrame,
                         ::alpaka::hierarchy::Blocks{}
@@ -159,7 +160,7 @@ namespace kernel
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             using ParticleDomCfg = IdxConfig<
                 particlesPerFrame,
@@ -195,7 +196,7 @@ namespace kernel
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             // supercell index of the particle relative to the origin of the local domain
             memory::CtxArray<
@@ -246,7 +247,7 @@ namespace kernel
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             memory::CtxArray<
                 int,
@@ -306,7 +307,7 @@ namespace kernel
                 }
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             forEachParticle(
                 [&](

--- a/include/pmacc/random/RNGProvider.tpp
+++ b/include/pmacc/random/RNGProvider.tpp
@@ -61,7 +61,7 @@ namespace random
                 using namespace mappings::threads;
 
                 constexpr uint32_t numWorkers = T_numWorkers;
-                uint32_t const workerIdx = threadIdx.x;
+                uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
                 using SupercellDomCfg = IdxConfig<
                     T_blockSize,
@@ -77,7 +77,7 @@ namespace random
                         uint32_t const
                     )
                     {
-                        uint32_t const linearTid = blockIdx.x * T_blockSize + linearIdx;
+                        uint32_t const linearTid = cupla::blockIdx(acc).x * T_blockSize + linearIdx;
                         if( linearTid >= size.productOfComponents() )
                             return;
 

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -151,8 +151,8 @@ public:
         {
             /* first synchronize: if something failed, we can spare the time
              * for the checkpoint writing */
-            CUDA_CHECK(cudaDeviceSynchronize());
-            CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cuplaDeviceSynchronize());
+            CUDA_CHECK(cuplaGetLastError());
 
             // avoid deadlock between not finished PMacc tasks and MPI_Barrier
             __getTransactionEvent().waitForFinished();
@@ -173,8 +173,8 @@ public:
 
             /* important synchronize: only if no errors occured until this
              * point guarantees that a checkpoint is usable */
-            CUDA_CHECK(cudaDeviceSynchronize());
-            CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cuplaDeviceSynchronize());
+            CUDA_CHECK(cuplaGetLastError());
 
             /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
             __getTransactionEvent().waitForFinished();

--- a/include/pmacc/test/particles/IdProvider.hpp
+++ b/include/pmacc/test/particles/IdProvider.hpp
@@ -63,9 +63,9 @@ namespace particles
 
             constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-            uint32_t const blockId = blockIdx.x * T_numIdsPerBlock;
+            uint32_t const blockId = cupla::blockIdx(acc).x * T_numIdsPerBlock;
             ForEachIdx<
                 IdxConfig<
                     T_numIdsPerBlock,

--- a/include/pmacc/test/random/2DDistribution.cpp
+++ b/include/pmacc/test/random/2DDistribution.cpp
@@ -71,7 +71,7 @@ struct RandomFiller
         using namespace pmacc::mappings::threads;
 
         constexpr uint32_t numWorkers = T_numWorkers;
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
         using SupercellDomCfg = IdxConfig<
             T_blockSize,
@@ -87,7 +87,7 @@ struct RandomFiller
                 uint32_t const
             )
             {
-                uint32_t const linearTid = blockIdx.x * T_blockSize + linearIdx;
+                uint32_t const linearTid = cupla::blockIdx(acc).x * T_blockSize + linearIdx;
 
                 if( linearTid >= boxSize.productOfComponents() )
                     return;
@@ -105,7 +105,7 @@ struct RandomFiller
                         acc,
                         boxSize
                     );
-                    atomicAdd(&box(idx), 1u, ::alpaka::hierarchy::Blocks{});
+                    cupla::atomicAdd(acc, &box(idx), 1u, ::alpaka::hierarchy::Blocks{});
                 }
             }
         );

--- a/include/pmacc/test/random/2DDistribution.cpp
+++ b/include/pmacc/test/random/2DDistribution.cpp
@@ -195,9 +195,9 @@ void writePGM(const std::string& filePath, T_Buffer& buffer)
 template<class T_DeviceBuffer, class T_Random>
 void generateRandomNumbers(const Space2D& rngSize, uint32_t numSamples, T_DeviceBuffer& buffer, const T_Random& rand)
 {
-    cudaEvent_t start, stop;
-    CUDA_CHECK(cudaEventCreate(&start));
-    CUDA_CHECK(cudaEventCreate(&stop));
+    cuplaEvent_t start, stop;
+    CUDA_CHECK(cuplaEventCreate(&start));
+    CUDA_CHECK(cuplaEventCreate(&stop));
 
     constexpr uint32_t blockSize = 256;
 
@@ -207,7 +207,7 @@ void generateRandomNumbers(const Space2D& rngSize, uint32_t numSamples, T_Device
 
     uint32_t gridSize = ( rngSize.productOfComponents() + blockSize - 1u ) / blockSize;
 
-    CUDA_CHECK(cudaEventRecord(
+    CUDA_CHECK(cuplaEventRecord(
         start,
         /* we need to pass a stream to avoid that we record the event in
          * an empty or wrong stream
@@ -230,7 +230,7 @@ void generateRandomNumbers(const Space2D& rngSize, uint32_t numSamples, T_Device
         numSamples
     );
 
-    CUDA_CHECK(cudaEventRecord(
+    CUDA_CHECK(cuplaEventRecord(
         stop,
         /* we need to pass a stream to avoid that we record the event in
          * an empty or wrong stream
@@ -238,12 +238,12 @@ void generateRandomNumbers(const Space2D& rngSize, uint32_t numSamples, T_Device
         pmacc::Environment<>::get( ).TransactionManager( ).
             getEventStream( pmacc::ITask::TASK_CUDA )->getCudaStream()
     ));
-    CUDA_CHECK(cudaEventSynchronize(stop));
+    CUDA_CHECK(cuplaEventSynchronize(stop));
     float milliseconds = 0;
-    CUDA_CHECK(cudaEventElapsedTime(&milliseconds, start, stop));
+    CUDA_CHECK(cuplaEventElapsedTime(&milliseconds, start, stop));
     std::cout << "Done in " << milliseconds << "ms" << std::endl;
-    CUDA_CHECK(cudaEventDestroy(start));
-    CUDA_CHECK(cudaEventDestroy(stop));
+    CUDA_CHECK(cuplaEventDestroy(start));
+    CUDA_CHECK(cuplaEventDestroy(stop));
 }
 
 template<class T_Method>

--- a/include/pmacc/test/random/2DDistribution.cpp
+++ b/include/pmacc/test/random/2DDistribution.cpp
@@ -213,7 +213,7 @@ void generateRandomNumbers(const Space2D& rngSize, uint32_t numSamples, T_Device
          * an empty or wrong stream
          */
         pmacc::Environment<>::get( ).TransactionManager( ).
-            getEventStream( pmacc::ITask::TASK_CUDA )->getCudaStream()
+            getEventStream( pmacc::ITask::TASK_DEVICE )->getCudaStream()
     ));
     PMACC_KERNEL(
         RandomFiller<
@@ -236,7 +236,7 @@ void generateRandomNumbers(const Space2D& rngSize, uint32_t numSamples, T_Device
          * an empty or wrong stream
          */
         pmacc::Environment<>::get( ).TransactionManager( ).
-            getEventStream( pmacc::ITask::TASK_CUDA )->getCudaStream()
+            getEventStream( pmacc::ITask::TASK_DEVICE )->getCudaStream()
     ));
     CUDA_CHECK(cuplaEventSynchronize(stop));
     float milliseconds = 0;

--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -41,23 +41,7 @@
 #endif
 
 
-#include <cuda_to_cupla.hpp>
-
-#if( PMACC_CUDA_ENABLED == 1 )
-/** @todo please remove this workaround
- * This workaround allows to use native CUDA on the CUDA device without
- * passing the variable `acc` to each function. This is only needed during the
- * porting phase to allow the full feature set of the plain PMacc and PIConGPU
- * CUDA version if the accelerator is CUDA.
- */
-#   undef blockIdx
-#   undef __syncthreads
-#   undef threadIdx
-#   undef gridDim
-#   undef blockDim
-#   undef uint3
-
-#endif
+#include <cupla.hpp>
 
 #include "pmacc/debug/PMaccVerbose.hpp"
 #include "pmacc/ppFunctions.hpp"

--- a/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -91,12 +91,12 @@ namespace kernel
                 Type
             >( acc, BlockArea( ) );
 
-            Space const block( mapper.getSuperCellIndex( Space( blockIdx ) ) );
+            Space const block( mapper.getSuperCellIndex( Space( cupla::blockIdx(acc) ) ) );
             Space const blockCell = block * T_Mapping::SuperCellSize::toRT( );
 
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             auto buffRead_shifted = buffRead.shift( blockCell );
 
@@ -113,7 +113,7 @@ namespace kernel
                 buffRead_shifted
             );
 
-            __syncthreads();
+            cupla::__syncthreads( acc );
 
             ForEachIdx<
                 IdxConfig<
@@ -185,14 +185,14 @@ namespace kernel
             using SuperCellSize = typename T_Mapping::SuperCellSize;
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume< SuperCellSize >::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
-            uint32_t const workerIdx = threadIdx.x;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             // get position in grid in units of SuperCells from blockID
-            Space const block( mapper.getSuperCellIndex( Space( blockIdx ) ) );
+            Space const block( mapper.getSuperCellIndex( Space( cupla::blockIdx(acc) ) ) );
             // convert position in unit of cells
             Space const blockCell = block * T_Mapping::SuperCellSize::toRT( );
             // convert CUDA dim3 to DataSpace<DIM3>
-            Space const threadIndex(threadIdx);
+            Space const threadIndex(cupla::threadIdx(acc));
 
             uint32_t const globalUniqueId = DataSpaceOperations< DIM2 >::map(
                 mapper.getGridSuperCells() * T_Mapping::SuperCellSize::toRT(),


### PR DESCRIPTION
Avoid that PMacc/PIConGPU depends on the preprocessor renaming to use
cupla.

Since PMacc is still using sometimes native cuda it is hard to see where cupla and whee CUDA is used. I also work on making the precompiler stuff in cupla optional to increase the compatibility of cupla.
