### PR TITLE
Add JetBrains project dir to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Visual Studio Code configuration files
 .vscode
 
+# JetBrains project files
+.idea/
+
 # python byte code
 *.pyc
 


### PR DESCRIPTION
Since there are similar excludes for netbeans, VS, etc. I though I would add one for Clion as well.