### PR TITLE
Fix incorrect initialization and data race

### DIFF
--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -433,8 +433,12 @@ namespace particleMerging
             if( linearThreadIdx < numInitialVoronoiCells )
                 listVoronoiCells[linearThreadIdx] = VoronoiCell();
 
+            cupla::__syncthreads( acc );
+
             /* init the voronoiCellId attribute for each particle */
             this->initVoronoiCellIdAttribute( acc, cellIndex );
+
+            cupla::__syncthreads( acc );
 
             /* main loop of the merging algorithm */
             while( voronoiIndexPool.size() > 0 )

--- a/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
+++ b/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
@@ -134,7 +134,7 @@ namespace particleMerging
             const float_X weighting
         )
         {
-            nvidia::atomicAllInc( acc, &this->numMacroParticles, ::alpaka::hierarchy::Threads{} );
+            cupla::atomicAdd(acc, &this->numMacroParticles, static_cast<uint32_t>(1), ::alpaka::hierarchy::Threads{} );
             cupla::atomicAdd(acc,  &this->numRealParticles, weighting, ::alpaka::hierarchy::Threads{} );
 
             if( this->splittingStage == VoronoiSplittingStage::position )


### PR DESCRIPTION
Replace atomicAllInc, which required the same address for all threads in a block, that сaused incorrect number of macroparticles in Voronoi cells with cupla::atomicAdd.
Add syncthreads after voronoi cells start initialization.