### PR TITLE
strategy for current deposition algorithm

### DIFF
--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -106,6 +106,8 @@ species.param
    :path: include/picongpu/param/species.param
    :no-link:
 
+:ref:`Current solver details <usage-params-core-currentdeposition>`.
+
 speciesDefinition.param
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/param/particles/current.rst
+++ b/docs/source/usage/param/particles/current.rst
@@ -1,0 +1,64 @@
+.. _usage-params-core-currentdeposition:
+
+Current Deposition
+""""""""""""""""""
+
+The current solver can be set in :ref:`species.param <usage-params-core>` or directly per species :ref:`speciesDefinition.param <usage-params-core>`.
+
+The following operations can be applied in the ``picongpu::particles::InitPipeline`` of the latter:
+
+.. _usage-params-core-particles-currentsolver:
+
+Current Solver
+''''''''''''''
+
+Esirkepov
+~~~~~~~~~
+
+.. doxygenstruct:: picongpu::currentSolver::Esirkepov
+   :project: PIConGPU
+
+EmZ
+~~~
+
+.. doxygenstruct:: picongpu::currentSolver::EmZ
+   :project: PIConGPU
+
+VillaBune
+~~~~~~~~~
+
+.. doxygenstruct:: picongpu::currentSolver::VillaBune
+   :project: PIConGPU
+
+EsirkepovNative
+~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: picongpu::currentSolver::EsirkepovNative
+   :project: PIConGPU
+
+
+.. _usage-params-core-particles-depositionstrategy:
+
+Deposition Strategy
+'''''''''''''''''''
+
+A current solver supports a strategy to change how the algorithm behaves on different compute architectures.
+The strategy is optional, changing could could effect the performance negative.
+
+StridedCachedSupercells
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: picongpu::currentSolver::strategy::StridedCachedSupercells
+   :project: PIConGPU
+
+CachedSupercells
+~~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: picongpu::currentSolver::strategy::CachedSupercells
+   :project: PIConGPU
+
+NonCachedSupercells
+~~~~~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: picongpu::currentSolver::strategy::NonCachedSupercells
+   :project: PIConGPU

--- a/docs/source/usage/param/particles/current.rst
+++ b/docs/source/usage/param/particles/current.rst
@@ -5,8 +5,6 @@ Current Deposition
 
 The current solver can be set in :ref:`species.param <usage-params-core>` or directly per species :ref:`speciesDefinition.param <usage-params-core>`.
 
-The following operations can be applied in the ``picongpu::particles::InitPipeline`` of the latter:
-
 .. _usage-params-core-particles-currentsolver:
 
 Current Solver
@@ -43,7 +41,7 @@ Deposition Strategy
 '''''''''''''''''''
 
 A current solver supports a strategy to change how the algorithm behaves on different compute architectures.
-The strategy is optional, changing could could effect the performance negative.
+The strategy is optional, could affect performance.
 
 StridedCachedSupercells
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -326,9 +326,9 @@ private:
 namespace traits
 {
     template<
-        class ParticleAlgo,
-        class Velocity,
-        class TVec
+        typename ParticleAlgo,
+        typename Velocity,
+        typename TVec
     >
     struct GetStrategy<
         ComputePerFrame<

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -20,34 +20,29 @@
 
 #pragma once
 
-#include <pmacc/types.hpp>
-#include <pmacc/particles/frame_types.hpp>
-
 #include "picongpu/simulation_defines.hpp"
-
-#include "FieldJ.hpp"
-#include <pmacc/particles/memory/boxes/ParticlesBox.hpp>
-
-
+#include "picongpu/fields/currentDeposition/Strategy.def"
+#include "picongpu/fields/currentDeposition/Cache.hpp"
+#include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/algorithms/Velocity.hpp"
 
 #include <pmacc/memory/boxes/CachedBox.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
-#include <pmacc/nvidia/functors/Add.hpp>
 #include <pmacc/mappings/threads/ThreadCollective.hpp>
-#include "picongpu/algorithms/Set.hpp"
 #include <pmacc/mappings/threads/ForEachIdx.hpp>
 #include <pmacc/mappings/threads/IdxConfig.hpp>
 #include <pmacc/memory/CtxArray.hpp>
 #include <pmacc/particles/frame_types.hpp>
+#include <pmacc/particles/memory/boxes/ParticlesBox.hpp>
+#include <pmacc/types.hpp>
+
+#include <type_traits>
+#include <utility>
 
 namespace picongpu
 {
-
-using namespace pmacc;
-
-using J_DataBox = FieldJ::DataBoxType;
-
+namespace currentSolver
+{
 /** compute current
  *
  * @tparam T_numWorkers number of workers
@@ -189,23 +184,18 @@ struct KernelComputeCurrent
             }
         );
 
+        DataSpace< simDim > const blockCell = block * SuperCellSize::toRT();
+        using Strategy = currentSolver::traits::GetStrategy_t< FrameSolver >;
+
         /* this memory is used by all virtual blocks */
-        auto cachedJ = CachedBox::create<
-            0u,
-            typename JBox::ValueType
+        auto cachedJ = detail::Cache< Strategy >::template create<
+            numWorkers,
+            T_BlockDescription
         >(
             acc,
-            T_BlockDescription()
+            fieldJ.shift( blockCell ),
+            workerIdx
         );
-
-        Set< typename JBox::ValueType > set( float3_X::create( 0.0 ) );
-        ThreadCollective<
-            T_BlockDescription,
-            numWorkers
-        > collectiveSet( workerIdx );
-
-        /* initialize shared memory with zeros */
-        collectiveSet( acc, set, cachedJ );
 
         cupla::__syncthreads( acc );
 
@@ -270,29 +260,25 @@ struct KernelComputeCurrent
         /* we wait that all workers finish the loop */
         cupla::__syncthreads( acc );
 
-        nvidia::functors::Add add;
-        DataSpace< simDim > const blockCell = block * SuperCellSize::toRT();
-        ThreadCollective<
-            T_BlockDescription,
-            numWorkers
-        > collectiveAdd( workerIdx );
-        auto fieldJBlock = fieldJ.shift( blockCell );
-
-        /* write scatter results back to the global memory */
-        collectiveAdd(
+        /* this memory is used by all virtual blocks */
+        detail::Cache< Strategy >::template flush<
+            numWorkers,
+            T_BlockDescription
+        >(
             acc,
-            add,
-            fieldJBlock,
-            cachedJ
+            fieldJ.shift( blockCell ),
+            cachedJ,
+            workerIdx
         );
     }
 };
 
-template<class ParticleAlgo, class Velocity, class TVec>
-struct ComputeCurrentPerFrame
+template<typename T_ParticleAlgo, typename Velocity, typename TVec>
+struct ComputePerFrame
 {
+    using ParticleAlgo = T_ParticleAlgo;
 
-    HDINLINE ComputeCurrentPerFrame(const float_X deltaTime) :
+    HDINLINE ComputePerFrame(const float_X deltaTime) :
     m_deltaTime(deltaTime)
     {
     }
@@ -337,6 +323,25 @@ private:
     PMACC_ALIGN(m_deltaTime, const float_32);
 };
 
+namespace traits
+{
+    template<
+        class ParticleAlgo,
+        class Velocity,
+        class TVec
+    >
+    struct GetStrategy<
+        ComputePerFrame<
+            ParticleAlgo,
+            Velocity,
+            TVec
+        >
+    >
+    {
+        using type = GetStrategy_t< ParticleAlgo >;
+    };
+} // namespace traits
+
 /** add current to electric and magnetic field
  *
  * @tparam T_numWorkers number of workers
@@ -355,7 +360,7 @@ struct KernelAddCurrentToEMF
         T_Acc const & acc,
         typename FieldE::DataBoxType fieldE,
         typename FieldB::DataBoxType fieldB,
-        J_DataBox fieldJ,
+        typename FieldJ::DataBoxType fieldJ,
         T_CurrentInterpolation currentInterpolation,
         T_Mapping mapper
     ) const
@@ -376,7 +381,7 @@ struct KernelAddCurrentToEMF
 
         auto cachedJ = CachedBox::create<
             0,
-            typename J_DataBox::ValueType
+            typename FieldJ::DataBoxType::ValueType
         >(
             acc,
             BlockArea( )
@@ -435,4 +440,5 @@ struct KernelAddCurrentToEMF
     }
 };
 
+} // namespace currentSolver
 } // namespace picongpu

--- a/include/picongpu/fields/currentDeposition/Cache.hpp
+++ b/include/picongpu/fields/currentDeposition/Cache.hpp
@@ -1,0 +1,199 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/algorithms/Set.hpp"
+
+#include <alpaka/core/Unused.hpp>
+
+#include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/types.hpp>
+
+
+namespace picongpu
+{
+namespace currentSolver
+{
+namespace detail
+{
+    /** Transparent cache implementation for the current solver
+     *
+     * @tparam T_Strategy Used strategy to reduce the scattered data [currentSolver::strategy]
+     * @tparam T_Sfinae Optional specialization
+     */
+    template<
+        typename T_Strategy,
+        typename T_Sfinae = void
+    >
+    struct Cache;
+
+    template< typename T_Strategy >
+    struct Cache<
+        T_Strategy,
+        typename std::enable_if< T_Strategy::useBlockCache >::type
+    >
+    {
+        /** Create a cache
+         *
+         * @attention thread collective operation, requires manually thread synchronization
+         */
+        template<
+            uint32_t T_numWorkers,
+            typename T_BlockDescription,
+            typename T_Acc,
+            typename T_FieldBox
+        >
+        DINLINE
+        static auto create(
+            T_Acc const & acc,
+            T_FieldBox const & fieldBox,
+            uint32_t const workerIdx
+        )
+        -> decltype(
+            CachedBox::create<
+                0u,
+                typename T_FieldBox::ValueType
+            >(
+                acc,
+                std::declval< T_BlockDescription >()
+            )
+        )
+        {
+            using ValueType = typename T_FieldBox::ValueType;
+            /* this memory is used by all virtual blocks */
+            auto cache = CachedBox::create<
+                0u,
+                ValueType
+            >(
+                acc,
+                T_BlockDescription{}
+            );
+
+            Set< ValueType > set( ValueType::create( 0.0_X ) );
+            ThreadCollective<
+                T_BlockDescription,
+                T_numWorkers
+            > collectiveSet( workerIdx );
+
+            /* initialize shared memory with zeros */
+            collectiveSet(
+                acc,
+                set,
+                cache
+            );
+            return cache;
+        }
+
+        /** Flush the cache
+         *
+         * @attention thread collective operation, requires manually thread synchronization
+         */
+        template<
+            uint32_t T_numWorkers,
+            typename T_BlockDescription,
+            typename T_Acc,
+            typename T_FieldBox,
+            typename T_FieldCache
+        >
+        DINLINE
+        static void flush(
+            T_Acc const & acc,
+            T_FieldBox fieldBox,
+            T_FieldCache const & cachedBox,
+            uint32_t const workerIdx
+        )
+        {
+            typename T_Strategy::GridReductionOp const op;
+            ThreadCollective<
+                T_BlockDescription,
+                T_numWorkers
+            > collectiveAdd( workerIdx );
+
+            /* write scatter results back to the global memory */
+            collectiveAdd(
+                acc,
+                op,
+                fieldBox,
+                cachedBox
+            );
+        }
+    };
+
+    template< typename T_Strategy >
+    struct Cache<
+        T_Strategy,
+        typename std::enable_if< !T_Strategy::useBlockCache >::type
+    >
+    {
+        /** Create a cache
+         *
+         * @attention thread collective operation, requires manually thread synchronization
+         */
+        template<
+            uint32_t T_numWorkers,
+            typename T_BlockDescription,
+            typename T_Acc,
+            typename T_FieldBox
+        >
+        DINLINE
+        static auto create(
+            T_Acc const & acc,
+            T_FieldBox const & fieldBox,
+            uint32_t const workerIdx
+        )
+        -> T_FieldBox
+        {
+            alpaka::ignore_unused(
+                acc,
+                workerIdx
+            );
+            return fieldBox;
+        }
+
+        /** Flush the cache
+         *
+         * @attention thread collective operation, requires manually thread synchronization
+         */
+        template<
+            uint32_t T_numWorkers,
+            typename T_BlockDescription,
+            typename T_Acc,
+            typename T_FieldBox,
+            typename T_FieldCache
+        >
+        DINLINE
+        static void flush(
+            T_Acc const & acc,
+            T_FieldBox fieldBox,
+            T_FieldCache const & cachedBox,
+            uint32_t const workerIdx
+        )
+        {
+            alpaka::ignore_unused(
+                acc,
+                fieldBox,
+                cachedBox,
+                workerIdx
+            );
+        }
+    };
+} // namespace detail
+} // namespace currentSolver
+} // namespace picongpu

--- a/include/picongpu/fields/currentDeposition/Cache.hpp
+++ b/include/picongpu/fields/currentDeposition/Cache.hpp
@@ -52,7 +52,7 @@ namespace detail
     {
         /** Create a cache
          *
-         * @attention thread collective operation, requires manually thread synchronization
+         * @attention thread-collective operation, requires external thread synchronization
          */
         template<
             uint32_t T_numWorkers,
@@ -90,10 +90,10 @@ namespace detail
             ThreadCollective<
                 T_BlockDescription,
                 T_numWorkers
-            > collectiveSet( workerIdx );
+            > collectiveFill( workerIdx );
 
             /* initialize shared memory with zeros */
-            collectiveSet(
+            collectiveFill(
                 acc,
                 set,
                 cache
@@ -103,7 +103,7 @@ namespace detail
 
         /** Flush the cache
          *
-         * @attention thread collective operation, requires manually thread synchronization
+         * @attention thread-collective operation, requires external thread synchronization
          */
         template<
             uint32_t T_numWorkers,
@@ -144,7 +144,7 @@ namespace detail
     {
         /** Create a cache
          *
-         * @attention thread collective operation, requires manually thread synchronization
+         * @attention thread-collective operation, requires external thread synchronization
          */
         template<
             uint32_t T_numWorkers,
@@ -169,7 +169,7 @@ namespace detail
 
         /** Flush the cache
          *
-         * @attention thread collective operation, requires manually thread synchronization
+         * @attention thread-collective operation, requires external thread synchronization
          */
         template<
             uint32_t T_numWorkers,

--- a/include/picongpu/fields/currentDeposition/Deposit.hpp
+++ b/include/picongpu/fields/currentDeposition/Deposit.hpp
@@ -1,0 +1,157 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/traits/GetCurrentSolver.hpp"
+#include "picongpu/traits/GetMargin.hpp"
+
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/mappings/kernel/StrideMapping.hpp>
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/types.hpp>
+
+
+namespace picongpu
+{
+namespace currentSolver
+{
+    /** Executes the current deposition kernel
+     *
+     * @tparam T_Strategy Used strategy to reduce the scattered data [currentSolver::strategy]
+     * @tparam T_Sfinae Optional specialization
+     */
+    template<
+        typename T_Strategy,
+        typename T_Sfinae = void
+    >
+    struct Deposit;
+
+    template< typename T_Strategy >
+    struct Deposit<
+        T_Strategy,
+        typename std::enable_if< T_Strategy::stridedMapping >::type
+    >
+    {
+        /** Execute the current deposition with a checker board
+         *
+         * The stride between the supercells for the checker board will be automatically
+         * adjusted, based on the species shape.
+         */
+        template<
+            uint32_t T_area,
+            uint32_t T_numWorkers,
+            typename T_CellDescription,
+            typename T_DepositionKernel,
+            typename T_FrameSolver,
+            typename T_JBox,
+            typename T_ParticleBox
+        >
+        void execute(
+            T_CellDescription const & cellDescription,
+            T_DepositionKernel const & depositionKernel,
+            T_FrameSolver const & frameSolver,
+            T_JBox const & jBox,
+            T_ParticleBox const & parBox
+        ) const
+        {
+            /* The needed stride for the stride mapper depends on the stencil width.
+             * If the upper and lower margin of the stencil fits into one supercell
+             * a double checker board (stride 2) is needed.
+             * The round up sum of margins is the number of supercells to skip.
+             */
+            using MarginPerDim = typename pmacc::math::CT::add<
+                typename GetMargin< typename T_FrameSolver::ParticleAlgo >::LowerMargin,
+                typename GetMargin< typename T_FrameSolver::ParticleAlgo >::UpperMargin
+            >::type;
+            using MaxMargin = typename pmacc::math::CT::max< MarginPerDim >::type;
+            using SuperCellMinSize = typename pmacc::math::CT::min< SuperCellSize >::type;
+
+            /* number of supercells which must be skipped to avoid overlapping areas
+             * between different blocks in the kernel
+             */
+            constexpr uint32_t skipSuperCells = ( MaxMargin::value + SuperCellMinSize::value - 1u ) / SuperCellMinSize::value;
+            StrideMapping<
+               T_area,
+               skipSuperCells + 1u, // stride 1u means each supercell is used
+               MappingDesc
+            > mapper( cellDescription );
+
+            do
+            {
+               PMACC_KERNEL( depositionKernel )(
+                   mapper.getGridDim( ),
+                   T_numWorkers
+               )(
+                   jBox,
+                   parBox,
+                   frameSolver,
+                   mapper
+               );
+            }
+            while ( mapper.next( ) );
+        }
+    };
+
+    template< typename T_Strategy >
+    struct Deposit<
+        T_Strategy,
+        typename std::enable_if< !T_Strategy::stridedMapping >::type
+    >
+    {
+        /** Execute the current deposition for each supercell
+         *
+         * All supercells will be processed in parallel.
+         */
+        template<
+            uint32_t T_area,
+            uint32_t T_numWorkers,
+            typename T_CellDescription,
+            typename T_DepositionKernel,
+            typename T_FrameSolver,
+            typename T_JBox,
+            typename T_ParticleBox
+        >
+        void execute(
+            T_CellDescription const & cellDescription,
+            T_DepositionKernel const & depositionKernel,
+            T_FrameSolver const & frameSolver,
+            T_JBox const & jBox,
+            T_ParticleBox const & parBox
+        ) const
+        {
+            AreaMapping<
+                T_area,
+                MappingDesc
+            > mapper( cellDescription );
+
+            PMACC_KERNEL( depositionKernel )(
+                mapper.getGridDim( ),
+                T_numWorkers
+            )(
+                jBox,
+                parBox,
+                frameSolver,
+                mapper
+            );
+        }
+    };
+
+} // namespace currentSolver
+} // namespace picongpu

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.def
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.def
@@ -60,7 +60,8 @@ namespace emz
      *                  Jinqing Yu, Xiaolin Jin, Weimin Zhou, Bin Li, Yuqiu Gu
      *                  DOI:10.1109/ICCIS.2012.159
      *
-     * \tparam T_ParticleShape the particle shape for the species, picongpu::particles::shapes
+     * @tparam T_ParticleShape the particle shape for the species [picongpu::particles::shapes]
+     * @tparam T_Strategy Used strategy to reduce the scattered data [currentSolver::strategy]
      *
      */
     template<

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.def
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.def
@@ -17,10 +17,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/currentDeposition/Strategy.def"
 
 
 namespace picongpu
@@ -31,6 +31,7 @@ namespace currentSolver
 namespace emz
 {
     template<
+        typename T_AtomicAddOp,
         typename ParticleAssign,
         int T_begin,
         int T_end,
@@ -39,54 +40,80 @@ namespace emz
     struct DepositCurrent;
 } //namespace emz
 
-/** EmZ (Esirkepov meets ZigZag) current deposition
- *
- * Deposit the particle current with a mixed algorithm based on Esirkepov and
- * the ZigZag way splitting.
- * EmZ supports arbitrary symmetric shapes and 2D/3D cartesian grids.
- *
- * ZigZag publications:
- * 1. order paper: "A new charge conservation method in electromagnetic
- *                  particle-in-cell simulations", Comput. Phys. Commun. (2003)
- *                  T. Umeda, Y. Omura, T. Tominaga, H. Matsumoto
- *                  DOI: 10.1016/S0010-4655(03)00437-5
- * 2. order paper: "Charge conservation methods for computing current densities
- *                  in electromagnetic particle-in-cell simulations",
- *                  Proceedings of ISSS. Vol. 7. 2005
- *                  T. Umeda, Y. Omura, H. Matsumoto
- * 3. order paper: "High-Order Interpolation Algorithms for Charge Conservation
- *                  in Particle-in-Cell Simulation", Commun. Comput. Phys 13 (2013)
- *                  Jinqing Yu, Xiaolin Jin, Weimin Zhou, Bin Li, Yuqiu Gu
- *                  DOI:10.1109/ICCIS.2012.159
- *
- * \tparam T_ParticleShape the particle shape for the species, \see picongpu::particles::shapes
- *
- */
-template< typename ParticleShape >
-struct EmZ;
+    /** EmZ (Esirkepov meets ZigZag) current deposition
+     *
+     * Deposit the particle current with a mixed algorithm based on Esirkepov and
+     * the ZigZag way splitting.
+     * EmZ supports arbitrary symmetric shapes and 2D/3D cartesian grids.
+     *
+     * ZigZag publications:
+     * 1. order paper: "A new charge conservation method in electromagnetic
+     *                  particle-in-cell simulations", Comput. Phys. Commun. (2003)
+     *                  T. Umeda, Y. Omura, T. Tominaga, H. Matsumoto
+     *                  DOI: 10.1016/S0010-4655(03)00437-5
+     * 2. order paper: "Charge conservation methods for computing current densities
+     *                  in electromagnetic particle-in-cell simulations",
+     *                  Proceedings of ISSS. Vol. 7. 2005
+     *                  T. Umeda, Y. Omura, H. Matsumoto
+     * 3. order paper: "High-Order Interpolation Algorithms for Charge Conservation
+     *                  in Particle-in-Cell Simulation", Commun. Comput. Phys 13 (2013)
+     *                  Jinqing Yu, Xiaolin Jin, Weimin Zhou, Bin Li, Yuqiu Gu
+     *                  DOI:10.1109/ICCIS.2012.159
+     *
+     * \tparam T_ParticleShape the particle shape for the species, picongpu::particles::shapes
+     *
+     */
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy = traits::GetDefaultStrategy_t<>
+    >
+    struct EmZ;
+
+namespace traits
+{
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy
+    >
+    struct GetStrategy<
+        EmZ<
+            T_ParticleShape,
+            T_Strategy
+        >
+    >
+    {
+        using type = T_Strategy;
+    };
+} // namespace traits
 
 } //namespace currentSolver
 
 namespace traits
 {
 
-/*Get margin of a solver
- * class must define a LowerMargin and UpperMargin
- */
-template< typename ParticleShape >
-struct GetMargin<
-    picongpu::currentSolver::EmZ<
-        ParticleShape
+    /*Get margin of a solver
+     * class must define a LowerMargin and UpperMargin
+     */
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy
     >
->
-{
-private:
-    typedef picongpu::currentSolver::EmZ< ParticleShape > Solver;
-public:
-    typedef typename Solver::LowerMargin LowerMargin;
-    typedef typename Solver::UpperMargin UpperMargin;
-};
+    struct GetMargin<
+        picongpu::currentSolver::EmZ<
+            T_ParticleShape,
+            T_Strategy
+        >
+    >
+    {
+    private:
+        using Solver = picongpu::currentSolver::EmZ<
+            T_ParticleShape,
+            T_Strategy
+        >;
+    public:
+        using LowerMargin = typename Solver::LowerMargin;
+        using UpperMargin = typename Solver::UpperMargin;
+    };
 
 } //namespace traits
-
 } //namespace picongpu

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -26,13 +26,15 @@
 #include "picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp"
 #include "picongpu/fields/currentDeposition/Esirkepov/Line.hpp"
 
+
 namespace picongpu
 {
 namespace currentSolver
 {
 
 template<
-    typename T_ParticleShape
+    typename T_ParticleShape,
+    typename T_Strategy
 >
 struct EmZ
 {
@@ -116,6 +118,7 @@ struct EmZ
 
         /* Esirkepov implementation for the current deposition */
         emz::DepositCurrent<
+            typename T_Strategy::BlockReductionOp,
             ParticleAssign,
             begin,
             end

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
@@ -17,53 +17,105 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/currentDeposition/Strategy.def"
 
 
 namespace picongpu
 {
 namespace currentSolver
 {
-using namespace pmacc;
 
+    /**
+     * Implements the current deposition algorithm from T.Zh. Esirkepov
+     *
+     * for an arbitrary particle assign function given as a template parameter.
+     * See available shapes at "intermediateLib/particleShape".
+     * paper: "Exact charge conservation scheme for Particle-in-Cell simulation
+     *  with an arbitrary form-factor"
+     *
+     * \tparam T_ParticleShape the particle shape for the species, \see picongpu::particles::shapes
+     * \tparam T_Dim Implementation for 2D or 3D
+     */
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy = traits::GetDefaultStrategy_t<>,
+        uint32_t T_dim = simDim
+    >
+    struct Esirkepov;
 
-/**
- * Implements the current deposition algorithm from T.Zh. Esirkepov
- *
- * for an arbitrary particle assign function given as a template parameter.
- * See available shapes at "intermediateLib/particleShape".
- * paper: "Exact charge conservation scheme for Particle-in-Cell simulation
- *  with an arbitrary form-factor"
- *
- * \tparam T_ParticleShape the particle shape for the species, \see picongpu::particles::shapes
- * \tparam T_Dim Implementation for 2D or 3D
- */
-template<typename ParticleShape,uint32_t T_dim=simDim>
-struct Esirkepov;
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy = traits::GetDefaultStrategy_t<>
+    >
+    struct EsirkepovNative;
 
-template<typename ParticleAssign>
-struct EsirkepovNative;
+namespace traits
+{
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy,
+        uint32_t T_dim
+    >
+    struct GetStrategy<
+        Esirkepov<
+            T_ParticleShape,
+            T_Strategy,
+            T_dim
+        >
+    >
+    {
+        using type = T_Strategy;
+    };
 
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy
+    >
+    struct GetStrategy<
+        EsirkepovNative<
+            T_ParticleShape,
+            T_Strategy
+        >
+    >
+    {
+        using type = T_Strategy;
+    };
+
+} // namespace traits
 } //namespace currentSolver
 
 namespace traits
 {
 
-/*Get margin of a solver
- * class must define a LowerMargin and UpperMargin
- */
-template<typename ParticleShape,uint32_t T_dim>
-struct GetMargin<picongpu::currentSolver::Esirkepov<ParticleShape,T_dim> >
-{
-private:
-    typedef picongpu::currentSolver::Esirkepov<ParticleShape,T_dim> Solver;
-public:
-    typedef typename Solver::LowerMargin LowerMargin;
-    typedef typename Solver::UpperMargin UpperMargin;
-};
+    /*Get margin of a solver
+     * class must define a LowerMargin and UpperMargin
+     */
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy,
+        uint32_t T_dim
+    >
+    struct GetMargin<
+        picongpu::currentSolver::Esirkepov<
+            T_ParticleShape,
+            T_Strategy,
+            T_dim
+        >
+    >
+    {
+    private:
+        using Solver = picongpu::currentSolver::Esirkepov<
+            T_ParticleShape,
+            T_Strategy,
+            T_dim
+        >;
+    public:
+        typedef typename Solver::LowerMargin LowerMargin;
+        typedef typename Solver::UpperMargin UpperMargin;
+    };
 
 } //namespace traits
 

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
@@ -36,8 +36,9 @@ namespace currentSolver
      * paper: "Exact charge conservation scheme for Particle-in-Cell simulation
      *  with an arbitrary form-factor"
      *
-     * \tparam T_ParticleShape the particle shape for the species, \see picongpu::particles::shapes
-     * \tparam T_Dim Implementation for 2D or 3D
+     * @tparam T_ParticleShape the particle shape for the species, [picongpu::particles::shapes]
+     * @tparam T_Strategy Used strategy to reduce the scattered data [currentSolver::strategy]
+     * @tparam T_Dim Implementation for 2D or 3D
      */
     template<
         typename T_ParticleShape,
@@ -46,6 +47,15 @@ namespace currentSolver
     >
     struct Esirkepov;
 
+    /** Paper like implementation of Esirkepov current deposition
+     *
+     * The implementation uses an non optimized stencil width and is therefore over
+     * 4x slower than the other Esirkepov implementation.
+     * @attention this solver is only for testing
+     *
+     * @tparam T_ParticleShape the particle shape for the species, [picongpu::particles::shapes]
+     * @tparam T_Strategy Used strategy to reduce the scattered data [currentSolver::strategy]
+     */
     template<
         typename T_ParticleShape,
         typename T_Strategy = traits::GetDefaultStrategy_t<>

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -24,7 +24,6 @@
 #include <pmacc/cuSTL/cursor/Cursor.hpp>
 #include <pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp>
 #include <pmacc/cuSTL/cursor/compile-time/SafeCursor.hpp>
-#include <pmacc/nvidia/atomic.hpp>
 
 #include "picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def"
 #include "picongpu/fields/currentDeposition/Esirkepov/Line.hpp"
@@ -35,247 +34,254 @@ namespace picongpu
 {
 namespace currentSolver
 {
-using namespace pmacc;
 
-template<typename T_ParticleShape>
-struct Esirkepov<T_ParticleShape, DIM3>
-{
-    using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
-    static constexpr int supp = ParticleAssign::support;
-
-    static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
-    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
-    typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
-    typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
-
-    PMACC_CASSERT_MSG(
-        __Esirkepov_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
-        pmacc::math::CT::min<
-            typename pmacc::math::CT::mul<
-                SuperCellSize,
-                GuardSize
-            >::type
-        >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min<
-            typename pmacc::math::CT::mul<
-                SuperCellSize,
-                GuardSize
-            >::type
-        >::type::value >= currentUpperMargin
-    );
-
-    float_X charge;
-
-    /* At the moment Esirkepov only supports Yee cells where W is defined at origin (0,0,0)
-     *
-     * \todo: please fix me that we can use CenteredCell
-     */
     template<
-        typename DataBoxJ,
-        typename PosType,
-        typename VelType,
-        typename ChargeType,
-        typename T_Acc
+        typename T_ParticleShape,
+        typename T_Strategy
     >
-    DINLINE void operator()(
-        T_Acc const & acc,
-        DataBoxJ dataBoxJ,
-        const PosType pos,
-        const VelType velocity,
-        const ChargeType charge,
-        const float_X deltaTime
-    )
+    struct Esirkepov<
+        T_ParticleShape,
+        T_Strategy,
+        DIM3
+    >
     {
-        this->charge = charge;
-        const float3_X deltaPos = float3_X(velocity.x() * deltaTime / cellSize.x(),
-                                           velocity.y() * deltaTime / cellSize.y(),
-                                           velocity.z() * deltaTime / cellSize.z());
-        const PosType oldPos = pos - deltaPos;
-        Line<float3_X> line(oldPos, pos);
+        using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
+        static constexpr int supp = ParticleAssign::support;
 
-        DataSpace<DIM3> gridShift;
+        static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+        static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
+        typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
+        typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
 
-        /* Define in which direction the particle leaves the cell.
-         * It is not relevant whether the particle leaves the cell via
-         * the positive or negative cell border.
+        PMACC_CASSERT_MSG(
+            __Esirkepov_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
+            pmacc::math::CT::min<
+                typename pmacc::math::CT::mul<
+                    SuperCellSize,
+                    GuardSize
+                >::type
+            >::type::value >= currentLowerMargin &&
+            pmacc::math::CT::min<
+                typename pmacc::math::CT::mul<
+                    SuperCellSize,
+                    GuardSize
+                >::type
+            >::type::value >= currentUpperMargin
+        );
+
+        float_X charge;
+
+        /* At the moment Esirkepov only supports Yee cells where W is defined at origin (0,0,0)
          *
-         * 0 == stay in cell
-         * 1 == leave cell
+         * \todo: please fix me that we can use CenteredCell
          */
-        DataSpace<simDim> leaveCell;
-
-        /* calculate the offset for the virtual coordinate system */
-        for(int d=0; d<simDim; ++d)
+        template<
+            typename DataBoxJ,
+            typename PosType,
+            typename VelType,
+            typename ChargeType,
+            typename T_Acc
+        >
+        DINLINE void operator()(
+            T_Acc const & acc,
+            DataBoxJ dataBoxJ,
+            const PosType pos,
+            const VelType velocity,
+            const ChargeType charge,
+            const float_X deltaTime
+        )
         {
-            int iStart;
-            int iEnd;
-            constexpr bool isSupportEven = ( supp % 2 == 0 );
-            RelayPoint< isSupportEven >()(
-                iStart,
-                iEnd,
-                line.m_pos0[d],
-                line.m_pos1[d]
-            );
-            gridShift[d] = iStart < iEnd ? iStart : iEnd; // integer min function
-            /* particle is leaving the cell */
-            leaveCell[d] = iStart != iEnd ? 1 : 0;
-            /* shift the particle position to the virtual coordinate system */
-            line.m_pos0[d] -= gridShift[d];
-            line.m_pos1[d] -= gridShift[d];
-        }
-        /* shift current field to the virtual coordinate system */
-        auto cursorJ = dataBoxJ.shift(gridShift).toCursor();
-        /**
-         * \brief the following three calls separate the 3D current deposition
-         * into three independent 1D calls, each for one direction and current component.
-         * Therefore the coordinate system has to be rotated so that the z-direction
-         * is always specific.
-         */
-        using namespace cursor::tools;
-        cptCurrent1D(
-            acc,
-            DataSpace<simDim>(leaveCell.y(),leaveCell.z(),leaveCell.x()),
-            twistVectorFieldAxes<pmacc::math::CT::Int < 1, 2, 0 > >(cursorJ),
-            rotateOrigin < 1, 2, 0 > (line),
-            cellSize.x()
-        );
-        cptCurrent1D(
-            acc,
-            DataSpace<simDim>(leaveCell.z(),leaveCell.x(),leaveCell.y()),
-            twistVectorFieldAxes<pmacc::math::CT::Int < 2, 0, 1 > >(cursorJ),
-            rotateOrigin < 2, 0, 1 > (line),
-            cellSize.y()
-        );
-        cptCurrent1D(
-            acc,
-            leaveCell,
-            cursorJ,
-            line,
-            cellSize.z()
-        );
-    }
+            this->charge = charge;
+            const float3_X deltaPos = float3_X(velocity.x() * deltaTime / cellSize.x(),
+                                               velocity.y() * deltaTime / cellSize.y(),
+                                               velocity.z() * deltaTime / cellSize.z());
+            const PosType oldPos = pos - deltaPos;
+            Line<float3_X> line(oldPos, pos);
 
-    /**
-     * deposites current in z-direction
-     *
-     * \param leaveCell vector with information if the particle is leaving the cell
-     *         (for each direction, 0 means stays in cell and 1 means leaves cell)
-     * \param cursorJ cursor pointing at the current density field of the particle's cell
-     * \param line trajectory of the particle from to last to the current time step
-     * \param cellEdgeLength length of edge of the cell in z-direction
-     */
-    template<
-        typename CursorJ,
-        typename T_Acc
-    >
-    DINLINE void cptCurrent1D(
-        T_Acc const & acc,
-        const DataSpace<simDim>& leaveCell,
-        CursorJ cursorJ,
-        const Line<float3_X>& line,
-        const float_X cellEdgeLength
-    )
-    {
-        /* skip calculation if the particle is not moving in z direction */
-        if(line.m_pos0[2] == line.m_pos1[2])
-            return;
+            DataSpace<DIM3> gridShift;
 
-        constexpr int begin = -currentLowerMargin + 1;
-        constexpr int end = begin + supp;
+            /* Define in which direction the particle leaves the cell.
+             * It is not relevant whether the particle leaves the cell via
+             * the positive or negative cell border.
+             *
+             * 0 == stay in cell
+             * 1 == leave cell
+             */
+            DataSpace<simDim> leaveCell;
 
-        /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
-         * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1)
-         */
-        const float_X currentSurfaceDensity = this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * cellEdgeLength;
-
-        /* pick every cell in the xy-plane that is overlapped by particle's
-         * form factor and deposit the current for the cells above and beneath
-         * that cell and for the cell itself.
-         *
-         * for loop optimization (help the compiler to generate better code):
-         *   - use a loop with a static range
-         *   - skip invalid indexes with a if condition around the full loop body
-         *     ( this helps the compiler to mask threads without work )
-         */
-        for( int i = begin ; i < end  + 1; ++i )
-            if( i < end + leaveCell[0] )
+            /* calculate the offset for the virtual coordinate system */
+            for(int d=0; d<simDim; ++d)
             {
-                const float_X s0i = S0( line, i, 0 );
-                const float_X dsi = S1( line, i, 0 ) - s0i;
-                for( int j = begin ; j < end  + 1; ++j )
-                    if( j < end + leaveCell[1] )
-                    {
-                        const float_X s0j = S0( line, j, 1 );
-                        const float_X dsj = S1( line, j, 1 ) - s0j;
-
-                        float_X tmp =
-                            -currentSurfaceDensity * (
-                                s0i * s0j +
-                                float_X( 0.5 ) * ( dsi * s0j + s0i * dsj ) +
-                                ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsj * dsi
-                            );
-
-                        float_X accumulated_J = float_X( 0.0 );
-
-                        /* attention: inner loop has no upper bound `end + 1` because
-                         * the current for the point `end` is always zero,
-                         * therefore we skip the calculation
-                         */
-                        for( int k = begin ; k < end; ++k )
-                            if( k < end + leaveCell[2] - 1 )
-                            {
-                                /* This is the implementation of the FORTRAN W(i,j,k,3)/ C style W(i,j,k,2) version from
-                                 * Esirkepov paper. All coordinates are rotated before thus we can
-                                 * always use C style W(i,j,k,2).
-                                 */
-                                const float_X W = DS( line, k, 2 ) * tmp;
-                                accumulated_J += W;
-                                cupla::atomicAdd(acc, &( ( *cursorJ( i, j, k ) ).z() ), accumulated_J, ::alpaka::hierarchy::Threads{} );
-                            }
-                    }
+                int iStart;
+                int iEnd;
+                constexpr bool isSupportEven = ( supp % 2 == 0 );
+                RelayPoint< isSupportEven >()(
+                    iStart,
+                    iEnd,
+                    line.m_pos0[d],
+                    line.m_pos1[d]
+                );
+                gridShift[d] = iStart < iEnd ? iStart : iEnd; // integer min function
+                /* particle is leaving the cell */
+                leaveCell[d] = iStart != iEnd ? 1 : 0;
+                /* shift the particle position to the virtual coordinate system */
+                line.m_pos0[d] -= gridShift[d];
+                line.m_pos1[d] -= gridShift[d];
             }
+            /* shift current field to the virtual coordinate system */
+            auto cursorJ = dataBoxJ.shift(gridShift).toCursor();
+            /**
+             * \brief the following three calls separate the 3D current deposition
+             * into three independent 1D calls, each for one direction and current component.
+             * Therefore the coordinate system has to be rotated so that the z-direction
+             * is always specific.
+             */
+            using namespace cursor::tools;
+            cptCurrent1D(
+                acc,
+                DataSpace<simDim>(leaveCell.y(),leaveCell.z(),leaveCell.x()),
+                twistVectorFieldAxes<pmacc::math::CT::Int < 1, 2, 0 > >(cursorJ),
+                rotateOrigin < 1, 2, 0 > (line),
+                cellSize.x()
+            );
+            cptCurrent1D(
+                acc,
+                DataSpace<simDim>(leaveCell.z(),leaveCell.x(),leaveCell.y()),
+                twistVectorFieldAxes<pmacc::math::CT::Int < 2, 0, 1 > >(cursorJ),
+                rotateOrigin < 2, 0, 1 > (line),
+                cellSize.y()
+            );
+            cptCurrent1D(
+                acc,
+                leaveCell,
+                cursorJ,
+                line,
+                cellSize.z()
+            );
+        }
 
-    }
+        /**
+         * deposites current in z-direction
+         *
+         * \param leaveCell vector with information if the particle is leaving the cell
+         *         (for each direction, 0 means stays in cell and 1 means leaves cell)
+         * \param cursorJ cursor pointing at the current density field of the particle's cell
+         * \param line trajectory of the particle from to last to the current time step
+         * \param cellEdgeLength length of edge of the cell in z-direction
+         */
+        template<
+            typename CursorJ,
+            typename T_Acc
+        >
+        DINLINE void cptCurrent1D(
+            T_Acc const & acc,
+            const DataSpace<simDim>& leaveCell,
+            CursorJ cursorJ,
+            const Line<float3_X>& line,
+            const float_X cellEdgeLength
+        )
+        {
+            /* skip calculation if the particle is not moving in z direction */
+            if(line.m_pos0[2] == line.m_pos1[2])
+                return;
 
-    /** calculate S0 (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {0,1,2} means {x,y,z}
-     *          different to Esirkepov paper, here we use C style
-     */
-    DINLINE float_X S0(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos0[d]);
-    }
+            constexpr int begin = -currentLowerMargin + 1;
+            constexpr int end = begin + supp;
 
-   /** calculate S1 (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {0,1,2} means {x,y,z}
-     *          different to Esirkepov paper, here we use C style
-     */
-    DINLINE float_X S1(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos1[d]);
-    }
+            /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
+             * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1)
+             */
+            const float_X currentSurfaceDensity = this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * cellEdgeLength;
 
-    /** calculate DS (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {0,1,2} means {x,y,z}]
-     *          different to Esirkepov paper, here we use C style
-     */
-    DINLINE float_X DS(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos1[d]) - ParticleAssign()(gridPoint - line.m_pos0[d]);
-    }
+            /* pick every cell in the xy-plane that is overlapped by particle's
+             * form factor and deposit the current for the cells above and beneath
+             * that cell and for the cell itself.
+             *
+             * for loop optimization (help the compiler to generate better code):
+             *   - use a loop with a static range
+             *   - skip invalid indexes with a if condition around the full loop body
+             *     ( this helps the compiler to mask threads without work )
+             */
+            for( int i = begin ; i < end  + 1; ++i )
+                if( i < end + leaveCell[0] )
+                {
+                    const float_X s0i = S0( line, i, 0 );
+                    const float_X dsi = S1( line, i, 0 ) - s0i;
+                    for( int j = begin ; j < end  + 1; ++j )
+                        if( j < end + leaveCell[1] )
+                        {
+                            const float_X s0j = S0( line, j, 1 );
+                            const float_X dsj = S1( line, j, 1 ) - s0j;
 
-    static pmacc::traits::StringProperty getStringProperties()
-    {
-        pmacc::traits::StringProperty propList( "name", "Esirkepov" );
-        return propList;
-    }
-};
+                            float_X tmp =
+                                -currentSurfaceDensity * (
+                                    s0i * s0j +
+                                    float_X( 0.5 ) * ( dsi * s0j + s0i * dsj ) +
+                                    ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsj * dsi
+                                );
+
+                            float_X accumulated_J = float_X( 0.0 );
+
+                            /* attention: inner loop has no upper bound `end + 1` because
+                             * the current for the point `end` is always zero,
+                             * therefore we skip the calculation
+                             */
+                            for( int k = begin ; k < end; ++k )
+                                if( k < end + leaveCell[2] - 1 )
+                                {
+                                    /* This is the implementation of the FORTRAN W(i,j,k,3)/ C style W(i,j,k,2) version from
+                                     * Esirkepov paper. All coordinates are rotated before thus we can
+                                     * always use C style W(i,j,k,2).
+                                     */
+                                    const float_X W = DS( line, k, 2 ) * tmp;
+                                    accumulated_J += W;
+                                    auto const atomicOp = typename T_Strategy::BlockReductionOp{};
+                                    atomicOp(acc, ( *cursorJ( i, j, k ) ).z(), accumulated_J);
+                                }
+                        }
+                }
+
+        }
+
+        /** calculate S0 (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1,2} means {x,y,z}
+         *          different to Esirkepov paper, here we use C style
+         */
+        DINLINE float_X S0(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos0[d]);
+        }
+
+       /** calculate S1 (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1,2} means {x,y,z}
+         *          different to Esirkepov paper, here we use C style
+         */
+        DINLINE float_X S1(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos1[d]);
+        }
+
+        /** calculate DS (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1,2} means {x,y,z}]
+         *          different to Esirkepov paper, here we use C style
+         */
+        DINLINE float_X DS(const Line<float3_X>& line, const float_X gridPoint, const uint32_t d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos1[d]) - ParticleAssign()(gridPoint - line.m_pos0[d]);
+        }
+
+        static pmacc::traits::StringProperty getStringProperties()
+        {
+            pmacc::traits::StringProperty propList( "name", "Esirkepov" );
+            return propList;
+        }
+    };
 
 } //namespace currentSolver
 

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -23,7 +23,6 @@
 #include <pmacc/cuSTL/cursor/Cursor.hpp>
 #include <pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp>
 #include <pmacc/cuSTL/cursor/compile-time/SafeCursor.hpp>
-#include <pmacc/nvidia/atomic.hpp>
 
 #include "picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp"
 #include "picongpu/fields/currentDeposition/Esirkepov/Line.hpp"
@@ -34,280 +33,288 @@ namespace picongpu
 {
 namespace currentSolver
 {
-using namespace pmacc;
 
-/**
- * Implements the current deposition algorithm from T.Zh. Esirkepov
- *
- * for an arbitrary particle assign function given as a template parameter.
- * See available shapes at "intermediateLib/particleShape".
- * paper: "Exact charge conservation scheme for Particle-in-Cell simulation
- *  with an arbitrary form-factor"
- */
-template<typename T_ParticleShape>
-struct Esirkepov<T_ParticleShape, DIM2>
-{
-    using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
-    static constexpr int supp = ParticleAssign::support;
-
-    static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
-    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
-    typedef typename pmacc::math::CT::make_Int<DIM2, currentLowerMargin>::type LowerMargin;
-    typedef typename pmacc::math::CT::make_Int<DIM2, currentUpperMargin>::type UpperMargin;
-
-    PMACC_CASSERT_MSG(
-        __Esirkepov2D_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
-        pmacc::math::CT::min<
-            typename pmacc::math::CT::mul<
-                SuperCellSize,
-                GuardSize
-            >::type
-        >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min<
-            typename pmacc::math::CT::mul<
-                SuperCellSize,
-                GuardSize
-            >::type
-        >::type::value >= currentUpperMargin
-    );
-
-    static constexpr int begin = -currentLowerMargin + 1;
-    static constexpr int end = begin + supp;
-
-    float_X charge;
-
+    /**
+     * Implements the current deposition algorithm from T.Zh. Esirkepov
+     *
+     * for an arbitrary particle assign function given as a template parameter.
+     * See available shapes at "intermediateLib/particleShape".
+     * paper: "Exact charge conservation scheme for Particle-in-Cell simulation
+     *  with an arbitrary form-factor"
+     */
     template<
-        typename DataBoxJ,
-        typename PosType,
-        typename VelType,
-        typename ChargeType,
-        typename T_Acc
+        typename T_ParticleShape,
+        typename T_Strategy
     >
-    DINLINE void operator()(
-        T_Acc const & acc,
-        DataBoxJ dataBoxJ,
-        const PosType pos,
-        const VelType velocity,
-        const ChargeType charge,
-        const float_X deltaTime
-    )
+    struct Esirkepov<
+        T_ParticleShape,
+        T_Strategy,
+        DIM2
+    >
     {
-        this->charge = charge;
-        const float2_X deltaPos = float2_X(velocity.x() * deltaTime / cellSize.x(),
-                                           velocity.y() * deltaTime / cellSize.y());
-        const PosType oldPos = pos - deltaPos;
-        Line<float2_X> line(oldPos, pos);
+        using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
+        static constexpr int supp = ParticleAssign::support;
 
-        DataSpace<simDim> gridShift;
-        /* Define in which direction the particle leaves the cell.
-         * It is not important whether the particle move over the positive or negative
-         * cell border.
-         *
-         * 0 == stay in cell
-         * 1 == leave cell
-         */
-        DataSpace<DIM2> leaveCell;
+        static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
+        static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
+        typedef typename pmacc::math::CT::make_Int<DIM2, currentLowerMargin>::type LowerMargin;
+        typedef typename pmacc::math::CT::make_Int<DIM2, currentUpperMargin>::type UpperMargin;
 
-        /* calculate the offset for the virtual coordinate system */
-        for(int d=0; d<simDim; ++d)
+        PMACC_CASSERT_MSG(
+            __Esirkepov2D_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
+            pmacc::math::CT::min<
+                typename pmacc::math::CT::mul<
+                    SuperCellSize,
+                    GuardSize
+                >::type
+            >::type::value >= currentLowerMargin &&
+            pmacc::math::CT::min<
+                typename pmacc::math::CT::mul<
+                    SuperCellSize,
+                    GuardSize
+                >::type
+            >::type::value >= currentUpperMargin
+        );
+
+        static constexpr int begin = -currentLowerMargin + 1;
+        static constexpr int end = begin + supp;
+
+        float_X charge;
+
+        template<
+            typename DataBoxJ,
+            typename PosType,
+            typename VelType,
+            typename ChargeType,
+            typename T_Acc
+        >
+        DINLINE void operator()(
+            T_Acc const & acc,
+            DataBoxJ dataBoxJ,
+            const PosType pos,
+            const VelType velocity,
+            const ChargeType charge,
+            const float_X deltaTime
+        )
         {
-            int iStart;
-            int iEnd;
-            constexpr bool isSupportEven = ( supp % 2 == 0 );
-            RelayPoint< isSupportEven >()(
-                iStart,
-                iEnd,
-                line.m_pos0[d],
-                line.m_pos1[d]
+            this->charge = charge;
+            const float2_X deltaPos = float2_X(velocity.x() * deltaTime / cellSize.x(),
+                                               velocity.y() * deltaTime / cellSize.y());
+            const PosType oldPos = pos - deltaPos;
+            Line<float2_X> line(oldPos, pos);
+
+            DataSpace<simDim> gridShift;
+            /* Define in which direction the particle leaves the cell.
+             * It is not important whether the particle move over the positive or negative
+             * cell border.
+             *
+             * 0 == stay in cell
+             * 1 == leave cell
+             */
+            DataSpace<DIM2> leaveCell;
+
+            /* calculate the offset for the virtual coordinate system */
+            for(int d=0; d<simDim; ++d)
+            {
+                int iStart;
+                int iEnd;
+                constexpr bool isSupportEven = ( supp % 2 == 0 );
+                RelayPoint< isSupportEven >()(
+                    iStart,
+                    iEnd,
+                    line.m_pos0[d],
+                    line.m_pos1[d]
+                );
+                gridShift[d] = iStart < iEnd ? iStart : iEnd; // integer min function
+                /* particle is leaving the cell */
+                leaveCell[d] = iStart != iEnd ? 1 : 0;
+                /* shift the particle position to the virtual coordinate system */
+                line.m_pos0[d] -= gridShift[d];
+                line.m_pos1[d] -= gridShift[d];
+            }
+            /* shift current field to the virtual coordinate system */
+            auto cursorJ = dataBoxJ.shift(gridShift).toCursor();
+
+            /**
+             * \brief the following three calls separate the 3D current deposition
+             * into three independent 1D calls, each for one direction and current component.
+             * Therefore the coordinate system has to be rotated so that the z-direction
+             * is always specific.
+             */
+
+            using namespace cursor::tools;
+            cptCurrent1D(
+                acc,
+                leaveCell,
+                cursorJ,
+                line,
+                cellSize.x()
             );
-            gridShift[d] = iStart < iEnd ? iStart : iEnd; // integer min function
-            /* particle is leaving the cell */
-            leaveCell[d] = iStart != iEnd ? 1 : 0;
-            /* shift the particle position to the virtual coordinate system */
-            line.m_pos0[d] -= gridShift[d];
-            line.m_pos1[d] -= gridShift[d];
+            cptCurrent1D(
+                acc,
+                DataSpace<DIM2>(
+                    leaveCell[1],
+                    leaveCell[0]
+                ),
+                twistVectorFieldAxes<pmacc::math::CT::Int < 1, 0 > >(cursorJ),
+                rotateOrigin < 1, 0 > (line),
+                cellSize.y()
+            );
+            cptCurrentZ(
+                acc,
+                leaveCell,
+                cursorJ,
+                line,
+                velocity.z()
+            );
         }
-        /* shift current field to the virtual coordinate system */
-        auto cursorJ = dataBoxJ.shift(gridShift).toCursor();
 
         /**
-         * \brief the following three calls separate the 3D current deposition
-         * into three independent 1D calls, each for one direction and current component.
-         * Therefore the coordinate system has to be rotated so that the z-direction
-         * is always specific.
+         * deposites current in z-direction
+         * \param leaveCell vector with information if the particle is leaving the cell
+         *         (for each direction, 0 means stays in cell and 1 means leaves cell)
+         * \param cursorJ cursor pointing at the current density field of the particle's cell
+         * \param line trajectory of the particle from to last to the current time step
+         * \param cellEdgeLength length of edge of the cell in z-direction
+         *
+         * @{
+         */
+        template<
+            typename CursorJ,
+            typename T_Acc
+        >
+        DINLINE void cptCurrent1D(
+            T_Acc const & acc,
+            const DataSpace<simDim>& leaveCell,
+            CursorJ cursorJ,
+            const Line<float2_X>& line,
+            const float_X cellEdgeLength
+        )
+        {
+            /* skip calculation if the particle is not moving in x direction */
+            if(line.m_pos0[0] == line.m_pos1[0])
+                return;
+
+            /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
+             * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1)
+             */
+            const float_X currentSurfaceDensity = this->charge * ( float_X( 1.0 ) / float_X( CELL_VOLUME * DELTA_T ) ) * cellEdgeLength;
+
+            for( int j = begin; j < end + 1; ++j )
+                if( j < end + leaveCell[1] )
+                {
+                    const float_X s0j = S0( line, j, 1 );
+                    const float_X dsj = S1( line, j, 1 ) - s0j;
+
+                    float_X tmp = -currentSurfaceDensity *
+                        (
+                            s0j +
+                            float_X( 0.5 ) * dsj
+                        );
+
+                    float_X accumulated_J = float_X(0.0);
+                    /* attention: inner loop has no upper bound `end + 1` because
+                     * the current for the point `end` is always zero,
+                     * therefore we skip the calculation
+                     */
+                    for( int i = begin; i < end; ++i )
+                        if( i < end + leaveCell[0] - 1 )
+                        {
+                            /* This is the implementation of the FORTRAN W(i,j,k,1)/ C style W(i,j,k,0) version from
+                             * Esirkepov paper. All coordinates are rotated before thus we can
+                             * always use C style W(i,j,k,0).
+                             */
+                            const float_X W = DS( line, i, 0 ) * tmp;
+                            accumulated_J += W;
+                            auto const atomicOp = typename T_Strategy::BlockReductionOp{};
+                            atomicOp( acc, ( *cursorJ( i, j ) ).x(), accumulated_J );
+                        }
+                }
+
+        }
+
+        template<
+            typename CursorJ,
+            typename T_Acc
+        >
+        DINLINE void cptCurrentZ(
+            T_Acc const & acc,
+            const DataSpace<simDim>& leaveCell,
+            CursorJ cursorJ,
+            const Line<float2_X>& line,
+            const float_X v_z
+        )
+        {
+            if( v_z == float_X( 0.0 ) )
+                return;
+
+            const float_X currentSurfaceDensityZ = this->charge * ( float_X( 1.0 ) / float_X( CELL_VOLUME ) ) * v_z;
+
+            for( int j = begin; j < end + 1; ++j )
+                if( j < end + leaveCell[1] )
+                {
+                    const float_X s0j = S0( line, j, 1 );
+                    const float_X dsj = S1( line, j, 1 ) - s0j;
+
+                    for( int i = begin; i < end + 1; ++i )
+                        if( i < end + leaveCell[0] )
+                        {
+                            const float_X s0i = S0( line, i, 0 );
+                            const float_X dsi = S1( line, i, 0 ) - s0i;
+                            float_X W = s0i * S0( line, j, 1 ) +
+                                float_X( 0.5 ) * ( dsi * s0j + s0i * dsj ) +
+                                ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsi * dsj;
+
+                            const float_X j_z = W * currentSurfaceDensityZ;
+                            auto const atomicOp = typename T_Strategy::BlockReductionOp{};
+                            atomicOp( acc, ( *cursorJ( i, j ) ).z(), j_z );
+                        }
+                }
+        }
+
+        /**
+         * @}
          */
 
-        using namespace cursor::tools;
-        cptCurrent1D(
-            acc,
-            leaveCell,
-            cursorJ,
-            line,
-            cellSize.x()
-        );
-        cptCurrent1D(
-            acc,
-            DataSpace<DIM2>(
-                leaveCell[1],
-                leaveCell[0]
-            ),
-            twistVectorFieldAxes<pmacc::math::CT::Int < 1, 0 > >(cursorJ),
-            rotateOrigin < 1, 0 > (line),
-            cellSize.y()
-        );
-        cptCurrentZ(
-            acc,
-            leaveCell,
-            cursorJ,
-            line,
-            velocity.z()
-        );
-    }
-
-    /**
-     * deposites current in z-direction
-     * \param leaveCell vector with information if the particle is leaving the cell
-     *         (for each direction, 0 means stays in cell and 1 means leaves cell)
-     * \param cursorJ cursor pointing at the current density field of the particle's cell
-     * \param line trajectory of the particle from to last to the current time step
-     * \param cellEdgeLength length of edge of the cell in z-direction
-     *
-     * @{
-     */
-    template<
-        typename CursorJ,
-        typename T_Acc
-    >
-    DINLINE void cptCurrent1D(
-        T_Acc const & acc,
-        const DataSpace<simDim>& leaveCell,
-        CursorJ cursorJ,
-        const Line<float2_X>& line,
-        const float_X cellEdgeLength
-    )
-    {
-        /* skip calculation if the particle is not moving in x direction */
-        if(line.m_pos0[0] == line.m_pos1[0])
-            return;
-
-        /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
-         * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1)
+        /** calculate S0 (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1} means {x,y}
+         *          different to Esirkepov paper, here we use C style
          */
-        const float_X currentSurfaceDensity = this->charge * ( float_X( 1.0 ) / float_X( CELL_VOLUME * DELTA_T ) ) * cellEdgeLength;
+        DINLINE float_X S0(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos0[d]);
+        }
 
-        for( int j = begin; j < end + 1; ++j )
-            if( j < end + leaveCell[1] )
-            {
-                const float_X s0j = S0( line, j, 1 );
-                const float_X dsj = S1( line, j, 1 ) - s0j;
+        /** calculate S1 (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1,2} means {x,y,z}
+         *          different to Esirkepov paper, here we use C style
+         */
+        DINLINE float_X S1(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos1[d]);
+        }
 
-                float_X tmp = -currentSurfaceDensity *
-                    (
-                        s0j +
-                        float_X( 0.5 ) * dsj
-                    );
+        /** calculate DS (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {0,1} means {x,y}
+         *          different to Esirkepov paper, here we use C style
+         */
+        DINLINE float_X DS(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos1[d]) - ParticleAssign()(gridPoint - line.m_pos0[d]);
+        }
 
-                float_X accumulated_J = float_X(0.0);
-                /* attention: inner loop has no upper bound `end + 1` because
-                 * the current for the point `end` is always zero,
-                 * therefore we skip the calculation
-                 */
-                for( int i = begin; i < end; ++i )
-                    if( i < end + leaveCell[0] - 1 )
-                    {
-                        /* This is the implementation of the FORTRAN W(i,j,k,1)/ C style W(i,j,k,0) version from
-                         * Esirkepov paper. All coordinates are rotated before thus we can
-                         * always use C style W(i,j,k,0).
-                         */
-                        const float_X W = DS( line, i, 0 ) * tmp;
-                        accumulated_J += W;
-                        cupla::atomicAdd(acc, &( ( *cursorJ( i, j ) ).x() ), accumulated_J, ::alpaka::hierarchy::Threads{} );
-                    }
-            }
-
-    }
-
-    template<
-        typename CursorJ,
-        typename T_Acc
-    >
-    DINLINE void cptCurrentZ(
-        T_Acc const & acc,
-        const DataSpace<simDim>& leaveCell,
-        CursorJ cursorJ,
-        const Line<float2_X>& line,
-        const float_X v_z
-    )
-    {
-        if( v_z == float_X( 0.0 ) )
-            return;
-
-        const float_X currentSurfaceDensityZ = this->charge * ( float_X( 1.0 ) / float_X( CELL_VOLUME ) ) * v_z;
-
-        for( int j = begin; j < end + 1; ++j )
-            if( j < end + leaveCell[1] )
-            {
-                const float_X s0j = S0( line, j, 1 );
-                const float_X dsj = S1( line, j, 1 ) - s0j;
-
-                for( int i = begin; i < end + 1; ++i )
-                    if( i < end + leaveCell[0] )
-                    {
-                        const float_X s0i = S0( line, i, 0 );
-                        const float_X dsi = S1( line, i, 0 ) - s0i;
-                        float_X W = s0i * S0( line, j, 1 ) +
-                            float_X( 0.5 ) * ( dsi * s0j + s0i * dsj ) +
-                            ( float_X( 1.0 ) / float_X( 3.0 ) ) * dsi * dsj;
-
-                        const float_X j_z = W * currentSurfaceDensityZ;
-                        cupla::atomicAdd(acc, &( ( *cursorJ( i, j ) ).z() ), j_z, ::alpaka::hierarchy::Threads{} );
-                    }
-            }
-    }
-
-    /**
-     * @}
-     */
-
-    /** calculate S0 (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {0,1} means {x,y}
-     *          different to Esirkepov paper, here we use C style
-     */
-    DINLINE float_X S0(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos0[d]);
-    }
-
-    /** calculate S1 (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {0,1,2} means {x,y,z}
-     *          different to Esirkepov paper, here we use C style
-     */
-    DINLINE float_X S1(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos1[d]);
-    }
-
-    /** calculate DS (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {0,1} means {x,y}
-     *          different to Esirkepov paper, here we use C style
-     */
-    DINLINE float_X DS(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos1[d]) - ParticleAssign()(gridPoint - line.m_pos0[d]);
-    }
-
-    static pmacc::traits::StringProperty getStringProperties()
-    {
-        pmacc::traits::StringProperty propList( "name", "Esirkepov" );
-        return propList;
-    }
-};
+        static pmacc::traits::StringProperty getStringProperties()
+        {
+            pmacc::traits::StringProperty propList( "name", "Esirkepov" );
+            return propList;
+        }
+    };
 
 } //namespace currentSolver
 

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -98,11 +98,9 @@ namespace currentSolver
         )
         {
             this->charge = charge;
-            const float3_X deltaPos = float3_X(velocity.x() * deltaTime / cellSize.x(),
-                                               velocity.y() * deltaTime / cellSize.y(),
-                                               velocity.z() * deltaTime / cellSize.z());
+            const float3_X deltaPos = velocity * deltaTime / cellSize;
             const PosType oldPos = pos - deltaPos;
-            Line<float3_X> line(oldPos, pos);
+            const Line<float3_X> line(oldPos, pos);
             auto cursorJ = dataBoxJ.toCursor();
 
             /**
@@ -152,7 +150,7 @@ namespace currentSolver
                     float_X accumulated_J = float_X(0.0);
                     for (int k = begin; k < end; ++k)
                     {
-                        float_X W = DS(line, k, 3) * tmp;
+                        const float_X W = DS(line, k, 3) * tmp;
                         /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
                          * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1) */
                         accumulated_J += -this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * W * cellEdgeLength;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -25,7 +25,6 @@
 #include <pmacc/cuSTL/cursor/Cursor.hpp>
 #include <pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp>
 #include <pmacc/cuSTL/cursor/compile-time/SafeCursor.hpp>
-#include <pmacc/nvidia/atomic.hpp>
 
 #include "picongpu/fields/currentDeposition/Esirkepov/Line.hpp"
 
@@ -34,182 +33,195 @@ namespace picongpu
 {
 namespace currentSolver
 {
-using namespace pmacc;
-
-/**
- * Implements the current deposition algorithm from T.Zh. Esirkepov
- *
- * for an arbitrary particle assign function given as a template parameter.
- * See available shapes at "intermediateLib/particleShape".
- * paper: "Exact charge conservation scheme for Particle-in-Cell simulation
- *  with an arbitrary form-factor"
- */
-template<typename T_ParticleShape>
-struct EsirkepovNative
-{
-    using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
-    static constexpr int supp = ParticleAssign::support;
-
-    static constexpr int currentLowerMargin = supp / 2 + 1;
-    static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
-    typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
-    typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
-
-    PMACC_CASSERT_MSG(
-        __EsirkepovNative_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
-        pmacc::math::CT::min<
-            typename pmacc::math::CT::mul<
-                SuperCellSize,
-                GuardSize
-            >::type
-        >::type::value >= currentLowerMargin &&
-        pmacc::math::CT::min<
-            typename pmacc::math::CT::mul<
-                SuperCellSize,
-                GuardSize
-            >::type
-        >::type::value >= currentUpperMargin
-    );
-
-    /* iterate over all grid points */
-    static constexpr int begin = -currentLowerMargin;
-    static constexpr int end = currentUpperMargin + 1;
-
-    float_X charge;
-
-    /* At the moment Esirkepov only supports Yee cells where W is defined at origin (0,0,0)
-     *
-     * \todo: please fix me that we can use CenteredCell
-     */
-    template<
-        typename DataBoxJ,
-        typename PosType,
-        typename VelType,
-        typename ChargeType,
-        typename T_Acc
-    >
-    DINLINE void operator()(
-        T_Acc const & acc,
-        DataBoxJ dataBoxJ,
-        const PosType pos,
-        const VelType velocity,
-        const ChargeType charge, const float_X deltaTime
-    )
-    {
-        this->charge = charge;
-        const float3_X deltaPos = float3_X(velocity.x() * deltaTime / cellSize.x(),
-                                           velocity.y() * deltaTime / cellSize.y(),
-                                           velocity.z() * deltaTime / cellSize.z());
-        const PosType oldPos = pos - deltaPos;
-        Line<float3_X> line(oldPos, pos);
-        auto cursorJ = dataBoxJ.toCursor();
-
-        /**
-         * \brief the following three calls separate the 3D current deposition
-         * into three independent 1D calls, each for one direction and current component.
-         * Therefore the coordinate system has to be rotated so that the z-direction
-         * is always specific.
-         */
-
-        using namespace cursor::tools;
-        cptCurrent1D(acc, twistVectorFieldAxes<pmacc::math::CT::Int < 1, 2, 0 > >(cursorJ), rotateOrigin < 1, 2, 0 > (line), cellSize.x());
-        cptCurrent1D(acc, twistVectorFieldAxes<pmacc::math::CT::Int < 2, 0, 1 > >(cursorJ), rotateOrigin < 2, 0, 1 > (line), cellSize.y());
-        cptCurrent1D(acc, cursorJ, line, cellSize.z());
-    }
 
     /**
-     * deposites current in z-direction
-     * \param cursorJ cursor pointing at the current density field of the particle's cell
-     * \param line trajectory of the particle from to last to the current time step
-     * \param cellEdgeLength length of edge of the cell in z-direction
+     * Implements the current deposition algorithm from T.Zh. Esirkepov
+     *
+     * for an arbitrary particle assign function given as a template parameter.
+     * See available shapes at "intermediateLib/particleShape".
+     * paper: "Exact charge conservation scheme for Particle-in-Cell simulation
+     *  with an arbitrary form-factor"
      */
     template<
-        typename CursorJ,
-        typename T_Acc
+        typename T_ParticleShape,
+        typename T_Strategy
     >
-    DINLINE void cptCurrent1D(
-        T_Acc const & acc,
-        CursorJ cursorJ,
-        const Line<float3_X>& line,
-        const float_X cellEdgeLength
-    )
+    struct EsirkepovNative
     {
-        /* pick every cell in the xy-plane that is overlapped by particle's
-         * form factor and deposit the current for the cells above and beneath
-         * that cell and for the cell itself.
-         */
-        for (int i = begin; i < end; ++i)
-        {
-            for (int j = begin; j < end; ++j)
-            {
-                float_X tmp =
-                    S0(line, i, 1) * S0(line, j, 2) +
-                    float_X(0.5) * DS(line, i, 1) * S0(line, j, 2) +
-                    float_X(0.5) * S0(line, i, 1) * DS(line, j, 2) +
-                    (float_X(1.0) / float_X(3.0)) * DS(line, i, 1) * DS(line, j, 2);
+        using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
+        static constexpr int supp = ParticleAssign::support;
 
-                float_X accumulated_J = float_X(0.0);
-                for (int k = begin; k < end; ++k)
-                {
-                    float_X W = DS(line, k, 3) * tmp;
-                    /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
-                     * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1) */
-                    accumulated_J += -this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * W * cellEdgeLength;
-                    cupla::atomicAdd(acc,&((*cursorJ(i, j, k)).z()), accumulated_J, ::alpaka::hierarchy::Threads{});
-                }
-            }
+        static constexpr int currentLowerMargin = supp / 2 + 1;
+        static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
+        typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
+        typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
+
+        PMACC_CASSERT_MSG(
+            __EsirkepovNative_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
+            pmacc::math::CT::min<
+                typename pmacc::math::CT::mul<
+                    SuperCellSize,
+                    GuardSize
+                >::type
+            >::type::value >= currentLowerMargin &&
+            pmacc::math::CT::min<
+                typename pmacc::math::CT::mul<
+                    SuperCellSize,
+                    GuardSize
+                >::type
+            >::type::value >= currentUpperMargin
+        );
+
+        /* iterate over all grid points */
+        static constexpr int begin = -currentLowerMargin;
+        static constexpr int end = currentUpperMargin + 1;
+
+        float_X charge;
+
+        /* At the moment Esirkepov only supports Yee cells where W is defined at origin (0,0,0)
+         *
+         * \todo: please fix me that we can use CenteredCell
+         */
+        template<
+            typename DataBoxJ,
+            typename PosType,
+            typename VelType,
+            typename ChargeType,
+            typename T_Acc
+        >
+        DINLINE void operator()(
+            T_Acc const & acc,
+            DataBoxJ dataBoxJ,
+            const PosType pos,
+            const VelType velocity,
+            const ChargeType charge, const float_X deltaTime
+        )
+        {
+            this->charge = charge;
+            const float3_X deltaPos = float3_X(velocity.x() * deltaTime / cellSize.x(),
+                                               velocity.y() * deltaTime / cellSize.y(),
+                                               velocity.z() * deltaTime / cellSize.z());
+            const PosType oldPos = pos - deltaPos;
+            Line<float3_X> line(oldPos, pos);
+            auto cursorJ = dataBoxJ.toCursor();
+
+            /**
+             * \brief the following three calls separate the 3D current deposition
+             * into three independent 1D calls, each for one direction and current component.
+             * Therefore the coordinate system has to be rotated so that the z-direction
+             * is always specific.
+             */
+
+            using namespace cursor::tools;
+            cptCurrent1D(acc, twistVectorFieldAxes<pmacc::math::CT::Int < 1, 2, 0 > >(cursorJ), rotateOrigin < 1, 2, 0 > (line), cellSize.x());
+            cptCurrent1D(acc, twistVectorFieldAxes<pmacc::math::CT::Int < 2, 0, 1 > >(cursorJ), rotateOrigin < 2, 0, 1 > (line), cellSize.y());
+            cptCurrent1D(acc, cursorJ, line, cellSize.z());
         }
 
-    }
+        /**
+         * deposites current in z-direction
+         * \param cursorJ cursor pointing at the current density field of the particle's cell
+         * \param line trajectory of the particle from to last to the current time step
+         * \param cellEdgeLength length of edge of the cell in z-direction
+         */
+        template<
+            typename CursorJ,
+            typename T_Acc
+        >
+        DINLINE void cptCurrent1D(
+            T_Acc const & acc,
+            CursorJ cursorJ,
+            const Line<float3_X>& line,
+            const float_X cellEdgeLength
+        )
+        {
+            /* pick every cell in the xy-plane that is overlapped by particle's
+             * form factor and deposit the current for the cells above and beneath
+             * that cell and for the cell itself.
+             */
+            for (int i = begin; i < end; ++i)
+            {
+                for (int j = begin; j < end; ++j)
+                {
+                    float_X tmp =
+                        S0(line, i, 1) * S0(line, j, 2) +
+                        float_X(0.5) * DS(line, i, 1) * S0(line, j, 2) +
+                        float_X(0.5) * S0(line, i, 1) * DS(line, j, 2) +
+                        (float_X(1.0) / float_X(3.0)) * DS(line, i, 1) * DS(line, j, 2);
 
-    /** calculate S0 (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {1,2,3} means {x,y,z}
-     *        same like in Esirkepov paper (FORTAN style)
-     */
-    DINLINE float_X S0(const Line<float3_X>& line, const float_X gridPoint, const float_X d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos0[d - 1]);
-    }
+                    float_X accumulated_J = float_X(0.0);
+                    for (int k = begin; k < end; ++k)
+                    {
+                        float_X W = DS(line, k, 3) * tmp;
+                        /* We multiply with `cellEdgeLength` due to the fact that the attribute for the
+                         * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1) */
+                        accumulated_J += -this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * W * cellEdgeLength;
+                        auto const atomicOp = typename T_Strategy::BlockReductionOp{};
+                        atomicOp( acc, (*cursorJ(i, j, k)).z(), accumulated_J );
+                    }
+                }
+            }
 
-    /** calculate DS (see paper)
-     * @param line element with previous and current position of the particle
-     * @param gridPoint used grid point to evaluate assignment shape
-     * @param d dimension range {1,2,3} means {x,y,z}
-     *        same like in Esirkepov paper (FORTAN style)
-     */
-    DINLINE float_X DS(const Line<float3_X>& line, const float_X gridPoint, const float_X d)
-    {
-        return ParticleAssign()(gridPoint - line.m_pos1[d - 1]) - ParticleAssign()(gridPoint - line.m_pos0[d - 1]);
-    }
+        }
 
-    static pmacc::traits::StringProperty getStringProperties()
-    {
-        pmacc::traits::StringProperty propList( "name", "Esirkepov" );
-        propList["param"] = "native implementation";
-        return propList;
-    }
-};
+        /** calculate S0 (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {1,2,3} means {x,y,z}
+         *        same like in Esirkepov paper (FORTAN style)
+         */
+        DINLINE float_X S0(const Line<float3_X>& line, const float_X gridPoint, const float_X d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos0[d - 1]);
+        }
+
+        /** calculate DS (see paper)
+         * @param line element with previous and current position of the particle
+         * @param gridPoint used grid point to evaluate assignment shape
+         * @param d dimension range {1,2,3} means {x,y,z}
+         *        same like in Esirkepov paper (FORTAN style)
+         */
+        DINLINE float_X DS(const Line<float3_X>& line, const float_X gridPoint, const float_X d)
+        {
+            return ParticleAssign()(gridPoint - line.m_pos1[d - 1]) - ParticleAssign()(gridPoint - line.m_pos0[d - 1]);
+        }
+
+        static pmacc::traits::StringProperty getStringProperties()
+        {
+            pmacc::traits::StringProperty propList( "name", "Esirkepov" );
+            propList["param"] = "native implementation";
+            return propList;
+        }
+    };
 
 } //namespace currentSolver
 
 namespace traits
 {
 
-/*Get margin of a solver
- * class must define a LowerMargin and UpperMargin
- */
-template<typename T_ParticleShape>
-struct GetMargin<picongpu::currentSolver::EsirkepovNative<T_ParticleShape> >
-{
-private:
-    typedef picongpu::currentSolver::EsirkepovNative<T_ParticleShape> Solver;
-public:
-    typedef typename Solver::LowerMargin LowerMargin;
-    typedef typename Solver::UpperMargin UpperMargin;
-};
+    /*Get margin of a solver
+     * class must define a LowerMargin and UpperMargin
+     */
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy
+    >
+    struct GetMargin<
+        picongpu::currentSolver::EsirkepovNative<
+            T_ParticleShape,
+            T_Strategy
+        >
+    >
+    {
+    private:
+        using Solver = picongpu::currentSolver::EsirkepovNative<
+            T_ParticleShape,
+            T_Strategy
+        >;
+    public:
+        using LowerMargin = typename Solver::LowerMargin;
+        using UpperMargin = typename Solver::UpperMargin;
+    };
 
 } //namespace traits
-
 } //namespace picongpu

--- a/include/picongpu/fields/currentDeposition/Solver.def
+++ b/include/picongpu/fields/currentDeposition/Solver.def
@@ -18,6 +18,7 @@
  */
 
 
+#include "picongpu/fields/currentDeposition/Strategy.def"
 #include "picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def"
 #include "picongpu/fields/currentDeposition/EmZ/EmZ.def"
 

--- a/include/picongpu/fields/currentDeposition/Strategy.def
+++ b/include/picongpu/fields/currentDeposition/Strategy.def
@@ -1,0 +1,152 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/nvidia/functors/Add.hpp>
+#include <pmacc/nvidia/functors/Atomic.hpp>
+#include <pmacc/types.hpp>
+
+
+namespace picongpu
+{
+namespace currentSolver
+{
+namespace strategy
+{
+
+    /** Work on strided supercell domains with local caching strategy
+     *
+     * The current for each particle will be reduced with atomic operations into a supercell
+     * local cache. The cache will be flushed to the global memory without atomics.
+     * The device local domain of fieldJ will be decomposed with a checker board.
+     *
+     * Suggestion: Use this strategy if atomic operations to global memory are slow.
+     * To utilize the device fully you should have enough supercells
+     *   - 2D: minimum multiprocessor count * 9 * 4
+     *   - 3D: minimum multiprocessor count * 27 * 4
+     */
+    struct StridedCachedSupercells
+    {
+        static constexpr bool useBlockCache = true;
+        static constexpr bool stridedMapping = true;
+        using BlockReductionOp = nvidia::functors::Atomic<
+            ::alpaka::atomic::op::Add,
+            ::alpaka::hierarchy::Threads
+        >;
+        using GridReductionOp = nvidia::functors::Add;
+    };
+
+    /** Local caching strategy
+     *
+     * The current for each particle will be reduced with atomic operations into a supercell
+     * local cache. The cache will be flushed with atomic operations to the global memory.
+     *
+     * Suggestion: Use this strategy if block local and global atomics are fast.
+     */
+    struct CachedSupercells
+    {
+        static constexpr bool useBlockCache = true;
+        static constexpr bool stridedMapping = false;
+        using BlockReductionOp = nvidia::functors::Atomic<
+            ::alpaka::atomic::op::Add,
+            ::alpaka::hierarchy::Threads
+        >;
+        using GridReductionOp = nvidia::functors::Atomic<
+            ::alpaka::atomic::op::Add,
+            ::alpaka::hierarchy::Blocks
+        >;
+    };
+
+    /** Non cached strategy
+     *
+     * The current for each particle will be reduced with atomic operations directly
+     * to the global memory.
+     *
+     * Suggestion: Use this strategy if global atomics are fast and random memory access
+     * to a wide are in the memory is not a bottle neck.
+     */
+    struct NonCachedSupercells
+    {
+        static constexpr bool useBlockCache = false;
+        static constexpr bool stridedMapping = false;
+        using BlockReductionOp = nvidia::functors::Atomic<
+            ::alpaka::atomic::op::Add,
+            ::alpaka::hierarchy::Blocks
+        >;
+        // dummy which produces a compile time error if used
+        using GridReductionOp = void;
+    };
+
+} // namespace strategy
+
+namespace traits
+{
+
+    /** Get current deposition strategy from a solver
+     *
+     * @tparam T_Solver type to derive the strategy
+     * @treturn ::type strategy description
+     */
+    template< typename T_Solver >
+    struct GetStrategy;
+
+    /** Get current deposition strategy from a solver
+     *
+     * @see GetStrategy
+     */
+    template< typename T_Solver >
+    using GetStrategy_t = typename GetStrategy< T_Solver >::type;
+
+    /** Default strategy for the current deposition
+     *
+     * Default will be selected based on the cupla accelerator.
+     *
+     * @tparam T_Acc the accelerator type
+     */
+    template<
+        typename T_Acc = cupla::AccThreadSeq
+    >
+    struct GetDefaultStrategy
+    {
+        using type = strategy::StridedCachedSupercells;
+    };
+
+    /** Default strategy for the current deposition
+     *
+     * @see GetDefaultStrategy
+     */
+    template< typename T_Acc = cupla::AccThreadSeq >
+    using GetDefaultStrategy_t = typename GetDefaultStrategy< T_Acc >::type;
+
+#if( ALPAKA_ACC_GPU_CUDA_ENABLED == 1 )
+    template<
+        typename ... T_Args
+    >
+    struct GetDefaultStrategy<
+        alpaka::acc::AccGpuCudaRt< T_Args... >
+    >
+    {
+        using type = strategy::CachedSupercells;
+    };
+#endif
+
+} // namespace traits
+} // namespace currentSolver
+} // namespace picongpu

--- a/include/picongpu/fields/currentDeposition/Strategy.def
+++ b/include/picongpu/fields/currentDeposition/Strategy.def
@@ -80,7 +80,7 @@ namespace strategy
      * to the global memory.
      *
      * Suggestion: Use this strategy if global atomics are fast and random memory access
-     * to a wide are in the memory is not a bottle neck.
+     * to a large range in memory is not a bottle neck.
      */
     struct NonCachedSupercells
     {

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def
@@ -17,23 +17,40 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include <pmacc/types.hpp>
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/particles/shapes/CIC.hpp"
+#include "picongpu/fields/currentDeposition/Strategy.def"
 
 
 namespace picongpu
 {
 namespace currentSolver
 {
-using namespace pmacc;
 
-template<typename ParticleShape = picongpu::particles::shapes::CIC>
-struct VillaBune;
+    template<
+        typename T_ParticleShape = picongpu::particles::shapes::CIC,
+        typename T_Strategy = traits::GetDefaultStrategy_t<>
+    >
+    struct VillaBune;
 
+namespace traits
+{
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy
+    >
+    struct GetStrategy<
+        VillaBune<
+            T_ParticleShape,
+            T_Strategy
+        >
+    >
+    {
+        using type = T_Strategy;
+    };
+} // namespace traits
 } //namespace currentSolver
-
 } //namespace picongpu

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def
@@ -30,6 +30,15 @@ namespace picongpu
 namespace currentSolver
 {
 
+    /** Current deposition algorithm from J. Villasenor and O. Buneman
+     *
+     * paper: J. Villasenor and O. Buneman. Rigorous charge conservation for local
+     * electromagnetic field solvers. Computer Physics Communications, 69:306, 1992.
+     * https://doi.org/10.1016/0010-4655(92)90169-Y
+     *
+     * @tparam T_ParticleShape the particle shape for the species, supports only [picongpu::particles::shapes::CIC]
+     * @tparam T_Strategy Used strategy to reduce the scattered data [currentSolver::strategy]
+     */
     template<
         typename T_ParticleShape = picongpu::particles::shapes::CIC,
         typename T_Strategy = traits::GetDefaultStrategy_t<>

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -20,270 +20,280 @@
 #pragma once
 
 #include <pmacc/types.hpp>
+#include "picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def"
 #include "picongpu/simulation_defines.hpp"
 #include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/math/Vector.hpp>
-#include <pmacc/nvidia/atomic.hpp>
-
-#include "picongpu/particles/shapes/CIC.hpp"
 
 
 namespace picongpu
 {
 namespace currentSolver
 {
-using namespace pmacc;
-
-template<typename T_ParticleShape>
-struct VillaBune
-{
-    template<class BoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Acc >
-    DINLINE void operator()(const T_Acc& acc,
-                            BoxJ& boxJ_par, /*box which is shifted to particles cell*/
-                            const PosType pos,
-                            const VelType velocity,
-                            const ChargeType charge, const float_X deltaTime)
-    {
-        /* VillaBune: field to particle interpolation _requires_ the CIC shape */
-        PMACC_CASSERT_MSG_TYPE(currentSolverVillaBune_requires_shapeCIC_in_particleConfig,
-                    T_ParticleShape,
-                    T_ParticleShape::support == 2);
-
-        // normalize deltaPos to innerCell units [0.; 1.)
-        //   that means: dx_real   = v.x() * dt
-        //               dx_inCell = v.x() * dt / cellSize.x()
-        const float3_X deltaPos(
-                                velocity.x() * deltaTime / cellSize.x(),
-                                velocity.y() * deltaTime / cellSize.y(),
-                                velocity.z() * deltaTime / cellSize.z());
-
-        const PosType oldPos = (PosType) (precisionCast<float_X > (pos) - deltaPos);
-
-        addCurrentSplitX(acc, oldPos, pos, charge, boxJ_par, deltaTime);
-    }
-
-    static pmacc::traits::StringProperty getStringProperties()
-    {
-        pmacc::traits::StringProperty propList( "name", "VillaBune" );
-        return propList;
-    }
-
-private:
-    //Splits the [oldPos,newPos] beam into two beams at the x-boundary of the cell
-    //if necessary
 
     template<
-        typename Buffer,
-        typename T_Acc
+        typename T_ParticleShape,
+        typename T_Strategy
     >
-    DINLINE void addCurrentSplitX(
-        T_Acc const & acc,
-        const float3_X& oldPos,
-        const float3_X& newPos,
-        const float_X charge,
-        Buffer & mem,
-        const float_X deltaTime
-    )
+    struct VillaBune
     {
-
-        if (math::float2int_rd(oldPos.x()) != math::float2int_rd(newPos.x()))
+        template<class BoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Acc >
+        DINLINE void operator()(const T_Acc& acc,
+                                BoxJ& boxJ_par, /*box which is shifted to particles cell*/
+                                const PosType pos,
+                                const VelType velocity,
+                                const ChargeType charge, const float_X deltaTime)
         {
-            const float3_X interPos = intersectXPlane(oldPos, newPos,
-                                                      math::max(math::float2int_rd(oldPos.x()), math::float2int_rd(newPos.x())));
-            addCurrentSplitY(acc, oldPos, interPos, charge, mem, deltaTime);
-            addCurrentSplitY(acc, interPos, newPos, charge, mem, deltaTime);
-            return;
+            /* VillaBune: field to particle interpolation _requires_ the CIC shape */
+            PMACC_CASSERT_MSG_TYPE(currentSolverVillaBune_requires_shapeCIC_in_particleConfig,
+                        T_ParticleShape,
+                        T_ParticleShape::support == 2);
+
+            // normalize deltaPos to innerCell units [0.; 1.)
+            //   that means: dx_real   = v.x() * dt
+            //               dx_inCell = v.x() * dt / cellSize.x()
+            const float3_X deltaPos(
+                                    velocity.x() * deltaTime / cellSize.x(),
+                                    velocity.y() * deltaTime / cellSize.y(),
+                                    velocity.z() * deltaTime / cellSize.z());
+
+            const PosType oldPos = (PosType) (precisionCast<float_X > (pos) - deltaPos);
+
+            addCurrentSplitX(acc, oldPos, pos, charge, boxJ_par, deltaTime);
         }
-        addCurrentSplitY(acc, oldPos, newPos, charge, mem, deltaTime);
-    }
 
-    template<
-        typename Buffer,
-        typename T_Acc
-    >
-    DINLINE void addCurrentToSingleCell(
-        T_Acc const & acc,
-        float3_X meanPos,
-        const float3_X& deltaPos,
-        const float_X charge,
-        Buffer & memIn,
-        const float_X deltaTime
-    )
-    {
-        //shift to the cell meanPos belongs to
-        //because meanPos may exceed the range [0,1)
-        DataSpace<DIM3> off(math::float2int_rd(meanPos.x()),
-                            math::float2int_rd(meanPos.y()),
-                            math::float2int_rd(meanPos.z()));
-
-        auto mem = memIn.shift(off);
-
-        //fit meanPos into the range [0,1)
-        meanPos.x() -= math::floor(meanPos.x());
-        meanPos.y() -= math::floor(meanPos.y());
-        meanPos.z() -= math::floor(meanPos.z());
-
-        //for the formulas used in here see Villasenor/Buneman paper page 314
-        const float_X tmp = deltaPos.x() * deltaPos.y() * deltaPos.z() * (float_X(1.0) / float_X(12.0));
-
-        // j = rho * v
-        //   = rho * dr / dt
-        //const float_X rho = charge * (1.0 / (CELL_WIDTH * CELL_HEIGHT * CELL_DEPTH));
-        //const float_X rho_dt = rho * (1.0 / deltaTime);
-
-        // now carefully:
-        // deltaPos is in "inCell" coordinates, that means:
-        //   deltaPos.x() = deltaPos_real.x() / cellSize.x()
-        // to calculate the current density in realUnits it is
-        //   j.x() = rho * deltaPos_real.x() / dt
-        //       = rho * deltaPos.x() * cellSize.x() / dt
-        // So put adding the constant directly to rho results in:
-        //   const float_X rho_dtX = rho * CELL_WIDTH;
-        //   const float_X rho_dtY = rho * CELL_HEIGHT;
-        //   const float_X rho_dtZ = rho * CELL_DEPTH;
-
-        // This is exactly the same like:
-        // j = Q / A / t
-        //   j.x() = Q.x() * (1.0 / (CELL_HEIGHT * CELL_DEPTH * deltaTime));
-        //   j.y() = Q.y() * (1.0 / (CELL_WIDTH * CELL_DEPTH * deltaTime));
-        //   j.z() = Q.z() * (1.0 / (CELL_WIDTH * CELL_HEIGHT * deltaTime));
-        // with the difference, that (imagine a moving quader)
-        //   Q.x() = charge * deltaPos_real.x() / cellsize.x()
-        //       = charge * deltaPos.x() / 1.0
-        //
-        const float_X rho_dtX = charge * (float_X(1.0) / (CELL_HEIGHT * CELL_DEPTH * deltaTime));
-        const float_X rho_dtY = charge * (float_X(1.0) / (CELL_WIDTH * CELL_DEPTH * deltaTime));
-        const float_X rho_dtZ = charge * (float_X(1.0) / (CELL_WIDTH * CELL_HEIGHT * deltaTime));
-
-        cupla::atomicAdd(acc, &(mem[1][1][0].x()), rho_dtX * (deltaPos.x() * meanPos.y() * meanPos.z() + tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[1][0][0].x()), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * meanPos.z() - tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[0][1][0].x()), rho_dtX * (deltaPos.x() * meanPos.y() * (float_X(1.0) - meanPos.z()) - tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[0][0][0].x()), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * (float_X(1.0) - meanPos.z()) + tmp), ::alpaka::hierarchy::Threads{});
-
-        cupla::atomicAdd(acc, &(mem[1][0][1].y()), rho_dtY * (deltaPos.y() * meanPos.z() * meanPos.x() + tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[0][0][1].y()), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * meanPos.x() - tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[1][0][0].y()), rho_dtY * (deltaPos.y() * meanPos.z() * (float_X(1.0) - meanPos.x()) - tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[0][0][0].y()), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * (float_X(1.0) - meanPos.x()) + tmp), ::alpaka::hierarchy::Threads{});
-
-        cupla::atomicAdd(acc, &(mem[0][1][1].z()), rho_dtZ * (deltaPos.z() * meanPos.x() * meanPos.y() + tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[0][1][0].z()), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * meanPos.y() - tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[0][0][1].z()), rho_dtZ * (deltaPos.z() * meanPos.x() * (float_X(1.0) - meanPos.y()) - tmp), ::alpaka::hierarchy::Threads{});
-        cupla::atomicAdd(acc, &(mem[0][0][0].z()), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * (float_X(1.0) - meanPos.y()) + tmp), ::alpaka::hierarchy::Threads{});
-
-    }
-
-    //calculates the intersection point of the [pos1,pos2] beam with an y,z-plane at position x0
-
-    DINLINE float3_X intersectXPlane(const float3_X& pos1, const float3_X& pos2, const float_X x0)
-    {
-        const float_X t = (x0 - pos1.x()) / (pos2.x() - pos1.x());
-
-        return float3_X(x0, pos1.y() + t * (pos2.y() - pos1.y()), pos1.z() + t * (pos2.z() - pos1.z()));
-    }
-
-    DINLINE float3_X intersectYPlane(const float3_X& pos1, const float3_X& pos2, const float_X y0)
-    {
-        const float_X t = (y0 - pos1.y()) / (pos2.y() - pos1.y());
-
-        return float3_X(pos1.x() + t * (pos2.x() - pos1.x()), y0, pos1.z() + t * (pos2.z() - pos1.z()));
-    }
-
-    DINLINE float3_X intersectZPlane(const float3_X& pos1, const float3_X& pos2, const float_X z0)
-    {
-        const float_X t = (z0 - pos1.z()) / (pos2.z() - pos1.z());
-
-        return float3_X(pos1.x() + t * (pos2.x() - pos1.x()), pos1.y() + t * (pos2.y() - pos1.y()), z0);
-    }
-
-    //Splits the [oldPos,newPos] beam into two beams at the z-boundary of the cell
-    //if necessary
-
-    template<
-        typename Buffer,
-        typename T_Acc
-    >
-    DINLINE void addCurrentSplitZ(
-        T_Acc const & acc,
-        const float3_X &oldPos,
-        const float3_X &newPos,
-        const float_X charge,
-        Buffer & mem,
-        const float_X deltaTime
-    )
-    {
-
-        if (math::float2int_rd(oldPos.z()) != math::float2int_rd(newPos.z()))
+        static pmacc::traits::StringProperty getStringProperties()
         {
-            const float3_X interPos = intersectZPlane(oldPos, newPos,
-                                                      math::max(math::float2int_rd(oldPos.z()), math::float2int_rd(newPos.z())));
-            float3_X deltaPos = interPos - oldPos;
-            float3_X meanPos = oldPos + float_X(0.5) * deltaPos;
+            pmacc::traits::StringProperty propList( "name", "VillaBune" );
+            return propList;
+        }
+
+    private:
+        //Splits the [oldPos,newPos] beam into two beams at the x-boundary of the cell
+        //if necessary
+
+        template<
+            typename Buffer,
+            typename T_Acc
+        >
+        DINLINE void addCurrentSplitX(
+            T_Acc const & acc,
+            const float3_X& oldPos,
+            const float3_X& newPos,
+            const float_X charge,
+            Buffer & mem,
+            const float_X deltaTime
+        )
+        {
+
+            if (math::float2int_rd(oldPos.x()) != math::float2int_rd(newPos.x()))
+            {
+                const float3_X interPos = intersectXPlane(oldPos, newPos,
+                                                          math::max(math::float2int_rd(oldPos.x()), math::float2int_rd(newPos.x())));
+                addCurrentSplitY(acc, oldPos, interPos, charge, mem, deltaTime);
+                addCurrentSplitY(acc, interPos, newPos, charge, mem, deltaTime);
+                return;
+            }
+            addCurrentSplitY(acc, oldPos, newPos, charge, mem, deltaTime);
+        }
+
+        template<
+            typename Buffer,
+            typename T_Acc
+        >
+        DINLINE void addCurrentToSingleCell(
+            T_Acc const & acc,
+            float3_X meanPos,
+            const float3_X& deltaPos,
+            const float_X charge,
+            Buffer & memIn,
+            const float_X deltaTime
+        )
+        {
+            //shift to the cell meanPos belongs to
+            //because meanPos may exceed the range [0,1)
+            DataSpace<DIM3> off(math::float2int_rd(meanPos.x()),
+                                math::float2int_rd(meanPos.y()),
+                                math::float2int_rd(meanPos.z()));
+
+            auto mem = memIn.shift(off);
+
+            //fit meanPos into the range [0,1)
+            meanPos.x() -= math::floor(meanPos.x());
+            meanPos.y() -= math::floor(meanPos.y());
+            meanPos.z() -= math::floor(meanPos.z());
+
+            //for the formulas used in here see Villasenor/Buneman paper page 314
+            const float_X tmp = deltaPos.x() * deltaPos.y() * deltaPos.z() * (float_X(1.0) / float_X(12.0));
+
+            // j = rho * v
+            //   = rho * dr / dt
+            //const float_X rho = charge * (1.0 / (CELL_WIDTH * CELL_HEIGHT * CELL_DEPTH));
+            //const float_X rho_dt = rho * (1.0 / deltaTime);
+
+            // now carefully:
+            // deltaPos is in "inCell" coordinates, that means:
+            //   deltaPos.x() = deltaPos_real.x() / cellSize.x()
+            // to calculate the current density in realUnits it is
+            //   j.x() = rho * deltaPos_real.x() / dt
+            //       = rho * deltaPos.x() * cellSize.x() / dt
+            // So put adding the constant directly to rho results in:
+            //   const float_X rho_dtX = rho * CELL_WIDTH;
+            //   const float_X rho_dtY = rho * CELL_HEIGHT;
+            //   const float_X rho_dtZ = rho * CELL_DEPTH;
+
+            // This is exactly the same like:
+            // j = Q / A / t
+            //   j.x() = Q.x() * (1.0 / (CELL_HEIGHT * CELL_DEPTH * deltaTime));
+            //   j.y() = Q.y() * (1.0 / (CELL_WIDTH * CELL_DEPTH * deltaTime));
+            //   j.z() = Q.z() * (1.0 / (CELL_WIDTH * CELL_HEIGHT * deltaTime));
+            // with the difference, that (imagine a moving quader)
+            //   Q.x() = charge * deltaPos_real.x() / cellsize.x()
+            //       = charge * deltaPos.x() / 1.0
+            //
+            const float_X rho_dtX = charge * (float_X(1.0) / (CELL_HEIGHT * CELL_DEPTH * deltaTime));
+            const float_X rho_dtY = charge * (float_X(1.0) / (CELL_WIDTH * CELL_DEPTH * deltaTime));
+            const float_X rho_dtZ = charge * (float_X(1.0) / (CELL_WIDTH * CELL_HEIGHT * deltaTime));
+
+            auto const atomicOp = typename T_Strategy::BlockReductionOp{};
+
+            atomicOp(acc, mem[1][1][0].x(), rho_dtX * (deltaPos.x() * meanPos.y() * meanPos.z() + tmp));
+            atomicOp(acc, mem[1][0][0].x(), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * meanPos.z() - tmp));
+            atomicOp(acc, mem[0][1][0].x(), rho_dtX * (deltaPos.x() * meanPos.y() * (float_X(1.0) - meanPos.z()) - tmp));
+            atomicOp(acc, mem[0][0][0].x(), rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * (float_X(1.0) - meanPos.z()) + tmp));
+
+            atomicOp(acc, mem[1][0][1].y(), rho_dtY * (deltaPos.y() * meanPos.z() * meanPos.x() + tmp));
+            atomicOp(acc, mem[0][0][1].y(), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * meanPos.x() - tmp));
+            atomicOp(acc, mem[1][0][0].y(), rho_dtY * (deltaPos.y() * meanPos.z() * (float_X(1.0) - meanPos.x()) - tmp));
+            atomicOp(acc, mem[0][0][0].y(), rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * (float_X(1.0) - meanPos.x()) + tmp));
+
+            atomicOp(acc, mem[0][1][1].z(), rho_dtZ * (deltaPos.z() * meanPos.x() * meanPos.y() + tmp));
+            atomicOp(acc, mem[0][1][0].z(), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * meanPos.y() - tmp));
+            atomicOp(acc, mem[0][0][1].z(), rho_dtZ * (deltaPos.z() * meanPos.x() * (float_X(1.0) - meanPos.y()) - tmp));
+            atomicOp(acc, mem[0][0][0].z(), rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * (float_X(1.0) - meanPos.y()) + tmp));
+
+        }
+
+        //calculates the intersection point of the [pos1,pos2] beam with an y,z-plane at position x0
+
+        DINLINE float3_X intersectXPlane(const float3_X& pos1, const float3_X& pos2, const float_X x0)
+        {
+            const float_X t = (x0 - pos1.x()) / (pos2.x() - pos1.x());
+
+            return float3_X(x0, pos1.y() + t * (pos2.y() - pos1.y()), pos1.z() + t * (pos2.z() - pos1.z()));
+        }
+
+        DINLINE float3_X intersectYPlane(const float3_X& pos1, const float3_X& pos2, const float_X y0)
+        {
+            const float_X t = (y0 - pos1.y()) / (pos2.y() - pos1.y());
+
+            return float3_X(pos1.x() + t * (pos2.x() - pos1.x()), y0, pos1.z() + t * (pos2.z() - pos1.z()));
+        }
+
+        DINLINE float3_X intersectZPlane(const float3_X& pos1, const float3_X& pos2, const float_X z0)
+        {
+            const float_X t = (z0 - pos1.z()) / (pos2.z() - pos1.z());
+
+            return float3_X(pos1.x() + t * (pos2.x() - pos1.x()), pos1.y() + t * (pos2.y() - pos1.y()), z0);
+        }
+
+        //Splits the [oldPos,newPos] beam into two beams at the z-boundary of the cell
+        //if necessary
+
+        template<
+            typename Buffer,
+            typename T_Acc
+        >
+        DINLINE void addCurrentSplitZ(
+            T_Acc const & acc,
+            const float3_X &oldPos,
+            const float3_X &newPos,
+            const float_X charge,
+            Buffer & mem,
+            const float_X deltaTime
+        )
+        {
+
+            if (math::float2int_rd(oldPos.z()) != math::float2int_rd(newPos.z()))
+            {
+                const float3_X interPos = intersectZPlane(oldPos, newPos,
+                                                          math::max(math::float2int_rd(oldPos.z()), math::float2int_rd(newPos.z())));
+                float3_X deltaPos = interPos - oldPos;
+                float3_X meanPos = oldPos + float_X(0.5) * deltaPos;
+                addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
+
+                deltaPos = newPos - interPos;
+                meanPos = interPos + float_X(0.5) * deltaPos;
+                addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
+                return;
+            }
+            const float3_X deltaPos = newPos - oldPos;
+            const float3_X meanPos = oldPos + float_X(0.5) * deltaPos;
             addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
-
-            deltaPos = newPos - interPos;
-            meanPos = interPos + float_X(0.5) * deltaPos;
-            addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
-            return;
         }
-        const float3_X deltaPos = newPos - oldPos;
-        const float3_X meanPos = oldPos + float_X(0.5) * deltaPos;
-        addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
-    }
 
-    //Splits the [oldPos,newPos] beam into two beams at the y-boundary of the cell
-    //if necessary
+        //Splits the [oldPos,newPos] beam into two beams at the y-boundary of the cell
+        //if necessary
 
-    template<
-        typename Buffer,
-        typename T_Acc
-    >
-    DINLINE void addCurrentSplitY(
-        T_Acc const & acc,
-        const float3_X& oldPos,
-        const float3_X& newPos,
-        const float_X charge,
-        Buffer & mem,
-        const float_X deltaTime
-    )
-    {
-
-        if (math::float2int_rd(oldPos.y()) != math::float2int_rd(newPos.y()))
+        template<
+            typename Buffer,
+            typename T_Acc
+        >
+        DINLINE void addCurrentSplitY(
+            T_Acc const & acc,
+            const float3_X& oldPos,
+            const float3_X& newPos,
+            const float_X charge,
+            Buffer & mem,
+            const float_X deltaTime
+        )
         {
-            const float3_X interPos = intersectYPlane(oldPos, newPos,
-                                                      math::max(math::float2int_rd(oldPos.y()), math::float2int_rd(newPos.y())));
-            addCurrentSplitZ(acc, oldPos, interPos, charge, mem, deltaTime);
-            addCurrentSplitZ(acc, interPos, newPos, charge, mem, deltaTime);
-            return;
-        }
-        addCurrentSplitZ(acc, oldPos, newPos, charge, mem, deltaTime);
-    }
 
-};
+            if (math::float2int_rd(oldPos.y()) != math::float2int_rd(newPos.y()))
+            {
+                const float3_X interPos = intersectYPlane(oldPos, newPos,
+                                                          math::max(math::float2int_rd(oldPos.y()), math::float2int_rd(newPos.y())));
+                addCurrentSplitZ(acc, oldPos, interPos, charge, mem, deltaTime);
+                addCurrentSplitZ(acc, interPos, newPos, charge, mem, deltaTime);
+                return;
+            }
+            addCurrentSplitZ(acc, oldPos, newPos, charge, mem, deltaTime);
+        }
+
+    };
 
 } //namespace currentSolver
 
 namespace traits
 {
 
-template<typename T_ParticleShape>
-struct GetMargin<picongpu::currentSolver::VillaBune<T_ParticleShape> >
-{
-    typedef ::pmacc::math::CT::Int < 1, 1, 1 > LowerMargin;
-    typedef ::pmacc::math::CT::Int < 2, 2, 2 > UpperMargin;
+    template<
+        typename T_ParticleShape,
+        typename T_Strategy
+    >
+    struct GetMargin<
+        picongpu::currentSolver::VillaBune<
+            T_ParticleShape,
+            T_Strategy
+        >
+    >
+    {
+        using LowerMargin = ::pmacc::math::CT::Int < 1, 1, 1 >;
+        using UpperMargin = ::pmacc::math::CT::Int < 2, 2, 2 >;
 
-    /** maximum margin size of LowerMargin and UpperMargin */
-    static constexpr int maxMargin = 2;
+        /** maximum margin size of LowerMargin and UpperMargin */
+        static constexpr int maxMargin = 2;
 
-    PMACC_CASSERT_MSG(
-        __VillaBune_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
-        pmacc::math::CT::min<
-            typename pmacc::math::CT::mul<
-                SuperCellSize,
-                GuardSize
-            >::type
-        >::type::value >= maxMargin
-    );
-};
+        PMACC_CASSERT_MSG(
+            __VillaBune_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
+            pmacc::math::CT::min<
+                typename pmacc::math::CT::mul<
+                    SuperCellSize,
+                    GuardSize
+                >::type
+            >::type::value >= maxMargin
+        );
+    };
 
 } //namespace traits
 

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -54,14 +54,19 @@ using UsedField2Particle = FieldToParticleInterpolation<
     AssignedTrilinearInterpolation
 >;
 
-/** select current solver method
- * - currentSolver::Esirkepov< SHAPE > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
- * - currentSolver::VillaBune<>        : particle shapes - CIC (1st order) only
- * - currentSolver::EmZ< SHAPE >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+/*! select current solver method
+ * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+ * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
  * For development purposes:
- * - currentSolver::currentSolver::EsirkepovNative< SHAPE > : generic version of currentSolverEsirkepov
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ *
+ * STRATEGY (optional):
+ * - currentSolver::StridedCachedSupercells
+ * - currentSolver::CachedSupercells
+ * - currentSolver::NonCachedSupercells
  */
 using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
 

--- a/include/pmacc/nvidia/functors/Atomic.hpp
+++ b/include/pmacc/nvidia/functors/Atomic.hpp
@@ -1,0 +1,108 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+namespace pmacc
+{
+namespace nvidia
+{
+namespace functors
+{
+
+    /** Addition of two values
+     *
+     * @tparam T_AlpakaOperation alpaka atomic operation [::alpaka::atomic::op]
+     * @tparam T_AlpakaHierarchy alpaka atomic hierarchy [::alpaka::hierarchy]
+     */
+    template<
+        typename T_AlpakaOperation,
+        typename T_AlpakaHierarchy = ::alpaka::hierarchy::Grids
+    >
+    struct Atomic
+    {
+        /** Generic atomic add implementation */
+        template<
+            typename T_Acc,
+            typename T_Dst,
+            typename T_Src
+        >
+        HDINLINE void operator()(
+            T_Acc const & acc,
+            T_Dst & dst,
+            T_Src const & src
+        ) const
+        {
+            ::alpaka::atomic::atomicOp< T_AlpakaOperation >(
+                acc,
+                &dst,
+                src,
+                T_AlpakaHierarchy{}
+            );
+        }
+
+        /** pmacc::math::Vector atomic add implementation */
+        template<
+            typename T_Acc,
+            typename T_Type,
+            int T_dim,
+            typename T_DstAccessor,
+            typename T_DstNavigator,
+            template < typename, int > typename T_DstStorage,
+            typename T_SrcAccessor,
+            typename T_SrcNavigator,
+            template < typename, int > typename T_SrcStorage
+        >
+        HDINLINE void operator()(
+            T_Acc const & acc,
+            pmacc::math::Vector<
+                T_Type,
+                T_dim,
+                T_DstAccessor,
+                T_DstNavigator,
+                T_DstStorage
+            > & dst,
+            pmacc::math::Vector<
+                T_Type,
+                T_dim,
+                T_SrcAccessor,
+                T_SrcNavigator,
+                T_SrcStorage
+            > const & src
+        ) const
+        {
+            for( int i = 0; i < T_dim; ++i )
+                ::alpaka::atomic::atomicOp< T_AlpakaOperation >(
+                    acc,
+                    &dst[ i ],
+                    src[ i ],
+                    T_AlpakaHierarchy{}
+                );
+        }
+    };
+
+} // namespace functors
+} // namespace nvidia
+} // namespace pmacc

--- a/share/picongpu/examples/Bunch/include/picongpu/param/species.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/species.param
@@ -45,14 +45,19 @@ using UsedParticleShape = particles::shapes::CIC;
 /* define which interpolation method is used to interpolate fields to particle*/
 using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
 
-/*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
- * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::EmZ<SHAPE>        : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+/*! select current solver method
+ * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+ * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
- * For development purposes: ---------------------------------------------------
- * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
+ * For development purposes:
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ *
+ * STRATEGY (optional):
+ * - currentSolver::strategy::StridedCachedSupercells
+ * - currentSolver::strategy::CachedSupercells
+ * - currentSolver::strategy::NonCachedSupercells
  */
 using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
@@ -48,14 +48,19 @@ using UsedParticleShape = particles::shapes::PARAM_PARTICLESHAPE;
 /* define which interpolation method is used to interpolate fields to particle*/
 using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
 
-/*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
- * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::EmZ<SHAPE>        : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+/*! select current solver method
+ * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+ * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
- * For development purposes: ---------------------------------------------------
- * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
+ * For development purposes:
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ *
+ * STRATEGY (optional):
+ * - currentSolver::strategy::StridedCachedSupercells
+ * - currentSolver::strategy::CachedSupercells
+ * - currentSolver::strategy::NonCachedSupercells
  */
 #ifndef PARAM_CURRENTSOLVER
 #define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
@@ -48,14 +48,19 @@ using UsedParticleShape = particles::shapes::PARAM_PARTICLESHAPE;
 /* define which interpolation method is used to interpolate fields to particle*/
 using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
 
-/*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
- * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::EmZ<SHAPE>        : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+/*! select current solver method
+ * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+ * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
- * For development purposes: ---------------------------------------------------
- * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
+ * For development purposes:
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ *
+ * STRATEGY (optional):
+ * - currentSolver::strategy::StridedCachedSupercells
+ * - currentSolver::strategy::CachedSupercells
+ * - currentSolver::strategy::NonCachedSupercells
  */
 #ifndef PARAM_CURRENTSOLVER
 #define PARAM_CURRENTSOLVER Esirkepov

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -45,14 +45,19 @@ using UsedParticleShape = particles::shapes::CIC;
 /* define which interpolation method is used to interpolate fields to particle*/
 using UsedField2Particle = FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation>;
 
-/*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
- * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::EmZ<SHAPE>        : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+/*! select current solver method
+ * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+ * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
- * For development purposes: ---------------------------------------------------
- * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
+ * For development purposes:
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ *
+ * STRATEGY (optional):
+ * - currentSolver::strategy::StridedCachedSupercells
+ * - currentSolver::strategy::CachedSupercells
+ * - currentSolver::strategy::NonCachedSupercells
  */
 using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
@@ -45,14 +45,19 @@ using UsedParticleShape = particles::shapes::CIC;
 /* define which interpolation method is used to interpolate fields to particle*/
 using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
 
-/*! select current solver method -----------------------------------------------
- * - currentSolver::Esirkepov<SHAPE>  : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
- * - currentSolver::VillaBune<>       : particle shapes - CIC (1st order) only
- * - currentSolver::EmZ<SHAPE>        : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+/*! select current solver method
+ * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+ * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
  *
- * For development purposes: ---------------------------------------------------
- * - currentSolver::EsirkepovNative<SHAPE> : generic version of currentSolverEsirkepov
+ * For development purposes:
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
  *   without optimization (~4x slower and needs more shared memory)
+ *
+ * STRATEGY (optional):
+ * - currentSolver::strategy::StridedCachedSupercells
+ * - currentSolver::strategy::CachedSupercells
+ * - currentSolver::strategy::NonCachedSupercells
  */
 using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
 


### PR DESCRIPTION
Implement different strategies for the reduction of the scattered
current from particles.

- PMacc: Add generic atomic functor
- add strategies:
  - StridedCachedSupercells (this is the old strategy used before this PR)
  - CachedSupercells
  - NonCachedSupercells
- Strategy will be selected based on the cupla accelerator 
  - for NVIDIA `CachedSupercells` is used
  - other backends use the old strategy `StridedCachedSupercells`
- add class `Cache` to implement different caching strategies
- move the curent deposition kernel call into a separate file: `Deposit.hpp`
update documentation 
  - add particle section for the current deposition
  - update `species.param` with information about the `Strategies`

This PR improves the performance for NVIDA P100 and V100 up to a factor 1.18 (example KHI).

This PR is required for the upcoming paper we currently preparing with  @ax3l.

**Note:** The caching class could be used later as base to write a generic caching object which can be include in other algorithm e.g. for Maxwell solver, ...
This is currently not the focus of this PR, therefore the creation method of the cache is fixed to the needs of the current deposition. 

**review Suggestion:** review without withe space changes. I fixed the indention within namespaces for files where I changed a many code lines.