### PR TITLE
fix clang compile

### DIFF
--- a/include/picongpu/fields/currentDeposition/Cache.hpp
+++ b/include/picongpu/fields/currentDeposition/Cache.hpp
@@ -66,6 +66,7 @@ namespace detail
             T_FieldBox const & fieldBox,
             uint32_t const workerIdx
         )
+#if(!BOOST_COMP_CLANG)
         -> decltype(
             CachedBox::create<
                 0u,
@@ -75,6 +76,7 @@ namespace detail
                 std::declval< T_BlockDescription >()
             )
         )
+#endif
         {
             using ValueType = typename T_FieldBox::ValueType;
             /* this memory is used by all virtual blocks */
@@ -158,7 +160,9 @@ namespace detail
             T_FieldBox const & fieldBox,
             uint32_t const workerIdx
         )
+#if(!BOOST_COMP_CLANG)
         -> T_FieldBox
+#endif
         {
             alpaka::ignore_unused(
                 acc,

--- a/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
@@ -236,10 +236,17 @@ namespace acc
         HINLINE float_X
         get_envelope( float_X runTime )
         {
-            float_X const AMP_PREPULSE = float_X( math::sqrt( Unitless::INT_RATIO_PREPULSE ) * Unitless::AMPLITUDE);
-            float_X const AMP_1 = float_X( math::sqrt( Unitless::INT_RATIO_POINT_1 ) * Unitless::AMPLITUDE );
-            float_X const AMP_2 = float_X( math::sqrt( Unitless::INT_RATIO_POINT_2 ) * Unitless::AMPLITUDE );
-            float_X const AMP_3 = float_X( math::sqrt( Unitless::INT_RATIO_POINT_3 ) * Unitless::AMPLITUDE );
+            /* workaround for clang 5 linker issues
+             * `undefined reference to `picongpu::fields::laserProfiles::ExpRampWithPrepulseParam::INT_RATIO_POINT_1'`
+             */
+            constexpr auto int_ratio_prepule =  Unitless::INT_RATIO_PREPULSE;
+            constexpr auto int_ratio_point_1 = Unitless::INT_RATIO_POINT_1;
+            constexpr auto int_ratio_point_2 = Unitless::INT_RATIO_POINT_2;
+            constexpr auto int_ratio_point_3 = Unitless::INT_RATIO_POINT_3;
+            float_X const AMP_PREPULSE = float_X( math::sqrt( int_ratio_prepule ) * Unitless::AMPLITUDE);
+            float_X const AMP_1 = float_X( math::sqrt( int_ratio_point_1 ) * Unitless::AMPLITUDE );
+            float_X const AMP_2 = float_X( math::sqrt( int_ratio_point_2 ) * Unitless::AMPLITUDE );
+            float_X const AMP_3 = float_X( math::sqrt( int_ratio_point_3 ) * Unitless::AMPLITUDE );
 
             float_X env = 0.0;
             bool const before_preupramp = runTime < Unitless::time_start_init;


### PR DESCRIPTION
- add workaround for clang-5 linker issues
- `Cache.hpp` disable explicit definition of the return value for clang