### PR TITLE
Fix wrong variable name in the LWFA setup

### DIFF
--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
@@ -77,7 +77,7 @@ TBG_plugins="!TBG_pngYX                    \
              !TBG_e_histogram              \
              !TBG_e_PSypy                  \
              !TBG_e_macroCount             \
-             !TBG_e_openPMD"
+             !TBG_openPMD"
 
 #################################
 ## Section: Program Parameters ##

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
@@ -78,7 +78,7 @@ TBG_plugins="!TBG_pngYX                    \
              !TBG_e_histogram              \
              !TBG_e_PSypy                  \
              !TBG_e_macroCount             \
-             !TBG_e_openPMD"
+             !TBG_openPMD"
 
 
 #################################


### PR DESCRIPTION
A typo in the name led to it not being resolved and therefore the `.cfg` files were broken. Notably, that includes the 1.cfg for LWFA which we use in the manual (and that's how it was discovered). This was introduced after 0.5.0, so does not affect the last release.