### PR TITLE
HZDR gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,100 +1,45 @@
 
-include:
-  - local: '/share/ci/compiler_clang.yml'
-  - local: '/share/ci/compiler_gcc.yml'
-  - local: '/share/ci/compiler_nvcc_cuda.yml'
-  - local: '/share/ci/compiler_clang_cuda.yml'
+stages:
+  - rebase
+  - generate
+  - compile
 
-# hidden base job to generate the test matrix
-# required variables (space separated lists):
-#   PIC_INPUTS - path to examples relative to share/picongpu
-#                e.g. 
-#                    "examples" starts one gitlab job per director in `examples/*`
-#                    "examples/" compile all directories in `examples/*` within one gitlab job
-#                    "examples/KelvinHelmholtz" compile all cases within one gitlab job
-#   GITLAB_BASES   - name of the hidden gitlab base job desctption `/share/ci/compiler_*`
-#   CXX_VERSIONS   - name of the compiler to use see `/share/ci/compiler_*` `e.g. "g++-8 g++-6"
-#   BOOST_VERSIONS - boost version to check e.g. "1.70.0"
-#                    supported version: {1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0, 1.70.0, 1.71.0, 1.72.0, 1.73.0}
-#   PIC_ACCS       - PIConGPU backend names see `pic-build --help`
-#                    e.g. "cuda cuda:35 serial"
-.base_generator:
-  stage: .pre
-  script: 
-    - $CI_PROJECT_DIR/share/ci/generate.sh > compile.yml
+.base_generate-reduced-matrix:
+  stage: generate
+  script:
+    - apt update
+    - apt install -y python3-pip
+    - pip3 install allpairspy
+    - $CI_PROJECT_DIR/share/ci/git_merge.sh
+    - $CI_PROJECT_DIR/share/ci/generate_reduced_matrix.sh -n ${TEST_TUPLE_NUM_ELEM} > compile.yml
     - cat compile.yml
   artifacts:
     paths:
       - compile.yml
 
-# gcc matrix
-matrix-gcc:
-  variables:
-    PIC_INPUTS: "examples/Empty"
-    GITLAB_BASES: ".base_gcc"
-    CXX_VERSIONS: "g++-5 g++-8"
-    BOOST_VERSIONS: "1.65.1"
-    PIC_ACCS: "omp2b"
-  extends: ".base_generator"
-    
-compile-matrix-gcc:
-  stage: build
-  trigger:
-    include:
-      - artifact: compile.yml
-        job: matrix-gcc
-    strategy: depend
+# test to rebase the PR to the destination branch
+test-rebase-to-mainline:
+  stage: rebase
+  script:
+    - source $CI_PROJECT_DIR/share/ci/git_merge.sh
 
-# clang matrix
-matrix-clang:
+# generate reduced test matrix
+# required variables (space separated lists):
+#   PIC_INPUTS - path to examples relative to share/picongpu
+#                e.g.
+#                    "examples" starts one gitlab job per directory in `examples/*`
+#                    "examples/" compile all directories in `examples/*` within one gitlab job
+#                    "examples/KelvinHelmholtz" compile all cases within one gitlab job
+generate-reduced-matrix:
   variables:
-    PIC_INPUTS: "examples/Empty"
-    GITLAB_BASES: ".base_clang"
-    CXX_VERSIONS: "clang++-5.0"
-    BOOST_VERSIONS: "1.65.1"
-    PIC_ACCS: "omp2b"
-  extends: ".base_generator"
-    
-compile-matrix-clang:
-  stage: build
-  trigger:
-    include:
-      - artifact: compile.yml
-        job: matrix-clang
-    strategy: depend
+    PIC_INPUTS: "examples"
+    TEST_TUPLE_NUM_ELEM: 1
+  extends: ".base_generate-reduced-matrix"
 
-# clang-cuda101 matrix
-matrix-clang-cuda101:
-  variables:
-    PIC_INPUTS: "examples/Empty"
-    GITLAB_BASES: ".clang_cuda101"
-    CXX_VERSIONS: "clang++-10"
-    BOOST_VERSIONS: "1.65.1"
-    PIC_ACCS: "cuda"
-  extends: ".base_generator" 
-    
-compile-matrix-clang-cuda101:
-  stage: build
+compile-reduced-matrix:
+  stage: compile
   trigger:
     include:
       - artifact: compile.yml
-        job: matrix-clang-cuda101
-    strategy: depend
-    
-# nvcc-cuda101 matrix
-matrix-nvcc-cuda102:
-  variables:
-    PIC_INPUTS: "examples/Empty"
-    GITLAB_BASES: ".nvcc_cuda102"
-    CXX_VERSIONS: "g++"
-    BOOST_VERSIONS: "1.65.1"
-    PIC_ACCS: "cuda:35"
-  extends: ".base_generator" 
-    
-compile-matrix-nvcc-cuda102:
-  stage: build
-  trigger:
-    include:
-      - artifact: compile.yml
-        job: matrix-nvcc-cuda102
+        job: generate-reduced-matrix
     strategy: depend

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -7,6 +7,9 @@
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
   script:
+      - apt update
+      - apt install -y curl
+      - $CI_PROJECT_DIR/share/ci/git_merge.sh
       - source share/ci/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -1,24 +1,28 @@
 ################################################################################
 #   [clang++-X] : X = {4.0, 5.0, 6.0, 7, 8, 9, 10}
+# cuda9.2Clang is not supporting clang-7
 
 .base_cuda_clang:
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
   script:
-      - source share/ci/run_test.sh
+    - apt update
+    - apt install -y curl
+    - $CI_PROJECT_DIR/share/ci/git_merge.sh
+    - source share/ci/run_test.sh
   tags:
     - cuda
     - x86_64 
 
-.clang_cuda92:
+.base_clangCuda_cuda_9.2:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2Clang
   extends: .base_cuda_clang
   
-.clang_cuda100:
+.base_clangCuda_cuda_10.0:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0Clang
   extends: .base_cuda_clang
 
-.clang_cuda101:
+.base_clangCuda_cuda_10.1:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1Clang
   extends: .base_cuda_clang

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -6,6 +6,9 @@
   variables:
     GIT_SUBMODULE_STRATEGY: normal
   script:
+    - apt update
+    - apt install -y curl
+    - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source share/ci/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -1,30 +1,33 @@
 ################################################################################
 #   [g++-X] : X = {5, 6, 7, 8, 9}
 
-.base_cuda:
+.base_nvcc:
   variables:
     GIT_SUBMODULE_STRATEGY: normal
   before_script:
     - nvidia-smi
     - nvcc --version
   script:
-      - source share/ci/run_test.sh
+    - apt update
+    - apt install -y curl
+    - $CI_PROJECT_DIR/share/ci/git_merge.sh
+    - source share/ci/run_test.sh
   tags:
     - cuda
     - x86_64 
     
-.nvcc_cuda92:
+.base_nvcc_cuda_9.2:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2gcc
-  extends: .base_cuda
+  extends: .base_nvcc
 
-.nvcc_cuda100:
+.base_nvcc_cuda_10.0:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0gcc
-  extends: .base_cuda
+  extends: .base_nvcc
   
-.nvcc_cuda101:
+.base_nvcc_cuda_10.1:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1gcc
-  extends: .base_cuda  
+  extends: .base_nvcc
 
-.nvcc_cuda102:
+.base_nvcc_cuda_10.2:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.2gcc
-  extends: .base_cuda
+  extends: .base_nvcc

--- a/share/ci/generate.sh
+++ b/share/ci/generate.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 # generate a job matrix based on the environment variable lists (space separated)
-# variables: GITLAB_BASES CXX_VERSIONS BOOST_VERSIONS PIC_INPUTS PIC_ACCS
+# hidden base job to generate the test matrix
+# required variables (space separated lists):
+#   PIC_INPUTS - path to examples relative to share/picongpu
+#                e.g.
+#                    "examples" starts one gitlab job per directory in `examples/*`
+#                    "examples/" compile all directories in `examples/*` within one gitlab job
+#                    "examples/KelvinHelmholtz" compile all cases within one gitlab job
+#   GITLAB_BASES   - name of the hidden gitlab base job desctption `/share/ci/compiler_*`
+#   CXX_VERSIONS   - name of the compiler to use see `/share/ci/compiler_*` `e.g. "g++-8 g++-6"
+#   BOOST_VERSIONS - boost version to check e.g. "1.70.0"
+#                    supported version: {1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0, 1.70.0, 1.71.0, 1.72.0, 1.73.0}
+#   PIC_ACCS       - PIConGPU backend names see `pic-build --help`
+#                    e.g. "cuda cuda:35 serial"
 
 export picongpu_DIR=$CI_PROJECT_DIR
 cd $picongpu_DIR/share/picongpu/

--- a/share/ci/generate_reduced_matrix.sh
+++ b/share/ci/generate_reduced_matrix.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# generate a reduced matrix with ci jobs based on the list (space separated) provided by the environment variable PIC_INPUTS
+
+export PATH=$CI_PROJECT_DIR/share/ci:$PATH
+export picongpu_DIR=$CI_PROJECT_DIR
+
+cd $picongpu_DIR/share/picongpu/
+
+echo "include:"
+echo "  - local: '/share/ci/compiler_clang.yml'"
+echo "  - local: '/share/ci/compiler_gcc.yml'"
+echo "  - local: '/share/ci/compiler_nvcc_cuda.yml'"
+echo "  - local: '/share/ci/compiler_clang_cuda.yml'"
+echo ""
+
+folders=()
+for CASE in ${PIC_INPUTS}; do
+  if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] ; then
+      all_cases=$(find ${CASE}/* -maxdepth 0 -type d)
+  else
+      all_cases=$(find $CASE -maxdepth 0 -type d)
+  fi
+  for test_case_folder in $all_cases ; do
+      folders+=($test_case_folder)
+  done
+done
+
+echo "${folders[@]}" | tr " " "\n" | n_wise_generator.py $@

--- a/share/ci/git_merge.sh
+++ b/share/ci/git_merge.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# merge the PR to the latest version of the destination branch
+
+cd $CI_PROJECT_DIR
+
+github_group_repo="ComputationalRadiationPhysics/picongpu"
+
+pr_id=$(echo "$CI_BUILD_REF_NAME" | cut -d"/" -f1 | cut -d"-" -f2)
+# used a token without any rights from psychocoderHPC to avoid API query limitations
+curl_data=$(curl -u psychocoderHPC:$GITHUB_TOKEN -X GET https://api.github.com/repos/${github_group_repo}/pulls/${pr_id} 2>/dev/null)
+# get the destination branch
+destination_branch=$(echo "$curl_data" | python3 -c 'import json,sys;obj=json.loads(sys.stdin.read());print(obj["base"]["ref"])')
+destination_sha=$(echo "$curl_data" | python3 -c 'import json,sys;obj=json.loads(sys.stdin.read());print(obj["base"]["sha"])')
+echo "destination_branch=${destination_branch}"
+echo "destination_sha=${destination_sha}"
+
+mainline_exists=$(git remote -v | cut -f1 | grep mainline -q && echo 0 || echo 1)
+# avoid adding the remote repository twice if gitlab already cached this operation
+if [ $mainline_exists -ne 0 ] ; then
+  git remote add mainline https://github.com/${github_group_repo}.git
+else
+  # if the PR was set to a different branch before
+  git remote set-url mainline https://github.com/${github_group_repo}.git
+fi
+git fetch mainline
+
+# required by git to be able to use `git rebase`
+git config --global user.email "CI-BOT"
+git config --global user.name "CI-BOT@hzdr.d"
+
+# make a copy of the pull request branch
+git checkout -b pr_to_merge
+# switch to the destination hash
+git checkout -b destination_branch ${destination_sha}
+# merge pull request to the destination
+git merge --no-edit pr_to_merge

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+# generate a reduced test matrix based on the N-wise testing model
+# https://en.wikipedia.org/wiki/All-pairs_testing
+
+from allpairspy import AllPairs
+import argparse
+import sys
+
+
+parser = argparse.ArgumentParser(description='Generate tesing pairs')
+parser.add_argument('-n', dest='n_pairs', default=1, action="store",
+                    help='number of tuple elements')
+parser.add_argument('--compact', dest='compact', action="store_true",
+                    help='print compact form of the test matrix')
+args = parser.parse_args()
+n_pairs = int(args.n_pairs)
+
+examples = []
+for i in sys.stdin:
+    examples.append(i.rstrip())
+
+
+def get_version(tuple):
+    if len(tuple) >= 2:
+        return float(tuple[1])
+    return 0
+
+
+# lookup table with compiler name and the required base container suffix
+image_dict = {
+    "nvcc": ".base_nvcc",
+    "g++": ".base_gcc",
+    "clang++": ".base_clang",
+    "clangCuda": ".base_clangCuda"
+}
+
+
+def get_base_image(compiler, backend):
+    if len(compiler) == 3 and backend[0] == "cuda":
+        return image_dict[compiler[2]] + "_" + backend[0] + "_" \
+            + str(backend[1])
+
+    return image_dict[compiler[0]]
+
+
+# filter invalid cominations
+#
+# filter based on the compatibility overview
+# https://gist.github.com/ax3l/9489132
+def is_valid_combination(row):
+    n = len(row)
+
+    if n >= 2:
+        v_compiler = get_version(row[0])
+
+        is_clang_cuda = True if len(row[0]) == 3 and \
+            row[0][2] == "clangCuda" else False
+        is_clang = True if row[0][0] == "clang" or is_clang_cuda else False
+
+        is_gnu = True if row[0][0] == "g++" else False
+
+        is_nvcc = True if len(row[0]) == 3 and row[0][2] == "nvcc" else False
+        is_cuda = True if row[1][0] == "cuda" else False
+        v_cuda = get_version(row[1])
+
+        # docker images for clang cuda do not support clang++-7
+        # together with cuda-9.2
+        if is_clang_cuda and v_compiler == 7 and v_cuda == 9.2:
+            return False
+
+        # CUDA compiler requires backed `cuda`
+        if (is_nvcc or is_clang_cuda) and not is_cuda:
+            return False
+
+        # cpu only compiler can not handle the backend `cuda`
+        if (not is_nvcc and not is_clang_cuda) and is_cuda:
+            return False
+
+        # clang cuda compatibility
+        if is_clang_cuda:
+            if not is_cuda:
+                return False
+            if v_cuda == 9.2 and v_compiler >= 7:
+                return True
+            if v_cuda == 10.0 and v_compiler >= 8:
+                return True
+            if v_cuda == 10.1 and v_compiler >= 9:
+                return True
+
+            return False
+
+        # nvcc compatibility
+        if is_cuda and is_nvcc:
+            # g++-5.5 is not compatible with CUDA
+            # https://github.com/tensorflow/tensorflow/issues/10220
+            if is_gnu and v_compiler == 5:
+                return False
+            if v_cuda <= 10.1 and is_gnu and v_compiler <= 7:
+                return True
+            if v_cuda <= 10.2 and is_gnu and v_compiler <= 8:
+                return True
+            if v_cuda >= 11.0 and is_gnu and v_compiler <= 9:
+                return True
+
+            if v_cuda == 9.2 and is_clang and v_compiler <= 5:
+                return True
+            if v_cuda <= 10.2 and is_clang and v_compiler <= 8:
+                return True
+            if v_cuda >= 11.0 and is_clang:
+                return False
+            return False
+
+    return True
+
+
+# compiler list
+# tuple with two components (compiler name, version)
+clang_compiers = [("clang++", 5.0), ("clang++", 6.0), ("clang++", 7),
+                  ("clang++", 8), ("clang++", 9), ("clang++", 10)]
+gnu_compilers = [("g++", 5), ("g++", 6), ("g++", 7), ("g++", 8), ("g++", 9)]
+compilers = [
+    clang_compiers,
+    gnu_compilers
+]
+
+# generate clang cuda compiler list
+# add third component with the device compiler name
+cuda_clang_compilers = []
+for i in clang_compiers:
+    cuda_clang_compilers.append(i + ("clangCuda", ))
+compilers.append(cuda_clang_compilers)
+
+# nvcc compiler
+cuda_nvcc_compilers = []
+for i in clang_compiers:
+    cuda_nvcc_compilers.append(i + ("nvcc", ))
+for i in gnu_compilers:
+    cuda_nvcc_compilers.append(i + ("nvcc", ))
+compilers.append(cuda_nvcc_compilers)
+
+# PIConGPU backend list
+# tuple with two components (backend name, version)
+# version is only required for the cuda backend
+backends = [("cuda", 9.2), ("cuda", 10.0), ("cuda", 10.1),
+            ("cuda", 10.2), ("omp2b", ), ("serial", )]
+boost_libs = ["1.65.1", "1.66.0", "1.67.0", "1.68.0", "1.69.0",
+              "1.70.0", "1.71.0", "1.72.0", "1.73.0"]
+
+rounds = 1
+# activate looping over the compiler categories to minimize the test matrix
+# a small test matrix for each compiler e.g. clang, nvcc, g++, clang,
+# clangCuda is created
+if n_pairs == 1:
+    rounds = len(compilers)
+
+for i in range(rounds):
+    used_compilers = []
+    if n_pairs == 1:
+        used_compilers = compilers[i]
+    else:
+        for c in compilers:
+            used_compilers += c
+
+    parameters = [
+        used_compilers,
+        backends,
+        boost_libs,
+        examples
+    ]
+
+    for i, pairs in enumerate(
+            AllPairs(parameters,
+                     filter_func=is_valid_combination, n=n_pairs)):
+        if args.compact:
+            print("{:2d}: {}".format(i, pairs))
+        else:
+            compiler = pairs[0][0] + "-" + str(pairs[0][1])
+            backend = pairs[1][0]
+            boost_version = pairs[2]
+            folder = pairs[3]
+            v_cuda = get_version(pairs[1])
+            v_cuda_str = "" if v_cuda == 0 else str(v_cuda)
+            job_name = compiler + "_" + backend + v_cuda_str + "_boost" + \
+                boost_version + "_" + folder.replace("/", ".")
+            print(job_name + ":")
+            print("  variables:")
+            print("    PIC_TEST_CASE_FOLDER: '" + folder + "'")
+            print("    PIC_BACKEND: '" + backend + "'")
+            print("    BOOST_VERSION: '" + boost_version + "'")
+            print("    CXX_VERSION: '" + compiler + "'")
+            print("  before_script:")
+            print("    - apt-get update -qq")
+            print("    - apt-get install -y -qq libopenmpi-dev "
+                  "openmpi-bin openssh-server")
+            print("  extends: " + get_base_image(pairs[0], pairs[1]))
+            print("")

--- a/share/ci/run_test.sh
+++ b/share/ci/run_test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 # the default build type is Release
 # if neccesary, you can rerun the pipeline with another build type-> https://docs.gitlab.com/ee/ci/pipelines.html#manually-executing-pipelines
 # to change the build type, you must set the environment variable PIC_BUILD_TYPE
@@ -28,9 +31,10 @@ export picongpu_DIR=$CI_PROJECT_DIR
 export PATH=$picongpu_DIR/bin:$PATH
 
 PIC_PARALLEL_BUILDS=$(nproc)
-# limit to 8 parallel builds to avoid out of memory errors
-if [ $PIC_PARALLEL_BUILDS -gt 8 ] ; then
-    PIC_PARALLEL_BUILDS=8
+# limit to $CI_MAX_PARALLELISM parallel builds to avoid out of memory errors
+# CI_MAX_PARALLELISM is a configured variable in the CI web interface
+if [ $PIC_PARALLEL_BUILDS -gt $CI_MAX_PARALLELISM ] ; then
+    PIC_PARALLEL_BUILDS=$CI_MAX_PARALLELISM
 fi
 echo -e "\033[0;32m///////////////////////////////////////////////////"
 echo "number of processor threads -> $(nproc)"


### PR DESCRIPTION
Use n-wise testing to select test configurations for the compiler, cuda,
boost version.

- add n-wise matrix generator `n_wise_generator.py`
  - add filter for invalid combinations e.g. compiler, boost, cuda
- build dynamic jobs based on the reduced matrix