### PR TITLE
build CI tests with all dependencies

### DIFF
--- a/share/ci/bash.profile
+++ b/share/ci/bash.profile
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# setup dependencies for PIConGPU for CMake and runtime usage
+
+set -e
+set -o pipefail
+
+if [ -d "/opt/pngwriter" ] ; then
+  export PNGWRITER_ROOT=/opt/pngwriter/0.7.0
+else
+  # pngwriter is currently install to the / instead of /opt
+  export PNGWRITER_ROOT=/pngwriter/0.7.0
+fi
+export CMAKE_PREFIX_PATH=$PNGWRITER_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$PNGWRITER_ROOT/lib:$LD_LIBRARY_PATH
+
+export HDF5_ROOT=/opt/hdf5/1.8.20/
+export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+
+export SPLASH_ROOT=/opt/libsplash/1.7.0
+export CMAKE_PREFIX_PATH=$SPLASH_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$SPLASH_ROOT/lib:$LD_LIBRARY_PATH
+
+export ADIOS1_ROOT=/opt/adios/1.13.1
+export CMAKE_PREFIX_PATH=$ADIOS1_ROOT:$CMAKE_PREFIX_PATH
+export PATH=$ADIOS1_ROOT/bin:$PATH
+export LD_LIBRARY_PATH=$ADIOS1_ROOT/lib:$LD_LIBRARY_PATH
+
+export ICET_ROOT=/opt/icet/2.9.0
+export CMAKE_PREFIX_PATH=$ICET_ROOT/lib:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$ICET_ROOT/lib:$LD_LIBRARY_PATH
+
+export JANSSON_ROOT=/opt/jansson/2.9.0/
+export CMAKE_PREFIX_PATH=$JANSSON_ROOT/lib/cmake:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$JANSSON_ROOT/lib:$LD_LIBRARY_PATH
+
+# disabled:
+#   - test container are shipped with the wrong issac version
+#   - issac must be tested with different compilers
+#export ISAAC_ROOT=/opt/isaac/1.6.0-dev
+#export CMAKE_PREFIX_PATH=$ISAAC_ROOT:$CMAKE_PREFIX_PATH
+#export LD_LIBRARY_PATH=$ISAAC_ROOT/lib:$LD_LIBRARY_PATH
+
+export OPENPMD_ROOT=/opt/openPMD-api/0.12.0-dev
+export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib:$LD_LIBRARY_PATH

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -2,7 +2,7 @@
 #   [clang++-X] : X = {4.0, 5.0, 6.0, 7, 8, 9, 10}
 
 .base_clang:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:clang
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:clangPic
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
@@ -10,6 +10,7 @@
       - apt update
       - apt install -y curl
       - $CI_PROJECT_DIR/share/ci/git_merge.sh
+      - source share/ci/bash.profile
       - source share/ci/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -10,19 +10,20 @@
     - apt update
     - apt install -y curl
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
+    - source share/ci/bash.profile
     - source share/ci/run_test.sh
   tags:
     - cuda
     - x86_64 
 
 .base_clangCuda_cuda_9.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2Clang
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2ClangPic
   extends: .base_cuda_clang
   
 .base_clangCuda_cuda_10.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0Clang
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0ClangPic
   extends: .base_cuda_clang
 
 .base_clangCuda_cuda_10.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1Clang
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1ClangPic
   extends: .base_cuda_clang

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -2,13 +2,14 @@
 #   [g++-X] : X = {5, 6, 7, 8, 9}
 
 .base_gcc:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:gcc
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:gccPic
   variables:
     GIT_SUBMODULE_STRATEGY: normal
   script:
     - apt update
     - apt install -y curl
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
+    - source share/ci/bash.profile
     - source share/ci/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -11,23 +11,24 @@
     - apt update
     - apt install -y curl
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
+    - source share/ci/bash.profile
     - source share/ci/run_test.sh
   tags:
     - cuda
     - x86_64 
     
 .base_nvcc_cuda_9.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2gcc
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2gccPic
   extends: .base_nvcc
 
 .base_nvcc_cuda_10.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0gcc
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0gccPic
   extends: .base_nvcc
   
 .base_nvcc_cuda_10.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1gcc
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1gccPic
   extends: .base_nvcc
 
 .base_nvcc_cuda_10.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.2gcc
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.2gccPic
   extends: .base_nvcc

--- a/share/ci/run_test.sh
+++ b/share/ci/run_test.sh
@@ -15,8 +15,18 @@ fi
 ###################################################
 
 PIC_CONST_ARGS=""
-PIC_CONST_ARGS="${PIC_CONST_ARGS} -DCMAKE_BUILD_TYPE=${PIC_BUILD_TYPE}"
+# to save compile time reduce the isaac functor chain length to one
+PIC_CONST_ARGS="${PIC_CONST_ARGS} -DISAAC_MAX_FUNCTORS=1 -DCMAKE_BUILD_TYPE=${PIC_BUILD_TYPE}"
 CMAKE_ARGS="${PIC_CONST_ARGS} ${PIC_CMAKE_ARGS} -DCMAKE_CXX_COMPILER=${CXX_VERSION} -DBOOST_ROOT=/opt/boost/${BOOST_VERSION}"
+
+# workaround for clang cuda
+# HDF5 from the apt sources is pulling -D_FORTIFY_SOURCE=2 into the compile flags
+# this workaround is creating a warning about the double definition of _FORTIFY_SOURCE
+#
+# Workaround will be removed after the test container are shipped with a self compiled HDF5
+if [[ $CXX_VERSION =~ ^clang && $PIC_BACKEND =~ ^cuda ]] ; then
+    CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CXX_FLAGS=-D_FORTIFY_SOURCE=0"
+fi
 
 ###################################################
 # build an run tests


### PR DESCRIPTION
[Edit by Sergei] Motivation: the existing CI builds PIConGPU without dependencies and so parts of the code are not compiled. This PR shifts to another container that has all optional dependencies, and so provides better testing coverage.

This PR:
- ship `bash.profile` to setup the path to all dependencies (currently
one fixed version)
- use PIConGPU container instead alpaka container
- isaac is currently disabled (requires testing with all compiler versions)
- include a workaround for clang cuda with HDF5 from the apt source (can be removed after HDF5 is self compiled)

# What's next

After we merged this PR I will disable the old CI for the `dev` branch. For the `master` branch we will keep the old CI in case we like to ship backports for `PIConGPU 0.5.0`

# Thanks

Thanks @ax3l for hosting the web infrastructure for our self made PIConGPU CI over the last 7 years.