### PR TITLE
Feature: Ionization Current

### DIFF
--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -56,6 +56,24 @@ Overview: Implemented Models
 
     Models marked with "(R&D)" are under *research and development* and should be used with care.
 
+Ionization Current
+------------------
+
+In order to conserve energy, PIConGPU supports an ionization current to decrease the electric field according to the amount of energy lost to field ioniztion processes.
+The current for a single ion is
+
+.. math::
+
+    \mathbf{J}_\mathrm{ion} = E_\mathrm{ion} \frac{\mathbf{E}}{|\mathbf{E}|^2 \Delta t V_\mathrm{cell}}
+
+It is assigned to the grid according to the macroparticle shape.
+:math:`E_\mathrm{ion}` is the energy required to ionize the atom/ion, :math:`\mathbf{E}` is the electric field at the particle position and :math:`V_\mathrm{cell}` is the cell volume.
+This formula makes the assumption that the ejection energy of the electron is zero.
+See [Mulser]_.
+The ionization current is accessible in :ref:`speciesDefinition.param <usage-params-core>`. To activate ionization current, set the second template of the ionization model to particles::ionization::current::EnergyConservation.
+By default the ionization current is deactivated.
+
+
 Usage
 -----
 
@@ -200,3 +218,9 @@ References
         *Atomic Screening Constant from SCF Functions. II. Atoms with 37 to 86 Electrons*,
         The Journal of Chemical Physics 47, 1300-1307 (1967)
         https://dx.doi.org/10.1063/1.1712084
+
+.. [Mulser]
+        P. Mulser et al.
+        *Modeling field ionization in an energy conserving form and resulting nonstandard fluid dynamcis*,
+        Physics of Plasmas 5, 4466 (1998)
+        https://doi.org/10.1063/1.873184

--- a/include/picongpu/param/ionizer.param
+++ b/include/picongpu/param/ionizer.param
@@ -23,7 +23,6 @@
  * of the periodic table. The elements here should have a matching list of
  * ionization energies in @see ionizationEnergies.param. Moreover this file
  * contains a description of how to configure an ionization model for a species.
- * Currently each species can only be assigned exactly one ionization model.
  *
  * Furthermore there are parameters for specific ionization models to be found
  * here. That includes lists of screened nuclear charges as seen by bound

--- a/include/picongpu/particles/ionization/byField/ADK/ADK.def
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2020 Marco Garten
+/* Copyright 2015-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def"
 #include <pmacc/types.hpp>
 
 namespace picongpu
@@ -31,12 +32,13 @@ namespace ionization
     /** Ammosov-Delone-Krainov tunneling model
      *
      * \tparam T_DestSpecies electron species to be created
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
      * \tparam T_SrcSpecies ion species to be ionized
      *         default is boost::mpl placeholder because specialization
      *         cannot be known in list of particle species' flags
      *         \see speciesDefinition.param
      */
-    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
+    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_IonizationCurrent, typename T_SrcSpecies = bmpl::_1>
     struct ADK_Impl;
 
     /** Ammosov-Delone-Krainov tunneling model - linear laser polarization
@@ -55,14 +57,14 @@ namespace ionization
      * first specialization of the ionization model in the particle definition
      * \see speciesDefinition.param
      */
-    template<typename T_DestSpecies>
+    template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
     struct ADKLinPol
     {
         /* Boolean value that results in an additional polarization factor in
          * the ionization rate for linear polarization */
         static constexpr bool linPol = true;
         using IonizationAlgorithm = particles::ionization::AlgorithmADK< linPol >;
-        using type = ADK_Impl< IonizationAlgorithm, T_DestSpecies >;
+        using type = ADK_Impl< IonizationAlgorithm, T_DestSpecies, T_IonizationCurrent>;
     };
 
     /** Ammosov-Delone-Krainov tunneling model - circular laser polarization
@@ -81,14 +83,14 @@ namespace ionization
      * first specialization of the ionization model in the particle definition
      * \see speciesDefinition.param
      */
-    template<typename T_DestSpecies>
+    template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
     struct ADKCircPol
     {
         /* Boolean value that results in an additional polarization factor in
          * the ionization rate for linear polarization */
         static constexpr bool linPol = false;
         using IonizationAlgorithm = particles::ionization::AlgorithmADK< linPol >;
-        using type = ADK_Impl< IonizationAlgorithm, T_DestSpecies >;
+        using type = ADK_Impl< IonizationAlgorithm, T_DestSpecies, T_IonizationCurrent >;
     };
 
 } // namespace ionization

--- a/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2020 Marco Garten
+/* Copyright 2015-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -27,6 +27,7 @@
 #include <pmacc/algorithms/math/defines/pi.hpp>
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
 #include "picongpu/particles/ionization/utilities.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp"
 
 /** \file AlgorithmADK.hpp
  *
@@ -65,10 +66,10 @@ namespace ionization
          * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
          * \param randNr random number, equally distributed in range [0.:1.0]
          *
-         * \return number of new macro electrons to be created
+         * \return ionization energy and number of new macro electrons to be created
          */
         template<typename EType, typename BType, typename ParticleType >
-        HDINLINE uint32_t
+        HDINLINE IonizerReturn
         operator()( const BType bField, const EType eField, ParticleType& parentIon, float_X randNr )
         {
 
@@ -131,12 +132,12 @@ namespace ionization
                 /* ionization condition */
                 if( randNr < probADK )
                 {
-                    /* return number of macro electrons to produce */
-                    return 1u;
+                    /* return ionization energy and number of macro electrons to produce */
+                    return IonizerReturn{ iEnergy, 1u };
                 }
             }
             /* no ionization */
-            return 0u;
+            return IonizerReturn{ 0.0, 0u };
         }
     };
 

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2020 Marco Garten
+/* Copyright 2014-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -23,6 +23,7 @@
 #include "picongpu/particles/traits/GetIonizationEnergies.hpp"
 #include "picongpu/particles/traits/GetAtomicNumbers.hpp"
 #include "picongpu/traits/attribute/GetChargeState.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp"
 
 /** @file AlgorithmBSI.hpp
  *
@@ -44,7 +45,6 @@ namespace ionization
      */
     struct AlgorithmBSI
     {
-
         /** Functor implementation
          *
          * \tparam EType type of electric field
@@ -55,11 +55,11 @@ namespace ionization
          *
          * and "t" being with respect to the current time step (on step/half a step backward/-""-forward)
          *
-         * \return the number of electrons to produce
+         * \return ionization energy and number of new macro electrons to be created
          * (current implementation supports only 0 or 1 per execution)
          */
         template<typename EType, typename ParticleType >
-        HDINLINE uint32_t
+        HDINLINE IonizerReturn
         operator()( const EType eField, ParticleType& parentIon )
         {
 
@@ -81,12 +81,11 @@ namespace ionization
                 /* ionization condition */
                 if (math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
                 {
-                    /* return number of macro electrons to produce */
-                    return 1u;
+                    /* return ionization energy and number of macro electrons to produce */
+                    return IonizerReturn{iEnergy, 1u};
                 }
             }
-            /* no ionization */
-            return 0u;
+            return IonizerReturn{0.0, 0u};
         }
     };
 

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2020 Marco Garten
+/* Copyright 2014-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -24,6 +24,7 @@
 #include "picongpu/particles/traits/GetAtomicNumbers.hpp"
 #include "picongpu/particles/traits/GetEffectiveNuclearCharge.hpp"
 #include "picongpu/traits/attribute/GetChargeState.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp"
 
 /** @file AlgorithmBSIEffectiveZ.hpp
  *
@@ -56,11 +57,11 @@ namespace ionization
          *
          * and "t" being with respect to the current time step (on step/half a step backward/-""-forward)
          *
-         * \return the number of electrons to produce
+         * \return ionization energy and number of new macro electrons to be created
          * (current implementation supports only 0 or 1 per execution)
          */
         template<typename EType, typename ParticleType >
-        HDINLINE uint32_t
+        HDINLINE IonizerReturn
         operator()( const EType eField, ParticleType& parentIon )
         {
 
@@ -80,12 +81,12 @@ namespace ionization
                 /* ionization condition */
                 if (math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
                 {
-                    /* return number of macro electrons to produce */
-                    return 1u;
+                    /* return ionization energy and number of macro electrons to produce */
+                    return IonizerReturn{iEnergy, 1u};
                 }
             }
             /* no ionization */
-            return 0u;
+            return IonizerReturn{0.0, 0u};
         }
     };
 

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2020 Marco Garten
+/* Copyright 2014-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -23,6 +23,7 @@
 #include "picongpu/particles/traits/GetIonizationEnergies.hpp"
 #include "picongpu/particles/traits/GetAtomicNumbers.hpp"
 #include "picongpu/traits/attribute/GetChargeState.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp"
 
 /** @file AlgorithmBSIStarkShifted.hpp
  *
@@ -55,11 +56,11 @@ namespace ionization
          *
          * and "t" being with respect to the current time step (on step/half a step backward/-""-forward)
          *
-         * \return the number of electrons to produce
+         * \return ionization energy and number of new macro electrons to be created
          * (current implementation supports only 0 or 1 per execution)
          */
         template<typename EType, typename ParticleType >
-        HDINLINE uint32_t
+        HDINLINE IonizerReturn
         operator()( const EType eField, ParticleType& parentIon )
         {
 
@@ -78,12 +79,12 @@ namespace ionization
                 /* ionization condition */
                 if (math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
                 {
-                    /* return number of electrons to produce */
-                    return 1u;
+                    /* return ionization energy number of electrons to produce */
+                    return IonizerReturn{iEnergy, 1u};
                 }
             }
             /* no ionization */
-            return 0u;
+            return IonizerReturn{0.0, 0u};
         }
     };
 

--- a/include/picongpu/particles/ionization/byField/BSI/BSI.def
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2020 Marco Garten
+/* Copyright 2015-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <pmacc/types.hpp>
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def"
 
 namespace picongpu
 {
@@ -30,12 +31,13 @@ namespace ionization
     /** Barrier Suppression Ionization - Implementation
      *
      * \tparam T_DestSpecies electron species to be created
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
      * \tparam T_SrcSpecies particle species that is ionized
      *         default is boost::mpl placeholder because specialization
      *         cannot be known in list of particle species' flags
      *         \see speciesDefinition.param
      */
-    template< typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1 >
+    template< typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_IonizationCurrent, typename T_SrcSpecies = bmpl::_1 >
     struct BSI_Impl;
 
     /** Barrier Suppression Ionization - Hydrogen-Like
@@ -54,17 +56,18 @@ namespace ionization
      * - This model neglects the Stark upshift of ionization energies.
      *
      * \tparam T_DestSpecies electron species to be created
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
      *
      * wrapper class,
      * needed because the SrcSpecies cannot be known during the
      * first specialization of the ionization model in the particle definition
      * \see speciesDefinition.param
      */
-    template< typename T_DestSpecies >
+    template< typename T_DestSpecies, typename T_IonizationCurrent = current::None >
     struct BSI
     {
         using IonizationAlgorithm = particles::ionization::AlgorithmBSI;
-        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies >;
+        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies, T_IonizationCurrent >;
     };
 
     /** Barrier Suppression Ionization - Effective Atomic Numbers
@@ -76,12 +79,13 @@ namespace ionization
      * - unvalidated and still in development
      *
      * \tparam T_DestSpecies electron species to be created
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
      */
-    template< typename T_DestSpecies >
+    template< typename T_DestSpecies, typename T_IonizationCurrent = current::None >
     struct BSIEffectiveZ
     {
         using IonizationAlgorithm = particles::ionization::AlgorithmBSIEffectiveZ;
-        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies >;
+        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies, T_IonizationCurrent >;
     };
 
     /** Barrier Suppression Ionization - Ion. energies Stark-upshifted
@@ -94,12 +98,13 @@ namespace ionization
      * - \todo needs to be extrapolated to arbitrary ions
      *
      * \tparam T_DestSpecies electron species to be created
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
      */
-    template< typename T_DestSpecies >
+    template< typename T_DestSpecies, typename T_IonizationCurrent = current::None >
     struct BSIStarkShifted
     {
         using IonizationAlgorithm = particles::ionization::AlgorithmBSIStarkShifted;
-        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies >;
+        using type = BSI_Impl< IonizationAlgorithm, T_DestSpecies, T_IonizationCurrent >;
     };
 
 } // namespace ionization

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
@@ -1,0 +1,61 @@
+/* Copyright 2020 Jakob Trojok
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace particles
+{
+namespace ionization
+{
+namespace current
+{
+    /** possible inputs for T_IonizationCurrent
+     * EnergyConservation -> with ionization current
+     * None -> without
+     */
+    struct EnergyConservation;
+    struct None;
+} // namespace current
+    /** Implementation of Ionization Current
+     *
+     * In order to conserve energy, PIConGPU supports an ionization current
+     * to decrease the electric field according to the amount of energy lost to field ioniztion processes.
+     *
+     * Reference: P. Mulser et al.
+     *            Modeling field ionization in an energy conserving form and resulting nonstandard fluid dynamcis,
+     *            Physics of Plasmas 5, 4466 (1998)
+     *            https://doi.org/10.1063/1.873184
+     *
+     * \tparam T_Acc alpaka accelerator type
+     * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * \tparam T_Dim dimension of simulation
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+     */
+    template<
+        typename T_Acc,
+        typename T_DestSpecies,
+        unsigned T_Dim,
+        typename T_IonizationCurrent
+    >
+    struct IonizationCurrent;
+} // namespace ionization
+} // namespace particles
+} // namespacepicongpu

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
@@ -1,0 +1,89 @@
+/* Copyright 2020 Jakob Trojok
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/ParticlesFunctors.hpp"
+#include "picongpu/fields/FieldE.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp"
+
+
+
+namespace picongpu
+{
+namespace particles
+{
+namespace ionization
+{
+    /**@{*/
+    /** Implementation of actual ionization current
+     *
+     * \tparam T_Acc alpaka accelerator type
+     * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * \tparam T_Dim dimension of simulation
+     */
+    template<
+        typename T_Acc,
+        typename T_DestSpecies,
+        unsigned T_Dim
+    >
+    struct IonizationCurrent<T_Acc, T_DestSpecies, T_Dim, current::EnergyConservation>
+    {
+        using ValueType_E = FieldE::ValueType;
+
+        /** Ionization current routine
+         *
+         * \tparam T_JBox type of current density data box
+         */
+        template<typename T_JBox>
+        HDINLINE void
+        operator()(IonizerReturn retValue, float_X const weighting, T_JBox jBoxPar, ValueType_E eField, T_Acc const & acc, floatD_X const pos)
+        {
+            auto ionizationEnergy = weighting * retValue.ionizationEnergy * SI::ATOMIC_UNIT_ENERGY / UNIT_ENERGY; // convert to PIConGPU units
+            /* calculate ionization current at particle position */
+            float3_X jIonizationPar = JIonizationCalc{}(ionizationEnergy, eField);
+            /* assign ionization current to grid points */
+            JIonizationAssignment<T_Acc, T_DestSpecies, simDim>{}(acc, jIonizationPar, pos, jBoxPar);
+        }
+    };
+
+    /** Ionization current deactivated
+     */
+    template<
+        typename T_Acc,
+        typename T_DestSpecies,
+        unsigned T_Dim
+    >
+    struct IonizationCurrent<T_Acc, T_DestSpecies, T_Dim, current::None>
+    {
+        using ValueType_E = FieldE::ValueType;
+
+        /** no ionization current
+         */
+        template<typename T_JBox>
+        HDINLINE void
+        operator()(IonizerReturn, float_X const, T_JBox, ValueType_E, T_Acc const &, floatD_X const){}
+        /**@}*/
+    };
+} // namespace ionization
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp
@@ -1,0 +1,39 @@
+/* Copyright 2020 Jakob Trojok
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace ionization
+{
+    /** return type for ionization algorithms
+     */
+    struct IonizerReturn
+    {
+        float_X ionizationEnergy = 0._X;
+        uint32_t newMacroElectrons = 0u;
+    };
+} // namespace ionization
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
@@ -1,0 +1,141 @@
+/* Copyright 2020 Jakob Trojok
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/ParticlesFunctors.hpp"
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/FieldJ.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace ionization
+{
+    /** defining traits for current assignment
+     *
+     * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     */
+    template< typename T_DestSpecies >
+    struct JIonizationAssignmentParent
+    {
+        using Shape = typename ::picongpu::traits::GetShape<T_DestSpecies>::type;
+        using AssignmentFunction = typename Shape::ChargeAssignmentOnSupport;
+        static constexpr int supp = AssignmentFunction::support;
+        /*(supp + 1) % 2 is 1 for even supports else 0*/
+        static constexpr int begin = -supp / 2 + (supp + 1) % 2;
+        static constexpr int end = begin+supp;
+    };
+
+    /**@{*/
+    /** implementation of current assignment
+     *
+     * \tparam T_Acc alpaka accelerator type
+     * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * \tparam T_Dim dimension of simulation
+     */
+    template<
+        typename T_Acc,
+        typename T_DestSpecies,
+        unsigned T_Dim
+    >
+    struct JIonizationAssignment;
+
+    /** 3d case
+     */
+    template<
+        typename T_Acc,
+        typename T_DestSpecies
+    >
+    struct JIonizationAssignment<T_Acc, T_DestSpecies, DIM3> : public JIonizationAssignmentParent<T_DestSpecies>
+    {
+        /** functor for  assigning current to databox
+         *
+         * \tparam T_JBox type of current density data box
+         */
+        template<typename T_JBox>
+        HDINLINE void
+        operator()(T_Acc const & acc, float3_X const jIonizationPar, float3_X const pos, T_JBox jBoxPar)
+        {
+            /* actual assignment */
+            for( int z = JIonizationAssignmentParent<T_DestSpecies>::begin; z < JIonizationAssignmentParent<T_DestSpecies>::end; ++z)
+            {
+                float3_X jGridz = jIonizationPar;
+                jGridz *= typename JIonizationAssignmentParent<T_DestSpecies>::AssignmentFunction{}( float_X(z) - pos.z());
+                for( int y = JIonizationAssignmentParent<T_DestSpecies>::begin; y < JIonizationAssignmentParent<T_DestSpecies>::end; ++y)
+                {
+                    float3_X jGridy = jGridz;
+                    jGridy *= typename JIonizationAssignmentParent<T_DestSpecies>::AssignmentFunction{}( float_X(y) - pos.y());
+                    for( int x = JIonizationAssignmentParent<T_DestSpecies>::begin; x < JIonizationAssignmentParent<T_DestSpecies>::end; ++x)
+                    {
+                        float3_X jGridx = jGridy;
+                        jGridx *= typename JIonizationAssignmentParent<T_DestSpecies>::AssignmentFunction{}( float_X(x) - pos.x());
+                        for( int i = 0; i <= 2 ; i++)
+                        {
+                            cupla::atomicAdd(
+                                acc,
+                                &(jBoxPar(DataSpace< DIM3 >(x,y,z))[i]),
+                                jGridx[i]
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    /** 2d case
+     */
+    template<
+        typename T_Acc,
+        typename T_DestSpecies
+    >
+    struct JIonizationAssignment<T_Acc, T_DestSpecies, DIM2> : public JIonizationAssignmentParent<T_DestSpecies>
+    {
+        /** functor for assigning current to databox
+         */
+        template<typename T_JBox>
+        HDINLINE void
+        operator()(T_Acc const & acc, float3_X const jIonizationPar, float2_X const pos, T_JBox jBoxPar)
+        {
+            for( int y = JIonizationAssignmentParent<T_DestSpecies>::begin; y < JIonizationAssignmentParent<T_DestSpecies>::end; ++y)
+            {
+                float3_X jGridy = jIonizationPar;
+                jGridy *= typename JIonizationAssignmentParent<T_DestSpecies>::AssignmentFunction{}( float_X(y) - pos.y());
+                for( int x = JIonizationAssignmentParent<T_DestSpecies>::begin; x < JIonizationAssignmentParent<T_DestSpecies>::end; ++x)
+                {
+                    float3_X jGridx = jGridy;
+                    jGridx *= typename JIonizationAssignmentParent<T_DestSpecies>::AssignmentFunction{}( float_X(x) - pos.x());
+                    for( int i = 0; i <= 2 ; i++)
+                        {
+                            cupla::atomicAdd(
+                                acc,
+                                &(jBoxPar(DataSpace< DIM2 >(x,y))[i]),
+                                jGridx[i]
+                            );
+                        }
+                }
+            }
+        }
+    };
+    /**@}*/
+} // namespace ionization
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2020 Jakob Trojok
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+namespace picongpu
+{
+namespace particles
+{
+namespace ionization
+{
+    /** calculates ionization current
+     */
+    struct JIonizationCalc
+    {
+        /** functor calculating ionization current
+         */
+        HDINLINE float3_X
+        operator()( float_X const ionizationEnergy, float3_X const eField )
+        {
+            float3_X jion = ionizationEnergy * eField / pmacc::math::abs2(eField) / DELTA_T / CELL_VOLUME;
+            return jion;
+        }
+    };
+} // namespace ionization
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Marco Garten
+/* Copyright 2016-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -27,6 +27,7 @@
 #include <pmacc/algorithms/math/defines/pi.hpp>
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
 #include "picongpu/particles/ionization/utilities.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp"
 
 /** @file AlgorithmKeldysh.hpp
  *
@@ -57,10 +58,10 @@ namespace ionization
          * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
          * \param randNr random number, equally distributed in range [0.:1.0]
          *
-         * \return number of new macro electrons to be created
+         * \return ionization energy and number of new macro electrons to be created
          */
         template<typename EType, typename BType, typename ParticleType >
-        HDINLINE uint32_t
+        HDINLINE IonizerReturn
         operator()( const BType bField, const EType eField, ParticleType& parentIon, float_X randNr )
         {
 
@@ -104,12 +105,12 @@ namespace ionization
                 /* ionization condition */
                 if( randNr < probKeldysh )
                 {
-                    /* return number of macro electrons to produce */
-                    return 1u;
+                    /* return ionization energy number of macro electrons to produce */
+                    return IonizerReturn{iEnergy, 1u};
                 }
             }
             /* no ionization */
-            return 0u;
+            return IonizerReturn{0.0, 0u};
         }
     };
 

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Marco Garten
+/* Copyright 2016-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <pmacc/types.hpp>
+#include "picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def"
 
 namespace picongpu
 {
@@ -31,12 +32,13 @@ namespace ionization
     /** Keldysh model
      *
      * \tparam T_DestSpecies electron species to be created
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
      * \tparam T_SrcSpecies ion species to be ionized
      *         default is boost::mpl placeholder because specialization
      *         cannot be known in list of particle species' flags
      *         \see speciesDefinition.param
      */
-    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
+    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_IonizationCurrent, typename T_SrcSpecies = bmpl::_1>
     struct Keldysh_Impl;
 
     /** Keldysh ionization model
@@ -58,11 +60,11 @@ namespace ionization
      * first specialization of the ionization model in the particle definition
      * \see speciesDefinition.param
      */
-    template<typename T_DestSpecies>
+    template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
     struct Keldysh
     {
         using IonizationAlgorithm = particles::ionization::AlgorithmKeldysh;
-        using type = Keldysh_Impl< IonizationAlgorithm, T_DestSpecies >;
+        using type = Keldysh_Impl< IonizationAlgorithm, T_DestSpecies, T_IonizationCurrent >;
     };
 
 } // namespace ionization

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Marco Garten
+/* Copyright 2016-2020 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *
@@ -27,6 +27,8 @@
 #include "picongpu/traits/FieldPosition.hpp"
 #include "picongpu/particles/ionization/byField/Keldysh/Keldysh.def"
 #include "picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp"
+#include "picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp"
 
 #include <pmacc/random/methods/methods.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
@@ -56,9 +58,10 @@ namespace ionization
      *        Tunneling ionization for hydrogenlike atoms
      *
      * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+     * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
      * \tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
      */
-    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies>
+    template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_IonizationCurrent, typename T_SrcSpecies>
     struct Keldysh_Impl
     {
 
@@ -106,9 +109,10 @@ namespace ionization
 
             using ValueType_E = FieldE::ValueType;
             using ValueType_B = FieldB::ValueType;
-            /* global memory EM-field device databoxes */
+            /* global memory EM-field and current density device databoxes */
             PMACC_ALIGN(eBox, FieldE::DataBoxType);
             PMACC_ALIGN(bBox, FieldB::DataBoxType);
+            PMACC_ALIGN(jBox, FieldJ::DataBoxType);
             /* shared memory EM-field device databoxes */
             PMACC_ALIGN(cachedE, DataBox<SharedBox<ValueType_E, typename BlockArea::FullSuperCellSize,1> >);
             PMACC_ALIGN(cachedB, DataBox<SharedBox<ValueType_B, typename BlockArea::FullSuperCellSize,0> >);
@@ -118,13 +122,14 @@ namespace ionization
             Keldysh_Impl(const uint32_t currentStep) : randomGen(RNGFactory::createRandom<Distribution>())
             {
                 DataConnector &dc = Environment<>::get().DataConnector();
-                /* initialize pointers on host-side E-(B-)field databoxes */
+                /* initialize pointers on host-side E-(B-)field and current density databoxes */
                 auto fieldE = dc.get< FieldE >( FieldE::getName(), true );
                 auto fieldB = dc.get< FieldB >( FieldB::getName(), true );
-                /* initialize device-side E-(B-)field databoxes */
+                auto fieldJ = dc.get< FieldJ >( FieldJ::getName(), true );
+                /* initialize device-side E-(B-)field and current density databoxes */
                 eBox = fieldE->getDeviceDataBox();
                 bBox = fieldB->getDeviceDataBox();
-
+                jBox = fieldJ->getDeviceDataBox();
             }
 
             /** cache fields used by this functor
@@ -148,6 +153,9 @@ namespace ionization
                 const T_WorkerCfg & workerCfg
             )
             {
+                /* shifting origin of jbox to supercell of particle */
+                jBox = jBox.shift(blockCell);
+
                 /* caching of E and B fields */
                 cachedB = CachedBox::create<
                     0,
@@ -240,13 +248,21 @@ namespace ionization
                 float_X prevBoundElectrons = particle[boundElectrons_];
 
                 IonizationAlgorithm ionizeAlgo;
-                /* determine number of new macro electrons to be created */
-                uint32_t newMacroElectrons = ionizeAlgo(
+                /* determine number of new macro electrons to be created and energy used for ionization */
+                auto retValue = ionizeAlgo(
                      bField, eField,
                      particle, this->randomGen(acc)
                      );
+                IonizationCurrent<T_Acc, T_DestSpecies, simDim, T_IonizationCurrent>{}(
+                    retValue,
+                    particle[ weighting_ ],
+                    jBox.shift(localCell),
+                    eField,
+                    acc,
+                    pos
+                );
 
-                return newMacroElectrons;
+                return retValue.newMacroElectrons;
 
             }
 

--- a/include/picongpu/simulation/control/MySimulation.hpp
+++ b/include/picongpu/simulation/control/MySimulation.hpp
@@ -553,6 +553,7 @@ public:
     {
         using namespace simulation::stage;
         MomentumBackup{ }( currentStep );
+        CurrentReset{ }( currentStep );
         ParticleIonization{ *cellDescription }( currentStep );
         PopulationKinetics{ }( currentStep );
         SynchrotronRadiation{
@@ -570,7 +571,6 @@ public:
         ParticlePush{ }( currentStep, commEvent );
         FieldBackground{ *cellDescription }( currentStep, nvidia::functors::Sub( ) );
         myFieldSolver->update_beforeCurrent( currentStep );
-        CurrentReset{ }( currentStep );
         __setTransactionEvent( commEvent );
         CurrentBackground{ *cellDescription }( currentStep );
         CurrentDeposition{ }( currentStep );

--- a/share/picongpu/examples/FoilLCT/cmakeFlags
+++ b/share/picongpu/examples/FoilLCT/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2020 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2020 Axel Huebl, Rene Widera, Richard Pausch, Jakob Trojok
 #
 # This file is part of PIConGPU.
 #
@@ -30,7 +30,7 @@
 #   - increase by 1, no gaps
 
 flags[0]=""
-flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_LASERPROFILE=ExpRampWithPrepulse'"
+flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_LASERPROFILE=ExpRampWithPrepulse;-DPARAM_IONIZATIONCURRENT=EnergyConservation'"
 
 ################################################################################
 # execution

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
@@ -95,6 +95,10 @@ value_identifier( float_X, ChargeRatioHydrogen, -1.0 );
 /* ratio relative to BASE_DENSITY (n_e) */
 value_identifier( float_X, DensityRatioHydrogen, 25. / 158. );
 
+
+#ifndef PARAM_IONIZATIONCURRENT
+#define PARAM_IONIZATIONCURRENT None
+#endif
 using ParticleFlagsHydrogen = MakeSeq_t<
     particlePusher< UsedParticlePusher >,
     shape< UsedParticleShape >,
@@ -108,8 +112,8 @@ using ParticleFlagsHydrogen = MakeSeq_t<
     effectiveNuclearCharge< ionization::effectiveNuclearCharge::Hydrogen_t >,
     ionizers<
         MakeSeq_t<
-            particles::ionization::BSIEffectiveZ< Electrons >,
-            particles::ionization::ADKLinPol< Electrons >,
+            particles::ionization::BSIEffectiveZ< Electrons, particles::ionization::current::PARAM_IONIZATIONCURRENT >,
+            particles::ionization::ADKLinPol< Electrons, particles::ionization::current::PARAM_IONIZATIONCURRENT >,
             particles::ionization::ThomasFermi< Electrons >
         >
     >
@@ -144,8 +148,8 @@ using ParticleFlagsCarbon = MakeSeq_t<
     effectiveNuclearCharge< ionization::effectiveNuclearCharge::Carbon_t >,
     ionizers<
         MakeSeq_t<
-            particles::ionization::BSIEffectiveZ< Electrons >,
-            particles::ionization::ADKLinPol< Electrons >,
+            particles::ionization::BSIEffectiveZ< Electrons, particles::ionization::current::PARAM_IONIZATIONCURRENT >,
+            particles::ionization::ADKLinPol< Electrons, particles::ionization::current::PARAM_IONIZATIONCURRENT >,
             particles::ionization::ThomasFermi< Electrons >
         >
     >
@@ -180,8 +184,8 @@ using ParticleFlagsNitrogen = MakeSeq_t<
     effectiveNuclearCharge< ionization::effectiveNuclearCharge::Nitrogen_t >,
     ionizers<
         MakeSeq_t<
-            particles::ionization::BSIEffectiveZ< Electrons >,
-            particles::ionization::ADKLinPol< Electrons >,
+            particles::ionization::BSIEffectiveZ< Electrons, particles::ionization::current::PARAM_IONIZATIONCURRENT >,
+            particles::ionization::ADKLinPol< Electrons, particles::ionization::current::PARAM_IONIZATIONCURRENT >,
             particles::ionization::ThomasFermi< Electrons >
         >
     >

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
@@ -93,8 +93,8 @@ using ParticleFlagsIons = MakeSeq_t<
 #if( PARAM_IONIZATION == 1 )
     ionizers<
         MakeSeq_t<
-            particles::ionization::BSIEffectiveZ< PIC_Electrons >,
-            particles::ionization::ADKCircPol< PIC_Electrons >
+            particles::ionization::BSIEffectiveZ< PIC_Electrons, particles::ionization::current::None >,
+            particles::ionization::ADKCircPol< PIC_Electrons, particles::ionization::current::None >
         >
     >,
     ionizationEnergies< ionization::energies::AU::Hydrogen_t >,


### PR DESCRIPTION
This PR adds the implementation of ionization current.    
Every field ionization routine now also calculates an ionization current that reduces the local electric field according to the energy used in ionization processes while correctly accounting for the macroparticle shape.

References:
[1] (Eq. 21) http://stacks.iop.org/0741-3335/57/i=11/a=113001?key=crossref.907aa156b73b99b125b1a0ae886c4c22
[2] (p. 223) https://linkinghub.elsevier.com/retrieve/pii/S0021999112007097
[3] (Eq.   2) http://aip.scitation.org/doi/10.1063/1.1814367
[4] (Eq. 15) https://link.aps.org/doi/10.1103/PhysRevA.46.1084
[5] (Eq. 10) https://link.aps.org/doi/10.1103/PhysRevA.43.3100