### PR TITLE
Add generic utilities to get absorber thickness

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -223,7 +223,8 @@ namespace maxwellSolver
                 Thickness globalThickness;
                 for( uint32_t axis = 0u; axis < simDim; axis++ )
                     for( auto direction = 0; direction < 2; direction++ )
-                        globalThickness( axis, direction ) = absorber::numCells[ axis ][ direction ];
+                        globalThickness( axis, direction ) =
+                            absorber::getGlobalThickness()( axis, direction );
                 return globalThickness;
             }
 


### PR DESCRIPTION
These are to be used in the upcoming incident field implementation.

I did not change the usage in domain adjuster and exponential absorber so far, only in PML.