### PR TITLE
fix clang-cuda and boost compile

### DIFF
--- a/include/picongpu/boost_workaround.hpp
+++ b/include/picongpu/boost_workaround.hpp
@@ -1,0 +1,37 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/** @file This file should be included in each `cpp`-file before any other boost include
+ * to workaround compiler errors when compiling with clang-cuda and boost <1.69.0
+ *
+ * https://github.com/ComputationalRadiationPhysics/picongpu/issues/3294
+ */
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 106900 && defined(__CUDACC__) && defined(__clang__))
+#   if defined(__CUDACC__)
+#       include <boost/config/compiler/nvcc.hpp>
+#   endif
+#   if (!defined(__ibmxl__))
+#       include <boost/config/compiler/clang.hpp>
+#   endif
+#   undef __CUDACC__
+#   include <boost/config/detail/select_compiler_config.hpp>
+#   define __CUDACC__
+#endif

--- a/include/picongpu/main.cpp
+++ b/include/picongpu/main.cpp
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "picongpu/boost_workaround.hpp"
+
 #include "picongpu/ArgsParser.hpp"
 #include <pmacc/Environment.hpp>
 #include <pmacc/types.hpp>

--- a/include/picongpu/versionFormat.cpp
+++ b/include/picongpu/versionFormat.cpp
@@ -17,6 +17,14 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "picongpu/boost_workaround.hpp"
+
+/* workaround for compile error with clang-cuda
+ * boost/type_traits/is_base_and_derived.hpp:142:25: error: invalid application of 'sizeof' to an incomplete type 'boost::in_place_factory_base'
+ *   BOOST_STATIC_ASSERT(sizeof(B) != 0);
+ */
+#include <boost/optional/optional.hpp>
+
 #include "picongpu/versionFormat.hpp"
 
 #include <boost/version.hpp>


### PR DESCRIPTION
fix #3294

Solve invalid compiler detection in the clang-cuda device compile path.