### PR TITLE
refactor pmacc  identifier and alias

### DIFF
--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -188,7 +188,7 @@ namespace picongpu
     alias( ionizationEnergies );
 
     //! alias for synchrotronPhotons, see also speciesDefinition.param
-    alias( synchrotronPhotons )
+    alias( synchrotronPhotons );
 
     //! alias for ion species used for bremsstrahlung
     alias( bremsstrahlungIons );

--- a/include/pmacc/identifier/alias.hpp
+++ b/include/pmacc/identifier/alias.hpp
@@ -36,44 +36,6 @@ identifier(pmacc_void);
 identifier(pmacc_isAlias);
 } //namespace pmacc
 
-#ifdef __CUDACC__
-#   define PMACC_alias_CUDA(name,id)                                          \
-        namespace PMACC_JOIN(device_placeholder,id){                          \
-            /* This variable exists only for template parameter deduction, its
-             * value is never used. So in this case it is fine to have a
-             * separate version in each translation unit due to static.
-             */                                                               \
-            static __constant__ PMACC_JOIN(placeholder_definition,id)::name<> \
-                PMACC_JOIN(name,_);                                           \
-        }
-#else
-#   define PMACC_alias_CUDA(name,id)
-#endif
-
-/*define special makros for creating classes which are only used as identifer*/
-#define PMACC_alias(name,id)                                                   \
-    namespace PMACC_JOIN(placeholder_definition,id) {                          \
-        template<typename T_Type=pmacc::pmacc_void,typename T_IsAlias=pmacc::pmacc_isAlias> \
-        struct name                                                            \
-        {                                                                      \
-            static std::string getName()                                       \
-            {                                                                  \
-                return std::string(#name);                                     \
-            }                                                                  \
-        };                                                                     \
-    }                                                                          \
-    using namespace PMACC_JOIN(placeholder_definition,id);                     \
-    namespace PMACC_JOIN(host_placeholder,id){                                 \
-        /* This variable exists only for template parameter deduction, its value
-         * is never used. So in this case it is fine to have a separate version
-         * in each translation unit due to static.
-         */                                                                    \
-        static PMACC_JOIN(placeholder_definition,id)::name<>                   \
-            PMACC_JOIN(name,_);                                                \
-    }                                                                          \
-    PMACC_alias_CUDA(name,id);                                                 \
-    PMACC_PLACEHOLDER(id);
-
 
 /** create an alias
  *
@@ -90,7 +52,19 @@ identifier(pmacc_isAlias);
  * get type which is represented by the alias
  *      typedef typename traits::Resolve<name>::type resolved_type;
  */
-#define alias(name) PMACC_alias(name,__COUNTER__)
+#define alias(name)                                                            \
+        template<                                                              \
+            typename T_Type = pmacc::pmacc_void,                               \
+            typename T_IsAlias = pmacc::pmacc_isAlias                          \
+        >                                                                      \
+        struct name                                                            \
+        {                                                                      \
+            static std::string getName()                                       \
+            {                                                                  \
+                return std::string(#name);                                     \
+            }                                                                  \
+        };                                                                     \
+        constexpr name<> PMACC_JOIN(name,_)
 
 namespace pmacc
 {

--- a/include/pmacc/identifier/identifier.hpp
+++ b/include/pmacc/identifier/identifier.hpp
@@ -24,46 +24,6 @@
 #include "pmacc/types.hpp"
 #include "pmacc/ppFunctions.hpp"
 
-/* No namespace is needed because we only have defines*/
-
-#ifdef __CUDA_ARCH__ //we are on gpu
-#   define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(device_placeholder,id)
-#else
-#   define PMACC_PLACEHOLDER(id) using namespace PMACC_JOIN(host_placeholder,id)
-#endif
-
-#ifdef __CUDACC__
-#   define PMACC_identifier_CUDA(name,id)                                         \
-        namespace PMACC_JOIN(device_placeholder,id){                               \
-            /* This variable exists only for template parameter deduction, its value
-             * is never used. So in this case it is fine to have a separate version
-             * in each translation unit due to static.
-             */                                                                    \
-            static __constant__ PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
-        }
-#else
-#   define PMACC_identifier_CUDA(name,id)
-#endif
-
-/*define special macros for creating classes which are only used as identifier*/
-#define PMACC_identifier(name,id,...)                                          \
-    namespace PMACC_JOIN(placeholder_definition,id) {                          \
-        struct name{                                                           \
-            __VA_ARGS__                                                        \
-        };                                                                     \
-    }                                                                          \
-    using namespace PMACC_JOIN(placeholder_definition,id);                     \
-    namespace PMACC_JOIN(host_placeholder,id){                                 \
-        /* This variable exists only for template parameter deduction, its value
-         * is never used. So in this case it is fine to have a separate version
-         * in each translation unit due to static.
-         */                                                                    \
-        static PMACC_JOIN(placeholder_definition,id)::name PMACC_JOIN(name,_); \
-    }                                                                          \
-    PMACC_identifier_CUDA(name,id);                                            \
-    PMACC_PLACEHOLDER(id);
-
-
 /** create an identifier (identifier with arbitrary code as second parameter
  * !! second parameter is optional and can be any C++ code one can add inside a class
  *
@@ -74,4 +34,9 @@
  * to create an instance of this identifier you can use:
  *      varname();   or varname_
  */
-#define identifier(name,...) PMACC_identifier(name,__COUNTER__,__VA_ARGS__)
+#define identifier(name, ...)                                                  \
+    struct name                                                                \
+    {                                                                          \
+        __VA_ARGS__                                                            \
+    };                                                                         \
+    constexpr name PMACC_JOIN(name, _)


### PR DESCRIPTION
- use `constexpr` for instances e.g. `momentum_`
- enforce a semicolon after the macro
- fix `speciesAttributes.param` - add missing semicolon

Co-authored-by: Jeffrey Kelling <j.kelling@hzdr.de>

Since the namespaces for the types are removed our kernel names will be 300-400 characters shorter :tada: