### PR TITLE
Separate project and account for Juwels profile

### DIFF
--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -10,15 +10,16 @@ export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Project Information ######################################## (edit this line)
-#   - project account for computing time
+#   - project and account for allocation
 export proj=$(groups | awk '{print $4}')
+export account=$(jutil user projects -n | awk '{print $NF}')
 
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
 # Set up environment, including $SCRATCH and $PROJECT
-jutil env activate -p $proj
+jutil env activate -p $proj A $account
 
 # General modules #############################################################
 #
@@ -86,7 +87,7 @@ function getNode() {
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=48
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=2 --mem=94000 -A $proj -p batch bash
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=2 --mem=94000 -A $account -p batch bash
 }
 
 # allocate an interactive shell for one hour
@@ -104,7 +105,7 @@ function getDevice() {
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=48
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p batch bash
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch bash
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -19,7 +19,7 @@ export account=$(jutil user projects -n | awk '{print $NF}')
 #export EDITOR="nano"
 
 # Set up environment, including $SCRATCH and $PROJECT
-jutil env activate -p $proj A $account
+jutil env activate -p $proj -A $account
 
 # General modules #############################################################
 #

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -10,14 +10,16 @@ export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Project Information ######################################## (edit this line)
-#   - project account for computing time
-export proj=$(jutil user projects -n | awk '{print $NF}')
+#   - project and account for allocation
+export proj=$(groups | awk '{print $4}')
+export account=$(jutil user projects -n | awk '{print $NF}')
+
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
 # Set up environment, including $SCRATCH and $PROJECT
-jutil env activate -p $proj
+jutil env activate -p $proj -A $account
 
 # General modules #############################################################
 #
@@ -84,7 +86,7 @@ function getNode() {
         return 1
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=180000 -A $proj -p gpus bash
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=180000 -A $account -p gpus bash
 }
 
 # allocate an interactive shell for one hour
@@ -101,7 +103,7 @@ function getDevice() {
         fi
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $proj -p gpus bash
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus bash
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -11,7 +11,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Project Information ######################################## (edit this line)
 #   - project account for computing time
-export proj=$(groups | awk '{print $NF}')
+export proj=$(jutil user projects -n | awk '{print $NF}')
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"


### PR DESCRIPTION
Juwels has two codes for the allocation project (e.g., hhh123) and account (chhh123). This PR proposes to put them in two separate variables. This fixed the `#SBATCH -A ...` bug reported in https://github.com/ComputationalRadiationPhysics/picongpu/issues/3365.