### PR TITLE
Add output of fieldSolverParameters attribute to output

### DIFF
--- a/include/picongpu/plugins/adios/WriteMeta.hpp
+++ b/include/picongpu/plugins/adios/WriteMeta.hpp
@@ -184,6 +184,13 @@ namespace writeMeta
             const std::string fieldSolver( fieldSolverProps["name"].value );
             ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
                 "fieldSolver", fullMeshesPath.c_str(), adios_string, 1, (void*)fieldSolver.c_str()));
+            if( fieldSolverProps.find( "param" ) != fieldSolverProps.end() )
+            {
+                const std::string fieldSolverParam( fieldSolverProps[ "param" ].value );
+                ADIOS_CMD(adios_define_attribute_byvalue(threadParams->adiosGroupHandle,
+                    "fieldSolverParameters", fullMeshesPath.c_str(), adios_string,
+                    1, (void*)fieldSolverParam.c_str()));
+            }
 
             /* order as in axisLabels:
              *    3D: z-lower, z-upper, y-lower, y-upper, x-lower, x-upper

--- a/include/picongpu/plugins/openPMD/WriteMeta.hpp
+++ b/include/picongpu/plugins/openPMD/WriteMeta.hpp
@@ -163,6 +163,12 @@ namespace openPMD
             const std::string fieldSolver( fieldSolverProps[ "name" ].value );
             meshes.setAttribute( "fieldSolver", fieldSolver );
 
+            if( fieldSolverProps.find( "param" ) != fieldSolverProps.end() )
+            {
+                const std::string fieldSolverParam( fieldSolverProps[ "param" ].value );
+                meshes.setAttribute( "fieldSolverParameters", fieldSolverParam );
+            }
+
             /* order as in axisLabels:
              *    3D: z-lower, z-upper, y-lower, y-upper, x-lower, x-upper
              *    2D: y-lower, y-upper, x-lower, x-upper

--- a/include/pmacc/traits/GetStringProperties.hpp
+++ b/include/pmacc/traits/GetStringProperties.hpp
@@ -35,6 +35,11 @@ namespace traits
      * This class inherit from `std::map`.
      * If the `operator[]` is used to access a not existing key an empty StringProperty
      * with the given key is inserted (default behavior of `std::map`)
+     *
+     * Key naming convention:
+     *     "name" for name, openPMD-compatible when possible
+     *     "param" for additional parameters, corresdponding to openPMD
+     *             ...Parameters attribute
      */
     struct StringProperty : public std::map< std::string, StringProperty >
     {


### PR DESCRIPTION
As mentioned [here](https://github.com/ComputationalRadiationPhysics/picongpu/issues/2472#issuecomment-698180089), the `fieldOutputParameters` attribute of openPMD was not output. For all existing field solvers (after #3362 is merged) it was optional, so this is not a bug, however, with new field solver #3338 coming soon, the extension is needed.

Only modify the openPMD and ADIOS plugins to avoid conflicts with removal of HDF5 in #3361.

