### PR TITLE
[WIP] Docker: Nvidia apt Update Package

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -24,7 +24,7 @@ RUN        apt-get update && \
               coreutils \
               cuda-cupti-$CUDA_PKG_VERSION \
               cuda-command-line-tools-$CUDA_PKG_VERSION \
-              cuda-core-$CUDA_PKG_VERSION \
+              cuda-compiler-$CUDA_PKG_VERSION \
               cuda-cudart-dev-$CUDA_PKG_VERSION \
               cuda-curand-dev-$CUDA_PKG_VERSION \
               cuda-minimal-build-$CUDA_PKG_VERSION \


### PR DESCRIPTION
Exchange a package that is marked as deprecated.
Seen in CI as warning in the `apt` install step with CUDA 10.1.243.

To Do:

- [ ] double check this works with CUDA 9.2 (current docker image; check minimal version constraint for Nvidia NGC) or...
- [ ] update Docker image to newer CUDA