### PR TITLE
Set cmake version explicitly for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - spack clean -a
   - source /etc/profile &&
     source $SPACK_ROOT/share/spack/setup-env.sh
-  - spack load cmake
+  - spack load cmake@3.15.0%gcc@7.5.0
   - spack load boost $COMPILERSPEC
 
 jobs:


### PR DESCRIPTION
Originally it matched mutiple packages, causing error.
Fixes #3304
(I know it fixes, as tried it out in #3303 which [passes](https://travis-ci.org/github/ComputationalRadiationPhysics/picongpu/jobs/711131736))

Thanks @psychocoderHPC for hinting the fix.