### PR TITLE
Fix returning a stringstream by value

### DIFF
--- a/include/picongpu/plugins/ResourceLog.cpp
+++ b/include/picongpu/plugins/ResourceLog.cpp
@@ -38,7 +38,7 @@ namespace picongpu
 {
 namespace detail
 {
-    std::stringstream
+    std::string
     writeMapToPropertyTree(
         std::map< std::string, size_t > valueMap,
         std::string outputFormat
@@ -83,7 +83,7 @@ namespace detail
             );
         }
 
-        return ss;
+        return ss.str();
     }
 } // namespace detail
 } // namespace picongpu

--- a/include/picongpu/plugins/ResourceLog.hpp
+++ b/include/picongpu/plugins/ResourceLog.hpp
@@ -54,7 +54,7 @@ namespace picongpu
 
 namespace detail
 {
-    std::stringstream
+    std::string
     writeMapToPropertyTree(
         std::map<std::string, size_t> valueMap,
         std::string outputFormat
@@ -119,23 +119,23 @@ namespace detail
             }
 
             //
-            // Write property tree to string stream
-            std::stringstream ss = ::picongpu::detail::writeMapToPropertyTree( valueMap, outputFormat );
+            // Write property tree to a string
+            std::string properties = ::picongpu::detail::writeMapToPropertyTree( valueMap, outputFormat );
 
             //
             // Write property tree to the output stream
             if(streamType == "stdout")
             {
-                std::cout << ss.str();
+                std::cout << properties;
             }
             else if (streamType == "stderr")
             {
-                std::cerr << ss.str();
+                std::cerr << properties;
             }
             else if (streamType == "file")
             {
                 std::ostream os(&fileBuf);
-                os << ss.str();
+                os << properties;
             }
             else
             {


### PR DESCRIPTION
It is not copyable, but only movable. So replace with just returning the `string` as this is all we need.

I looked into that while investigating #3249. I am not sure if it caused that issue, but this definitely looks like an issue.