### PR TITLE
warning: used C++17 extension

### DIFF
--- a/include/pmacc/nvidia/functors/Atomic.hpp
+++ b/include/pmacc/nvidia/functors/Atomic.hpp
@@ -70,10 +70,10 @@ namespace functors
             int T_dim,
             typename T_DstAccessor,
             typename T_DstNavigator,
-            template < typename, int > typename T_DstStorage,
+            template < typename, int > class T_DstStorage,
             typename T_SrcAccessor,
             typename T_SrcNavigator,
-            template < typename, int > typename T_SrcStorage
+            template < typename, int > class T_SrcStorage
         >
         HDINLINE void operator()(
             T_Acc const & acc,


### PR DESCRIPTION
fix warning:
```
pmacc/nvidia/functors/Atomic.hpp:73:40: warning: template template parameter using 'typename' is a C++17 extension [-Wc++17-extensions]
            template < typename, int > typename T_DstStorage,
                                       ^~~~~~~~
                                       class
```

Warning was found with HIP-clang (clang version 10.0.0)