### PR TITLE
Add support for Lehe solver with PML absorber

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/LehePML/LehePML.def
+++ b/include/picongpu/fields/MaxwellSolver/LehePML/LehePML.def
@@ -1,0 +1,60 @@
+/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
+ *                     Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/currentInterpolation/CurrentInterpolation.def"
+#include "picongpu/fields/MaxwellSolver/Lehe/Lehe.def"
+#include "picongpu/fields/MaxwellSolver/YeePML/YeePML.def"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+namespace fields
+{
+namespace maxwellSolver
+{
+
+    /** modified Yee solver with PML absorber
+     *
+     * Reference: R. Lehe et al
+     *            Phys. Rev. ST Accel. Beams 16, 021301 (2013)
+     *
+     * @tparam T_CherenkovFreeDir the direction (axis) which should be free of cherenkov radiation
+     *                            0 = x, 1 = y, 2 = z
+     */
+    template<
+        typename T_CurrentInterpolation = currentInterpolation::None,
+        uint32_t T_cherenkovFreeDir = lehe::CherenkovFreeDirection_Y
+    >
+    using LehePML = ::picongpu::fields::maxwellSolver::YeePML<
+        T_CurrentInterpolation,
+        lehe::CurlE< T_cherenkovFreeDir >
+    >;
+
+    /* We need no definition of margins, because the YeePML solver uses its curl
+     * classes to define margins
+     */
+
+} // namespace maxwellSolver
+} // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/LehePML/LehePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/LehePML/LehePML.hpp
@@ -1,0 +1,60 @@
+/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
+ *                     Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp"
+#include "picongpu/fields/MaxwellSolver/LehePML/LehePML.def"
+
+#include <cstdint>
+
+
+namespace pmacc
+{
+namespace traits
+{
+
+    template<
+        typename T_CurrentInterpolation,
+        uint32_t T_cherenkovFreeDir
+    >
+    struct StringProperties<
+        ::picongpu::fields::maxwellSolver::LehePML<
+            T_CurrentInterpolation,
+            T_cherenkovFreeDir
+        >
+    >
+    {
+        static StringProperty get()
+        {
+            auto propList =
+                ::picongpu::fields::maxwellSolver::LehePML<
+                    T_CurrentInterpolation,
+                    T_cherenkovFreeDir
+                >::getStringProperties();
+            // overwrite the name of the YeePML solver (inherit all other properties)
+            propList["name"].value = "LehePML";
+            return propList;
+        }
+    };
+
+} // namespace traits
+} // namespace pmacc

--- a/include/picongpu/fields/MaxwellSolver/Solvers.def
+++ b/include/picongpu/fields/MaxwellSolver/Solvers.def
@@ -26,6 +26,7 @@
 #include "picongpu/fields/MaxwellSolver/YeePML/YeePML.def"
 #if (SIMDIM==3)
 #include "picongpu/fields/MaxwellSolver/Lehe/Lehe.def"
+#include "picongpu/fields/MaxwellSolver/LehePML/LehePML.def"
 #if( PMACC_CUDA_ENABLED == 1 )
 #   include "picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.def"
 #endif

--- a/include/picongpu/fields/MaxwellSolver/Solvers.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Solvers.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp"
 #if (SIMDIM==3)
 #include "picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp"
+#include "picongpu/fields/MaxwellSolver/LehePML/LehePML.hpp"
 #if( PMACC_CUDA_ENABLED == 1 )
 #   include "picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp"
 #endif

--- a/include/picongpu/fields/absorber/Absorber.hpp
+++ b/include/picongpu/fields/absorber/Absorber.hpp
@@ -111,7 +111,7 @@ namespace detail
 
     /** Absorber wrapper
      *
-     * Specialization for PML
+     * Specialization for PML, works for both YeePML and LehePML
      *
      * @tparam T_CurrentInterpolation current interpolation for YeePML
      * @tparam T_CurlE curl E for YeePML

--- a/include/picongpu/param/fieldSolver.param
+++ b/include/picongpu/param/fieldSolver.param
@@ -63,6 +63,8 @@ namespace fields
      *  - Yee< CurrentInterpolation > : standard Yee solver
      *  - YeePML< CurrentInterpolation >: standard Yee solver using Perfectly Matched Layer Absorbing Boundary Conditions (PML)
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
+     *  - LehePML< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
+     *                                     using Perfectly Matched Layer Absorbing Boundary Conditions (PML)
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B
      */

--- a/include/picongpu/param/pml.param
+++ b/include/picongpu/param/pml.param
@@ -21,7 +21,7 @@
  *
  * Configure the Perfectly Matched Layer absorbing boundary conditions (PML).
  *
- * To enable PML use YeePML field solver.
+ * To enable PML use YeePML or LehePML field solver.
  */
 
 #pragma once

--- a/include/picongpu/unitless/checkpoints.unitless
+++ b/include/picongpu/unitless/checkpoints.unitless
@@ -41,7 +41,10 @@ namespace detail
             using type = MakeSeq_t< >;
         };
 
-        //! Only the YeePML solver needs additional fields for checkpointing
+        /** Only the YeePML solver needs additional fields for checkpointing
+         *
+         * Currently LehePML is YeePML so automatically works for it as well.
+         */
         template< typename ... T_Args >
         struct AdditionalCheckpointFields<
             fields::maxwellSolver::YeePML< T_Args ... >

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldSolver.param
@@ -63,6 +63,8 @@ namespace fields
      *  - Yee< CurrentInterpolation >: standard Yee solver
      *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
+     *  - LehePML< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
+     *                                     with PML absorber
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B
      */

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/pml.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/pml.param
@@ -21,7 +21,7 @@
  *
  * Configure the perfectly matched layer (PML).
  *
- * To enable PML use YeePML field solver.
+ * To enable PML use YeePML or LehePML field solver.
  */
 
 #pragma once
@@ -36,7 +36,7 @@ namespace maxwellSolver
 namespace Pml
 {
 
-    /* The parameters in this file are only used if field solver is YeePML.
+    /* The parameters in this file are only used if field solver is YeePML or LehePML.
      * The original paper on this approach is J.A. Roden, S.D. Gedney.
      * Convolution PML (CPML): An efficient FDTD implementation of the CFS - PML
      * for arbitrary media. Microwave and optical technology letters. 27 (5),

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fieldSolver.param
@@ -66,6 +66,8 @@ namespace fields
      *  - Yee< CurrentInterpolation >: standard Yee solver
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
      *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
+     *  - LehePML< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
+     *                                     with PML absorber
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B
      */

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/fieldSolver.param
@@ -66,6 +66,8 @@ namespace fields
      *  - Yee< CurrentInterpolation >: standard Yee solver
      *  - YeePML< CurrentInterpolation >: standard Yee solver with PML absorber
      *  - Lehe< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
+     *  - LehePML< CurrentInterpolation >: Num. Cherenkov free field solver in a chosen direction
+     *                                     with PML absorber
      *  - DirSplitting< CurrentInterpolation >: Sentoku's Directional Splitting Method
      *  - None< CurrentInterpolation >: disable the vacuum update of E and B
      */


### PR DESCRIPTION
Currently the branch has some version of this combination, that may work, but requires more testing. The code changes are also occasionally hacky, I will refactor if the approach works.
To enable the combination, use this branch and set
```cpp
using Solver = maxwellSolver::YeePML<
        CurrentInterpolation,
        maxwellSolver::lehe::CurlE< maxwellSolver::lehe::CherenkovFreeDirection_Y >
    >;
```
in `fieldSolver.param`.

In case this works, it solves #3296.
@Anton-Le , could you try running your test from that issue with my branch?
