### PR TITLE
Backport: Breathe: <4.15.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx_rtd_theme>=0.3.1
 recommonmark
 sphinx==2.0.1
-breathe>=4.12.0
+breathe>=4.12.0,<4.15.0
 sphinxcontrib.programoutput
 sphinxcontrib-napoleon>=0.7
 pygments


### PR DESCRIPTION
RTD does not yet provide Sphinx 3 but Breathe 4.15.0+
requires Sphinx 3.

Ref.: https://github.com/michaeljones/breathe/issues/495