### PR TITLE
Additional debug info in guard check for SC size

### DIFF
--- a/include/pmacc/mappings/kernel/MappingDescription.hpp
+++ b/include/pmacc/mappings/kernel/MappingDescription.hpp
@@ -76,9 +76,12 @@ public:
             {
                 minBlock = std::min(minBlock, gridSuperCells[2]);
             }
-            PMACC_VERIFY(
+            PMACC_VERIFY_MSG((
                 ( guardingSuperCells[ d ] == 0 && gridSuperCells[ d ] >= 1) ||
-                gridSuperCells[ d ] >= 2 * guardingSuperCells[ d ] + 1
+                gridSuperCells[ d ] >= 2 * guardingSuperCells[ d ] + 1 ),
+                "d=" + std::to_string( d )  + "guardingSuperCells[ d ] = " +
+                std::to_string( guardingSuperCells[ d ] )  + "gridSuperCells[ d ] = " +
+                std::to_string( gridSuperCells[ d ] )
             );
         }
     }


### PR DESCRIPTION
In the first PR #3266 I accidentally  branched  from `master` instead of `dev`. This one shouldn't have any conflicts. 

> This adds some additional debugging information in a case of a super cell size that's too small to fit the guard. Maybe it could be useful to someone else.
> 
> I've added this lines when I was wondering why my code keeps throwing this. In that particular case the problem was caused by an initialization of an empty mapping description with a SC size (0,0,0). Something that couldn't be addressed by verifying the .param files.
> 
> 