### PR TITLE
Backport: Fix incorrect initialization and data race

### DIFF
--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -433,8 +433,12 @@ namespace particleMerging
             if( linearThreadIdx < numInitialVoronoiCells )
                 listVoronoiCells[linearThreadIdx] = VoronoiCell();
 
+            __syncthreads();
+
             /* init the voronoiCellId attribute for each particle */
             this->initVoronoiCellIdAttribute( acc, cellIndex );
+
+            __syncthreads();
 
             /* main loop of the merging algorithm */
             while( voronoiIndexPool.size() > 0 )

--- a/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
+++ b/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
@@ -134,7 +134,7 @@ namespace particleMerging
             const float_X weighting
         )
         {
-            nvidia::atomicAllInc( acc, &this->numMacroParticles, ::alpaka::hierarchy::Threads{} );
+            atomicAdd( &this->numMacroParticles, static_cast<uint32_t>(1), ::alpaka::hierarchy::Threads{} );
             atomicAdd( &this->numRealParticles, weighting, ::alpaka::hierarchy::Threads{} );
 
             if( this->splittingStage == VoronoiSplittingStage::position )


### PR DESCRIPTION
backport #3239

- replace atomicAllInc, which required same adress for all threads in block with cupla::atomicAdd
- add syncthreads after voronoi cells initialization