### PR TITLE
Fix warnings in the openPMD plugin

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -110,7 +110,7 @@ namespace openPMD
                                           window to local domain */
 
         ::openPMD::Series &
-        openSeries( ::openPMD::AccessType at );
+        openSeries( ::openPMD::Access at );
 
         void
         closeSeries();

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -132,7 +132,7 @@ namespace openPMD
     }
 
     ::openPMD::Series &
-    ThreadParams::openSeries( ::openPMD::AccessType at )
+    ThreadParams::openSeries( ::openPMD::Access at )
     {
         if( !openPMDSeries )
         {

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -101,8 +101,6 @@ namespace openPMD
                 ::openPMD::RecordComponent recordComponent = components > 1
                     ? record[ name_lookup[ d ] ]
                     : record[::openPMD::MeshRecordComponent::SCALAR ];
-                ::openPMD::Datatype openPMDType =
-                    ::openPMD::determineDatatype< ComponentType >();
 
                 ValueType * dataPtr = frame.getIdentifier( Identifier() )
                                           .getPointer(); // can be moved up?


### PR DESCRIPTION
See https://github.com/ComputationalRadiationPhysics/picongpu/issues/3278

1. A variable was declared and defined equivalently in two scopes
2. Rename `AccessType` (deprecated) → `Access`