### PR TITLE
fix clang cuda compile

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -120,11 +120,14 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 # Find OpenMP
 ################################################################################
 
-find_package(OpenMP)
-if(OPENMP_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND ALPAKA_ACC_GPU_CUDA_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "clang")
+    message(WARNING "OpenMP host side acceleration is disabled: CUDA compilation with clang is not supporting OpenMP.")
+else()
+    find_package(OpenMP)
+    if(OPENMP_FOUND)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    endif()
 endif()
-
 
 ################################################################################
 # Find mallocMC

--- a/include/picongpu/boost_workaround.hpp
+++ b/include/picongpu/boost_workaround.hpp
@@ -35,3 +35,8 @@
 #   include <boost/config/detail/select_compiler_config.hpp>
 #   define __CUDACC__
 #endif
+/* workaround for compile error with clang-cuda
+ * boost/type_traits/is_base_and_derived.hpp:142:25: error: invalid application of 'sizeof' to an incomplete type 'boost::in_place_factory_base'
+ *   BOOST_STATIC_ASSERT(sizeof(B) != 0);
+ */
+#include <boost/optional/optional.hpp>

--- a/include/picongpu/versionFormat.cpp
+++ b/include/picongpu/versionFormat.cpp
@@ -18,13 +18,6 @@
  */
 
 #include "picongpu/boost_workaround.hpp"
-
-/* workaround for compile error with clang-cuda
- * boost/type_traits/is_base_and_derived.hpp:142:25: error: invalid application of 'sizeof' to an incomplete type 'boost::in_place_factory_base'
- *   BOOST_STATIC_ASSERT(sizeof(B) != 0);
- */
-#include <boost/optional/optional.hpp>
-
 #include "picongpu/versionFormat.hpp"
 
 #include <boost/version.hpp>

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -354,9 +354,13 @@ endif()
 # Find OpenMP
 ################################################################################
 
-find_package(OpenMP)
-if(OPENMP_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND ALPAKA_ACC_GPU_CUDA_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "clang")
+    message(WARNING "OpenMP host side acceleration is disabled: CUDA compilation with clang is not supporting OpenMP.")
+else()
+    find_package(OpenMP)
+    if(OPENMP_FOUND)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    endif()
 endif()
 
 

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -580,7 +580,7 @@ struct Vector<Type, 0 >
         /* this method should never be actually called,
          * it exists only for Visual Studio to handle pmacc::math::Size_t< 0 >
          */
-        PMACC_CASSERT_MSG(Vector_dim_0_create_cannot_be_called, false);
+        PMACC_CASSERT_MSG(Vector_dim_0_create_cannot_be_called, sizeof(Type) != 0 && false);
     }
 };
 


### PR DESCRIPTION
- fix clang-cuda boost compatibility
  - The include workaround is required for `main.cpp` too. Move the workaround include to `boost_workaround.hpp`
- Fix early evaluation of a static assert.
  ```
  pmacc/math/vector/Vector.hpp:583:9: error: static_assert failed "Vector_dim_0_create_cannot_be_called"
        PMACC_CASSERT_MSG(Vector_dim_0_create_cannot_be_called, false);
  ```
- fix clang-cuda incompatibility with OpenMP
  - If clang is used as CUDA compiler and OpenMP is enabled the compilation will crash. It is a general clang-cuda bug which will hopfully be fixed with clang 11.