### PR TITLE
Fix checkpointing and output of PML fields for uneven domains

### DIFF
--- a/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
@@ -26,10 +26,12 @@
 #include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/IsFieldDomainBound.hpp"
 
+#include <pmacc/communication/manager_common.hpp>
 #include <pmacc/particles/frame_types.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/dimensions/GridLayout.hpp>
+#include <pmacc/Environment.hpp>
 #include "picongpu/simulation/control/MovingWindow.hpp"
 
 #include <adios.h>
@@ -77,19 +79,45 @@ public:
         bool useLinearIdxAsDestination = false;
 
         /* Patch for non-domain-bound fields
-        * This is an ugly fix to allow output of reduced 1d PML buffers,
-        * that are the same size on each domain.
-        * This code is to be replaced with the openPMD output plugin soon.
-        */
+         * This is an ugly fix to allow output of reduced 1d PML buffers
+         */
         if( !isDomainBound )
         {
             auto const field_layout = params->gridLayout;
             auto const field_no_guard = field_layout.getDataSpaceWithoutGuarding();
             auto const elementCount = field_no_guard.productOfComponents();
-            auto const & gridController = Environment<simDim>::get().GridController();
-            auto const rank = gridController.getGlobalRank();
+
+            /* Scan the PML buffer local size along all local domains
+             * This code is symmetric to one in Field::writeField()
+             */
+            log< picLog::INPUT_OUTPUT > ("ADIOS:  (begin) collect PML sizes for %1%") % objectName;
+            auto & gridController = Environment<simDim>::get().GridController();
+            auto const numRanks = uint64_t{ gridController.getGlobalSize() };
+            /* Use domain position-based rank, not MPI rank, to be independent
+             * of the MPI rank assignment scheme
+             */
+            auto const rank = uint64_t{ gridController.getScalarPosition() };
+            std::vector< uint64_t > localSizes( 2 * numRanks, 0u );
+            uint64_t localSizeInfo[ 2 ] = {
+                static_cast<uint64_t>( elementCount ),
+                rank
+            };
+            __getTransactionEvent().waitForFinished();
+            MPI_CHECK(MPI_Allgather(
+                localSizeInfo, 2, MPI_UINT64_T,
+                &( *localSizes.begin() ), 2, MPI_UINT64_T,
+                gridController.getCommunicator().getMPIComm()
+            ));
+            uint64_t domainOffset = 0;
+            for( uint64_t r = 0; r < numRanks; ++r )
+            {
+                if( localSizes.at( 2u * r + 1u ) < rank )
+                    domainOffset += localSizes.at( 2u * r );
+            }
+            log< picLog::INPUT_OUTPUT > ("ADIOS:  (end) collect PML sizes for %1%") % objectName;
+
             domain_offset = DataSpace<simDim>::create( 0 );
-            domain_offset[ 0 ] = rank * elementCount;
+            domain_offset[ 0 ] = static_cast<int>( domainOffset );
             local_domain_size = DataSpace<simDim>::create( 1 );
             local_domain_size[ 0 ] = elementCount;
             useLinearIdxAsDestination = true;

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -37,8 +37,10 @@
 #include "picongpu/traits/IsFieldDomainBound.hpp"
 
 #include <pmacc/assert.hpp>
+#include <pmacc/communication/manager_common.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/GridLayout.hpp>
+#include <pmacc/Environment.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/mappings/simulation/SubGrid.hpp>
 #include <pmacc/math/Vector.hpp>
@@ -1086,8 +1088,7 @@ namespace openPMD
             auto fieldsOffsetDims = params->fieldsOffsetDims;
 
             /* Patch for non-domain-bound fields
-             * Allow for the output of reduced 1d PML buffers,
-             * that are the same size on each domain.
+             * Allow for the output of reduced 1d PML buffer
              */
             if( !isDomainBound )
             {
@@ -1099,16 +1100,45 @@ namespace openPMD
                 fieldsSizeDims = precisionCast< uint64_t >(
                     params->gridLayout.getDataSpaceWithoutGuarding() );
                 dc.releaseData( name );
-                auto const & gridController =
-                    Environment< simDim >::get().GridController();
-                auto const numRanks = gridController.getGlobalSize();
-                auto const rank = gridController.getGlobalRank();
+
+                /* Scan the PML buffer local size along all local domains
+                 * This code is based on the same operation in hdf5::Field::writeField(),
+                 * the same comments apply here
+                 */
+                log< picLog::INPUT_OUTPUT > ("openPMD:  (begin) collect PML sizes for %1%") % name;
+                auto & gridController = Environment<simDim>::get().GridController();
+                auto const numRanks = uint64_t{ gridController.getGlobalSize() };
+                /* Use domain position-based rank, not MPI rank, to be independent
+                 * of the MPI rank assignment scheme
+                 */
+                auto const rank = uint64_t{ gridController.getScalarPosition() };
+                std::vector< uint64_t > localSizes( 2u * numRanks, 0u );
+                uint64_t localSizeInfo[ 2 ] = {
+                    fieldsSizeDims[ 0 ],
+                    rank
+                };
+                __getTransactionEvent().waitForFinished();
+                MPI_CHECK(MPI_Allgather(
+                    localSizeInfo, 2, MPI_UINT64_T,
+                    &( *localSizes.begin() ), 2, MPI_UINT64_T,
+                    gridController.getCommunicator().getMPIComm()
+                ));
+                uint64_t globalOffsetFile = 0;
+                uint64_t globalSize = 0;
+                for( uint64_t r = 0; r < numRanks; ++r )
+                {
+                    globalSize += localSizes.at( 2u * r );
+                    if( localSizes.at( 2u * r + 1u ) < rank )
+                        globalOffsetFile += localSizes.at( 2u * r );
+                }
+                log< picLog::INPUT_OUTPUT > ("openPMD:  (end) collect PML sizes for %1%") % name;
+
                 fieldsGlobalSizeDims =
                     pmacc::math::UInt64< simDim >::create( 1 );
-                fieldsGlobalSizeDims[ 0 ] = numRanks * fieldsSizeDims[ 0 ];
+                fieldsGlobalSizeDims[ 0 ] = globalSize;
                 fieldsOffsetDims =
                     pmacc::math::UInt64< simDim >::create( 0 );
-                fieldsOffsetDims[ 0 ] = rank * fieldsSizeDims[ 0 ];
+                fieldsOffsetDims[ 0 ] = globalOffsetFile;
             }
 
             /* write the actual field data */

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -26,9 +26,11 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/traits/IsFieldDomainBound.hpp"
 
+#include <pmacc/communication/manager_common.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/dimensions/GridLayout.hpp>
+#include <pmacc/Environment.hpp>
 #include <pmacc/particles/frame_types.hpp>
 #include <pmacc/types.hpp>
 
@@ -79,8 +81,7 @@ namespace openPMD
             bool useLinearIdxAsDestination = false;
 
             /* Patch for non-domain-bound fields
-             * This is an ugly fix to allow output of reduced 1d PML buffers,
-             * that are the same size on each domain.
+             * This is an ugly fix to allow output of reduced 1d PML buffers
              */
             if( !isDomainBound )
             {
@@ -88,11 +89,38 @@ namespace openPMD
                 auto const field_no_guard =
                     field_layout.getDataSpaceWithoutGuarding();
                 auto const elementCount = field_no_guard.productOfComponents();
-                auto const & gridController =
-                    Environment< simDim >::get().GridController();
-                auto const rank = gridController.getGlobalRank();
+
+                /* Scan the PML buffer local size along all local domains
+                 * This code is symmetric to one in Field::writeField()
+                 */
+                log< picLog::INPUT_OUTPUT > ("openPMD:  (begin) collect PML sizes for %1%") % objectName;
+                auto & gridController = Environment<simDim>::get().GridController();
+                auto const numRanks = uint64_t{ gridController.getGlobalSize() };
+                /* Use domain position-based rank, not MPI rank, to be independent
+                 * of the MPI rank assignment scheme
+                 */
+                auto const rank = uint64_t{ gridController.getScalarPosition() };
+                std::vector< uint64_t > localSizes( 2 * numRanks, 0u );
+                uint64_t localSizeInfo[ 2 ] = {
+                    static_cast<uint64_t>( elementCount ),
+                    rank
+                };
+                __getTransactionEvent().waitForFinished();
+                MPI_CHECK(MPI_Allgather(
+                    localSizeInfo, 2, MPI_UINT64_T,
+                    &( *localSizes.begin() ), 2, MPI_UINT64_T,
+                    gridController.getCommunicator().getMPIComm()
+                ));
+                uint64_t domainOffset = 0;
+                for( uint64_t r = 0; r < numRanks; ++r )
+                {
+                    if( localSizes.at( 2u * r + 1u ) < rank )
+                        domainOffset += localSizes.at( 2u * r );
+                }
+                log< picLog::INPUT_OUTPUT > ("openPMD:  (end) collect PML sizes for %1%") % objectName;
+
                 domain_offset = DataSpace< simDim >::create( 0 );
-                domain_offset[ 0 ] = rank * elementCount;
+                domain_offset[ 0 ] = static_cast<int>( domainOffset );
                 local_domain_size = DataSpace< simDim >::create( 1 );
                 local_domain_size[ 0 ] = elementCount;
                 useLinearIdxAsDestination = true;


### PR DESCRIPTION
Fix #3275 for all three output backends.

Since the three output plugins we have are largely similar, the changes are basically copy-pasted in all 3 plugins. I deliberately did not go into abstracting and reusing, since this is a patch (to a patch for PML support) and the HDF5 and ADIOS plugins will (hopefully) be removed soon.