### PR TITLE
activate reduced HZDR CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,100 @@
 
-dummy_job:
-  script:
-    - echo "To be continued ..."
+include:
+  - local: '/share/ci/compiler_clang.yml'
+  - local: '/share/ci/compiler_gcc.yml'
+  - local: '/share/ci/compiler_nvcc_cuda.yml'
+  - local: '/share/ci/compiler_clang_cuda.yml'
 
+# hidden base job to generate the test matrix
+# required variables (space separated lists):
+#   PIC_INPUTS - path to examples relative to share/picongpu
+#                e.g. 
+#                    "examples" starts one gitlab job per director in `examples/*`
+#                    "examples/" compile all directories in `examples/*` within one gitlab job
+#                    "examples/KelvinHelmholtz" compile all cases within one gitlab job
+#   GITLAB_BASES   - name of the hidden gitlab base job desctption `/share/ci/compiler_*`
+#   CXX_VERSIONS   - name of the compiler to use see `/share/ci/compiler_*` `e.g. "g++-8 g++-6"
+#   BOOST_VERSIONS - boost version to check e.g. "1.70.0"
+#                    supported version: {1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0, 1.70.0, 1.71.0, 1.72.0, 1.73.0}
+#   PIC_ACCS       - PIConGPU backend names see `pic-build --help`
+#                    e.g. "cuda cuda:35 serial"
+.base_generator:
+  stage: .pre
+  script: 
+    - $CI_PROJECT_DIR/share/ci/generate.sh > compile.yml
+    - cat compile.yml
+  artifacts:
+    paths:
+      - compile.yml
+
+# gcc matrix
+matrix-gcc:
+  variables:
+    PIC_INPUTS: "examples/Empty"
+    GITLAB_BASES: ".base_gcc"
+    CXX_VERSIONS: "g++-5 g++-8"
+    BOOST_VERSIONS: "1.65.1"
+    PIC_ACCS: "omp2b"
+  extends: ".base_generator"
+    
+compile-matrix-gcc:
+  stage: build
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: matrix-gcc
+    strategy: depend
+
+# clang matrix
+matrix-clang:
+  variables:
+    PIC_INPUTS: "examples/Empty"
+    GITLAB_BASES: ".base_clang"
+    CXX_VERSIONS: "clang++-5.0"
+    BOOST_VERSIONS: "1.65.1"
+    PIC_ACCS: "omp2b"
+  extends: ".base_generator"
+    
+compile-matrix-clang:
+  stage: build
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: matrix-clang
+    strategy: depend
+
+# clang-cuda101 matrix
+matrix-clang-cuda101:
+  variables:
+    PIC_INPUTS: "examples/Empty"
+    GITLAB_BASES: ".clang_cuda101"
+    CXX_VERSIONS: "clang++-10"
+    BOOST_VERSIONS: "1.65.1"
+    PIC_ACCS: "cuda"
+  extends: ".base_generator" 
+    
+compile-matrix-clang-cuda101:
+  stage: build
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: matrix-clang-cuda101
+    strategy: depend
+    
+# nvcc-cuda101 matrix
+matrix-nvcc-cuda102:
+  variables:
+    PIC_INPUTS: "examples/Empty"
+    GITLAB_BASES: ".nvcc_cuda102"
+    CXX_VERSIONS: "g++"
+    BOOST_VERSIONS: "1.65.1"
+    PIC_ACCS: "cuda:35"
+  extends: ".base_generator" 
+    
+compile-matrix-nvcc-cuda102:
+  stage: build
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: matrix-nvcc-cuda102
+    strategy: depend

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -1,0 +1,13 @@
+################################################################################
+#   [clang++-X] : X = {4.0, 5.0, 6.0, 7, 8, 9, 10}
+
+.base_clang:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:clang
+  variables:
+    GIT_SUBMODULE_STRATEGY: normal
+    PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
+  script:
+      - source share/ci/run_test.sh
+  # x86_64 tag is used to get a multi-core CPU for the tests
+  tags:
+    - x86_64

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -1,0 +1,24 @@
+################################################################################
+#   [clang++-X] : X = {4.0, 5.0, 6.0, 7, 8, 9, 10}
+
+.base_cuda_clang:
+  variables:
+    GIT_SUBMODULE_STRATEGY: normal
+    PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
+  script:
+      - source share/ci/run_test.sh
+  tags:
+    - cuda
+    - x86_64 
+
+.clang_cuda92:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2Clang
+  extends: .base_cuda_clang
+  
+.clang_cuda100:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0Clang
+  extends: .base_cuda_clang
+
+.clang_cuda101:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1Clang
+  extends: .base_cuda_clang

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -1,0 +1,12 @@
+################################################################################
+#   [g++-X] : X = {5, 6, 7, 8, 9}
+
+.base_gcc:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:gcc
+  variables:
+    GIT_SUBMODULE_STRATEGY: normal
+  script:
+    - source share/ci/run_test.sh
+  # x86_64 tag is used to get a multi-core CPU for the tests
+  tags:
+    - x86_64

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -1,0 +1,30 @@
+################################################################################
+#   [g++-X] : X = {5, 6, 7, 8, 9}
+
+.base_cuda:
+  variables:
+    GIT_SUBMODULE_STRATEGY: normal
+  before_script:
+    - nvidia-smi
+    - nvcc --version
+  script:
+      - source share/ci/run_test.sh
+  tags:
+    - cuda
+    - x86_64 
+    
+.nvcc_cuda92:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2gcc
+  extends: .base_cuda
+
+.nvcc_cuda100:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0gcc
+  extends: .base_cuda
+  
+.nvcc_cuda101:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1gcc
+  extends: .base_cuda  
+
+.nvcc_cuda102:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.2gcc
+  extends: .base_cuda

--- a/share/ci/generate.sh
+++ b/share/ci/generate.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# generate a job matrix based on the environment variable lists (space separated)
+# variables: GITLAB_BASES CXX_VERSIONS BOOST_VERSIONS PIC_INPUTS PIC_ACCS
+
+export picongpu_DIR=$CI_PROJECT_DIR
+cd $picongpu_DIR/share/picongpu/
+
+echo "include:"
+echo "  - local: '/share/ci/compiler_clang.yml'"
+echo "  - local: '/share/ci/compiler_gcc.yml'"
+echo "  - local: '/share/ci/compiler_nvcc_cuda.yml'"
+echo "  - local: '/share/ci/compiler_clang_cuda.yml'"
+echo ""
+
+for base_job in $GITLAB_BASES; do
+    for CXX_VERSION in $CXX_VERSIONS; do
+        for BOOST_VERSION in ${BOOST_VERSIONS}; do
+            for CASE in ${PIC_INPUTS}; do
+                for ACC in ${PIC_ACCS}; do
+                    if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] ; then
+                        all_cases=$(find ${CASE}/* -maxdepth 0 -type d)
+                    else
+                        all_cases=$(find $CASE -maxdepth 0 -type d)
+                    fi
+                    for test_case_folder in $all_cases ; do
+                        job_name="${CXX_VERSION}_${ACC}_${BOOST_VERSION}_$(echo $test_case_folder | tr '/' '.')"
+                        echo "${job_name}:"
+                        echo "  variables:"
+                        echo "    PIC_TEST_CASE_FOLDER: \"${test_case_folder}\""
+                        echo "    CXX_VERSION: \"${CXX_VERSION}\""
+                        echo "    PIC_BACKEND: \"${ACC}\""
+                        echo "    BOOST_VERSION: \"${BOOST_VERSION}\""
+                        echo "  before_script:"
+                        echo "    - apt-get update -qq"
+                        echo "    - apt-get install -y -qq libopenmpi-dev openmpi-bin openssh-server"
+                        echo "  extends: $base_job"
+                        echo ""
+                    done
+                done
+            done
+        done
+    done
+done

--- a/share/ci/run_test.sh
+++ b/share/ci/run_test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# the default build type is Release
+# if neccesary, you can rerun the pipeline with another build type-> https://docs.gitlab.com/ee/ci/pipelines.html#manually-executing-pipelines
+# to change the build type, you must set the environment variable PIC_BUILD_TYPE
+if [[ ! -v PIC_BUILD_TYPE ]] ; then
+    PIC_BUILD_TYPE=Release ;
+fi
+
+###################################################
+# cmake config builder
+###################################################
+
+PIC_CONST_ARGS=""
+PIC_CONST_ARGS="${PIC_CONST_ARGS} -DCMAKE_BUILD_TYPE=${PIC_BUILD_TYPE}"
+CMAKE_ARGS="${PIC_CONST_ARGS} ${PIC_CMAKE_ARGS} -DCMAKE_CXX_COMPILER=${CXX_VERSION} -DBOOST_ROOT=/opt/boost/${BOOST_VERSION}"
+
+###################################################
+# build an run tests
+###################################################
+
+# use one build directory for all build configurations
+cd $HOME
+mkdir buildCI
+cd buildCI
+
+export picongpu_DIR=$CI_PROJECT_DIR
+export PATH=$picongpu_DIR/bin:$PATH
+
+PIC_PARALLEL_BUILDS=$(nproc)
+# limit to 8 parallel builds to avoid out of memory errors
+if [ $PIC_PARALLEL_BUILDS -gt 8 ] ; then
+    PIC_PARALLEL_BUILDS=8
+fi
+echo -e "\033[0;32m///////////////////////////////////////////////////"
+echo "number of processor threads -> $(nproc)"
+echo "number of parallel builds -> $PIC_PARALLEL_BUILDS"
+echo "cmake version   -> $(cmake --version | head -n 1)"
+echo "build directory -> $(pwd)"
+echo "CMAKE_ARGS      -> ${CMAKE_ARGS}"
+echo "accelerator     -> ${PIC_BACKEND}"
+echo "input set       -> ${PIC_TEST_CASE_FOLDER}"
+echo -e "/////////////////////////////////////////////////// \033[0m \n\n"
+
+if [ "$PIC_TEST_CASE_FOLDER" == "examples/" ] || [ "$PIC_TEST_CASE_FOLDER" == "tests/" ] ; then
+    extended_compile_options="-l"
+fi
+
+# test compiling
+error_code=$(pic-compile -q -c"$CMAKE_ARGS" $extended_compile_options -j $PIC_PARALLEL_BUILDS ${picongpu_DIR}/share/picongpu/$PIC_TEST_CASE_FOLDER  . 2>&1 > pic_compile.log && echo "0" || echo "1")
+cat pic_compile.log
+for test_case in $(ls -w1 ./build) ; do
+    if [ -f  "build/$test_case/returnCode" ] ; then
+        returnCode=$(cat "build/$test_case/returnCode")
+        if [ "$returnCode" != "0" ] ; then
+            echo -e "\033[0;31m compile FAILED - $test_case \033[0m"
+            cat "build/$test_case/compile.log"
+        else
+            echo -e "\033[0;32m compile PASSED - $test_case \033[0m"
+        fi
+    else
+        echo -e "\033[0;33m compile NOT tested - $test_case \033[0m"
+    fi
+done
+if [ "$error_code" != "0" ] ; then
+    return 1
+fi
+# runtime test (call --help)
+for test_case_folder in $(ls params/*/* -d -w1) ; do
+    export LD_LIBRARY_PATH=/opt/boost/${BOOST_VERSION}/lib:$LD_LIBRARY_PATH
+    echo -e "\033[0;33m runtime test- $(basename $test_case_folder) \033[0m"
+    ${test_case_folder}/bin/picongpu --help
+done


### PR DESCRIPTION
Introcude the infrastructure and basic test for the HDZ gitlab CI.

- provide a matrix yaml generator script for PIConGPU
- test `example/Empty` with clang, gnu, clang-cuda and nvcc

Currently the HZDR CI will not test the empty example to keep the test time low. Clang compiler will still fail until all open clang fixes are merged.
It is not required for merging that the HZDR CI is passing all tests.