### PR TITLE
Fix names in string properties of PML solvers to be openPMD-compatible

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/LehePML/LehePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/LehePML/LehePML.hpp
@@ -50,8 +50,8 @@ namespace traits
                     T_CurrentInterpolation,
                     T_cherenkovFreeDir
                 >::getStringProperties();
-            // overwrite the name of the YeePML solver (inherit all other properties)
-            propList["name"].value = "LehePML";
+            // overwrite the name of the solver (inherit all other properties)
+            propList[ "name" ].value = "Lehe";
             return propList;
         }
     };

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -444,7 +444,7 @@ namespace maxwellSolver
 
         static pmacc::traits::StringProperty getStringProperties( )
         {
-            pmacc::traits::StringProperty propList( "name", "YeePML" );
+            pmacc::traits::StringProperty propList( "name", "Yee" );
             return propList;
         }
 


### PR DESCRIPTION
Absorber properties are handled separately and properly already.