### PR TITLE
Refactor margin traits for field derivatives

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp
@@ -74,6 +74,40 @@ namespace lehe
         T_direction
     >
     {
+    private:
+
+        //! Internally used derivative functor
+        using InternalDerivativeFunctor = differentiation::DerivativeFunctor<
+            differentiation::Forward,
+            T_direction
+        >;
+
+    public:
+
+        /** Lower margin: we move by 1 along each direction and
+         *  apply InternalDerivativeFunctor, add those up
+         */
+        using LowerMargin = typename pmacc::math::CT::add<
+            typename pmacc::math::CT::make_Int<
+                simDim,
+                1
+            >::type,
+            typename GetLowerMargin< InternalDerivativeFunctor >::type
+        >::type;
+
+        /** Upper margin: we move by 1 along each direction and
+         *  effectively apply InternalDerivativeFunctor (for T_direction not
+         *  literally, but structurally), add those up
+         */
+        using UpperMargin = typename pmacc::math::CT::add<
+            typename pmacc::math::CT::make_Int<
+                simDim,
+                1
+            >::type,
+            typename GetUpperMargin< InternalDerivativeFunctor >::type
+        >::type;
+
+        //! Create a functor
         HDINLINE DerivativeFunctor( )
         {
             // differentiate along dir0; dir1 and dir2 are the other two directions
@@ -141,10 +175,11 @@ namespace lehe
                 Index,
                 dir2
             >();
-            auto forwardDerivative = differentiation::makeDerivativeFunctor<
-                differentiation::Forward,
-                T_direction
-            >();
+            InternalDerivativeFunctor forwardDerivative =
+                differentiation::makeDerivativeFunctor<
+                    differentiation::Forward,
+                    T_direction
+                >();
             return
                 alpha * forwardDerivative( data ) +
                 betaDir1 * forwardDerivative( data.shift( upperNeighborDir1 ) ) +
@@ -187,6 +222,40 @@ namespace lehe
             T_cherenkovFreeDirection != T_direction
         );
 
+    private:
+
+        //! Internally used derivative functor
+        using InternalDerivativeFunctor = differentiation::DerivativeFunctor<
+            differentiation::Forward,
+            T_direction
+        >;
+
+    public:
+
+        /** Lower margin: we move by 1 along T_cherenkovFreeDirection and
+         *  apply InternalDerivativeFunctor, add those up
+         */
+        using LowerMargin = typename pmacc::math::CT::add<
+            typename pmacc::math::CT::make_BasisVector<
+                simDim,
+                T_cherenkovFreeDirection,
+                int
+            >::type,
+            typename GetLowerMargin< InternalDerivativeFunctor >::type
+        >::type;
+
+        /** Upper margin: we move by 1 along T_cherenkovFreeDirection and
+         *  apply InternalDerivativeFunctor, add those up
+         */
+        using UpperMargin = typename pmacc::math::CT::add<
+            typename pmacc::math::CT::make_BasisVector<
+                simDim,
+                T_cherenkovFreeDirection,
+                int
+            >::type,
+            typename GetUpperMargin< InternalDerivativeFunctor >::type
+        >::type;
+
         /** Return derivative value at the given point
          *
          * @tparam T_DataBox data box type with field data
@@ -205,10 +274,11 @@ namespace lehe
              */
             constexpr float_X beta = 0.125_X;
             constexpr float_X alpha = 1.0_X - 2.0_X * beta;
-            auto forwardDerivative = differentiation::makeDerivativeFunctor<
-                differentiation::Forward,
-                T_direction
-            >();
+            InternalDerivativeFunctor forwardDerivative =
+                differentiation::makeDerivativeFunctor<
+                    differentiation::Forward,
+                    T_direction
+                >();
             auto const upperNeighbor = pmacc::math::basisVector<
                 pmacc::DataSpace< simDim >,
                 T_cherenkovFreeDirection
@@ -252,29 +322,4 @@ namespace traits
 } // namespace traits
 } // namespace differentiation
 } // namespace fields
-
-namespace traits
-{
-
-    /** Get margin of the Lehe solver derivative
-     *
-     * @tparam T_cherenkovFreeDirection direction to remove numerical Cherenkov
-     *                                  radiation in, 0 = x, 1 = y, 2 = z
-     */
-    template< uint32_t T_cherenkovFreeDirection >
-    struct GetMargin<
-        fields::maxwellSolver::lehe::Derivative< T_cherenkovFreeDirection >
-    >
-    {
-        using LowerMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            1
-        >::type;
-        using UpperMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            2
-        >::type;
-    };
-
-} // namespace traits
 } // namespace picongpu

--- a/include/picongpu/fields/differentiation/BackwardDerivative.hpp
+++ b/include/picongpu/fields/differentiation/BackwardDerivative.hpp
@@ -22,7 +22,6 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/differentiation/Derivative.def"
 #include "picongpu/fields/differentiation/Traits.hpp"
-#include "picongpu/traits/GetMargin.hpp"
 
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/meta/accessors/Identity.hpp>
@@ -46,6 +45,19 @@ namespace differentiation
     template< uint32_t T_direction >
     struct BackwardDerivativeFunctor
     {
+        //! Lower margin
+        using LowerMargin = typename pmacc::math::CT::make_BasisVector<
+            simDim,
+            T_direction,
+            int
+        >::type;
+
+        //! Upper margin
+        using UpperMargin = typename pmacc::math::CT::make_Int<
+            simDim,
+            0
+        >::type;
+
         /** Return derivative value at the given point
          *
          * @tparam T_DataBox data box type with field data
@@ -85,23 +97,4 @@ namespace traits
 } // namespace traits
 } // namespace differentiation
 } // namespace fields
-
-namespace traits
-{
-
-    //! Get margin of the backward derivative
-    template<>
-    struct GetMargin< fields::differentiation::Backward >
-    {
-        using LowerMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            1
-        >::type;
-        using UpperMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            0
-        >::type;
-    };
-
-} // namespace traits
 } // namespace picongpu

--- a/include/picongpu/fields/differentiation/Curl.hpp
+++ b/include/picongpu/fields/differentiation/Curl.hpp
@@ -23,6 +23,8 @@
 #include "picongpu/fields/differentiation/Derivative.hpp"
 #include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/math/Vector.hpp>
+
 
 namespace picongpu
 {
@@ -42,11 +44,47 @@ namespace differentiation
         //! Derivative tag
         using Derivative = T_Derivative;
 
-        //! Lower margin
-        using LowerMargin = typename GetLowerMargin< Derivative >::type;
+        //! Derivative function along x type
+        using XDerivativeFunctor = decltype(
+            makeDerivativeFunctor<
+                Derivative,
+                0
+            >()
+        );
 
-        //! Upper margin
-        using UpperMargin = typename GetUpperMargin< Derivative >::type;
+        //! Derivative function along y type
+        using YDerivativeFunctor = decltype(
+            makeDerivativeFunctor<
+                Derivative,
+                1
+            >()
+        );
+
+        //! Derivative function along z type
+        using ZDerivativeFunctor = decltype(
+            makeDerivativeFunctor<
+                Derivative,
+                2
+            >()
+        );
+
+        //! Lower margin: max of the derivative lower margins
+        using LowerMargin = typename pmacc::math::CT::max<
+            typename pmacc::math::CT::max<
+                typename GetLowerMargin< XDerivativeFunctor >::type,
+                typename GetLowerMargin< YDerivativeFunctor >::type
+            >::type,
+            typename GetLowerMargin< ZDerivativeFunctor >::type
+        >::type;
+
+        //! Upper margin: max of the derivative upper margins
+        using UpperMargin =  typename pmacc::math::CT::max<
+            typename pmacc::math::CT::max<
+                typename GetUpperMargin< XDerivativeFunctor >::type,
+                typename GetUpperMargin< YDerivativeFunctor >::type
+            >::type,
+            typename GetUpperMargin< ZDerivativeFunctor >::type
+        >::type;
 
         //! Create curl functor
         HDINLINE Curl():
@@ -123,25 +161,6 @@ namespace differentiation
         }
 
     private:
-
-        using XDerivativeFunctor = decltype(
-            makeDerivativeFunctor<
-                Derivative,
-                0
-            >()
-        );
-        using YDerivativeFunctor = decltype(
-            makeDerivativeFunctor<
-                Derivative,
-                1
-            >()
-        );
-        using ZDerivativeFunctor = decltype(
-            makeDerivativeFunctor<
-                Derivative,
-                2
-            >()
-        );
 
         XDerivativeFunctor const xDerivativeFunctor;
         YDerivativeFunctor const yDerivativeFunctor;

--- a/include/picongpu/fields/differentiation/ForwardDerivative.hpp
+++ b/include/picongpu/fields/differentiation/ForwardDerivative.hpp
@@ -22,7 +22,6 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/differentiation/Derivative.def"
 #include "picongpu/fields/differentiation/Traits.hpp"
-#include "picongpu/traits/GetMargin.hpp"
 
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/meta/accessors/Identity.hpp>
@@ -46,6 +45,19 @@ namespace differentiation
     template< uint32_t T_direction >
     struct ForwardDerivativeFunctor
     {
+        //! Lower margin
+        using LowerMargin = typename pmacc::math::CT::make_Int<
+            simDim,
+            0
+        >::type;
+
+        //! Upper margin
+        using UpperMargin = typename pmacc::math::CT::make_BasisVector<
+            simDim,
+            T_direction,
+            int
+        >::type;
+
         /** Return derivative value at the given point
          *
          * @tparam T_DataBox data box type with field data
@@ -85,23 +97,4 @@ namespace traits
 } // namespace traits
 } // namespace differentiation
 } // namespace fields
-
-namespace traits
-{
-
-    //! Get margin of the forward derivative
-    template<>
-    struct GetMargin< fields::differentiation::Forward >
-    {
-        using LowerMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            0
-        >::type;
-        using UpperMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            1
-        >::type;
-    };
-
-} // namespace traits
 } // namespace picongpu

--- a/include/picongpu/fields/differentiation/ZeroDerivative.hpp
+++ b/include/picongpu/fields/differentiation/ZeroDerivative.hpp
@@ -22,8 +22,8 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/differentiation/Derivative.def"
 #include "picongpu/fields/differentiation/Traits.hpp"
-#include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/math/Vector.hpp>
 #include <pmacc/meta/accessors/Identity.hpp>
 
 #include <cstdint>
@@ -45,6 +45,18 @@ namespace differentiation
     template< uint32_t T_direction >
     struct ZeroDerivativeFunctor
     {
+        //! Lower margin
+        using LowerMargin = typename pmacc::math::CT::make_Int<
+            simDim,
+            0
+        >::type;
+
+        //! Upper margin
+        using UpperMargin = typename pmacc::math::CT::make_Int<
+            simDim,
+            0
+        >::type;
+
         /** Return zero
          *
          * @tparam T_DataBox data box type with field data
@@ -78,23 +90,4 @@ namespace traits
 } // namespace traits
 } // namespace differentiation
 } // namespace fields
-
-namespace traits
-{
-
-    //! Get margin of the zero derivative
-    template<>
-    struct GetMargin< fields::differentiation::Zero >
-    {
-        using LowerMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            0
-        >::type;
-        using UpperMargin = typename pmacc::math::CT::make_Int<
-            simDim,
-            0
-        >::type;
-    };
-
-} // namespace traits
 } // namespace picongpu


### PR DESCRIPTION
Previously, the margins were sometimes overly conservative. E.g. Lehe solver defined upper margin for derivative, and therefore curl, as (2, 2, 2), while it actually used (1, 2, 1) with 2 along the Cherenkov-free direction. Move the margins to be defined for functors, not tags, and put precise values. Make use of recently introduced #3319 compile-time basis vectors to express the margins. Adjust curl margin definition accordingly, to be max of derivative margins.

This PR will allow easier uniform implementation of `Lehe` / `LehePML` solvers for both 3D and 2D. Practically speaking, the current 3D-only implementation will only need a slight adjustment to work for 2D as well. This will be done as a follow-up PR.