### PR TITLE
Add support for composite pushers

### DIFF
--- a/include/picongpu/param/pusher.param
+++ b/include/picongpu/param/pusher.param
@@ -98,6 +98,14 @@ namespace picongpu
 #if(SIMDIM==DIM3)
         struct Axel;
 #endif
+        template<
+            typename T_FirstPusher,
+            typename T_SecondPusher,
+            typename T_ActivationFunctor
+        >
+        struct Composite;
+        template< uint32_t T_switchTimeStep >
+        struct CompositeBinarySwitchActivationFunctor;
     } // namespace pusher
     } // namespace particles
 

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -79,6 +79,8 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
+ * - particles::pusher::Composite : composite of two given pushers,
+ *                                  switches between using one (or none) of those
  *
  * For diagnostics & modeling: ------------------------------------------------
  * - particles::pusher::Acceleration : Accelerate particles by applying a constant electric field

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -218,7 +218,11 @@ public:
         return propList;
     }
 
+    template< typename T_Pusher >
+    void push( uint32_t const currentStep );
+
 private:
+
     SimulationDataId m_datasetID;
 
     FieldE *fieldE;

--- a/include/picongpu/particles/pusher/Traits.hpp
+++ b/include/picongpu/particles/pusher/Traits.hpp
@@ -1,0 +1,54 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/pusher/particlePusherComposite.hpp"
+
+#include <pmacc/traits/IsBaseTemplateOf.hpp>
+
+#include <type_traits>
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace pusher
+{
+
+    /** Check if pusher type is composite (use several underlying pushers)
+     *
+     * The only composite pusher types are children of
+     * particlePusherComposite::Push template classes
+     *
+     * @tparam T_Pusher pusher type
+     * @treturn ::type std::true_type or std::false_type
+     */
+    template< typename T_Pusher >
+    struct IsComposite : public pmacc::traits::IsBaseTemplateOf_t<
+        particlePusherComposite::Push,
+        T_Pusher
+    >
+    {
+    };
+
+} // namespace pusher
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/pusher/particlePusherComposite.hpp
+++ b/include/picongpu/particles/pusher/particlePusherComposite.hpp
@@ -1,0 +1,164 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/math/vector/compile-time/Vector.hpp>
+
+#include <cstdint>
+#include <string>
+
+
+namespace picongpu
+{
+namespace particlePusherComposite
+{
+
+    /** Concept for an activation functor for a composite pusher
+     *
+     * This concept defines an interface for the corresponding template
+     * argument. This class is not supposed to be used directly.
+     * However, a helper activator class to be reused is provided below.
+     */
+    struct ActivationFunctor
+    {
+        /** Return a 1-based index of which pusher of the composite to use
+         *
+         * Return value out of the range [1, #pushers] means no pusher to be used.
+         *
+         * @param currentStep current time iteration
+         */
+        HDINLINE uint32_t operator()( uint32_t const currentStep ) const;
+    };
+
+    /** Helper activation functor for a composite of two pushers
+     *
+     * Uses the first pusher for currentStep < T_switchTimeStep and the second
+     * one otherwise.
+     */
+    template< uint32_t T_switchTimeStep >
+    struct BinarySwitchActivationFunctor
+    {
+        HDINLINE constexpr uint32_t operator()( uint32_t const currentStep ) const
+        {
+            return currentStep < T_switchTimeStep ? 1 : 2;
+        }
+    };
+
+    /** Composite of two particle pushers, each implementing the pusher concept.
+     *
+     * The decision which pusher to use is made by the activation functor.
+     * The composite pushers implement the pusher concept themselves, however
+     * for performance reasons special treatment is recommended during the
+     * particle push simulation stage.
+     *
+     * @tparam T_FirstPusher first pusher type
+     * @tparam T_SecondPusher second pusher type
+     * @tparam T_ActivationFunctor activation functor to decide which pusher to use,
+     *                             implements the ActivationFunctor concept
+     */
+    template<
+        typename T_FirstPusher,
+        typename T_SecondPusher,
+        typename T_ActivationFunctor
+    >
+    struct Push : public T_FirstPusher, T_SecondPusher
+    {
+        using FirstPusher = T_FirstPusher;
+        using SecondPusher = T_SecondPusher;
+        using ActivationFunctor = T_ActivationFunctor;
+
+        /* These are done logically correct, but should not be used directly for
+         * the particle push stage.
+         */
+        using LowerMargin = typename pmacc::math::CT::max<
+            typename traits::GetLowerMargin< FirstPusher >::type,
+            typename traits::GetLowerMargin< SecondPusher >::type
+        >::type;
+        using UpperMargin = typename pmacc::math::CT::max<
+            typename GetUpperMargin< FirstPusher >::type,
+            typename GetUpperMargin< SecondPusher >::type
+        >::type;
+
+        /** Get active pusher 1-based index
+         *
+         * Result other than 1 or 2 means no pusher should be used
+         *
+         * @param currentStep current time iteration
+         */
+        static HDINLINE uint32_t activePusherIdx( uint32_t const currentStep )
+        {
+            return ActivationFunctor{}( currentStep );
+        }
+
+        /** Push one particle, this is compatibility-only
+         *
+         * Should not be used for the particle push stage due to shared memory
+         * and register consumption.
+         */
+        template<
+            typename T_FunctorFieldE,
+            typename T_FunctorFieldB,
+            typename T_Particle,
+            typename T_Pos
+        >
+        HDINLINE void operator()(
+            T_FunctorFieldB const functorBField,
+            T_FunctorFieldE const functorEField,
+            T_Particle & particle,
+            T_Pos & pos,
+            uint32_t const currentStep
+        ) const
+        {
+            auto const pusherIdx = activePusherIdx( currentStep );
+            if( pusherIdx == 1 )
+                FirstPusher::operator()(
+                    functorBField,
+                    functorEField,
+                    particle,
+                    pos,
+                    currentStep
+                );
+            else if( pusherIdx == 2 )
+                SecondPusher::operator()(
+                    functorBField,
+                    functorEField,
+                    particle,
+                    pos,
+                    currentStep
+                );
+        }
+
+        static pmacc::traits::StringProperty getStringProperties()
+        {
+            auto const firstProperty = FirstPusher::getStringProperties();
+            auto const secondProperty = SecondPusher::getStringProperties();
+            pmacc::traits::StringProperty propList(
+                "name",
+                std::string{"Composite of "} + firstProperty[ "name" ] + " and " +
+                    secondProperty[ "name" ]
+            );
+            return propList;
+        }
+    };
+
+} // namespace particlePusherComposite
+} // namespace picongpu

--- a/include/picongpu/particles/pusher/particlePusherComposite.hpp
+++ b/include/picongpu/particles/pusher/particlePusherComposite.hpp
@@ -149,12 +149,12 @@ namespace particlePusherComposite
 
         static pmacc::traits::StringProperty getStringProperties()
         {
-            auto const firstProperty = FirstPusher::getStringProperties();
-            auto const secondProperty = SecondPusher::getStringProperties();
+            auto firstProperty = FirstPusher::getStringProperties();
+            auto secondProperty = SecondPusher::getStringProperties();
             pmacc::traits::StringProperty propList(
                 "name",
-                std::string{"Composite of "} + firstProperty[ "name" ] + " and " +
-                    secondProperty[ "name" ]
+                std::string("Composite of ") + firstProperty[ "name" ].value +
+                    " and " + secondProperty[ "name" ].value
             );
             return propList;
         }

--- a/include/picongpu/particles/traits/GetMarginPusher.hpp
+++ b/include/picongpu/particles/traits/GetMarginPusher.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2020 Richard Pausch
+/* Copyright 2015-2020 Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -27,36 +27,100 @@
 
 namespace picongpu
 {
-
 namespace traits
 {
-template<typename T_Species>
-struct GetMarginPusher
-{
-    using AddLowerMargins = pmacc::math::CT::add<
-        GetLowerMargin< GetInterpolation< bmpl::_1 > >,
-        GetLowerMargin< GetPusher< bmpl::_1 > >
-    >;
-    using LowerMargin = typename bmpl::apply<AddLowerMargins, T_Species>::type;
 
-    using AddUpperMargins = pmacc::math::CT::add<
-        GetUpperMargin< GetInterpolation< bmpl::_1 > >,
-        GetUpperMargin< GetPusher< bmpl::_1 > >
-    >;
-    using UpperMargin = typename bmpl::apply<AddUpperMargins, T_Species>::type;
-};
+    /** Get margins of a pusher for species
+     *
+     * @tparam T_Species particle species type
+     * @tparam T_GetLowerMargin lower margin for pusher getter type
+     * @tparam T_GetUpperMargin upper margin for pusher getter type
+     */
+    template<
+        typename T_Species,
+        typename T_GetLowerMargin = GetLowerMargin< GetPusher< bmpl::_1 > >,
+        typename T_GetUpperMargin = GetUpperMargin< GetPusher< bmpl::_1 > >
+    >
+    struct GetMarginPusher
+    {
+        using AddLowerMargins = pmacc::math::CT::add<
+            GetLowerMargin< GetInterpolation< bmpl::_1 > >,
+            T_GetLowerMargin
+        >;
+        using LowerMargin = typename bmpl::apply<AddLowerMargins, T_Species>::type;
 
-template<typename T_Species>
-struct GetLowerMarginPusher
-{
-    using type = typename traits::GetMarginPusher<T_Species>::LowerMargin;
-};
+        using AddUpperMargins = pmacc::math::CT::add<
+            GetUpperMargin< GetInterpolation< bmpl::_1 > >,
+            T_GetUpperMargin
+        >;
+        using UpperMargin = typename bmpl::apply<AddUpperMargins, T_Species>::type;
+    };
 
-template<typename T_Species>
-struct GetUpperMarginPusher
-{
-    using type = typename traits::GetMarginPusher<T_Species>::UpperMargin;
-};
+    /** Get lower margin of a pusher for species
+     *
+     * @tparam T_Species particle species type
+     */
+    template< typename T_Species >
+    struct GetLowerMarginPusher
+    {
+        using type = typename traits::GetMarginPusher<
+            T_Species
+        >::LowerMargin;
+    };
+
+    /** Get lower margin of the given pusher for species
+     *
+     * Normally, the pusher does not have to be given explicitly.
+     * However, it is needed for composite pushers
+     *
+     * @tparam T_Species particle species type
+     * @tparam T_Pusher pusher type
+     */
+    template<
+        typename T_Species,
+        typename T_Pusher
+    >
+    struct GetLowerMarginForPusher
+    {
+        using type = typename traits::GetMarginPusher<
+            T_Species,
+            typename GetLowerMargin< T_Pusher >::type,
+            typename GetUpperMargin< T_Pusher >::type
+        >::LowerMargin;
+    };
+
+    /** Get upper margin of a pusher for species
+     *
+     * @tparam T_Species particle species type
+     */
+    template< typename T_Species >
+    struct GetUpperMarginPusher
+    {
+        using type = typename traits::GetMarginPusher<
+            T_Species
+        >::UpperMargin;
+    };
+
+    /** Get upper margin of the given pusher for species
+     *
+     * Normally, the pusher does not have to be given explicitly.
+     * However, it is needed for composite pushers
+     *
+     * @tparam T_Species particle species type
+     * @tparam T_Pusher pusher type
+     */
+    template<
+        typename T_Species,
+        typename T_Pusher
+    >
+    struct GetUpperMarginForPusher
+    {
+        using type = typename traits::GetMarginPusher<
+            T_Species,
+            typename GetLowerMargin< T_Pusher >::type,
+            typename GetUpperMargin< T_Pusher >::type
+        >::UpperMargin;
+    };
 
 }// namespace traits
 }// namespace picongpu

--- a/include/picongpu/unitless/pusher.unitless
+++ b/include/picongpu/unitless/pusher.unitless
@@ -24,6 +24,7 @@
 
 #include "picongpu/particles/pusher/particlePusherAcceleration.hpp"
 #include "picongpu/particles/pusher/particlePusherBoris.hpp"
+#include "picongpu/particles/pusher/particlePusherComposite.hpp"
 #include "picongpu/particles/pusher/particlePusherVay.hpp"
 #include "picongpu/particles/pusher/particlePusherHigueraCary.hpp"
 #include "picongpu/particles/pusher/particlePusherFree.hpp"
@@ -94,6 +95,25 @@ public particlePusherProbe::Push<
     pmacc::nvidia::functors::Assign,
     particlePusherProbe::ActualPusher
 >
+{
+};
+
+template<
+    typename T_FirstPusher,
+    typename T_SecondPusher,
+    typename T_ActivationFunctor
+>
+struct Composite : public particlePusherComposite::Push<
+    T_FirstPusher,
+    T_SecondPusher,
+    T_ActivationFunctor
+>
+{
+};
+
+template< uint32_t T_switchTimeStep >
+struct CompositeBinarySwitchActivationFunctor :
+    public particlePusherComposite::BinarySwitchActivationFunctor< T_switchTimeStep >
 {
 };
 

--- a/include/pmacc/traits/IsBaseTemplateOf.hpp
+++ b/include/pmacc/traits/IsBaseTemplateOf.hpp
@@ -1,0 +1,72 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+
+namespace pmacc
+{
+namespace traits
+{
+
+    /** Check if a type inherits the given class template (with any arguments)
+     *
+     * This is basically a version of std::is_base_of but for class template as base.
+     * Based on Stack Overflow post:
+     *   source: https://stackoverflow.com/a/34672753
+     *   author: rmawatson
+     *   date: Aug 23 '18
+     *
+     * @tparam T_Base base template (itself, without arguments)
+     * @tparam T_Derived derived type to check
+     * @treturn ::type std::true_type or std::false_type
+     */
+    template<
+        template< typename... > class T_Base,
+        typename T_Derived
+    >
+    struct IsBaseTemplateOf
+    {
+        template< typename... T_Args>
+        static constexpr std::true_type test( const T_Base<T_Args...> * );
+        static constexpr std::false_type test( ... );
+        using type = decltype( test( std::declval< T_Derived* >() ) );
+    };
+
+    /** Helper alias for IsBaseTemplateOf<...>::type
+     *
+     * @tparam T_Base base template (itself, without arguments)
+     * @tparam T_Derived derived type to check
+     * @treturn std::true_type or std::false_type
+     */
+    template<
+        template< typename... > class T_Base,
+        typename T_Derived
+    >
+    using IsBaseTemplateOf_t = typename IsBaseTemplateOf<
+        T_Base,
+        T_Derived
+    >::type;
+
+} // namespace traits
+} // namespace pmacc

--- a/share/picongpu/examples/Bunch/include/picongpu/param/species.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/species.param
@@ -70,6 +70,8 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
+ * - particles::pusher::Composite : composite of two given pushers,
+ *                                  switches between using one (or none) of those
  *
  * For diagnostics & modeling: ------------------------------------------------
  * - particles::pusher::Free : free propagation, ignore fields

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/species.param
@@ -76,6 +76,8 @@ using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER;
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
+ * - particles::pusher::Composite : composite of two given pushers,
+ *                                  switches between using one (or none) of those
  *
  * For diagnostics & modeling: ------------------------------------------------
  * - particles::pusher::Free : free propagation, ignore fields

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/species.param
@@ -76,6 +76,8 @@ using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER< UsedPartic
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
+ * - particles::pusher::Composite : composite of two given pushers,
+ *                                  switches between using one (or none) of those
  *
  * For diagnostics & modeling: ------------------------------------------------
  * - particles::pusher::Free : free propagation, ignore fields

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -70,6 +70,8 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
+ * - particles::pusher::Composite : composite of two given pushers,
+ *                                  switches between using one (or none) of those
  *
  * For diagnostics & modeling: ------------------------------------------------
  * - particles::pusher::Free : free propagation, ignore fields

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/species.param
@@ -70,6 +70,8 @@ using UsedParticleCurrentSolver = currentSolver::Esirkepov< UsedParticleShape >;
  * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
  * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
  *                                              with classical radiation reaction
+ * - particles::pusher::Composite : composite of two given pushers,
+ *                                  switches between using one (or none) of those
  *
  * For diagnostics & modeling: ------------------------------------------------
  * - particles::pusher::Free : free propagation, ignore fields


### PR DESCRIPTION
Composite pushers allow to switch to one of the underlying pushers. So far it is only for two pushers (however, they could be composite as well), but can be reasonably extended to any amount later (maybe even in this PR, will see).

Note that the decision is done by a user-provided functor. So the easy use is just decide based on the current time iteration. And realistically that's about all one could do right now. But theoretically, this can be used to take into account any globally accessible data, or command-line parameters, once there is a way to access that info from the functor.

Example usage in `species.param`:
```cpp
// Old: always Boris
// using UsedParticlePusher = particles::pusher::Boris;
// New: Boris for 100 time iterations and then Vay
using UsedParticlePusher = particles::pusher::Composite<
    particles::pusher::Boris,
    particles::pusher::Vay,
    particles::pusher::CompositeBinarySwitchActivationFunctor< 100 > /* this is a preset, a user could write their own functor and provide here */
>;
```

ToDo:
- [x] figure out proper traits use, now it is not everywhere correct due to the convoluted relations of things
- [x] decide on 0- vs. 1-based indexing. 1-base currently, as this is more logical with `FirstPusher` and `SecondPusher` names
- [x] test on Hemera, so far only made it compile locally

Implements feature request #3185, and makes some progress towards #3277