### PR TITLE
fix usage of `::abs()`

### DIFF
--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -156,7 +156,7 @@ struct typicalFields < 5 >
         const float_X tyEField = fields::laserProfiles::Selected::Unitless::W0 * BASE_DENSITY / 3.0f / EPS0;
         const float_X tyBField = tyEField * MUE0_EPS0;
         const float_X tyCurrent = particles::TYPICAL_PARTICLES_PER_CELL * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
-            * abs(baseCharge) / DELTA_T;
+            * math::abs(baseCharge) / DELTA_T;
 
         return float3_X(tyBField, tyEField, tyCurrent);
 #endif


### PR DESCRIPTION
Use cupla math implementation of `abs()` instead of `abs` from the global scope.
This change solves compile issues with HIP, found in my HIP prototype branch.