### PR TITLE
Add Higuera-Cary pusher

### DIFF
--- a/include/picongpu/param/pusher.param
+++ b/include/picongpu/param/pusher.param
@@ -62,13 +62,13 @@ namespace picongpu
         namespace sqrt_Vay = precision64Bit;
     }
 
-    namespace particlePusherHC
+    namespace particlePusherHigueraCary
     {
         /** Precision of the square roots during the push step
          *  - precision32Bit
          *  - precision64Bit
          */
-        namespace sqrt_HC = precision64Bit;
+        namespace sqrt_HigueraCary = precision64Bit;
     }
 
     namespace particlePusherAxel
@@ -87,7 +87,7 @@ namespace picongpu
     {
     namespace pusher
     {
-        struct HC;
+        struct HigueraCary;
         struct Vay;
         struct Boris;
         struct Photon;

--- a/include/picongpu/param/pusher.param
+++ b/include/picongpu/param/pusher.param
@@ -69,7 +69,7 @@ namespace picongpu
          *  - precision64Bit
          */
         namespace sqrt_HC = precision64Bit;
-    }    
+    }
 
     namespace particlePusherAxel
     {

--- a/include/picongpu/param/pusher.param
+++ b/include/picongpu/param/pusher.param
@@ -62,6 +62,15 @@ namespace picongpu
         namespace sqrt_Vay = precision64Bit;
     }
 
+    namespace particlePusherHC
+    {
+        /** Precision of the square roots during the push step
+         *  - precision32Bit
+         *  - precision64Bit
+         */
+        namespace sqrt_HC = precision64Bit;
+    }    
+
     namespace particlePusherAxel
     {
 
@@ -78,6 +87,7 @@ namespace picongpu
     {
     namespace pusher
     {
+        struct HC;
         struct Vay;
         struct Boris;
         struct Photon;

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -89,6 +89,6 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  * For development purposes: --------------------------------------------------
  * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  */
-using UsedParticlePusher = particles::pusher::HigueraCary;
+using UsedParticlePusher = particles::pusher::Boris;
 
 } // namespace picongpu

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2020 Rene Widera, Richard Pausch
+/* Copyright 2014-2020 Rene Widera, Richard Pausch, Annegret Roessler
  *
  * This file is part of PIConGPU.
  *
@@ -74,6 +74,7 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *
  * Defining a pusher is optional for particles
  *
+ * - particles::pusher::HC : best of Vay and Boris pusher
  * - particles::pusher::Vay : better suited relativistic boris pusher
  * - particles::pusher::Boris : standard boris pusher
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -74,9 +74,9 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::HC : best of Vay and Boris pusher
- * - particles::pusher::Vay : better suited relativistic boris pusher
- * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+ * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
  *
@@ -89,6 +89,6 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  * For development purposes: --------------------------------------------------
  * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  */
-using UsedParticlePusher = particles::pusher::Boris;
+using UsedParticlePusher = particles::pusher::HC;
 
 } // namespace picongpu

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2020 Rene Widera, Richard Pausch, Annegret Roessler
+/* Copyright 2014-2020 Rene Widera, Richard Pausch, Annegret Roeszler
  *
  * This file is part of PIConGPU.
  *
@@ -74,7 +74,7 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
  * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
@@ -89,6 +89,6 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  * For development purposes: --------------------------------------------------
  * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
  */
-using UsedParticlePusher = particles::pusher::HC;
+using UsedParticlePusher = particles::pusher::HigueraCary;
 
 } // namespace picongpu

--- a/include/picongpu/particles/pusher/particlePusherHC.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHC.hpp
@@ -1,0 +1,127 @@
+/* Copyright 2013-2020 Heiko Burau, Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/traits/attribute/GetMass.hpp"
+#include "picongpu/traits/attribute/GetCharge.hpp"
+
+namespace picongpu
+{
+namespace particlePusherHC
+{
+/* Implementation of the Higuera-Cary pusher as presented in doi:10.1063/1.4979989.
+ * A correction is applied to the given formulas as documented by the WarpX team:
+ * (https://github.com/ECP-WarpX/WarpX/issues/320).
+ * 
+ * Note, while Higuera and Ripperda present the formulas for the quantity u = gamma * v,
+ * PIConGPU uses the real momentum p = gamma * m * v = u * m for calculations.
+ * 
+ * Further references:
+ * [Higuera's article on arxiv](https://arxiv.org/abs/1701.05605)
+ * [Riperda's comparison of relativistic particle integrators](https://doi.org/10.3847/1538-4365/aab114)
+ */
+
+template<class Velocity, class Gamma>
+struct Push
+{
+    /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
+     * for particle positions outside the super cell in one push
+     */
+    using LowerMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
+    using UpperMargin = typename pmacc::math::CT::make_Int<simDim,0>::type;
+
+    template< typename T_FunctorFieldE, typename T_FunctorFieldB, typename T_Particle, typename T_Pos >
+    HDINLINE void operator()(
+        const T_FunctorFieldB functorBField,
+        const T_FunctorFieldE functorEField,
+        T_Particle & particle,
+        T_Pos & pos,
+        const uint32_t
+    )
+    {
+        float_X const weighting = particle[ weighting_ ];
+        float_X const mass = attribute::getMass( weighting , particle );
+        float_X const charge = attribute::getCharge( weighting , particle );
+
+        using MomType = momentum::type;
+        MomType const mom = particle[ momentum_ ];
+
+        auto bField  = functorBField(pos);
+        auto eField  = functorEField(pos);
+
+        const float_X deltaT = DELTA_T;
+
+
+        Gamma gamma;
+
+        /*
+         * Momentum update
+         * Notation is according to Ripperda's paper
+         */
+        // First half electric field acceleration
+        const MomType mom_minus = mom + float_X(0.5) * charge * eField * deltaT;
+
+        // Auxiliary quantitites
+        const sqrt_HC::float_X gamma_minus = gamma( mom_minus , mass );
+
+        const sqrt_HC::float3_X tau = precisionCast<sqrt_HC::float_X>( float_X(0.5) * bField * charge * deltaT / mass );
+
+        const sqrt_HC::float_X sigma = pmacc::math::abs2( gamma_minus ) - pmacc::math::abs2( tau );
+
+        const sqrt_HC::float_X u_star = pmacc::math::dot( precisionCast<sqrt_HC::float_X>( mom_minus ), tau ) / precisionCast<sqrt_HC::float_X>( mass * SPEED_OF_LIGHT );
+
+        const float_X gamma_plus = math::sqrt( ( sigma + math::sqrt( pmacc::math::abs2( sigma ) + ( sqrt_HC::float_X(4.0) ) * ( pmacc::math::abs2( tau ) + pmacc::math::abs2( u_star ) ) ) ) * ( sqrt_HC::float_X(0.5) ) );
+
+        const float3_X t_vector =  precisionCast<float_X>( tau ) / gamma_plus;
+
+        const float_X s = float_X(1.0) / ( float_X(1.0) + pmacc::math::abs2( t_vector ) );
+
+        // Rotation step
+        const MomType mom_plus = s * ( mom_minus + pmacc::math::dot( mom_minus , t_vector ) * t_vector + pmacc::math::cross( mom_minus , t_vector) );
+
+        // Second half electric field acceleration (Note correction mom_minus -> mom_plus compared to Ripperda)
+        const MomType new_mom = mom_plus + float_X(0.5) * eField * charge * deltaT + pmacc::math::cross( mom_plus , t_vector );
+
+        particle[ momentum_ ] = new_mom;
+
+        /*
+         * Position update
+         */
+        Velocity velocity;
+
+        const float3_X vel = velocity( new_mom , mass );
+
+        for( uint32_t d=0 ; d<simDim ; ++d )
+        {
+            pos[d] += ( vel[d] * deltaT ) / cellSize[d];
+        }
+    }
+
+    static pmacc::traits::StringProperty getStringProperties()
+    {
+        pmacc::traits::StringProperty propList( "name", "HC" );
+        return propList;
+    }
+};
+} // namespace particlePusherHC
+} // namespace picongpu

--- a/include/picongpu/particles/pusher/particlePusherHC.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHC.hpp
@@ -90,17 +90,28 @@ struct Push
 
         const sqrt_HC::float_X u_star = pmacc::math::dot( precisionCast<sqrt_HC::float_X>( mom_minus ), tau ) / precisionCast<sqrt_HC::float_X>( mass * SPEED_OF_LIGHT );
 
-        const float_X gamma_plus = math::sqrt( ( sigma + math::sqrt( pmacc::math::abs2( sigma ) + ( sqrt_HC::float_X(4.0) ) * ( pmacc::math::abs2( tau ) + pmacc::math::abs2( u_star ) ) ) ) * ( sqrt_HC::float_X(0.5) ) );
+        const sqrt_HC::float_X gamma_plus = math::sqrt( 
+                sqrt_HC::float_X(0.5) * ( sigma + math::sqrt( 
+                        pmacc::math::abs2( sigma ) + sqrt_HC::float_X(4.0) * ( pmacc::math::abs2( tau ) + pmacc::math::abs2( u_star ) )
+                    ) )
+            );
 
-        const float3_X t_vector =  precisionCast<float_X>( tau ) / gamma_plus;
+        const sqrt_HC::float3_X t_vector =  tau / gamma_plus;
 
-        const float_X s = float_X(1.0) / ( float_X(1.0) + pmacc::math::abs2( t_vector ) );
+        const sqrt_HC::float_X s = sqrt_HC::float_X(1.0) / ( sqrt_HC::float_X(1.0) + pmacc::math::abs2( t_vector ) );
 
         // Rotation step
-        const MomType mom_plus = s * ( mom_minus + pmacc::math::dot( mom_minus , t_vector ) * t_vector + pmacc::math::cross( mom_minus , t_vector) );
+        const MomType mom_plus = precisionCast<float_X>( s * (
+                precisionCast<sqrt_HC::float_X>( mom_minus )
+                + pmacc::math::dot( precisionCast<sqrt_HC::float_X>( mom_minus ) , t_vector ) * t_vector
+                + pmacc::math::cross( precisionCast<sqrt_HC::float_X>( mom_minus ) , t_vector) 
+            ) );
 
         // Second half electric field acceleration (Note correction mom_minus -> mom_plus compared to Ripperda)
-        const MomType new_mom = mom_plus + float_X(0.5) * eField * charge * deltaT + pmacc::math::cross( mom_plus , t_vector );
+        const  sqrt_HC::float3_X mom_diff = sqrt_HC::float_X(0.5) * precisionCast<sqrt_HC::float_X>( eField * charge * deltaT ) 
+            + pmacc::math::cross( precisionCast<sqrt_HC::float_X>( mom_plus ) , t_vector );
+        
+        const MomType new_mom = mom_plus + precisionCast<float_X>( mom_diff );
 
         particle[ momentum_ ] = new_mom;
 

--- a/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
@@ -30,7 +30,7 @@ namespace particlePusherHigueraCary
 {
 
 /** Implementation of the Higuera-Cary pusher as presented in doi:10.1063/1.4979989.
- * 
+ *
  * A correction is applied to the given formulas as documented by the WarpX team:
  * (https://github.com/ECP-WarpX/WarpX/issues/320).
  *
@@ -41,7 +41,7 @@ namespace particlePusherHigueraCary
  * Further references:
  * [Higuera's article on arxiv](https://arxiv.org/abs/1701.05605)
  * [Riperda's comparison of relativistic particle integrators](https://doi.org/10.3847/1538-4365/aab114)
- * 
+ *
  * @tparam Velocity functor to compute the velocity of a particle with momentum p and mass m
  * @tparam Gamma functor to compute the Lorentz factor (= Energy/mc^2) of a particle with momentum p and mass m
  */
@@ -86,7 +86,7 @@ struct Push
          */
         // First half electric field acceleration
         namespace sqrt_HC = sqrt_HigueraCary;
-        
+
         sqrt_HC::float3_X const mom_minus = precisionCast<sqrt_HC::float_X>( mom + float_X(0.5) * charge * eField * deltaT );
 
         // Auxiliary quantitites

--- a/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
@@ -17,19 +17,19 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/traits/attribute/GetMass.hpp"
 #include "picongpu/traits/attribute/GetCharge.hpp"
 
+
 namespace picongpu
 {
-namespace particlePusherHC
+namespace particlePusherHigueraCary
 {
-/* Implementation of the Higuera-Cary pusher as presented in doi:10.1063/1.4979989.
+
+/** Implementation of the Higuera-Cary pusher as presented in doi:10.1063/1.4979989.
  * A correction is applied to the given formulas as documented by the WarpX team:
  * (https://github.com/ECP-WarpX/WarpX/issues/320).
  *
@@ -41,8 +41,7 @@ namespace particlePusherHC
  * [Higuera's article on arxiv](https://arxiv.org/abs/1701.05605)
  * [Riperda's comparison of relativistic particle integrators](https://doi.org/10.3847/1538-4365/aab114)
  */
-
-template<class Velocity, class Gamma>
+template<typename Velocity, typename Gamma>
 struct Push
 {
     /* this is an optional extension for sub-sampling pushes that enables grid to particle interpolation
@@ -75,11 +74,12 @@ struct Push
 
         Gamma gamma;
 
-        /*
-         * Momentum update
+        /* Momentum update
          * Notation is according to Ripperda's paper
          */
         // First half electric field acceleration
+        namespace sqrt_HC = sqrt_HigueraCary;
+        
         const sqrt_HC::float3_X mom_minus = precisionCast<sqrt_HC::float_X>( mom + float_X(0.5) * charge * eField * deltaT );
 
         // Auxiliary quantitites
@@ -116,9 +116,7 @@ struct Push
 
         particle[ momentum_ ] = new_mom;
 
-        /*
-         * Position update
-         */
+        // Position update
         Velocity velocity;
 
         const float3_X vel = velocity( new_mom , mass );
@@ -131,9 +129,10 @@ struct Push
 
     static pmacc::traits::StringProperty getStringProperties()
     {
-        pmacc::traits::StringProperty propList( "name", "HC" );
+        pmacc::traits::StringProperty propList( "name", "HigueraCary" );
         return propList;
     }
 };
-} // namespace particlePusherHC
+
+} // namespace particlePusherHigueraCary
 } // namespace picongpu

--- a/include/picongpu/unitless/pusher.unitless
+++ b/include/picongpu/unitless/pusher.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Axel Huebl, Rene Widera, Richard Pausch, Annegret Roessler
+/* Copyright 2013-2020 Axel Huebl, Rene Widera, Richard Pausch, Annegret Roeszler
  *
  * This file is part of PIConGPU.
  *
@@ -25,7 +25,7 @@
 #include "picongpu/particles/pusher/particlePusherAcceleration.hpp"
 #include "picongpu/particles/pusher/particlePusherBoris.hpp"
 #include "picongpu/particles/pusher/particlePusherVay.hpp"
-#include "picongpu/particles/pusher/particlePusherHC.hpp"
+#include "picongpu/particles/pusher/particlePusherHigueraCary.hpp"
 #include "picongpu/particles/pusher/particlePusherFree.hpp"
 #include "picongpu/particles/pusher/particlePusherPhoton.hpp"
 #include "picongpu/particles/pusher/particlePusherProbe.hpp"
@@ -69,8 +69,8 @@ public particlePusherVay::Push<Velocity, Gamma<> >
 {
 };
 
-struct HC :
-public particlePusherHC::Push<Velocity, Gamma<> >
+struct HigueraCary :
+public particlePusherHigueraCary::Push<Velocity, Gamma<> >
 {
 };
 

--- a/include/picongpu/unitless/pusher.unitless
+++ b/include/picongpu/unitless/pusher.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2020 Axel Huebl, Rene Widera, Richard Pausch, Annegret Roessler
  *
  * This file is part of PIConGPU.
  *
@@ -25,6 +25,7 @@
 #include "picongpu/particles/pusher/particlePusherAcceleration.hpp"
 #include "picongpu/particles/pusher/particlePusherBoris.hpp"
 #include "picongpu/particles/pusher/particlePusherVay.hpp"
+#include "picongpu/particles/pusher/particlePusherHC.hpp"
 #include "picongpu/particles/pusher/particlePusherFree.hpp"
 #include "picongpu/particles/pusher/particlePusherPhoton.hpp"
 #include "picongpu/particles/pusher/particlePusherProbe.hpp"
@@ -65,6 +66,11 @@ public particlePusherBoris::Push<Velocity, Gamma<> >
 
 struct Vay :
 public particlePusherVay::Push<Velocity, Gamma<> >
+{
+};
+
+struct HC :
+public particlePusherHC::Push<Velocity, Gamma<> >
 {
 };
 

--- a/share/picongpu/examples/Bunch/include/picongpu/param/species.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/species.param
@@ -65,7 +65,7 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
  * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher

--- a/share/picongpu/examples/Bunch/include/picongpu/param/species.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/species.param
@@ -65,8 +65,9 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::Vay : better suited relativistic boris pusher
- * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+ * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
@@ -71,7 +71,7 @@ using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
  * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
@@ -71,8 +71,9 @@ using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::Vay : better suited relativistic boris pusher
- * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+ * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
@@ -71,8 +71,9 @@ using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER< UsedPartic
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::Vay : better suited relativistic boris pusher
- * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+ * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
@@ -71,7 +71,7 @@ using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER< UsedPartic
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
  * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -65,7 +65,7 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
  * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -65,8 +65,9 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::Vay : better suited relativistic boris pusher
- * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+ * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
  *

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
@@ -65,7 +65,7 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
  * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
@@ -65,8 +65,9 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  *
  * Defining a pusher is optional for particles
  *
- * - particles::pusher::Vay : better suited relativistic boris pusher
- * - particles::pusher::Boris : standard boris pusher
+ * - particles::pusher::HC : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+ * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
  *


### PR DESCRIPTION
Add Higuera-Cary pusher as presented in [doi:10.1063/1.4979989](https://doi.org/10.1063/1.4979989).
The HC method is 2nd order, structure preserving, and relativistically correct.
Compared to Vay's method, the HC method has the additional property of being structure preserving while it correctly calculates the velocity in ExB direction when E·B=0 in contrast to Boris' method.
A correction to the formulas given in the original article is applied as documented by the WarpX team: (https://github.com/ECP-WarpX/WarpX/issues/320).
 
Further references:
* [Higuera's article on arxiv](https://arxiv.org/abs/1701.05605)
* [Riperda's comparison of relativistic particle integrators](https://doi.org/10.3847/1538-4365/aab114)

**Tests performed so far**
* Single particle acceleration in constant electric field
  - HC produces the exact same result as Boris

* Single particle turning circles in a constant magnetic field
  - particle sticks closer to (expected) circular trajectory than Boris' or Vay's method

* Single particle movement with constant velocity in a force-free field composed of constant magnetic and electric fields
  - ~HC performs better than Boris, but the deviation from the expected straight line motion is still large.
    Only Vay produces the expected result, but it was Vay's design goal to reproduce the correct behavior truthfully.
    HC's issue arises mainly due to insufficient precision of the input values (i.e. fields), as it relies on the cancellation of two very large equal but opposite numbers when calculating the new momentum, in this test case.~
  - UPDATE: I experimented a bit with `precisionCast`s and finally figured how to reduce errors due to upcasting while calculating with the necessary high precision, too.
    The HC pusher now performs as good as the Vay pusher and reproduces the trajectory.
    (Therefore, I would like to spare discussions on that)

* Kelvin-Helmholtz instability
  - Virtually no difference in electron distribution between Boris and HC at step 800. See the plot below showing where the distributions differ.
    ![KHI_diff_800_gimp](https://user-images.githubusercontent.com/26382442/86904885-99f81a80-c111-11ea-8bcd-9b9601248b6c.png)
    Note, this picture amplifies the real difference. White pixels just mark that there is a change in that pixel, but not how large it is. Drawing the absolute difference in electron distributions results in a black void only.
  - Charge conservation: for HC is about the same as for Boris, i.e. max|d|/ρ_0=3.8e-5 and 4.0e-5, respectively, at the end of the simulation
  - Numerical heating: curves of particle energy over time relative to initial energy are identical for Boris and HC


**To Do**
- [x] figure out if HC pusher gives expected results in force-free test
- [x] perform many particle test (e.g. KHI)
- [x] add option of the new HC pusher in list of available pushers in `species.param` in all examples

Big THANKS to @aroeszler who implemented most of the method.

This will close #2589.