### PR TITLE
Replace remaining cupla renamings with calls to cupla API

### DIFF
--- a/docs/source/prgpatterns/lockstep.rst
+++ b/docs/source/prgpatterns/lockstep.rst
@@ -45,7 +45,7 @@ Collective Loop
     // `frame` is a list which must be traversed collectively
     while( frame.isValid() )
     {
-        uint32_t const workerIdx = threadIdx.x;
+        uint32_t const workerIdx = cupla::threadIdx( acc ).x;
         using ParticleDomCfg = IdxConfig<
             frameSize,
             numWorker
@@ -67,7 +67,7 @@ Non-Collective Loop
 
 .. code-block:: cpp
 
-    uint32_t const workerIdx = threadIdx.x;
+    uint32_t const workerIdx = cupla::threadIdx( acc ).x;
     using ParticleDomCfg = IdxConfig<
         frameSize,
         numWorkers
@@ -91,7 +91,7 @@ Create a Context Variable
 
 .. code-block:: cpp
 
-    uint32_t const workerIdx = threadIdx.x;
+    uint32_t const workerIdx = cupla::threadIdx( acc ).x;
     using ParticleDomCfg = IdxConfig<
         frameSize,
         numWorkers
@@ -128,7 +128,7 @@ Using a Master Worker
         bool
     );
 
-    uint32_t const workerIdx = threadIdx.x;
+    uint32_t const workerIdx = cupla::threadIdx( acc ).x;
     ForEachIdx<
         IdxConfig<
             1,
@@ -150,4 +150,4 @@ Using a Master Worker
     /* important: synchronize now, in case upcoming operations (with
      * other workers) access that manipulated shared memory section
      */
-    __syncthreads();
+    cupla::__syncthreads( acc );

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -403,7 +403,7 @@ struct KernelAddCurrentToEMF
             fieldJBlock
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         ForEachIdx<
             IdxConfig<

--- a/include/picongpu/fields/FieldTmp.kernel
+++ b/include/picongpu/fields/FieldTmp.kernel
@@ -121,7 +121,7 @@ namespace picongpu
                 cachedVal
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             while( frame.isValid() )
             {
@@ -155,7 +155,7 @@ namespace picongpu
 
             }
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             nvidia::functors::Add add;
             DataSpace< simDim > const blockCell = block * SuperCellSize::toRT( );

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel
@@ -331,7 +331,7 @@ namespace yeePML
                 cachedB,
                 fieldBBlock
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             // Threads process values of the supercell in parallel
             constexpr auto numCellsPerSuperCell =
@@ -492,7 +492,7 @@ namespace yeePML
                 cachedE,
                 fieldEBlock
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             // Threads process values of the supercell in parallel
             constexpr auto numCellsPerSuperCell =

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -157,7 +157,7 @@ struct KernelDeriveParticles
             WorkerCfg< numWorker >{ workerIdx }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         // move over all Frames
         while( srcFrame.isValid( ) )
@@ -196,7 +196,7 @@ struct KernelDeriveParticles
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             onlyMaster(
                 [&](
@@ -217,7 +217,7 @@ struct KernelDeriveParticles
                     }
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
         }
     }
 };

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -228,7 +228,7 @@ namespace creation
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             /* move over source species frames and call particleCreator
              * frames are worked on in backwards order to avoid asking if there is another frame
@@ -271,7 +271,7 @@ namespace creation
                     }
                 );
 
-                __syncthreads( );
+                cupla::__syncthreads( acc );
 
                 /* always true while-loop over all particles inside source frame until each thread breaks out individually
                  *
@@ -300,7 +300,7 @@ namespace creation
 
                     oldFrameFillLvl = newFrameFillLvl;
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     /* < CHECK & ADD >
                      * - if a thread wants to create target particles in each cycle it can do that only once
@@ -322,7 +322,7 @@ namespace creation
                         }
                     );
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     /* < EXIT? >
                      * - if the counter hasn't changed all threads break out of the loop
@@ -330,7 +330,7 @@ namespace creation
                     if( oldFrameFillLvl == newFrameFillLvl )
                         break;
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     /* < NEW FRAME >
                      * - if there is no frame, yet, the master will create a new target particle frame
@@ -355,7 +355,7 @@ namespace creation
                         }
                     );
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     /* < CREATE >
                      * - all target particles were created
@@ -392,7 +392,7 @@ namespace creation
                         }
                     );
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     onlyMasters(
                         [&](
@@ -411,10 +411,10 @@ namespace creation
                         }
                     );
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
                 }
 
-                __syncthreads( );
+                cupla::__syncthreads( acc );
 
                 sourceFrame = sourceBox.getPreviousFrame( sourceFrame );
 

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -172,7 +172,7 @@ namespace picongpu
                     shCount_e[ linearIdx ] = 0.0_X;
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             DataSpace< simDim > const superCellIdx( mapper.getSuperCellIndex(
                 DataSpace< simDim >( cupla::blockIdx(acc) )
@@ -295,7 +295,7 @@ namespace picongpu
 
 
             // wait that all virtual threads updated the shared memory
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             const int gOffset = (
                 (

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -143,7 +143,7 @@ namespace picongpu
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             DataSpace< simDim > const superCellIdx( mapper.getSuperCellIndex(
                 DataSpace< simDim >( cupla::blockIdx(acc) )
@@ -265,7 +265,7 @@ namespace picongpu
             );
 
             // wait that all virtual threads updated the shared memory energies
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             // add energies on global level using global memory
             ForEachIdx< MasterOnly >{ workerIdx }(

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -185,7 +185,7 @@ namespace transitionRadiation
                     *  all threads must wait for the selection of a new frame
                     *  until all threads have evaluated "isValid"
                     */
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     ForEachIdx<
                         IdxConfig<
@@ -209,7 +209,7 @@ namespace transitionRadiation
                         }
                     );
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     using ParticleDomCfg = IdxConfig<
                         frameSize,
@@ -326,7 +326,7 @@ namespace transitionRadiation
                             } // only threads with particle
                         }
                     ); // for each particle
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     // run over all  valid omegas for this thread
                     for( int o = workerIdx; o < transitionRadiation::frequencies::nOmega; o += T_numWorkers )
@@ -368,7 +368,7 @@ namespace transitionRadiation
                         cohTransRadPerp[ index ] += ctrSumPerp;
                     }
 
-                    __syncthreads( );
+                    cupla::__syncthreads( acc );
 
                     /* First threads starts loading next frame of the super-cell:
                     *

--- a/include/pmacc/nvidia/reduce/Reduce.hpp
+++ b/include/pmacc/nvidia/reduce/Reduce.hpp
@@ -254,7 +254,7 @@ namespace kernel
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
             /*now reduce shared memory*/
             uint32_t chunk_count = T_blockSize;
 

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -142,7 +142,7 @@ struct KernelFillGapsLastFrame
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         if ( lastFrame.isValid( ) )
         {
@@ -182,7 +182,7 @@ struct KernelFillGapsLastFrame
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             forEachParticle(
                 [&](
@@ -197,7 +197,7 @@ struct KernelFillGapsLastFrame
                     }
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
             forEachParticle(
                 [&](
                     uint32_t const linearIdx,
@@ -345,7 +345,7 @@ struct KernelFillGaps
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         while ( firstFrame.isValid( ) && firstFrame != lastFrame )
         {
@@ -360,7 +360,7 @@ struct KernelFillGaps
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             using ParticleDomCfg = IdxConfig<
                 frameSize,
@@ -388,7 +388,7 @@ struct KernelFillGaps
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             if( numGaps != 0 )
             {
@@ -408,7 +408,7 @@ struct KernelFillGaps
                     }
                 );
 
-                __syncthreads( );
+                cupla::__syncthreads( acc );
 
                 // copy particles from lastFrame to the gaps in firstFrame
                 forEachParticle(
@@ -434,7 +434,7 @@ struct KernelFillGaps
                     }
                 );
 
-                __syncthreads( );
+                cupla::__syncthreads( acc );
 
                 onlyMaster(
                     [&](
@@ -489,7 +489,7 @@ struct KernelFillGaps
                 );
             }
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
         }
 
@@ -609,7 +609,7 @@ struct KernelShiftParticles
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
         if ( !mustShift || !frame.isValid( ) ) return;
 
         using ExchangeDomCfg = IdxConfig<
@@ -668,7 +668,7 @@ struct KernelShiftParticles
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         /* iterate over the frame list of the current supercell */
         while ( frame.isValid( ) )
@@ -708,7 +708,7 @@ struct KernelShiftParticles
                     }
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             forEachExchange(
                 [&](
@@ -751,7 +751,7 @@ struct KernelShiftParticles
                     }
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             forEachParticle(
                 [&](
@@ -787,7 +787,7 @@ struct KernelShiftParticles
                     }
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             forEachExchange(
                 [&](
@@ -812,7 +812,7 @@ struct KernelShiftParticles
                     }
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
         }
 
         forEachExchange(
@@ -911,7 +911,7 @@ struct KernelDeleteParticles
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         while( frame.isValid( ) )
         {
@@ -933,7 +933,7 @@ struct KernelDeleteParticles
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             onlyMaster(
                 [&](
@@ -949,7 +949,7 @@ struct KernelDeleteParticles
                     );
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
         }
 
         onlyMaster(
@@ -1068,7 +1068,7 @@ struct KernelCopyGuardToExchange
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         while ( frame.isValid( ) && allParticlesCopied )
         {
@@ -1096,7 +1096,7 @@ struct KernelCopyGuardToExchange
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
              // loop over all particles in the frame
             ForEachIdx< ParticleDomCfg > forEachParticle( workerIdx );
@@ -1113,7 +1113,7 @@ struct KernelCopyGuardToExchange
                     }
                 }
             );
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             if( numParticles > 0 )
             {
@@ -1140,7 +1140,7 @@ struct KernelCopyGuardToExchange
                     }
                 );
 
-                __syncthreads( );
+                cupla::__syncthreads( acc );
 
                 forEachParticle(
                     [&](
@@ -1157,7 +1157,7 @@ struct KernelCopyGuardToExchange
                         }
                     }
                 );
-                __syncthreads( );
+                cupla::__syncthreads( acc );
             }
 
             onlyMaster(
@@ -1174,7 +1174,7 @@ struct KernelCopyGuardToExchange
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
         }
         onlyMaster(
             [&](
@@ -1288,7 +1288,7 @@ struct KernelInsertParticles
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         // loop over all particles in the frame
         ForEachIdx<
@@ -1319,7 +1319,7 @@ struct KernelInsertParticles
         /** @bug This synchronize fixes a kernel crash in special cases,
          * psychocoderHPC: I can't tell why.
          */
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         onlyMaster(
             [&](

--- a/include/pmacc/particles/operations/CountParticles.hpp
+++ b/include/pmacc/particles/operations/CountParticles.hpp
@@ -129,7 +129,7 @@ struct KernelCountParticles
             }
         );
 
-        __syncthreads( );
+        cupla::__syncthreads( acc );
 
         if( !frame.isValid() )
             return; //end kernel if we have no frames
@@ -180,7 +180,7 @@ struct KernelCountParticles
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
 
             onlyMaster(
                 [&](
@@ -193,7 +193,7 @@ struct KernelCountParticles
                 }
             );
 
-            __syncthreads( );
+            cupla::__syncthreads( acc );
         }
 
         onlyMaster(


### PR DESCRIPTION
This is a fixup of #3211 which did these renamings for most of the code. Also, update usage in the docs since this is now the preferred way.

Perhaps these were missed in #3211 because only `__syncthreads();` occurances were checked, but not `__syncthreads( );`

I found out as it failed to build on my machine for the CPU accelerator. Wondering why did the tests pass for that PR?