### PR TITLE
fix KHI for non CUDA devices

### DIFF
--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fieldSolver.param
@@ -70,12 +70,6 @@ namespace fields
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B
      */
 
-#ifndef PARAM_FIELDSOLVER
-    /* WARNING: if you change field solver by hand please update your CELL_WIDTH_SI
-     * in `grid.param` to fulfill the convergence condition (CFL)
-     */
-#   define PARAM_FIELDSOLVER Yee
-#endif
     using Solver = maxwellSolver::PARAM_FIELDSOLVER< CurrentInterpolation >;
 
 } // namespace fields

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
@@ -33,7 +33,34 @@ namespace picongpu
 
         /** equals X
          *  unit: meter */
+
+#ifndef PARAM_FIELDSOLVER
+#   define PARAM_FIELDSOLVER Yee
+#endif
+
 #define DirSplitting 1
+
+#if( PMACC_CUDA_ENABLED != 1 )
+/* DirSplitting is only available for the CUDA accelerator.
+ * Automatically switch back to Yee when we compile for non CUDA accelerator.
+ */
+#   if (PARAM_FIELDSOLVER == 1)
+#       warning "DirSplitting is only for CUDA available, solver will be set to Yee."
+#       warning "CurrentInterpolation solver will be set to None."
+// rest current interpolation
+#       ifdef PARAM_CURRENTINTERPOLATION
+#           undef PARAM_CURRENTINTERPOLATION
+#       endif
+#       define PARAM_CURRENTINTERPOLATION None
+#       undef DirSplitting
+// switch to the field solver Yee
+#       undef PARAM_FIELDSOLVER
+#       define PARAM_FIELDSOLVER Yee
+// define DirSplitting to two to force cell size calculation based on Yee solver conditions
+#       define DirSplitting 2
+#   endif
+#endif
+// check if DirSplitting is activated
 #if (PARAM_FIELDSOLVER == 1)
         /* THIS CODE PATH IS ONLY USED IF `PARAM_FIELDSOLVER` IS CHANGED IN
          * `cmakeFlags` and the field solver there is set to fieldSolverDirSplitting


### PR DESCRIPTION
If KHI is compiled for non CUDA devices and the field solver `DirSplitting` is enabled the compile will fail.
`DirSplitting` requires CUDA. One case defined in `cmakeFlags` is using directional splitting.
This PR added a precompiler guard section to switch to the field solver Yee if we compile for non CUDA devices.