### PR TITLE
Add pmacc functions to get basis unit vectors

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp
@@ -124,12 +124,23 @@ namespace lehe
             constexpr float_X betaDir2 = 0.125_X * stepRatio2 * stepRatio2;
 
             // finite-difference expression from eq. (6), generic for any T_direction
-            pmacc::DataSpace< simDim > secondUpperIndexDir0, lowerIndexDir0;
-            secondUpperIndexDir0[ dir0 ] = 2;
-            lowerIndexDir0[ dir0 ] = -1;
-            pmacc::DataSpace< simDim > upperNeighborDir1, upperNeighborDir2;
-            upperNeighborDir1[ dir1 ] = 1;
-            upperNeighborDir2[ dir2 ] = 1;
+            using Index = pmacc::DataSpace< simDim >;
+            auto const secondUpperIndexDir0 = 2 * pmacc::math::basisVector<
+                Index,
+                dir0
+            >();
+            auto const lowerIndexDir0 = -pmacc::math::basisVector<
+                Index,
+                dir0
+            >();
+            auto const upperNeighborDir1 = pmacc::math::basisVector<
+                Index,
+                dir1
+            >();
+            auto const upperNeighborDir2 = pmacc::math::basisVector<
+                Index,
+                dir2
+            >();
             auto forwardDerivative = differentiation::makeDerivativeFunctor<
                 differentiation::Forward,
                 T_direction
@@ -198,8 +209,10 @@ namespace lehe
                 differentiation::Forward,
                 T_direction
             >();
-            pmacc::DataSpace< simDim > upperNeighbor;
-            upperNeighbor[ T_cherenkovFreeDirection ] = 1;
+            auto const upperNeighbor = pmacc::math::basisVector<
+                pmacc::DataSpace< simDim >,
+                T_cherenkovFreeDirection
+            >();
             return alpha * forwardDerivative( data ) +
                 beta * forwardDerivative( data.shift( upperNeighbor ) ) +
                 beta * forwardDerivative( data.shift( -upperNeighbor ) );

--- a/include/picongpu/fields/differentiation/BackwardDerivative.hpp
+++ b/include/picongpu/fields/differentiation/BackwardDerivative.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/fields/differentiation/Traits.hpp"
 #include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/math/Vector.hpp>
 #include <pmacc/meta/accessors/Identity.hpp>
 
 #include <cstdint>
@@ -54,10 +55,12 @@ namespace differentiation
         HDINLINE typename T_DataBox::ValueType operator()(
             T_DataBox const & data) const
         {
-            pmacc::DataSpace< simDim > const currentIndex;
-            pmacc::DataSpace< simDim > lowerIndex;
-            lowerIndex[ T_direction ] = -1;
-            return ( data( currentIndex ) - data( lowerIndex ) ) /
+            using Index = pmacc::DataSpace< simDim >;
+            auto const lowerIndex = -pmacc::math::basisVector<
+                Index,
+                T_direction
+            >();
+            return ( data( Index{} ) - data( lowerIndex ) ) /
                 cellSize[ T_direction ];
         }
     };

--- a/include/picongpu/fields/differentiation/ForwardDerivative.hpp
+++ b/include/picongpu/fields/differentiation/ForwardDerivative.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/fields/differentiation/Traits.hpp"
 #include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/math/Vector.hpp>
 #include <pmacc/meta/accessors/Identity.hpp>
 
 #include <cstdint>
@@ -54,10 +55,12 @@ namespace differentiation
         HDINLINE typename T_DataBox::ValueType operator()(
             T_DataBox const & data ) const
         {
-            pmacc::DataSpace< simDim > const currentIndex;
-            pmacc::DataSpace< simDim > upperIndex;
-            upperIndex[ T_direction ] = 1;
-            return ( data( upperIndex ) - data( currentIndex ) ) /
+            using Index = pmacc::DataSpace< simDim >;
+            auto const upperIndex = pmacc::math::basisVector<
+                Index,
+                T_direction
+            >();
+            return ( data( upperIndex ) - data( Index{} ) ) /
                 cellSize[ T_direction ];
         }
     };

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -842,6 +842,21 @@ struct Abs
     }
 };
 
+/** Get the unit basis vector of the given type along the given direction
+ *
+ * In case 0 <= T_direction < T_Vector::dim, return the basis vector with value
+ * 1 in component T_direction and 0 in other components, otherwise return the
+ * zero vector.
+ *
+ * @tparam T_Vector result type
+ * @tparam T_direction index of the basis vector direction
+ */
+template<
+    typename T_Vector,
+    uint32_t T_direction
+>
+HDINLINE T_Vector basisVector();
+
 } //namespace math
 
 namespace result_of

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -25,6 +25,7 @@
 
 
 #include "pmacc/math/Vector.hpp"
+#include "pmacc/math/vector/compile-time/Vector.hpp"
 #include "pmacc/algorithms/math.hpp"
 #include "pmacc/algorithms/TypeCast.hpp"
 #include "pmacc/algorithms/PromoteType.hpp"
@@ -149,6 +150,21 @@ namespace math
             return tmp;
         }
     };
+
+    template<
+        typename T_Vector,
+        uint32_t T_direction
+    >
+    HDINLINE T_Vector basisVector()
+    {
+        using Result = typename CT::make_BasisVector<
+            T_Vector::dim,
+            T_direction,
+            typename T_Vector::type
+        >::type;
+        return Result::toRT();
+    }
+
 } // namespace math
 } // namespace pmacc
 

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -489,6 +489,33 @@ struct make_Vector<3, T_Type>
     using type = pmacc::math::CT::Vector<T_Type, T_Type, T_Type>;
 };
 
+//________________________make_BasisVector___________________
+
+/** Create CT::Vector that is the unit basis vector along the given direction
+ *
+ * Defines a public type as result.
+ * In case 0 <= T_direction < T_dim, return the basis vector type with value
+ * 1 in component T_direction and 0 in other components, otherwise return the
+ * zero vector type.
+ *
+ * @tparam T_dim count of components
+ * @tparam T_direction index of the basis vector direction
+ * @tparam T_ValueType value type of the vector
+ */
+template<uint32_t T_dim, uint32_t T_direction, typename T_ValueType = int>
+struct make_BasisVector
+{
+    using Zeroes = typename make_Vector<
+        T_dim,
+        bmpl::integral_c<T_ValueType, 0>
+    >::type;
+    using type = typename AssignIfInRange<
+        Zeroes,
+        bmpl::integral_c<size_t, T_direction>,
+        bmpl::integral_c<T_ValueType, 1>
+    >::type;
+};
+
 } // CT
 } // math
 } // pmacc


### PR DESCRIPTION
This is useful to express derivatives more naturally. Especially, and this is what motivated making this function, for the upcoming 2D Lehe solver. Also, to set derivative and therefore curl and solver margins more precisely, e.g. for X derivative to have (1, 0, 0) instead of the current (1, 1, 1).