### PR TITLE
Abstract PML definitions from YeePML field solver

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2019-2020 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
- *                Sergei Bastrakov
+ *                Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *
@@ -200,14 +200,16 @@ namespace maxwellSolver
 
             void initParameters( )
             {
+                namespace pml = maxwellSolver::Pml;
+
                 globalSize = getGlobalThickness( );
-                parameters.sigmaKappaGradingOrder = SIGMA_KAPPA_GRADING_ORDER;
-                parameters.alphaGradingOrder = ALPHA_GRADING_ORDER;
+                parameters.sigmaKappaGradingOrder = pml::SIGMA_KAPPA_GRADING_ORDER;
+                parameters.alphaGradingOrder = pml::ALPHA_GRADING_ORDER;
                 for( uint32_t dim = 0u; dim < simDim; dim++ )
                 {
-                    parameters.normalizedSigmaMax[ dim ] = NORMALIZED_SIGMA_MAX[ dim ];
-                    parameters.kappaMax[ dim ] = KAPPA_MAX[ dim ];
-                    parameters.normalizedAlphaMax[ dim ] = NORMALIZED_ALPHA_MAX[ dim ];
+                    parameters.normalizedSigmaMax[ dim ] = pml::NORMALIZED_SIGMA_MAX[ dim ];
+                    parameters.kappaMax[ dim ] = pml::KAPPA_MAX[ dim ];
+                    parameters.normalizedAlphaMax[ dim ] = pml::NORMALIZED_ALPHA_MAX[ dim ];
                 }
             }
 

--- a/include/picongpu/fields/absorber/Absorber.hpp
+++ b/include/picongpu/fields/absorber/Absorber.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Axel Huebl, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2020 Axel Huebl, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *
@@ -107,7 +107,7 @@ namespace detail
         }
     };
 
-    namespace pml = maxwellSolver::yeePML;
+    namespace pml = maxwellSolver::Pml;
 
     /** Absorber wrapper
      *

--- a/include/picongpu/param/fieldSolver.param
+++ b/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *
@@ -61,7 +61,7 @@ namespace fields
      *
      * Field Solver Selection:
      *  - Yee< CurrentInterpolation > : standard Yee solver
-     *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
+     *  - YeePML< CurrentInterpolation >: standard Yee solver using Perfectly Matched Layer Absorbing Boundary Conditions (PML)
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B

--- a/include/picongpu/param/pml.param
+++ b/include/picongpu/param/pml.param
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Sergei Bastrakov
+/* Copyright 2019-2020 Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *
@@ -19,7 +19,7 @@
 
 /** @file
  *
- * Configure the perfectly matched layer (PML).
+ * Configure the Perfectly Matched Layer absorbing boundary conditions (PML).
  *
  * To enable PML use YeePML field solver.
  */
@@ -33,11 +33,11 @@ namespace fields
 {
 namespace maxwellSolver
 {
-namespace yeePML
+namespace Pml
 {
 
-    /* The parameters in this file are only used if the field solver selected is
-     * YeePML.
+    /* The parameters in this file are only used if the field solver selected
+     * uses Perfectly Matched Layer Absorbing Boundary Conditions (PML).
      * The original paper on this approach is J.A. Roden, S.D. Gedney.
      * Convolution PML (CPML): An efficient FDTD implementation of the CFS - PML
      * for arbitrary media. Microwave and optical technology letters. 27 (5),
@@ -155,7 +155,7 @@ namespace yeePML
         0.2
     };
 
-} // namespace yeePML
+} // namespace Pml
 } // namespace maxwellSolver
 } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/unitless/pml.unitless
+++ b/include/picongpu/unitless/pml.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Sergei Bastrakov
+/* Copyright 2019-2020 Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *
@@ -28,7 +28,7 @@ namespace fields
 {
 namespace maxwellSolver
 {
-namespace yeePML
+namespace Pml
 {
 
     // Assert parameters are in the valid ranges
@@ -86,7 +86,7 @@ namespace yeePML
         NORMALIZED_ALPHA_MAX_SI[ 2 ] * UNIT_TIME
     };
 
-} // namespace yeePML
+} // namespace Pml
 } // namespace maxwellSolver
 } // namespace fields
 } // namespace picongpu

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/pml.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/pml.param
@@ -33,7 +33,7 @@ namespace fields
 {
 namespace maxwellSolver
 {
-namespace yeePML
+namespace Pml
 {
 
     /* The parameters in this file are only used if field solver is YeePML.


### PR DESCRIPTION
PMLs could be used in other field solvers, too. But to do so, the variables of the PML in `pml.param` need to be separated from the `YeePML` field solver. This PR puts the definitions of the PML variables in their own namespace `PML` and updates the `YeePML` field solver to use the variables from this namespace.

A test with laser propagation in vacuum using PML boundaries compiles without error. (I am not sure if there is one compile test in the CI using PMLs.)