### PR TITLE
PMacc warp and atomic function refactor

### DIFF
--- a/include/pmacc/nvidia/atomic.hpp
+++ b/include/pmacc/nvidia/atomic.hpp
@@ -21,12 +21,16 @@
 
 #pragma once
 
-
 #include "pmacc/types.hpp"
-#if( PMACC_CUDA_ENABLED == 1 )
-#   include "pmacc/nvidia/warp.hpp"
-#endif
+#include "pmacc/memory/Array.hpp"
+#include "pmacc/nvidia/warp.hpp"
+
+#include <alpaka/intrinsic/Traits.hpp>
+#include <alpaka/warp/Traits.hpp>
+
 #include <boost/type_traits.hpp>
+
+#include <type_traits>
 #include <climits>
 
 
@@ -34,169 +38,162 @@ namespace pmacc
 {
 namespace nvidia
 {
+namespace detail
+{
 
-    namespace detail {
-
-        template<typename T_Type, bool T_isKepler>
-        struct AtomicAllInc
+    template<typename T_Type, bool T_isKepler>
+    struct AtomicAllInc
+    {
+        template< typename T_Acc, typename T_Hierarchy >
+        HDINLINE T_Type
+        operator()(const T_Acc& acc, T_Type* ptr, const T_Hierarchy& hierarchy)
         {
-            template< typename T_Acc, typename T_Hierarchy >
-            HDINLINE T_Type
-            operator()(const T_Acc& acc, T_Type* ptr, const T_Hierarchy& hierarchy)
-            {
-                return ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc, ptr, T_Type(1), hierarchy);
-            }
-        };
+            return ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc, ptr, T_Type(1), hierarchy);
+        }
+    };
 
-#if PMACC_CUDA_ARCH >= 300
-       /**
-         * Trait that returns whether an optimized version of AtomicAllInc
-         * exists for Kepler architectures (and up)
-         */
-        template<typename T>
-        struct AtomicAllIncIsOptimized
+#if CUPLA_DEVICE_COMPILE == 1
+   /**
+     * Trait that returns whether an optimized version of AtomicAllInc
+     * exists for Kepler architectures (and up)
+     */
+    template<typename T>
+    struct AtomicAllIncIsOptimized
+    {
+        enum{
+            value = boost::is_same<T,          int>::value ||
+                    boost::is_same<T, unsigned int>::value ||
+                    boost::is_same<T,          long long int>::value ||
+                    boost::is_same<T, unsigned long long int>::value ||
+                    boost::is_same<T, float>::value
+        };
+    };
+
+    /**
+     * AtomicAllInc for Kepler and up
+     * Defaults to unoptimized version for unsupported types
+     */
+    template<typename T_Type, bool T_UseOptimized = AtomicAllIncIsOptimized<T_Type>::value>
+    struct AtomicAllIncKepler: public AtomicAllInc<T_Type, false>
+    {};
+
+    /**
+     * Optimized version
+     *
+     * This warp aggregated atomic increment implementation based on nvidia parallel forall example
+     * http://devblogs.nvidia.com/parallelforall/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/
+     * (author: Andrew Adinetz, date: October 1th, 2014)
+     *
+     */
+    template<typename T_Type>
+    struct AtomicAllIncKepler<T_Type, true>
+    {
+        template< typename T_Acc, typename T_Hierarchy >
+        HDINLINE T_Type
+        operator()(const T_Acc& acc,T_Type* ptr, const T_Hierarchy& hierarchy)
         {
-            enum{
-                value = boost::is_same<T,          int>::value ||
-                        boost::is_same<T, unsigned int>::value ||
-                        boost::is_same<T,          long long int>::value ||
-                        boost::is_same<T, unsigned long long int>::value ||
-                        boost::is_same<T, float>::value
-            };
-        };
+            const auto mask = alpaka::warp::activemask(acc);
+            const auto leader = alpaka::intrinsic::ffs(acc, static_cast<std::make_signed_t<decltype(mask)>>(mask)) - 1;
 
-        /**
-         * AtomicAllInc for Kepler and up
-         * Defaults to unoptimized version for unsupported types
-         */
-        template<typename T_Type, bool T_UseOptimized = AtomicAllIncIsOptimized<T_Type>::value>
-        struct AtomicAllIncKepler: public AtomicAllInc<T_Type, false>
-        {};
+            T_Type result;
+            const int laneId = getLaneId();
+            /* Get the start value for this warp */
+            if (laneId == leader)
+                result = ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc,ptr, static_cast<T_Type>(alpaka::intrinsic::popcount(acc, mask)), hierarchy);
+            result = warpBroadcast(result, leader);
+            /* Add offset per thread */
+            return result + static_cast<T_Type>(alpaka::intrinsic::popcount(acc, mask & (( static_cast<decltype(mask)>(1u) << laneId) - 1u)));
 
-        /**
-         * Optimized version
+        }
+    };
+
+    /**
+     * Optimized version for int64.
+     * As CUDA atomicAdd does not support int64 directly we just cast it
+     * and call the uint64 implementation
+     */
+    template<>
+    struct AtomicAllIncKepler<long long int, true>
+    {
+        template< typename T_Acc, typename T_Hierarchy >
+        HDINLINE long long int
+        operator()(const T_Acc& acc, long long int* ptr, const T_Hierarchy&, const T_Hierarchy& hierarchy )
+        {
+            return static_cast<long long int>(
+                    AtomicAllIncKepler<unsigned long long int>()(
+                        acc,
+                        reinterpret_cast<unsigned long long int*>(ptr),
+                        hierarchy
+                    )
+            );
+        }
+    };
+
+    template<typename T_Type>
+    struct AtomicAllInc<T_Type, true>: public AtomicAllIncKepler<T_Type>
+    {};
+#endif // CUPLA_DEVICE_COMPILE == 1
+
+}  // namespace detail
+
+    /** optimized atomic increment
+     *
+     * - only optimized if PTX ISA >=3.0
+     * - this atomic uses warp aggregation to speedup the operation compared to cuda `atomicInc()`
+     * - cuda `atomicAdd()` is used if the compute architecture does not support warp aggregation
+     * - all participate threads must change the same pointer (ptr) else the result is unspecified
+     *
+     * @param ptr pointer to memory (must be the same address for all threads in a block)
+     *
+     */
+    template<typename T, typename T_Acc, typename T_Hierarchy>
+    HDINLINE
+    T atomicAllInc(const T_Acc& acc, T *ptr, const T_Hierarchy& hierarchy)
+    {
+        return detail::AtomicAllInc<T, (PMACC_CUDA_ARCH >= 300 || BOOST_COMP_HIP) >()(acc, ptr, hierarchy);
+    }
+
+    template<typename T>
+    HDINLINE
+    T atomicAllInc(T *ptr)
+    {
+        /* Dirty hack to call an alpaka accelerator based function.
+         * Members of the fakeAcc will be uninitialized and must not be accessed.
          *
-         * This warp aggregated atomic increment implementation based on nvidia parallel forall example
-         * http://devblogs.nvidia.com/parallelforall/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/
-         * (author: Andrew Adinetz, date: October 1th, 2014)
-         *
+         * The id provider for particles is the only code where atomicAllInc is used without an accelerator.
+         * @todo remove the unsafe faked accelerator
          */
-        template<typename T_Type>
-        struct AtomicAllIncKepler<T_Type, true>
-        {
-            template< typename T_Acc, typename T_Hierarchy >
-            HDINLINE T_Type
-            operator()(const T_Acc& acc,T_Type* ptr, const T_Hierarchy& hierarchy)
-            {
-                /* Get a bitmask with 1 for each thread in the warp, that executes this */
-#if(__CUDACC_VER_MAJOR__ >= 9)
-                const int mask = __activemask();
-#else
-                const int mask = __ballot(1);
+        pmacc::memory::Array<cupla::AccThreadSeq, 1> fakeAcc;
+        return atomicAllInc(fakeAcc[0], ptr, ::alpaka::hierarchy::Grids());
+    }
+
+    /** optimized atomic value exchange
+     *
+     * - only optimized if PTX ISA >=2.0
+     * - this atomic uses warp vote function to speedup the operation
+     *   compared to cuda `atomicExch()`
+     * - cuda `atomicExch()` is used if the compute architecture not supports
+     *   warps vote functions
+     * - all participate threads must change the same
+     *   pointer (ptr) and set the same value, else the
+     *   result is unspecified
+     *
+     * @param ptr pointer to memory (must be the same address for all threads in a block)
+     * @param value new value (must be the same for all threads in a block)
+     */
+    template<typename T_Type, typename T_Acc, typename T_Hierarchy>
+    DINLINE void
+    atomicAllExch(const T_Acc& acc, T_Type* ptr, const T_Type value, const T_Hierarchy& hierarchy)
+    {
+
+        const auto mask = alpaka::warp::activemask(acc);
+        const auto leader = alpaka::intrinsic::ffs(acc, static_cast<std::make_signed_t<decltype(mask)>>(mask)) - 1;
+
+#if CUPLA_DEVICE_COMPILE == 1
+        if (getLaneId() == leader)
 #endif
-                /* select the leader */
-                const int leader = __ffs(mask) - 1;
-                T_Type result;
-                const int laneId = getLaneId();
-                /* Get the start value for this warp */
-                if (laneId == leader)
-                    result = ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc,ptr, static_cast<T_Type>(__popc(mask)), hierarchy);
-                result = warpBroadcast(result, leader);
-                /* Add offset per thread */
-                return result + static_cast<T_Type>(__popc(mask & ((1 << laneId) - 1)));
-            }
-        };
-
-        /**
-         * Optimized version for int64.
-         * As CUDA atomicAdd does not support int64 directly we just cast it
-         * and call the uint64 implementation
-         */
-        template<>
-        struct AtomicAllIncKepler<long long int, true>
-        {
-            template< typename T_Acc, typename T_Hierarchy >
-            HDINLINE long long int
-            operator()(const T_Acc& acc, long long int* ptr, const T_Hierarchy&, const T_Hierarchy& hierarchy )
-            {
-                return static_cast<long long int>(
-                        AtomicAllIncKepler<unsigned long long int>()(
-                            acc,
-                            reinterpret_cast<unsigned long long int*>(ptr),
-                            hierarchy
-                        )
-                );
-            }
-        };
-
-        template<typename T_Type>
-        struct AtomicAllInc<T_Type, true>: public AtomicAllIncKepler<T_Type>
-        {};
-#endif /* PMACC_CUDA_ARCH >= 300 */
-
-    }  // namespace detail
-
-/** optimized atomic increment
- *
- * - only optimized if PTX ISA >=3.0
- * - this atomic uses warp aggregation to speedup the operation compared to cuda `atomicInc()`
- * - cuda `atomicAdd()` is used if the compute architecture does not support warp aggregation
- * - all participate threads must change the same pointer (ptr) else the result is unspecified
- *
- * @param ptr pointer to memory (must be the same address for all threads in a block)
- *
- */
-template<typename T, typename T_Acc, typename T_Hierarchy>
-HDINLINE
-T atomicAllInc(const T_Acc& acc, T *ptr, const T_Hierarchy& hierarchy)
-{
-    return detail::AtomicAllInc<T, (PMACC_CUDA_ARCH >= 300) >()(acc, ptr, hierarchy);
-}
-
-template<typename T>
-HDINLINE
-T atomicAllInc(T *ptr)
-{
-#ifdef __CUDA_ARCH__
-    return atomicAllInc(alpaka::atomic::AtomicUniformCudaHipBuiltIn(), ptr, ::alpaka::hierarchy::Grids());
-#else
-    // assume that we can use the standard library atomics if we are not on gpu
-    return atomicAllInc(alpaka::atomic::AtomicStdLibLock<16>(), ptr, ::alpaka::hierarchy::Grids());
-#endif
-}
-
-/** optimized atomic value exchange
- *
- * - only optimized if PTX ISA >=2.0
- * - this atomic uses warp vote function to speedup the operation
- *   compared to cuda `atomicExch()`
- * - cuda `atomicExch()` is used if the compute architecture not supports
- *   warps vote functions
- * - all participate threads must change the same
- *   pointer (ptr) and set the same value, else the
- *   result is unspecified
- *
- * @param ptr pointer to memory (must be the same address for all threads in a block)
- * @param value new value (must be the same for all threads in a block)
- */
-template<typename T_Type, typename T_Acc, typename T_Hierarchy>
-DINLINE void
-atomicAllExch(const T_Acc& acc, T_Type* ptr, const T_Type value, const T_Hierarchy& hierarchy)
-{
-#if (__CUDA_ARCH__ >= 200)
-#   if(__CUDACC_VER_MAJOR__ >= 9)
-    const int mask = __activemask();
-#   else
-    const int mask = __ballot(1);
-#   endif
-    // select the leader
-    const int leader = __ffs(mask) - 1;
-    // leader does the update
-    if (getLaneId() == leader)
-#endif
-        ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ptr, value, hierarchy);
-}
-
+            ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ptr, value, hierarchy);
+    }
 
 } //namespace nvidia
 } //namespace pmacc

--- a/include/pmacc/nvidia/warp.hpp
+++ b/include/pmacc/nvidia/warp.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#if( BOOST_LANG_CUDA || BOOST_COMP_HIP)
 
 #include "pmacc/types.hpp"
 
@@ -42,10 +43,15 @@ DINLINE uint32_t getLaneId()
     asm("mov.u32 %0, %%laneid;" : "=r" (id));
     return id;
 }
+#elif BOOST_COMP_HIP
+DINLINE uint32_t getLaneId()
+{
+    return __lane_id();
+}
 #endif
 
 
-#if (__CUDA_ARCH__ >= 300)
+#if (__CUDA_ARCH__ >= 300 || BOOST_COMP_HIP)
 /** broadcast data within a warp
  *
  * required PTX ISA >=3.0
@@ -114,3 +120,5 @@ DINLINE double warpBroadcast(double data, const int32_t srcLaneId)
 
 } //namespace nvidia
 } //namespace pmacc
+
+#endif


### PR DESCRIPTION
- introduce support for HIP
- change the way how `atomicAllInc` is implemented if no accelerator is
given
- use alpaka intrinsics and warp functions