### PR TITLE
fix clang10-cuda compile

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
+++ b/include/picongpu/fields/MaxwellSolver/DirSplitting/DirSplitting.hpp
@@ -67,18 +67,18 @@ namespace dirSplitting
          * http://www.boost.org/doc/libs/1_60_0/doc/html/boost_staticassert.html
          *
          * A workaround is to add a template dependency to the expression.
-         * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
+         * `sizeof(ANY_TYPE*) != 0` is always true and defers the evaluation.
          */
         PMACC_CASSERT_MSG(DirectionSplitting_Set_dX_equal_dt_times_c____check_your_grid_param_file,
                           (SI::SPEED_OF_LIGHT_SI * SI::DELTA_T_SI) == SI::CELL_WIDTH_SI &&
-                          (sizeof(T_Dummy) != 0));
+                          (sizeof(T_Dummy*) != 0));
         PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_grid_param_file,
                           SI::CELL_HEIGHT_SI == SI::CELL_WIDTH_SI &&
-                          (sizeof(T_Dummy) != 0));
+                          (sizeof(T_Dummy*) != 0));
 #if (SIMDIM == DIM3)
         PMACC_CASSERT_MSG(DirectionSplitting_use_cubic_cells____check_your_grid_param_file,
                           SI::CELL_DEPTH_SI == SI::CELL_WIDTH_SI &&
-                          (sizeof(T_Dummy) != 0));
+                          (sizeof(T_Dummy*) != 0));
 #endif
     };
 } // namespace dirSplitting

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -50,9 +50,13 @@ namespace none
         T_Dummy
     >
     {
-        /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
+        /* Courant-Friedrichs-Levy-Condition for Yee Field Solver:
+         *
+         * A workaround is to add a template dependency to the expression.
+         * `sizeof(ANY_TYPE*) != 0` is always true and defers the evaluation.
+         */
         PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
-            (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
+            (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0 && sizeof(T_Dummy*) != 0);
     };
 } // namespace none
 

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -60,9 +60,13 @@ namespace maxwellSolver
         template<uint32_t AREA>
         void updateE()
         {
-            /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
+            /* Courant-Friedrichs-Levy-Condition for Yee Field Solver:
+             *
+             * A workaround is to add a template dependency to the expression.
+             * `sizeof(ANY_TYPE*) != 0` is always true and defers the evaluation.
+             */
             PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
-                (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
+                (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0 && sizeof(T_CurrentInterpolation*) != 0);
 
             typedef SuperCellDescription<
                     SuperCellSize,

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -137,9 +137,13 @@ namespace maxwellSolver
             template< uint32_t T_Area >
             void updateE( uint32_t currentStep )
             {
-                /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
+                /* Courant-Friedrichs-Levy-Condition for Yee Field Solver:
+                 *
+                 * A workaround is to add a template dependency to the expression.
+                 * `sizeof(ANY_TYPE*) != 0` is always true and defers the evaluation.
+                 */
                 PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
-                    (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
+                    (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0 && sizeof(T_CurlE*) != 0);
 
                 constexpr auto numWorkers = getNumWorkers( );
                 using Kernel = yeePML::KernelUpdateE<


### PR DESCRIPTION
Clang is evaluating static asserts within a class even if the class is
not used.
A template dependent condition must be introduced to avoid an to early
evaluation.


note: condition `sizeof(T*) != 0` should be used to avoid incomplete type compile errors
