### PR TITLE
Update "name" property of Higuera-Cary pusher

### DIFF
--- a/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
@@ -136,7 +136,7 @@ struct Push
 
     static pmacc::traits::StringProperty getStringProperties()
     {
-        pmacc::traits::StringProperty propList( "name", "HigueraCary" );
+        pmacc::traits::StringProperty propList( "name", "other:Higuera-Cary" );
         return propList;
     }
 };


### PR DESCRIPTION
The name update ensures conformity with the openPMD standard.
See openPMD/openPMD-standard#225.