### PR TITLE
replace workdir with chdir in Juwels profiles

### DIFF
--- a/etc/picongpu/juwels-jsc/batch.tpl
+++ b/etc/picongpu/juwels-jsc/batch.tpl
@@ -32,7 +32,7 @@
 #SBATCH --mem=!TBG_memPerNode
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
+#SBATCH --chdir=!TBG_dstPath
 
 #SBATCH -o stdout
 #SBATCH -e stderr

--- a/etc/picongpu/juwels-jsc/gpus.tpl
+++ b/etc/picongpu/juwels-jsc/gpus.tpl
@@ -34,7 +34,7 @@
 #SBATCH --gres=gpu:!TBG_devicesPerNode
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
+#SBATCH --chdir=!TBG_dstPath
 
 #SBATCH -o stdout
 #SBATCH -e stderr


### PR DESCRIPTION
As reported in https://github.com/ComputationalRadiationPhysics/picongpu/issues/3365, option `$SBATCH --workdir` doesn't work on Juwels. This PR proposes to replace it with `#SBATCH --chdir`.