### PR TITLE
Fix a bug with wrong exponential absorber strength

### DIFF
--- a/include/picongpu/fields/absorber/ExponentialDamping.hpp
+++ b/include/picongpu/fields/absorber/ExponentialDamping.hpp
@@ -65,7 +65,7 @@ public:
                 uint32_t pos_or_neg = i % 2;
 
                 uint32_t thickness = absorber::numCells[direction][pos_or_neg];
-                float_X absorber_strength = absorber::numCells[direction][pos_or_neg];
+                float_X absorber_strength = ABSORBER_STRENGTH[direction][pos_or_neg];
 
                 if (thickness == 0) continue; /*if the absorber has no thickness we check the next side*/
 


### PR DESCRIPTION
The bug was introduced in #3161 by a copy-paste mistake.
Was likely the cause of report #3217.

backport of PR #3218