### PR TITLE
update hemera modules and add openPMDapi module

### DIFF
--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -29,6 +29,8 @@ module load c-blosc/1.14.4
 module load adios/1.13.1
 module load hdf5-parallel/1.8.20
 module load libsplash/1.7.0
+module load python/3.6.5
+module load openpmd/0.11.1
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -18,8 +18,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.0
-module load openmpi/2.1.2-cuda100
+module load cuda/10.2
+module load openmpi/2.1.2-cuda102
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -27,9 +27,11 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load adios/1.13.1-cuda100
-module load hdf5-parallel/1.8.20-cuda100
-module load libsplash/1.7.0-cuda100
+module load adios/1.13.1-cuda102
+module load hdf5-parallel/1.8.20-cuda102
+module load libsplash/1.7.0-cuda102
+module load python/3.6.5
+module load openpmd/0.11.1-cuda102
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -18,8 +18,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.0
-module load openmpi/2.1.2-cuda100
+module load cuda/10.2
+module load openmpi/2.1.2-cuda102
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -27,9 +27,11 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load adios/1.13.1-cuda100
-module load hdf5-parallel/1.8.20-cuda100
-module load libsplash/1.7.0-cuda100
+module load adios/1.13.1-cuda102
+module load hdf5-parallel/1.8.20-cuda102
+module load libsplash/1.7.0-cuda102
+module load python/3.6.5
+module load openpmd/0.11.1-cuda102
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -18,8 +18,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.0
-module load openmpi/2.1.2-cuda100
+module load cuda/10.2
+module load openmpi/2.1.2-cuda102
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -27,9 +27,11 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load adios/1.13.1-cuda100
-module load hdf5-parallel/1.8.20-cuda100
-module load libsplash/1.7.0-cuda100
+module load adios/1.13.1-cuda102
+module load hdf5-parallel/1.8.20-cuda102
+module load libsplash/1.7.0-cuda102
+module load python/3.6.5
+module load openpmd/0.11.1-cuda102
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -18,8 +18,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.0
-module load openmpi/2.1.2-cuda100
+module load cuda/10.2
+module load openmpi/2.1.2-cuda102
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -27,9 +27,11 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load adios/1.13.1-cuda100
-module load hdf5-parallel/1.8.20-cuda100
-module load libsplash/1.7.0-cuda100
+module load adios/1.13.1-cuda102
+module load hdf5-parallel/1.8.20-cuda102
+module load libsplash/1.7.0-cuda102
+module load python/3.6.5
+module load openpmd/0.11.1-cuda102
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0


### PR DESCRIPTION
After the IT team at HZDR added a newer openPMD-api module to the module system, this could be included in the PIConGPU example profiles for the hemera cluster. 

- update to CUDA 10.2
- load openPMD module

@psychocoderHPC and @sbastrakov Please see internal  IT ticket number `SR.10732` for details.  

This should be hopefully consistent with the just merged #2966. I have requested the module update due to compile issues with #3134.  