### PR TITLE
fix docker container

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -22,6 +22,7 @@ RUN        apt-get update && \
               build-essential \
               ca-certificates \
               coreutils \
+              cuda-cupti-$CUDA_PKG_VERSION \
               cuda-command-line-tools-$CUDA_PKG_VERSION \
               cuda-core-$CUDA_PKG_VERSION \
               cuda-cudart-dev-$CUDA_PKG_VERSION \


### PR DESCRIPTION
fix `apt` error: `cuda-command-line-tools-9-2 : Depends: cuda-cupti-9-2 (>= 9.2.148) but it is not going to be installed`

solution: explicit install `cuda-cupti-*`