### PR TITLE
Fix cuSTL CartBuffer dereferencing a null pointer when CUDA is enabled

### DIFF
--- a/include/pmacc/cuSTL/container/CartBuffer.tpp
+++ b/include/pmacc/cuSTL/container/CartBuffer.tpp
@@ -168,8 +168,8 @@ void CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::init()
     this->dataPointer = cursor.getMarker();
 #ifndef __CUDA_ARCH__
     this->refCount = new int;
-#endif
     *this->refCount = 1;
+#endif
     this->pitch = detail::PitchHelper<T_dim>()(cursor);
 }
 


### PR DESCRIPTION
With CUDA enabled, the memory for `refCount` is not allocated, but then accessed. All other access places have guards for null pointer, except this one. So this change is sufficient.

This bug was found during investigation of #3329, but this is not what causes it. The situation fixed by this PR should have actually occurred when running with CUDA, which surprisingly did not lead to a crash.

Note: this concerns cuSTL's `CartBuffer`, not a `pmacc::memory` one, which is way more frequently used as of now.